### PR TITLE
fix(webhook): add webhook for payment events

### DIFF
--- a/internal/webhook/dto/payment.go
+++ b/internal/webhook/dto/payment.go
@@ -1,0 +1,16 @@
+package webhookDto
+
+import "github.com/flexprice/flexprice/internal/api/dto"
+
+type InternalPaymentEvent struct {
+	PaymentID string `json:"payment_id"`
+	TenantID  string `json:"tenant_id"`
+}
+
+type PaymentWebhookPayload struct {
+	Payment *dto.PaymentResponse `json:"payment"`
+}
+
+func NewPaymentWebhookPayload(payment *dto.PaymentResponse) *PaymentWebhookPayload {
+	return &PaymentWebhookPayload{Payment: payment}
+}

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -48,6 +48,7 @@ func providePayloadBuilderFactory(
 	subscriptionService service.SubscriptionService,
 	walletService service.WalletService,
 	customerService service.CustomerService,
+	paymentService service.PaymentService,
 ) payload.PayloadBuilderFactory {
 	services := payload.NewServices(
 		invoiceService,
@@ -58,6 +59,7 @@ func providePayloadBuilderFactory(
 		subscriptionService,
 		walletService,
 		customerService,
+		paymentService,
 	)
 	return payload.NewPayloadBuilderFactory(services)
 }

--- a/internal/webhook/payload/factory.go
+++ b/internal/webhook/payload/factory.go
@@ -93,6 +93,24 @@ func NewPayloadBuilderFactory(services *Services) PayloadBuilderFactory {
 	f.builders[types.WebhookEventCustomerDeleted] = func() PayloadBuilder {
 		return NewCustomerPayloadBuilder(f.services)
 	}
+
+	// payment builders
+	f.builders[types.WebhookEventPaymentCreated] = func() PayloadBuilder {
+		return NewPaymentPayloadBuilder(f.services)
+	}
+	f.builders[types.WebhookEventPaymentUpdated] = func() PayloadBuilder {
+		return NewPaymentPayloadBuilder(f.services)
+	}
+	f.builders[types.WebhookEventPaymentFailed] = func() PayloadBuilder {
+		return NewPaymentPayloadBuilder(f.services)
+	}
+	f.builders[types.WebhookEventPaymentSuccess] = func() PayloadBuilder {
+		return NewPaymentPayloadBuilder(f.services)
+	}
+	f.builders[types.WebhookEventPaymentPending] = func() PayloadBuilder {
+		return NewPaymentPayloadBuilder(f.services)
+	}
+
 	return f
 }
 

--- a/internal/webhook/payload/payment.go
+++ b/internal/webhook/payload/payment.go
@@ -1,0 +1,49 @@
+package payload
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	webhookDto "github.com/flexprice/flexprice/internal/webhook/dto"
+)
+
+type PaymentPayloadBuilder struct {
+	services *Services
+}
+
+func NewPaymentPayloadBuilder(services *Services) PayloadBuilder {
+	return &PaymentPayloadBuilder{services: services}
+}
+
+func (b *PaymentPayloadBuilder) BuildPayload(ctx context.Context, eventType string, data json.RawMessage) (json.RawMessage, error) {
+	var parsedPayload webhookDto.InternalPaymentEvent
+
+	err := json.Unmarshal(data, &parsedPayload)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Unable to unmarshal payment event payload").
+			Mark(ierr.ErrInvalidOperation)
+	}
+
+	paymentID, tenantID := parsedPayload.PaymentID, parsedPayload.TenantID
+	if paymentID == "" || tenantID == "" {
+		return nil, ierr.NewError("invalid data type for payment event").
+			WithHint("Please provide a valid payment ID and tenant ID").
+			WithReportableDetails(map[string]any{
+				"expected": "string",
+				"got":      fmt.Sprintf("%T", data),
+			}).
+			Mark(ierr.ErrInvalidOperation)
+	}
+
+	payment, err := b.services.PaymentService.GetPayment(ctx, paymentID)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := webhookDto.NewPaymentWebhookPayload(payment)
+
+	return json.Marshal(payload)
+}

--- a/internal/webhook/payload/services.go
+++ b/internal/webhook/payload/services.go
@@ -12,6 +12,7 @@ type Services struct {
 	SubscriptionService service.SubscriptionService
 	WalletService       service.WalletService
 	CustomerService     service.CustomerService
+	PaymentService      service.PaymentService
 }
 
 // NewServices creates a new Services container
@@ -24,6 +25,7 @@ func NewServices(
 	subscriptionService service.SubscriptionService,
 	walletService service.WalletService,
 	customerService service.CustomerService,
+	paymentService service.PaymentService,
 ) *Services {
 	return &Services{
 		InvoiceService:      invoiceService,
@@ -34,5 +36,6 @@ func NewServices(
 		SubscriptionService: subscriptionService,
 		WalletService:       walletService,
 		CustomerService:     customerService,
+		PaymentService:      paymentService,
 	}
 }


### PR DESCRIPTION
_/flexprice/internal/service/payment.go_

> payment.created - Fired when a new payment is created
> payment.updated - Fired when payment details are updated

_/flexprice/internal/service/payment_processor.go_

> payment.failed - Fired when a payment attempt fails
> payment.success - Fired when a payment is successful
> payment.pending - Fired when a payment is awaiting processing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add webhook support for payment events, including creation, update, and processing statuses, with new payload builders and DTOs.
> 
>   - **Behavior**:
>     - Add webhook events for `payment.created`, `payment.updated`, `payment.failed`, `payment.success`, and `payment.pending` in `payment.go` and `payment_processor.go`.
>     - `publishWebhookEvent()` method added to both `paymentService` and `paymentProcessor` to handle event publishing.
>   - **DTOs**:
>     - New `InternalPaymentEvent` and `PaymentWebhookPayload` types in `payment.go` for webhook payloads.
>   - **Webhook Module**:
>     - Add `paymentService` to `providePayloadBuilderFactory()` in `module.go`.
>     - Register new payment event builders in `factory.go` for handling payment-related webhook events.
>   - **Payload Builders**:
>     - Implement `PaymentPayloadBuilder` in `payment.go` to build payloads for payment events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 99145198f265df88df1c5ac7d694a2691a4aad14. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->