### PR TITLE
Implement optional start time with best practices

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -26,7 +26,7 @@ type CreateSubscriptionRequest struct {
 	PlanID             string               `json:"plan_id" validate:"required"`
 	Currency           string               `json:"currency" validate:"required,len=3"`
 	LookupKey          string               `json:"lookup_key"`
-	StartDate          time.Time            `json:"start_date" validate:"required"`
+	StartDate          *time.Time           `json:"start_date,omitempty"`
 	EndDate            *time.Time           `json:"end_date,omitempty"`
 	TrialStart         *time.Time           `json:"trial_start,omitempty"`
 	TrialEnd           *time.Time           `json:"trial_end,omitempty"`
@@ -105,11 +105,17 @@ func (r *CreateSubscriptionRequest) Validate() error {
 		return err
 	}
 
-	if r.EndDate != nil && r.EndDate.Before(r.StartDate) {
+	// Set default start date if not provided
+	if r.StartDate == nil {
+		now := time.Now().UTC()
+		r.StartDate = &now
+	}
+
+	if r.EndDate != nil && r.EndDate.Before(*r.StartDate) {
 		return ierr.NewError("end_date cannot be before start_date").
 			WithHint("End date must be after start date").
 			WithReportableDetails(map[string]interface{}{
-				"start_date": r.StartDate,
+				"start_date": *r.StartDate,
 				"end_date":   *r.EndDate,
 			}).
 			Mark(ierr.ErrValidation)
@@ -130,30 +136,30 @@ func (r *CreateSubscriptionRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.StartDate.After(time.Now().UTC()) {
+	if r.StartDate != nil && r.StartDate.After(time.Now().UTC()) {
 		return ierr.NewError("start_date cannot be in the future").
 			WithHint("Start date must be in the past or present").
 			WithReportableDetails(map[string]interface{}{
-				"start_date": r.StartDate,
+				"start_date": *r.StartDate,
 			}).
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.TrialStart != nil && r.TrialStart.After(r.StartDate) {
+	if r.TrialStart != nil && r.TrialStart.After(*r.StartDate) {
 		return ierr.NewError("trial_start cannot be after start_date").
 			WithHint("Trial start date must be before or equal to start date").
 			WithReportableDetails(map[string]interface{}{
-				"start_date":  r.StartDate,
+				"start_date":  *r.StartDate,
 				"trial_start": *r.TrialStart,
 			}).
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.TrialEnd != nil && r.TrialEnd.Before(r.StartDate) {
+	if r.TrialEnd != nil && r.TrialEnd.Before(*r.StartDate) {
 		return ierr.NewError("trial_end cannot be before start_date").
 			WithHint("Trial end date must be after or equal to start date").
 			WithReportableDetails(map[string]interface{}{
-				"start_date": r.StartDate,
+				"start_date": *r.StartDate,
 				"trial_end":  *r.TrialEnd,
 			}).
 			Mark(ierr.ErrValidation)
@@ -202,11 +208,11 @@ func (r *CreateSubscriptionRequest) Validate() error {
 	// Validate phases if provided
 	if len(r.Phases) > 0 {
 		// First phase must start on or after subscription start date
-		if r.Phases[0].StartDate.Before(r.StartDate) {
+		if r.Phases[0].StartDate.Before(*r.StartDate) {
 			return ierr.NewError("first phase start date cannot be before subscription start date").
 				WithHint("The first phase must start on or after the subscription start date").
 				WithReportableDetails(map[string]interface{}{
-					"subscription_start_date": r.StartDate,
+					"subscription_start_date": *r.StartDate,
 					"first_phase_start_date":  r.Phases[0].StartDate,
 				}).
 				Mark(ierr.ErrValidation)
@@ -295,8 +301,8 @@ func (r *CreateSubscriptionRequest) Validate() error {
 
 func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscription.Subscription {
 	now := time.Now().UTC()
-	if r.StartDate.IsZero() {
-		r.StartDate = now
+	if r.StartDate == nil {
+		r.StartDate = &now
 	}
 
 	sub := &subscription.Subscription{
@@ -306,14 +312,14 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		Currency:           strings.ToLower(r.Currency),
 		LookupKey:          r.LookupKey,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		StartDate:          r.StartDate,
+		StartDate:          *r.StartDate,
 		EndDate:            r.EndDate,
 		TrialStart:         r.TrialStart,
 		TrialEnd:           r.TrialEnd,
 		BillingCadence:     r.BillingCadence,
 		BillingPeriod:      r.BillingPeriod,
 		BillingPeriodCount: r.BillingPeriodCount,
-		BillingAnchor:      r.StartDate,
+		BillingAnchor:      *r.StartDate,
 		Metadata:           r.Metadata,
 		EnvironmentID:      types.GetEnvironmentID(ctx),
 		BaseModel:          types.GetDefaultBaseModel(ctx),

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -958,7 +958,7 @@ func (s *onboardingService) createDefaultSubscriptions(ctx context.Context, cust
 		CustomerID:         customer.ID,
 		PlanID:             proPlan.ID,
 		Currency:           "USD",
-		StartDate:          time.Now(),
+		StartDate:          lo.ToPtr(time.Now()),
 		BillingCadence:     types.BILLING_CADENCE_RECURRING,
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -153,17 +153,9 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			Mark(ierr.ErrValidation)
 	}
 
-	now := time.Now().UTC()
-
-	// Set start date and ensure it's in UTC
-	// TODO: handle when start date is in the past and there are
-	// multiple billing periods in the past so in this case we need to keep
-	// the current period start as now only and handle past periods in proration
-	if sub.StartDate.IsZero() {
-		sub.StartDate = now
-	} else {
-		sub.StartDate = sub.StartDate.UTC()
-	}
+	// Ensure start date is in UTC format
+	// Note: StartDate is now guaranteed to be set (either from request or defaulted in DTO validation)
+	sub.StartDate = sub.StartDate.UTC()
 
 	if sub.BillingCycle == types.BillingCycleCalendar {
 		sub.BillingAnchor = types.CalculateCalendarBillingAnchor(sub.StartDate, sub.BillingPeriod)

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -147,7 +147,7 @@ func (s *tenantService) onboardTenantOnFreePlan(ctx context.Context, t *tenant.T
 		BillingCadence:     freePrice.BillingCadence,
 		BillingPeriod:      freePrice.BillingPeriod,
 		BillingPeriodCount: freePrice.BillingPeriodCount,
-		StartDate:          time.Now(),
+		StartDate:          lo.ToPtr(time.Now()),
 		BillingCycle:       types.BillingCycleAnniversary,
 	})
 	if err != nil {


### PR DESCRIPTION
Make `StartDate` optional in create subscription APIs, defaulting to current UTC time if not provided.

This change updates the `CreateSubscriptionRequest` DTO to allow `StartDate` to be omitted, automatically setting it to the current UTC time during validation. This simplifies the service layer by removing redundant checks and aligns with existing patterns for optional time fields.

---
[Slack Thread](https://flexpriceio.slack.com/archives/C0978HMAAQM/p1754625383522179?thread_ts=1754625383.522179&cid=C0978HMAAQM)

<a href="https://cursor.com/background-agent?bcId=bc-bcf063ec-2537-4ab7-a6ec-5badd592c43e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bcf063ec-2537-4ab7-a6ec-5badd592c43e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `StartDate` optional in subscription creation, defaulting to current UTC if not provided, simplifying DTO validation and service logic.
> 
>   - **Behavior**:
>     - `StartDate` in `CreateSubscriptionRequest` is now optional, defaults to current UTC if not provided.
>     - Updates `Validate()` in `subscription.go` to set `StartDate` to current UTC if nil.
>     - Removes redundant `StartDate` checks in `CreateSubscription()` in `subscription.go`.
>   - **Service Layer**:
>     - Updates `createDefaultSubscriptions()` in `onboarding.go` to use pointer for `StartDate`.
>     - Updates `CreateSubscription()` in `subscription.go` to ensure `StartDate` is in UTC.
>   - **Misc**:
>     - Minor updates to `ToSubscription()` in `subscription.go` to handle `StartDate` as a pointer.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8a07143c3a2f13c40bdc3c970b1062a66f09b0c2. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->