### PR TITLE
fix(entitlement): report 100% for no limit case

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1073,8 +1073,8 @@ func (s *billingService) getUsagePercent(usage decimal.Decimal, limit *int64) de
 		return decimal.Zero
 	}
 
-	if *limit == 0 {
-		return decimal.Zero
+	if *limit <= 0 {
+		return decimal.NewFromInt(100)
 	}
 
 	return usage.Div(decimal.NewFromInt(*limit))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `getUsagePercent` in `billing.go` to return 100% for no limit cases.
> 
>   - **Behavior**:
>     - Modify `getUsagePercent` in `billing.go` to return 100% when `limit` is less than or equal to zero.
>     - Previously returned 0% for `limit` equal to zero, now handles no limit case correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 1b6a343379198a5b9ca90cf3463976021919f018. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->