### PR TITLE
fix(usage): handle daily reset for customer usage api

### DIFF
--- a/internal/api/dto/customer_entitlement.go
+++ b/internal/api/dto/customer_entitlement.go
@@ -81,15 +81,16 @@ func (e EntitlementSourceEntityType) Validate() error {
 
 // EntitlementSource tracks which subscription provided the entitlement
 type EntitlementSource struct {
-	SubscriptionID string                      `json:"subscription_id"`
-	EntityID       string                      `json:"entity_id"`
-	EntityType     EntitlementSourceEntityType `json:"entity_type"`
-	Quantity       int64                       `json:"quantity"`
-	EntitiyName    string                      `json:"entity_name"`
-	EntitlementID  string                      `json:"entitlement_id"`
-	IsEnabled      bool                        `json:"is_enabled"`
-	UsageLimit     *int64                      `json:"usage_limit,omitempty"`
-	StaticValue    string                      `json:"static_value,omitempty"`
+	SubscriptionID   string                      `json:"subscription_id"`
+	EntityID         string                      `json:"entity_id"`
+	EntityType       EntitlementSourceEntityType `json:"entity_type"`
+	Quantity         int64                       `json:"quantity"`
+	EntitiyName      string                      `json:"entity_name"`
+	EntitlementID    string                      `json:"entitlement_id"`
+	IsEnabled        bool                        `json:"is_enabled"`
+	UsageLimit       *int64                      `json:"usage_limit,omitempty"`
+	StaticValue      string                      `json:"static_value,omitempty"`
+	UsageResetPeriod types.BillingPeriod         `json:"usage_reset_period,omitempty"`
 }
 
 // GetCustomerUsageSummaryRequest represents the request for getting customer usage summary

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1274,6 +1274,13 @@ func (s *billingService) GetCustomerEntitlements(ctx context.Context, customerID
 
 func (s *billingService) GetCustomerUsageSummary(ctx context.Context, customerID string, req *dto.GetCustomerUsageSummaryRequest) (*dto.CustomerUsageSummaryResponse, error) {
 	subscriptionService := NewSubscriptionService(s.ServiceParams)
+	eventService := NewEventService(s.EventRepo, s.MeterRepo, s.EventPublisher, s.Logger, s.Config)
+	// get customer
+	customer, err := s.CustomerRepo.Get(ctx, customerID)
+	if err != nil {
+		return nil, err
+	}
+
 	// 1. Get customer entitlements first
 	entitlementsReq := &dto.GetCustomerEntitlementsRequest{
 		SubscriptionIDs: req.SubscriptionIDs,
@@ -1307,10 +1314,14 @@ func (s *billingService) GetCustomerUsageSummary(ctx context.Context, customerID
 	// 3. Create a map to track usage by feature ID
 	usageByFeature := make(map[string]decimal.Decimal)
 	meterFeatureMap := make(map[string]string)
+	featureMeterMap := make(map[string]string)
+	featureUsageResetPeriodMap := make(map[string]types.BillingPeriod)
 
 	for _, feature := range entitlements.Features {
 		usageByFeature[feature.Feature.ID] = decimal.Zero
 		meterFeatureMap[feature.Feature.MeterID] = feature.Feature.ID
+		featureMeterMap[feature.Feature.ID] = feature.Feature.MeterID
+		featureUsageResetPeriodMap[feature.Feature.ID] = feature.Entitlement.UsageResetPeriod
 	}
 
 	// 4. Get usage for each subscription
@@ -1324,11 +1335,68 @@ func (s *billingService) GetCustomerUsageSummary(ctx context.Context, customerID
 			return nil, err
 		}
 
+		sub, err := s.SubRepo.Get(ctx, subscriptionID)
+		if err != nil {
+			return nil, err
+		}
+
 		// Add usage if found for this feature
 		for _, charge := range usage.Charges {
 			if featureID, ok := meterFeatureMap[charge.MeterID]; ok {
-				currentUsage := usageByFeature[featureID]
-				usageByFeature[featureID] = currentUsage.Add(decimal.NewFromFloat(charge.Quantity))
+				resetPeriod := featureUsageResetPeriodMap[featureID]
+				if resetPeriod == types.BILLING_PERIOD_DAILY {
+					// Handle daily reset features: get today's usage from daily windows
+					meterID := featureMeterMap[featureID]
+					// Create usage request with daily window size for current billing period
+					usageRequest := &dto.GetUsageByMeterRequest{
+						MeterID:            meterID,
+						ExternalCustomerID: customer.ExternalID,
+						StartTime:          sub.CurrentPeriodStart,
+						EndTime:            sub.CurrentPeriodEnd,
+						WindowSize:         types.WindowSizeDay, // Use daily window size
+					}
+
+					// Get usage data with daily windows
+					usageResult, err := eventService.GetUsageByMeter(ctx, usageRequest)
+					if err != nil {
+						s.Logger.Warnw("failed to get daily usage for feature",
+							"feature_id", featureID,
+							"meter_id", meterID,
+							"subscription_id", subscriptionID,
+							"error", err)
+						continue
+					}
+
+					// Pick the last bucket (today's usage) if available
+					dailyUsage := decimal.Zero
+					today := time.Now().In(sub.CurrentPeriodStart.Location())
+					todayStart := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, today.Location())
+					todayEnd := todayStart.AddDate(0, 0, 1)
+					if len(usageResult.Results) > 0 {
+						lastBucket := usageResult.Results[len(usageResult.Results)-1]
+						// check if last bucket is today's usage
+						if (lastBucket.WindowSize.After(todayStart) || lastBucket.WindowSize.Equal(todayStart)) && lastBucket.WindowSize.Before(todayEnd) {
+							dailyUsage = lastBucket.Value
+						}
+
+						s.Logger.Debugw("using daily usage for feature summary",
+							"customer_id", customerID,
+							"external_customer_id", customer.ExternalID,
+							"feature_id", featureID,
+							"meter_id", meterID,
+							"subscription_id", subscriptionID,
+							"today_usage", dailyUsage,
+							"today_start", todayStart,
+							"today_end", todayEnd,
+							"last_bucket", lastBucket.WindowSize,
+							"last_bucket_value", lastBucket.Value,
+							"total_daily_windows", len(usageResult.Results))
+					}
+					usageByFeature[featureID] = dailyUsage
+				} else {
+					currentUsage := usageByFeature[featureID]
+					usageByFeature[featureID] = currentUsage.Add(decimal.NewFromFloat(charge.Quantity))
+				}
 			}
 		}
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR adds support for daily reset periods in customer usage summaries by updating the `GetCustomerUsageSummary` function to fetch and process daily usage data.
> 
>   - **Behavior**:
>     - Adds `UsageResetPeriod` field to `EntitlementSource` in `customer_entitlement.go`.
>     - Updates `GetCustomerUsageSummary` in `billing.go` to handle daily reset periods by fetching daily usage data.
>     - Logs errors and debug information when fetching daily usage fails or succeeds.
>   - **Functions**:
>     - Modifies `GetCustomerUsageSummary` in `billing.go` to calculate usage based on daily reset periods.
>     - Adds logic to fetch and process daily usage data for features with daily reset periods.
>   - **Misc**:
>     - Adds logging for daily usage calculations in `billing.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 9ca6dd6bcbd7e33c0075a02c150e84f212c4563e. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->