### PR TITLE
fix(events): remove ingested_at form merge logic

### DIFF
--- a/migrations/clickhouse/000001_create_events_table.up.sql
+++ b/migrations/clickhouse/000001_create_events_table.up.sql
@@ -14,7 +14,7 @@ CREATE TABLE flexprice.events (
     CONSTRAINT check_event_id CHECK id != '',
     CONSTRAINT check_environment_id CHECK environment_id != ''
 )
-ENGINE = ReplacingMergeTree(ingested_at)
+ENGINE = ReplacingMergeTree()
 PARTITION BY toYYYYMM(timestamp)
 PRIMARY KEY (tenant_id, environment_id)
 ORDER BY (tenant_id, environment_id, timestamp, id)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes `ingested_at` from `ReplacingMergeTree()` in ClickHouse events table migration, changing row replacement logic to use insertion order.
> 
>   - **ClickHouse Migration**:
>     - Removes `ingested_at` as the versioning column from `ReplacingMergeTree()` in `000001_create_events_table.up.sql`.
>     - Now uses `ReplacingMergeTree()` with default versioning (insertion order) for the `flexprice.events` table.
>     - Affects deduplication/row replacement logic: latest row is determined by insertion order, not `ingested_at`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c8ca91e46c8ecd502d5cb03cf04d3f6aeb35e147. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->