### PR TITLE
fix(plan): add display-order support in create and update

### DIFF
--- a/internal/api/dto/plan.go
+++ b/internal/api/dto/plan.go
@@ -17,6 +17,7 @@ type CreatePlanRequest struct {
 	Name         string                         `json:"name" validate:"required"`
 	LookupKey    string                         `json:"lookup_key"`
 	Description  string                         `json:"description"`
+	DisplayOrder *int                           `json:"display_order,omitempty"`
 	Prices       []CreatePlanPriceRequest       `json:"prices"`
 	Entitlements []CreatePlanEntitlementRequest `json:"entitlements"`
 	CreditGrants []CreateCreditGrantRequest     `json:"credit_grants"`
@@ -233,6 +234,10 @@ func (r *CreatePlanRequest) ToPlan(ctx context.Context) *plan.Plan {
 		Metadata:      r.Metadata,
 		BaseModel:     types.GetDefaultBaseModel(ctx),
 	}
+	if r.DisplayOrder != nil {
+		plan.DisplayOrder = r.DisplayOrder
+	}
+
 	return plan
 }
 
@@ -266,6 +271,7 @@ type UpdatePlanRequest struct {
 	Name         *string                        `json:"name,omitempty"`
 	LookupKey    *string                        `json:"lookup_key,omitempty"`
 	Description  *string                        `json:"description,omitempty"`
+	DisplayOrder *int                           `json:"display_order,omitempty"`
 	Prices       []UpdatePlanPriceRequest       `json:"prices,omitempty"`
 	Entitlements []UpdatePlanEntitlementRequest `json:"entitlements,omitempty"`
 	CreditGrants []UpdatePlanCreditGrantRequest `json:"credit_grants,omitempty"`

--- a/internal/repository/ent/plan.go
+++ b/internal/repository/ent/plan.go
@@ -67,6 +67,7 @@ func (r *planRepository) Create(ctx context.Context, p *domainPlan.Plan) error {
 		SetUpdatedBy(p.UpdatedBy).
 		SetEnvironmentID(p.EnvironmentID).
 		SetMetadata(p.Metadata).
+		SetNillableDisplayOrder(p.DisplayOrder).
 		Save(ctx)
 
 	if err != nil {
@@ -298,6 +299,7 @@ func (r *planRepository) Update(ctx context.Context, p *domainPlan.Plan) error {
 		SetName(p.Name).
 		SetDescription(p.Description).
 		SetMetadata(p.Metadata).
+		SetNillableDisplayOrder(p.DisplayOrder).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		Save(ctx)

--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -372,6 +372,9 @@ func (s *planService) UpdatePlan(ctx context.Context, id string, req dto.UpdateP
 	if req.Metadata != nil {
 		plan.Metadata = req.Metadata
 	}
+	if req.DisplayOrder != nil {
+		plan.DisplayOrder = req.DisplayOrder
+	}
 
 	// Start a transaction for updating plan, prices, and entitlements
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `DisplayOrder` support to plan creation and update processes in DTO, repository, and service layers.
> 
>   - **DTO Changes**:
>     - Add `DisplayOrder` field to `CreatePlanRequest` and `UpdatePlanRequest` in `dto/plan.go`.
>     - Update `ToPlan()` method in `dto/plan.go` to set `DisplayOrder`.
>   - **Repository Changes**:
>     - Use `SetNillableDisplayOrder()` in `Create()` and `Update()` methods in `ent/plan.go`.
>   - **Service Changes**:
>     - Handle `DisplayOrder` in `CreatePlan()` and `UpdatePlan()` methods in `service/plan.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 3c601fea3b600e4d998a6624536bc7bb4851be6a. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->