### PR TITLE
fix(payments): use stripe customer id as external customer id

### DIFF
--- a/internal/api/dto/payment.go
+++ b/internal/api/dto/payment.go
@@ -55,7 +55,6 @@ type PaymentResponse struct {
 	GatewayTrackingID *string                      `json:"gateway_tracking_id,omitempty"`
 	GatewayMetadata   types.Metadata               `json:"gateway_metadata,omitempty"`
 	PaymentURL        *string                      `json:"payment_url,omitempty"`
-	SessionID         *string                      `json:"session_id,omitempty"`
 	Metadata          types.Metadata               `json:"metadata,omitempty"`
 	SucceededAt       *time.Time                   `json:"succeeded_at,omitempty"`
 	FailedAt          *time.Time                   `json:"failed_at,omitempty"`
@@ -119,13 +118,10 @@ func NewPaymentResponse(p *payment.Payment) *PaymentResponse {
 		UpdatedBy:         p.UpdatedBy,
 	}
 
-	// Extract payment URL and session ID from gateway metadata for payment links
+	// Extract payment URL from gateway metadata for payment links
 	if p.PaymentMethodType == types.PaymentMethodTypePaymentLink && p.GatewayMetadata != nil {
 		if paymentURL, exists := p.GatewayMetadata["payment_url"]; exists {
 			resp.PaymentURL = &paymentURL
-		}
-		if sessionID, exists := p.GatewayMetadata["session_id"]; exists {
-			resp.SessionID = &sessionID
 		}
 	}
 

--- a/internal/service/stripe.go
+++ b/internal/service/stripe.go
@@ -151,6 +151,7 @@ func (s *StripeService) CreateCustomerInStripe(ctx context.Context, customerID s
 		Metadata: map[string]string{
 			"flexprice_customer_id": ourCustomer.ID,
 			"flexprice_environment": ourCustomer.EnvironmentID,
+			"external_id":           ourCustomer.ExternalID,
 		},
 	}
 
@@ -222,8 +223,8 @@ func (s *StripeService) CreateCustomerFromStripe(ctx context.Context, stripeCust
 			return err
 		}
 	} else {
-		// Generate external ID if not present
-		externalID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER)
+		// When syncing from Stripe webhook, set external_id as stripe_customer_id
+		externalID = stripeCustomer.ID
 	}
 
 	// Create new customer using DTO


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `SessionID` from `PaymentResponse` and update `external_id` handling in Stripe customer synchronization.
> 
>   - **API Changes**:
>     - Remove `SessionID` from `PaymentResponse` in `payment.go`.
>     - Update `NewPaymentResponse()` to no longer extract `session_id` from `GatewayMetadata`.
>   - **Stripe Service**:
>     - In `CreateCustomerInStripe()`, add `external_id` to customer metadata.
>     - In `CreateCustomerFromStripe()`, set `external_id` to `stripe_customer_id` when syncing from Stripe webhook.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for f7d2639e62d245c22e68a7fbc592543c4075f995. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->