### PR TITLE
feat(fix): make lookup key optional

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -55,7 +55,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{CustomersColumns[1], CustomersColumns[7]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status != 'deleted'",
+					Where: "status != 'deleted' AND external_id != ''",
 				},
 			},
 			{
@@ -277,7 +277,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
-		{Name: "lookup_key", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
+		{Name: "lookup_key", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "name", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "description", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "invoice_cadence", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(20)"}},
@@ -294,7 +294,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{PlansColumns[1], PlansColumns[7]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status != 'deleted'",
+					Where: "status != 'deleted' AND lookup_key IS NOT NULL AND lookup_key != ''",
 				},
 			},
 			{
@@ -327,7 +327,7 @@ var (
 		{Name: "tier_mode", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(20)"}},
 		{Name: "tiers", Type: field.TypeJSON, Nullable: true},
 		{Name: "transform_quantity", Type: field.TypeJSON, Nullable: true},
-		{Name: "lookup_key", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
+		{Name: "lookup_key", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "description", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true},
 	}
@@ -342,7 +342,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{PricesColumns[1], PricesColumns[21]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status != 'deleted' AND lookup_key != ''",
+					Where: "status != 'deleted' AND lookup_key IS NOT NULL AND lookup_key != ''",
 				},
 			},
 			{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -7332,9 +7332,22 @@ func (m *PlanMutation) OldLookupKey(ctx context.Context) (v string, err error) {
 	return oldValue.LookupKey, nil
 }
 
+// ClearLookupKey clears the value of the "lookup_key" field.
+func (m *PlanMutation) ClearLookupKey() {
+	m.lookup_key = nil
+	m.clearedFields[plan.FieldLookupKey] = struct{}{}
+}
+
+// LookupKeyCleared returns if the "lookup_key" field was cleared in this mutation.
+func (m *PlanMutation) LookupKeyCleared() bool {
+	_, ok := m.clearedFields[plan.FieldLookupKey]
+	return ok
+}
+
 // ResetLookupKey resets all changes to the "lookup_key" field.
 func (m *PlanMutation) ResetLookupKey() {
 	m.lookup_key = nil
+	delete(m.clearedFields, plan.FieldLookupKey)
 }
 
 // SetName sets the "name" field.
@@ -7780,6 +7793,9 @@ func (m *PlanMutation) ClearedFields() []string {
 	if m.FieldCleared(plan.FieldUpdatedBy) {
 		fields = append(fields, plan.FieldUpdatedBy)
 	}
+	if m.FieldCleared(plan.FieldLookupKey) {
+		fields = append(fields, plan.FieldLookupKey)
+	}
 	if m.FieldCleared(plan.FieldDescription) {
 		fields = append(fields, plan.FieldDescription)
 	}
@@ -7802,6 +7818,9 @@ func (m *PlanMutation) ClearField(name string) error {
 		return nil
 	case plan.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case plan.FieldLookupKey:
+		m.ClearLookupKey()
 		return nil
 	case plan.FieldDescription:
 		m.ClearDescription()
@@ -8939,9 +8958,22 @@ func (m *PriceMutation) OldLookupKey(ctx context.Context) (v string, err error) 
 	return oldValue.LookupKey, nil
 }
 
+// ClearLookupKey clears the value of the "lookup_key" field.
+func (m *PriceMutation) ClearLookupKey() {
+	m.lookup_key = nil
+	m.clearedFields[price.FieldLookupKey] = struct{}{}
+}
+
+// LookupKeyCleared returns if the "lookup_key" field was cleared in this mutation.
+func (m *PriceMutation) LookupKeyCleared() bool {
+	_, ok := m.clearedFields[price.FieldLookupKey]
+	return ok
+}
+
 // ResetLookupKey resets all changes to the "lookup_key" field.
 func (m *PriceMutation) ResetLookupKey() {
 	m.lookup_key = nil
+	delete(m.clearedFields, price.FieldLookupKey)
 }
 
 // SetDescription sets the "description" field.
@@ -9503,6 +9535,9 @@ func (m *PriceMutation) ClearedFields() []string {
 	if m.FieldCleared(price.FieldTransformQuantity) {
 		fields = append(fields, price.FieldTransformQuantity)
 	}
+	if m.FieldCleared(price.FieldLookupKey) {
+		fields = append(fields, price.FieldLookupKey)
+	}
 	if m.FieldCleared(price.FieldDescription) {
 		fields = append(fields, price.FieldDescription)
 	}
@@ -9543,6 +9578,9 @@ func (m *PriceMutation) ClearField(name string) error {
 		return nil
 	case price.FieldTransformQuantity:
 		m.ClearTransformQuantity()
+		return nil
+	case price.FieldLookupKey:
+		m.ClearLookupKey()
 		return nil
 	case price.FieldDescription:
 		m.ClearDescription()

--- a/ent/plan/plan.go
+++ b/ent/plan/plan.go
@@ -76,8 +76,6 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
-	// LookupKeyValidator is a validator for the "lookup_key" field. It is called by the builders before save.
-	LookupKeyValidator func(string) error
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
 	// InvoiceCadenceValidator is a validator for the "invoice_cadence" field. It is called by the builders before save.

--- a/ent/plan/where.go
+++ b/ent/plan/where.go
@@ -534,6 +534,16 @@ func LookupKeyHasSuffix(v string) predicate.Plan {
 	return predicate.Plan(sql.FieldHasSuffix(FieldLookupKey, v))
 }
 
+// LookupKeyIsNil applies the IsNil predicate on the "lookup_key" field.
+func LookupKeyIsNil() predicate.Plan {
+	return predicate.Plan(sql.FieldIsNull(FieldLookupKey))
+}
+
+// LookupKeyNotNil applies the NotNil predicate on the "lookup_key" field.
+func LookupKeyNotNil() predicate.Plan {
+	return predicate.Plan(sql.FieldNotNull(FieldLookupKey))
+}
+
 // LookupKeyEqualFold applies the EqualFold predicate on the "lookup_key" field.
 func LookupKeyEqualFold(v string) predicate.Plan {
 	return predicate.Plan(sql.FieldEqualFold(FieldLookupKey, v))

--- a/ent/plan_create.go
+++ b/ent/plan_create.go
@@ -102,6 +102,14 @@ func (pc *PlanCreate) SetLookupKey(s string) *PlanCreate {
 	return pc
 }
 
+// SetNillableLookupKey sets the "lookup_key" field if the given value is not nil.
+func (pc *PlanCreate) SetNillableLookupKey(s *string) *PlanCreate {
+	if s != nil {
+		pc.SetLookupKey(*s)
+	}
+	return pc
+}
+
 // SetName sets the "name" field.
 func (pc *PlanCreate) SetName(s string) *PlanCreate {
 	pc.mutation.SetName(s)
@@ -219,14 +227,6 @@ func (pc *PlanCreate) check() error {
 	}
 	if _, ok := pc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`ent: missing required field "Plan.updated_at"`)}
-	}
-	if _, ok := pc.mutation.LookupKey(); !ok {
-		return &ValidationError{Name: "lookup_key", err: errors.New(`ent: missing required field "Plan.lookup_key"`)}
-	}
-	if v, ok := pc.mutation.LookupKey(); ok {
-		if err := plan.LookupKeyValidator(v); err != nil {
-			return &ValidationError{Name: "lookup_key", err: fmt.Errorf(`ent: validator failed for field "Plan.lookup_key": %w`, err)}
-		}
 	}
 	if _, ok := pc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`ent: missing required field "Plan.name"`)}

--- a/ent/plan_update.go
+++ b/ent/plan_update.go
@@ -82,6 +82,12 @@ func (pu *PlanUpdate) SetNillableLookupKey(s *string) *PlanUpdate {
 	return pu
 }
 
+// ClearLookupKey clears the value of the "lookup_key" field.
+func (pu *PlanUpdate) ClearLookupKey() *PlanUpdate {
+	pu.mutation.ClearLookupKey()
+	return pu
+}
+
 // SetName sets the "name" field.
 func (pu *PlanUpdate) SetName(s string) *PlanUpdate {
 	pu.mutation.SetName(s)
@@ -194,11 +200,6 @@ func (pu *PlanUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (pu *PlanUpdate) check() error {
-	if v, ok := pu.mutation.LookupKey(); ok {
-		if err := plan.LookupKeyValidator(v); err != nil {
-			return &ValidationError{Name: "lookup_key", err: fmt.Errorf(`ent: validator failed for field "Plan.lookup_key": %w`, err)}
-		}
-	}
 	if v, ok := pu.mutation.Name(); ok {
 		if err := plan.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Plan.name": %w`, err)}
@@ -241,6 +242,9 @@ func (pu *PlanUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := pu.mutation.LookupKey(); ok {
 		_spec.SetField(plan.FieldLookupKey, field.TypeString, value)
+	}
+	if pu.mutation.LookupKeyCleared() {
+		_spec.ClearField(plan.FieldLookupKey, field.TypeString)
 	}
 	if value, ok := pu.mutation.Name(); ok {
 		_spec.SetField(plan.FieldName, field.TypeString, value)
@@ -331,6 +335,12 @@ func (puo *PlanUpdateOne) SetNillableLookupKey(s *string) *PlanUpdateOne {
 	if s != nil {
 		puo.SetLookupKey(*s)
 	}
+	return puo
+}
+
+// ClearLookupKey clears the value of the "lookup_key" field.
+func (puo *PlanUpdateOne) ClearLookupKey() *PlanUpdateOne {
+	puo.mutation.ClearLookupKey()
 	return puo
 }
 
@@ -459,11 +469,6 @@ func (puo *PlanUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (puo *PlanUpdateOne) check() error {
-	if v, ok := puo.mutation.LookupKey(); ok {
-		if err := plan.LookupKeyValidator(v); err != nil {
-			return &ValidationError{Name: "lookup_key", err: fmt.Errorf(`ent: validator failed for field "Plan.lookup_key": %w`, err)}
-		}
-	}
 	if v, ok := puo.mutation.Name(); ok {
 		if err := plan.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Plan.name": %w`, err)}
@@ -523,6 +528,9 @@ func (puo *PlanUpdateOne) sqlSave(ctx context.Context) (_node *Plan, err error) 
 	}
 	if value, ok := puo.mutation.LookupKey(); ok {
 		_spec.SetField(plan.FieldLookupKey, field.TypeString, value)
+	}
+	if puo.mutation.LookupKeyCleared() {
+		_spec.ClearField(plan.FieldLookupKey, field.TypeString)
 	}
 	if value, ok := puo.mutation.Name(); ok {
 		_spec.SetField(plan.FieldName, field.TypeString, value)

--- a/ent/price/price.go
+++ b/ent/price/price.go
@@ -128,8 +128,6 @@ var (
 	BillingModelValidator func(string) error
 	// BillingCadenceValidator is a validator for the "billing_cadence" field. It is called by the builders before save.
 	BillingCadenceValidator func(string) error
-	// LookupKeyValidator is a validator for the "lookup_key" field. It is called by the builders before save.
-	LookupKeyValidator func(string) error
 )
 
 // OrderOption defines the ordering options for the Price queries.

--- a/ent/price/where.go
+++ b/ent/price/where.go
@@ -1289,6 +1289,16 @@ func LookupKeyHasSuffix(v string) predicate.Price {
 	return predicate.Price(sql.FieldHasSuffix(FieldLookupKey, v))
 }
 
+// LookupKeyIsNil applies the IsNil predicate on the "lookup_key" field.
+func LookupKeyIsNil() predicate.Price {
+	return predicate.Price(sql.FieldIsNull(FieldLookupKey))
+}
+
+// LookupKeyNotNil applies the NotNil predicate on the "lookup_key" field.
+func LookupKeyNotNil() predicate.Price {
+	return predicate.Price(sql.FieldNotNull(FieldLookupKey))
+}
+
 // LookupKeyEqualFold applies the EqualFold predicate on the "lookup_key" field.
 func LookupKeyEqualFold(v string) predicate.Price {
 	return predicate.Price(sql.FieldEqualFold(FieldLookupKey, v))

--- a/ent/price_create.go
+++ b/ent/price_create.go
@@ -211,6 +211,14 @@ func (pc *PriceCreate) SetLookupKey(s string) *PriceCreate {
 	return pc
 }
 
+// SetNillableLookupKey sets the "lookup_key" field if the given value is not nil.
+func (pc *PriceCreate) SetNillableLookupKey(s *string) *PriceCreate {
+	if s != nil {
+		pc.SetLookupKey(*s)
+	}
+	return pc
+}
+
 // SetDescription sets the "description" field.
 func (pc *PriceCreate) SetDescription(s string) *PriceCreate {
 	pc.mutation.SetDescription(s)
@@ -370,14 +378,6 @@ func (pc *PriceCreate) check() error {
 	if v, ok := pc.mutation.BillingCadence(); ok {
 		if err := price.BillingCadenceValidator(v); err != nil {
 			return &ValidationError{Name: "billing_cadence", err: fmt.Errorf(`ent: validator failed for field "Price.billing_cadence": %w`, err)}
-		}
-	}
-	if _, ok := pc.mutation.LookupKey(); !ok {
-		return &ValidationError{Name: "lookup_key", err: errors.New(`ent: missing required field "Price.lookup_key"`)}
-	}
-	if v, ok := pc.mutation.LookupKey(); ok {
-		if err := price.LookupKeyValidator(v); err != nil {
-			return &ValidationError{Name: "lookup_key", err: fmt.Errorf(`ent: validator failed for field "Price.lookup_key": %w`, err)}
 		}
 	}
 	return nil

--- a/ent/price_update.go
+++ b/ent/price_update.go
@@ -314,6 +314,12 @@ func (pu *PriceUpdate) SetNillableLookupKey(s *string) *PriceUpdate {
 	return pu
 }
 
+// ClearLookupKey clears the value of the "lookup_key" field.
+func (pu *PriceUpdate) ClearLookupKey() *PriceUpdate {
+	pu.mutation.ClearLookupKey()
+	return pu
+}
+
 // SetDescription sets the "description" field.
 func (pu *PriceUpdate) SetDescription(s string) *PriceUpdate {
 	pu.mutation.SetDescription(s)
@@ -429,11 +435,6 @@ func (pu *PriceUpdate) check() error {
 			return &ValidationError{Name: "billing_cadence", err: fmt.Errorf(`ent: validator failed for field "Price.billing_cadence": %w`, err)}
 		}
 	}
-	if v, ok := pu.mutation.LookupKey(); ok {
-		if err := price.LookupKeyValidator(v); err != nil {
-			return &ValidationError{Name: "lookup_key", err: fmt.Errorf(`ent: validator failed for field "Price.lookup_key": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -534,6 +535,9 @@ func (pu *PriceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := pu.mutation.LookupKey(); ok {
 		_spec.SetField(price.FieldLookupKey, field.TypeString, value)
+	}
+	if pu.mutation.LookupKeyCleared() {
+		_spec.ClearField(price.FieldLookupKey, field.TypeString)
 	}
 	if value, ok := pu.mutation.Description(); ok {
 		_spec.SetField(price.FieldDescription, field.TypeString, value)
@@ -851,6 +855,12 @@ func (puo *PriceUpdateOne) SetNillableLookupKey(s *string) *PriceUpdateOne {
 	return puo
 }
 
+// ClearLookupKey clears the value of the "lookup_key" field.
+func (puo *PriceUpdateOne) ClearLookupKey() *PriceUpdateOne {
+	puo.mutation.ClearLookupKey()
+	return puo
+}
+
 // SetDescription sets the "description" field.
 func (puo *PriceUpdateOne) SetDescription(s string) *PriceUpdateOne {
 	puo.mutation.SetDescription(s)
@@ -979,11 +989,6 @@ func (puo *PriceUpdateOne) check() error {
 			return &ValidationError{Name: "billing_cadence", err: fmt.Errorf(`ent: validator failed for field "Price.billing_cadence": %w`, err)}
 		}
 	}
-	if v, ok := puo.mutation.LookupKey(); ok {
-		if err := price.LookupKeyValidator(v); err != nil {
-			return &ValidationError{Name: "lookup_key", err: fmt.Errorf(`ent: validator failed for field "Price.lookup_key": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -1101,6 +1106,9 @@ func (puo *PriceUpdateOne) sqlSave(ctx context.Context) (_node *Price, err error
 	}
 	if value, ok := puo.mutation.LookupKey(); ok {
 		_spec.SetField(price.FieldLookupKey, field.TypeString, value)
+	}
+	if puo.mutation.LookupKeyCleared() {
+		_spec.ClearField(price.FieldLookupKey, field.TypeString)
 	}
 	if value, ok := puo.mutation.Description(); ok {
 		_spec.SetField(price.FieldDescription, field.TypeString, value)

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -279,10 +279,6 @@ func init() {
 	plan.DefaultUpdatedAt = planDescUpdatedAt.Default.(func() time.Time)
 	// plan.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	plan.UpdateDefaultUpdatedAt = planDescUpdatedAt.UpdateDefault.(func() time.Time)
-	// planDescLookupKey is the schema descriptor for lookup_key field.
-	planDescLookupKey := planFields[1].Descriptor()
-	// plan.LookupKeyValidator is a validator for the "lookup_key" field. It is called by the builders before save.
-	plan.LookupKeyValidator = planDescLookupKey.Validators[0].(func(string) error)
 	// planDescName is the schema descriptor for name field.
 	planDescName := planFields[2].Descriptor()
 	// plan.NameValidator is a validator for the "name" field. It is called by the builders before save.
@@ -350,10 +346,6 @@ func init() {
 	priceDescBillingCadence := priceFields[9].Descriptor()
 	// price.BillingCadenceValidator is a validator for the "billing_cadence" field. It is called by the builders before save.
 	price.BillingCadenceValidator = priceDescBillingCadence.Validators[0].(func(string) error)
-	// priceDescLookupKey is the schema descriptor for lookup_key field.
-	priceDescLookupKey := priceFields[15].Descriptor()
-	// price.LookupKeyValidator is a validator for the "lookup_key" field. It is called by the builders before save.
-	price.LookupKeyValidator = priceDescLookupKey.Validators[0].(func(string) error)
 	subscriptionMixin := schema.Subscription{}.Mixin()
 	subscriptionMixinFields0 := subscriptionMixin[0].Fields()
 	_ = subscriptionMixinFields0

--- a/ent/schema/customer.go
+++ b/ent/schema/customer.go
@@ -57,7 +57,7 @@ func (Customer) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "external_id").
 			Unique().
-			Annotations(entsql.IndexWhere("status != 'deleted'")),
+			Annotations(entsql.IndexWhere("status != 'deleted'" + " AND external_id != ''")),
 		index.Fields("tenant_id"),
 	}
 }

--- a/ent/schema/plan.go
+++ b/ent/schema/plan.go
@@ -33,7 +33,7 @@ func (Plan) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				"postgres": "varchar(255)",
 			}).
-			NotEmpty(),
+			Optional(),
 		field.String("name").
 			SchemaType(map[string]string{
 				"postgres": "varchar(255)",
@@ -61,7 +61,7 @@ func (Plan) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "lookup_key").
 			Unique().
-			Annotations(entsql.IndexWhere("status != 'deleted'")),
+			Annotations(entsql.IndexWhere("status != 'deleted'" + " AND lookup_key IS NOT NULL AND lookup_key != ''")),
 		index.Fields("tenant_id"),
 	}
 }

--- a/ent/schema/price.go
+++ b/ent/schema/price.go
@@ -93,7 +93,7 @@ func (Price) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				"postgres": "varchar(255)",
 			}).
-			NotEmpty(),
+			Optional(),
 		field.Text("description").
 			Optional(),
 		field.JSON("metadata", map[string]string{}).
@@ -111,7 +111,7 @@ func (Price) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "lookup_key").
 			Unique().
-			Annotations(entsql.IndexWhere("status != 'deleted' AND lookup_key != ''")),
+			Annotations(entsql.IndexWhere("status != 'deleted' AND lookup_key IS NOT NULL AND lookup_key != ''")),
 		index.Fields("tenant_id", "plan_id"),
 		index.Fields("tenant_id"),
 	}

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -30,7 +30,7 @@ func NewPriceRepository(client postgres.IClient, log *logger.Logger) domainPrice
 func (r *priceRepository) Create(ctx context.Context, p *domainPrice.Price) error {
 	client := r.client.Querier(ctx)
 
-	r.log.Debug("creating price",
+	r.log.Debugw("creating price",
 		"price_id", p.ID,
 		"tenant_id", p.TenantID,
 		"plan_id", p.PlanID,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> The pull request makes the `lookup_key` field optional in `Plan` and `Price` schemas, updates index conditions, and removes related validators.
> 
>   - **Schema Changes**:
>     - `lookup_key` field in `Plan` and `Price` schemas is now optional.
>     - Updated index conditions in `customer.go`, `plan.go`, and `price.go` to handle null or empty `lookup_key`.
>   - **Mutation Logic**:
>     - Added `ClearLookupKey` and `LookupKeyCleared` methods in `PlanMutation` and `PriceMutation`.
>     - Removed `LookupKeyValidator` from `plan.go` and `price.go`.
>   - **Index Conditions**:
>     - Updated index conditions in `schema.go` files to include checks for `lookup_key IS NOT NULL AND lookup_key != ''`.
>   - **Repository Logging**:
>     - Changed logging method from `Debug` to `Debugw` in `price.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for bb933592ba783f449d72caa66c3ca1e85c90dbec. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->