### PR TITLE
feat(subscription): remove filter params in usage query

### DIFF
--- a/internal/api/dto/price.go
+++ b/internal/api/dto/price.go
@@ -226,12 +226,6 @@ func (r *CreatePriceRequest) ToPrice(ctx context.Context) (*price.Price, error) 
 		}
 	}
 
-	// Initialize empty JSONB fields with proper zero values
-	filterValues := make(price.JSONBFilters)
-	if r.FilterValues != nil {
-		filterValues = price.JSONBFilters(r.FilterValues)
-	}
-
 	metadata := make(price.JSONBMetadata)
 	if r.Metadata != nil {
 		metadata = price.JSONBMetadata(r.Metadata)
@@ -293,7 +287,6 @@ func (r *CreatePriceRequest) ToPrice(ctx context.Context) (*price.Price, error) 
 		InvoiceCadence:     r.InvoiceCadence,
 		TrialPeriod:        r.TrialPeriod,
 		MeterID:            r.MeterID,
-		FilterValues:       filterValues,
 		LookupKey:          r.LookupKey,
 		Description:        r.Description,
 		Metadata:           metadata,

--- a/internal/domain/price/model.go
+++ b/internal/domain/price/model.go
@@ -76,8 +76,6 @@ type Price struct {
 	// Description of the price
 	Description string `db:"description" json:"description"`
 
-	FilterValues JSONBFilters `db:"filter_values,jsonb" json:"filter_values"`
-
 	TransformQuantity JSONBTransformQuantity `db:"transform_quantity,jsonb" json:"transform_quantity"`
 
 	Metadata JSONBMetadata `db:"metadata,jsonb" json:"metadata"`
@@ -324,7 +322,6 @@ func FromEnt(e *ent.Price) *Price {
 		MeterID:            lo.FromPtr(e.MeterID),
 		LookupKey:          e.LookupKey,
 		Description:        e.Description,
-		FilterValues:       JSONBFilters(e.FilterValues),
 		TransformQuantity:  JSONBTransformQuantity(e.TransformQuantity),
 		Metadata:           JSONBMetadata(e.Metadata),
 		EnvironmentID:      e.EnvironmentID,

--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -140,8 +140,9 @@ func (a *SumAggregator) GetQuery(ctx context.Context, params *events.UsageParams
             SELECT
                 %s anyLast(JSONExtractFloat(assumeNotNull(properties), '%s')) as value
             FROM events
-            PREWHERE event_name = '%s' 
-                AND tenant_id = '%s'
+            PREWHERE tenant_id = '%s'
+				AND environment_id = '%s'
+				AND event_name = '%s'
 				%s
 				%s
                 %s
@@ -153,8 +154,9 @@ func (a *SumAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 		selectClause,
 		windowClause,
 		params.PropertyName,
-		params.EventName,
 		types.GetTenantID(ctx),
+		types.GetEnvironmentID(ctx),
+		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -198,8 +200,9 @@ func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsagePara
         SELECT 
             %s count(DISTINCT %s) as total
         FROM events
-        PREWHERE event_name = '%s'
-            AND tenant_id = '%s'
+        PREWHERE tenant_id = '%s'
+			AND environment_id = '%s'
+			AND event_name = '%s'
 			%s
 			%s
             %s
@@ -208,8 +211,9 @@ func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsagePara
     `,
 		selectClause,
 		getDeduplicationKey(),
-		params.EventName,
 		types.GetTenantID(ctx),
+		types.GetEnvironmentID(ctx),
+		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -258,8 +262,9 @@ func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.Usa
             SELECT
                 %s JSONExtractString(assumeNotNull(properties), '%s') as property_value
             FROM events
-            PREWHERE event_name = '%s'
-                AND tenant_id = '%s'
+            PREWHERE tenant_id = '%s'
+				AND environment_id = '%s'
+				AND event_name = '%s'
 				%s
 				%s
                 %s
@@ -271,8 +276,9 @@ func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.Usa
 		selectClause,
 		windowClause,
 		params.PropertyName,
-		params.EventName,
 		types.GetTenantID(ctx),
+		types.GetEnvironmentID(ctx),
+		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -323,8 +329,9 @@ func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams
             SELECT
                 %s anyLast(JSONExtractFloat(assumeNotNull(properties), '%s')) as value
             FROM events
-            PREWHERE event_name = '%s' 
-                AND tenant_id = '%s'
+            PREWHERE tenant_id = '%s'
+				AND environment_id = '%s'
+				AND event_name = '%s' 
 				%s
 				%s
 				%s
@@ -336,8 +343,9 @@ func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 		selectClause,
 		windowClause,
 		params.PropertyName,
-		params.EventName,
 		types.GetTenantID(ctx),
+		types.GetEnvironmentID(ctx),
+		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,

--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -376,7 +376,7 @@ func (r *EventRepository) GetEvents(ctx context.Context, params *events.GetEvent
 			source,
 			properties,
 			environment_id
-		FROM events FINAL
+		FROM events
 		WHERE tenant_id = ?
 	`
 	args := make([]interface{}, 0)
@@ -412,7 +412,7 @@ func (r *EventRepository) GetEvents(ctx context.Context, params *events.GetEvent
 	}
 
 	// Apply property filters
-	if params.PropertyFilters != nil && len(params.PropertyFilters) > 0 {
+	if len(params.PropertyFilters) > 0 {
 		for property, values := range params.PropertyFilters {
 			if len(values) > 0 {
 				if len(values) == 1 {

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -60,7 +60,6 @@ func (r *priceRepository) Create(ctx context.Context, p *domainPrice.Price) erro
 		SetNillableMeterID(lo.ToPtr(p.MeterID)).
 		SetInvoiceCadence(string(p.InvoiceCadence)).
 		SetTrialPeriod(p.TrialPeriod).
-		SetFilterValues(map[string][]string(p.FilterValues)).
 		SetNillableTierMode(lo.ToPtr(string(p.TierMode))).
 		SetTiers(p.ToEntTiers()).
 		SetTransformQuantity(schema.TransformQuantity(p.TransformQuantity)).
@@ -208,7 +207,6 @@ func (r *priceRepository) Update(ctx context.Context, p *domainPrice.Price) erro
 		SetBillingModel(string(p.BillingModel)).
 		SetBillingCadence(string(p.BillingCadence)).
 		SetNillableMeterID(lo.ToPtr(p.MeterID)).
-		SetFilterValues(map[string][]string(p.FilterValues)).
 		SetNillableTierMode(lo.ToPtr(string(p.TierMode))).
 		SetTiers(p.ToEntTiers()).
 		SetTransformQuantity(schema.TransformQuantity(p.TransformQuantity)).
@@ -301,7 +299,6 @@ func (r *priceRepository) CreateBulk(ctx context.Context, prices []*domainPrice.
 			SetInvoiceCadence(string(p.InvoiceCadence)).
 			SetTrialPeriod(p.TrialPeriod).
 			SetNillableMeterID(lo.ToPtr(p.MeterID)).
-			SetFilterValues(map[string][]string(p.FilterValues)).
 			SetNillableTierMode(lo.ToPtr(string(p.TierMode))).
 			SetTiers(p.ToEntTiers()).
 			SetTransformQuantity(schema.TransformQuantity(p.TransformQuantity)).

--- a/internal/service/billing_test.go
+++ b/internal/service/billing_test.go
@@ -28,8 +28,9 @@ type BillingServiceSuite struct {
 		customer *customer.Customer
 		plan     *plan.Plan
 		meters   struct {
-			apiCalls *meter.Meter
-			storage  *meter.Meter
+			apiCalls       *meter.Meter
+			storage        *meter.Meter
+			storageArchive *meter.Meter
 		}
 		prices struct {
 			fixed          *price.Price
@@ -132,9 +133,41 @@ func (s *BillingServiceSuite) setupTestData() {
 			Type:  types.AggregationSum,
 			Field: "bytes_used",
 		},
+		Filters: []meter.Filter{
+			{
+				Key:    "region",
+				Values: []string{"us-east-1"},
+			},
+			{
+				Key:    "tier",
+				Values: []string{"standard"},
+			},
+		},
 		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
 	}
 	s.NoError(s.GetStores().MeterRepo.CreateMeter(s.GetContext(), s.testData.meters.storage))
+
+	s.testData.meters.storageArchive = &meter.Meter{
+		ID:        "meter_storage_archive",
+		Name:      "Storage Archive",
+		EventName: "storage_usage",
+		Aggregation: meter.Aggregation{
+			Type:  types.AggregationSum,
+			Field: "bytes_used",
+		},
+		Filters: []meter.Filter{
+			{
+				Key:    "region",
+				Values: []string{"us-east-1"},
+			},
+			{
+				Key:    "tier",
+				Values: []string{"archive"},
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(s.GetContext(), s.testData.meters.storageArchive))
 
 	// Create test prices
 	upTo1000 := uint64(1000)
@@ -191,8 +224,7 @@ func (s *BillingServiceSuite) setupTestData() {
 		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
 		BillingCadence:     types.BILLING_CADENCE_RECURRING,
 		InvoiceCadence:     types.InvoiceCadenceArrear, // Fixed charges with arrear cadence
-		MeterID:            s.testData.meters.storage.ID,
-		FilterValues:       map[string][]string{"region": {"us-east-1"}, "tier": {"archive"}},
+		MeterID:            s.testData.meters.storageArchive.ID,
 		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
 	}
 	s.NoError(s.GetStores().PriceRepo.Create(s.GetContext(), s.testData.prices.storageArchive))
@@ -256,8 +288,8 @@ func (s *BillingServiceSuite) setupTestData() {
 			PlanDisplayName:  s.testData.plan.Name,
 			PriceID:          s.testData.prices.storageArchive.ID,
 			PriceType:        s.testData.prices.storageArchive.Type,
-			MeterID:          s.testData.meters.storage.ID,
-			MeterDisplayName: s.testData.meters.storage.Name,
+			MeterID:          s.testData.meters.storageArchive.ID,
+			MeterDisplayName: s.testData.meters.storageArchive.Name,
 			DisplayName:      "Archive Storage",
 			Quantity:         decimal.NewFromInt(1), // 1 unit of archive storage
 			Currency:         s.testData.subscription.Currency,

--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -135,6 +135,8 @@ func (s *eventService) GetUsageByMeter(ctx context.Context, req *dto.GetUsageByM
 	return usage, nil
 }
 
+// GetUsageByMeterWithFilters returns usage for a meter with specific filters on top of the meter as defined in the price
+// TODO : deprecate this flow completely as we now allow only one meter per price without filters
 func (s *eventService) GetUsageByMeterWithFilters(ctx context.Context, req *dto.GetUsageByMeterRequest, filterGroups map[string]map[string][]string) ([]*events.AggregationResult, error) {
 	m, err := s.meterRepo.GetMeter(ctx, req.MeterID)
 	if err != nil {

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -3,12 +3,9 @@ package service
 import (
 	"context"
 	"encoding/json"
-	"sort"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
-	"github.com/flexprice/flexprice/internal/domain/events"
-	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -398,6 +395,7 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 		usageStartTime = subscription.CurrentPeriodStart
 	}
 
+	// TODO: handle this to honour line item level end time
 	usageEndTime := req.EndTime
 	if usageEndTime.IsZero() {
 		usageEndTime = subscription.CurrentPeriodEnd
@@ -407,11 +405,6 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 		usageStartTime = time.Time{}
 		usageEndTime = time.Now().UTC()
 	}
-
-	// Maintain meter order as they first appear in line items
-	meterOrder := []string{}
-	seenMeters := make(map[string]bool)
-	meterPrices := make(map[string][]*price.Price)
 
 	// Collect all price IDs
 	priceIDs := make([]string, 0, len(lineItems))
@@ -428,48 +421,24 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 	// Fetch all prices in one call
 	priceFilter := types.NewNoLimitPriceFilter()
 	priceFilter.PriceIDs = priceIDs
-	prices, err := s.PriceRepo.List(ctx, priceFilter)
+	priceFilter.Expand = lo.ToPtr(string(types.ExpandMeters))
+	pricesList, err := priceService.GetPrices(ctx, priceFilter)
 	if err != nil {
 		return nil, err
 	}
 
 	// Build price map for quick lookup
-	priceMap := make(map[string]*price.Price, len(prices))
-	for _, p := range prices {
-		priceMap[p.ID] = p
-	}
-
-	// Build meterPrices from line items
-	for _, item := range lineItems {
-		if item.PriceType != types.PRICE_TYPE_USAGE {
-			continue
-		}
-		if item.MeterID == "" {
-			continue
-		}
-		meterID := item.MeterID
-		if !seenMeters[meterID] {
-			meterOrder = append(meterOrder, meterID)
-			seenMeters[meterID] = true
-		}
-
-		// Get price details from map
-		price, ok := priceMap[item.PriceID]
-		if !ok {
-			return nil, ierr.NewError("failed to get price %s: price not found").
-				WithHint("Ensure all prices are valid and available").
-				WithReportableDetails(map[string]interface{}{
-					"price_id": item.PriceID,
-				}).
-				Mark(ierr.ErrDatabase)
-		}
-		meterPrices[meterID] = append(meterPrices[meterID], price)
-	}
-
+	priceMap := make(map[string]*price.Price, len(pricesList.Items))
+	meterMap := make(map[string]*dto.MeterResponse, len(pricesList.Items))
 	// Pre-fetch all meter display names
 	meterDisplayNames := make(map[string]string)
-	for _, meterID := range meterOrder {
-		meterDisplayNames[meterID] = getMeterDisplayName(ctx, s.MeterRepo, meterID, meterDisplayNames)
+
+	for _, p := range pricesList.Items {
+		priceMap[p.ID] = p.Price
+		meterMap[p.Price.MeterID] = p.Meter
+		if p.Meter != nil {
+			meterDisplayNames[p.Price.MeterID] = p.Meter.Name
+		}
 	}
 
 	totalCost := decimal.Zero
@@ -478,108 +447,73 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 		"subscription_id", req.SubscriptionID,
 		"start_time", usageStartTime,
 		"end_time", usageEndTime,
-		"num_meters", len(meterOrder))
+		"metered_line_items", len(priceIDs))
 
-	for _, meterID := range meterOrder {
-		meterPriceGroup := meterPrices[meterID]
-
-		// Sort prices by filter count (stable order)
-		sort.Slice(meterPriceGroup, func(i, j int) bool {
-			return len(meterPriceGroup[i].FilterValues) > len(meterPriceGroup[j].FilterValues)
-		})
-
-		type filterGroup struct {
-			ID           string
-			Priority     int
-			FilterValues map[string][]string
+	for _, lineItem := range lineItems {
+		if lineItem.PriceType != types.PRICE_TYPE_USAGE {
+			continue
 		}
 
-		filterGroups := make([]filterGroup, 0, len(meterPriceGroup))
-		for _, price := range meterPriceGroup {
-			filterGroups = append(filterGroups, filterGroup{
-				ID:           price.ID,
-				Priority:     calculatePriority(price.FilterValues),
-				FilterValues: price.FilterValues,
-			})
+		if lineItem.MeterID == "" {
+			continue
 		}
 
-		// Sort filter groups by priority and ID
-		sort.SliceStable(filterGroups, func(i, j int) bool {
-			pi := calculatePriority(filterGroups[i].FilterValues)
-			pj := calculatePriority(filterGroups[j].FilterValues)
-			if pi != pj {
-				return pi > pj
-			}
-			return filterGroups[i].ID < filterGroups[j].ID
-		})
-
-		filterGroupsMap := make(map[string]map[string][]string)
-		for _, group := range filterGroups {
-			if len(group.FilterValues) == 0 {
-				filterGroupsMap[group.ID] = map[string][]string{}
-			} else {
-				filterGroupsMap[group.ID] = group.FilterValues
-			}
+		price := priceMap[lineItem.PriceID]
+		meter := meterMap[lineItem.MeterID]
+		meterID := lineItem.MeterID
+		meterDisplayName := ""
+		if meter, ok := meterDisplayNames[meterID]; ok {
+			meterDisplayName = meter
 		}
 
-		usages, err := eventService.GetUsageByMeterWithFilters(ctx, &dto.GetUsageByMeterRequest{
+		usageRequest := &dto.GetUsageByMeterRequest{
 			MeterID:            meterID,
 			ExternalCustomerID: customer.ExternalID,
 			StartTime:          usageStartTime,
 			EndTime:            usageEndTime,
-		}, filterGroupsMap)
+			Filters:            make(map[string][]string),
+		}
+
+		for _, filter := range meter.Filters {
+			usageRequest.Filters[filter.Key] = filter.Values
+		}
+
+		// TODO: make this a bulk call
+		usage, err := eventService.GetUsageByMeter(ctx, usageRequest)
 		if err != nil {
 			return nil, err
 		}
 
-		// Append charges in the same order as meterPriceGroup
-		for _, price := range meterPriceGroup {
-			var quantity decimal.Decimal
-			var matchingUsage *events.AggregationResult
-			for _, usage := range usages {
-				if fgID, ok := usage.Metadata["filter_group_id"]; ok && fgID == price.ID {
-					matchingUsage = usage
-					break
-				}
-			}
-
-			// if no matching usage, create a 0 value usage rather than ommiting it
-			if matchingUsage == nil {
-				matchingUsage = &events.AggregationResult{
-					Value: decimal.Zero,
-				}
-			}
-
-			if matchingUsage != nil {
-				quantity = matchingUsage.Value
-				cost := priceService.CalculateCost(ctx, price, quantity)
-				totalCost = totalCost.Add(cost)
-
-				s.Logger.Debugw("calculated usage for meter",
-					"meter_id", meterID,
-					"quantity", quantity,
-					"cost", cost,
-					"total_cost", totalCost,
-					"meter_display_name", meterDisplayNames[meterID],
-					"subscription_id", req.SubscriptionID,
-					"usage", matchingUsage,
-					"price", price,
-					"filter_values", price.FilterValues,
-				)
-
-				filteredUsageCharge := createChargeResponse(
-					price,
-					quantity,
-					cost,
-					meterDisplayNames[meterID],
-				)
-
-				if filteredUsageCharge == nil {
-					continue
-				}
-				response.Charges = append(response.Charges, filteredUsageCharge)
-			}
+		if usage == nil {
+			continue
 		}
+
+		quantity := usage.Value
+		cost := priceService.CalculateCost(ctx, price, quantity)
+		totalCost = totalCost.Add(cost)
+
+		s.Logger.Debugw("calculated usage for meter",
+			"meter_id", meterID,
+			"quantity", quantity,
+			"cost", cost,
+			"total_cost", totalCost,
+			"meter_display_name", meterDisplayName,
+			"subscription_id", req.SubscriptionID,
+			"usage", usage,
+			"price", price,
+		)
+
+		filteredUsageCharge := createChargeResponse(
+			price,
+			quantity,
+			cost,
+			meterDisplayName,
+		)
+
+		if filteredUsageCharge == nil {
+			continue
+		}
+		response.Charges = append(response.Charges, filteredUsageCharge)
 	}
 
 	response.StartTime = usageStartTime
@@ -910,29 +844,10 @@ func createChargeResponse(priceObj *price.Price, quantity decimal.Decimal, cost 
 		Currency:         priceObj.Currency,
 		DisplayAmount:    price.GetDisplayAmountWithPrecision(cost, priceObj.Currency),
 		Quantity:         quantity.InexactFloat64(),
-		FilterValues:     priceObj.FilterValues,
 		MeterID:          priceObj.MeterID,
 		MeterDisplayName: meterDisplayName,
 		Price:            priceObj,
 	}
-}
-
-func getMeterDisplayName(ctx context.Context, meterRepo meter.Repository, meterID string, cache map[string]string) string {
-	if name, ok := cache[meterID]; ok {
-		return name
-	}
-
-	m, err := meterRepo.GetMeter(ctx, meterID)
-	if err != nil {
-		return meterID
-	}
-
-	displayName := m.Name
-	if displayName == "" {
-		displayName = m.EventName
-	}
-	cache[meterID] = displayName
-	return displayName
 }
 
 func filterValidPricesForSubscription(prices []*dto.PriceResponse, subscriptionObj *subscription.Subscription) []*dto.PriceResponse {
@@ -945,15 +860,6 @@ func filterValidPricesForSubscription(prices []*dto.PriceResponse, subscriptionO
 		}
 	}
 	return validPrices
-}
-
-func calculatePriority(filterValues map[string][]string) int {
-	priority := 0
-	for _, values := range filterValues {
-		priority += len(values)
-	}
-	priority += len(filterValues) * 10
-	return priority
 }
 
 // PauseSubscription pauses a subscription

--- a/internal/testutil/inmemory_event_store.go
+++ b/internal/testutil/inmemory_event_store.go
@@ -140,7 +140,7 @@ func (s *InMemoryEventStore) GetEvents(ctx context.Context, params *events.GetEv
 		}
 
 		// Apply property filters
-		if params.PropertyFilters != nil && len(params.PropertyFilters) > 0 {
+		if len(params.PropertyFilters) > 0 {
 			propertyFilterMatched := true
 			for property, values := range params.PropertyFilters {
 				if len(values) == 0 {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `FilterValues` from usage query in subscription service, updating models, queries, and tests accordingly.
> 
>   - **Behavior**:
>     - Remove `FilterValues` from `Price` model in `model.go` and related DTOs in `price.go`.
>     - Update ClickHouse query logic in `aggregators.go` and `event.go` to exclude `FilterValues`.
>     - Adjust `GetUsageBySubscription` in `subscription.go` to handle usage without `FilterValues`.
>   - **Tests**:
>     - Update test data in `billing_test.go`, `invoice_test.go`, `subscription_test.go`, and `wallet_test.go` to remove `FilterValues`.
>     - Modify test cases in `billing_test.go` and `invoice_test.go` to reflect changes in usage calculation.
>   - **Misc**:
>     - Remove deprecated `GetUsageByMeterWithFilters` function in `event.go`.
>     - Update `GetEvents` and `GetUsage` logic in `inmemory_event_store.go` to align with new query structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c1d19d6ae07205def49aa59b958168c36ad1f10d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->