### PR TITLE
feat(subscription): allow price override while creation

### DIFF
--- a/docs/prds/subscription-overrides.md
+++ b/docs/prds/subscription-overrides.md
@@ -1,0 +1,203 @@
+# Subscription Price Overrides - Technical Requirements Document
+
+## 1. Overview
+
+### 1.1 Purpose
+This document outlines the technical requirements for implementing price overrides in the subscription creation flow. This feature will allow customers to customize pricing on a per-subscription basis, enabling flexible pricing strategies while maintaining the core plan structure.
+
+### 1.2 Problem Statement
+Currently, all subscriptions created from a plan inherit the exact same pricing structure. Businesses need the flexibility to offer custom pricing for specific customers without creating entirely new plans for each pricing variation.
+
+### 1.3 Proposed Solution
+Implement a price override mechanism that allows creation of subscription-specific prices that override the default plan prices. These overridden prices will be stored as separate entities with links to their parent prices, ensuring proper tracking and audit capabilities.
+
+## 2. Data Model Changes
+
+### 2.1 Price Schema Updates
+
+Update the `Price` entity in both Ent schema and domain model:
+
+#### 2.1.1 New Columns
+| Column | Type | Description |
+|--------|------|-------------|
+| `scope` | `enum('PLAN','SUBSCRIPTION')` | Indicates if price is a plan default or subscription override |
+| `parent_price_id` | `varchar(50)` FK → `prices.id` | References the original price (only set when `scope='SUBSCRIPTION'`) |
+| `subscription_id` | `varchar(50)` FK nullable | References the subscription (only set when `scope='SUBSCRIPTION'`) |
+
+#### 2.1.2 Schema Implementation Notes
+- All existing prices will be marked with `scope='PLAN'`
+- `parent_price_id` and `subscription_id` will be `NULL` for plan prices
+- For subscription-scoped prices, all fields except the overridden values will be copied from the parent price
+- All prices, regardless of scope, will be immutable after creation
+
+### 2.2 Migration Strategy
+1. Add the new columns to the Prices table
+2. Update existing prices to have `scope='PLAN'`
+3. Add appropriate indexes for efficient lookups
+
+## 3. API Changes
+
+### 3.1 Subscription Creation API
+
+Add support for line item overrides in the subscription creation endpoint:
+
+```json
+{
+  "customer_id": "cust_123",
+  "plan_id": "plan_456",
+  // existing fields...
+
+  "override_line_items": [
+    {
+      "price_id": "price_base_usd",
+      "quantity": 10,
+      "amount": "8.00"
+    }
+  ]
+}
+```
+
+### 3.2 Override Line Items Schema
+- `price_id` (required): References the plan price to override
+- `quantity` (optional): Quantity for this line item
+- `amount` (optional): New price amount that overrides the original price
+
+## 4. Repository Layer Changes
+
+### 4.1 Price Repository Updates
+
+1. Update `List` and `ListAll` methods to filter by `scope` and handle subscription-specific queries
+2. Add a new method to create subscription-scoped price overrides
+3. Ensure appropriate caching strategies for both plan and subscription prices
+
+### 4.2 Query Changes
+
+When fetching prices:
+- Default behavior should be to fetch only `PLAN` scoped prices
+- Add support to fetch prices by subscription ID for subscription-scoped prices
+- Update price filters to include scope filtering
+
+## 5. Service Layer Changes
+
+### 5.1 Subscription Service Changes
+
+Update the `CreateSubscription` method to:
+1. Process the standard plan prices
+2. Process any override line items:
+   - For each override, create a clone of the original price with modified values
+   - Set the appropriate scope and reference fields
+   - Include these subscription-scoped prices in the subscription line items
+
+### 5.2 Price Service Changes
+
+1. Update methods to ensure they maintain the scope separation
+2. Add support for creating derived subscription-scoped prices
+3. Ensure price calculations properly consider overridden values
+
+## 6. Business Logic Implementation
+
+### 6.1 Price Override Flow
+
+1. Customer selects a plan
+2. Optional: Customer provides overrides for specific prices
+3. System creates subscription with standard plan prices
+4. For any overridden prices:
+   - System creates subscription-scoped price clones
+   - These clones reference both the parent price and the subscription
+   - Subscription line items reference these new prices instead of the originals
+
+### 6.2 Comparison Logic
+
+When determining if a price has been overridden:
+- Check if there's a subscription-scoped price with matching `parent_price_id`
+- Compare relevant fields (amount, etc.) to identify specific differences
+
+## 7. Edge Cases and Considerations
+
+### 7.1 Partial Updates and Validation
+
+- Validate that overridden prices only modify allowed fields
+- Ensure currency matches between original and overridden prices
+- Verify the original price exists and is valid for overriding
+
+### 7.2 Reporting and Analytics
+
+- Consider impact on reporting when prices are overridden
+- Ensure data aggregations account for both plan and subscription-scoped prices
+- Provide traceability for auditing price changes
+
+### 7.3 Invoice and Billing Considerations
+
+- Ensure invoicing logic properly handles subscription-specific prices
+- Update billing calculation to use overridden prices when available
+- Verify that preview invoices reflect the correct overridden values
+
+### 7.4 Subscription Changes
+
+- Define behavior when a subscription with custom pricing is modified
+- Determine policy for price overrides during plan changes or upgrades
+- Consider version control for price changes over time
+
+## 8. Migration and Backward Compatibility
+
+### 8.1 Existing Data
+
+- Ensure existing subscriptions continue to function with plan-scoped prices
+- Validate that existing price queries aren't affected by the scope changes
+- Add appropriate database constraints to maintain data integrity
+
+### 8.2 API Compatibility
+
+- Maintain backward compatibility for existing API consumers
+- Document the new override capabilities clearly
+- Consider versioning strategy for the enhanced endpoints
+
+## 9. Testing Strategy
+
+### 9.1 Test Cases
+
+1. Create subscription with no overrides (baseline)
+2. Create subscription with price amount overrides
+3. Attempt invalid overrides (mismatched currencies, etc.)
+4. Verify invoice generation with overridden prices
+5. Test subscription modification with overridden prices
+6. Ensure billing calculations correctly use overridden values
+
+### 9.2 Performance Testing
+
+- Measure impact of price scope filtering on query performance
+- Verify caching strategies work effectively with the new model
+- Test with large numbers of subscription-specific prices
+
+## 10. Implementation Phases
+
+### 10.1 Phase 1 - Core Schema Changes
+- Add new columns to the price table
+- Update repositories to handle the scope filtering
+- Migrate existing data
+
+### 10.2 Phase 2 - Override Functionality
+- Implement subscription creation with override_line_items
+- Add price cloning logic
+- Update affected services
+
+### 10.3 Phase 3 - Testing and Refinement
+- Comprehensive testing of all scenarios
+- Performance tuning
+- Documentation updates
+
+## 11. Dependencies and Impacts
+
+### 11.1 Services Impacted
+- Subscription service
+- Price service
+- Billing service
+- Invoice service
+
+### 11.2 API Endpoints Affected
+- `POST /subscriptions` (create subscription)
+- `GET /prices` (when filtering by plan)
+
+## 12. Summary
+
+The subscription price override feature provides much-needed flexibility for custom pricing while maintaining the structure and organization of the plan-based subscription model. By carefully separating plan-scoped and subscription-scoped prices, we can implement this feature with minimal disruption to existing functionality while enabling powerful new business capabilities. 

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -702,6 +702,9 @@ var (
 		{Name: "lookup_key", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "description", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true},
+		{Name: "scope", Type: field.TypeString, Default: "PLAN", SchemaType: map[string]string{"postgres": "varchar(20)"}},
+		{Name: "parent_price_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
 	// PricesTable holds the schema information for the "prices" table.
 	PricesTable = &schema.Table{
@@ -721,6 +724,16 @@ var (
 				Name:    "price_tenant_id_environment_id",
 				Unique:  false,
 				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7]},
+			},
+			{
+				Name:    "price_tenant_id_environment_id_scope_subscription_id",
+				Unique:  false,
+				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[27], PricesColumns[29]},
+			},
+			{
+				Name:    "price_tenant_id_environment_id_scope_plan_id",
+				Unique:  false,
+				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[27], PricesColumns[11]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -17673,6 +17673,9 @@ type PriceMutation struct {
 	lookup_key              *string
 	description             *string
 	metadata                *map[string]string
+	scope                   *types.PriceScope
+	parent_price_id         *string
+	subscription_id         *string
 	clearedFields           map[string]struct{}
 	done                    bool
 	oldValue                func(context.Context) (*Price, error)
@@ -18951,6 +18954,140 @@ func (m *PriceMutation) ResetMetadata() {
 	delete(m.clearedFields, price.FieldMetadata)
 }
 
+// SetScope sets the "scope" field.
+func (m *PriceMutation) SetScope(ts types.PriceScope) {
+	m.scope = &ts
+}
+
+// Scope returns the value of the "scope" field in the mutation.
+func (m *PriceMutation) Scope() (r types.PriceScope, exists bool) {
+	v := m.scope
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldScope returns the old "scope" field's value of the Price entity.
+// If the Price object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PriceMutation) OldScope(ctx context.Context) (v types.PriceScope, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldScope is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldScope requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldScope: %w", err)
+	}
+	return oldValue.Scope, nil
+}
+
+// ResetScope resets all changes to the "scope" field.
+func (m *PriceMutation) ResetScope() {
+	m.scope = nil
+}
+
+// SetParentPriceID sets the "parent_price_id" field.
+func (m *PriceMutation) SetParentPriceID(s string) {
+	m.parent_price_id = &s
+}
+
+// ParentPriceID returns the value of the "parent_price_id" field in the mutation.
+func (m *PriceMutation) ParentPriceID() (r string, exists bool) {
+	v := m.parent_price_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldParentPriceID returns the old "parent_price_id" field's value of the Price entity.
+// If the Price object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PriceMutation) OldParentPriceID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldParentPriceID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldParentPriceID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldParentPriceID: %w", err)
+	}
+	return oldValue.ParentPriceID, nil
+}
+
+// ClearParentPriceID clears the value of the "parent_price_id" field.
+func (m *PriceMutation) ClearParentPriceID() {
+	m.parent_price_id = nil
+	m.clearedFields[price.FieldParentPriceID] = struct{}{}
+}
+
+// ParentPriceIDCleared returns if the "parent_price_id" field was cleared in this mutation.
+func (m *PriceMutation) ParentPriceIDCleared() bool {
+	_, ok := m.clearedFields[price.FieldParentPriceID]
+	return ok
+}
+
+// ResetParentPriceID resets all changes to the "parent_price_id" field.
+func (m *PriceMutation) ResetParentPriceID() {
+	m.parent_price_id = nil
+	delete(m.clearedFields, price.FieldParentPriceID)
+}
+
+// SetSubscriptionID sets the "subscription_id" field.
+func (m *PriceMutation) SetSubscriptionID(s string) {
+	m.subscription_id = &s
+}
+
+// SubscriptionID returns the value of the "subscription_id" field in the mutation.
+func (m *PriceMutation) SubscriptionID() (r string, exists bool) {
+	v := m.subscription_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSubscriptionID returns the old "subscription_id" field's value of the Price entity.
+// If the Price object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PriceMutation) OldSubscriptionID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSubscriptionID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSubscriptionID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSubscriptionID: %w", err)
+	}
+	return oldValue.SubscriptionID, nil
+}
+
+// ClearSubscriptionID clears the value of the "subscription_id" field.
+func (m *PriceMutation) ClearSubscriptionID() {
+	m.subscription_id = nil
+	m.clearedFields[price.FieldSubscriptionID] = struct{}{}
+}
+
+// SubscriptionIDCleared returns if the "subscription_id" field was cleared in this mutation.
+func (m *PriceMutation) SubscriptionIDCleared() bool {
+	_, ok := m.clearedFields[price.FieldSubscriptionID]
+	return ok
+}
+
+// ResetSubscriptionID resets all changes to the "subscription_id" field.
+func (m *PriceMutation) ResetSubscriptionID() {
+	m.subscription_id = nil
+	delete(m.clearedFields, price.FieldSubscriptionID)
+}
+
 // Where appends a list predicates to the PriceMutation builder.
 func (m *PriceMutation) Where(ps ...predicate.Price) {
 	m.predicates = append(m.predicates, ps...)
@@ -18985,7 +19122,7 @@ func (m *PriceMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PriceMutation) Fields() []string {
-	fields := make([]string, 0, 26)
+	fields := make([]string, 0, 29)
 	if m.tenant_id != nil {
 		fields = append(fields, price.FieldTenantID)
 	}
@@ -19064,6 +19201,15 @@ func (m *PriceMutation) Fields() []string {
 	if m.metadata != nil {
 		fields = append(fields, price.FieldMetadata)
 	}
+	if m.scope != nil {
+		fields = append(fields, price.FieldScope)
+	}
+	if m.parent_price_id != nil {
+		fields = append(fields, price.FieldParentPriceID)
+	}
+	if m.subscription_id != nil {
+		fields = append(fields, price.FieldSubscriptionID)
+	}
 	return fields
 }
 
@@ -19124,6 +19270,12 @@ func (m *PriceMutation) Field(name string) (ent.Value, bool) {
 		return m.Description()
 	case price.FieldMetadata:
 		return m.Metadata()
+	case price.FieldScope:
+		return m.Scope()
+	case price.FieldParentPriceID:
+		return m.ParentPriceID()
+	case price.FieldSubscriptionID:
+		return m.SubscriptionID()
 	}
 	return nil, false
 }
@@ -19185,6 +19337,12 @@ func (m *PriceMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldDescription(ctx)
 	case price.FieldMetadata:
 		return m.OldMetadata(ctx)
+	case price.FieldScope:
+		return m.OldScope(ctx)
+	case price.FieldParentPriceID:
+		return m.OldParentPriceID(ctx)
+	case price.FieldSubscriptionID:
+		return m.OldSubscriptionID(ctx)
 	}
 	return nil, fmt.Errorf("unknown Price field %s", name)
 }
@@ -19376,6 +19534,27 @@ func (m *PriceMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetMetadata(v)
 		return nil
+	case price.FieldScope:
+		v, ok := value.(types.PriceScope)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetScope(v)
+		return nil
+	case price.FieldParentPriceID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetParentPriceID(v)
+		return nil
+	case price.FieldSubscriptionID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSubscriptionID(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Price field %s", name)
 }
@@ -19481,6 +19660,12 @@ func (m *PriceMutation) ClearedFields() []string {
 	if m.FieldCleared(price.FieldMetadata) {
 		fields = append(fields, price.FieldMetadata)
 	}
+	if m.FieldCleared(price.FieldParentPriceID) {
+		fields = append(fields, price.FieldParentPriceID)
+	}
+	if m.FieldCleared(price.FieldSubscriptionID) {
+		fields = append(fields, price.FieldSubscriptionID)
+	}
 	return fields
 }
 
@@ -19530,6 +19715,12 @@ func (m *PriceMutation) ClearField(name string) error {
 		return nil
 	case price.FieldMetadata:
 		m.ClearMetadata()
+		return nil
+	case price.FieldParentPriceID:
+		m.ClearParentPriceID()
+		return nil
+	case price.FieldSubscriptionID:
+		m.ClearSubscriptionID()
 		return nil
 	}
 	return fmt.Errorf("unknown Price nullable field %s", name)
@@ -19616,6 +19807,15 @@ func (m *PriceMutation) ResetField(name string) error {
 		return nil
 	case price.FieldMetadata:
 		m.ResetMetadata()
+		return nil
+	case price.FieldScope:
+		m.ResetScope()
+		return nil
+	case price.FieldParentPriceID:
+		m.ResetParentPriceID()
+		return nil
+	case price.FieldSubscriptionID:
+		m.ResetSubscriptionID()
 		return nil
 	}
 	return fmt.Errorf("unknown Price field %s", name)

--- a/ent/price.go
+++ b/ent/price.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/schema"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // Price is the model entity for the Price schema.
@@ -70,8 +71,14 @@ type Price struct {
 	// Description holds the value of the "description" field.
 	Description string `json:"description,omitempty"`
 	// Metadata holds the value of the "metadata" field.
-	Metadata     map[string]string `json:"metadata,omitempty"`
-	selectValues sql.SelectValues
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// Scope holds the value of the "scope" field.
+	Scope types.PriceScope `json:"scope,omitempty"`
+	// ParentPriceID holds the value of the "parent_price_id" field.
+	ParentPriceID *string `json:"parent_price_id,omitempty"`
+	// SubscriptionID holds the value of the "subscription_id" field.
+	SubscriptionID *string `json:"subscription_id,omitempty"`
+	selectValues   sql.SelectValues
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -85,7 +92,7 @@ func (*Price) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case price.FieldBillingPeriodCount, price.FieldTrialPeriod:
 			values[i] = new(sql.NullInt64)
-		case price.FieldID, price.FieldTenantID, price.FieldStatus, price.FieldCreatedBy, price.FieldUpdatedBy, price.FieldEnvironmentID, price.FieldCurrency, price.FieldDisplayAmount, price.FieldPlanID, price.FieldType, price.FieldBillingPeriod, price.FieldBillingModel, price.FieldBillingCadence, price.FieldInvoiceCadence, price.FieldMeterID, price.FieldTierMode, price.FieldLookupKey, price.FieldDescription:
+		case price.FieldID, price.FieldTenantID, price.FieldStatus, price.FieldCreatedBy, price.FieldUpdatedBy, price.FieldEnvironmentID, price.FieldCurrency, price.FieldDisplayAmount, price.FieldPlanID, price.FieldType, price.FieldBillingPeriod, price.FieldBillingModel, price.FieldBillingCadence, price.FieldInvoiceCadence, price.FieldMeterID, price.FieldTierMode, price.FieldLookupKey, price.FieldDescription, price.FieldScope, price.FieldParentPriceID, price.FieldSubscriptionID:
 			values[i] = new(sql.NullString)
 		case price.FieldCreatedAt, price.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -276,6 +283,26 @@ func (pr *Price) assignValues(columns []string, values []any) error {
 					return fmt.Errorf("unmarshal field metadata: %w", err)
 				}
 			}
+		case price.FieldScope:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field scope", values[i])
+			} else if value.Valid {
+				pr.Scope = types.PriceScope(value.String)
+			}
+		case price.FieldParentPriceID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field parent_price_id", values[i])
+			} else if value.Valid {
+				pr.ParentPriceID = new(string)
+				*pr.ParentPriceID = value.String
+			}
+		case price.FieldSubscriptionID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field subscription_id", values[i])
+			} else if value.Valid {
+				pr.SubscriptionID = new(string)
+				*pr.SubscriptionID = value.String
+			}
 		default:
 			pr.selectValues.Set(columns[i], values[i])
 		}
@@ -393,6 +420,19 @@ func (pr *Price) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("metadata=")
 	builder.WriteString(fmt.Sprintf("%v", pr.Metadata))
+	builder.WriteString(", ")
+	builder.WriteString("scope=")
+	builder.WriteString(fmt.Sprintf("%v", pr.Scope))
+	builder.WriteString(", ")
+	if v := pr.ParentPriceID; v != nil {
+		builder.WriteString("parent_price_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := pr.SubscriptionID; v != nil {
+		builder.WriteString("subscription_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/price/price.go
+++ b/ent/price/price.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 const (
@@ -65,6 +66,12 @@ const (
 	FieldDescription = "description"
 	// FieldMetadata holds the string denoting the metadata field in the database.
 	FieldMetadata = "metadata"
+	// FieldScope holds the string denoting the scope field in the database.
+	FieldScope = "scope"
+	// FieldParentPriceID holds the string denoting the parent_price_id field in the database.
+	FieldParentPriceID = "parent_price_id"
+	// FieldSubscriptionID holds the string denoting the subscription_id field in the database.
+	FieldSubscriptionID = "subscription_id"
 	// Table holds the table name of the price in the database.
 	Table = "prices"
 )
@@ -98,6 +105,9 @@ var Columns = []string{
 	FieldLookupKey,
 	FieldDescription,
 	FieldMetadata,
+	FieldScope,
+	FieldParentPriceID,
+	FieldSubscriptionID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -141,6 +151,8 @@ var (
 	BillingCadenceValidator func(string) error
 	// DefaultTrialPeriod holds the default value on creation for the "trial_period" field.
 	DefaultTrialPeriod int
+	// DefaultScope holds the default value on creation for the "scope" field.
+	DefaultScope types.PriceScope
 )
 
 // OrderOption defines the ordering options for the Price queries.
@@ -259,4 +271,19 @@ func ByLookupKey(opts ...sql.OrderTermOption) OrderOption {
 // ByDescription orders the results by the description field.
 func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
+}
+
+// ByScope orders the results by the scope field.
+func ByScope(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldScope, opts...).ToFunc()
+}
+
+// ByParentPriceID orders the results by the parent_price_id field.
+func ByParentPriceID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldParentPriceID, opts...).ToFunc()
+}
+
+// BySubscriptionID orders the results by the subscription_id field.
+func BySubscriptionID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSubscriptionID, opts...).ToFunc()
 }

--- a/ent/price/where.go
+++ b/ent/price/where.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent/predicate"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // ID filters vertices based on their ID field.
@@ -172,6 +173,22 @@ func LookupKey(v string) predicate.Price {
 // Description applies equality check predicate on the "description" field. It's identical to DescriptionEQ.
 func Description(v string) predicate.Price {
 	return predicate.Price(sql.FieldEQ(FieldDescription, v))
+}
+
+// Scope applies equality check predicate on the "scope" field. It's identical to ScopeEQ.
+func Scope(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldEQ(FieldScope, vc))
+}
+
+// ParentPriceID applies equality check predicate on the "parent_price_id" field. It's identical to ParentPriceIDEQ.
+func ParentPriceID(v string) predicate.Price {
+	return predicate.Price(sql.FieldEQ(FieldParentPriceID, v))
+}
+
+// SubscriptionID applies equality check predicate on the "subscription_id" field. It's identical to SubscriptionIDEQ.
+func SubscriptionID(v string) predicate.Price {
+	return predicate.Price(sql.FieldEQ(FieldSubscriptionID, v))
 }
 
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
@@ -1597,6 +1614,240 @@ func MetadataIsNil() predicate.Price {
 // MetadataNotNil applies the NotNil predicate on the "metadata" field.
 func MetadataNotNil() predicate.Price {
 	return predicate.Price(sql.FieldNotNull(FieldMetadata))
+}
+
+// ScopeEQ applies the EQ predicate on the "scope" field.
+func ScopeEQ(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldEQ(FieldScope, vc))
+}
+
+// ScopeNEQ applies the NEQ predicate on the "scope" field.
+func ScopeNEQ(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldNEQ(FieldScope, vc))
+}
+
+// ScopeIn applies the In predicate on the "scope" field.
+func ScopeIn(vs ...types.PriceScope) predicate.Price {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = string(vs[i])
+	}
+	return predicate.Price(sql.FieldIn(FieldScope, v...))
+}
+
+// ScopeNotIn applies the NotIn predicate on the "scope" field.
+func ScopeNotIn(vs ...types.PriceScope) predicate.Price {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = string(vs[i])
+	}
+	return predicate.Price(sql.FieldNotIn(FieldScope, v...))
+}
+
+// ScopeGT applies the GT predicate on the "scope" field.
+func ScopeGT(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldGT(FieldScope, vc))
+}
+
+// ScopeGTE applies the GTE predicate on the "scope" field.
+func ScopeGTE(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldGTE(FieldScope, vc))
+}
+
+// ScopeLT applies the LT predicate on the "scope" field.
+func ScopeLT(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldLT(FieldScope, vc))
+}
+
+// ScopeLTE applies the LTE predicate on the "scope" field.
+func ScopeLTE(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldLTE(FieldScope, vc))
+}
+
+// ScopeContains applies the Contains predicate on the "scope" field.
+func ScopeContains(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldContains(FieldScope, vc))
+}
+
+// ScopeHasPrefix applies the HasPrefix predicate on the "scope" field.
+func ScopeHasPrefix(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldHasPrefix(FieldScope, vc))
+}
+
+// ScopeHasSuffix applies the HasSuffix predicate on the "scope" field.
+func ScopeHasSuffix(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldHasSuffix(FieldScope, vc))
+}
+
+// ScopeEqualFold applies the EqualFold predicate on the "scope" field.
+func ScopeEqualFold(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldEqualFold(FieldScope, vc))
+}
+
+// ScopeContainsFold applies the ContainsFold predicate on the "scope" field.
+func ScopeContainsFold(v types.PriceScope) predicate.Price {
+	vc := string(v)
+	return predicate.Price(sql.FieldContainsFold(FieldScope, vc))
+}
+
+// ParentPriceIDEQ applies the EQ predicate on the "parent_price_id" field.
+func ParentPriceIDEQ(v string) predicate.Price {
+	return predicate.Price(sql.FieldEQ(FieldParentPriceID, v))
+}
+
+// ParentPriceIDNEQ applies the NEQ predicate on the "parent_price_id" field.
+func ParentPriceIDNEQ(v string) predicate.Price {
+	return predicate.Price(sql.FieldNEQ(FieldParentPriceID, v))
+}
+
+// ParentPriceIDIn applies the In predicate on the "parent_price_id" field.
+func ParentPriceIDIn(vs ...string) predicate.Price {
+	return predicate.Price(sql.FieldIn(FieldParentPriceID, vs...))
+}
+
+// ParentPriceIDNotIn applies the NotIn predicate on the "parent_price_id" field.
+func ParentPriceIDNotIn(vs ...string) predicate.Price {
+	return predicate.Price(sql.FieldNotIn(FieldParentPriceID, vs...))
+}
+
+// ParentPriceIDGT applies the GT predicate on the "parent_price_id" field.
+func ParentPriceIDGT(v string) predicate.Price {
+	return predicate.Price(sql.FieldGT(FieldParentPriceID, v))
+}
+
+// ParentPriceIDGTE applies the GTE predicate on the "parent_price_id" field.
+func ParentPriceIDGTE(v string) predicate.Price {
+	return predicate.Price(sql.FieldGTE(FieldParentPriceID, v))
+}
+
+// ParentPriceIDLT applies the LT predicate on the "parent_price_id" field.
+func ParentPriceIDLT(v string) predicate.Price {
+	return predicate.Price(sql.FieldLT(FieldParentPriceID, v))
+}
+
+// ParentPriceIDLTE applies the LTE predicate on the "parent_price_id" field.
+func ParentPriceIDLTE(v string) predicate.Price {
+	return predicate.Price(sql.FieldLTE(FieldParentPriceID, v))
+}
+
+// ParentPriceIDContains applies the Contains predicate on the "parent_price_id" field.
+func ParentPriceIDContains(v string) predicate.Price {
+	return predicate.Price(sql.FieldContains(FieldParentPriceID, v))
+}
+
+// ParentPriceIDHasPrefix applies the HasPrefix predicate on the "parent_price_id" field.
+func ParentPriceIDHasPrefix(v string) predicate.Price {
+	return predicate.Price(sql.FieldHasPrefix(FieldParentPriceID, v))
+}
+
+// ParentPriceIDHasSuffix applies the HasSuffix predicate on the "parent_price_id" field.
+func ParentPriceIDHasSuffix(v string) predicate.Price {
+	return predicate.Price(sql.FieldHasSuffix(FieldParentPriceID, v))
+}
+
+// ParentPriceIDIsNil applies the IsNil predicate on the "parent_price_id" field.
+func ParentPriceIDIsNil() predicate.Price {
+	return predicate.Price(sql.FieldIsNull(FieldParentPriceID))
+}
+
+// ParentPriceIDNotNil applies the NotNil predicate on the "parent_price_id" field.
+func ParentPriceIDNotNil() predicate.Price {
+	return predicate.Price(sql.FieldNotNull(FieldParentPriceID))
+}
+
+// ParentPriceIDEqualFold applies the EqualFold predicate on the "parent_price_id" field.
+func ParentPriceIDEqualFold(v string) predicate.Price {
+	return predicate.Price(sql.FieldEqualFold(FieldParentPriceID, v))
+}
+
+// ParentPriceIDContainsFold applies the ContainsFold predicate on the "parent_price_id" field.
+func ParentPriceIDContainsFold(v string) predicate.Price {
+	return predicate.Price(sql.FieldContainsFold(FieldParentPriceID, v))
+}
+
+// SubscriptionIDEQ applies the EQ predicate on the "subscription_id" field.
+func SubscriptionIDEQ(v string) predicate.Price {
+	return predicate.Price(sql.FieldEQ(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDNEQ applies the NEQ predicate on the "subscription_id" field.
+func SubscriptionIDNEQ(v string) predicate.Price {
+	return predicate.Price(sql.FieldNEQ(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDIn applies the In predicate on the "subscription_id" field.
+func SubscriptionIDIn(vs ...string) predicate.Price {
+	return predicate.Price(sql.FieldIn(FieldSubscriptionID, vs...))
+}
+
+// SubscriptionIDNotIn applies the NotIn predicate on the "subscription_id" field.
+func SubscriptionIDNotIn(vs ...string) predicate.Price {
+	return predicate.Price(sql.FieldNotIn(FieldSubscriptionID, vs...))
+}
+
+// SubscriptionIDGT applies the GT predicate on the "subscription_id" field.
+func SubscriptionIDGT(v string) predicate.Price {
+	return predicate.Price(sql.FieldGT(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDGTE applies the GTE predicate on the "subscription_id" field.
+func SubscriptionIDGTE(v string) predicate.Price {
+	return predicate.Price(sql.FieldGTE(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDLT applies the LT predicate on the "subscription_id" field.
+func SubscriptionIDLT(v string) predicate.Price {
+	return predicate.Price(sql.FieldLT(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDLTE applies the LTE predicate on the "subscription_id" field.
+func SubscriptionIDLTE(v string) predicate.Price {
+	return predicate.Price(sql.FieldLTE(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDContains applies the Contains predicate on the "subscription_id" field.
+func SubscriptionIDContains(v string) predicate.Price {
+	return predicate.Price(sql.FieldContains(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDHasPrefix applies the HasPrefix predicate on the "subscription_id" field.
+func SubscriptionIDHasPrefix(v string) predicate.Price {
+	return predicate.Price(sql.FieldHasPrefix(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDHasSuffix applies the HasSuffix predicate on the "subscription_id" field.
+func SubscriptionIDHasSuffix(v string) predicate.Price {
+	return predicate.Price(sql.FieldHasSuffix(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDIsNil applies the IsNil predicate on the "subscription_id" field.
+func SubscriptionIDIsNil() predicate.Price {
+	return predicate.Price(sql.FieldIsNull(FieldSubscriptionID))
+}
+
+// SubscriptionIDNotNil applies the NotNil predicate on the "subscription_id" field.
+func SubscriptionIDNotNil() predicate.Price {
+	return predicate.Price(sql.FieldNotNull(FieldSubscriptionID))
+}
+
+// SubscriptionIDEqualFold applies the EqualFold predicate on the "subscription_id" field.
+func SubscriptionIDEqualFold(v string) predicate.Price {
+	return predicate.Price(sql.FieldEqualFold(FieldSubscriptionID, v))
+}
+
+// SubscriptionIDContainsFold applies the ContainsFold predicate on the "subscription_id" field.
+func SubscriptionIDContainsFold(v string) predicate.Price {
+	return predicate.Price(sql.FieldContainsFold(FieldSubscriptionID, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/ent/price_create.go
+++ b/ent/price_create.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/schema"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // PriceCreate is the builder for creating a Price entity.
@@ -281,6 +282,48 @@ func (pc *PriceCreate) SetMetadata(m map[string]string) *PriceCreate {
 	return pc
 }
 
+// SetScope sets the "scope" field.
+func (pc *PriceCreate) SetScope(ts types.PriceScope) *PriceCreate {
+	pc.mutation.SetScope(ts)
+	return pc
+}
+
+// SetNillableScope sets the "scope" field if the given value is not nil.
+func (pc *PriceCreate) SetNillableScope(ts *types.PriceScope) *PriceCreate {
+	if ts != nil {
+		pc.SetScope(*ts)
+	}
+	return pc
+}
+
+// SetParentPriceID sets the "parent_price_id" field.
+func (pc *PriceCreate) SetParentPriceID(s string) *PriceCreate {
+	pc.mutation.SetParentPriceID(s)
+	return pc
+}
+
+// SetNillableParentPriceID sets the "parent_price_id" field if the given value is not nil.
+func (pc *PriceCreate) SetNillableParentPriceID(s *string) *PriceCreate {
+	if s != nil {
+		pc.SetParentPriceID(*s)
+	}
+	return pc
+}
+
+// SetSubscriptionID sets the "subscription_id" field.
+func (pc *PriceCreate) SetSubscriptionID(s string) *PriceCreate {
+	pc.mutation.SetSubscriptionID(s)
+	return pc
+}
+
+// SetNillableSubscriptionID sets the "subscription_id" field if the given value is not nil.
+func (pc *PriceCreate) SetNillableSubscriptionID(s *string) *PriceCreate {
+	if s != nil {
+		pc.SetSubscriptionID(*s)
+	}
+	return pc
+}
+
 // SetID sets the "id" field.
 func (pc *PriceCreate) SetID(s string) *PriceCreate {
 	pc.mutation.SetID(s)
@@ -341,6 +384,10 @@ func (pc *PriceCreate) defaults() {
 	if _, ok := pc.mutation.TrialPeriod(); !ok {
 		v := price.DefaultTrialPeriod
 		pc.mutation.SetTrialPeriod(v)
+	}
+	if _, ok := pc.mutation.Scope(); !ok {
+		v := price.DefaultScope
+		pc.mutation.SetScope(v)
 	}
 }
 
@@ -432,6 +479,9 @@ func (pc *PriceCreate) check() error {
 	}
 	if _, ok := pc.mutation.TrialPeriod(); !ok {
 		return &ValidationError{Name: "trial_period", err: errors.New(`ent: missing required field "Price.trial_period"`)}
+	}
+	if _, ok := pc.mutation.Scope(); !ok {
+		return &ValidationError{Name: "scope", err: errors.New(`ent: missing required field "Price.scope"`)}
 	}
 	return nil
 }
@@ -571,6 +621,18 @@ func (pc *PriceCreate) createSpec() (*Price, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.Metadata(); ok {
 		_spec.SetField(price.FieldMetadata, field.TypeJSON, value)
 		_node.Metadata = value
+	}
+	if value, ok := pc.mutation.Scope(); ok {
+		_spec.SetField(price.FieldScope, field.TypeString, value)
+		_node.Scope = value
+	}
+	if value, ok := pc.mutation.ParentPriceID(); ok {
+		_spec.SetField(price.FieldParentPriceID, field.TypeString, value)
+		_node.ParentPriceID = &value
+	}
+	if value, ok := pc.mutation.SubscriptionID(); ok {
+		_spec.SetField(price.FieldSubscriptionID, field.TypeString, value)
+		_node.SubscriptionID = &value
 	}
 	return _node, _spec
 }

--- a/ent/price_update.go
+++ b/ent/price_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flexprice/flexprice/ent/predicate"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/schema"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // PriceUpdate is the builder for updating Price entities.
@@ -352,6 +353,60 @@ func (pu *PriceUpdate) ClearMetadata() *PriceUpdate {
 	return pu
 }
 
+// SetScope sets the "scope" field.
+func (pu *PriceUpdate) SetScope(ts types.PriceScope) *PriceUpdate {
+	pu.mutation.SetScope(ts)
+	return pu
+}
+
+// SetNillableScope sets the "scope" field if the given value is not nil.
+func (pu *PriceUpdate) SetNillableScope(ts *types.PriceScope) *PriceUpdate {
+	if ts != nil {
+		pu.SetScope(*ts)
+	}
+	return pu
+}
+
+// SetParentPriceID sets the "parent_price_id" field.
+func (pu *PriceUpdate) SetParentPriceID(s string) *PriceUpdate {
+	pu.mutation.SetParentPriceID(s)
+	return pu
+}
+
+// SetNillableParentPriceID sets the "parent_price_id" field if the given value is not nil.
+func (pu *PriceUpdate) SetNillableParentPriceID(s *string) *PriceUpdate {
+	if s != nil {
+		pu.SetParentPriceID(*s)
+	}
+	return pu
+}
+
+// ClearParentPriceID clears the value of the "parent_price_id" field.
+func (pu *PriceUpdate) ClearParentPriceID() *PriceUpdate {
+	pu.mutation.ClearParentPriceID()
+	return pu
+}
+
+// SetSubscriptionID sets the "subscription_id" field.
+func (pu *PriceUpdate) SetSubscriptionID(s string) *PriceUpdate {
+	pu.mutation.SetSubscriptionID(s)
+	return pu
+}
+
+// SetNillableSubscriptionID sets the "subscription_id" field if the given value is not nil.
+func (pu *PriceUpdate) SetNillableSubscriptionID(s *string) *PriceUpdate {
+	if s != nil {
+		pu.SetSubscriptionID(*s)
+	}
+	return pu
+}
+
+// ClearSubscriptionID clears the value of the "subscription_id" field.
+func (pu *PriceUpdate) ClearSubscriptionID() *PriceUpdate {
+	pu.mutation.ClearSubscriptionID()
+	return pu
+}
+
 // Mutation returns the PriceMutation object of the builder.
 func (pu *PriceUpdate) Mutation() *PriceMutation {
 	return pu.mutation
@@ -556,6 +611,21 @@ func (pu *PriceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if pu.mutation.MetadataCleared() {
 		_spec.ClearField(price.FieldMetadata, field.TypeJSON)
+	}
+	if value, ok := pu.mutation.Scope(); ok {
+		_spec.SetField(price.FieldScope, field.TypeString, value)
+	}
+	if value, ok := pu.mutation.ParentPriceID(); ok {
+		_spec.SetField(price.FieldParentPriceID, field.TypeString, value)
+	}
+	if pu.mutation.ParentPriceIDCleared() {
+		_spec.ClearField(price.FieldParentPriceID, field.TypeString)
+	}
+	if value, ok := pu.mutation.SubscriptionID(); ok {
+		_spec.SetField(price.FieldSubscriptionID, field.TypeString, value)
+	}
+	if pu.mutation.SubscriptionIDCleared() {
+		_spec.ClearField(price.FieldSubscriptionID, field.TypeString)
 	}
 	if n, err = sqlgraph.UpdateNodes(ctx, pu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
@@ -899,6 +969,60 @@ func (puo *PriceUpdateOne) ClearMetadata() *PriceUpdateOne {
 	return puo
 }
 
+// SetScope sets the "scope" field.
+func (puo *PriceUpdateOne) SetScope(ts types.PriceScope) *PriceUpdateOne {
+	puo.mutation.SetScope(ts)
+	return puo
+}
+
+// SetNillableScope sets the "scope" field if the given value is not nil.
+func (puo *PriceUpdateOne) SetNillableScope(ts *types.PriceScope) *PriceUpdateOne {
+	if ts != nil {
+		puo.SetScope(*ts)
+	}
+	return puo
+}
+
+// SetParentPriceID sets the "parent_price_id" field.
+func (puo *PriceUpdateOne) SetParentPriceID(s string) *PriceUpdateOne {
+	puo.mutation.SetParentPriceID(s)
+	return puo
+}
+
+// SetNillableParentPriceID sets the "parent_price_id" field if the given value is not nil.
+func (puo *PriceUpdateOne) SetNillableParentPriceID(s *string) *PriceUpdateOne {
+	if s != nil {
+		puo.SetParentPriceID(*s)
+	}
+	return puo
+}
+
+// ClearParentPriceID clears the value of the "parent_price_id" field.
+func (puo *PriceUpdateOne) ClearParentPriceID() *PriceUpdateOne {
+	puo.mutation.ClearParentPriceID()
+	return puo
+}
+
+// SetSubscriptionID sets the "subscription_id" field.
+func (puo *PriceUpdateOne) SetSubscriptionID(s string) *PriceUpdateOne {
+	puo.mutation.SetSubscriptionID(s)
+	return puo
+}
+
+// SetNillableSubscriptionID sets the "subscription_id" field if the given value is not nil.
+func (puo *PriceUpdateOne) SetNillableSubscriptionID(s *string) *PriceUpdateOne {
+	if s != nil {
+		puo.SetSubscriptionID(*s)
+	}
+	return puo
+}
+
+// ClearSubscriptionID clears the value of the "subscription_id" field.
+func (puo *PriceUpdateOne) ClearSubscriptionID() *PriceUpdateOne {
+	puo.mutation.ClearSubscriptionID()
+	return puo
+}
+
 // Mutation returns the PriceMutation object of the builder.
 func (puo *PriceUpdateOne) Mutation() *PriceMutation {
 	return puo.mutation
@@ -1133,6 +1257,21 @@ func (puo *PriceUpdateOne) sqlSave(ctx context.Context) (_node *Price, err error
 	}
 	if puo.mutation.MetadataCleared() {
 		_spec.ClearField(price.FieldMetadata, field.TypeJSON)
+	}
+	if value, ok := puo.mutation.Scope(); ok {
+		_spec.SetField(price.FieldScope, field.TypeString, value)
+	}
+	if value, ok := puo.mutation.ParentPriceID(); ok {
+		_spec.SetField(price.FieldParentPriceID, field.TypeString, value)
+	}
+	if puo.mutation.ParentPriceIDCleared() {
+		_spec.ClearField(price.FieldParentPriceID, field.TypeString)
+	}
+	if value, ok := puo.mutation.SubscriptionID(); ok {
+		_spec.SetField(price.FieldSubscriptionID, field.TypeString, value)
+	}
+	if puo.mutation.SubscriptionIDCleared() {
+		_spec.ClearField(price.FieldSubscriptionID, field.TypeString)
 	}
 	_node = &Price{config: puo.config}
 	_spec.Assign = _node.assignValues

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -30,6 +30,7 @@ import (
 	"github.com/flexprice/flexprice/ent/user"
 	"github.com/flexprice/flexprice/ent/wallet"
 	"github.com/flexprice/flexprice/ent/wallettransaction"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 )
 
@@ -681,6 +682,10 @@ func init() {
 	priceDescTrialPeriod := priceFields[11].Descriptor()
 	// price.DefaultTrialPeriod holds the default value on creation for the trial_period field.
 	price.DefaultTrialPeriod = priceDescTrialPeriod.Default.(int)
+	// priceDescScope is the schema descriptor for scope field.
+	priceDescScope := priceFields[20].Descriptor()
+	// price.DefaultScope holds the default value on creation for the scope field.
+	price.DefaultScope = types.PriceScope(priceDescScope.Default.(string))
 	secretMixin := schema.Secret{}.Mixin()
 	secretMixinFields0 := secretMixin[0].Fields()
 	_ = secretMixinFields0

--- a/ent/schema/price.go
+++ b/ent/schema/price.go
@@ -6,6 +6,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	baseMixin "github.com/flexprice/flexprice/ent/schema/mixin"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 )
 
@@ -108,6 +109,25 @@ func (Price) Fields() []ent.Field {
 			Optional(),
 		field.JSON("metadata", map[string]string{}).
 			Optional(),
+		// New fields for subscription price overrides
+		field.String("scope").
+			GoType(types.PriceScope(types.PriceScopePlan)).
+			SchemaType(map[string]string{
+				"postgres": "varchar(20)",
+			}).
+			Default(string(types.PriceScopePlan)), // Default to PLAN scope for all prices
+		field.String("parent_price_id").
+			SchemaType(map[string]string{
+				"postgres": "varchar(50)",
+			}).
+			Optional().
+			Nillable(), // Will be NULL for PLAN scoped prices
+		field.String("subscription_id").
+			SchemaType(map[string]string{
+				"postgres": "varchar(50)",
+			}).
+			Optional().
+			Nillable(), // Will be NULL for PLAN scoped prices
 	}
 }
 
@@ -123,6 +143,9 @@ func (Price) Indexes() []ent.Index {
 			Unique().
 			Annotations(entsql.IndexWhere("status = 'published' AND lookup_key IS NOT NULL AND lookup_key != ''")),
 		index.Fields("tenant_id", "environment_id"),
+		// New indexes for subscription price overrides
+		index.Fields("tenant_id", "environment_id", "scope", "subscription_id"),
+		index.Fields("tenant_id", "environment_id", "scope", "plan_id"),
 	}
 }
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// CreateSubscriptionRequest defines the request payload for creating a subscription.
 type CreateSubscriptionRequest struct {
 	CustomerID         string               `json:"customer_id" validate:"required"`
 	PlanID             string               `json:"plan_id" validate:"required"`
@@ -37,6 +38,15 @@ type CreateSubscriptionRequest struct {
 	BillingCycle types.BillingCycle `json:"billing_cycle"`
 	// Credit grants to be applied when subscription is created
 	CreditGrants []CreateCreditGrantRequest `json:"credit_grants,omitempty"`
+	// New field for subscription price overrides
+	OverrideLineItems []SubscriptionOverrideLineItem `json:"override_line_items,omitempty"`
+}
+
+// SubscriptionOverrideLineItem represents a line item with a price override for a subscription
+type SubscriptionOverrideLineItem struct {
+	PriceID  string          `json:"price_id" validate:"required"`
+	Quantity decimal.Decimal `json:"quantity,omitempty"`
+	Amount   decimal.Decimal `json:"amount,omitempty"`
 }
 
 type UpdateSubscriptionRequest struct {

--- a/internal/domain/price/model.go
+++ b/internal/domain/price/model.go
@@ -63,25 +63,30 @@ type Price struct {
 	// Note: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)
 	TrialPeriod int `db:"trial_period" json:"trial_period"`
 
-	TierMode types.BillingTier `db:"tier_mode" json:"tier_mode"`
+	TierMode types.BillingTier `db:"tier_mode" json:"tier_mode,omitempty"`
 
-	Tiers JSONBTiers `db:"tiers,jsonb" json:"tiers"`
+	Tiers JSONBTiers `db:"tiers" json:"tiers,omitempty"`
 
 	// MeterID is the id of the meter for usage based pricing
-	MeterID string `db:"meter_id" json:"meter_id"`
+	MeterID string `db:"meter_id" json:"meter_id,omitempty"`
 
 	// LookupKey used for looking up the price in the database
-	LookupKey string `db:"lookup_key" json:"lookup_key"`
+	LookupKey string `db:"lookup_key" json:"lookup_key,omitempty"`
 
 	// Description of the price
-	Description string `db:"description" json:"description"`
+	Description string `db:"description" json:"description,omitempty"`
 
-	TransformQuantity JSONBTransformQuantity `db:"transform_quantity,jsonb" json:"transform_quantity"`
+	TransformQuantity JSONBTransformQuantity `db:"transform_quantity" json:"transform_quantity,omitempty"`
 
-	Metadata JSONBMetadata `db:"metadata,jsonb" json:"metadata"`
+	Metadata JSONBMetadata `db:"metadata" json:"metadata,omitempty"`
 
 	// EnvironmentID is the environment identifier for the price
 	EnvironmentID string `db:"environment_id" json:"environment_id"`
+
+	// New fields for subscription price overrides
+	Scope          types.PriceScope `db:"scope" json:"scope"`
+	ParentPriceID  string           `db:"parent_price_id" json:"parent_price_id,omitempty"`
+	SubscriptionID string           `db:"subscription_id" json:"subscription_id,omitempty"`
 
 	types.BaseModel
 }
@@ -333,6 +338,9 @@ func FromEnt(e *ent.Price) *Price {
 		TransformQuantity:  JSONBTransformQuantity(e.TransformQuantity),
 		Metadata:           JSONBMetadata(e.Metadata),
 		EnvironmentID:      e.EnvironmentID,
+		Scope:              e.Scope,
+		ParentPriceID:      lo.FromPtr(e.ParentPriceID),
+		SubscriptionID:     lo.FromPtr(e.SubscriptionID),
 		BaseModel: types.BaseModel{
 			TenantID:  e.TenantID,
 			Status:    types.Status(e.Status),

--- a/internal/domain/price/repository.go
+++ b/internal/domain/price/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
 )
 
 // Repository defines the interface for price persistence operations
@@ -20,4 +21,14 @@ type Repository interface {
 	// Bulk operations
 	CreateBulk(ctx context.Context, prices []*Price) error
 	DeleteBulk(ctx context.Context, ids []string) error
+
+	// Subscription price override operations
+	CreateSubscriptionPriceOverride(ctx context.Context, override SubscriptionPriceOverride) (*Price, error)
+}
+
+// SubscriptionPriceOverride contains the necessary information to create a subscription-scoped price
+type SubscriptionPriceOverride struct {
+	OriginalPriceID string          // The ID of the original price to override
+	SubscriptionID  string          // The ID of the subscription
+	NewAmount       decimal.Decimal // The new amount for the override
 }

--- a/internal/types/price.go
+++ b/internal/types/price.go
@@ -21,6 +21,9 @@ type BillingTier string
 // PriceType is the type of the price ex USAGE, FIXED
 type PriceType string
 
+// PriceScope represents the scope of a price (plan or subscription specific)
+type PriceScope string
+
 const (
 	PRICE_TYPE_USAGE PriceType = "USAGE"
 	PRICE_TYPE_FIXED PriceType = "FIXED"
@@ -64,6 +67,12 @@ const (
 
 	// DEFAULT_FLOATING_PRECISION is the default floating point precision
 	DEFAULT_FLOATING_PRECISION = 2
+
+	// PriceScopePlan indicates the price is associated with a plan
+	PriceScopePlan PriceScope = "PLAN"
+
+	// PriceScopeSubscription indicates the price is a subscription-specific override
+	PriceScopeSubscription PriceScope = "SUBSCRIPTION"
 )
 
 func (b BillingCadence) Validate() error {
@@ -163,8 +172,10 @@ func (p PriceType) Validate() error {
 type PriceFilter struct {
 	*QueryFilter
 	*TimeRangeFilter
-	PlanIDs  []string `json:"plan_ids,omitempty" form:"plan_ids"`
-	PriceIDs []string `json:"price_ids,omitempty" form:"price_ids"`
+	PlanIDs        []string `json:"plan_ids,omitempty" form:"plan_ids"`
+	PriceIDs       []string `json:"price_ids,omitempty" form:"price_ids"`
+	Scope          *string  `json:"scope,omitempty" form:"scope"`
+	SubscriptionID *string  `json:"subscription_id,omitempty" form:"subscription_id"`
 }
 
 // NewPriceFilter creates a new PriceFilter with default values
@@ -222,6 +233,18 @@ func (f *PriceFilter) WithPlanIDs(planIDs []string) *PriceFilter {
 // WithPriceIDs adds price IDs to the filter
 func (f *PriceFilter) WithPriceIDs(priceIDs []string) *PriceFilter {
 	f.PriceIDs = priceIDs
+	return f
+}
+
+// WithScope sets the scope for the filter
+func (f *PriceFilter) WithScope(scope string) *PriceFilter {
+	f.Scope = lo.ToPtr(scope)
+	return f
+}
+
+// WithSubscriptionID sets the subscription ID for the filter
+func (f *PriceFilter) WithSubscriptionID(subscriptionID string) *PriceFilter {
+	f.SubscriptionID = lo.ToPtr(subscriptionID)
 	return f
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for subscription-specific price overrides, allowing custom pricing per subscription with new fields and methods across models, API, and services.
> 
>   - **Behavior**:
>     - Adds support for price overrides in subscription creation, allowing custom pricing per subscription.
>     - New fields `scope`, `parent_price_id`, and `subscription_id` added to `Price` entity to support overrides.
>     - Overrides are immutable and linked to parent prices for auditability.
>   - **API Changes**:
>     - `CreateSubscriptionRequest` in `subscription.go` now supports `override_line_items` for price overrides.
>   - **Repository**:
>     - `CreateSubscriptionPriceOverride` method added to `priceRepository` in `price.go` to handle creation of subscription-specific prices.
>     - Updates to `List` and `ListAll` methods to filter by `scope` and `subscription_id`.
>   - **Service Layer**:
>     - `CreateSubscription` in `subscription.go` updated to process price overrides and create subscription-scoped prices.
>     - New helper `GetSubscriptionPrices` to fetch prices for subscription line items.
>   - **Schema and Migration**:
>     - Updates to `schema/price.go` to include new fields and indexes for subscription price overrides.
>     - Migration strategy outlined in `subscription-overrides.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 09d2942070b7f65f0bf8e06c55fa6d9092b2a862. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->