### PR TITLE
fix(meters): parse price id in case of NEVER reset feature

### DIFF
--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -147,6 +147,9 @@ func (s *eventService) GetUsageByMeter(ctx context.Context, req *dto.GetUsageByM
 			return nil, err
 		}
 
+		historicUsage.PriceID = req.PriceID
+		historicUsage.MeterID = req.MeterID
+
 		return s.combineResults(historicUsage, usage, m), nil
 	}
 	return usage, nil
@@ -369,6 +372,8 @@ func (s *eventService) combineResults(historicUsage, currentUsage *events.Aggreg
 	}
 
 	return &events.AggregationResult{
+		PriceID:   historicUsage.PriceID,
+		MeterID:   historicUsage.MeterID,
 		Value:     totalValue,
 		Results:   currentUsage.Results,
 		EventName: m.EventName,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure `PriceID` and `MeterID` are set in `AggregationResult` for `NEVER` reset usage in `event.go`.
> 
>   - **Behavior**:
>     - In `GetUsageByMeter` in `event.go`, set `PriceID` and `MeterID` in `historicUsage` when `ResetUsage` is `NEVER`.
>     - In `combineResults` in `event.go`, ensure `PriceID` and `MeterID` are included in the returned `AggregationResult`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 1cacdd8bc6cfc18cafb89c8e06657c20b61efa73. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->