### PR TITLE
fix(usage): simply group by to just use id

### DIFF
--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -25,7 +25,7 @@ func GetAggregator(aggregationType types.AggregationType) events.Aggregator {
 }
 
 func getDeduplicationKey() string {
-	return "id, tenant_id, external_customer_id, customer_id, event_name"
+	return "id"
 }
 
 func formatClickHouseDateTime(t time.Time) string {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies deduplication key in ClickHouse queries to use only `id`, affecting grouping behavior.
> 
>   - **Behavior**:
>     - Simplifies deduplication key in `getDeduplicationKey()` in `aggregators.go` to use only `id`.
>     - Affects grouping in ClickHouse queries, potentially altering deduplication results.
>   - **Functions**:
>     - `getDeduplicationKey()` now returns "id" instead of "id, tenant_id, external_customer_id, customer_id, event_name".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 666b02654d9586320a1d41104e4c7896688d4cf5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->