### PR TITLE
Add: Building kafka-ui image and running it on dev-setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ restart-flexprice: stop-flexprice start-flexprice
 dev-setup:
 	@echo "Setting up FlexPrice development environment..."
 	@echo "Step 1: Starting infrastructure services..."
-	@docker compose up -d postgres kafka clickhouse temporal temporal-ui
+	@docker compose up -d postgres kafka kafka-ui clickhouse temporal temporal-ui
 	@echo "Step 2: Building FlexPrice application image..."
 	@make build-image
 	@echo "Step 3: Running database migrations and initializing Kafka..."


### PR DESCRIPTION
Fix for the issue
#67

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `kafka-ui` service to `dev-setup` in `Makefile` for Kafka management UI.
> 
>   - **Makefile**:
>     - Add `kafka-ui` to `docker compose up` command in `dev-setup` target to start Kafka UI service.
>     - Enhances development setup by providing a UI for Kafka management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for fe4c62e857ce63d17648bd1259442ac3d98009ec. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->