### PR TITLE
fix(price): create subscription filter plan prices

### DIFF
--- a/internal/service/price_test.go
+++ b/internal/service/price_test.go
@@ -120,6 +120,7 @@ func (s *PriceServiceSuite) TestGetPrices() {
 
 	// Retrieve all prices within limit
 	priceFilter := types.NewPriceFilter()
+	priceFilter.Scope = lo.ToPtr(types.PRICE_SCOPE_PLAN)
 	priceFilter.QueryFilter.Offset = lo.ToPtr(0)
 	priceFilter.QueryFilter.Limit = lo.ToPtr(10)
 	resp, err := s.priceService.GetPrices(s.ctx, priceFilter)
@@ -139,6 +140,7 @@ func (s *PriceServiceSuite) TestGetPrices() {
 	// Retrieve with offset exceeding available records
 	priceFilter.QueryFilter.Offset = lo.ToPtr(10)
 	priceFilter.QueryFilter.Limit = lo.ToPtr(10)
+	priceFilter.Scope = lo.ToPtr(types.PRICE_SCOPE_PLAN)
 	resp, err = s.priceService.GetPrices(s.ctx, priceFilter)
 	s.NoError(err)
 	s.NotNil(resp)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -114,10 +114,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 	}
 
 	priceService := NewPriceService(s.PriceRepo, s.MeterRepo, s.PriceUnitRepo, s.Logger)
-	priceFilter := types.NewNoLimitPriceFilter().
-		WithPlanIDs([]string{plan.ID}).
-		WithExpand(string(types.ExpandMeters))
-	pricesResponse, err := priceService.GetPrices(ctx, priceFilter)
+	pricesResponse, err := priceService.GetPricesByPlanID(ctx, plan.ID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `CreateSubscription` to use `GetPricesByPlanID` for price retrieval and update tests for plan-specific price filtering.
> 
>   - **Behavior**:
>     - `CreateSubscription` in `subscription.go` now uses `GetPricesByPlanID` instead of manually creating a `PriceFilter`.
>     - `TestGetPrices` in `price_test.go` updated to set `Scope` to `PRICE_SCOPE_PLAN` for filtering plan-specific prices.
>   - **Tests**:
>     - Updated `TestGetPrices` in `price_test.go` to include scope filtering for plan prices.
>   - **Misc**:
>     - Simplifies price retrieval in `CreateSubscription` by directly querying with plan ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 7959de8a88433ce6c23ee140b13f58b90ebaf69b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->