### PR TITLE
fix(plan): expand meter for get plan by id

### DIFF
--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -71,7 +71,7 @@ func (s *planService) GetPlan(ctx context.Context, id string) (*dto.PlanResponse
 	response := &dto.PlanResponse{Plan: plan}
 	for _, p := range pricesResponse.Items {
 		if p.Price.PlanID == plan.ID {
-			response.Prices = append(response.Prices, &dto.PriceResponse{Price: p.Price})
+			response.Prices = append(response.Prices, p)
 		}
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `GetPlan` in `planService` to append full `PriceResponse` objects instead of just `Price` objects.
> 
>   - **Behavior**:
>     - Fix in `GetPlan` method of `planService` in `plan.go` to append full `PriceResponse` objects instead of just `Price` objects to `response.Prices`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for da408a37b0f66b4bbfc393a046987846138e22f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->