### PR TITLE
feat(billing): implement daily usage reset for metered entitlements

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -240,10 +240,10 @@ func (s *billingService) CalculateUsageCharges(
 						usageAllowed := decimal.NewFromFloat(float64(*matchingEntitlement.UsageLimit))
 						adjustedQuantity := decimal.NewFromFloat(matchingCharge.Quantity).Sub(usageAllowed)
 						quantityForCalculation = decimal.Max(adjustedQuantity, decimal.Zero)
-					}
 
-					// case 2 : when the usage reset period is daily
-					if matchingEntitlement.UsageResetPeriod == types.BILLING_PERIOD_DAILY {
+					} else if matchingEntitlement.UsageResetPeriod == types.BILLING_PERIOD_DAILY {
+
+						// case 2 : when the usage reset period is daily
 						// For daily reset periods, we need to fetch usage with daily window size
 						// and calculate overage per day, then sum the total overage
 
@@ -268,7 +268,6 @@ func (s *billingService) CalculateUsageCharges(
 							StartTime:          periodStart,
 							EndTime:            periodEnd,
 							WindowSize:         types.WindowSizeDay, // Use daily window size
-							Filters:            make(map[string][]string),
 						}
 
 						// Add meter filters
@@ -317,6 +316,10 @@ func (s *billingService) CalculateUsageCharges(
 
 						// Use the total billable quantity for calculation
 						quantityForCalculation = totalBillableQuantity
+					} else {
+						usageAllowed := decimal.NewFromFloat(float64(*matchingEntitlement.UsageLimit))
+						adjustedQuantity := decimal.NewFromFloat(matchingCharge.Quantity).Sub(usageAllowed)
+						quantityForCalculation = decimal.Max(adjustedQuantity, decimal.Zero)
 					}
 
 					// Recalculate the amount based on the adjusted quantity

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -275,7 +275,7 @@ func (s *billingService) CalculateUsageCharges(
 							dailyUsage := dailyResult.Value
 
 							// Calculate overage for this day: max(0, daily_usage - daily_limit)
-							dailyOverage := decimal.Max(dailyUsage.Sub(dailyLimit), decimal.Zero)
+							dailyOverage := decimal.Max(decimal.Zero, dailyUsage.Sub(dailyLimit))
 
 							if dailyOverage.GreaterThan(decimal.Zero) {
 								// Add to total billable quantity

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -333,6 +333,11 @@ func (s *billingService) CalculateUsageCharges(
 				displayName = lo.ToPtr(fmt.Sprintf("%s (Overage)", item.DisplayName))
 			}
 
+			// Add usage reset period metadata if entitlement has daily reset
+			if !matchingCharge.IsOverage && ok && matchingEntitlement.IsEnabled && matchingEntitlement.UsageResetPeriod == types.BILLING_PERIOD_DAILY {
+				metadata["usage_reset_period"] = "daily"
+			}
+
 			s.Logger.Debugw("usage charges for line item",
 				"amount", matchingCharge.Amount,
 				"quantity", matchingCharge.Quantity,

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -225,18 +225,7 @@ func (s *billingService) CalculateUsageCharges(
 
 					// case 1 : when the usage reset period is billing period
 					if matchingEntitlement.UsageResetPeriod == sub.BillingPeriod {
-						usageAllowed := decimal.NewFromFloat(float64(*matchingEntitlement.UsageLimit))
-						adjustedQuantity := decimal.NewFromFloat(matchingCharge.Quantity).Sub(usageAllowed)
-						quantityForCalculation = decimal.Max(adjustedQuantity, decimal.Zero)
-					}
 
-					// case 2 : when the usage reset period is daily
-					// consider the usage reset period
-					// TODO: Suppport other reset periods i.e. weekly, monthly, yearly
-					// usage limit is set, so we decrement the usage quantity by the already entitled usage
-
-					// case 1 : when the usage reset period is billing period
-					if matchingEntitlement.UsageResetPeriod == sub.BillingPeriod {
 						usageAllowed := decimal.NewFromFloat(float64(*matchingEntitlement.UsageLimit))
 						adjustedQuantity := decimal.NewFromFloat(matchingCharge.Quantity).Sub(usageAllowed)
 						quantityForCalculation = decimal.Max(adjustedQuantity, decimal.Zero)

--- a/internal/service/billing_test.go
+++ b/internal/service/billing_test.go
@@ -1454,7 +1454,7 @@ func (s *BillingServiceSuite) TestCalculateUsageChargesWithDailyReset() {
 		"Expected quantity %s, got %s", expectedQuantity, lineItems[0].Quantity)
 
 	// Check that the amount is calculated correctly
-	s.True(totalAmount.GreaterThan(decimal.Zero), "Should have positive total amount")
+	s.Equal(decimal.NewFromFloat(0.14), totalAmount, "Should have correct total amount for daily overage")
 
 	// Check metadata indicates daily reset
 	s.Equal("daily", lineItems[0].Metadata["usage_reset_period"])

--- a/internal/service/billing_test.go
+++ b/internal/service/billing_test.go
@@ -1348,3 +1348,114 @@ func (s *BillingServiceSuite) TestCalculateUsageChargesWithEntitlements() {
 		})
 	}
 }
+
+func (s *BillingServiceSuite) TestCalculateUsageChargesWithDailyReset() {
+	// Setup test data for daily usage calculation
+	ctx := s.GetContext()
+
+	// Create test feature with daily reset
+	testFeature := &feature.Feature{
+		ID:          "feat_daily_123",
+		Name:        "Daily API Calls",
+		Description: "API calls with daily reset",
+		Type:        types.FeatureTypeMetered,
+		MeterID:     s.testData.meters.apiCalls.ID,
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, testFeature))
+
+	// Create entitlement with daily reset
+	entitlement := &entitlement.Entitlement{
+		ID:               "ent_daily_123",
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         s.testData.plan.ID,
+		FeatureID:        testFeature.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       lo.ToPtr(int64(10)), // 10 requests per day
+		UsageResetPeriod: types.BILLING_PERIOD_DAILY,
+		IsSoftLimit:      false,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, entitlement)
+	s.NoError(err)
+
+	// Create test events for different days
+	// Day 1: 15 requests (5 over limit)
+	// Day 2: 3 requests (0 over limit)
+	// Day 3: 12 requests (2 over limit)
+	eventDates := []time.Time{
+		s.testData.now.Add(-48 * time.Hour), // Day 1
+		s.testData.now.Add(-24 * time.Hour), // Day 2
+		s.testData.now,                      // Day 3
+	}
+
+	for i, eventDate := range eventDates {
+		var eventCount int
+		switch i {
+		case 0:
+			eventCount = 15 // Day 1: 15 requests
+		case 1:
+			eventCount = 3 // Day 2: 3 requests
+		case 2:
+			eventCount = 12 // Day 3: 12 requests
+		}
+
+		for j := 0; j < eventCount; j++ {
+			event := &events.Event{
+				ID:                 s.GetUUID(),
+				TenantID:           s.testData.subscription.TenantID,
+				EventName:          s.testData.meters.apiCalls.EventName,
+				ExternalCustomerID: s.testData.customer.ExternalID,
+				Timestamp:          eventDate,
+				Properties:         map[string]interface{}{},
+			}
+			s.NoError(s.GetStores().EventRepo.InsertEvent(ctx, event))
+		}
+	}
+
+	// Create usage data that would normally come from GetUsageBySubscription
+	usage := &dto.GetUsageBySubscriptionResponse{
+		StartTime: s.testData.subscription.CurrentPeriodStart,
+		EndTime:   s.testData.subscription.CurrentPeriodEnd,
+		Currency:  s.testData.subscription.Currency,
+		Charges: []*dto.SubscriptionUsageByMetersResponse{
+			{
+				Price:     s.testData.prices.apiCalls,
+				Quantity:  30,  // Total usage across all days (15+3+12)
+				Amount:    0.6, // $0.6 without entitlement adjustment (30 * 0.02)
+				IsOverage: false,
+				MeterID:   s.testData.meters.apiCalls.ID,
+			},
+		},
+	}
+
+	// Calculate charges
+	lineItems, totalAmount, err := s.service.CalculateUsageCharges(
+		ctx,
+		s.testData.subscription,
+		usage,
+		s.testData.subscription.CurrentPeriodStart,
+		s.testData.subscription.CurrentPeriodEnd,
+	)
+
+	s.NoError(err)
+	s.Len(lineItems, 1, "Should have one line item for daily usage")
+
+	// Expected calculation:
+	// Day 1: 15 - 10 = 5 overage
+	// Day 2: 3 - 10 = 0 overage (max(0, -7) = 0)
+	// Day 3: 12 - 10 = 2 overage
+	// Total overage: 5 + 0 + 2 = 7 requests
+	// Total cost: 7 * $0.02 = $0.14 (using tiered pricing)
+	expectedQuantity := decimal.NewFromInt(7)
+
+	s.True(expectedQuantity.Equal(lineItems[0].Quantity),
+		"Expected quantity %s, got %s", expectedQuantity, lineItems[0].Quantity)
+
+	// Check that the amount is calculated correctly
+	s.True(totalAmount.GreaterThan(decimal.Zero), "Should have positive total amount")
+
+	// Check metadata indicates daily reset
+	s.Equal("daily", lineItems[0].Metadata["usage_reset_period"])
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implement daily usage reset for metered entitlements in billing service with corresponding tests.
> 
>   - **Behavior**:
>     - Implement daily usage reset for metered entitlements in `CalculateUsageCharges()` in `billing.go`.
>     - Supports daily reset period; other periods (weekly, monthly, yearly) are not yet supported.
>     - Calculates overage per day and sums total overage for billing.
>   - **Tests**:
>     - Add `TestCalculateUsageChargesWithDailyReset()` in `billing_test.go` to verify daily reset functionality.
>     - Test covers multiple days with varying usage to ensure correct overage calculation.
>   - **Misc**:
>     - Add logging for daily usage calculations in `billing.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d618ea125a466802fe927799d9c8908c912fd2e8. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->