### PR TITLE
feat(wallets): use parallel queries to clickhouse for usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/samber/lo v1.47.0
 	github.com/shopspring/decimal v1.4.0
+	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1
@@ -144,7 +145,6 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sony/gobreaker v1.0.0 // indirect
-	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/validator"
 )
@@ -61,12 +62,14 @@ type GetUsageRequest struct {
 
 type GetUsageByMeterRequest struct {
 	MeterID            string              `form:"meter_id" json:"meter_id" binding:"required" example:"123"`
+	Meter              *meter.Meter        `form:"-" json:"-"` // caller can set this in case already fetched from db to avoid extra db call
 	ExternalCustomerID string              `form:"external_customer_id" json:"external_customer_id" example:"user_5"`
 	CustomerID         string              `form:"customer_id" json:"customer_id" example:"customer456"`
 	StartTime          time.Time           `form:"start_time" json:"start_time" example:"2024-11-09T00:00:00Z"`
 	EndTime            time.Time           `form:"end_time" json:"end_time" example:"2024-12-09T00:00:00Z"`
 	WindowSize         types.WindowSize    `form:"window_size" json:"window_size"`
 	Filters            map[string][]string `form:"filters,omitempty" json:"filters,omitempty"`
+	PriceID            string              `form:"-" json:"-"` // this is just for internal use to store the price id
 }
 
 type GetEventsRequest struct {

--- a/internal/api/dto/meter.go
+++ b/internal/api/dto/meter.go
@@ -36,6 +36,23 @@ type MeterResponse struct {
 	Status      string            `json:"status" example:"published"`
 }
 
+func (r *MeterResponse) ToMeter() *meter.Meter {
+	return &meter.Meter{
+		ID:          r.ID,
+		Name:        r.Name,
+		EventName:   r.EventName,
+		Aggregation: r.Aggregation,
+		Filters:     r.Filters,
+		ResetUsage:  r.ResetUsage,
+		BaseModel: types.BaseModel{
+			Status:    types.Status(r.Status),
+			CreatedAt: r.CreatedAt,
+			UpdatedAt: r.UpdatedAt,
+			TenantID:  r.TenantID,
+		},
+	}
+}
+
 // Convert domain Meter to MeterResponse
 func ToMeterResponse(m *meter.Meter) *MeterResponse {
 	return &MeterResponse{

--- a/internal/domain/events/repository.go
+++ b/internal/domain/events/repository.go
@@ -54,6 +54,8 @@ type AggregationResult struct {
 	EventName string                `json:"event_name"`
 	Type      types.AggregationType `json:"type"`
 	Metadata  map[string]string     `json:"metadata,omitempty"`
+	MeterID   string                `json:"meter_id"`
+	PriceID   string                `json:"price_id"`
 }
 
 type EventIterator struct {

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -76,9 +76,13 @@ func NewSentryService(cfg *config.Configuration, logger *logger.Logger) *Service
 	}
 }
 
+func (s *Service) IsEnabled() bool {
+	return s.cfg.Sentry.Enabled
+}
+
 // CaptureException captures an error in Sentry
 func (s *Service) CaptureException(err error) {
-	if !s.cfg.Sentry.Enabled {
+	if !s.IsEnabled() {
 		return
 	}
 	sentry.CaptureException(err)
@@ -86,7 +90,7 @@ func (s *Service) CaptureException(err error) {
 
 // AddBreadcrumb adds a breadcrumb to the current scope
 func (s *Service) AddBreadcrumb(category, message string, data map[string]interface{}) {
-	if !s.cfg.Sentry.Enabled {
+	if !s.IsEnabled() {
 		return
 	}
 	sentry.AddBreadcrumb(&sentry.Breadcrumb{
@@ -99,7 +103,7 @@ func (s *Service) AddBreadcrumb(category, message string, data map[string]interf
 
 // Flush waits for queued events to be sent
 func (s *Service) Flush(timeout uint) bool {
-	if !s.cfg.Sentry.Enabled {
+	if !s.IsEnabled() {
 		return true
 	}
 	return sentry.Flush(time.Duration(timeout) * time.Second)
@@ -107,7 +111,7 @@ func (s *Service) Flush(timeout uint) bool {
 
 // StartDBSpan starts a new database span in the current transaction
 func (s *Service) StartDBSpan(ctx context.Context, operation string, params map[string]interface{}) (*sentry.Span, context.Context) {
-	if !s.cfg.Sentry.Enabled {
+	if !s.IsEnabled() {
 		return nil, ctx
 	}
 

--- a/internal/service/event_test.go
+++ b/internal/service/event_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -22,6 +23,7 @@ type EventServiceSuite struct {
 	eventRepo *testutil.InMemoryEventStore
 	publisher *testutil.InMemoryPublisherService
 	logger    *logger.Logger
+	config    *config.Configuration
 }
 
 func TestEventService(t *testing.T) {
@@ -33,12 +35,14 @@ func (s *EventServiceSuite) SetupTest() {
 	s.eventRepo = testutil.NewInMemoryEventStore()
 	s.publisher = testutil.NewInMemoryEventPublisher(s.eventRepo).(*testutil.InMemoryPublisherService)
 	s.logger = logger.GetLogger()
+	s.config = config.GetDefaultConfig()
 
 	s.service = NewEventService(
 		s.eventRepo,
 		nil, // meter repo not needed for these tests
 		s.publisher,
 		s.logger,
+		s.config,
 	)
 }
 
@@ -294,6 +298,7 @@ func (s *EventServiceSuite) TestGetUsageByMeter() {
 		mockedMeterRepo,
 		s.publisher,
 		s.logger,
+		s.config,
 	)
 
 	// Setup test events

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -234,7 +234,7 @@ func (s *onboardingService) processMessage(msg *message.Message) error {
 
 // generateEvents generates events at a rate of 1 per second
 func (s *onboardingService) generateEvents(ctx context.Context, eventMsg *types.OnboardingEventsMessage) {
-	eventService := NewEventService(s.EventRepo, s.MeterRepo, s.EventPublisher, s.Logger)
+	eventService := NewEventService(s.EventRepo, s.MeterRepo, s.EventPublisher, s.Logger, s.Config)
 
 	// Create a ticker to generate events at a rate of 5 per second
 	ticker := time.NewTicker(time.Millisecond * 200)

--- a/internal/service/task.go
+++ b/internal/service/task.go
@@ -472,6 +472,7 @@ func (s *taskService) processEvents(ctx context.Context, t *task.Task, tracker t
 			s.MeterRepo,
 			s.EventPublisher,
 			s.Logger,
+			s.Config,
 		)
 		err := eventSvc.CreateEvent(ctx, eventReq)
 		if err != nil {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances ClickHouse usage data retrieval with parallel processing using `conc` library and refactors Sentry service for improved code clarity.
> 
>   - **Behavior**:
>     - Introduces `BulkGetUsageByMeter` in `event.go` for parallel processing of meter usage using `conc` library.
>     - Integrates `BulkGetUsageByMeter` into `GetUsageBySubscription` in `subscription.go` for efficient usage data retrieval.
>   - **Concurrency**:
>     - Adds `github.com/sourcegraph/conc` as a direct dependency in `go.mod`.
>   - **Sentry**:
>     - Refactors Sentry service in `sentry.go` to use `IsEnabled()` method for checking Sentry status.
>   - **DTOs**:
>     - Adds `Meter` and `PriceID` fields to `GetUsageByMeterRequest` in `events.go` for internal use.
>   - **Misc**:
>     - Updates tests in `event_test.go` to cover new parallel processing logic.
>     - Minor refactoring in `onboarding.go` and `task.go` to accommodate new service parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for e2726f682cde2cb90b097af938b2b8cd777f8c39. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->