### PR TITLE
fix(customer): list customers items set to empty list if no results

### DIFF
--- a/internal/service/customer.go
+++ b/internal/service/customer.go
@@ -76,7 +76,7 @@ func (s *customerService) GetCustomers(ctx context.Context, filter *types.Custom
 		return nil, errors.Wrap(err, errors.ErrCodeInvalidOperation, "failed to count customers")
 	}
 
-	var response []*dto.CustomerResponse
+	response := make([]*dto.CustomerResponse, 0, len(customers))
 	for _, c := range customers {
 		response = append(response, &dto.CustomerResponse{Customer: c})
 	}

--- a/internal/service/entitlement_test.go
+++ b/internal/service/entitlement_test.go
@@ -33,6 +33,7 @@ func (s *EntitlementServiceSuite) setupService() {
 		stores.EntitlementRepo,
 		stores.PlanRepo,
 		stores.FeatureRepo,
+		testutil.NewInMemoryMeterStore(),
 		s.GetLogger(),
 	)
 }

--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -121,7 +121,7 @@ func (s *planService) GetPlan(ctx context.Context, id string) (*dto.PlanResponse
 	}
 
 	priceService := NewPriceService(s.priceRepo, s.meterRepo, s.logger)
-	entitlementService := NewEntitlementService(s.entitlementRepo, s.planRepo, s.featureRepo, s.logger)
+	entitlementService := NewEntitlementService(s.entitlementRepo, s.planRepo, s.featureRepo, s.meterRepo, s.logger)
 
 	pricesResponse, err := priceService.GetPricesByPlanID(ctx, plan.ID)
 	if err != nil {
@@ -192,7 +192,7 @@ func (s *planService) GetPlans(ctx context.Context, filter *types.PlanFilter) (*
 	entitlementsByPlanID := make(map[string][]*dto.EntitlementResponse)
 
 	priceService := NewPriceService(s.priceRepo, s.meterRepo, s.logger)
-	entitlementService := NewEntitlementService(s.entitlementRepo, s.planRepo, s.featureRepo, s.logger)
+	entitlementService := NewEntitlementService(s.entitlementRepo, s.planRepo, s.featureRepo, s.meterRepo, s.logger)
 
 	// If prices or entitlements expansion is requested, fetch them in bulk
 	// Fetch prices if requested


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Initialize customer response list to empty if no results and add meter expansion support in entitlements.
> 
>   - **Customer Service**:
>     - In `customer.go`, initialize `response` as an empty list in `GetCustomers()` to handle cases with no customers.
>   - **Entitlement Service**:
>     - In `entitlement.go`, add `meterRepo` to `entitlementService` and support for expanding meters in `ListEntitlements()`.
>     - Update `GetPlanEntitlements()` and `GetPlanFeatureEntitlements()` to include meter expansion.
>   - **Testing**:
>     - In `entitlement_test.go`, update `setupService()` to use `NewInMemoryMeterStore()` for testing meter expansion.
>   - **Plan Service**:
>     - In `plan.go`, update `NewEntitlementService()` calls to include `meterRepo`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for f132edce3da985179f72f67501668f7981da7504. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->