### PR TITLE
pdf render issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ api/*/*
 !api/*/tsconfig.json
 !api/*/tsconfig.node.json
 !api/*/tsconfig.app.json
+
+CLAUDE.m

--- a/assets/typst-templates/default.typ
+++ b/assets/typst-templates/default.typ
@@ -197,7 +197,10 @@
       (
         item.at("plan_display_name", default: "Plan"),
         item.at("description", default: "Recurring"),
-        if item.at("period_start", default: none) != none and item.at("period_end", default: none) != none {
+       if item.at("period_start", default: none) != none and 
+         item.at("period_end", default: none) != none and
+         item.at("period_start") != "" and 
+         item.at("period_end") != "" {
           [#format-date(parse-date(item.at("period_start"))) - #format-date(parse-date(item.at("period_end")))]
         } else {
           "-"

--- a/internal/domain/pdf/model.go
+++ b/internal/domain/pdf/model.go
@@ -70,5 +70,8 @@ type CustomTime struct {
 }
 
 func (ct CustomTime) MarshalJSON() ([]byte, error) {
+	if ct.IsZero() {
+		return json.Marshal("")
+	}
 	return json.Marshal(ct.Format("2006-01-02")) // Format to YYYY-MM-DD
 }

--- a/internal/typst/typst_test.go
+++ b/internal/typst/typst_test.go
@@ -201,3 +201,60 @@ func (s *TypstCompilerSuite) TestInvoiceCompilation() {
 	// Ensure invoice compilation does not fail
 	s.NoError(err)
 }
+
+func (s *TypstCompilerSuite) TestOneTimeInvoiceCompilation() {
+	// Create a JSON input for a one-time invoice (e.g., purchased credits)
+	invoiceJSON := []byte(`{
+		"currency": "USD",
+		"invoice_status": "paid",
+		"invoice_number": "CRED-123",
+		"issuing_date": "2023-01-01",
+		"due_date": "2023-01-10",
+		"vat": 0.00,
+		"amount_due": 25.00,
+		"notes": "One-time credit purchase",
+		"biller": {
+			"name": "Company Inc.",
+			"email": "contact@company.com",
+			"help_email": "help@company.com",
+			"address": {
+				"street": "123 Business Rd.",
+				"city": "Business City",
+				"postal_code": "12345",
+				"state": "CA",
+				"country": "USA"
+			}
+		},
+		"recipient": {
+			"name": "John Doe",
+			"email": "john.doe@example.com",
+			"address": {
+				"street": "456 Customer St.",
+				"city": "Customer City",
+				"postal_code": "67890",
+				"state": "NY",
+				"country": "USA"
+			}
+		},
+		"line_items": [
+			{
+				"display_name": "Purchased Credits",
+				"amount": 25.00,
+				"quantity": 1,
+				"currency": "USD",
+				"period_start": "",
+				"period_end": ""
+			}
+		],
+		"styling": {
+			"font": "Inter",
+			"secondary_color": "#919191"
+		}
+	}`)
+
+	// Compile the invoice template
+	_, err := s.compiler.CompileTemplate("invoice.typ", invoiceJSON)
+
+	// Ensure one-time invoice compilation does not fail
+	s.NoError(err)
+}


### PR DESCRIPTION
```
error: string index out of bounds (index: 2, len: 1)\n   ┌─ assets/typst-templates/default.typ:28:13\n   │\n28 │   let year = str(date.year()).slice(2) // Get last 2 digits\n   │              ^^^^^^^^^^^^^^^^^^^^^^^^^\n\nhelp: error occurred in this function call\n    ┌─ assets/typst-templates/default.typ:201:12\n    │\n201 │           [#format-date(parse-date(item.at(\"period_start\"))) - #format-date(parse-date(item.at(\"period_end\")))]\n    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\nhelp: error occurred in this call of function map\n    ┌─ assets/typst-templates/default.typ:196:6\n    │  \n196 │       ..items.map((item) =\u003e {\n    │ ╭───────^\n197 │ │       (\n198 │ │         item.at(\"plan_display_name\", default: \"Plan\"),\n199 │ │         item.at(\"description\", default: \"Recurring\"),\n    · │\n207 │ │       )\n208 │ │     }).flatten(),\n    │ ╰──────^\n\n
```
was due to period start and period end missing from a one time line item. Have handled this gracefully. Updated the model to return and empty string in case of zero timestamps. Handled empty strings in typst.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix PDF rendering issue by handling missing period dates in one-time line items and update model for zero timestamps.
> 
>   - **Behavior**:
>     - Fixes PDF rendering issue in `default.typ` by handling missing `period_start` and `period_end` in one-time line items.
>     - Updates `CustomTime.MarshalJSON()` in `model.go` to return an empty string for zero timestamps.
>   - **Tests**:
>     - Adds `TestOneTimeInvoiceCompilation()` in `typst_test.go` to ensure one-time invoice compilation does not fail.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 9fe994106c0fc03b622c1cad0d478dcf12850247. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->