### PR TITLE
feat(plan): add entitlement and subscription check logic for deletion

### DIFF
--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -648,6 +648,7 @@ func (s *onboardingService) createDefaultPlans(ctx context.Context, features []*
 		s.DB,
 		s.PlanRepo,
 		s.PriceRepo,
+		s.SubRepo,
 		s.MeterRepo,
 		s.EntitlementRepo,
 		s.FeatureRepo,

--- a/internal/service/plan_test.go
+++ b/internal/service/plan_test.go
@@ -35,6 +35,7 @@ func (s *PlanServiceSuite) setupService() {
 		s.GetDB(),
 		stores.PlanRepo,
 		stores.PriceRepo,
+		stores.SubscriptionRepo,
 		stores.MeterRepo,
 		stores.EntitlementRepo,
 		stores.FeatureRepo,

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -269,7 +269,7 @@ func (s *subscriptionService) GetSubscription(ctx context.Context, id string) (*
 	}
 
 	// expand plan
-	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
+	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.SubRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
 
 	plan, err := planService.GetPlan(ctx, subscription.PlanID)
 	if err != nil {
@@ -320,7 +320,7 @@ func (s *subscriptionService) CancelSubscription(ctx context.Context, id string,
 }
 
 func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *types.SubscriptionFilter) (*dto.ListSubscriptionsResponse, error) {
-	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
+	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.SubRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
 
 	subscriptions, err := s.SubRepo.List(ctx, filter)
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add checks for entitlements and subscriptions in `DeletePlan` to prevent deletion if associations exist.
> 
>   - **Behavior**:
>     - `DeletePlan` in `planService` now checks for associated entitlements and subscriptions before deletion, returning errors if any exist.
>     - Errors include hints and reportable details for better debugging.
>   - **Dependencies**:
>     - `planService` now requires `subscriptionRepo` for subscription checks.
>     - `onboardingService` and `subscriptionService` constructors updated to pass `subscriptionRepo` to `planService`.
>   - **Misc**:
>     - Minor formatting adjustments in `plan.go` and `subscription.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 349ce66d5eb695b9962c8b32eae2a88df3701e14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->