### PR TITLE
fix(billing): skip archived entitlements for customer usage

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -216,12 +216,6 @@ func (s *billingService) CalculateUsageCharges(
 			"line_item_id", item.ID,
 			"price_id", item.PriceID)
 
-		// TODO: for now we skip line items with no usage charges
-		// but this needs to be behind a feature flag as per tenant config
-		if lineItemAmount.Equal(decimal.Zero) {
-			continue
-		}
-
 		usageCharges = append(usageCharges, dto.CreateInvoiceLineItemRequest{
 			PlanID:           lo.ToPtr(item.PlanID),
 			PlanDisplayName:  lo.ToPtr(item.PlanDisplayName),
@@ -816,16 +810,18 @@ func (s *billingService) GetCustomerEntitlements(ctx context.Context, customerID
 		return nil, err
 	}
 
-	// Filter by feature IDs if provided
-	if len(req.FeatureIDs) > 0 {
-		filteredEntitlements := make([]*entitlement.Entitlement, 0)
-		for _, e := range entitlements {
-			if lo.Contains(req.FeatureIDs, e.FeatureID) {
-				filteredEntitlements = append(filteredEntitlements, e)
-			}
+	filteredEntitlements := make([]*entitlement.Entitlement, 0)
+	for _, e := range entitlements {
+		if len(req.FeatureIDs) > 0 && !lo.Contains(req.FeatureIDs, e.FeatureID) {
+			continue
 		}
-		entitlements = filteredEntitlements
+		// skip not enabled entitlements
+		if !e.IsEnabled || e.Status != types.StatusPublished {
+			continue
+		}
+		filteredEntitlements = append(filteredEntitlements, e)
 	}
+	entitlements = filteredEntitlements
 
 	if len(entitlements) == 0 {
 		return resp, nil

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -539,6 +539,13 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 				}
 			}
 
+			// if no matching usage, create a 0 value usage rather than ommiting it
+			if matchingUsage == nil {
+				matchingUsage = &events.AggregationResult{
+					Value: decimal.Zero,
+				}
+			}
+
 			if matchingUsage != nil {
 				quantity = matchingUsage.Value
 				cost := priceService.CalculateCost(ctx, price, quantity)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve billing by skipping archived entitlements and ensuring zero value usage for unmatched cases.
> 
>   - **Behavior**:
>     - In `billing.go`, `CalculateUsageCharges()` no longer skips line items with zero usage charges.
>     - In `GetCustomerEntitlements()`, skips entitlements that are not enabled or not published.
>     - In `subscription.go`, `GetUsageBySubscription()` now creates a zero value usage if no matching usage is found.
>   - **Filtering**:
>     - `GetCustomerEntitlements()` in `billing.go` filters out entitlements that are not enabled or not published.
>   - **Usage Handling**:
>     - `GetUsageBySubscription()` in `subscription.go` ensures a zero value usage is created if no matching usage is found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 2d3740caa2b0478b2a8ac3aeed070955995a5045. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->