### PR TITLE
fix(sentry): add nil check

### DIFF
--- a/internal/clickhouse/clickhouse.go
+++ b/internal/clickhouse/clickhouse.go
@@ -239,7 +239,9 @@ func (tb *tracedBatch) Flush() error {
 	ctx := context.Background()
 	span, _ := tb.sentry.StartClickHouseSpan(ctx, "clickhouse.batch_flush", nil)
 	if span != nil {
-		defer span.Finish()
+		if span != nil {
+			defer span.Finish()
+		}
 	}
 
 	return tb.batch.Flush()

--- a/internal/clickhouse/clickhouse.go
+++ b/internal/clickhouse/clickhouse.go
@@ -239,9 +239,7 @@ func (tb *tracedBatch) Flush() error {
 	ctx := context.Background()
 	span, _ := tb.sentry.StartClickHouseSpan(ctx, "clickhouse.batch_flush", nil)
 	if span != nil {
-		if span != nil {
-			defer span.Finish()
-		}
+		defer span.Finish()
 	}
 
 	return tb.batch.Flush()

--- a/internal/postgres/monitoring.go
+++ b/internal/postgres/monitoring.go
@@ -29,7 +29,9 @@ func (c *SentryClient) WithTx(ctx context.Context, fn func(context.Context) erro
 	span, spanCtx := c.sentry.StartDBSpan(ctx, "postgres.transaction", map[string]interface{}{
 		"operation": "transaction",
 	})
-	defer span.Finish()
+	if span != nil {
+		defer span.Finish()
+	}
 
 	// Use the original client's WithTx but with the new span context
 	return c.client.WithTx(spanCtx, fn)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add nil checks for `span` before calling `defer span.Finish()` in ClickHouse and Postgres monitoring code to prevent nil pointer dereference.
> 
>   - **ClickHouse**:
>     - In `clickhouse.go`, added a nil check for `span` before calling `defer span.Finish()` in `tracedBatch.Flush()`.
>   - **Postgres**:
>     - In `monitoring.go`, added a nil check for `span` before calling `defer span.Finish()` in `SentryClient.WithTx()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 31f8655d480b327fb55c4eed360ffb8cb54f629a. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->