### PR TITLE
fix(events): pull events desc for reprocessing

### DIFF
--- a/internal/service/event_post_processing.go
+++ b/internal/service/event_post_processing.go
@@ -1171,7 +1171,6 @@ func (s *eventPostProcessingService) ReprocessEvents(ctx context.Context, params
 		for _, event := range unprocessedEvents {
 			// hardcoded delay to avoid rate limiting
 			// TODO: remove this to make it configurable
-			time.Sleep(10 * time.Millisecond)
 			if err := s.PublishEvent(ctx, event, true); err != nil {
 				s.Logger.Errorw("failed to publish event for reprocessing",
 					"event_id", event.ID,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix event reprocessing by adjusting query logic and removing hardcoded delay.
> 
>   - **Repository Changes**:
>     - In `event.go`, change keyset pagination logic in `FindUnprocessedEvents()` to use descending order for `timestamp` and `id`.
>     - Remove partition pruning hint from `FindUnprocessedEvents()` query.
>   - **Service Changes**:
>     - In `event_post_processing.go`, remove hardcoded `time.Sleep(10 * time.Millisecond)` delay in `ReprocessEvents()`.
>   - **Misc**:
>     - Minor import cleanup in `event.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c626e67a18518aa93dcc49df5c30ae2235b9ae48. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->