### PR TITLE
fix(invoice): allow updates to safe fields for paid invoices

### DIFF
--- a/internal/api/v1/invoice.go
+++ b/internal/api/v1/invoice.go
@@ -451,7 +451,7 @@ func (h *InvoiceHandler) RecalculateInvoice(c *gin.Context) {
 // UpdateInvoice godoc
 // @Summary Update an invoice
 // @Description Update invoice details like PDF URL and due date.
-// Only works for draft or finalized invoices that haven't been paid.
+// Works for draft, finalized, and paid invoices. Only safe fields like PDF URL and due date can be updated for paid invoices.
 // @Tags Invoices
 // @Accept json
 // @Produce json


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow updates to safe fields for paid invoices in `UpdateInvoice` function, with updated tests and documentation.
> 
>   - **Behavior**:
>     - Allow updates to safe fields (PDF URL and due date) for paid invoices in `UpdateInvoice` in `internal/service/invoice.go`.
>     - Update `UpdateInvoice` docstring in `internal/api/v1/invoice.go` to reflect new behavior.
>   - **Validation**:
>     - Add `isSafeUpdateForPaidInvoice()` in `internal/service/invoice.go` to check if update request contains only safe fields.
>   - **Tests**:
>     - Modify `TestUpdateInvoice` in `internal/service/invoice_test.go` to test updates on paid invoices for safe fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 301fa0486a23b0d796fe6e97fb1de4f757fde1e8. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->