### PR TITLE
fix(meter): map usage by price_id to avoid meter_id collision

### DIFF
--- a/docs/prds/costsheet.md
+++ b/docs/prds/costsheet.md
@@ -55,7 +55,6 @@ The cost sheet implementation follows a clean domain-driven design:
        Update(ctx context.Context, costsheet *Costsheet) error
        Delete(ctx context.Context, id string) error
        List(ctx context.Context, filter *Filter) ([]*Costsheet, error)
-       GetByMeterAndPrice(ctx context.Context, meterID, priceID string) (*Costsheet, error)
    }
    ```
 

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/subscription"
+	"github.com/flexprice/flexprice/ent/subscriptionlineitem"
 	"github.com/flexprice/flexprice/ent/subscriptionpause"
 	"github.com/flexprice/flexprice/internal/cache"
 	domainSub "github.com/flexprice/flexprice/internal/domain/subscription"
@@ -284,7 +285,9 @@ func (r *subscriptionRepository) List(ctx context.Context, filter *types.Subscri
 	client := r.client.Querier(ctx)
 	query := client.Subscription.Query()
 	if filter.WithLineItems {
-		query = query.WithLineItems()
+		query = query.WithLineItems(func(q *ent.SubscriptionLineItemQuery) {
+			q.Where(subscriptionlineitem.Status(string(types.StatusPublished)))
+		})
 	}
 
 	// Apply entity-specific filters
@@ -620,7 +623,9 @@ func (r *subscriptionRepository) GetWithLineItems(ctx context.Context, id string
 			subscription.TenantID(types.GetTenantID(ctx)),
 			subscription.Status(string(types.StatusPublished)),
 		).
-		WithLineItems().
+		WithLineItems(func(q *ent.SubscriptionLineItemQuery) {
+			q.Where(subscriptionlineitem.Status(string(types.StatusPublished)))
+		}).
 		Only(ctx)
 
 	if err != nil {
@@ -890,7 +895,9 @@ func (r *subscriptionRepository) ListByIDs(ctx context.Context, subscriptionIDs 
 	// we need to use a direct query instead of the List method
 	client := r.client.Querier(ctx)
 	query := client.Subscription.Query().
-		WithLineItems().
+		WithLineItems(func(q *ent.SubscriptionLineItemQuery) {
+			q.Where(subscriptionlineitem.Status(string(types.StatusPublished)))
+		}).
 		Where(
 			subscription.IDIn(subscriptionIDs...),
 			subscription.TenantID(types.GetTenantID(ctx)),

--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -268,7 +268,7 @@ func (s *eventService) BulkGetUsageByMeter(ctx context.Context, req []*dto.GetUs
 
 			// Safely store result in map
 			resultsMu.Lock()
-			results[meterID] = result
+			results[r.PriceID] = result
 			resultsMu.Unlock()
 
 			countMu.Lock()

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -749,7 +749,6 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 	for _, request := range meterUsageRequests {
 		meterID := request.MeterID
 		priceID := request.PriceID
-		// usage, ok := usageMap[meterID]
 		usage, ok := usageMap[priceID]
 
 		if !ok {

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -748,7 +748,10 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 	// TODO: should add validation to ensure that same subscription does not have multiple line items with the same meterID
 	for _, request := range meterUsageRequests {
 		meterID := request.MeterID
-		usage, ok := usageMap[meterID]
+		priceID := request.PriceID
+		// usage, ok := usageMap[meterID]
+		usage, ok := usageMap[priceID]
+
 		if !ok {
 			continue
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix meter calculation bug by removing `GetByMeterAndPrice` and updating cost sheet and subscription services to use `PriceID`.
> 
>   - **Repository Changes**:
>     - Remove `GetByMeterAndPrice` from `costsheet.go`, affecting how costsheets are retrieved by meter and price.
>     - Update `subscription.go` to filter line items by `StatusPublished` in `List`, `GetWithLineItems`, and `ListByIDs`.
>   - **Service Changes**:
>     - Modify `GetInputCostForMargin` in `costsheet.go` to use `PriceID` instead of `MeterID` for usage data.
>     - Update `BulkGetUsageByMeter` in `event.go` to store results by `PriceID` instead of `MeterID`.
>     - Adjust `GetUsageBySubscription` in `subscription.go` to map usage data by `PriceID`.
>   - **Miscellaneous**:
>     - Remove `GetByMeterAndPrice` from `costsheet.md` documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 64de97fd6cbaab5a95286582bb8af4ff55055880. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->