### PR TITLE
fix(webhook): replace JSON error responses with context error handling

### DIFF
--- a/internal/api/v1/webhook.go
+++ b/internal/api/v1/webhook.go
@@ -51,9 +51,7 @@ func (h *WebhookHandler) GetDashboardURL(c *gin.Context) {
 			"tenant_id", tenantID,
 			"environment_id", environmentID,
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Failed to get webhook dashboard",
-		})
+		c.Error(err)
 		return
 	}
 
@@ -66,9 +64,7 @@ func (h *WebhookHandler) GetDashboardURL(c *gin.Context) {
 			"environment_id", environmentID,
 			"app_id", appID,
 		)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Failed to get webhook dashboard",
-		})
+		c.Error(err)
 		return
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces JSON error responses with Gin context error handling in `GetDashboardURL` of `webhook.go`.
> 
>   - **Error Handling**:
>     - Replaces JSON error responses with `c.Error(err)` in `GetDashboardURL` in `webhook.go`.
>     - Handles errors from `GetOrCreateApplication` and `GetDashboardURL` using Gin's context error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d001f5c5ad30eaf93c3f3e0949f9506f49daa40c. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->