### PR TITLE
fix(consumer): set consumer to offset oldest

### DIFF
--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -1,19 +1,36 @@
 package kafka
 
 import (
+	"time"
+
 	"github.com/Shopify/sarama"
 	"github.com/flexprice/flexprice/internal/config"
 )
 
 func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
+	saramaConfig := sarama.NewConfig()
+	saramaConfig.Version = sarama.V2_1_0_0
+
+	// Configure client ID regardless of SASL
+	saramaConfig.ClientID = cfg.Kafka.ClientID
+
+	// Set consumer offset reset policy to ensure we don't miss messages
+	// "earliest" ensures that when a consumer starts with no initial offset or
+	// current offset is out of range, it will start from the earliest message
+	saramaConfig.Consumer.Offsets.Initial = sarama.OffsetOldest
+
+	// Enable auto commit to ensure offsets are committed regularly
+	saramaConfig.Consumer.Offsets.AutoCommit.Enable = true
+	saramaConfig.Consumer.Offsets.AutoCommit.Interval = 5000 * time.Millisecond // 5 seconds
+
+	// When rebalancing happens, use the last committed offset
+	saramaConfig.Consumer.Offsets.Retry.Max = 3
+
 	if !cfg.Kafka.UseSASL {
-		return nil
+		return saramaConfig
 	}
 
-	saramaConfig := sarama.NewConfig()
-
-	// default configs
-	saramaConfig.Version = sarama.V2_1_0_0
+	// SASL specific configs
 	saramaConfig.Net.SASL.Enable = true
 	saramaConfig.Net.TLS.Enable = true
 
@@ -21,7 +38,6 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 	saramaConfig.Net.SASL.Mechanism = cfg.Kafka.SASLMechanism
 	saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
 	saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
-	saramaConfig.ClientID = cfg.Kafka.ClientID
 
 	return saramaConfig
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set Kafka consumer offset to oldest and improve error handling and logging in `main.go` and `base.go`.
> 
>   - **Kafka Consumer Configuration**:
>     - Set `saramaConfig.Consumer.Offsets.Initial` to `sarama.OffsetOldest` in `GetSaramaConfig()` in `base.go` to start consuming from the earliest message if no offset is set.
>     - Enable auto commit of offsets every 5 seconds.
>   - **Error Handling**:
>     - Introduced `shouldRetry()` in `main.go` to determine if an error is transient and should trigger a message retry.
>     - Added `recordDeadLetterMessage()` in `main.go` to log and capture non-retriable errors in Sentry.
>   - **Logging Enhancements**:
>     - Added logs for successful message processing and subscription in `consumeMessages()` in `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d3c1067cd1adc9c3930e9f0485d9deaa8d1f49ff. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->