### PR TITLE
Install typst and PR changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          go test -v -race ./...
+          make test

--- a/Makefile
+++ b/Makefile
@@ -54,32 +54,7 @@ run: run-server
 .PHONY: test test-verbose test-coverage
 
 # Run all tests
-test:
-	@which typst > /dev/null || (ARCH=$(uname -m) && OS=$(uname) && if [ "$OS" = "Darwin" ]; then \
-		echo "Installing typst binary for Darwin"; \
-		if [ "$ARCH" = "arm64" ]; then \
-			curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-aarch64-apple-darwin.tar.xz -o /usr/local/bin/typst; \
-		else \
-			curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-apple-darwin.tar.xz -o /usr/local/bin/typst; \
-		fi; \
-	elif [ "$OS" = "Linux" ]; then \
-		echo "Installing typst binary for Linux"; \
-		if [ "$ARCH" = "aarch64" ]; then \
-			curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-aarch64-unknown-linux-musl.tar.xz -o /usr/local/bin/typst; \
-		elif [ "$ARCH" = "x86_64" ]; then \
-			curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz -o /usr/local/bin/typst; \
-		elif [ "$ARCH" = "armv7" ]; then \
-			curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-armv7-unknown-linux-musleabi.tar.xz -o /usr/local/bin/typst; \
-		elif [ "$ARCH" = "riscv64" ]; then \
-			curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-riscv64gc-unknown-linux-gnu.tar.xz -o /usr/local/bin/typst; \
-		fi; \
-	elif [ "$OS" = "CYGWIN" ] || [ "$OS" = "MINGW" ]; then \
-		echo "Installing typst binary for Windows"; \
-		curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-pc-windows-msvc.zip -o /usr/local/bin/typst.zip; \
-		unzip /usr/local/bin/typst.zip -d /usr/local/bin/typst; \
-		rm /usr/local/bin/typst.zip; \
-	fi && chmod +x /usr/local/bin/typst)
-
+test: install-typst
 	go test ./...
 
 # Run tests with verbose output
@@ -266,4 +241,6 @@ apply-migration:
 docker-build-local:
 	docker compose build flexprice-build
 
-
+.PHONY: install-typst
+install-typst:
+	@./scripts/install-typst.sh

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ run: run-server
 
 # Run all tests
 test: install-typst
-	go test ./...
+	go test -v -race ./... 
 
 # Run tests with verbose output
 test-verbose:

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -935,6 +935,10 @@ func (s *invoiceService) getRecipientInfo(c *customer.Customer) *pdf.RecipientIn
 		},
 	}
 
+	if c.Email != "" {
+		result.Email = c.Email
+	}
+
 	if c.AddressLine1 != "" {
 		result.Address.Street = c.AddressLine1
 	}

--- a/internal/typst/typst_test.go
+++ b/internal/typst/typst_test.go
@@ -8,33 +8,8 @@ import (
 
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
-
-// MockCompiler is a mock implementation of the Compiler interface
-type MockCompiler struct {
-	mock.Mock
-}
-
-func (m *MockCompiler) Compile(opts CompileOpts) (string, error) {
-	args := m.Called(opts)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockCompiler) CompileToBytes(opts CompileOpts) ([]byte, error) {
-	args := m.Called(opts)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
-func (m *MockCompiler) CompileTemplate(templateName string, data []byte, opts ...CompileOptsBuilder) ([]byte, error) {
-	args := m.Called(templateName, data, opts)
-	return args.Get(0).([]byte), args.Error(1)
-}
-
-func (m *MockCompiler) CleanupGeneratedFiles(files ...string) {
-	m.Called(files)
-}
 
 type TypstCompilerSuite struct {
 	suite.Suite
@@ -76,11 +51,10 @@ func (s *TypstCompilerSuite) SetupTest() {
 	err = os.MkdirAll(s.fontsDir, 0755)
 	s.Require().NoError(err)
 
-	// copy templates from templates dir to temp dir
-	// get current directory
+	// copy templates from ../../assets/typst-templates dir to temp dir
 	currentDir, err := os.Getwd()
 	s.Require().NoError(err)
-	err = CopyDir(filepath.Join(currentDir, "templates"), s.templateDir)
+	err = CopyDir(filepath.Join(currentDir, "../../assets", "typst-templates"), s.templateDir)
 	s.Require().NoError(err)
 
 	// Create a sample Typst file

--- a/scripts/install-typst.sh
+++ b/scripts/install-typst.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 add_local_bin_to_path() {
     # Add ~/.local/bin to PATH if it's not already there
     if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then

--- a/scripts/install-typst.sh
+++ b/scripts/install-typst.sh
@@ -1,0 +1,62 @@
+add_local_bin_to_path() {
+    # Add ~/.local/bin to PATH if it's not already there
+    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+        export PATH="$HOME/.local/bin:$PATH"
+
+        # Check which shell is being used and update the appropriate config file
+        if [ -n "$ZSH_VERSION" ]; then
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >>~/.zshrc
+            echo "Added ~/.local/bin to your PATH in ~/.zshrc. Please run 'source ~/.zshrc' to update your current session."
+        else
+            echo 'export PATH="$HOME/.local/bin:$PATH"' >>~/.bashrc
+            echo "Added ~/.local/bin to your PATH in ~/.bashrc. Please run 'source ~/.bashrc' to update your current session."
+        fi
+    fi
+}
+
+create_local_bin_folder() {
+    # Create ~/.local/bin if it does not exist
+    if [ ! -d "$HOME/.local/bin" ]; then
+        mkdir -p "$HOME/.local/bin"
+        echo "Created ~/.local/bin directory."
+    fi
+}
+
+if ! which typst >/dev/null; then
+    ARCH=$(uname -m)
+    OS=$(uname)
+    if [ "$OS" = "Darwin" ]; then
+        echo "Installing typst binary for Darwin"
+        if [ "$ARCH" = "arm64" ]; then
+            curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-aarch64-apple-darwin.tar.xz -o typst.tar.xz
+        else
+            curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-apple-darwin.tar.xz -o typst.tar.xz
+        fi
+        create_local_bin_folder
+        mkdir -p typst-darwin && tar -xf typst.tar.xz -C typst-darwin --strip-components=1 && mv typst-darwin/typst ~/.local/bin/ && rm -rf typst.tar.xz typst-darwin
+        chmod +x ~/.local/bin/typst
+        add_local_bin_to_path
+    elif [ "$OS" = "Linux" ]; then
+        echo "Installing typst binary for Linux"
+        if [ "$ARCH" = "aarch64" ]; then
+            curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-aarch64-unknown-linux-musl.tar.xz -o typst.tar.xz
+        elif [ "$ARCH" = "x86_64" ]; then
+            curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz -o typst.tar.xz
+        elif [ "$ARCH" = "armv7" ]; then
+            curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-armv7-unknown-linux-musleabi.tar.xz -o typst.tar.xz
+        elif [ "$ARCH" = "riscv64" ]; then
+            curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-riscv64gc-unknown-linux-gnu.tar.xz -o typst.tar.xz
+        fi
+        create_local_bin_folder
+        mkdir -p typst-linux && tar -xf typst.tar.xz -C typst-linux --strip-components=1 && mv typst-linux/typst ~/.local/bin/ && rm -rf typst.tar.xz typst-linux
+        chmod +x ~/.local/bin/typst
+        add_local_bin_to_path
+    elif [ "$OS" = "CYGWIN" ] || [ "$OS" = "MINGW" ]; then
+        echo "Installing typst binary for Windows"
+        curl -L https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-pc-windows-msvc.zip -o typst.zip
+        create_local_bin_folder
+        mkdir -p typst-windows && unzip typst.zip -d typst-windows && mv typst-windows/typst.exe ~/.local/bin/ && rm -rf typst.zip typst-windows
+        chmod +x ~/.local/bin/typst.exe
+        add_local_bin_to_path
+    fi
+fi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Typst installation script, updates Makefile and test workflow, and refactors Typst tests.
> 
>   - **Installation**:
>     - Adds `scripts/install-typst.sh` to install Typst binary for different OS and architectures.
>     - Updates `Makefile` to use `install-typst` target for test dependencies.
>   - **Testing**:
>     - Changes test command in `.github/workflows/test.yml` to `make test`.
>     - Refactors `TypstCompilerSuite` in `typst_test.go` to skip tests if Typst is unavailable and corrects template path.
>   - **Misc**:
>     - Removes `MockCompiler` from `typst_test.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 1f8c566e7f0f0c429801bb62f38954be9d50d18f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->