### PR TITLE
fix(subscription): clear active pause id on resume

### DIFF
--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -116,10 +116,17 @@ func (r *subscriptionRepository) Update(ctx context.Context, sub *domainSub.Subs
 		SetCurrentPeriodEnd(sub.CurrentPeriodEnd).
 		SetNillableCancelledAt(sub.CancelledAt).
 		SetNillableCancelAt(sub.CancelAt).
+		SetPauseStatus(string(sub.PauseStatus)).
 		SetCancelAtPeriodEnd(sub.CancelAtPeriodEnd).
 		SetUpdatedAt(now).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		AddVersion(1) // Increment version atomically
+
+	if sub.ActivePauseID != nil {
+		query.SetActivePauseID(*sub.ActivePauseID)
+	} else {
+		query.ClearActivePauseID()
+	}
 
 	// Execute update
 	n, err := query.Save(ctx)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -246,9 +246,14 @@ func (s *subscriptionService) CancelSubscription(ctx context.Context, id string,
 	}
 
 	now := time.Now().UTC()
-	subscription.SubscriptionStatus = types.SubscriptionStatusCancelled
 	subscription.CancelledAt = &now
-	subscription.CancelAtPeriodEnd = cancelAtPeriodEnd
+	if cancelAtPeriodEnd {
+		subscription.CancelAtPeriodEnd = cancelAtPeriodEnd
+		subscription.CancelAt = lo.ToPtr(subscription.CurrentPeriodEnd)
+	} else {
+		subscription.SubscriptionStatus = types.SubscriptionStatusCancelled
+		subscription.CancelAt = nil
+	}
 
 	if err := s.SubRepo.Update(ctx, subscription); err != nil {
 		return fmt.Errorf("failed to cancel subscription: %w", err)

--- a/scripts/internal/seed_events.go
+++ b/scripts/internal/seed_events.go
@@ -1,0 +1,245 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/meter"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
+	"github.com/flexprice/flexprice/internal/repository"
+	"github.com/flexprice/flexprice/internal/types"
+	"golang.org/x/time/rate"
+)
+
+// EventGenerator holds the configuration for generating events
+type EventGenerator struct {
+	meters      []*meter.Meter
+	customerIDs []string
+	logger      *logger.Logger
+}
+
+// NewEventGenerator creates a new event generator with the given meters
+func NewEventGenerator(meters []*meter.Meter, customers []*customer.Customer, logger *logger.Logger) *EventGenerator {
+	// Sample customer IDs - replace with actual customer IDs from your system
+	customerIDs := []string{
+		"cus_01HKG8QWERTY123",
+		"cus_02HKG8ASDFGH456",
+		"cus_03HKG8ZXCVBN789",
+	}
+
+	if len(customers) > 0 {
+		customerIDs = make([]string, len(customers))
+		for i, c := range customers {
+			customerIDs[i] = c.ExternalID
+		}
+	}
+
+	return &EventGenerator{
+		meters:      meters,
+		customerIDs: customerIDs,
+		logger:      logger,
+	}
+}
+
+// generateEvent creates a random event based on the available meters
+func (g *EventGenerator) generateEvent(index int) dto.IngestEventRequest {
+	// Select a random meter
+	selectedMeter := g.meters[index%len(g.meters)]
+
+	// Generate properties based on meter configuration
+	properties := make(map[string]interface{})
+
+	// Handle properties based on meter aggregation and filters
+	if selectedMeter.Aggregation.Type == types.AggregationSum ||
+		selectedMeter.Aggregation.Type == types.AggregationAvg {
+		// For sum/avg aggregation, we need to generate a value for the aggregation field
+		if selectedMeter.Aggregation.Field != "" {
+			// Generate a random value between 1 and 1000
+			properties[selectedMeter.Aggregation.Field] = rand.Int63n(1000) + 1
+		}
+	}
+
+	// Apply filter values if available
+	for _, filter := range selectedMeter.Filters {
+		if len(filter.Values) > 0 {
+			// Select a random value from the filter values
+			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))]
+		}
+	}
+
+	// Generate timestamp within last 72 hours
+	timestamp := time.Now().Add(-time.Duration(randInt64(0, 72)) * time.Hour)
+
+	return dto.IngestEventRequest{
+		EventID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_EVENT),
+		ExternalCustomerID: g.customerIDs[rand.Intn(len(g.customerIDs))],
+		EventName:          selectedMeter.EventName,
+		Timestamp:          timestamp,
+		Properties:         properties,
+		Source:             "script",
+	}
+}
+
+// SeedEventsFromMeters seeds events data based on existing meters
+func SeedEventsFromMeters() error {
+	cfg, err := config.NewConfig()
+	if err != nil {
+		log.Fatalf("Error creating config: %v", err)
+	}
+
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		log.Fatalf("Error creating logger: %v", err)
+	}
+
+	// Fetch all meters from the repository
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.CtxTenantID, "<tenant_id>")
+
+	// Initialize the other DB
+	entClient, err := postgres.NewEntClient(cfg, log)
+	if err != nil {
+		log.Fatalf("Failed to connect to postgres: %v", err)
+	}
+	client := postgres.NewClient(entClient, log)
+
+	// Initialize repositories
+	repoParams := repository.RepositoryParams{
+		EntClient: client,
+		Logger:    log,
+	}
+
+	meterRepo := repository.NewMeterRepository(repoParams)
+	customerRepo := repository.NewCustomerRepository(repoParams)
+
+	meters, err := meterRepo.ListAll(ctx, types.NewNoLimitMeterFilter())
+	if err != nil {
+		return fmt.Errorf("failed to fetch meters: %v", err)
+	}
+
+	if len(meters) == 0 {
+		return fmt.Errorf("no meters found to generate events")
+	}
+
+	customers, err := customerRepo.List(ctx, types.NewCustomerFilter())
+	if err != nil {
+		return fmt.Errorf("failed to fetch customers: %v", err)
+	}
+
+	log.Info("Starting event seeding...")
+	log.Infof("Found %d meters to generate events for", len(meters))
+	log.Infof("Sending %d events in batches of %d with rate limit of %d req/s",
+		NUM_EVENTS, BATCH_SIZE, REQUESTS_PER_SEC)
+
+	// Create event generator
+	generator := NewEventGenerator(meters, customers, log)
+
+	// Create rate limiter
+	limiter := rate.NewLimiter(rate.Limit(REQUESTS_PER_SEC), 1)
+
+	var wg sync.WaitGroup
+	results := make(chan time.Duration, NUM_EVENTS)
+	errors := make(chan error, NUM_EVENTS)
+
+	// Track metrics
+	start := time.Now()
+	successCount := 0
+	errorCount := 0
+	batches := make([]BatchResult, 0)
+
+	// Process in batches
+	for i := 0; i < NUM_EVENTS; i += BATCH_SIZE {
+		batchStart := time.Now()
+		var lastEventID string
+
+		batchSize := BATCH_SIZE
+		if i+BATCH_SIZE > NUM_EVENTS {
+			batchSize = NUM_EVENTS - i
+		}
+
+		// Launch batch of requests
+		for j := 0; j < batchSize; j++ {
+			event := generator.generateEvent(i + j)
+			lastEventID = event.EventID
+			wg.Add(1)
+			go ingestEvent(event, limiter, &wg, results, errors)
+		}
+
+		// Wait for batch to complete
+		wg.Wait()
+
+		batch := BatchResult{
+			BatchNumber: i/BATCH_SIZE + 1,
+			LastEventID: lastEventID,
+			StartTime:   batchStart,
+			EndTime:     time.Now(),
+			EventCount:  batchSize,
+		}
+		batches = append(batches, batch)
+
+		log.Infof("Processed batch %d: %d/%d events in %v seconds. Last Event ID: %s",
+			batch.BatchNumber, i+batchSize, NUM_EVENTS, batch.EndTime.Sub(batch.StartTime).Seconds(), lastEventID)
+
+		// Add small delay between batches
+		time.Sleep(time.Second)
+	}
+
+	// Close channels
+	close(results)
+	close(errors)
+
+	// Calculate metrics
+	var totalDuration time.Duration
+	var maxDuration time.Duration
+	var minDuration = time.Hour // Start with a large value
+
+	for duration := range results {
+		successCount++
+		totalDuration += duration
+		if duration > maxDuration {
+			maxDuration = duration
+		}
+		if duration < minDuration {
+			minDuration = duration
+		}
+	}
+
+	for err := range errors {
+		errorCount++
+		log.Errorf("Error: %v", err)
+	}
+
+	// Print results
+	totalTime := time.Since(start)
+	avgDuration := totalDuration / time.Duration(successCount)
+
+	log.Info("Event seeding completed!")
+	log.Info("Results:")
+	log.Infof("Total Time: %v", totalTime)
+	log.Infof("Successful Requests: %d", successCount)
+	log.Infof("Failed Requests: %d", errorCount)
+	log.Infof("Average Request Duration: %v", avgDuration)
+	log.Infof("Min Request Duration: %v", minDuration)
+	log.Infof("Max Request Duration: %v", maxDuration)
+	log.Infof("Requests per Second: %.2f", float64(successCount)/totalTime.Seconds())
+
+	// Print batch information
+	log.Info("\nBatch Details:")
+	for _, batch := range batches {
+		log.Infof("Batch %d: Events=%d, Duration=%v, Last Event ID=%s",
+			batch.BatchNumber,
+			batch.EventCount,
+			batch.EndTime.Sub(batch.StartTime),
+			batch.LastEventID)
+	}
+
+	return nil
+}

--- a/scripts/main.go
+++ b/scripts/main.go
@@ -24,6 +24,11 @@ var commands = []Command{
 		Run:         internal.SeedEventsClickhouse,
 	},
 	{
+		Name:        "seed-events-by-meters",
+		Description: "Seed events data into Clickhouse by meters",
+		Run:         internal.SeedEventsFromMeters,
+	},
+	{
 		Name:        "generate-apikey",
 		Description: "Generate a new API key",
 		Run:         internal.GenerateNewAPIKey,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes subscription pause handling by clearing `ActivePauseID` on resume and adds event seeding script.
> 
>   - **Behavior**:
>     - Clears `ActivePauseID` in `Update()` in `subscriptionRepository` when resuming a subscription.
>     - Adjusts `CancelSubscription()` in `subscriptionService` to handle `cancelAtPeriodEnd` logic more explicitly.
>   - **Scripts**:
>     - Adds `seed_events.go` to generate events based on meters.
>     - Updates `main.go` to include `seed-events-by-meters` command.
>   - **Misc**:
>     - Minor adjustments in `subscription.go` to improve pause and resume logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8d88b0b2b879d7cd68a9719f76cbf18e232120e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->