### PR TITLE
feat(events): add environment_id in clickhouse

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -434,6 +434,7 @@ func handleEventConsumption(cfg *config.Configuration, log *logger.Logger, event
 			"", // Customer ID will be looked up by external ID
 			"", // Generate new ID
 			"system",
+			cfg.Billing.EnvironmentID,
 		)
 		eventsToInsert = append(eventsToInsert, billingEvent)
 	}

--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -43,6 +43,7 @@ func (r *IngestEventRequest) ToEvent(ctx context.Context) *events.Event {
 		r.EventID,
 		r.CustomerID,
 		r.Source,
+		types.GetEnvironmentID(ctx),
 	)
 }
 
@@ -99,6 +100,7 @@ type Event struct {
 	Timestamp          time.Time              `json:"timestamp"`
 	Properties         map[string]interface{} `json:"properties"`
 	Source             string                 `json:"source"`
+	EnvironmentID      string                 `json:"environment_id"`
 }
 
 type GetUsageResponse struct {

--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -16,6 +16,9 @@ type Event struct {
 	// Tenant identifier
 	TenantID string `json:"tenant_id" ch:"tenant_id" validate:"required"`
 
+	// Environment identifier
+	EnvironmentID string `json:"environment_id" ch:"environment_id"`
+
 	// Event name is an identifier for the event and will be used for filtering and aggregation
 	EventName string `json:"event_name" ch:"event_name" validate:"required"`
 
@@ -46,6 +49,7 @@ func NewEvent(
 	properties map[string]interface{},
 	timestamp time.Time,
 	eventID, customerID, source string,
+	environmentID string, // Add environmentID parameter
 ) *Event {
 	if eventID == "" {
 		eventID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_EVENT)
@@ -68,6 +72,7 @@ func NewEvent(
 		EventName:          eventName,
 		Timestamp:          timestamp,
 		Properties:         properties,
+		EnvironmentID:      environmentID,
 	}
 }
 

--- a/internal/repository/clickhouse/builder/query_builder_test.go
+++ b/internal/repository/clickhouse/builder/query_builder_test.go
@@ -31,7 +31,7 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				CustomerID:         "cust_123",
 				ExternalCustomerID: "ext_123",
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (id, tenant_id, external_customer_id, customer_id, event_name) * FROM events WHERE event_name = 'audio_transcription' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3) AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3) AND external_customer_id = 'ext_123' AND customer_id = 'cust_123' ORDER BY id, tenant_id, external_customer_id, customer_id, event_name, timestamp DESC))",
+			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'audio_transcription' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3) AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3) AND external_customer_id = 'ext_123' AND customer_id = 'cust_123' ORDER BY tenant_id, environment_id, timestamp, id DESC))",
 		},
 		{
 			name: "base filters without customer ID",
@@ -40,7 +40,7 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				StartTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				EndTime:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (id, tenant_id, external_customer_id, customer_id, event_name) * FROM events WHERE event_name = 'api_calls' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3) AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3) ORDER BY id, tenant_id, external_customer_id, customer_id, event_name, timestamp DESC))",
+			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'api_calls' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3) AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3) ORDER BY tenant_id, environment_id, timestamp, id DESC))",
 		},
 	}
 

--- a/internal/service/event_test.go
+++ b/internal/service/event_test.go
@@ -170,6 +170,7 @@ func (s *EventServiceSuite) TestGetUsage() {
 			evt.EventID,
 			evt.CustomerID,
 			evt.Source,
+			types.GetEnvironmentID(s.ctx),
 		)
 		err := s.eventRepo.InsertEvent(s.ctx, event)
 		s.NoError(err)
@@ -343,6 +344,7 @@ func (s *EventServiceSuite) TestGetUsageByMeter() {
 			evt.EventID,
 			evt.CustomerID,
 			evt.Source,
+			types.GetEnvironmentID(s.ctx),
 		)
 		err := s.eventRepo.InsertEvent(s.ctx, event)
 		s.NoError(err)
@@ -432,6 +434,7 @@ func (s *EventServiceSuite) TestGetEvents() {
 			evt.EventID,
 			evt.CustomerID,
 			evt.Source,
+			types.GetEnvironmentID(s.ctx),
 		)
 		err := s.eventRepo.InsertEvent(s.ctx, event)
 		s.NoError(err)

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -118,6 +118,8 @@ func (s *onboardingService) GenerateEvents(ctx context.Context, req *dto.Onboard
 		Duration:         req.Duration,
 		Meters:           meters,
 		TenantID:         types.GetTenantID(ctx),
+		EnvironmentID:    types.GetEnvironmentID(ctx),
+		UserID:           types.GetUserID(ctx),
 		RequestTimestamp: time.Now(),
 		SubscriptionID:   req.SubscriptionID,
 	}
@@ -133,6 +135,8 @@ func (s *onboardingService) GenerateEvents(ctx context.Context, req *dto.Onboard
 
 	watermillMsg := message.NewMessage(messageID, payload)
 	watermillMsg.Metadata.Set("tenant_id", types.GetTenantID(ctx))
+	watermillMsg.Metadata.Set("environment_id", types.GetEnvironmentID(ctx))
+	watermillMsg.Metadata.Set("user_id", types.GetUserID(ctx))
 
 	s.Logger.Infow("publishing onboarding events message",
 		"message_id", messageID,
@@ -220,6 +224,8 @@ func (s *onboardingService) processMessage(msg *message.Message) error {
 
 	// Copy tenant ID from original context to background context
 	bgCtx = context.WithValue(bgCtx, types.CtxTenantID, eventMsg.TenantID)
+	bgCtx = context.WithValue(bgCtx, types.CtxEnvironmentID, eventMsg.EnvironmentID)
+	bgCtx = context.WithValue(bgCtx, types.CtxUserID, eventMsg.UserID)
 
 	// Start a goroutine to generate events at a rate of 1 per second
 	go s.generateEvents(bgCtx, &eventMsg)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -639,8 +639,8 @@ func (s *subscriptionService) UpdateBillingPeriods(ctx context.Context) (*dto.Su
 		for _, sub := range subs {
 			// update context to include the tenant id
 			ctx = context.WithValue(ctx, types.CtxTenantID, sub.TenantID)
-			// clean the environment id to make sure it's not used
-			ctx = context.WithValue(ctx, types.CtxEnvironmentID, "")
+			ctx = context.WithValue(ctx, types.CtxEnvironmentID, sub.EnvironmentID)
+			ctx = context.WithValue(ctx, types.CtxUserID, sub.CreatedBy)
 
 			item := &dto.SubscriptionUpdatePeriodResponseItem{
 				SubscriptionID: sub.ID,

--- a/internal/testutil/base_service_suite.go
+++ b/internal/testutil/base_service_suite.go
@@ -76,7 +76,7 @@ func (s *BaseServiceTestSuite) SetupSuite() {
 	// Initialize logger with test config
 	cfg := &config.Configuration{
 		Logging: config.LoggingConfig{
-			Level: types.LogLevelDebug,
+			Level: types.LogLevelInfo,
 		},
 	}
 	var err error

--- a/internal/types/onboarding.go
+++ b/internal/types/onboarding.go
@@ -13,9 +13,11 @@ type OnboardingEventsMessage struct {
 	FeatureName      string      `json:"feature_name"`
 	Duration         int         `json:"duration"`
 	Meters           []MeterInfo `json:"meters"`
-	TenantID         string      `json:"tenant_id"`
 	RequestTimestamp time.Time   `json:"request_timestamp"`
 	SubscriptionID   string      `json:"subscription_id,omitempty"`
+	TenantID         string      `json:"tenant_id"`
+	EnvironmentID    string      `json:"environment_id"`
+	UserID           string      `json:"user_id"`
 }
 
 // MeterInfo contains the essential meter information for event generation

--- a/migrations/clickhouse/000001_create_events_table.up.sql
+++ b/migrations/clickhouse/000001_create_events_table.up.sql
@@ -1,23 +1,20 @@
-CREATE TABLE IF NOT EXISTS events (
-    -- Core identifiers
+CREATE TABLE flexprice.events (
     id String,
     tenant_id String,
     external_customer_id String,
-    customer_id String,
-
-    -- Event metadata
+    environment_id String,
     event_name String,
-    source String,
+    customer_id Nullable(String),
+    source Nullable(String),
     timestamp DateTime64(3),
     ingested_at DateTime64(3) DEFAULT now(),
-    -- Properties as JSON string
     properties String,
-
-    -- Ensure required fields
-    CONSTRAINT check_event_name CHECK (event_name != ''),
-    CONSTRAINT check_tenant_id CHECK (tenant_id != ''),
-    CONSTRAINT check_event_id CHECK (id != '')
-) ENGINE = ReplacingMergeTree(timestamp)
+    CONSTRAINT check_event_name CHECK event_name != '',
+    CONSTRAINT check_tenant_id CHECK tenant_id != '',
+    CONSTRAINT check_event_id CHECK id != ''
+)
+ENGINE = ReplacingMergeTree(ingested_at)
 PARTITION BY toYYYYMM(timestamp)
-ORDER BY (id, tenant_id, external_customer_id, customer_id, event_name, timestamp)
-SETTINGS index_granularity = 8192;
+PRIMARY KEY (tenant_id, environment_id)
+ORDER BY (tenant_id, environment_id, timestamp, id)
+SETTINGS index_granularity = 8192, allow_nullable_key = 1;

--- a/migrations/clickhouse/000001_create_events_table.up.sql
+++ b/migrations/clickhouse/000001_create_events_table.up.sql
@@ -6,12 +6,13 @@ CREATE TABLE flexprice.events (
     event_name String,
     customer_id Nullable(String),
     source Nullable(String),
-    timestamp DateTime64(3),
+    timestamp DateTime64(3) DEFAULT now(),
     ingested_at DateTime64(3) DEFAULT now(),
     properties String,
     CONSTRAINT check_event_name CHECK event_name != '',
     CONSTRAINT check_tenant_id CHECK tenant_id != '',
-    CONSTRAINT check_event_id CHECK id != ''
+    CONSTRAINT check_event_id CHECK id != '',
+    CONSTRAINT check_environment_id CHECK environment_id != ''
 )
 ENGINE = ReplacingMergeTree(ingested_at)
 PARTITION BY toYYYYMM(timestamp)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `environment_id` to ClickHouse events schema and propagate through ingestion, storage, queries, onboarding, and API layers.
> 
>   - **Schema and Migration**:
>     - Add `environment_id` column to ClickHouse `events` table in `000001_create_events_table.up.sql`.
>     - Update primary key and order by to include `environment_id`.
>   - **Domain Model and DTOs**:
>     - Add `EnvironmentID` to `events.Event` (in `model.go`) and `dto.Event` (in `events.go`).
>     - Update `IngestEventRequest.ToEvent()` to set `environment_id` from context.
>   - **Repository and Query Logic**:
>     - Update ClickHouse event insert and bulk insert in `event.go` to handle `environment_id`.
>     - Add `environment_id` to event queries and filters in `event.go` and `query_builder.go`.
>     - Update deduplication key and filter logic in `query_builder.go` to include `environment_id`.
>     - Update tests in `query_builder_test.go` and `event_test.go` for new field and query changes.
>   - **Service and Onboarding**:
>     - Propagate `environment_id` in onboarding event messages and context in `onboarding.go` and `onboarding.go` (types).
>     - Set `environment_id` in onboarding event generation and message metadata.
>   - **Misc**:
>     - Update event ingestion in `main.go` to include `environment_id` for billing events.
>     - Minor test config/logging update in `base_service_suite.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 662585c8d3466d44a0951974eac858a717294587. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->