### PR TITLE
fix(subscription): make cron handler to be tenant agnostic

### DIFF
--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -18,16 +18,6 @@ auth:
         user_id: "00000000-0000-0000-0000-000000000000"
         name: "Dev API Keys"
         is_active: true
-      "45634aed82b7eaebc6b4814adeebf0932e0253338cf69ac80e7c5b9ad6830b77":
-        tenant_id: "tenant_01JJ20ZF9M5GQQXJG2AQSMZCVM"
-        user_id: "dc609f12-f9c5-4c88-9786-6200180b43c0"
-        name: "Dev API Keys"
-        is_active: true
-      "f3d39ad24ef9a5461eade5d4b21e30bf11e822bc8213154f5138c987c1d2864b":
-        tenant_id: "tenant_01JH280NTMS33TWJ8V8V8M2KTR"
-        user_id: "afc67bd8-ffe7-49b2-b90d-37ecd3fff9f5"
-        name: "Dev API Keys"
-        is_active: true
 
 kafka:
   brokers:

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -475,6 +475,8 @@ func (s *subscriptionService) UpdateBillingPeriods(ctx context.Context) (*dto.Su
 
 		// Process each subscription in the batch
 		for _, sub := range subs {
+			// update context to include the tenant id
+			ctx = context.WithValue(ctx, types.CtxTenantID, sub.TenantID)
 			item := &dto.SubscriptionUpdatePeriodResponseItem{
 				SubscriptionID: sub.ID,
 				PeriodStart:    sub.CurrentPeriodStart,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `UpdateBillingPeriods` tenant agnostic by setting tenant ID in context and remove tenant-specific API keys from `config.yaml`.
> 
>   - **Behavior**:
>     - Update `UpdateBillingPeriods` in `subscription.go` to make the cron handler tenant agnostic by setting the tenant ID in the context for each subscription.
>   - **Configuration**:
>     - Remove tenant-specific API keys from `config.yaml` under `auth.api_key.keys`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for b8b8f77fa7ab299b87bd638ec814abb8ba18ad07. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->