### PR TITLE
Quick Fix for price override

### DIFF
--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -400,6 +400,11 @@ func (s *subscriptionService) processSubscriptionPriceOverrides(
 				Mark(ierr.ErrInternal)
 		}
 
+		priceUnitType := originalPrice.PriceUnitType
+		if priceUnitType == "" {
+			priceUnitType = types.PRICE_UNIT_TYPE_FIAT
+		}
+
 		// Create subscription-scoped price clone
 		overriddenPrice := &price.Price{
 			ID:                     types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
@@ -421,7 +426,7 @@ func (s *subscriptionService) processSubscriptionPriceOverrides(
 			Description:            originalPrice.Description,
 			PriceUnitID:            originalPrice.PriceUnitID,
 			PriceUnit:              originalPrice.PriceUnit,
-			PriceUnitType:          originalPrice.PriceUnitType,
+			PriceUnitType:          priceUnitType,
 			ConversionRate:         originalPrice.ConversionRate,
 			DisplayPriceUnitAmount: originalPrice.DisplayPriceUnitAmount,
 			PriceUnitAmount:        originalPrice.PriceUnitAmount,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes default `PriceUnitType` handling in `processSubscriptionPriceOverrides()` in `subscription.go`.
> 
>   - **Behavior**:
>     - In `processSubscriptionPriceOverrides()` in `subscription.go`, set `priceUnitType` to `types.PRICE_UNIT_TYPE_FIAT` if `originalPrice.PriceUnitType` is empty.
>     - Update `overriddenPrice.PriceUnitType` to use the new `priceUnitType` variable.
>   - **Misc**:
>     - Minor adjustment to ensure default `PriceUnitType` is set during price override processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 791e0dd1235b58d8d6947df82f23abc2db8ed5c4. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->