### PR TITLE
chore(migrations): increase default timeout to 300 seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,20 +86,20 @@ generate-ent: install-ent
 .PHONY: migrate-ent
 migrate-ent:
 	@echo "Running Ent migrations..."
-	@go run cmd/migrate/main.go
+	@go run cmd/migrate/main.go --timeout 300
 	@echo "Ent migrations complete"
 
 .PHONY: migrate-ent-dry-run
 migrate-ent-dry-run:
 	@echo "Generating SQL migration statements (dry run)..."
-	@go run cmd/migrate/main.go --dry-run
+	@go run cmd/migrate/main.go --dry-run --timeout 300
 	@echo "SQL migration statements generated"
 
 .PHONY: generate-migration
 generate-migration:
 	@echo "Generating SQL migration file..."
 	@mkdir -p migrations/ent
-	@go run cmd/migrate/main.go --dry-run > migrations/ent/migration_$(shell date +%Y%m%d%H%M%S).sql
+	@go run cmd/migrate/main.go --dry-run --timeout 300 > migrations/ent/migration_$(shell date +%Y%m%d%H%M%S).sql
 	@echo "SQL migration file generated in migrations/ent/"
 
 # Initialize databases and required topics

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -17,6 +17,7 @@ import (
 func main() {
 	// Parse command line flags
 	dryRun := flag.Bool("dry-run", false, "Print migration SQL without executing it")
+	timeout := flag.Int("timeout", 300, "Timeout in seconds for the migration")
 	flag.Parse()
 
 	// Load configuration
@@ -42,7 +43,7 @@ func main() {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeout)*time.Second)
 	defer cancel()
 
 	// Run auto migration


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase default timeout for Ent migrations to 300 seconds in `cmd/migrate/main.go` and update `Makefile` accordingly.
> 
>   - **Behavior**:
>     - Increase default timeout for Ent migrations to 300 seconds in `cmd/migrate/main.go`.
>     - Update `Makefile` to include `--timeout 300` in `migrate-ent`, `migrate-ent-dry-run`, and `generate-migration` targets.
>   - **Code Changes**:
>     - Add `timeout` flag in `cmd/migrate/main.go` with default value 300.
>     - Modify context creation in `cmd/migrate/main.go` to use the `timeout` flag value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 532e2c4bca7db47ae4328a06c7a158c08549d7a5. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->