### PR TITLE
 feat(plan): add entitlement and subscription check logic for deletion

### DIFF
--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -413,9 +413,13 @@ func (o *SubscriptionQueryOptions) applyEntityQueryOptions(_ context.Context, f 
 		query = query.Where(subscription.BillingPeriodIn(periods...))
 	}
 
-	// Apply canceled filter
-	if !f.IncludeCanceled {
-		query = query.Where(subscription.CancelledAtIsNil())
+	// Apply subscription status not in filter
+	if len(f.SubscriptionStatusNotIn) > 0 {
+		statuses := make([]string, len(f.SubscriptionStatusNotIn))
+		for i, status := range f.SubscriptionStatusNotIn {
+			statuses[i] = string(status)
+		}
+		query = query.Where(subscription.SubscriptionStatusNotIn(statuses...))
 	}
 
 	// Apply active at filter

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -609,7 +609,7 @@ func (s *invoiceService) GetCustomerMultiCurrencyInvoiceSummary(ctx context.Cont
 	subscriptionFilter := types.NewNoLimitSubscriptionFilter()
 	subscriptionFilter.CustomerID = customerID
 	subscriptionFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
-	subscriptionFilter.IncludeCanceled = true
+	subscriptionFilter.SubscriptionStatusNotIn = []types.SubscriptionStatus{types.SubscriptionStatusCancelled}
 
 	subs, err := s.SubRepo.List(ctx, subscriptionFilter)
 	if err != nil {

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -648,6 +648,7 @@ func (s *onboardingService) createDefaultPlans(ctx context.Context, features []*
 		s.DB,
 		s.PlanRepo,
 		s.PriceRepo,
+		s.SubRepo,
 		s.MeterRepo,
 		s.EntitlementRepo,
 		s.FeatureRepo,

--- a/internal/service/plan_test.go
+++ b/internal/service/plan_test.go
@@ -35,6 +35,7 @@ func (s *PlanServiceSuite) setupService() {
 		s.GetDB(),
 		stores.PlanRepo,
 		stores.PriceRepo,
+		stores.SubscriptionRepo,
 		stores.MeterRepo,
 		stores.EntitlementRepo,
 		stores.FeatureRepo,

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -269,7 +269,7 @@ func (s *subscriptionService) GetSubscription(ctx context.Context, id string) (*
 	}
 
 	// expand plan
-	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
+	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.SubRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
 
 	plan, err := planService.GetPlan(ctx, subscription.PlanID)
 	if err != nil {
@@ -320,7 +320,7 @@ func (s *subscriptionService) CancelSubscription(ctx context.Context, id string,
 }
 
 func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *types.SubscriptionFilter) (*dto.ListSubscriptionsResponse, error) {
-	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
+	planService := NewPlanService(s.DB, s.PlanRepo, s.PriceRepo, s.SubRepo, s.MeterRepo, s.EntitlementRepo, s.FeatureRepo, s.Logger)
 
 	subscriptions, err := s.SubRepo.List(ctx, filter)
 	if err != nil {

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -274,15 +274,15 @@ func (s *InMemorySubscriptionStore) Delete(ctx context.Context, id string) error
 func (s *InMemorySubscriptionStore) ListAll(ctx context.Context, filter *types.SubscriptionFilter) ([]*subscription.Subscription, error) {
 	// Create an unlimited filter
 	unlimitedFilter := &types.SubscriptionFilter{
-		QueryFilter:        types.NewNoLimitQueryFilter(),
-		TimeRangeFilter:    filter.TimeRangeFilter,
-		CustomerID:         filter.CustomerID,
-		PlanID:             filter.PlanID,
-		SubscriptionStatus: filter.SubscriptionStatus,
-		BillingCadence:     filter.BillingCadence,
-		BillingPeriod:      filter.BillingPeriod,
-		IncludeCanceled:    filter.IncludeCanceled,
-		ActiveAt:           filter.ActiveAt,
+		QueryFilter:             types.NewNoLimitQueryFilter(),
+		TimeRangeFilter:         filter.TimeRangeFilter,
+		CustomerID:              filter.CustomerID,
+		PlanID:                  filter.PlanID,
+		SubscriptionStatus:      filter.SubscriptionStatus,
+		BillingCadence:          filter.BillingCadence,
+		BillingPeriod:           filter.BillingPeriod,
+		SubscriptionStatusNotIn: filter.SubscriptionStatusNotIn,
+		ActiveAt:                filter.ActiveAt,
 	}
 
 	return s.List(ctx, unlimitedFilter)

--- a/internal/types/subscription.go
+++ b/internal/types/subscription.go
@@ -111,8 +111,8 @@ type SubscriptionFilter struct {
 	BillingCadence []BillingCadence `json:"billing_cadence,omitempty" form:"billing_cadence"`
 	// BillingPeriod filters by billing period
 	BillingPeriod []BillingPeriod `json:"billing_period,omitempty" form:"billing_period"`
-	// IncludeCanceled includes canceled subscriptions if true
-	IncludeCanceled bool `json:"include_canceled,omitempty" form:"include_canceled"`
+	// SubscriptionStatusNotIn filters by subscription status not in the list
+	SubscriptionStatusNotIn []SubscriptionStatus `json:"-"`
 	// ActiveAt filters subscriptions that are active at the given time
 	ActiveAt *time.Time `json:"active_at,omitempty" form:"active_at"`
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logic to prevent deletion of plans with active subscriptions in `plan.go`.
> 
>   - **Behavior**:
>     - `DeletePlan()` in `plan.go` now checks for active subscriptions before deleting a plan. If subscriptions exist, it returns an error.
>     - `createDefaultPlans()` in `onboarding.go` updated to include `SubRepo` in `NewPlanService()` call.
>     - `GetSubscription()` and `ListSubscriptions()` in `subscription.go` updated to use `NewPlanService()` with `SubRepo`.
>   - **Tests**:
>     - `setupService()` in `plan_test.go` updated to include `SubscriptionRepo` in `NewPlanService()` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for be593b39d0e6021660085beeec32bc03f0f82a37. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->