### PR TITLE
feat(wallet): honor usage only restrictions

### DIFF
--- a/internal/domain/wallet/model.go
+++ b/internal/domain/wallet/model.go
@@ -71,6 +71,10 @@ func (w *Wallet) ApplyConversionRate(rate decimal.Decimal) *Wallet {
 	return w
 }
 
+func (w *Wallet) IsUsageRestricted() bool {
+	return w.Config.AllowedPriceTypes != nil && !lo.Contains(w.Config.AllowedPriceTypes, types.WalletConfigPriceTypeAll)
+}
+
 // FromEnt converts an ent wallet to a domain wallet
 func FromEnt(e *ent.Wallet) *Wallet {
 	if e == nil {

--- a/internal/service/wallet_payment_test.go
+++ b/internal/service/wallet_payment_test.go
@@ -1,11 +1,13 @@
 package service
 
 import (
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/domain/payment"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
@@ -504,4 +506,903 @@ func (s *WalletPaymentServiceSuite) TestInvoiceWithNoRemainingAmount() {
 	})
 	s.NoError(err)
 	s.Empty(payments, "No payment requests should have been made")
+}
+
+// TestUsageRestrictedWalletsWithMixedLineItems tests wallets with usage restrictions on invoices with both usage and fixed line items
+func (s *WalletPaymentServiceSuite) TestUsageRestrictedWalletsWithMixedLineItems() {
+	// Clear existing data
+	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+	// Create usage-restricted wallet
+	usageRestrictedWallet := &wallet.Wallet{
+		ID:             "wallet_usage_restricted_mixed",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(100),
+		CreditBalance:  decimal.NewFromFloat(100),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), usageRestrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         usageRestrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           usageRestrictedWallet.Balance,
+		CreditAmount:     usageRestrictedWallet.CreditBalance,
+		CreditsAvailable: usageRestrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create unrestricted wallet
+	unrestrictedWallet := &wallet.Wallet{
+		ID:             "wallet_unrestricted_mixed",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(150),
+		CreditBalance:  decimal.NewFromFloat(150),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePrePaid,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeAll},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), unrestrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         unrestrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           unrestrictedWallet.Balance,
+		CreditAmount:     unrestrictedWallet.CreditBalance,
+		CreditsAvailable: unrestrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create invoice with mixed line items (usage + fixed)
+	mixedInvoice := &invoice.Invoice{
+		ID:              "inv_mixed_line_items_test",
+		CustomerID:      s.testData.customer.ID,
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		AmountDue:       decimal.NewFromFloat(200), // $80 usage + $120 fixed
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.NewFromFloat(200),
+		LineItems: []*invoice.InvoiceLineItem{
+			{
+				ID:        "line_usage_1_mixed",
+				InvoiceID: "inv_mixed_line_items_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+				Amount:    decimal.NewFromFloat(50),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+			{
+				ID:        "line_usage_2_mixed",
+				InvoiceID: "inv_mixed_line_items_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+				Amount:    decimal.NewFromFloat(30),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+			{
+				ID:        "line_fixed_1_mixed",
+				InvoiceID: "inv_mixed_line_items_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+				Amount:    decimal.NewFromFloat(120),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), mixedInvoice))
+
+	// Process payment
+	amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+		s.GetContext(),
+		mixedInvoice,
+		DefaultWalletPaymentOptions(),
+	)
+
+	// Verify results
+	s.NoError(err)
+	// Expected: $80 from restricted wallet (all usage) + $120 from unrestricted wallet (remaining amount)
+	s.True(decimal.NewFromFloat(200).Equal(amountPaid), "Should pay full amount: expected 200, got %s", amountPaid)
+
+	// Verify payment breakdown
+	payments, err := s.GetStores().PaymentRepo.List(s.GetContext(), &types.PaymentFilter{
+		DestinationID:   &mixedInvoice.ID,
+		DestinationType: lo.ToPtr(string(types.PaymentDestinationTypeInvoice)),
+	})
+	s.NoError(err)
+	s.Equal(2, len(payments), "Should have 2 payments (one from each wallet)")
+
+	// Find payments by wallet
+	var restrictedPayment, unrestrictedPayment *payment.Payment
+	for _, payment := range payments {
+		if payment.PaymentMethodID == usageRestrictedWallet.ID {
+			restrictedPayment = payment
+		} else if payment.PaymentMethodID == unrestrictedWallet.ID {
+			unrestrictedPayment = payment
+		}
+	}
+
+	s.NotNil(restrictedPayment, "Should have payment from restricted wallet")
+	s.NotNil(unrestrictedPayment, "Should have payment from unrestricted wallet")
+	s.True(decimal.NewFromFloat(80).Equal(restrictedPayment.Amount), "Restricted wallet should pay exactly the usage amount: expected 80, got %s", restrictedPayment.Amount)
+	s.True(decimal.NewFromFloat(120).Equal(unrestrictedPayment.Amount), "Unrestricted wallet should pay remaining amount: expected 120, got %s", unrestrictedPayment.Amount)
+}
+
+// TestUsageRestrictedWalletsWithNoUsageLineItems tests that restricted wallets cannot pay when there are no usage line items
+func (s *WalletPaymentServiceSuite) TestUsageRestrictedWalletsWithNoUsageLineItems() {
+	// Clear existing data
+	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+	// Create usage-restricted wallet
+	usageRestrictedWallet := &wallet.Wallet{
+		ID:             "wallet_usage_restricted_no_usage_test",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(100),
+		CreditBalance:  decimal.NewFromFloat(100),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), usageRestrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         usageRestrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           usageRestrictedWallet.Balance,
+		CreditAmount:     usageRestrictedWallet.CreditBalance,
+		CreditsAvailable: usageRestrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create invoice with only fixed line items
+	fixedOnlyInvoice := &invoice.Invoice{
+		ID:              "inv_fixed_only_test",
+		CustomerID:      s.testData.customer.ID,
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		AmountDue:       decimal.NewFromFloat(100),
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.NewFromFloat(100),
+		LineItems: []*invoice.InvoiceLineItem{
+			{
+				ID:        "line_fixed_only_test",
+				InvoiceID: "inv_fixed_only_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+				Amount:    decimal.NewFromFloat(100),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), fixedOnlyInvoice))
+
+	// Process payment
+	amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+		s.GetContext(),
+		fixedOnlyInvoice,
+		DefaultWalletPaymentOptions(),
+	)
+
+	// Verify results
+	s.NoError(err)
+	s.True(decimal.Zero.Equal(amountPaid), "Should pay nothing since restricted wallet cannot pay for fixed line items")
+
+	// Verify no payment requests were made
+	payments, err := s.GetStores().PaymentRepo.List(s.GetContext(), &types.PaymentFilter{
+		DestinationID:   &fixedOnlyInvoice.ID,
+		DestinationType: lo.ToPtr(string(types.PaymentDestinationTypeInvoice)),
+	})
+	s.NoError(err)
+	s.Empty(payments, "No payment requests should have been made")
+}
+
+// TestMultipleUsageRestrictedWallets tests multiple restricted wallets competing for limited usage amount
+func (s *WalletPaymentServiceSuite) TestMultipleUsageRestrictedWallets() {
+	// Clear existing data
+	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+	// Create multiple usage-restricted wallets
+	restrictedWallet1 := &wallet.Wallet{
+		ID:             "wallet_restricted_1_test",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(60),
+		CreditBalance:  decimal.NewFromFloat(60),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), restrictedWallet1))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         restrictedWallet1.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           restrictedWallet1.Balance,
+		CreditAmount:     restrictedWallet1.CreditBalance,
+		CreditsAvailable: restrictedWallet1.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	restrictedWallet2 := &wallet.Wallet{
+		ID:             "wallet_restricted_2_test",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(40),
+		CreditBalance:  decimal.NewFromFloat(40),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), restrictedWallet2))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         restrictedWallet2.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           restrictedWallet2.Balance,
+		CreditAmount:     restrictedWallet2.CreditBalance,
+		CreditsAvailable: restrictedWallet2.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create invoice with limited usage amount
+	limitedUsageInvoice := &invoice.Invoice{
+		ID:              "inv_limited_usage_test",
+		CustomerID:      s.testData.customer.ID,
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		AmountDue:       decimal.NewFromFloat(150), // $50 usage + $100 fixed
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.NewFromFloat(150),
+		LineItems: []*invoice.InvoiceLineItem{
+			{
+				ID:        "line_usage_limited_test",
+				InvoiceID: "inv_limited_usage_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+				Amount:    decimal.NewFromFloat(50),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+			{
+				ID:        "line_fixed_limited_test",
+				InvoiceID: "inv_limited_usage_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+				Amount:    decimal.NewFromFloat(100),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), limitedUsageInvoice))
+
+	// Process payment with balance optimized strategy to use smallest balance wallet first
+	amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+		s.GetContext(),
+		limitedUsageInvoice,
+		WalletPaymentOptions{
+			Strategy:        BalanceOptimizedStrategy,
+			MaxWalletsToUse: 0,
+		},
+	)
+
+	// Verify results
+	s.NoError(err)
+	// Expected: Only $50 should be paid (the usage amount) since only restricted wallets are available
+	s.True(decimal.NewFromFloat(50).Equal(amountPaid), "Should pay only the usage amount: expected 50, got %s", amountPaid)
+
+	// Verify payment breakdown
+	payments, err := s.GetStores().PaymentRepo.List(s.GetContext(), &types.PaymentFilter{
+		DestinationID:   &limitedUsageInvoice.ID,
+		DestinationType: lo.ToPtr(string(types.PaymentDestinationTypeInvoice)),
+	})
+	s.NoError(err)
+	s.Equal(2, len(payments), "Should have 2 payments: first wallet pays $40, second pays remaining $10")
+
+	// Sort payments by amount to make assertions predictable
+	sort.Slice(payments, func(i, j int) bool {
+		return payments[i].Amount.GreaterThan(payments[j].Amount)
+	})
+
+	// The first payment should be from wallet2 (smaller balance wallet) paying its full balance
+	s.Equal(restrictedWallet2.ID, payments[0].PaymentMethodID, "First payment should be from wallet with smaller balance")
+	s.True(decimal.NewFromFloat(40).Equal(payments[0].Amount), "First payment should be wallet's full balance: expected 40, got %s", payments[0].Amount)
+
+	// The second payment should be from wallet1 paying the remaining usage amount
+	s.Equal(restrictedWallet1.ID, payments[1].PaymentMethodID, "Second payment should be from wallet with larger balance")
+	s.True(decimal.NewFromFloat(10).Equal(payments[1].Amount), "Second payment should be remaining usage amount: expected 10, got %s", payments[1].Amount)
+}
+
+// TestUsageRestrictedWalletsWithExistingPayments tests restricted wallets when usage has been partially paid
+func (s *WalletPaymentServiceSuite) TestUsageRestrictedWalletsWithExistingPayments() {
+	// Clear existing data
+	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+	// Create usage-restricted wallet
+	usageRestrictedWallet := &wallet.Wallet{
+		ID:             "wallet_restricted_existing_payments_test",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(100),
+		CreditBalance:  decimal.NewFromFloat(100),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), usageRestrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         usageRestrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           usageRestrictedWallet.Balance,
+		CreditAmount:     usageRestrictedWallet.CreditBalance,
+		CreditsAvailable: usageRestrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create invoice with usage + fixed line items
+	existingPaymentInvoice := &invoice.Invoice{
+		ID:              "inv_existing_payments_test",
+		CustomerID:      s.testData.customer.ID,
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		AmountDue:       decimal.NewFromFloat(200), // $100 usage + $100 fixed
+		AmountPaid:      decimal.NewFromFloat(30),  // $30 already paid via credits
+		AmountRemaining: decimal.NewFromFloat(170),
+		LineItems: []*invoice.InvoiceLineItem{
+			{
+				ID:        "line_usage_existing_test",
+				InvoiceID: "inv_existing_payments_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+				Amount:    decimal.NewFromFloat(100),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+			{
+				ID:        "line_fixed_existing_test",
+				InvoiceID: "inv_existing_payments_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+				Amount:    decimal.NewFromFloat(100),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), existingPaymentInvoice))
+
+	// Create existing credit payment (simulating previous payment)
+	existingPayment := &payment.Payment{
+		ID:                types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PAYMENT),
+		Amount:            decimal.NewFromFloat(30),
+		Currency:          "usd",
+		PaymentMethodType: types.PaymentMethodTypeCredits,
+		PaymentMethodID:   "some_previous_wallet_test",
+		PaymentStatus:     types.PaymentStatusSucceeded,
+		DestinationType:   types.PaymentDestinationTypeInvoice,
+		DestinationID:     existingPaymentInvoice.ID,
+		BaseModel:         types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().PaymentRepo.Create(s.GetContext(), existingPayment))
+
+	// Process payment
+	amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+		s.GetContext(),
+		existingPaymentInvoice,
+		DefaultWalletPaymentOptions(),
+	)
+
+	// Verify results
+	s.NoError(err)
+	// Expected: $70 from restricted wallet (remaining usage after $30 already paid)
+	// This tests the critical issue: should the restricted wallet be able to pay $70 or only $70 (100-30)?
+	s.True(decimal.NewFromFloat(70).Equal(amountPaid), "Should pay remaining usage amount: expected 70, got %s", amountPaid)
+}
+
+// TestCombinedRestrictedAndUnrestrictedWallets tests the complex scenario with both types of wallets
+func (s *WalletPaymentServiceSuite) TestCombinedRestrictedAndUnrestrictedWallets() {
+	// Clear existing data
+	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+	// Create two restricted wallets with different balances
+	restrictedWallet1 := &wallet.Wallet{
+		ID:             "wallet_restricted_small_combo",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(30),
+		CreditBalance:  decimal.NewFromFloat(30),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), restrictedWallet1))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         restrictedWallet1.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           restrictedWallet1.Balance,
+		CreditAmount:     restrictedWallet1.CreditBalance,
+		CreditsAvailable: restrictedWallet1.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	restrictedWallet2 := &wallet.Wallet{
+		ID:             "wallet_restricted_large_combo",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(80),
+		CreditBalance:  decimal.NewFromFloat(80),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), restrictedWallet2))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         restrictedWallet2.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           restrictedWallet2.Balance,
+		CreditAmount:     restrictedWallet2.CreditBalance,
+		CreditsAvailable: restrictedWallet2.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create unrestricted wallet
+	unrestrictedWallet := &wallet.Wallet{
+		ID:             "wallet_unrestricted_combo_test",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(200),
+		CreditBalance:  decimal.NewFromFloat(200),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePrePaid,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeAll},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), unrestrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         unrestrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           unrestrictedWallet.Balance,
+		CreditAmount:     unrestrictedWallet.CreditBalance,
+		CreditsAvailable: unrestrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create invoice with usage + fixed line items
+	comboInvoice := &invoice.Invoice{
+		ID:              "inv_combo_test",
+		CustomerID:      s.testData.customer.ID,
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		AmountDue:       decimal.NewFromFloat(250), // $60 usage + $190 fixed
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.NewFromFloat(250),
+		LineItems: []*invoice.InvoiceLineItem{
+			{
+				ID:        "line_usage_combo_test",
+				InvoiceID: "inv_combo_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+				Amount:    decimal.NewFromFloat(60),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+			{
+				ID:        "line_fixed_combo_test",
+				InvoiceID: "inv_combo_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+				Amount:    decimal.NewFromFloat(190),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), comboInvoice))
+
+	// Process payment with balance optimized strategy to ensure smaller restricted wallet goes first
+	amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+		s.GetContext(),
+		comboInvoice,
+		WalletPaymentOptions{
+			Strategy:        BalanceOptimizedStrategy,
+			MaxWalletsToUse: 0,
+		},
+	)
+
+	// Verify results
+	s.NoError(err)
+	// Expected: $30 (from small restricted) + $30 (from large restricted) + $190 (from unrestricted) = $250
+	s.True(decimal.NewFromFloat(250).Equal(amountPaid), "Should pay full amount: expected 250, got %s", amountPaid)
+
+	// Verify payment breakdown
+	payments, err := s.GetStores().PaymentRepo.List(s.GetContext(), &types.PaymentFilter{
+		DestinationID:   &comboInvoice.ID,
+		DestinationType: lo.ToPtr(string(types.PaymentDestinationTypeInvoice)),
+	})
+	s.NoError(err)
+	s.Equal(3, len(payments), "Should have 3 payments (2 restricted + 1 unrestricted)")
+
+	// Verify that usage amount is fully covered by restricted wallets
+	restrictedPaymentsTotal := decimal.Zero
+	for _, payment := range payments {
+		if payment.PaymentMethodID == restrictedWallet1.ID || payment.PaymentMethodID == restrictedWallet2.ID {
+			restrictedPaymentsTotal = restrictedPaymentsTotal.Add(payment.Amount)
+		}
+	}
+	s.True(decimal.NewFromFloat(60).Equal(restrictedPaymentsTotal), "Restricted wallets should pay exactly the usage amount: expected 60, got %s", restrictedPaymentsTotal)
+}
+
+// TestUsageRestrictedWalletsWithPartialUsagePayment tests when usage amount exceeds what restricted wallets can pay
+func (s *WalletPaymentServiceSuite) TestUsageRestrictedWalletsWithPartialUsagePayment() {
+	// Clear existing data
+	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+	// Create restricted wallet with insufficient balance for all usage
+	restrictedWallet := &wallet.Wallet{
+		ID:             "wallet_restricted_insufficient",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(20), // Less than usage amount
+		CreditBalance:  decimal.NewFromFloat(20),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePromotional,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), restrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         restrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           restrictedWallet.Balance,
+		CreditAmount:     restrictedWallet.CreditBalance,
+		CreditsAvailable: restrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create unrestricted wallet
+	unrestrictedWallet := &wallet.Wallet{
+		ID:             "wallet_unrestricted_partial",
+		CustomerID:     s.testData.customer.ID,
+		Currency:       "usd",
+		Balance:        decimal.NewFromFloat(200),
+		CreditBalance:  decimal.NewFromFloat(200),
+		ConversionRate: decimal.NewFromFloat(1.0),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePrePaid,
+		Config: types.WalletConfig{
+			AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeAll},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), unrestrictedWallet))
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         unrestrictedWallet.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           unrestrictedWallet.Balance,
+		CreditAmount:     unrestrictedWallet.CreditBalance,
+		CreditsAvailable: unrestrictedWallet.CreditBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}))
+
+	// Create invoice with high usage amount
+	partialUsageInvoice := &invoice.Invoice{
+		ID:              "inv_partial_usage_test",
+		CustomerID:      s.testData.customer.ID,
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		AmountDue:       decimal.NewFromFloat(200), // $100 usage + $100 fixed
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.NewFromFloat(200),
+		LineItems: []*invoice.InvoiceLineItem{
+			{
+				ID:        "line_usage_partial_test",
+				InvoiceID: "inv_partial_usage_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+				Amount:    decimal.NewFromFloat(100),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+			{
+				ID:        "line_fixed_partial_test",
+				InvoiceID: "inv_partial_usage_test",
+				PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+				Amount:    decimal.NewFromFloat(100),
+				Currency:  "usd",
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), partialUsageInvoice))
+
+	// Process payment
+	amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+		s.GetContext(),
+		partialUsageInvoice,
+		DefaultWalletPaymentOptions(),
+	)
+
+	// Verify results
+	s.NoError(err)
+	// Expected: $20 (restricted, partial usage) + $180 (unrestricted, remaining amount)
+	s.True(decimal.NewFromFloat(200).Equal(amountPaid), "Should pay full amount: expected 200, got %s", amountPaid)
+
+	// Verify payment breakdown
+	payments, err := s.GetStores().PaymentRepo.List(s.GetContext(), &types.PaymentFilter{
+		DestinationID:   &partialUsageInvoice.ID,
+		DestinationType: lo.ToPtr(string(types.PaymentDestinationTypeInvoice)),
+	})
+	s.NoError(err)
+	s.Equal(2, len(payments), "Should have 2 payments")
+
+	// Find payments by wallet
+	var restrictedPayment, unrestrictedPayment *payment.Payment
+	for _, payment := range payments {
+		if payment.PaymentMethodID == restrictedWallet.ID {
+			restrictedPayment = payment
+		} else if payment.PaymentMethodID == unrestrictedWallet.ID {
+			unrestrictedPayment = payment
+		}
+	}
+
+	s.NotNil(restrictedPayment, "Should have payment from restricted wallet")
+	s.NotNil(unrestrictedPayment, "Should have payment from unrestricted wallet")
+	s.True(decimal.NewFromFloat(20).Equal(restrictedPayment.Amount), "Restricted wallet should pay its full balance: expected 20, got %s", restrictedPayment.Amount)
+	s.True(decimal.NewFromFloat(180).Equal(unrestrictedPayment.Amount), "Unrestricted wallet should pay remaining amount: expected 180, got %s", unrestrictedPayment.Amount)
+}
+
+// TestUsageRestrictedWalletsEdgeCases tests various edge cases
+func (s *WalletPaymentServiceSuite) TestUsageRestrictedWalletsEdgeCases() {
+	tests := []struct {
+		name                    string
+		usageAmount             decimal.Decimal
+		fixedAmount             decimal.Decimal
+		restrictedWalletBalance decimal.Decimal
+		existingCreditPayment   decimal.Decimal
+		expectedRestrictedPay   decimal.Decimal
+		expectedTotalPay        decimal.Decimal
+	}{
+		{
+			name:                    "Zero usage amount",
+			usageAmount:             decimal.Zero,
+			fixedAmount:             decimal.NewFromFloat(100),
+			restrictedWalletBalance: decimal.NewFromFloat(50),
+			existingCreditPayment:   decimal.Zero,
+			expectedRestrictedPay:   decimal.Zero,
+			expectedTotalPay:        decimal.Zero, // No unrestricted wallet in this test
+		},
+		{
+			name:                    "Usage fully paid by existing credits",
+			usageAmount:             decimal.NewFromFloat(50),
+			fixedAmount:             decimal.NewFromFloat(100),
+			restrictedWalletBalance: decimal.NewFromFloat(50),
+			existingCreditPayment:   decimal.NewFromFloat(50), // Usage fully paid
+			expectedRestrictedPay:   decimal.Zero,
+			expectedTotalPay:        decimal.Zero,
+		},
+		{
+			name:                    "Usage partially paid by existing credits",
+			usageAmount:             decimal.NewFromFloat(100),
+			fixedAmount:             decimal.NewFromFloat(50),
+			restrictedWalletBalance: decimal.NewFromFloat(80),
+			existingCreditPayment:   decimal.NewFromFloat(30), // $70 usage remaining
+			expectedRestrictedPay:   decimal.NewFromFloat(70),
+			expectedTotalPay:        decimal.NewFromFloat(70),
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			// Clear existing data
+			s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+			s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
+
+			// Create restricted wallet
+			restrictedWallet := &wallet.Wallet{
+				ID:             "wallet_restricted_edge_" + tc.name,
+				CustomerID:     s.testData.customer.ID,
+				Currency:       "usd",
+				Balance:        tc.restrictedWalletBalance,
+				CreditBalance:  tc.restrictedWalletBalance,
+				ConversionRate: decimal.NewFromFloat(1.0),
+				WalletStatus:   types.WalletStatusActive,
+				WalletType:     types.WalletTypePromotional,
+				Config: types.WalletConfig{
+					AllowedPriceTypes: []types.WalletConfigPriceType{types.WalletConfigPriceTypeUsage},
+				},
+				BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+			}
+			s.NoError(s.GetStores().WalletRepo.CreateWallet(s.GetContext(), restrictedWallet))
+			s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+				ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+				WalletID:         restrictedWallet.ID,
+				Type:             types.TransactionTypeCredit,
+				Amount:           restrictedWallet.Balance,
+				CreditAmount:     restrictedWallet.CreditBalance,
+				CreditsAvailable: restrictedWallet.CreditBalance,
+				TxStatus:         types.TransactionStatusCompleted,
+				BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+			}))
+			s.NoError(s.GetStores().WalletRepo.CreateTransaction(s.GetContext(), &wallet.Transaction{
+				ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+				WalletID:         restrictedWallet.ID,
+				Type:             types.TransactionTypeCredit,
+				Amount:           restrictedWallet.Balance,
+				CreditAmount:     restrictedWallet.CreditBalance,
+				CreditsAvailable: restrictedWallet.CreditBalance,
+				TxStatus:         types.TransactionStatusCompleted,
+				BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+			}))
+
+			// Create line items
+			invoiceID := "inv_edge_" + tc.name
+			lineItems := []*invoice.InvoiceLineItem{}
+			if tc.usageAmount.GreaterThan(decimal.Zero) {
+				lineItems = append(lineItems, &invoice.InvoiceLineItem{
+					ID:        "line_usage_edge_" + tc.name,
+					InvoiceID: invoiceID,
+					PriceType: lo.ToPtr(types.PRICE_TYPE_USAGE.String()),
+					Amount:    tc.usageAmount,
+					Currency:  "usd",
+					BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+				})
+			}
+			if tc.fixedAmount.GreaterThan(decimal.Zero) {
+				lineItems = append(lineItems, &invoice.InvoiceLineItem{
+					ID:        "line_fixed_edge_" + tc.name,
+					InvoiceID: invoiceID,
+					PriceType: lo.ToPtr(types.PRICE_TYPE_FIXED.String()),
+					Amount:    tc.fixedAmount,
+					Currency:  "usd",
+					BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+				})
+			}
+
+			totalAmount := tc.usageAmount.Add(tc.fixedAmount)
+			invoiceID = "inv_edge_" + tc.name
+			edgeInvoice := &invoice.Invoice{
+				ID:              invoiceID,
+				CustomerID:      s.testData.customer.ID,
+				InvoiceType:     types.InvoiceTypeOneOff,
+				InvoiceStatus:   types.InvoiceStatusFinalized,
+				PaymentStatus:   types.PaymentStatusPending,
+				Currency:        "usd",
+				AmountDue:       totalAmount,
+				AmountPaid:      tc.existingCreditPayment,
+				AmountRemaining: totalAmount.Sub(tc.existingCreditPayment),
+				LineItems:       lineItems,
+				BaseModel:       types.GetDefaultBaseModel(s.GetContext()),
+			}
+			s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), edgeInvoice))
+
+			// Create existing credit payment if any
+			if tc.existingCreditPayment.GreaterThan(decimal.Zero) {
+				existingPayment := &payment.Payment{
+					ID:                types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PAYMENT),
+					Amount:            tc.existingCreditPayment,
+					Currency:          "usd",
+					PaymentMethodType: types.PaymentMethodTypeCredits,
+					PaymentMethodID:   "previous_wallet",
+					PaymentStatus:     types.PaymentStatusSucceeded,
+					DestinationType:   types.PaymentDestinationTypeInvoice,
+					DestinationID:     edgeInvoice.ID,
+					BaseModel:         types.GetDefaultBaseModel(s.GetContext()),
+				}
+				s.NoError(s.GetStores().PaymentRepo.Create(s.GetContext(), existingPayment))
+			}
+
+			// Process payment
+			amountPaid, err := s.service.ProcessInvoicePaymentWithWallets(
+				s.GetContext(),
+				edgeInvoice,
+				DefaultWalletPaymentOptions(),
+			)
+
+			// Verify results
+			s.NoError(err)
+			s.True(tc.expectedTotalPay.Equal(amountPaid),
+				"Amount paid mismatch for %s: expected %s, got %s",
+				tc.name, tc.expectedTotalPay, amountPaid)
+
+			// Verify restricted wallet payment amount
+			allPayments, err := s.GetStores().PaymentRepo.List(s.GetContext(), &types.PaymentFilter{
+				DestinationID:   &edgeInvoice.ID,
+				DestinationType: lo.ToPtr(string(types.PaymentDestinationTypeInvoice)),
+			})
+			s.NoError(err)
+
+			// Filter payments by restricted wallet
+			var payments []*payment.Payment
+			for _, p := range allPayments {
+				if p.PaymentMethodID == restrictedWallet.ID {
+					payments = append(payments, p)
+				}
+			}
+
+			if tc.expectedRestrictedPay.IsZero() {
+				s.Empty(payments, "Restricted wallet should not make any payment for %s", tc.name)
+			} else {
+				s.Equal(1, len(payments), "Should have 1 payment from restricted wallet for %s", tc.name)
+				s.True(tc.expectedRestrictedPay.Equal(payments[0].Amount),
+					"Restricted wallet payment mismatch for %s: expected %s, got %s",
+					tc.name, tc.expectedRestrictedPay, payments[0].Amount)
+			}
+		})
+	}
 }

--- a/internal/types/price.go
+++ b/internal/types/price.go
@@ -230,6 +230,10 @@ func (p PriceType) Validate() error {
 	return nil
 }
 
+func (p PriceType) String() string {
+	return string(p)
+}
+
 func (p PriceScope) Validate() error {
 	allowed := []PriceScope{
 		PRICE_SCOPE_PLAN,

--- a/internal/types/wallet.go
+++ b/internal/types/wallet.go
@@ -285,7 +285,6 @@ type WalletConfigPriceType string
 const (
 	WalletConfigPriceTypeAll   WalletConfigPriceType = "ALL"
 	WalletConfigPriceTypeUsage WalletConfigPriceType = WalletConfigPriceType(PRICE_TYPE_USAGE)
-	WalletConfigPriceTypeFixed WalletConfigPriceType = WalletConfigPriceType(PRICE_TYPE_FIXED)
 )
 
 // WalletConfig represents configuration constraints for a wallet
@@ -305,7 +304,6 @@ func (c WalletConfig) Validate() error {
 	allowedPriceTypes := []string{
 		string(WalletConfigPriceTypeAll),
 		string(WalletConfigPriceTypeUsage),
-		string(WalletConfigPriceTypeFixed),
 	}
 
 	if c.AllowedPriceTypes != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for usage-restricted wallets in payment processing, ensuring they only pay for usage line items, with extensive test coverage.
> 
>   - **Behavior**:
>     - Adds `IsUsageRestricted()` to `Wallet` in `model.go` to check for usage restrictions.
>     - Updates `ProcessInvoicePaymentWithWallets()` in `wallet_payment.go` to handle usage-restricted wallets, ensuring they only pay for usage line items.
>     - Introduces logic to sort wallets, prioritizing usage-restricted wallets.
>   - **Tests**:
>     - Adds multiple test cases in `wallet_payment_test.go` to cover scenarios with usage-restricted wallets, including mixed line items, no usage line items, and partial payments.
>   - **Types**:
>     - Adds `String()` method to `PriceType` in `price.go`.
>     - Removes `WalletConfigPriceTypeFixed` from `wallet.go` to align with usage-only restrictions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 453ec259fdcf4e3ce31488cf6aa61b2a6e6df07c. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->