### PR TITLE
invoice pdf subscription name fixes

### DIFF
--- a/assets/typst-templates/default.typ
+++ b/assets/typst-templates/default.typ
@@ -196,7 +196,11 @@
     ..items.map((item) => {
       (
         item.at("plan_display_name", default: "Plan"),
-        item.at("description", default: "Recurring"),
+        if item.at("description", default: "Recurring") != "" {
+          item.at("description", default: "Recurring")
+        } else {
+          "-"
+        },
         if item.at("period_start", default: "") != "" and 
          item.at("period_end", default: "") != "" {
           [#format-date(parse-date(item.at("period_start"))) - #format-date(parse-date(item.at("period_end")))]

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -919,6 +919,10 @@ func (s *invoiceService) getInvoiceDataForPDFGen(
 			Currency:        types.GetCurrencySymbol(item.Currency),
 		}
 
+		if lineItem.PlanDisplayName == "" {
+			lineItem.PlanDisplayName = lineItem.DisplayName
+		}
+
 		if item.PeriodStart != nil {
 			lineItem.PeriodStart = pdf.CustomTime{Time: *item.PeriodStart}
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of empty subscription names and descriptions in invoice PDFs in `default.typ` and `invoice.go`.
> 
>   - **Behavior**:
>     - In `default.typ`, if `item.description` is empty, it defaults to `"-"` instead of `"Recurring"`.
>     - In `invoice.go`, if `lineItem.PlanDisplayName` is empty, it defaults to `lineItem.DisplayName` in `getInvoiceDataForPDFGen()`.
>   - **Misc**:
>     - Minor logic adjustments in `default.typ` and `invoice.go` to handle empty values more gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8b0094f8405872c5bc1514be9e28651db8ab667c. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->