### PR TITLE
fix(credit-invoice): Add total, subtotal in create invoice request

### DIFF
--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -355,9 +355,12 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 	var paymentID string
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 		// Create invoice for credit purchase
+		amount := s.GetCurrencyAmountFromCredits(req.CreditsToAdd, w.ConversionRate)
 		invoice, err := invoiceService.CreateInvoice(ctx, dto.CreateInvoiceRequest{
 			CustomerID:     w.CustomerID,
-			AmountDue:      s.GetCurrencyAmountFromCredits(req.CreditsToAdd, w.ConversionRate),
+			AmountDue:      amount,
+			Subtotal:       amount,
+			Total:          amount,
 			Currency:       w.Currency,
 			InvoiceType:    types.InvoiceTypeCredit,
 			DueDate:        lo.ToPtr(time.Now().UTC()),
@@ -365,7 +368,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			InvoiceStatus:  lo.ToPtr(types.InvoiceStatusFinalized),
 			LineItems: []dto.CreateInvoiceLineItemRequest{
 				{
-					Amount:      s.GetCurrencyAmountFromCredits(req.CreditsToAdd, w.ConversionRate),
+					Amount:      amount,
 					Quantity:    decimal.NewFromInt(1),
 					DisplayName: lo.ToPtr("Purchased Credits"),
 				},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Subtotal` and `Total` fields to invoice creation in `handlePurchasedCreditInvoicedTransaction()` in `wallet.go`, setting them equal to `AmountDue`.
> 
>   - **Behavior**:
>     - Add `Subtotal` and `Total` fields in `CreateInvoiceRequest` in `handlePurchasedCreditInvoicedTransaction()` in `wallet.go`.
>     - Both fields are set to the same value as `AmountDue`, calculated from credits and conversion rate.
>   - **Misc**:
>     - Refactor to use a single `amount` variable for `AmountDue`, `Subtotal`, and `Total` in `wallet.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 9e2df83f3ef0b22caa2d77e13d4f0d744e1879e4. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->