### PR TITLE
fix(sdk): remove github release step

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -179,15 +179,6 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.SDK_DEPLOY_GIT_TOKEN }}@github.com/flexprice/go-sdk.git || true
           git push -f origin main || echo "Push failed but continuing"
           git push --tags || echo "Tag push failed but continuing"
-          
-          # Create GitHub Release
-          gh auth login --with-token <<< "${{ secrets.SDK_DEPLOY_GIT_TOKEN }}"
-          gh release create "v${{ env.VERSION }}" \
-            --repo="flexprice/go-sdk" \
-            --title="v${{ env.VERSION }}" \
-            --notes="Release version ${{ env.VERSION }}" \
-            --target main \
-            || echo "Release creation failed but continuing"
             
           echo "Go SDK publishing steps completed"
         env:
@@ -233,14 +224,8 @@ jobs:
           git push -f origin main || echo "Push failed but continuing"
           git push --tags || echo "Tag push failed but continuing"
           
-          # Create GitHub Release
-          gh auth login --with-token <<< "${{ secrets.SDK_DEPLOY_GIT_TOKEN }}"
-          gh release create "v${{ env.VERSION }}" \
-            --repo="flexprice/javascript-sdk" \
-            --title="v${{ env.VERSION }}" \
-            --notes="Release version ${{ env.VERSION }}" \
-            --target main \
-            || echo "Release creation failed but continuing"
+          # Create .npmrc file with auth token to avoid browser authentication
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
           
           # Publish to npm
           npm publish --access public || echo "npm publish failed but continuing"
@@ -288,15 +273,6 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.SDK_DEPLOY_GIT_TOKEN }}@github.com/flexprice/python-sdk.git || true
           git push -f origin main || echo "Push failed but continuing"
           git push --tags || echo "Tag push failed but continuing"
-          
-          # Create GitHub Release
-          gh auth login --with-token <<< "${{ secrets.SDK_DEPLOY_GIT_TOKEN }}"
-          gh release create "v${{ env.VERSION }}" \
-            --repo="flexprice/python-sdk" \
-            --title="v${{ env.VERSION }}" \
-            --notes="Release version ${{ env.VERSION }}" \
-            --target main \
-            || echo "Release creation failed but continuing"
           
           # Build and publish to PyPI
           # Clean dist directory

--- a/.github/workflows/test-event.json
+++ b/.github/workflows/test-event.json
@@ -1,5 +1,5 @@
 {
   "release": {
-    "tag_name": "v1.0.12"
+    "tag_name": "v1.0.15"
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove GitHub release creation step from SDK publishing workflow and update test event tag.
> 
>   - **Workflow Changes**:
>     - Remove GitHub release creation step from `.github/workflows/sdk-publish.yml` for Go, JavaScript, and Python SDKs.
>     - Add `.npmrc` file creation for JavaScript SDK to handle npm authentication.
>   - **Test Event**:
>     - Update `tag_name` in `test-event.json` from `v1.0.12` to `v1.0.15`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for bdab67db5d322952fd3b48ea8258e531f1141aff. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->