### PR TITLE
refactor(filters): reverted the timefilter options in plan-repo

### DIFF
--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -781,14 +781,61 @@ func (o InvoiceQueryOptions) ApplyPaginationFilter(query InvoiceQuery, limit int
 
 func (o InvoiceQueryOptions) GetFieldName(field string) string {
 	switch field {
+	case "invoice_number":
+		return invoice.FieldInvoiceNumber
+	case "invoice_type":
+		return invoice.FieldInvoiceType
+	case "invoice_status":
+		return invoice.FieldInvoiceStatus
+	case "payment_status":
+		return invoice.FieldPaymentStatus
+	case "status":
+		return invoice.FieldStatus
+	case "amount_due":
+		return invoice.FieldAmountDue
+	case "amount_paid":
+		return invoice.FieldAmountPaid
+	case "amount_remaining":
+		return invoice.FieldAmountRemaining
+	case "adjustment_amount":
+		return invoice.FieldAdjustmentAmount
+	case "refunded_amount":
+		return invoice.FieldRefundedAmount
+	case "subtotal":
+		return invoice.FieldSubtotal
+	case "total":
+		return invoice.FieldTotal
+	case "currency":
+		return invoice.FieldCurrency
+	case "due_date":
+		return invoice.FieldDueDate
+	case "period_start":
+		return invoice.FieldPeriodStart
+	case "period_end":
+		return invoice.FieldPeriodEnd
+	case "billing_period":
+		return invoice.FieldBillingPeriod
+	case "paid_at":
+		return invoice.FieldPaidAt
+	case "voided_at":
+		return invoice.FieldVoidedAt
+	case "finalized_at":
+		return invoice.FieldFinalizedAt
 	case "created_at":
 		return invoice.FieldCreatedAt
 	case "updated_at":
 		return invoice.FieldUpdatedAt
-	case "invoice_number":
-		return invoice.FieldInvoiceNumber
+	case "idempotency_key":
+		return invoice.FieldIdempotencyKey
+	case "customer_id":
+		return invoice.FieldCustomerID
+	case "subscription_id":
+		return invoice.FieldSubscriptionID
+	case "description":
+		return invoice.FieldDescription
 	default:
-		return field
+		// unknown field
+		return ""
 	}
 }
 

--- a/internal/repository/ent/plan.go
+++ b/internal/repository/ent/plan.go
@@ -429,8 +429,13 @@ func (o PlanQueryOptions) GetFieldName(field string) string {
 		return plan.FieldLookupKey
 	case "name":
 		return plan.FieldName
+	case "description":
+		return plan.FieldDescription
+	case "status":
+		return plan.FieldStatus
 	default:
-		return field
+		// unknown field
+		return ""
 	}
 }
 
@@ -475,6 +480,16 @@ func (o PlanQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.Pl
 		)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Apply time range filters if specified
+	if f.TimeRangeFilter != nil {
+		if f.StartTime != nil {
+			query = query.Where(plan.CreatedAtGTE(*f.StartTime))
+		}
+		if f.EndTime != nil {
+			query = query.Where(plan.CreatedAtLTE(*f.EndTime))
 		}
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `GetFieldName` to return empty string for unknown fields and reintroduce time range filters in `plan.go`.
> 
>   - **Refactor `GetFieldName`**:
>     - In `invoice.go` and `plan.go`, `GetFieldName` now returns an empty string for unknown fields instead of the field name.
>   - **Reintroduce Time Range Filters**:
>     - In `plan.go`, `applyEntityQueryOptions` now applies time range filters using `StartTime` and `EndTime` if specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for be145284e6e667f2cd78e601a4b8f1005bad308d. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->