### PR TITLE
fix/subscription omit start time

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -300,10 +300,6 @@ func (r *CreateSubscriptionRequest) Validate() error {
 }
 
 func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscription.Subscription {
-	now := time.Now().UTC()
-	if r.StartDate == nil {
-		r.StartDate = &now
-	}
 
 	sub := &subscription.Subscription{
 		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -26,7 +26,7 @@ type CreateSubscriptionRequest struct {
 	PlanID             string               `json:"plan_id" validate:"required"`
 	Currency           string               `json:"currency" validate:"required,len=3"`
 	LookupKey          string               `json:"lookup_key"`
-	StartDate          time.Time            `json:"start_date" validate:"required"`
+	StartDate          *time.Time           `json:"start_date,omitempty"`
 	EndDate            *time.Time           `json:"end_date,omitempty"`
 	TrialStart         *time.Time           `json:"trial_start,omitempty"`
 	TrialEnd           *time.Time           `json:"trial_end,omitempty"`
@@ -105,11 +105,17 @@ func (r *CreateSubscriptionRequest) Validate() error {
 		return err
 	}
 
-	if r.EndDate != nil && r.EndDate.Before(r.StartDate) {
+	// Set default start date if not provided
+	if r.StartDate == nil {
+		now := time.Now().UTC()
+		r.StartDate = &now
+	}
+
+	if r.EndDate != nil && r.EndDate.Before(*r.StartDate) {
 		return ierr.NewError("end_date cannot be before start_date").
 			WithHint("End date must be after start date").
 			WithReportableDetails(map[string]interface{}{
-				"start_date": r.StartDate,
+				"start_date": *r.StartDate,
 				"end_date":   *r.EndDate,
 			}).
 			Mark(ierr.ErrValidation)
@@ -130,30 +136,30 @@ func (r *CreateSubscriptionRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.StartDate.After(time.Now().UTC()) {
+	if r.StartDate != nil && r.StartDate.After(time.Now().UTC()) {
 		return ierr.NewError("start_date cannot be in the future").
 			WithHint("Start date must be in the past or present").
 			WithReportableDetails(map[string]interface{}{
-				"start_date": r.StartDate,
+				"start_date": *r.StartDate,
 			}).
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.TrialStart != nil && r.TrialStart.After(r.StartDate) {
+	if r.TrialStart != nil && r.TrialStart.After(*r.StartDate) {
 		return ierr.NewError("trial_start cannot be after start_date").
 			WithHint("Trial start date must be before or equal to start date").
 			WithReportableDetails(map[string]interface{}{
-				"start_date":  r.StartDate,
+				"start_date":  *r.StartDate,
 				"trial_start": *r.TrialStart,
 			}).
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.TrialEnd != nil && r.TrialEnd.Before(r.StartDate) {
+	if r.TrialEnd != nil && r.TrialEnd.Before(*r.StartDate) {
 		return ierr.NewError("trial_end cannot be before start_date").
 			WithHint("Trial end date must be after or equal to start date").
 			WithReportableDetails(map[string]interface{}{
-				"start_date": r.StartDate,
+				"start_date": *r.StartDate,
 				"trial_end":  *r.TrialEnd,
 			}).
 			Mark(ierr.ErrValidation)
@@ -202,11 +208,11 @@ func (r *CreateSubscriptionRequest) Validate() error {
 	// Validate phases if provided
 	if len(r.Phases) > 0 {
 		// First phase must start on or after subscription start date
-		if r.Phases[0].StartDate.Before(r.StartDate) {
+		if r.Phases[0].StartDate.Before(*r.StartDate) {
 			return ierr.NewError("first phase start date cannot be before subscription start date").
 				WithHint("The first phase must start on or after the subscription start date").
 				WithReportableDetails(map[string]interface{}{
-					"subscription_start_date": r.StartDate,
+					"subscription_start_date": *r.StartDate,
 					"first_phase_start_date":  r.Phases[0].StartDate,
 				}).
 				Mark(ierr.ErrValidation)
@@ -295,8 +301,8 @@ func (r *CreateSubscriptionRequest) Validate() error {
 
 func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscription.Subscription {
 	now := time.Now().UTC()
-	if r.StartDate.IsZero() {
-		r.StartDate = now
+	if r.StartDate == nil {
+		r.StartDate = &now
 	}
 
 	sub := &subscription.Subscription{
@@ -306,14 +312,14 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		Currency:           strings.ToLower(r.Currency),
 		LookupKey:          r.LookupKey,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		StartDate:          r.StartDate,
+		StartDate:          *r.StartDate,
 		EndDate:            r.EndDate,
 		TrialStart:         r.TrialStart,
 		TrialEnd:           r.TrialEnd,
 		BillingCadence:     r.BillingCadence,
 		BillingPeriod:      r.BillingPeriod,
 		BillingPeriodCount: r.BillingPeriodCount,
-		BillingAnchor:      r.StartDate,
+		BillingAnchor:      *r.StartDate,
 		Metadata:           r.Metadata,
 		EnvironmentID:      types.GetEnvironmentID(ctx),
 		BaseModel:          types.GetDefaultBaseModel(ctx),

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -958,7 +958,7 @@ func (s *onboardingService) createDefaultSubscriptions(ctx context.Context, cust
 		CustomerID:         customer.ID,
 		PlanID:             proPlan.ID,
 		Currency:           "USD",
-		StartDate:          time.Now(),
+		StartDate:          lo.ToPtr(time.Now()),
 		BillingCadence:     types.BILLING_CADENCE_RECURRING,
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -153,17 +153,9 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			Mark(ierr.ErrValidation)
 	}
 
-	now := time.Now().UTC()
-
-	// Set start date and ensure it's in UTC
-	// TODO: handle when start date is in the past and there are
-	// multiple billing periods in the past so in this case we need to keep
-	// the current period start as now only and handle past periods in proration
-	if sub.StartDate.IsZero() {
-		sub.StartDate = now
-	} else {
-		sub.StartDate = sub.StartDate.UTC()
-	}
+	// Ensure start date is in UTC format
+	// Note: StartDate is now guaranteed to be set (either from request or defaulted in DTO validation)
+	sub.StartDate = sub.StartDate.UTC()
 
 	if sub.BillingCycle == types.BillingCycleCalendar {
 		sub.BillingAnchor = types.CalculateCalendarBillingAnchor(sub.StartDate, sub.BillingPeriod)

--- a/internal/service/subscription_price_override_test.go
+++ b/internal/service/subscription_price_override_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 			CustomerID:         "test_customer_123",
 			PlanID:             "test_plan_456",
 			Currency:           "USD",
-			StartDate:          time.Now(),
+			StartDate:          lo.ToPtr(time.Now()),
 			BillingCadence:     types.BILLING_CADENCE_RECURRING,
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
@@ -91,7 +92,7 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 			CustomerID:         "test_customer",
 			PlanID:             "test_plan",
 			Currency:           "USD",
-			StartDate:          time.Now(),
+			StartDate:          lo.ToPtr(time.Now()),
 			BillingCadence:     types.BILLING_CADENCE_RECURRING,
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
@@ -143,16 +144,16 @@ func TestPriceScopeFiltering(t *testing.T) {
 }
 
 // Example of how the price override functionality would be tested in integration tests
-func ExamplePriceOverrideWorkflow() {
-	// This example shows the expected workflow for price overrides
+// func ExamplePriceOverrideWorkflow() {
+// This example shows the expected workflow for price overrides
 
-	// 1. Create a plan with standard prices
-	// 2. Create a subscription with override_line_items
-	// 3. Verify that subscription-scoped prices are created
-	// 4. Verify that line items reference the subscription-scoped prices
-	// 5. Verify that billing calculations use the overridden prices
-	// 6. Verify that plan queries only return plan-scoped prices
-	// 7. Verify that subscription queries return subscription-scoped prices
+// 1. Create a plan with standard prices
+// 2. Create a subscription with override_line_items
+// 3. Verify that subscription-scoped prices are created
+// 4. Verify that line items reference the subscription-scoped prices
+// 5. Verify that billing calculations use the overridden prices
+// 6. Verify that plan queries only return plan-scoped prices
+// 7. Verify that subscription queries return subscription-scoped prices
 
-	// Note: Actual implementation would require full test environment setup
-}
+// Note: Actual implementation would require full test environment setup
+// }

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -566,7 +566,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			name: "both_customer_id_and_external_id_absent",
 			input: dto.CreateSubscriptionRequest{
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -583,7 +583,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			input: dto.CreateSubscriptionRequest{
 				CustomerID:         s.testData.customer.ID,
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -598,7 +598,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			input: dto.CreateSubscriptionRequest{
 				ExternalCustomerID: s.testData.customer.ExternalID,
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -614,7 +614,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 				CustomerID:         s.testData.customer.ID,
 				ExternalCustomerID: "some_other_external_id",
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -629,7 +629,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			input: dto.CreateSubscriptionRequest{
 				ExternalCustomerID: "non_existent_external_id",
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -646,7 +646,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			input: dto.CreateSubscriptionRequest{
 				CustomerID:         "invalid_id",
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -663,7 +663,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			input: dto.CreateSubscriptionRequest{
 				CustomerID:         s.testData.customer.ID,
 				PlanID:             "invalid_id",
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -680,7 +680,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			input: dto.CreateSubscriptionRequest{
 				CustomerID:         s.testData.customer.ID,
 				PlanID:             s.testData.plan.ID,
-				StartDate:          s.testData.now,
+				StartDate:          lo.ToPtr(s.testData.now),
 				EndDate:            lo.ToPtr(s.testData.now.Add(-24 * time.Hour)),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
@@ -1084,7 +1084,7 @@ func (s *SubscriptionServiceSuite) TestSubscriptionAnchor_CalendarAndAnniversary
 			input := dto.CreateSubscriptionRequest{
 				CustomerID:         s.testData.customer.ID,
 				PlanID:             s.testData.plan.ID,
-				StartDate:          tt.startDate,
+				StartDate:          lo.ToPtr(tt.startDate),
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,
 				BillingPeriod:      tt.billingPeriod,
@@ -1275,7 +1275,7 @@ func (s *SubscriptionServiceSuite) TestSubscriptionWithEndDate() {
 			input := dto.CreateSubscriptionRequest{
 				CustomerID:         s.testData.customer.ID,
 				PlanID:             s.testData.plan.ID,
-				StartDate:          tt.startDate,
+				StartDate:          lo.ToPtr(tt.startDate),
 				EndDate:            tt.endDate,
 				Currency:           "usd",
 				BillingCadence:     types.BILLING_CADENCE_RECURRING,

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -147,7 +147,7 @@ func (s *tenantService) onboardTenantOnFreePlan(ctx context.Context, t *tenant.T
 		BillingCadence:     freePrice.BillingCadence,
 		BillingPeriod:      freePrice.BillingPeriod,
 		BillingPeriodCount: freePrice.BillingPeriodCount,
-		StartDate:          lo.ToPtr(time.Now()),
+		StartDate:          lo.ToPtr(time.Now().UTC()),
 		BillingCycle:       types.BillingCycleAnniversary,
 	})
 	if err != nil {

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -147,7 +147,7 @@ func (s *tenantService) onboardTenantOnFreePlan(ctx context.Context, t *tenant.T
 		BillingCadence:     freePrice.BillingCadence,
 		BillingPeriod:      freePrice.BillingPeriod,
 		BillingPeriodCount: freePrice.BillingPeriodCount,
-		StartDate:          time.Now(),
+		StartDate:          lo.ToPtr(time.Now()),
 		BillingCycle:       types.BillingCycleAnniversary,
 	})
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `StartDate` optional in `CreateSubscriptionRequest`, defaulting to current time if not provided, and update related logic and tests.
> 
>   - **Behavior**:
>     - `StartDate` in `CreateSubscriptionRequest` in `subscription.go` is now optional and defaults to current time if not provided.
>     - Validation logic in `Validate()` updated to handle `nil` `StartDate`.
>     - `ToSubscription()` in `subscription.go` updated to handle `nil` `StartDate`.
>   - **Service Logic**:
>     - `CreateSubscription()` in `subscription.go` updated to ensure `StartDate` is set and in UTC.
>   - **Tests**:
>     - Tests in `subscription_test.go` and `subscription_price_override_test.go` updated to reflect optional `StartDate` behavior.
>     - `onboarding.go` and `tenant.go` updated to use `lo.ToPtr(time.Now())` for `StartDate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 40c13ab93a2bb5b962ea3ada39b402971bf2869b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->