### PR TITLE
Add LATEST Aggregator for Fetching Most Recent 'Property' Value

### DIFF
--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -405,10 +405,11 @@ func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsagePar
 
 	return fmt.Sprintf(`
         SELECT 
-            %s anyLast(value) as total
+            %s argMax(value, timestamp) as total
         FROM (
             SELECT
-                %s JSONExtractString(assumeNotNull(properties), '%s') as value
+                %s JSONExtractString(assumeNotNull(properties), '%s') as value,
+                timestamp
             FROM events
             PREWHERE tenant_id = '%s'
                 AND environment_id = '%s'
@@ -417,7 +418,7 @@ func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsagePar
                 %s
                 %s
                 %s
-            GROUP BY %s %s
+            GROUP BY %s, timestamp %s
         )
         %s
     `,

--- a/internal/types/aggregation.go
+++ b/internal/types/aggregation.go
@@ -9,11 +9,12 @@ const (
 	AggregationSum         AggregationType = "SUM"
 	AggregationAvg         AggregationType = "AVG"
 	AggregationCountUnique AggregationType = "COUNT_UNIQUE"
+	AggregationLatest      AggregationType = "LATEST"
 )
 
 func (t AggregationType) Validate() bool {
 	switch t {
-	case AggregationCount, AggregationSum, AggregationAvg, AggregationCountUnique:
+	case AggregationCount, AggregationSum, AggregationAvg, AggregationCountUnique, AggregationLatest:
 		return true
 	default:
 		return false


### PR DESCRIPTION
**Description-**

> This PR introduces a new aggregation type called LATEST, enabling retrieval of the most recent (latest) property value from events stored in ClickHouse. This feature is particularly useful for scenarios where tracking the most up-to-date information or state is required.


**Changes Made-**

> Defined a new aggregation type AggregationLatest within the types package.
> 
> Implemented the LatestAggregator struct and corresponding methods, particularly GetQuery, which uses ClickHouse's efficient argMax(value, timestamp) aggregation function.
> 
> Updated the GetAggregator factory method to include the new LatestAggregator.
> 
> Ensured validation logic within AggregationType.Validate() and AggregationType.RequiresField() correctly reflects the requirements for the new aggregation type.

**Usage-**
The LATEST aggregator can be utilized similarly to existing aggregators (COUNT, SUM, AVG, etc.) and supports optional time-windowed queries. It accurately returns the latest property value based on timestamps, with optional filtering by tenant, environment, customer IDs, and custom property filters.


argMax in GetQuery- 
> Events:
> timestamp           value
> 2024-03-20 10:00   100
> 2024-03-20 10:05   200
> 2024-03-20 10:02   150
> 
> anyLast(value) might return: any of 100, 150, or 200 (non-deterministic)
> argMax(value, timestamp) will return: 200 (guaranteed latest by timestamp)


**Testing-**

request-

> {
>     "name": "LATEST Feat",
>     "type": "metered",
>     "unit_singular": "unit",
>     "unit_plural": "units",
>     "meter": {
>         "aggregation": {
>             "type": "LATEST",
>             "field": "value"
>         },
>         "reset_usage": "BILLING_PERIOD",
>         "name": "LATEST Feat",
>         "filters": [],
>         "event_name": "latest_agg_feat"
>     }
> }
> 

response- 

> {
>     "id": "feat_01JYGBGXY16JCJ3D6QV06AE2R4",
>     "name": "LATEST Feat",
>     "lookup_key": "",
>     "description": "",
>     "meter_id": "meter_01JYGBGXSHKR50R3004FEJ9PQG",
>     "metadata": null,
>     "type": "metered",
>     "unit_singular": "unit",
>     "unit_plural": "units",
>     "environment_id": "env_01JQVJSC15DQW6T2RDRSF9BE1E",
>     "tenant_id": "00000000-0000-0000-0000-000000000000",
>     "status": "published",
>     "created_at": "2025-06-24T06:55:33.313212Z",
>     "updated_at": "2025-06-24T06:55:33.313212Z",
>     "created_by": "dde9a118-f186-45a6-969b-a9dab4590a75",
>     "updated_by": "dde9a118-f186-45a6-969b-a9dab4590a75"
> }

Get Feature by ID- {{baseUrl}}/features/feat_01JYGBGXY16JCJ3D6QV06AE2R4

> 
> {
>     "id": "feat_01JYGBGXY16JCJ3D6QV06AE2R4",
>     "name": "LATEST Feat",
>     "lookup_key": "",
>     "description": "",
>     "meter_id": "meter_01JYGBGXSHKR50R3004FEJ9PQG",
>     "metadata": null,
>     "type": "metered",
>     "unit_singular": "unit",
>     "unit_plural": "units",
>     "environment_id": "env_01JQVJSC15DQW6T2RDRSF9BE1E",
>     "tenant_id": "00000000-0000-0000-0000-000000000000",
>     "status": "published",
>     "created_at": "2025-06-24T06:55:33.313212Z",
>     "updated_at": "2025-06-24T06:55:33.313212Z",
>     "created_by": "dde9a118-f186-45a6-969b-a9dab4590a75",
>     "updated_by": "dde9a118-f186-45a6-969b-a9dab4590a75",
>     "meter": {
>         "id": "meter_01JYGBGXSHKR50R3004FEJ9PQG",
>         "name": "LATEST Feat",
>         "tenant_id": "00000000-0000-0000-0000-000000000000",
>         "event_name": "latest_agg_feat",
>         "aggregation": {
>             "type": "LATEST",
>             "field": "value"
>         },
>         "filters": [],
>         "reset_usage": "BILLING_PERIOD",
>         "created_at": "2025-06-24T06:55:33.169657Z",
>         "updated_at": "2025-06-24T06:55:33.169657Z",
>         "status": "published"
>     }
> }