### PR TITLE
feat(payment): add recorded_at field to Payment entity

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -640,6 +640,7 @@ var (
 		{Name: "succeeded_at", Type: field.TypeTime, Nullable: true},
 		{Name: "failed_at", Type: field.TypeTime, Nullable: true},
 		{Name: "refunded_at", Type: field.TypeTime, Nullable: true},
+		{Name: "recorded_at", Type: field.TypeTime, Nullable: true},
 		{Name: "error_message", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "text"}},
 	}
 	// PaymentsTable holds the schema information for the "payments" table.

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -16316,6 +16316,7 @@ type PaymentMutation struct {
 	succeeded_at        *time.Time
 	failed_at           *time.Time
 	refunded_at         *time.Time
+	recorded_at         *time.Time
 	error_message       *string
 	clearedFields       map[string]struct{}
 	attempts            map[string]struct{}
@@ -17352,6 +17353,55 @@ func (m *PaymentMutation) ResetRefundedAt() {
 	delete(m.clearedFields, payment.FieldRefundedAt)
 }
 
+// SetRecordedAt sets the "recorded_at" field.
+func (m *PaymentMutation) SetRecordedAt(t time.Time) {
+	m.recorded_at = &t
+}
+
+// RecordedAt returns the value of the "recorded_at" field in the mutation.
+func (m *PaymentMutation) RecordedAt() (r time.Time, exists bool) {
+	v := m.recorded_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRecordedAt returns the old "recorded_at" field's value of the Payment entity.
+// If the Payment object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentMutation) OldRecordedAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRecordedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRecordedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRecordedAt: %w", err)
+	}
+	return oldValue.RecordedAt, nil
+}
+
+// ClearRecordedAt clears the value of the "recorded_at" field.
+func (m *PaymentMutation) ClearRecordedAt() {
+	m.recorded_at = nil
+	m.clearedFields[payment.FieldRecordedAt] = struct{}{}
+}
+
+// RecordedAtCleared returns if the "recorded_at" field was cleared in this mutation.
+func (m *PaymentMutation) RecordedAtCleared() bool {
+	_, ok := m.clearedFields[payment.FieldRecordedAt]
+	return ok
+}
+
+// ResetRecordedAt resets all changes to the "recorded_at" field.
+func (m *PaymentMutation) ResetRecordedAt() {
+	m.recorded_at = nil
+	delete(m.clearedFields, payment.FieldRecordedAt)
+}
+
 // SetErrorMessage sets the "error_message" field.
 func (m *PaymentMutation) SetErrorMessage(s string) {
 	m.error_message = &s
@@ -17489,7 +17539,7 @@ func (m *PaymentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PaymentMutation) Fields() []string {
-	fields := make([]string, 0, 23)
+	fields := make([]string, 0, 24)
 	if m.tenant_id != nil {
 		fields = append(fields, payment.FieldTenantID)
 	}
@@ -17556,6 +17606,9 @@ func (m *PaymentMutation) Fields() []string {
 	if m.refunded_at != nil {
 		fields = append(fields, payment.FieldRefundedAt)
 	}
+	if m.recorded_at != nil {
+		fields = append(fields, payment.FieldRecordedAt)
+	}
 	if m.error_message != nil {
 		fields = append(fields, payment.FieldErrorMessage)
 	}
@@ -17611,6 +17664,8 @@ func (m *PaymentMutation) Field(name string) (ent.Value, bool) {
 		return m.FailedAt()
 	case payment.FieldRefundedAt:
 		return m.RefundedAt()
+	case payment.FieldRecordedAt:
+		return m.RecordedAt()
 	case payment.FieldErrorMessage:
 		return m.ErrorMessage()
 	}
@@ -17666,6 +17721,8 @@ func (m *PaymentMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldFailedAt(ctx)
 	case payment.FieldRefundedAt:
 		return m.OldRefundedAt(ctx)
+	case payment.FieldRecordedAt:
+		return m.OldRecordedAt(ctx)
 	case payment.FieldErrorMessage:
 		return m.OldErrorMessage(ctx)
 	}
@@ -17831,6 +17888,13 @@ func (m *PaymentMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetRefundedAt(v)
 		return nil
+	case payment.FieldRecordedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRecordedAt(v)
+		return nil
 	case payment.FieldErrorMessage:
 		v, ok := value.(string)
 		if !ok {
@@ -17898,6 +17962,9 @@ func (m *PaymentMutation) ClearedFields() []string {
 	if m.FieldCleared(payment.FieldRefundedAt) {
 		fields = append(fields, payment.FieldRefundedAt)
 	}
+	if m.FieldCleared(payment.FieldRecordedAt) {
+		fields = append(fields, payment.FieldRecordedAt)
+	}
 	if m.FieldCleared(payment.FieldErrorMessage) {
 		fields = append(fields, payment.FieldErrorMessage)
 	}
@@ -17944,6 +18011,9 @@ func (m *PaymentMutation) ClearField(name string) error {
 		return nil
 	case payment.FieldRefundedAt:
 		m.ClearRefundedAt()
+		return nil
+	case payment.FieldRecordedAt:
+		m.ClearRecordedAt()
 		return nil
 	case payment.FieldErrorMessage:
 		m.ClearErrorMessage()
@@ -18021,6 +18091,9 @@ func (m *PaymentMutation) ResetField(name string) error {
 		return nil
 	case payment.FieldRefundedAt:
 		m.ResetRefundedAt()
+		return nil
+	case payment.FieldRecordedAt:
+		m.ResetRecordedAt()
 		return nil
 	case payment.FieldErrorMessage:
 		m.ResetErrorMessage()

--- a/ent/payment.go
+++ b/ent/payment.go
@@ -63,6 +63,8 @@ type Payment struct {
 	FailedAt *time.Time `json:"failed_at,omitempty"`
 	// RefundedAt holds the value of the "refunded_at" field.
 	RefundedAt *time.Time `json:"refunded_at,omitempty"`
+	// RecordedAt holds the value of the "recorded_at" field.
+	RecordedAt *time.Time `json:"recorded_at,omitempty"`
 	// ErrorMessage holds the value of the "error_message" field.
 	ErrorMessage *string `json:"error_message,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -102,7 +104,7 @@ func (*Payment) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case payment.FieldID, payment.FieldTenantID, payment.FieldStatus, payment.FieldCreatedBy, payment.FieldUpdatedBy, payment.FieldEnvironmentID, payment.FieldIdempotencyKey, payment.FieldDestinationType, payment.FieldDestinationID, payment.FieldPaymentMethodType, payment.FieldPaymentMethodID, payment.FieldPaymentGateway, payment.FieldGatewayPaymentID, payment.FieldCurrency, payment.FieldPaymentStatus, payment.FieldErrorMessage:
 			values[i] = new(sql.NullString)
-		case payment.FieldCreatedAt, payment.FieldUpdatedAt, payment.FieldSucceededAt, payment.FieldFailedAt, payment.FieldRefundedAt:
+		case payment.FieldCreatedAt, payment.FieldUpdatedAt, payment.FieldSucceededAt, payment.FieldFailedAt, payment.FieldRefundedAt, payment.FieldRecordedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -264,6 +266,13 @@ func (pa *Payment) assignValues(columns []string, values []any) error {
 				pa.RefundedAt = new(time.Time)
 				*pa.RefundedAt = value.Time
 			}
+		case payment.FieldRecordedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field recorded_at", values[i])
+			} else if value.Valid {
+				pa.RecordedAt = new(time.Time)
+				*pa.RecordedAt = value.Time
+			}
 		case payment.FieldErrorMessage:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field error_message", values[i])
@@ -385,6 +394,11 @@ func (pa *Payment) String() string {
 	builder.WriteString(", ")
 	if v := pa.RefundedAt; v != nil {
 		builder.WriteString("refunded_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := pa.RecordedAt; v != nil {
+		builder.WriteString("recorded_at=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteString(", ")

--- a/ent/payment/payment.go
+++ b/ent/payment/payment.go
@@ -59,6 +59,8 @@ const (
 	FieldFailedAt = "failed_at"
 	// FieldRefundedAt holds the string denoting the refunded_at field in the database.
 	FieldRefundedAt = "refunded_at"
+	// FieldRecordedAt holds the string denoting the recorded_at field in the database.
+	FieldRecordedAt = "recorded_at"
 	// FieldErrorMessage holds the string denoting the error_message field in the database.
 	FieldErrorMessage = "error_message"
 	// EdgeAttempts holds the string denoting the attempts edge name in mutations.
@@ -99,6 +101,7 @@ var Columns = []string{
 	FieldSucceededAt,
 	FieldFailedAt,
 	FieldRefundedAt,
+	FieldRecordedAt,
 	FieldErrorMessage,
 }
 
@@ -252,6 +255,11 @@ func ByFailedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByRefundedAt orders the results by the refunded_at field.
 func ByRefundedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRefundedAt, opts...).ToFunc()
+}
+
+// ByRecordedAt orders the results by the recorded_at field.
+func ByRecordedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRecordedAt, opts...).ToFunc()
 }
 
 // ByErrorMessage orders the results by the error_message field.

--- a/ent/payment/where.go
+++ b/ent/payment/where.go
@@ -171,6 +171,11 @@ func RefundedAt(v time.Time) predicate.Payment {
 	return predicate.Payment(sql.FieldEQ(FieldRefundedAt, v))
 }
 
+// RecordedAt applies equality check predicate on the "recorded_at" field. It's identical to RecordedAtEQ.
+func RecordedAt(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldEQ(FieldRecordedAt, v))
+}
+
 // ErrorMessage applies equality check predicate on the "error_message" field. It's identical to ErrorMessageEQ.
 func ErrorMessage(v string) predicate.Payment {
 	return predicate.Payment(sql.FieldEQ(FieldErrorMessage, v))
@@ -1434,6 +1439,56 @@ func RefundedAtIsNil() predicate.Payment {
 // RefundedAtNotNil applies the NotNil predicate on the "refunded_at" field.
 func RefundedAtNotNil() predicate.Payment {
 	return predicate.Payment(sql.FieldNotNull(FieldRefundedAt))
+}
+
+// RecordedAtEQ applies the EQ predicate on the "recorded_at" field.
+func RecordedAtEQ(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldEQ(FieldRecordedAt, v))
+}
+
+// RecordedAtNEQ applies the NEQ predicate on the "recorded_at" field.
+func RecordedAtNEQ(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldNEQ(FieldRecordedAt, v))
+}
+
+// RecordedAtIn applies the In predicate on the "recorded_at" field.
+func RecordedAtIn(vs ...time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldIn(FieldRecordedAt, vs...))
+}
+
+// RecordedAtNotIn applies the NotIn predicate on the "recorded_at" field.
+func RecordedAtNotIn(vs ...time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldNotIn(FieldRecordedAt, vs...))
+}
+
+// RecordedAtGT applies the GT predicate on the "recorded_at" field.
+func RecordedAtGT(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldGT(FieldRecordedAt, v))
+}
+
+// RecordedAtGTE applies the GTE predicate on the "recorded_at" field.
+func RecordedAtGTE(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldGTE(FieldRecordedAt, v))
+}
+
+// RecordedAtLT applies the LT predicate on the "recorded_at" field.
+func RecordedAtLT(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldLT(FieldRecordedAt, v))
+}
+
+// RecordedAtLTE applies the LTE predicate on the "recorded_at" field.
+func RecordedAtLTE(v time.Time) predicate.Payment {
+	return predicate.Payment(sql.FieldLTE(FieldRecordedAt, v))
+}
+
+// RecordedAtIsNil applies the IsNil predicate on the "recorded_at" field.
+func RecordedAtIsNil() predicate.Payment {
+	return predicate.Payment(sql.FieldIsNull(FieldRecordedAt))
+}
+
+// RecordedAtNotNil applies the NotNil predicate on the "recorded_at" field.
+func RecordedAtNotNil() predicate.Payment {
+	return predicate.Payment(sql.FieldNotNull(FieldRecordedAt))
 }
 
 // ErrorMessageEQ applies the EQ predicate on the "error_message" field.

--- a/ent/payment_create.go
+++ b/ent/payment_create.go
@@ -266,6 +266,20 @@ func (pc *PaymentCreate) SetNillableRefundedAt(t *time.Time) *PaymentCreate {
 	return pc
 }
 
+// SetRecordedAt sets the "recorded_at" field.
+func (pc *PaymentCreate) SetRecordedAt(t time.Time) *PaymentCreate {
+	pc.mutation.SetRecordedAt(t)
+	return pc
+}
+
+// SetNillableRecordedAt sets the "recorded_at" field if the given value is not nil.
+func (pc *PaymentCreate) SetNillableRecordedAt(t *time.Time) *PaymentCreate {
+	if t != nil {
+		pc.SetRecordedAt(*t)
+	}
+	return pc
+}
+
 // SetErrorMessage sets the "error_message" field.
 func (pc *PaymentCreate) SetErrorMessage(s string) *PaymentCreate {
 	pc.mutation.SetErrorMessage(s)
@@ -552,6 +566,10 @@ func (pc *PaymentCreate) createSpec() (*Payment, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.RefundedAt(); ok {
 		_spec.SetField(payment.FieldRefundedAt, field.TypeTime, value)
 		_node.RefundedAt = &value
+	}
+	if value, ok := pc.mutation.RecordedAt(); ok {
+		_spec.SetField(payment.FieldRecordedAt, field.TypeTime, value)
+		_node.RecordedAt = &value
 	}
 	if value, ok := pc.mutation.ErrorMessage(); ok {
 		_spec.SetField(payment.FieldErrorMessage, field.TypeString, value)

--- a/ent/payment_update.go
+++ b/ent/payment_update.go
@@ -286,6 +286,26 @@ func (pu *PaymentUpdate) ClearRefundedAt() *PaymentUpdate {
 	return pu
 }
 
+// SetRecordedAt sets the "recorded_at" field.
+func (pu *PaymentUpdate) SetRecordedAt(t time.Time) *PaymentUpdate {
+	pu.mutation.SetRecordedAt(t)
+	return pu
+}
+
+// SetNillableRecordedAt sets the "recorded_at" field if the given value is not nil.
+func (pu *PaymentUpdate) SetNillableRecordedAt(t *time.Time) *PaymentUpdate {
+	if t != nil {
+		pu.SetRecordedAt(*t)
+	}
+	return pu
+}
+
+// ClearRecordedAt clears the value of the "recorded_at" field.
+func (pu *PaymentUpdate) ClearRecordedAt() *PaymentUpdate {
+	pu.mutation.ClearRecordedAt()
+	return pu
+}
+
 // SetErrorMessage sets the "error_message" field.
 func (pu *PaymentUpdate) SetErrorMessage(s string) *PaymentUpdate {
 	pu.mutation.SetErrorMessage(s)
@@ -497,6 +517,12 @@ func (pu *PaymentUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if pu.mutation.RefundedAtCleared() {
 		_spec.ClearField(payment.FieldRefundedAt, field.TypeTime)
+	}
+	if value, ok := pu.mutation.RecordedAt(); ok {
+		_spec.SetField(payment.FieldRecordedAt, field.TypeTime, value)
+	}
+	if pu.mutation.RecordedAtCleared() {
+		_spec.ClearField(payment.FieldRecordedAt, field.TypeTime)
 	}
 	if value, ok := pu.mutation.ErrorMessage(); ok {
 		_spec.SetField(payment.FieldErrorMessage, field.TypeString, value)
@@ -825,6 +851,26 @@ func (puo *PaymentUpdateOne) ClearRefundedAt() *PaymentUpdateOne {
 	return puo
 }
 
+// SetRecordedAt sets the "recorded_at" field.
+func (puo *PaymentUpdateOne) SetRecordedAt(t time.Time) *PaymentUpdateOne {
+	puo.mutation.SetRecordedAt(t)
+	return puo
+}
+
+// SetNillableRecordedAt sets the "recorded_at" field if the given value is not nil.
+func (puo *PaymentUpdateOne) SetNillableRecordedAt(t *time.Time) *PaymentUpdateOne {
+	if t != nil {
+		puo.SetRecordedAt(*t)
+	}
+	return puo
+}
+
+// ClearRecordedAt clears the value of the "recorded_at" field.
+func (puo *PaymentUpdateOne) ClearRecordedAt() *PaymentUpdateOne {
+	puo.mutation.ClearRecordedAt()
+	return puo
+}
+
 // SetErrorMessage sets the "error_message" field.
 func (puo *PaymentUpdateOne) SetErrorMessage(s string) *PaymentUpdateOne {
 	puo.mutation.SetErrorMessage(s)
@@ -1066,6 +1112,12 @@ func (puo *PaymentUpdateOne) sqlSave(ctx context.Context) (_node *Payment, err e
 	}
 	if puo.mutation.RefundedAtCleared() {
 		_spec.ClearField(payment.FieldRefundedAt, field.TypeTime)
+	}
+	if value, ok := puo.mutation.RecordedAt(); ok {
+		_spec.SetField(payment.FieldRecordedAt, field.TypeTime, value)
+	}
+	if puo.mutation.RecordedAtCleared() {
+		_spec.ClearField(payment.FieldRecordedAt, field.TypeTime)
 	}
 	if value, ok := puo.mutation.ErrorMessage(); ok {
 		_spec.SetField(payment.FieldErrorMessage, field.TypeString, value)

--- a/ent/schema/payment.go
+++ b/ent/schema/payment.go
@@ -102,6 +102,9 @@ func (Payment) Fields() []ent.Field {
 		field.Time("refunded_at").
 			Optional().
 			Nillable(),
+		field.Time("recorded_at").
+			Optional().
+			Nillable(),
 		field.String("error_message").
 			SchemaType(map[string]string{
 				"postgres": "text",

--- a/internal/domain/payment/model.go
+++ b/internal/domain/payment/model.go
@@ -12,39 +12,68 @@ import (
 
 // Payment represents a payment transaction
 type Payment struct {
-	ID                string                       `json:"id"`
-	IdempotencyKey    string                       `json:"idempotency_key"`
-	DestinationType   types.PaymentDestinationType `json:"destination_type"`
-	DestinationID     string                       `json:"destination_id"`
-	PaymentMethodType types.PaymentMethodType      `json:"payment_method_type"`
-	PaymentMethodID   string                       `json:"payment_method_id"`
-	PaymentGateway    *string                      `json:"payment_gateway,omitempty"`
-	GatewayPaymentID  *string                      `json:"gateway_payment_id,omitempty"`
-	Amount            decimal.Decimal              `json:"amount"`
-	Currency          string                       `json:"currency"`
-	PaymentStatus     types.PaymentStatus          `json:"payment_status"`
-	TrackAttempts     bool                         `json:"track_attempts"`
-	Metadata          types.Metadata               `json:"metadata,omitempty"`
-	SucceededAt       *time.Time                   `json:"succeeded_at,omitempty"`
-	FailedAt          *time.Time                   `json:"failed_at,omitempty"`
-	RefundedAt        *time.Time                   `json:"refunded_at,omitempty"`
-	ErrorMessage      *string                      `json:"error_message,omitempty"`
-	Attempts          []*PaymentAttempt            `json:"attempts,omitempty"`
-	EnvironmentID     string                       `json:"environment_id"`
+	// Unique identifier for this payment transaction
+	ID string `json:"id"`
+	// Unique key used in the idempotency_key field to prevent duplicate payment processing
+	IdempotencyKey string `json:"idempotency_key"`
+	// The destination_type indicates what entity this payment is being made to (invoice, subscription, etc.)
+	DestinationType types.PaymentDestinationType `json:"destination_type"`
+	// The destination_id specifies which specific entity is receiving this payment
+	DestinationID string `json:"destination_id"`
+	// The payment_method_type defines how the payment will be processed (credit_card, bank_transfer, offline, etc.)
+	PaymentMethodType types.PaymentMethodType `json:"payment_method_type"`
+	// The payment_method_id identifies which specific payment method to use for processing
+	PaymentMethodID string `json:"payment_method_id"`
+	// The payment_gateway field contains the name of the gateway used to process this transaction (optional)
+	PaymentGateway *string `json:"payment_gateway,omitempty"`
+	// The gateway_payment_id is the transaction identifier from the external payment gateway (optional)
+	GatewayPaymentID *string `json:"gateway_payment_id,omitempty"`
+	// The amount field specifies the payment value in the given currency
+	Amount decimal.Decimal `json:"amount"`
+	// The currency field uses a three-letter ISO code (USD, EUR, GBP, etc.)
+	Currency string `json:"currency"`
+	// The payment_status shows the current state of this payment (pending, succeeded, failed, etc.)
+	PaymentStatus types.PaymentStatus `json:"payment_status"`
+	// The track_attempts flag indicates whether payment processing attempts are being monitored
+	TrackAttempts bool `json:"track_attempts"`
+	// The metadata field contains additional custom key-value pairs for this payment (optional)
+	Metadata types.Metadata `json:"metadata,omitempty"`
+	// The succeeded_at timestamp shows when this payment was successfully completed (optional)
+	SucceededAt *time.Time `json:"succeeded_at,omitempty"`
+	// The failed_at timestamp indicates when this payment failed (optional)
+	FailedAt *time.Time `json:"failed_at,omitempty"`
+	// The refunded_at timestamp shows when this payment was refunded (optional)
+	RefundedAt *time.Time `json:"refunded_at,omitempty"`
+	// The recorded_at timestamp indicates when this payment was manually recorded (optional)
+	RecordedAt *time.Time `json:"recorded_at,omitempty"`
+	// The error_message field provides details about why the payment failed (optional)
+	ErrorMessage *string `json:"error_message,omitempty"`
+	// The attempts array contains all processing attempts made for this payment (optional)
+	Attempts []*PaymentAttempt `json:"attempts,omitempty"`
+	// The environment_id identifies which environment this payment belongs to
+	EnvironmentID string `json:"environment_id"`
 
 	types.BaseModel
 }
 
 // PaymentAttempt represents an attempt to process a payment
 type PaymentAttempt struct {
-	ID               string              `json:"id"`
-	PaymentID        string              `json:"payment_id"`
-	AttemptNumber    int                 `json:"attempt_number"`
-	PaymentStatus    types.PaymentStatus `json:"payment_status"`
-	GatewayAttemptID *string             `json:"gateway_attempt_id,omitempty"`
-	ErrorMessage     *string             `json:"error_message,omitempty"`
-	Metadata         types.Metadata      `json:"metadata,omitempty"`
-	EnvironmentID    string              `json:"environment_id"`
+	// Unique identifier for this specific payment attempt
+	ID string `json:"id"`
+	// The payment_id links this attempt to its parent payment transaction
+	PaymentID string `json:"payment_id"`
+	// The attempt_number shows the sequential order of this processing attempt
+	AttemptNumber int `json:"attempt_number"`
+	// The payment_status indicates the outcome of this specific attempt (pending, succeeded, failed, etc.)
+	PaymentStatus types.PaymentStatus `json:"payment_status"`
+	// The gateway_attempt_id is the identifier from the external payment gateway for this attempt (optional)
+	GatewayAttemptID *string `json:"gateway_attempt_id,omitempty"`
+	// The error_message field explains why this particular attempt failed (optional)
+	ErrorMessage *string `json:"error_message,omitempty"`
+	// The metadata field stores additional custom data for this attempt (optional)
+	Metadata types.Metadata `json:"metadata,omitempty"`
+	// The environment_id specifies which environment this attempt belongs to
+	EnvironmentID string `json:"environment_id"`
 
 	types.BaseModel
 }
@@ -141,6 +170,7 @@ func FromEnt(p *ent.Payment) *Payment {
 		SucceededAt:       p.SucceededAt,
 		FailedAt:          p.FailedAt,
 		RefundedAt:        p.RefundedAt,
+		RecordedAt:        p.RecordedAt,
 		ErrorMessage:      p.ErrorMessage,
 		EnvironmentID:     p.EnvironmentID,
 		BaseModel: types.BaseModel{

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -74,6 +74,7 @@ func (r *paymentRepository) Create(ctx context.Context, p *domainPayment.Payment
 		SetNillableFailedAt(p.FailedAt).
 		SetNillableRefundedAt(p.RefundedAt).
 		SetNillableErrorMessage(p.ErrorMessage).
+		SetNillableRecordedAt(p.RecordedAt).
 		SetTenantID(p.TenantID).
 		SetCreatedAt(p.CreatedAt).
 		SetUpdatedAt(p.UpdatedAt).
@@ -244,6 +245,7 @@ func (r *paymentRepository) Update(ctx context.Context, p *domainPayment.Payment
 		SetTrackAttempts(p.TrackAttempts).
 		SetMetadata(p.Metadata).
 		SetUpdatedAt(time.Now().UTC()).
+		SetNillableRecordedAt(p.RecordedAt).
 		SetNillableSucceededAt(p.SucceededAt).
 		SetNillableFailedAt(p.FailedAt).
 		SetNillableRefundedAt(p.RefundedAt).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `recorded_at` field to `Payment` entity schema, model, and repository handling.
> 
>   - **Schema**:
>     - Add `recorded_at` field to `Payment` schema in `ent/schema/payment.go`.
>     - Update `ent/migrate/schema.go` to include `recorded_at` in `PaymentsColumns`.
>   - **Model**:
>     - Add `RecordedAt` field to `Payment` struct in `ent/payment.go` and `internal/domain/payment/model.go`.
>     - Update `FromEnt` function in `internal/domain/payment/model.go` to map `recorded_at`.
>   - **Repository**:
>     - Update `Create`, `Update`, and `Get` methods in `internal/repository/ent/payment.go` to handle `recorded_at`.
>   - **Mutation and Query**:
>     - Add `SetRecordedAt`, `ClearRecordedAt`, and related methods in `ent/mutation.go`.
>     - Add predicates for `recorded_at` in `ent/payment/where.go`.
>     - Update `ent/payment_create.go` and `ent/payment_update.go` to include `recorded_at` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6f8cdb15bb9dfb2c9046e0c17550138059fa283f. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->