### PR TITLE
feat(invoice): add support to send invoice pdf url externally

### DIFF
--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -146,6 +146,15 @@ func (r *CreateInvoiceRequest) Validate() error {
 		}
 	}
 
+	// url validation if url is provided
+	if r.InvoicePDFURL != nil {
+		if err := validator.ValidateURL(r.InvoicePDFURL); err != nil {
+			return ierr.WithError(err).
+				WithHint("invalid invoice_pdf_url").
+				Mark(ierr.ErrValidation)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -76,6 +76,9 @@ type CreateInvoiceRequest struct {
 
 	// environment_id is the unique identifier of the environment this invoice belongs to
 	EnvironmentID string `json:"environment_id,omitempty"`
+
+	// invoice_pdf_url is the URL where customers can download the PDF version of this invoice
+	InvoicePDFURL *string `json:"invoice_pdf_url,omitempty"`
 }
 
 func (r *CreateInvoiceRequest) Validate() error {
@@ -169,6 +172,7 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 		PeriodEnd:       r.PeriodEnd,
 		BillingReason:   string(r.BillingReason),
 		Metadata:        r.Metadata,
+		InvoicePDFURL:   r.InvoicePDFURL,
 		BaseModel:       types.GetDefaultBaseModel(ctx),
 		AmountRemaining: decimal.Zero,
 	}

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -808,15 +808,24 @@ func (s *invoiceService) performPaymentAttemptActions(ctx context.Context, inv *
 }
 
 func (s *invoiceService) GetInvoicePDFUrl(ctx context.Context, id string) (string, error) {
+
+	// get invoice
+	inv, err := s.InvoiceRepo.Get(ctx, id)
+	if err != nil {
+		return "", err
+	}
+
+	if inv.InvoicePDFURL != nil {
+		return lo.FromPtr(inv.InvoicePDFURL), nil
+	}
+
 	if s.S3 == nil {
 		return "", ierr.NewError("s3 is not enabled").
 			WithHint("s3 is not enabled but is required to generate invoice pdf url.").
 			Mark(ierr.ErrSystem)
 	}
 
-	tenantId := types.GetTenantID(ctx)
-
-	key := fmt.Sprintf("%s/%s", tenantId, id)
+	key := fmt.Sprintf("%s/%s", inv.TenantID, id)
 
 	exists, err := s.S3.Exists(ctx, key, s3.DocumentTypeInvoice)
 	if err != nil {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,6 +1,9 @@
 package validator
 
 import (
+	"errors"
+	"net/url"
+	"strings"
 	"sync"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -45,5 +48,30 @@ func ValidateRequest(req interface{}) error {
 			WithReportableDetails(details).
 			Mark(ierr.ErrValidation)
 	}
+	return nil
+}
+
+func ValidateURL(raw *string) error {
+	if raw == nil {
+		return nil
+	}
+
+	if strings.TrimSpace(*raw) == "" {
+		return nil
+	}
+
+	u, err := url.ParseRequestURI(*raw)
+	if err != nil {
+		return errors.New("url must be a valid URL")
+	}
+
+	if u.Scheme != "https" {
+		return errors.New("url must start with https://")
+	}
+
+	if u.Host == "" {
+		return errors.New("url must have a valid host")
+	}
+
 	return nil
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for sending invoice PDF URLs externally by introducing `InvoicePDFURL` field in `CreateInvoiceRequest` and updating `GetInvoicePDFUrl()` in `invoiceService`.
> 
>   - **DTO Changes**:
>     - Add `InvoicePDFURL` field to `CreateInvoiceRequest` in `invoice.go` for storing PDF URL.
>     - Update `ToInvoice()` to include `InvoicePDFURL`.
>   - **Service Changes**:
>     - Update `GetInvoicePDFUrl()` in `invoice.go` to return existing `InvoicePDFURL` if present, otherwise generate and upload PDF to S3.
>     - Modify `GetInvoicePDFUrl()` to use `inv.TenantID` for S3 key generation instead of `types.GetTenantID(ctx)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ee372150958f15510efc10ae94d787e2228c13a2. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->