### PR TITLE
fix(aggregators): default to 0 when latest aggregator receives event with negative value

### DIFF
--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -277,6 +277,11 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 						Mark(ierr.ErrDatabase)
 				}
 				value = decimal.NewFromFloat(floatValue)
+
+				// For Latest aggregation, return 0 if negative
+				if params.AggregationType == types.AggregationLatest && value.LessThan(decimal.Zero) {
+					value = decimal.Zero
+				}
 			default:
 				err := ierr.NewError("unsupported aggregation type for scanning").
 					WithHint("The specified aggregation type is not supported for scanning").
@@ -320,6 +325,11 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 						Mark(ierr.ErrDatabase)
 				}
 				result.Value = decimal.NewFromFloat(value)
+
+				// For Latest aggregation, return 0 if negative
+				if params.AggregationType == types.AggregationLatest && result.Value.LessThan(decimal.Zero) {
+					result.Value = decimal.Zero
+				}
 			default:
 				err := ierr.NewError("unsupported aggregation type for scanning").
 					WithHint("The specified aggregation type is not supported for scanning").


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `event.go`, `GetUsage()` now defaults negative `AggregationLatest` values to 0.
> 
>   - **Behavior**:
>     - In `GetUsage()` in `event.go`, for `AggregationLatest`, negative values are now set to 0.
>     - This change is applied in both windowed and non-windowed query results.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6a5c1f660ed0ae7fc182d4e82f356b94c5cd1368. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->