### PR TITLE
fix(wallet): skip all usage charges if no events

### DIFF
--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -459,26 +459,7 @@ func (s *SubscriptionServiceSuite) TestGetUsageBySubscription() {
 				EndTime:   s.testData.now.Add(-50 * 24 * time.Hour),
 				Amount:    0,
 				Currency:  "usd",
-				Charges: []*dto.SubscriptionUsageByMetersResponse{
-					{
-						MeterDisplayName: "Storage",
-						Quantity:         decimal.NewFromInt(0).InexactFloat64(),
-						Amount:           0,
-						Price:            s.testData.prices.storage,
-					},
-					{
-						MeterDisplayName: "Storage Archive",
-						Quantity:         decimal.NewFromInt(0).InexactFloat64(),
-						Amount:           0,
-						Price:            s.testData.prices.storageArchive,
-					},
-					{
-						MeterDisplayName: "API Calls",
-						Quantity:         decimal.NewFromInt(0).InexactFloat64(),
-						Amount:           0,
-						Price:            s.testData.prices.apiCalls,
-					},
-				},
+				Charges:   []*dto.SubscriptionUsageByMetersResponse{},
 			},
 			wantErr: false,
 		},

--- a/internal/testutil/inmemory_event_store.go
+++ b/internal/testutil/inmemory_event_store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/events"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
 
@@ -514,6 +515,7 @@ func (s *InMemoryEventStore) GetDistinctEventNames(ctx context.Context, external
 		}
 	}
 
+	eventNames = lo.Uniq(eventNames)
 	sort.Strings(eventNames)
 
 	return eventNames, nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Skip processing usage charges in `GetUsageBySubscription` if no events are present, and update tests accordingly.
> 
>   - **Behavior**:
>     - In `GetUsageBySubscription` in `subscription.go`, skip processing usage charges if `distinctEventNames` is empty, indicating no event data.
>     - Log debug message when skipping due to no events.
>   - **Tests**:
>     - Update `TestGetUsageBySubscription` in `subscription_test.go` to expect empty `Charges` when no events are present.
>   - **Utilities**:
>     - Use `lo.Uniq` in `GetDistinctEventNames` in `inmemory_event_store.go` to ensure unique event names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 605143eed1ae2947e5bbe1d269c45416f6ac98d8. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->