### PR TITLE
added meter level filters in subscription usage query

### DIFF
--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -140,6 +140,12 @@ func (s *eventService) GetUsageByMeterWithFilters(ctx context.Context, req *dto.
 		return nil, fmt.Errorf("failed to get meter: %w", err)
 	}
 
+	// Convert meter.Filters to map format
+	meterFilters := make(map[string][]string)
+	for _, filter := range meter.Filters {
+		meterFilters[filter.Key] = filter.Values
+	}
+
 	prioritizedGroups := make([]events.FilterGroup, len(filterGroups))
 	priceIDs := make([]string, 0, len(filterGroups))
 	for priceID := range filterGroups {
@@ -163,6 +169,7 @@ func (s *eventService) GetUsageByMeterWithFilters(ctx context.Context, req *dto.
 			ExternalCustomerID: req.ExternalCustomerID,
 			StartTime:          req.StartTime,
 			EndTime:            req.EndTime,
+			Filters:            meterFilters,
 		},
 		FilterGroups: prioritizedGroups,
 	}

--- a/internal/testutil/inmemory_price_store.go
+++ b/internal/testutil/inmemory_price_store.go
@@ -12,8 +12,8 @@ import (
 
 // InMemoryPriceStore implements price.Repository
 type InMemoryPriceStore struct {
-	mu      sync.RWMutex
-	prices  map[string]*price.Price
+	mu     sync.RWMutex
+	prices map[string]*price.Price
 }
 
 func NewInMemoryPriceStore() *InMemoryPriceStore {
@@ -26,6 +26,10 @@ func (s *InMemoryPriceStore) Create(ctx context.Context, p *price.Price) error {
 	if p == nil {
 		return fmt.Errorf("price cannot be nil")
 	}
+
+	// Set TenantID from the context
+	tenantID, _ := ctx.Value(types.CtxTenantID).(string)
+	p.TenantID = tenantID
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -52,14 +56,15 @@ func (s *InMemoryPriceStore) GetByPlanID(ctx context.Context, planID string) ([]
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	tenantID, _ := ctx.Value(types.CtxTenantID).(string)
 	var result []*price.Price
 	for _, p := range s.prices {
-		if p.PlanID == planID {
+		if p.PlanID == planID && p.TenantID == tenantID {
 			result = append(result, p)
 		}
 	}
 
-	// Sort by created date desc (default)
+	// Sort by created date desc
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].CreatedAt.After(result[j].CreatedAt)
 	})
@@ -76,7 +81,7 @@ func (s *InMemoryPriceStore) List(ctx context.Context, filter types.Filter) ([]*
 		result = append(result, p)
 	}
 
-	// Sort by created date desc (default)
+	// Sort by created date desc
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].CreatedAt.After(result[j].CreatedAt)
 	})


### PR DESCRIPTION
# Add Meter-Level Filters to Base Query in Usage Calculation

## Problem
Currently, meter-level filters are not being applied at the base query level when calculating usage with filter groups. This means events that should be filtered out by meter configuration are still being processed through the filter groups logic, potentially leading to incorrect results.

## Solution
- Modified query builder to include meter-level filters in the base query clause
- Uses the existing `Filters` field from `UsageParams` to maintain consistency with codebase
- Maintains safety checks for nil filters and empty filter values
- Keeps the same JSON property extraction and IN clause pattern for filtering