### PR TITLE
feat(filters): default status filter on not deleted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,17 @@ test-coverage:
 # Database related targets
 .PHONY: init-db migrate-postgres migrate-clickhouse seed-db
 
+.PHONY: install-ent
+install-ent:
+	@which ent > /dev/null || (go install entgo.io/ent/cmd/ent@latest)
+
+.PHONY: generate-ent
+generate-ent: install-ent
+	@echo "Generating ent code..."
+	@go run -mod=mod entgo.io/ent/cmd/ent generate --feature sql/execquery ./ent/schema
+
 # Initialize databases and required topics
-init-db: up migrate-postgres migrate-clickhouse seed-db
+init-db: up migrate-postgres migrate-clickhouse generate-ent seed-db
 	@echo "Database initialization complete"
 
 # Run postgres migrations

--- a/ent/customer/customer.go
+++ b/ent/customer/customer.go
@@ -74,8 +74,6 @@ var (
 	ExternalIDValidator func(string) error
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
-	// EmailValidator is a validator for the "email" field. It is called by the builders before save.
-	EmailValidator func(string) error
 )
 
 // OrderOption defines the ordering options for the Customer queries.

--- a/ent/customer/where.go
+++ b/ent/customer/where.go
@@ -654,6 +654,16 @@ func EmailHasSuffix(v string) predicate.Customer {
 	return predicate.Customer(sql.FieldHasSuffix(FieldEmail, v))
 }
 
+// EmailIsNil applies the IsNil predicate on the "email" field.
+func EmailIsNil() predicate.Customer {
+	return predicate.Customer(sql.FieldIsNull(FieldEmail))
+}
+
+// EmailNotNil applies the NotNil predicate on the "email" field.
+func EmailNotNil() predicate.Customer {
+	return predicate.Customer(sql.FieldNotNull(FieldEmail))
+}
+
 // EmailEqualFold applies the EqualFold predicate on the "email" field.
 func EmailEqualFold(v string) predicate.Customer {
 	return predicate.Customer(sql.FieldEqualFold(FieldEmail, v))

--- a/ent/customer_create.go
+++ b/ent/customer_create.go
@@ -114,6 +114,14 @@ func (cc *CustomerCreate) SetEmail(s string) *CustomerCreate {
 	return cc
 }
 
+// SetNillableEmail sets the "email" field if the given value is not nil.
+func (cc *CustomerCreate) SetNillableEmail(s *string) *CustomerCreate {
+	if s != nil {
+		cc.SetEmail(*s)
+	}
+	return cc
+}
+
 // SetID sets the "id" field.
 func (cc *CustomerCreate) SetID(s string) *CustomerCreate {
 	cc.mutation.SetID(s)
@@ -202,14 +210,6 @@ func (cc *CustomerCreate) check() error {
 	if v, ok := cc.mutation.Name(); ok {
 		if err := customer.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Customer.name": %w`, err)}
-		}
-	}
-	if _, ok := cc.mutation.Email(); !ok {
-		return &ValidationError{Name: "email", err: errors.New(`ent: missing required field "Customer.email"`)}
-	}
-	if v, ok := cc.mutation.Email(); ok {
-		if err := customer.EmailValidator(v); err != nil {
-			return &ValidationError{Name: "email", err: fmt.Errorf(`ent: validator failed for field "Customer.email": %w`, err)}
 		}
 	}
 	return nil

--- a/ent/customer_update.go
+++ b/ent/customer_update.go
@@ -110,6 +110,12 @@ func (cu *CustomerUpdate) SetNillableEmail(s *string) *CustomerUpdate {
 	return cu
 }
 
+// ClearEmail clears the value of the "email" field.
+func (cu *CustomerUpdate) ClearEmail() *CustomerUpdate {
+	cu.mutation.ClearEmail()
+	return cu
+}
+
 // Mutation returns the CustomerMutation object of the builder.
 func (cu *CustomerUpdate) Mutation() *CustomerMutation {
 	return cu.mutation
@@ -163,11 +169,6 @@ func (cu *CustomerUpdate) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Customer.name": %w`, err)}
 		}
 	}
-	if v, ok := cu.mutation.Email(); ok {
-		if err := customer.EmailValidator(v); err != nil {
-			return &ValidationError{Name: "email", err: fmt.Errorf(`ent: validator failed for field "Customer.email": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -206,6 +207,9 @@ func (cu *CustomerUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := cu.mutation.Email(); ok {
 		_spec.SetField(customer.FieldEmail, field.TypeString, value)
+	}
+	if cu.mutation.EmailCleared() {
+		_spec.ClearField(customer.FieldEmail, field.TypeString)
 	}
 	if n, err = sqlgraph.UpdateNodes(ctx, cu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
@@ -309,6 +313,12 @@ func (cuo *CustomerUpdateOne) SetNillableEmail(s *string) *CustomerUpdateOne {
 	return cuo
 }
 
+// ClearEmail clears the value of the "email" field.
+func (cuo *CustomerUpdateOne) ClearEmail() *CustomerUpdateOne {
+	cuo.mutation.ClearEmail()
+	return cuo
+}
+
 // Mutation returns the CustomerMutation object of the builder.
 func (cuo *CustomerUpdateOne) Mutation() *CustomerMutation {
 	return cuo.mutation
@@ -375,11 +385,6 @@ func (cuo *CustomerUpdateOne) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Customer.name": %w`, err)}
 		}
 	}
-	if v, ok := cuo.mutation.Email(); ok {
-		if err := customer.EmailValidator(v); err != nil {
-			return &ValidationError{Name: "email", err: fmt.Errorf(`ent: validator failed for field "Customer.email": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -435,6 +440,9 @@ func (cuo *CustomerUpdateOne) sqlSave(ctx context.Context) (_node *Customer, err
 	}
 	if value, ok := cuo.mutation.Email(); ok {
 		_spec.SetField(customer.FieldEmail, field.TypeString, value)
+	}
+	if cuo.mutation.EmailCleared() {
+		_spec.ClearField(customer.FieldEmail, field.TypeString)
 	}
 	_node = &Customer{config: cuo.config}
 	_spec.Assign = _node.assignValues

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -42,7 +42,7 @@ var (
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "external_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "name", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
-		{Name: "email", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
+		{Name: "email", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 	}
 	// CustomersTable holds the schema information for the "customers" table.
 	CustomersTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -1097,9 +1097,22 @@ func (m *CustomerMutation) OldEmail(ctx context.Context) (v string, err error) {
 	return oldValue.Email, nil
 }
 
+// ClearEmail clears the value of the "email" field.
+func (m *CustomerMutation) ClearEmail() {
+	m.email = nil
+	m.clearedFields[customer.FieldEmail] = struct{}{}
+}
+
+// EmailCleared returns if the "email" field was cleared in this mutation.
+func (m *CustomerMutation) EmailCleared() bool {
+	_, ok := m.clearedFields[customer.FieldEmail]
+	return ok
+}
+
 // ResetEmail resets all changes to the "email" field.
 func (m *CustomerMutation) ResetEmail() {
 	m.email = nil
+	delete(m.clearedFields, customer.FieldEmail)
 }
 
 // Where appends a list predicates to the CustomerMutation builder.
@@ -1325,6 +1338,9 @@ func (m *CustomerMutation) ClearedFields() []string {
 	if m.FieldCleared(customer.FieldUpdatedBy) {
 		fields = append(fields, customer.FieldUpdatedBy)
 	}
+	if m.FieldCleared(customer.FieldEmail) {
+		fields = append(fields, customer.FieldEmail)
+	}
 	return fields
 }
 
@@ -1344,6 +1360,9 @@ func (m *CustomerMutation) ClearField(name string) error {
 		return nil
 	case customer.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case customer.FieldEmail:
+		m.ClearEmail()
 		return nil
 	}
 	return fmt.Errorf("unknown Customer nullable field %s", name)

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -79,10 +79,6 @@ func init() {
 	customerDescName := customerFields[2].Descriptor()
 	// customer.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	customer.NameValidator = customerDescName.Validators[0].(func(string) error)
-	// customerDescEmail is the schema descriptor for email field.
-	customerDescEmail := customerFields[3].Descriptor()
-	// customer.EmailValidator is a validator for the "email" field. It is called by the builders before save.
-	customer.EmailValidator = customerDescEmail.Validators[0].(func(string) error)
 	invoiceMixin := schema.Invoice{}.Mixin()
 	invoiceMixinFields0 := invoiceMixin[0].Fields()
 	_ = invoiceMixinFields0

--- a/ent/schema/customer.go
+++ b/ent/schema/customer.go
@@ -43,7 +43,7 @@ func (Customer) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				"postgres": "varchar(255)",
 			}).
-			NotEmpty(),
+			Optional(),
 	}
 }
 

--- a/internal/repository/ent/customer.go
+++ b/internal/repository/ent/customer.go
@@ -165,7 +165,7 @@ func (r *customerRepository) Delete(ctx context.Context, id string) error {
 			customer.ID(id),
 			customer.TenantID(types.GetTenantID(ctx)),
 		).
-		SetStatus(string(types.StatusDeleted)).
+		SetStatus(string(types.StatusArchived)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		Save(ctx)
@@ -195,10 +195,10 @@ func (o CustomerQueryOptions) ApplyTenantFilter(ctx context.Context, query Custo
 }
 
 func (o CustomerQueryOptions) ApplyStatusFilter(query CustomerQuery, status string) CustomerQuery {
-	if status != "" {
-		query = query.Where(customer.Status(status))
+	if status == "" {
+		return query.Where(customer.StatusNotIn(string(types.StatusDeleted)))
 	}
-	return query
+	return query.Where(customer.Status(status))
 }
 
 func (o CustomerQueryOptions) ApplySortFilter(query CustomerQuery, field string, order string) CustomerQuery {

--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -515,6 +515,9 @@ func (o InvoiceQueryOptions) ApplyTenantFilter(ctx context.Context, query Invoic
 }
 
 func (o InvoiceQueryOptions) ApplyStatusFilter(query InvoiceQuery, status string) InvoiceQuery {
+	if status == "" {
+		query = query.Where(invoice.StatusNotIn(string(types.StatusDeleted)))
+	}
 	return query.Where(invoice.Status(status))
 }
 

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -180,6 +180,9 @@ func (o MeterQueryOptions) ApplyTenantFilter(ctx context.Context, query MeterQue
 }
 
 func (o MeterQueryOptions) ApplyStatusFilter(query MeterQuery, status string) MeterQuery {
+	if status == "" {
+		return query.Where(meter.StatusNotIn(string(types.StatusDeleted)))
+	}
 	return query.Where(meter.Status(status))
 }
 

--- a/internal/repository/ent/plan.go
+++ b/internal/repository/ent/plan.go
@@ -198,7 +198,7 @@ func (r *planRepository) Delete(ctx context.Context, id string) error {
 			plan.ID(id),
 			plan.TenantID(types.GetTenantID(ctx)),
 		).
-		SetStatus(string(types.StatusDeleted)).
+		SetStatus(string(types.StatusArchived)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		Save(ctx)
@@ -224,6 +224,9 @@ func (o PlanQueryOptions) ApplyTenantFilter(ctx context.Context, query PlanQuery
 }
 
 func (o PlanQueryOptions) ApplyStatusFilter(query PlanQuery, status string) PlanQuery {
+	if status == "" {
+		return query.Where(plan.StatusNotIn(string(types.StatusDeleted)))
+	}
 	return query.Where(plan.Status(status))
 }
 

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -211,7 +211,7 @@ func (r *priceRepository) Delete(ctx context.Context, id string) error {
 			price.ID(id),
 			price.TenantID(types.GetTenantID(ctx)),
 		).
-		SetStatus(string(types.StatusDeleted)).
+		SetStatus(string(types.StatusArchived)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		Save(ctx)
@@ -237,6 +237,9 @@ func (o PriceQueryOptions) ApplyTenantFilter(ctx context.Context, query PriceQue
 }
 
 func (o PriceQueryOptions) ApplyStatusFilter(query PriceQuery, status string) PriceQuery {
+	if status == "" {
+		return query.Where(price.StatusNotIn(string(types.StatusDeleted)))
+	}
 	return query.Where(price.Status(status))
 }
 

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -146,7 +146,7 @@ func (r *subscriptionRepository) Delete(ctx context.Context, id string) error {
 			subscription.TenantID(types.GetTenantID(ctx)),
 			subscription.Status(string(types.StatusPublished)),
 		).
-		SetStatus(string(types.StatusDeleted)).
+		SetStatus(string(types.StatusArchived)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		Exec(ctx)
@@ -240,6 +240,9 @@ func (o SubscriptionQueryOptions) ApplyTenantFilter(ctx context.Context, query S
 }
 
 func (o SubscriptionQueryOptions) ApplyStatusFilter(query SubscriptionQuery, status string) SubscriptionQuery {
+	if status == "" {
+		return query.Where(subscription.StatusNotIn(string(types.StatusDeleted)))
+	}
 	return query.Where(subscription.Status(status))
 }
 

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -393,6 +393,9 @@ func (o WalletTransactionQueryOptions) ApplyTenantFilter(ctx context.Context, qu
 }
 
 func (o WalletTransactionQueryOptions) ApplyStatusFilter(query WalletTransactionQuery, status string) WalletTransactionQuery {
+	if status == "" {
+		return query.Where(wallettransaction.StatusNotIn(string(types.StatusDeleted)))
+	}
 	return query.Where(wallettransaction.Status(status))
 }
 

--- a/internal/repository/postgres/customer.go
+++ b/internal/repository/postgres/customer.go
@@ -1,3 +1,0 @@
-package postgres
-
-// TODO : remove

--- a/internal/repository/postgres/meter.go
+++ b/internal/repository/postgres/meter.go
@@ -1,1 +1,0 @@
-package postgres

--- a/internal/repository/postgres/plan.go
+++ b/internal/repository/postgres/plan.go
@@ -1,3 +1,0 @@
-package postgres
-
-// TODO : remove

--- a/internal/repository/postgres/price.go
+++ b/internal/repository/postgres/price.go
@@ -1,3 +1,0 @@
-package postgres
-
-// TODO : remove

--- a/internal/repository/postgres/wallet.go
+++ b/internal/repository/postgres/wallet.go
@@ -1,3 +1,0 @@
-package postgres
-
-// TODO : remove

--- a/internal/types/filter.go
+++ b/internal/types/filter.go
@@ -72,7 +72,7 @@ func NewDefaultQueryFilter() *QueryFilter {
 	return &QueryFilter{
 		Limit:  lo.ToPtr(50),
 		Offset: lo.ToPtr(0),
-		Status: lo.ToPtr(StatusPublished),
+		Status: nil,
 		Sort:   lo.ToPtr("created_at"),
 		Order:  lo.ToPtr("desc"),
 	}
@@ -83,7 +83,7 @@ func NewNoLimitQueryFilter() *QueryFilter {
 	return &QueryFilter{
 		Limit:  nil, // No limit for unlimited queries
 		Offset: lo.ToPtr(0),
-		Status: lo.ToPtr(StatusPublished),
+		Status: nil,
 		Sort:   lo.ToPtr("created_at"),
 		Order:  lo.ToPtr("desc"),
 	}
@@ -140,7 +140,7 @@ func (f QueryFilter) GetExpand() Expand {
 // GetStatus returns the status value or default if not set
 func (f QueryFilter) GetStatus() string {
 	if f.Status == nil {
-		return string(*NewDefaultQueryFilter().Status)
+		return ""
 	}
 	return string(*f.Status)
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Default status filter now excludes deleted statuses across multiple entities, with schema and code generation updates.
> 
>   - **Behavior**:
>     - Default status filter now excludes `StatusDeleted` for `Customer`, `Invoice`, `Meter`, `Plan`, `Price`, `Subscription`, and `WalletTransaction` queries when status is not specified.
>     - `SetStatus` changed from `StatusDeleted` to `StatusArchived` in `customer.go`, `plan.go`, `price.go`, and `subscription.go`.
>   - **Schema**:
>     - `Email` field in `customer.go` is now optional.
>     - Removed `EmailValidator` from `customer` entity.
>   - **Code Generation**:
>     - Added `generate-ent` target in `Makefile` to generate ent code.
>   - **Cleanup**:
>     - Removed unused `postgres` files: `customer.go`, `meter.go`, `plan.go`, `price.go`, `wallet.go`.
>   - **Filters**:
>     - Updated `NewDefaultQueryFilter` and `NewNoLimitQueryFilter` in `filter.go` to set `Status` to `nil`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c5b57e083a2c2f01b390642b2cbabc71e4bddf73. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->