### PR TITLE
feat(events): filter usage for meters with any usage in the time

### DIFF
--- a/internal/domain/events/repository.go
+++ b/internal/domain/events/repository.go
@@ -15,6 +15,7 @@ type Repository interface {
 	GetUsageWithFilters(ctx context.Context, params *UsageWithFiltersParams) ([]*AggregationResult, error)
 	GetEvents(ctx context.Context, params *GetEventsParams) ([]*Event, uint64, error)
 	FindUnprocessedEvents(ctx context.Context, params *FindUnprocessedEventsParams) ([]*Event, error)
+	GetDistinctEventNames(ctx context.Context, externalCustomerID string, startTime, endTime time.Time) ([]string, error)
 }
 
 // ProcessedEventRepository defines operations for processed events

--- a/internal/testutil/inmemory_event_store.go
+++ b/internal/testutil/inmemory_event_store.go
@@ -503,6 +503,22 @@ func (s *InMemoryEventStore) GetUsageWithFilters(ctx context.Context, params *ev
 	return results, nil
 }
 
+func (s *InMemoryEventStore) GetDistinctEventNames(ctx context.Context, externalCustomerID string, startTime, endTime time.Time) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var eventNames []string
+	for _, event := range s.events {
+		if event.ExternalCustomerID == externalCustomerID && event.Timestamp.After(startTime) && event.Timestamp.Before(endTime) {
+			eventNames = append(eventNames, event.EventName)
+		}
+	}
+
+	sort.Strings(eventNames)
+
+	return eventNames, nil
+}
+
 func (s *InMemoryEventStore) matchesBaseFilters(ctx context.Context, event *events.Event, params *events.UsageParams) bool {
 	// check tenant ID
 	tenantID := types.GetTenantID(ctx)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GetDistinctEventNames` to optimize meter usage filtering by retrieving distinct event names for a customer, reducing processed meters in `GetUsageBySubscription`.
> 
>   - **Behavior**:
>     - Add `GetDistinctEventNames` to `Repository` interface in `repository.go` to retrieve distinct event names for a customer within a time range.
>     - Implement `GetDistinctEventNames` in `EventRepository` in `event.go` for ClickHouse, optimizing meter usage filtering.
>     - Update `GetUsageBySubscription` in `subscription.go` to use `GetDistinctEventNames`, reducing processed meters from 400-500 to 5-7.
>   - **Testing**:
>     - Implement `GetDistinctEventNames` in `InMemoryEventStore` in `inmemory_event_store.go` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 14b44206bb106a96e0b18c16ae1eafdaa5a032e6. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->