### PR TITLE
feat(subscription): Add lineitem start date

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -75,6 +75,9 @@ type CreateSubscriptionRequest struct {
 	// Timezone of the customer.
 	// If not set, the default value is UTC.
 	CustomerTimezone string `json:"customer_timezone" validate:"omitempty,timezone"`
+
+	// LineItems startdate for usage based charges
+	LineItemsStartDate *time.Time `json:"-,omitempty"`
 }
 
 // AddAddonRequest is used by body-based endpoint /subscriptions/addon

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -218,6 +218,11 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			item.ID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM)
 		}
 
+		lineItemStartDate := sub.StartDate
+		if price.Type == types.PRICE_TYPE_USAGE && req.LineItemsStartDate != nil {
+			lineItemStartDate = *req.LineItemsStartDate
+		}
+
 		item.SubscriptionID = sub.ID
 		item.PriceType = price.Type
 		item.EntityID = plan.ID
@@ -230,7 +235,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		item.TrialPeriod = price.TrialPeriod
 		item.PriceUnitID = price.PriceUnitID
 		item.PriceUnit = price.PriceUnit
-		item.StartDate = sub.StartDate
+		item.StartDate = lineItemStartDate
 		if sub.EndDate != nil {
 			item.EndDate = *sub.EndDate
 		}
@@ -1069,8 +1074,8 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 			PriceID:            lineItem.PriceID,
 			Meter:              meter.ToMeter(),
 			ExternalCustomerID: customer.ExternalID,
-			StartTime:          usageStartTime,
-			EndTime:            usageEndTime,
+			StartTime:          lineItem.GetPeriodStart(usageStartTime),
+			EndTime:            lineItem.GetPeriodEnd(usageEndTime),
 			Filters:            make(map[string][]string),
 		}
 

--- a/internal/service/subscription_change.go
+++ b/internal/service/subscription_change.go
@@ -589,7 +589,7 @@ func (s *subscriptionChangeService) executeChange(
 	}
 
 	// Step 4: Create new subscription with credit grants
-	newSub, err := s.createNewSubscription(ctx, currentSub, lineItems, targetPlan, req, creditGrantRequests)
+	newSub, err := s.createNewSubscription(ctx, currentSub, lineItems, targetPlan, req, creditGrantRequests, effectiveDate)
 	if err != nil {
 		return nil, err
 	}
@@ -670,6 +670,7 @@ func (s *subscriptionChangeService) createNewSubscription(
 	targetPlan *plan.Plan,
 	req dto.SubscriptionChangeRequest,
 	creditGrantRequests []dto.CreateCreditGrantRequest,
+	effectiveDate time.Time,
 ) (*subscription.Subscription, error) {
 
 	prices, err := s.serviceParams.PriceRepo.GetByPlanID(ctx, targetPlan.ID)
@@ -706,7 +707,7 @@ func (s *subscriptionChangeService) createNewSubscription(
 		CreditGrants:       creditGrantRequests,
 		CommitmentAmount:   currentSub.CommitmentAmount,
 		OverageFactor:      currentSub.OverageFactor,
-		LineItemsStartDate: lo.ToPtr(time.Now()),
+		LineItemsStartDate: lo.ToPtr(effectiveDate),
 	}
 
 	// Use the existing subscription service to create the new subscription


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `LineItemsStartDate` to handle usage-based charges in subscriptions, updating DTOs and services for correct start date handling.
> 
>   - **DTO Changes**:
>     - Add `LineItemsStartDate` to `CreateSubscriptionRequest` in `subscription.go` for usage-based charges.
>   - **Service Changes**:
>     - Update `CreateSubscription` in `subscription.go` to set `lineItemStartDate` based on `LineItemsStartDate` or `sub.StartDate`.
>     - Modify `GetUsageBySubscription` in `subscription.go` to use `lineItem.GetPeriodStart()` and `lineItem.GetPeriodEnd()`.
>   - **Subscription Change**:
>     - Update `executeChange` in `subscription_change.go` to use `CancelSubscription` for archiving old subscriptions.
>     - Pass `effectiveDate` as `LineItemsStartDate` when creating new subscriptions in `createNewSubscription`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 4cb19ac9179d25de38e8754152a73f8b6b79b463. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->