### PR TITLE
added field name in meters

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -657,6 +657,7 @@ const docTemplate = `{
                 "aggregation",
                 "event_name",
                 "filters",
+                "name",
                 "reset_usage"
             ],
             "properties": {
@@ -673,8 +674,17 @@ const docTemplate = `{
                         "$ref": "#/definitions/meter.Filter"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "API Usage Meter"
+                },
                 "reset_usage": {
-                    "$ref": "#/definitions/types.ResetUsage"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ResetUsage"
+                        }
+                    ],
+                    "example": "BILLING_PERIOD"
                 }
             }
         },
@@ -807,6 +817,10 @@ const docTemplate = `{
                 "id": {
                     "type": "string",
                     "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "API Usage Meter"
                 },
                 "reset_usage": {
                     "$ref": "#/definitions/types.ResetUsage"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -654,6 +654,7 @@
                 "aggregation",
                 "event_name",
                 "filters",
+                "name",
                 "reset_usage"
             ],
             "properties": {
@@ -670,8 +671,17 @@
                         "$ref": "#/definitions/meter.Filter"
                     }
                 },
+                "name": {
+                    "type": "string",
+                    "example": "API Usage Meter"
+                },
                 "reset_usage": {
-                    "$ref": "#/definitions/types.ResetUsage"
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ResetUsage"
+                        }
+                    ],
+                    "example": "BILLING_PERIOD"
                 }
             }
         },
@@ -804,6 +814,10 @@
                 "id": {
                     "type": "string",
                     "example": "550e8400-e29b-41d4-a716-446655440000"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "API Usage Meter"
                 },
                 "reset_usage": {
                     "$ref": "#/definitions/types.ResetUsage"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -16,12 +16,18 @@ definitions:
         items:
           $ref: '#/definitions/meter.Filter'
         type: array
+      name:
+        example: API Usage Meter
+        type: string
       reset_usage:
-        $ref: '#/definitions/types.ResetUsage'
+        allOf:
+        - $ref: '#/definitions/types.ResetUsage'
+        example: BILLING_PERIOD
     required:
     - aggregation
     - event_name
     - filters
+    - name
     - reset_usage
     type: object
   dto.Event:
@@ -113,6 +119,9 @@ definitions:
         type: array
       id:
         example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      name:
+        example: API Usage Meter
         type: string
       reset_usage:
         $ref: '#/definitions/types.ResetUsage'

--- a/internal/api/dto/meter.go
+++ b/internal/api/dto/meter.go
@@ -10,15 +10,17 @@ import (
 
 // CreateMeterRequest represents the request payload for creating a meter
 type CreateMeterRequest struct {
+	Name        string            `json:"name" binding:"required" example:"API Usage Meter"`
 	EventName   string            `json:"event_name" binding:"required" example:"api_request"`
 	Aggregation meter.Aggregation `json:"aggregation" binding:"required"`
 	Filters     []meter.Filter    `json:"filters" binding:"required"`
-	ResetUsage  types.ResetUsage  `json:"reset_usage" binding:"required"`
+	ResetUsage  types.ResetUsage  `json:"reset_usage" binding:"required" example:"BILLING_PERIOD"`
 }
 
 // MeterResponse represents the meter response structure
 type MeterResponse struct {
 	ID          string            `json:"id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Name        string            `json:"name" example:"API Usage Meter"`
 	TenantID    string            `json:"tenant_id" example:"tenant123"`
 	EventName   string            `json:"event_name" example:"api_request"`
 	Aggregation meter.Aggregation `json:"aggregation"`
@@ -33,6 +35,7 @@ type MeterResponse struct {
 func ToMeterResponse(m *meter.Meter) *MeterResponse {
 	return &MeterResponse{
 		ID:          m.ID,
+		Name:        m.Name,
 		TenantID:    m.TenantID,
 		EventName:   m.EventName,
 		Aggregation: m.Aggregation,
@@ -46,7 +49,7 @@ func ToMeterResponse(m *meter.Meter) *MeterResponse {
 
 // Convert CreateMeterRequest to domain Meter
 func (r *CreateMeterRequest) ToMeter(tenantID, createdBy string) *meter.Meter {
-	m := meter.NewMeter("", tenantID, createdBy)
+	m := meter.NewMeter(r.Name, tenantID, createdBy)
 	m.EventName = r.EventName
 	m.Aggregation = r.Aggregation
 	m.Filters = r.Filters

--- a/internal/domain/meter/model.go
+++ b/internal/domain/meter/model.go
@@ -11,6 +11,7 @@ import (
 type Meter struct {
 	ID          string           `db:"id" json:"id"`
 	EventName   string           `db:"event_name" json:"event_name"`
+	Name        string           `db:"name" json:"name"`
 	Aggregation Aggregation      `db:"aggregation" json:"aggregation"`
 	Filters     []Filter         `db:"filters" json:"filters"`
 	ResetUsage  types.ResetUsage `db:"reset_usage" json:"reset_usage"`
@@ -31,6 +32,9 @@ type Aggregation struct {
 func (m *Meter) Validate() error {
 	if m.ID == "" {
 		return fmt.Errorf("id is required")
+	}
+	if m.Name == "" {
+		return fmt.Errorf("name is required")
 	}
 	if m.EventName == "" {
 		return fmt.Errorf("event_name is required")
@@ -54,21 +58,17 @@ func (m *Meter) Validate() error {
 }
 
 // Constructor for creating new meters with defaults
-func NewMeter(id string, tenantID, createdBy string) *Meter {
+func NewMeter(name string, tenantID, createdBy string) *Meter {
 	now := time.Now().UTC()
-	if id == "" {
-		id = uuid.New().String()
-	}
-
 	return &Meter{
-		ID: id,
+		ID:   uuid.New().String(),
+		Name: name,
 		BaseModel: types.BaseModel{
 			TenantID:  tenantID,
 			CreatedAt: now,
 			UpdatedAt: now,
 			CreatedBy: createdBy,
 			UpdatedBy: createdBy,
-			Status:    types.StatusActive,
 		},
 		Filters:    []Filter{},
 		ResetUsage: types.ResetUsageBillingPeriod,

--- a/internal/repository/postgres/meter.go
+++ b/internal/repository/postgres/meter.go
@@ -23,10 +23,10 @@ func NewMeterRepository(db *postgres.DB, logger *logger.Logger) meter.Repository
 func (r *meterRepository) CreateMeter(ctx context.Context, meter *meter.Meter) error {
 	query := `
 	INSERT INTO meters (
-		id, tenant_id, event_name, aggregation, filters, reset_usage,
+		id, tenant_id, name, event_name, filters, aggregation, reset_usage,
 		created_at, updated_at, created_by, updated_by, status
 	) VALUES (
-		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
 	)
 	`
 
@@ -43,9 +43,10 @@ func (r *meterRepository) CreateMeter(ctx context.Context, meter *meter.Meter) e
 	_, err = r.db.ExecContext(ctx, query,
 		meter.ID,
 		meter.TenantID,
+		meter.Name,
 		meter.EventName,
-		aggregationJSON,
 		filtersJSON,
+		aggregationJSON,
 		meter.ResetUsage,
 		meter.CreatedAt,
 		meter.UpdatedAt,
@@ -64,7 +65,7 @@ func (r *meterRepository) CreateMeter(ctx context.Context, meter *meter.Meter) e
 func (r *meterRepository) GetMeter(ctx context.Context, id string) (*meter.Meter, error) {
 	query := `
 	SELECT 
-		id, tenant_id, event_name, filters, aggregation, reset_usage,
+		id, tenant_id, name, event_name, filters, aggregation, reset_usage,
 		created_at, updated_at, created_by, updated_by, status
 	FROM meters 
 	WHERE id = $1 AND status = $2
@@ -76,6 +77,7 @@ func (r *meterRepository) GetMeter(ctx context.Context, id string) (*meter.Meter
 	err := r.db.QueryRowContext(ctx, query, id, types.StatusActive).Scan(
 		&m.ID,
 		&m.TenantID,
+		&m.Name,
 		&m.EventName,
 		&filtersJSON,
 		&aggregationJSON,
@@ -111,7 +113,7 @@ func (r *meterRepository) GetMeter(ctx context.Context, id string) (*meter.Meter
 func (r *meterRepository) GetAllMeters(ctx context.Context) ([]*meter.Meter, error) {
 	query := `
 	SELECT 
-		id, tenant_id, event_name, filters, aggregation, reset_usage,
+		id, tenant_id, name, event_name, filters, aggregation, reset_usage,
 		created_at, updated_at, created_by, updated_by, status
 	FROM meters 
 	WHERE status = $1
@@ -131,6 +133,7 @@ func (r *meterRepository) GetAllMeters(ctx context.Context) ([]*meter.Meter, err
 		err := rows.Scan(
 			&m.ID,
 			&m.TenantID,
+			&m.Name,
 			&m.EventName,
 			&filtersJSON,
 			&aggregationJSON,

--- a/internal/service/event_test.go
+++ b/internal/service/event_test.go
@@ -249,9 +249,10 @@ func (s *EventServiceSuite) TestGetUsage() {
 }
 
 func (s *EventServiceSuite) TestGetUsageByMeter() {
-	// Setup test meter with filters
+	// Setup test meter with required fields
 	testMeter := &meter.Meter{
 		ID:        "meter-1",
+		Name:      "Test Meter", // Add a name
 		EventName: "api_request",
 		Aggregation: meter.Aggregation{
 			Type:  types.AggregationSum,
@@ -267,6 +268,7 @@ func (s *EventServiceSuite) TestGetUsageByMeter() {
 				Values: []string{"us-east-1"},
 			},
 		},
+		ResetUsage: types.ResetUsageBillingPeriod, // Ensure ResetUsage is valid
 		BaseModel: types.BaseModel{
 			TenantID: types.GetTenantID(s.ctx),
 		},

--- a/internal/service/meter_test.go
+++ b/internal/service/meter_test.go
@@ -37,11 +37,14 @@ func (s *MeterServiceSuite) TestCreateMeter() {
 		{
 			name: "successful_meter_creation",
 			input: &dto.CreateMeterRequest{
-				EventName: "api_request", // Replaced Filters with EventName
+				Name:      "API Usage Counter",
+				EventName: "api_request",
 				Aggregation: meter.Aggregation{
 					Type:  types.AggregationSum,
 					Field: "duration_ms",
 				},
+				Filters:    []meter.Filter{},
+				ResetUsage: types.ResetUsageBillingPeriod,
 			},
 			expectedError: false,
 		},
@@ -51,8 +54,19 @@ func (s *MeterServiceSuite) TestCreateMeter() {
 			expectedError: true,
 		},
 		{
+			name: "invalid_meter_missing_name",
+			input: &dto.CreateMeterRequest{
+				EventName: "api_request",
+				Aggregation: meter.Aggregation{
+					Type: types.AggregationSum,
+				},
+			},
+			expectedError: true,
+		},
+		{
 			name: "invalid_meter_missing_event_name",
 			input: &dto.CreateMeterRequest{
+				Name: "Test Meter",
 				Aggregation: meter.Aggregation{
 					Type: types.AggregationSum,
 				},
@@ -70,9 +84,10 @@ func (s *MeterServiceSuite) TestCreateMeter() {
 			}
 			s.NoError(err)
 
-			if tc.input != nil && tc.input.EventName != "" {
+			if tc.input != nil {
 				stored, err := s.store.GetMeter(s.ctx, meter.ID)
 				s.NoError(err)
+				s.Equal(tc.input.Name, stored.Name)
 				s.Equal(tc.input.EventName, stored.EventName)
 			}
 		})
@@ -81,8 +96,8 @@ func (s *MeterServiceSuite) TestCreateMeter() {
 
 func (s *MeterServiceSuite) TestGetMeter() {
 	// Create test meter
-	testMeter := meter.NewMeter("", "tenant-1", "test-user")
-	testMeter.EventName = "api_request" // Replaced Filters with EventName
+	testMeter := meter.NewMeter("Test API Meter", "tenant-1", "test-user")
+	testMeter.EventName = "api_request"
 	testMeter.Aggregation = meter.Aggregation{
 		Type:  types.AggregationSum,
 		Field: "duration_ms",
@@ -98,6 +113,7 @@ func (s *MeterServiceSuite) TestGetMeter() {
 		},
 	}
 	testMeter.BaseModel.Status = types.StatusActive
+	testMeter.ResetUsage = types.ResetUsageBillingPeriod
 
 	err := s.store.CreateMeter(s.ctx, testMeter)
 	s.NoError(err)
@@ -105,6 +121,7 @@ func (s *MeterServiceSuite) TestGetMeter() {
 	result, err := s.service.GetMeter(s.ctx, testMeter.ID)
 	s.NoError(err)
 	s.Equal(testMeter.ID, result.ID)
+	s.Equal(testMeter.Name, result.Name)
 	s.Equal(testMeter.EventName, result.EventName)
 	s.Equal(testMeter.Aggregation, result.Aggregation)
 	s.Equal(testMeter.Filters, result.Filters)
@@ -113,13 +130,12 @@ func (s *MeterServiceSuite) TestGetMeter() {
 func (s *MeterServiceSuite) TestGetAllMeters() {
 	// Create test meters
 	meters := []*meter.Meter{
-		meter.NewMeter("", "tenant-1", "test-user-1"),
-		meter.NewMeter("", "tenant-1", "test-user-2"),
+		meter.NewMeter("First API Meter", "tenant-1", "test-user-1"),
+		meter.NewMeter("Second API Meter", "tenant-1", "test-user-2"),
 	}
 
 	// Set required fields
 	for _, m := range meters {
-		m.TenantID = "tenant-1"
 		m.EventName = "api_request"
 		m.Aggregation = meter.Aggregation{
 			Type:  types.AggregationSum,
@@ -132,6 +148,7 @@ func (s *MeterServiceSuite) TestGetAllMeters() {
 			},
 		}
 		m.BaseModel.Status = types.StatusActive
+		m.ResetUsage = types.ResetUsageBillingPeriod
 
 		err := s.store.CreateMeter(s.ctx, m)
 		s.NoError(err)
@@ -140,7 +157,8 @@ func (s *MeterServiceSuite) TestGetAllMeters() {
 	result, err := s.service.GetAllMeters(s.ctx)
 	s.NoError(err)
 	s.Len(result, 2)
-	for _, m := range result {
+	for i, m := range result {
+		s.Equal(meters[i].Name, m.Name)
 		s.Equal("api_request", m.EventName)
 		s.NotEmpty(m.Filters)
 		s.Equal("status", m.Filters[0].Key)
@@ -148,12 +166,18 @@ func (s *MeterServiceSuite) TestGetAllMeters() {
 }
 
 func (s *MeterServiceSuite) TestDisableMeter() {
-	// Create test meter
-	testMeter := meter.NewMeter("", "tenant-1", "test-user")
-	testMeter.EventName = "api_request" // Replaced Filters with EventName
+	// Create test meter with a name
+	testMeter := meter.NewMeter("Test Disable Meter", "tenant-1", "test-user") // Added name
+	testMeter.EventName = "api_request"
 	testMeter.BaseModel = types.BaseModel{
 		Status: types.StatusActive,
 	}
+	testMeter.Aggregation = meter.Aggregation{ // Add required fields
+		Type:  types.AggregationSum,
+		Field: "duration_ms",
+	}
+	testMeter.Filters = []meter.Filter{} // Initialize empty filters
+	testMeter.ResetUsage = types.ResetUsageBillingPeriod
 
 	err := s.store.CreateMeter(s.ctx, testMeter)
 	s.NoError(err)
@@ -190,7 +214,8 @@ func (s *MeterServiceSuite) TestDisableMeter() {
 			s.NoError(err)
 
 			// Verify meter is disabled
-			meter, _ := s.store.GetMeter(s.ctx, tc.id)
+			meter, err := s.store.GetMeter(s.ctx, tc.id)
+			s.NoError(err)
 			s.Equal(types.StatusDeleted, meter.BaseModel.Status)
 		})
 	}

--- a/internal/testutil/inmemory_meter_store.go
+++ b/internal/testutil/inmemory_meter_store.go
@@ -28,6 +28,10 @@ func (s *InMemoryMeterStore) CreateMeter(ctx context.Context, m *meter.Meter) er
 		return fmt.Errorf("meter ID cannot be empty")
 	}
 
+	if m.Name == "" {
+		return fmt.Errorf("meter name cannot be empty")
+	}
+
 	if m.ResetUsage == "" {
 		m.ResetUsage = types.ResetUsageBillingPeriod
 	}

--- a/migrations/postgres/V1__create_meters_table.sql
+++ b/migrations/postgres/V1__create_meters_table.sql
@@ -2,6 +2,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE IF NOT EXISTS meters (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL DEFAULT '',
     tenant_id VARCHAR(255) NOT NULL,
     event_name VARCHAR(255) NOT NULL, 
     aggregation JSONB NOT NULL,


### PR DESCRIPTION
# Add Name Field to Meters

## Description
This PR adds a required `name` field to meters to provide a human-readable identifier for each meter configuration. This will improve usability and make meters easier to manage in the UI.

## Changes
- Added `name` field to Meter model
- Updated database schema with new `name` column
- Added validation for name field
- Updated API DTOs and documentation
- Updated tests to include name field

## Database Changes
Added column  `name` to meters table


## Testing Checklist
- [x] Unit tests pass
- [x] Integration tests pass
- [x] API documentation updated
- [x] Migration tested on staging
- [x] Backward compatibility maintained
