### PR TITLE
fix(invoice): Invoice sequencing logic change

### DIFF
--- a/internal/api/dto/settings.go
+++ b/internal/api/dto/settings.go
@@ -51,15 +51,25 @@ func ConvertToInvoiceConfig(value map[string]interface{}) (*types.InvoiceConfig,
 	if invoiceNumberTimezone, ok := value["timezone"].(string); ok {
 		invoiceConfig.InvoiceNumberTimezone = invoiceNumberTimezone
 	}
-	if invoiceNumberStartSequence, ok := value["start_sequence"].(float64); ok {
-		invoiceConfig.InvoiceNumberStartSequence = int(invoiceNumberStartSequence)
+	if startSequenceRaw, exists := value["start_sequence"]; exists {
+		switch v := startSequenceRaw.(type) {
+		case int:
+			invoiceConfig.InvoiceNumberStartSequence = v
+		case float64:
+			invoiceConfig.InvoiceNumberStartSequence = int(v)
+		}
 	}
 
 	if invoiceNumberSeparator, ok := value["separator"].(string); ok {
 		invoiceConfig.InvoiceNumberSeparator = invoiceNumberSeparator
 	}
-	if invoiceNumberSuffixLength, ok := value["suffix_length"].(float64); ok {
-		invoiceConfig.InvoiceNumberSuffixLength = int(invoiceNumberSuffixLength)
+	if suffixLengthRaw, exists := value["suffix_length"]; exists {
+		switch v := suffixLengthRaw.(type) {
+		case int:
+			invoiceConfig.InvoiceNumberSuffixLength = v
+		case float64:
+			invoiceConfig.InvoiceNumberSuffixLength = int(v)
+		}
 	}
 
 	return invoiceConfig, nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `ConvertToInvoiceConfig` in `settings.go` now handles `start_sequence` and `suffix_length` as both `int` and `float64`.
> 
>   - **Behavior**:
>     - `ConvertToInvoiceConfig` in `settings.go` now handles `start_sequence` and `suffix_length` as both `int` and `float64`, converting `float64` to `int`.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 2cfd813c82549224416b419f0bffab3e51954cac. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->