### PR TITLE
Upgrade Stripe Go SDK from v79 to v82, updating client initialization…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
-	github.com/stripe/stripe-go/v79 v79.12.0
+	github.com/stripe/stripe-go/v82 v82.5.0
 	github.com/svix/svix-webhooks v1.68.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stripe/stripe-go/v79 v79.12.0 h1:HQs/kxNEB3gYA7FnkSFkp0kSOeez0fsmCWev6SxftYs=
-github.com/stripe/stripe-go/v79 v79.12.0/go.mod h1:cuH6X0zC8peY6f1AubHwgJ/fJSn2dh5pfiCr6CjyKVU=
+github.com/stripe/stripe-go/v82 v82.5.0 h1:Kcf4EmxnkRhUBmZEc1u2nHtlGkoe1yzd8gdtCWYhQqQ=
+github.com/stripe/stripe-go/v82 v82.5.0/go.mod h1:majCQX6AfObAvJiHraPi/5udwHi4ojRvJnnxckvHrX8=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/svix/svix-webhooks v1.68.0 h1:cdhABlYCYLzVH3k2Jx+Mi5vsl1x3tpAiOVTHGtP7U+Q=
@@ -501,7 +501,6 @@ golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/internal/api/dto/stripe.go
+++ b/internal/api/dto/stripe.go
@@ -83,3 +83,20 @@ type PaymentStatusResponse struct {
 	ExpiresAt       int64             `json:"expires_at"`
 	Metadata        map[string]string `json:"metadata"`
 }
+
+// StripeInvoiceSyncRequest represents the request for syncing an invoice to Stripe
+type StripeInvoiceSyncRequest struct {
+	InvoiceID        string                 `json:"invoice_id"`
+	CollectionMethod types.CollectionMethod `json:"collection_method"`
+	PaymentBehavior  *types.PaymentBehavior `json:"payment_behavior,omitempty"`
+}
+
+// StripeInvoiceSyncResponse represents the response from Stripe invoice sync
+type StripeInvoiceSyncResponse struct {
+	StripeInvoiceID  string                 `json:"stripe_invoice_id"`
+	Status           string                 `json:"status"`
+	PaymentIntentID  string                 `json:"payment_intent_id,omitempty"`
+	HostedInvoiceURL string                 `json:"hosted_invoice_url,omitempty"`
+	InvoicePDF       string                 `json:"invoice_pdf,omitempty"`
+	Metadata         map[string]interface{} `json:"metadata,omitempty"`
+}

--- a/internal/service/integration.go
+++ b/internal/service/integration.go
@@ -11,8 +11,7 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v79"
-	"github.com/stripe/stripe-go/v79/client"
+	"github.com/stripe/stripe-go/v82"
 )
 
 // IntegrationService handles generic integration operations with multiple providers
@@ -642,11 +641,10 @@ func (s *integrationService) validateStripeCustomer(ctx context.Context, conn *c
 
 	// Initialize Stripe client with the secret key
 	// Use dedicated client instance to avoid race conditions
-	sc := &client.API{}
-	sc.Init(stripeConfig.SecretKey, nil)
+	sc := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Validate that the customer exists in Stripe
-	cust, err := sc.Customers.Get(customerID, nil)
+	cust, err := sc.V1Customers.Retrieve(context.Background(), customerID, nil)
 	if err != nil {
 		s.Logger.Errorw("failed to validate Stripe customer",
 			"customer_id", customerID,

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -696,6 +696,17 @@ func (s *invoiceService) ProcessDraftInvoice(ctx context.Context, id string, pay
 		return err
 	}
 
+	// Sync to Stripe if Stripe connection is enabled and invoice is for subscription
+	if sub != nil {
+		if err := s.syncInvoiceToStripeIfEnabled(ctx, inv, sub, paymentParams); err != nil {
+			// Log error but don't fail the entire process
+			s.Logger.Errorw("failed to sync invoice to Stripe",
+				"error", err,
+				"invoice_id", inv.ID,
+				"subscription_id", sub.ID)
+		}
+	}
+
 	// try to process payment for the invoice based on behavior and log any errors
 	// Pass the subscription object to avoid extra DB call
 	// Error handling logic is properly handled in attemptPaymentForSubscriptionInvoice
@@ -703,6 +714,53 @@ func (s *invoiceService) ProcessDraftInvoice(ctx context.Context, id string, pay
 		// Only return error if it's a blocking error (e.g., subscription creation with error_if_incomplete)
 		return err
 	}
+
+	return nil
+}
+
+// syncInvoiceToStripeIfEnabled syncs the invoice to Stripe if Stripe connection is enabled
+func (s *invoiceService) syncInvoiceToStripeIfEnabled(ctx context.Context, inv *invoice.Invoice, sub *subscription.Subscription, paymentParams *dto.PaymentParameters) error {
+	// Check if Stripe connection exists
+	conn, err := s.ConnectionRepo.GetByProvider(ctx, types.SecretProviderStripe)
+	if err != nil || conn == nil {
+		s.Logger.Debugw("Stripe connection not available, skipping invoice sync",
+			"invoice_id", inv.ID,
+			"error", err)
+		return nil // Not an error, just skip sync
+	}
+
+	s.Logger.Infow("syncing invoice to Stripe",
+		"invoice_id", inv.ID,
+		"subscription_id", sub.ID,
+		"collection_method", sub.CollectionMethod)
+
+	// Initialize Stripe sync service
+	stripeInvoiceSyncService := NewStripeInvoiceSyncService(s.ServiceParams)
+
+	// Determine collection method from subscription
+	collectionMethod := types.CollectionMethod(sub.CollectionMethod)
+
+	// Create sync request
+	syncRequest := dto.StripeInvoiceSyncRequest{
+		InvoiceID:        inv.ID,
+		CollectionMethod: collectionMethod,
+	}
+
+	if paymentParams != nil {
+		syncRequest.PaymentBehavior = paymentParams.PaymentBehavior
+	}
+
+	// Perform the sync
+	syncResponse, err := stripeInvoiceSyncService.SyncInvoiceToStripe(ctx, syncRequest)
+	if err != nil {
+		return err
+	}
+
+	s.Logger.Infow("successfully synced invoice to Stripe",
+		"invoice_id", inv.ID,
+		"stripe_invoice_id", syncResponse.StripeInvoiceID,
+		"status", syncResponse.Status,
+		"hosted_invoice_url", syncResponse.HostedInvoiceURL)
 
 	return nil
 }

--- a/internal/service/stripe.go
+++ b/internal/service/stripe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/connection"
@@ -983,6 +984,7 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 			"flexprice_customer_id": req.CustomerID,
 			"environment_id":        types.GetEnvironmentID(ctx),
 			"invoice_id":            req.InvoiceID,
+			"payment_source":        "flexprice", // KEY DIFFERENTIATOR
 		},
 	}
 
@@ -1662,6 +1664,254 @@ func (s *StripeService) AttachPaymentToStripeInvoice(ctx context.Context, stripe
 	s.Logger.Infow("successfully attached payment to Stripe invoice",
 		"payment_intent_id", paymentIntentID,
 		"stripe_invoice_id", stripeInvoiceID)
+
+	return nil
+}
+
+// GetPaymentIntent retrieves a payment intent from Stripe
+func (s *StripeService) GetPaymentIntent(ctx context.Context, paymentIntentID, environmentID string) (*stripe.PaymentIntent, error) {
+	// Get Stripe connection
+	conn, err := s.ConnectionRepo.GetByProvider(ctx, types.SecretProviderStripe)
+	if err != nil {
+		return nil, ierr.NewError("failed to get Stripe connection").
+			WithHint("Stripe connection not configured for this environment").
+			Mark(ierr.ErrNotFound)
+	}
+
+	stripeConfig, err := s.GetDecryptedStripeConfig(conn)
+	if err != nil {
+		return nil, ierr.NewError("failed to get Stripe configuration").
+			WithHint("Invalid Stripe configuration").
+			Mark(ierr.ErrValidation)
+	}
+
+	// Initialize Stripe client
+	client := stripe.NewClient(stripeConfig.SecretKey, nil)
+
+	// Retrieve the payment intent
+	paymentIntent, err := client.V1PaymentIntents.Retrieve(ctx, paymentIntentID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return paymentIntent, nil
+}
+
+// ProcessExternalStripePayment processes an external Stripe payment and reconciles it with FlexPrice
+func (s *StripeService) ProcessExternalStripePayment(ctx context.Context, paymentIntent *stripe.PaymentIntent, stripeInvoiceID string) error {
+	// Find the FlexPrice invoice via entity integration mapping
+	flexInvoiceID, err := s.getFlexPriceInvoiceID(ctx, stripeInvoiceID)
+	if err != nil {
+		s.Logger.Errorw("failed to find FlexPrice invoice for Stripe payment",
+			"error", err,
+			"stripe_invoice_id", stripeInvoiceID,
+			"payment_intent_id", paymentIntent.ID)
+		return err
+	}
+
+	if flexInvoiceID == "" {
+		s.Logger.Warnw("no FlexPrice invoice found for external Stripe payment",
+			"payment_intent_id", paymentIntent.ID,
+			"stripe_invoice_id", stripeInvoiceID)
+		return nil // Not an error, just no FlexPrice invoice to sync
+	}
+
+	// Process the external payment
+	return s.createExternalPaymentRecord(ctx, paymentIntent, flexInvoiceID)
+}
+
+// getFlexPriceInvoiceID finds the FlexPrice invoice ID from Stripe invoice ID via entity integration mapping
+func (s *StripeService) getFlexPriceInvoiceID(ctx context.Context, stripeInvoiceID string) (string, error) {
+	// Create filter to find entity integration mapping for the Stripe invoice
+	filter := &types.EntityIntegrationMappingFilter{
+		EntityType:        types.IntegrationEntityTypeInvoice,
+		ProviderTypes:     []string{string(types.SecretProviderStripe)},
+		ProviderEntityIDs: []string{stripeInvoiceID},
+	}
+
+	// Get entity integration mappings
+	mappings, err := s.EntityIntegrationMappingRepo.List(ctx, filter)
+	if err != nil {
+		return "", err
+	}
+
+	if len(mappings) == 0 {
+		return "", nil // No mapping found, not an error
+	}
+
+	return mappings[0].EntityID, nil
+}
+
+// createExternalPaymentRecord creates a payment record and reconciles the invoice for external Stripe payments
+func (s *StripeService) createExternalPaymentRecord(ctx context.Context, paymentIntent *stripe.PaymentIntent, invoiceID string) error {
+	// Convert amount from cents to decimal
+	amount := decimal.NewFromInt(paymentIntent.Amount).Div(decimal.NewFromInt(100))
+
+	// Get invoice to validate payment amount
+	invoiceService := NewInvoiceService(s.ServiceParams)
+	invoiceResp, err := invoiceService.GetInvoice(ctx, invoiceID)
+	if err != nil {
+		s.Logger.Errorw("failed to get invoice for payment validation",
+			"error", err,
+			"invoice_id", invoiceID,
+			"payment_intent_id", paymentIntent.ID)
+		return err
+	}
+
+	// Check if invoice is already paid
+	if invoiceResp.PaymentStatus == types.PaymentStatusSucceeded {
+		s.Logger.Infow("invoice is already paid, skipping payment processing",
+			"invoice_id", invoiceID,
+			"payment_intent_id", paymentIntent.ID,
+			"payment_status", invoiceResp.PaymentStatus)
+		return nil
+	}
+
+	// Validate payment amount doesn't exceed remaining balance
+	if amount.GreaterThan(invoiceResp.AmountRemaining) {
+		s.Logger.Warnw("payment amount exceeds invoice remaining balance",
+			"payment_amount", amount,
+			"invoice_remaining", invoiceResp.AmountRemaining,
+			"invoice_id", invoiceID,
+			"payment_intent_id", paymentIntent.ID)
+		// Continue processing but log the warning
+	}
+
+	// Create payment record
+	paymentService := NewPaymentService(s.ServiceParams)
+
+	// Create as CARD payment with all Stripe details (same as regular Stripe charge)
+	gatewayType := types.PaymentGatewayTypeStripe
+	createReq := &dto.CreatePaymentRequest{
+		DestinationType:   types.PaymentDestinationTypeInvoice,
+		DestinationID:     invoiceID,
+		PaymentMethodType: types.PaymentMethodTypeCard, // Mark as card payment
+		Amount:            amount,
+		Currency:          strings.ToUpper(string(paymentIntent.Currency)),
+		PaymentGateway:    &gatewayType,
+		ProcessPayment:    false, // Don't process - already succeeded in Stripe
+		Metadata: types.Metadata{
+			"payment_source":        "stripe_external",
+			"stripe_payment_intent": paymentIntent.ID,
+			"webhook_event_id":      paymentIntent.ID, // For idempotency
+		},
+	}
+
+	// Add customer ID if available
+	if paymentIntent.Customer != nil {
+		createReq.Metadata["stripe_customer_id"] = paymentIntent.Customer.ID
+	}
+
+	// Add Stripe payment method ID (required for CARD payments)
+	if paymentIntent.PaymentMethod != nil {
+		createReq.PaymentMethodID = paymentIntent.PaymentMethod.ID
+	}
+
+	paymentResp, err := paymentService.CreatePayment(ctx, createReq)
+	if err != nil {
+		s.Logger.Errorw("failed to create external payment record",
+			"error", err,
+			"payment_intent_id", paymentIntent.ID,
+			"invoice_id", invoiceID)
+		return err
+	}
+
+	// Update payment to succeeded status with all Stripe details (same as regular Stripe charge)
+	now := time.Now().UTC()
+	updateReq := dto.UpdatePaymentRequest{
+		PaymentStatus:    lo.ToPtr(string(types.PaymentStatusSucceeded)),
+		GatewayPaymentID: lo.ToPtr(paymentIntent.ID),
+		PaymentGateway:   lo.ToPtr(string(types.PaymentGatewayTypeStripe)),
+		SucceededAt:      lo.ToPtr(now),
+	}
+
+	// Add payment method ID if available
+	if paymentIntent.PaymentMethod != nil {
+		updateReq.PaymentMethodID = lo.ToPtr(paymentIntent.PaymentMethod.ID)
+	}
+
+	_, err = paymentService.UpdatePayment(ctx, paymentResp.ID, updateReq)
+	if err != nil {
+		s.Logger.Errorw("failed to update external payment status",
+			"error", err,
+			"payment_id", paymentResp.ID,
+			"payment_intent_id", paymentIntent.ID)
+		return err
+	}
+
+	s.Logger.Infow("successfully created external payment record",
+		"payment_id", paymentResp.ID,
+		"payment_intent_id", paymentIntent.ID,
+		"invoice_id", invoiceID,
+		"amount", amount)
+
+	// Reconcile the invoice with the payment
+	if err := s.reconcileInvoiceWithExternalPayment(ctx, invoiceID, amount); err != nil {
+		s.Logger.Errorw("failed to reconcile invoice with external payment",
+			"error", err,
+			"invoice_id", invoiceID,
+			"payment_id", paymentResp.ID,
+			"amount", amount)
+		return err
+	}
+
+	return nil
+}
+
+// reconcileInvoiceWithExternalPayment updates the invoice amounts and status
+func (s *StripeService) reconcileInvoiceWithExternalPayment(ctx context.Context, invoiceID string, paymentAmount decimal.Decimal) error {
+	invoiceService := NewInvoiceService(s.ServiceParams)
+
+	// Get the current invoice to calculate proper payment status
+	invoiceResp, err := invoiceService.GetInvoice(ctx, invoiceID)
+	if err != nil {
+		s.Logger.Errorw("failed to get invoice for external payment reconciliation",
+			"error", err,
+			"invoice_id", invoiceID)
+		return err
+	}
+
+	// Calculate new amounts
+	newAmountPaid := invoiceResp.AmountPaid.Add(paymentAmount)
+	newAmountRemaining := invoiceResp.AmountDue.Sub(newAmountPaid)
+
+	// Determine payment status based on remaining amount
+	var newPaymentStatus types.PaymentStatus
+	if newAmountRemaining.IsZero() {
+		newPaymentStatus = types.PaymentStatusSucceeded
+	} else if newAmountRemaining.IsNegative() {
+		// Invoice is overpaid
+		newPaymentStatus = types.PaymentStatusOverpaid
+		// For overpaid invoices, amount_remaining should be 0
+		newAmountRemaining = decimal.Zero
+	} else {
+		newPaymentStatus = types.PaymentStatusPending // Partial payment
+	}
+
+	s.Logger.Infow("calculated payment status for external payment",
+		"invoice_id", invoiceID,
+		"payment_amount", paymentAmount,
+		"current_amount_paid", invoiceResp.AmountPaid,
+		"new_amount_paid", newAmountPaid,
+		"amount_due", invoiceResp.AmountDue,
+		"new_amount_remaining", newAmountRemaining,
+		"new_payment_status", newPaymentStatus)
+
+	// Use the existing ReconcilePaymentStatus method with calculated status
+	err = invoiceService.ReconcilePaymentStatus(ctx, invoiceID, newPaymentStatus, &paymentAmount)
+	if err != nil {
+		s.Logger.Errorw("failed to update invoice payment status",
+			"error", err,
+			"invoice_id", invoiceID,
+			"payment_amount", paymentAmount,
+			"payment_status", newPaymentStatus)
+		return err
+	}
+
+	s.Logger.Infow("successfully reconciled invoice with external payment",
+		"invoice_id", invoiceID,
+		"payment_amount", paymentAmount,
+		"payment_status", newPaymentStatus)
 
 	return nil
 }

--- a/internal/service/stripe.go
+++ b/internal/service/stripe.go
@@ -13,9 +13,8 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
-	"github.com/stripe/stripe-go/v79"
-	"github.com/stripe/stripe-go/v79/client"
-	"github.com/stripe/stripe-go/v79/webhook"
+	"github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/webhook"
 )
 
 // StripeService handles Stripe integration operations
@@ -224,8 +223,7 @@ func (s *StripeService) CreateCustomerInStripe(ctx context.Context, customerID s
 	}
 
 	// Initialize Stripe client
-	sc := &client.API{}
-	sc.Init(stripeConfig.SecretKey, nil)
+	sc := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Check if customer already has Stripe ID
 	if stripeID, exists := ourCustomer.Metadata["stripe_customer_id"]; exists && stripeID != "" {
@@ -235,7 +233,7 @@ func (s *StripeService) CreateCustomerInStripe(ctx context.Context, customerID s
 	}
 
 	// Create customer in Stripe
-	params := &stripe.CustomerParams{
+	params := &stripe.CustomerCreateParams{
 		Name:  stripe.String(ourCustomer.Name),
 		Email: stripe.String(ourCustomer.Email),
 		Metadata: map[string]string{
@@ -257,7 +255,7 @@ func (s *StripeService) CreateCustomerInStripe(ctx context.Context, customerID s
 		}
 	}
 
-	stripeCustomer, err := sc.Customers.New(params)
+	stripeCustomer, err := sc.V1Customers.Create(context.Background(), params)
 	if err != nil {
 		return ierr.NewError("failed to create customer in Stripe").
 			WithHint("Stripe API error").
@@ -440,8 +438,7 @@ func (s *StripeService) CreatePaymentLink(ctx context.Context, req *dto.CreateSt
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Convert amount to cents (Stripe expects amounts in smallest currency unit)
 	amountCents := req.Amount.Mul(decimal.NewFromInt(100)).IntPart()
@@ -502,11 +499,11 @@ func (s *StripeService) CreatePaymentLink(ctx context.Context, req *dto.CreateSt
 	productDescription := strings.Join(descriptionParts, " • ")
 
 	// Create a single line item for the exact payment amount requested
-	lineItems := []*stripe.CheckoutSessionLineItemParams{
+	lineItems := []*stripe.CheckoutSessionCreateLineItemParams{
 		{
-			PriceData: &stripe.CheckoutSessionLineItemPriceDataParams{
+			PriceData: &stripe.CheckoutSessionCreateLineItemPriceDataParams{
 				Currency: stripe.String(req.Currency),
-				ProductData: &stripe.CheckoutSessionLineItemPriceDataProductDataParams{
+				ProductData: &stripe.CheckoutSessionCreateLineItemPriceDataProductDataParams{
 					Name:        stripe.String(productName),
 					Description: stripe.String(productDescription),
 				},
@@ -540,7 +537,7 @@ func (s *StripeService) CreatePaymentLink(ctx context.Context, req *dto.CreateSt
 	}
 
 	// Create checkout session parameters
-	params := &stripe.CheckoutSessionParams{
+	params := &stripe.CheckoutSessionCreateParams{
 		LineItems:           lineItems,
 		Mode:                stripe.String("payment"),
 		AllowPromotionCodes: stripe.Bool(true),
@@ -552,7 +549,7 @@ func (s *StripeService) CreatePaymentLink(ctx context.Context, req *dto.CreateSt
 
 	// Only save payment method for future use if SaveCardAndMakeDefault is true
 	if req.SaveCardAndMakeDefault {
-		params.PaymentIntentData = &stripe.CheckoutSessionPaymentIntentDataParams{
+		params.PaymentIntentData = &stripe.CheckoutSessionCreatePaymentIntentDataParams{
 			SetupFutureUsage: stripe.String("off_session"),
 		}
 		s.Logger.Infow("payment link configured to save card and make default",
@@ -567,7 +564,7 @@ func (s *StripeService) CreatePaymentLink(ctx context.Context, req *dto.CreateSt
 	}
 
 	// Create the checkout session
-	session, err := stripeClient.CheckoutSessions.New(params)
+	session, err := stripeClient.V1CheckoutSessions.Create(context.Background(), params)
 	if err != nil {
 		s.Logger.Errorw("failed to create Stripe checkout session",
 			"error", err,
@@ -627,8 +624,7 @@ func (s *StripeService) GetCustomerPaymentMethods(ctx context.Context, req *dto.
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Get our customer to find Stripe customer ID
 	customerService := NewCustomerService(s.ServiceParams)
@@ -659,11 +655,18 @@ func (s *StripeService) GetCustomerPaymentMethods(ctx context.Context, req *dto.
 		Type:     stripe.String("card"),
 	}
 
-	paymentMethods := stripeClient.PaymentMethods.List(params)
+	paymentMethods := stripeClient.V1PaymentMethods.List(context.Background(), params)
 	var responses []*dto.PaymentMethodResponse
 
-	for paymentMethods.Next() {
-		pm := paymentMethods.PaymentMethod()
+	paymentMethods(func(pm *stripe.PaymentMethod, err error) bool {
+		if err != nil {
+			s.Logger.Errorw("failed to list payment methods",
+				"error", err,
+				"customer_id", req.CustomerID,
+				"stripe_customer_id", stripeCustomerID)
+			return false // Stop iteration on error
+		}
+
 		response := &dto.PaymentMethodResponse{
 			ID:       pm.ID,
 			Type:     string(pm.Type),
@@ -688,20 +691,14 @@ func (s *StripeService) GetCustomerPaymentMethods(ctx context.Context, req *dto.
 		}
 
 		responses = append(responses, response)
-	}
+		return true // Continue iteration
+	})
 
-	if err := paymentMethods.Err(); err != nil {
-		s.Logger.Errorw("failed to list payment methods",
-			"error", err,
+	if len(responses) == 0 {
+		s.Logger.Warnw("no payment methods found for customer",
 			"customer_id", req.CustomerID,
 			"stripe_customer_id", stripeCustomerID)
-		return nil, ierr.NewError("failed to list payment methods").
-			WithHint("Unable to retrieve saved payment methods").
-			WithReportableDetails(map[string]interface{}{
-				"customer_id": req.CustomerID,
-				"error":       err.Error(),
-			}).
-			Mark(ierr.ErrSystem)
+		return responses, nil // Return empty list instead of error
 	}
 
 	s.Logger.Infow("successfully retrieved payment methods",
@@ -731,8 +728,7 @@ func (s *StripeService) SetDefaultPaymentMethod(ctx context.Context, customerID,
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Get our customer to find Stripe customer ID
 	customerService := NewCustomerService(s.ServiceParams)
@@ -756,13 +752,13 @@ func (s *StripeService) SetDefaultPaymentMethod(ctx context.Context, customerID,
 	)
 
 	// Update customer's default payment method in Stripe
-	params := &stripe.CustomerParams{
-		InvoiceSettings: &stripe.CustomerInvoiceSettingsParams{
+	params := &stripe.CustomerUpdateParams{
+		InvoiceSettings: &stripe.CustomerUpdateInvoiceSettingsParams{
 			DefaultPaymentMethod: stripe.String(paymentMethodID),
 		},
 	}
 
-	_, err = stripeClient.Customers.Update(stripeCustomerID, params)
+	_, err = stripeClient.V1Customers.Update(context.Background(), stripeCustomerID, params)
 	if err != nil {
 		s.Logger.Errorw("failed to set default payment method in Stripe",
 			"error", err,
@@ -806,8 +802,7 @@ func (s *StripeService) GetDefaultPaymentMethod(ctx context.Context, customerID 
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Get our customer to find Stripe customer ID
 	customerService := NewCustomerService(s.ServiceParams)
@@ -825,7 +820,7 @@ func (s *StripeService) GetDefaultPaymentMethod(ctx context.Context, customerID 
 	}
 
 	// Get customer from Stripe to find default payment method
-	customer, err := stripeClient.Customers.Get(stripeCustomerID, nil)
+	customer, err := stripeClient.V1Customers.Retrieve(context.Background(), stripeCustomerID, nil)
 	if err != nil {
 		s.Logger.Errorw("failed to get customer from Stripe",
 			"error", err,
@@ -850,7 +845,7 @@ func (s *StripeService) GetDefaultPaymentMethod(ctx context.Context, customerID 
 	defaultPaymentMethodID := customer.InvoiceSettings.DefaultPaymentMethod.ID
 
 	// Get the payment method details
-	paymentMethod, err := stripeClient.PaymentMethods.Get(defaultPaymentMethodID, nil)
+	paymentMethod, err := stripeClient.V1PaymentMethods.Retrieve(context.Background(), defaultPaymentMethodID, nil)
 	if err != nil {
 		s.Logger.Errorw("failed to get default payment method from Stripe",
 			"error", err,
@@ -914,8 +909,7 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Ensure customer is synced to Stripe before charging saved payment method
 	ourCustomerResp, err := s.EnsureCustomerSyncedToStripe(ctx, req.CustomerID)
@@ -966,7 +960,7 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 
 	// Create PaymentIntent with saved payment method
 	amountInCents := req.Amount.Mul(decimal.NewFromInt(100)).IntPart()
-	params := &stripe.PaymentIntentParams{
+	params := &stripe.PaymentIntentCreateParams{
 		Amount:        stripe.Int64(amountInCents),
 		Currency:      stripe.String(req.Currency),
 		Customer:      stripe.String(stripeCustomerID),
@@ -980,7 +974,7 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 		},
 	}
 
-	paymentIntent, err := stripeClient.PaymentIntents.New(params)
+	paymentIntent, err := stripeClient.V1PaymentIntents.Create(context.Background(), params)
 	if err != nil {
 		// Handle specific error cases
 		if stripeErr, ok := err.(*stripe.Error); ok {
@@ -1271,18 +1265,17 @@ func (s *StripeService) GetPaymentStatus(ctx context.Context, sessionID string, 
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Get the checkout session with expanded fields
-	params := &stripe.CheckoutSessionParams{
+	params := &stripe.CheckoutSessionRetrieveParams{
 		Expand: []*string{
 			stripe.String("payment_intent"),
 			stripe.String("line_items"),
 			stripe.String("customer"),
 		},
 	}
-	session, err := stripeClient.CheckoutSessions.Get(sessionID, params)
+	session, err := stripeClient.V1CheckoutSessions.Retrieve(context.Background(), sessionID, params)
 	if err != nil {
 		s.Logger.Errorw("failed to get Stripe checkout session",
 			"error", err,
@@ -1331,7 +1324,7 @@ func (s *StripeService) GetPaymentStatus(ctx context.Context, sessionID string, 
 
 		// Get payment method ID from payment intent
 		if paymentIntentID != "" {
-			paymentIntent, err := stripeClient.PaymentIntents.Get(paymentIntentID, nil)
+			paymentIntent, err := stripeClient.V1PaymentIntents.Retrieve(context.Background(), paymentIntentID, nil)
 			if err != nil {
 				s.Logger.Warnw("failed to get payment intent details",
 					"error", err,
@@ -1432,17 +1425,16 @@ func (s *StripeService) GetPaymentStatusByPaymentIntent(ctx context.Context, pay
 	}
 
 	// Initialize Stripe client
-	stripeClient := &client.API{}
-	stripeClient.Init(stripeConfig.SecretKey, nil)
+	stripeClient := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Get the payment intent with expanded fields
-	params := &stripe.PaymentIntentParams{
+	params := &stripe.PaymentIntentRetrieveParams{
 		Expand: []*string{
 			stripe.String("payment_method"),
 			stripe.String("customer"),
 		},
 	}
-	paymentIntent, err := stripeClient.PaymentIntents.Get(paymentIntentID, params)
+	paymentIntent, err := stripeClient.V1PaymentIntents.Retrieve(context.Background(), paymentIntentID, params)
 	if err != nil {
 		s.Logger.Errorw("failed to get Stripe payment intent",
 			"error", err,
@@ -1547,17 +1539,16 @@ func (s *StripeService) UpdateStripeCustomerMetadata(ctx context.Context, stripe
 	}
 
 	// Initialize Stripe client
-	sc := &client.API{}
-	sc.Init(stripeConfig.SecretKey, nil)
+	sc := stripe.NewClient(stripeConfig.SecretKey, nil)
 
 	// Create update parameters
-	params := &stripe.CustomerParams{}
+	params := &stripe.CustomerUpdateParams{}
 	params.AddMetadata("flexprice_customer_id", customerID)
 	params.AddMetadata("flexprice_environment", environmentID)
 	params.AddMetadata("external_id", externalID)
 
 	// Update the Stripe customer
-	_, err = sc.Customers.Update(stripeCustomerID, params)
+	_, err = sc.V1Customers.Update(context.Background(), stripeCustomerID, params)
 	if err != nil {
 		s.Logger.Errorw("failed to update Stripe customer metadata",
 			"stripe_customer_id", stripeCustomerID,

--- a/internal/service/stripe.go
+++ b/internal/service/stripe.go
@@ -520,6 +520,18 @@ func (s *StripeService) CreatePaymentLink(ctx context.Context, req *dto.CreateSt
 		"environment_id": req.EnvironmentID,
 	}
 
+	// Try to get Stripe invoice ID for attachment tracking
+	if stripeInvoiceID, err := s.getStripeInvoiceID(ctx, req.InvoiceID); err == nil && stripeInvoiceID != "" {
+		metadata["stripe_invoice_id"] = stripeInvoiceID
+		s.Logger.Infow("payment link will be tracked for Stripe invoice attachment",
+			"flexprice_invoice_id", req.InvoiceID,
+			"stripe_invoice_id", stripeInvoiceID)
+	} else {
+		s.Logger.Debugw("no Stripe invoice found for payment link",
+			"flexprice_invoice_id", req.InvoiceID,
+			"error", err)
+	}
+
 	// Add custom metadata if provided
 	for k, v := range req.Metadata {
 		metadata[k] = v
@@ -974,6 +986,22 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 		},
 	}
 
+	// Try to get Stripe invoice ID for later attachment
+	stripeInvoiceID, err := s.getStripeInvoiceID(ctx, req.InvoiceID)
+	if err != nil {
+		s.Logger.Debugw("no Stripe invoice found, creating standalone payment",
+			"flexprice_invoice_id", req.InvoiceID,
+			"error", err)
+		stripeInvoiceID = "" // Clear any partial value
+	} else {
+		s.Logger.Infow("will attach payment to Stripe invoice after successful payment",
+			"flexprice_invoice_id", req.InvoiceID,
+			"stripe_invoice_id", stripeInvoiceID,
+			"payment_method_id", req.PaymentMethodID)
+		// Add to metadata for tracking
+		params.Metadata["stripe_invoice_id"] = stripeInvoiceID
+	}
+
 	paymentIntent, err := stripeClient.V1PaymentIntents.Create(context.Background(), params)
 	if err != nil {
 		// Handle specific error cases
@@ -1019,6 +1047,18 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 			Mark(ierr.ErrSystem)
 	}
 
+	// If payment succeeded and we have a Stripe invoice, attach the payment to the invoice
+	if paymentIntent.Status == stripe.PaymentIntentStatusSucceeded && stripeInvoiceID != "" {
+		if err := s.AttachPaymentToStripeInvoice(ctx, stripeClient, paymentIntent.ID, stripeInvoiceID); err != nil {
+			s.Logger.Errorw("failed to attach payment to Stripe invoice",
+				"error", err,
+				"payment_intent_id", paymentIntent.ID,
+				"stripe_invoice_id", stripeInvoiceID)
+			// Don't fail the whole payment, just log the error
+			// The payment was successful, attachment is a bonus feature
+		}
+	}
+
 	response := &dto.PaymentIntentResponse{
 		ID:            paymentIntent.ID,
 		Status:        string(paymentIntent.Status),
@@ -1035,6 +1075,8 @@ func (s *StripeService) ChargeSavedPaymentMethod(ctx context.Context, req *dto.C
 		"payment_method_id", req.PaymentMethodID,
 		"amount", req.Amount.String(),
 		"status", paymentIntent.Status,
+		"stripe_invoice_id", stripeInvoiceID,
+		"attached_to_invoice", stripeInvoiceID != "",
 	)
 
 	return response, nil
@@ -1562,6 +1604,64 @@ func (s *StripeService) UpdateStripeCustomerMetadata(ctx context.Context, stripe
 	s.Logger.Infow("successfully updated Stripe customer metadata",
 		"stripe_customer_id", stripeCustomerID,
 		"flexprice_customer_id", customerID)
+
+	return nil
+}
+
+// getStripeInvoiceID gets the Stripe invoice ID for a FlexPrice invoice
+func (s *StripeService) getStripeInvoiceID(ctx context.Context, invoiceID string) (string, error) {
+	mappingService := NewEntityIntegrationMappingService(s.ServiceParams)
+
+	filter := &types.EntityIntegrationMappingFilter{
+		EntityID:      invoiceID,
+		EntityType:    types.IntegrationEntityTypeInvoice,
+		ProviderTypes: []string{"stripe"},
+		QueryFilter:   types.NewDefaultQueryFilter(),
+	}
+
+	mappings, err := mappingService.GetEntityIntegrationMappings(ctx, filter)
+	if err != nil {
+		return "", err
+	}
+
+	if len(mappings.Items) == 0 {
+		return "", ierr.NewError("no Stripe invoice mapping found").
+			WithHint("Invoice not synced to Stripe").
+			WithReportableDetails(map[string]interface{}{
+				"invoice_id": invoiceID,
+			}).
+			Mark(ierr.ErrNotFound)
+	}
+
+	return mappings.Items[0].ProviderEntityID, nil
+}
+
+// AttachPaymentToStripeInvoice attaches a successful PaymentIntent to a Stripe invoice
+func (s *StripeService) AttachPaymentToStripeInvoice(ctx context.Context, stripeClient *stripe.Client, paymentIntentID, stripeInvoiceID string) error {
+	s.Logger.Infow("attaching payment to Stripe invoice",
+		"payment_intent_id", paymentIntentID,
+		"stripe_invoice_id", stripeInvoiceID)
+
+	// Use the invoice.AttachPayment method as per Stripe documentation
+	attachParams := &stripe.InvoiceAttachPaymentParams{
+		PaymentIntent: stripe.String(paymentIntentID),
+	}
+
+	_, err := stripeClient.V1Invoices.AttachPayment(context.Background(), stripeInvoiceID, attachParams)
+	if err != nil {
+		return ierr.NewError("failed to attach payment to Stripe invoice").
+			WithHint("Payment succeeded but couldn't be attached to invoice").
+			WithReportableDetails(map[string]interface{}{
+				"stripe_invoice_id": stripeInvoiceID,
+				"payment_intent_id": paymentIntentID,
+				"error":             err.Error(),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	s.Logger.Infow("successfully attached payment to Stripe invoice",
+		"payment_intent_id", paymentIntentID,
+		"stripe_invoice_id", stripeInvoiceID)
 
 	return nil
 }

--- a/internal/service/stripe_invoice_sync.go
+++ b/internal/service/stripe_invoice_sync.go
@@ -1,0 +1,602 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stripe/stripe-go/v82"
+)
+
+// StripeInvoiceSyncService handles synchronization of FlexPrice invoices with Stripe
+type StripeInvoiceSyncService struct {
+	ServiceParams
+	stripeService *StripeService
+}
+
+// NewStripeInvoiceSyncService creates a new Stripe invoice sync service
+func NewStripeInvoiceSyncService(params ServiceParams) *StripeInvoiceSyncService {
+	return &StripeInvoiceSyncService{
+		ServiceParams: params,
+		stripeService: NewStripeService(params),
+	}
+}
+
+// SyncInvoiceToStripe syncs a FlexPrice invoice to Stripe following the complete flow
+func (s *StripeInvoiceSyncService) SyncInvoiceToStripe(ctx context.Context, req dto.StripeInvoiceSyncRequest) (*dto.StripeInvoiceSyncResponse, error) {
+	s.Logger.Infow("starting Stripe invoice sync",
+		"invoice_id", req.InvoiceID,
+		"collection_method", req.CollectionMethod)
+
+	// Step 1: Check if Stripe connection exists
+	if !s.hasStripeConnection(ctx) {
+		return nil, ierr.NewError("Stripe connection not available").
+			WithHint("Stripe integration must be configured for invoice sync").
+			Mark(ierr.ErrNotFound)
+	}
+
+	// Step 2: Get FlexPrice invoice
+	flexInvoice, err := s.InvoiceRepo.Get(ctx, req.InvoiceID)
+	if err != nil {
+		return nil, ierr.WithError(err).WithHint("Failed to get FlexPrice invoice").Mark(ierr.ErrDatabase)
+	}
+
+	// Step 3: Check if invoice is already synced
+	existingMapping, err := s.getExistingStripeMapping(ctx, req.InvoiceID)
+	if err != nil && !ierr.IsNotFound(err) {
+		return nil, err
+	}
+
+	var stripeInvoiceID string
+	if existingMapping != nil {
+		stripeInvoiceID = existingMapping.ProviderEntityID
+		s.Logger.Infow("invoice already synced to Stripe",
+			"invoice_id", req.InvoiceID,
+			"stripe_invoice_id", stripeInvoiceID)
+	} else {
+		// Step 4: Create draft invoice in Stripe
+		stripeInvoiceID, err = s.createDraftInvoiceInStripe(ctx, flexInvoice, req.CollectionMethod)
+		if err != nil {
+			return nil, err
+		}
+
+		// Step 5: Create entity integration mapping
+		if err := s.createInvoiceMapping(ctx, req.InvoiceID, stripeInvoiceID); err != nil {
+			s.Logger.Errorw("failed to create invoice mapping", "error", err)
+			// Continue with sync even if mapping fails
+		}
+	}
+
+	// Step 6: Sync line items to Stripe
+	if err := s.syncLineItemsToStripe(ctx, flexInvoice, stripeInvoiceID); err != nil {
+		return nil, err
+	}
+
+	// Step 7: Finalize invoice in Stripe
+	finalizedInvoice, err := s.finalizeStripeInvoice(ctx, stripeInvoiceID, req.CollectionMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 8: Update FlexPrice invoice with Stripe data
+	if err := s.updateFlexPriceInvoiceFromStripe(ctx, flexInvoice, finalizedInvoice); err != nil {
+		s.Logger.Errorw("failed to update FlexPrice invoice from Stripe", "error", err)
+		// Don't fail the entire sync for this
+	}
+
+	response := &dto.StripeInvoiceSyncResponse{
+		StripeInvoiceID:  finalizedInvoice.ID,
+		Status:           string(finalizedInvoice.Status),
+		HostedInvoiceURL: finalizedInvoice.HostedInvoiceURL,
+		InvoicePDF:       finalizedInvoice.InvoicePDF,
+		Metadata: map[string]interface{}{
+			"flexprice_invoice_id": req.InvoiceID,
+			"sync_timestamp":       finalizedInvoice.Created,
+		},
+	}
+
+	s.Logger.Infow("Stripe invoice sync completed successfully",
+		"invoice_id", req.InvoiceID,
+		"stripe_invoice_id", finalizedInvoice.ID,
+		"status", finalizedInvoice.Status)
+
+	return response, nil
+}
+
+// createDraftInvoiceInStripe creates a draft invoice in Stripe
+func (s *StripeInvoiceSyncService) createDraftInvoiceInStripe(ctx context.Context, flexInvoice *invoice.Invoice, collectionMethod types.CollectionMethod) (string, error) {
+	// Get Stripe connection and client
+	stripeClient, err := s.getStripeClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Get customer's Stripe ID
+	stripeCustomerID, err := s.getStripeCustomerID(ctx, flexInvoice.CustomerID)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare invoice metadata
+	metadata := map[string]string{
+		"flexprice_invoice_id":     flexInvoice.ID,
+		"flexprice_customer_id":    flexInvoice.CustomerID,
+		"flexprice_invoice_number": lo.FromPtr(flexInvoice.InvoiceNumber),
+		"sync_source":              "flexprice",
+	}
+
+	if flexInvoice.SubscriptionID != nil {
+		metadata["flexprice_subscription_id"] = *flexInvoice.SubscriptionID
+	}
+
+	// Create invoice parameters
+	params := &stripe.InvoiceCreateParams{
+		Customer:    stripe.String(stripeCustomerID),
+		Currency:    stripe.String(strings.ToLower(flexInvoice.Currency)),
+		AutoAdvance: stripe.Bool(false), // We control finalization
+		Description: stripe.String(flexInvoice.Description),
+		Metadata:    metadata,
+	}
+
+	// Set collection method
+	switch collectionMethod {
+	case types.CollectionMethodChargeAutomatically:
+		params.CollectionMethod = stripe.String(string(stripe.InvoiceCollectionMethodChargeAutomatically))
+	case types.CollectionMethodSendInvoice:
+		params.CollectionMethod = stripe.String(string(stripe.InvoiceCollectionMethodSendInvoice))
+	default:
+		params.CollectionMethod = stripe.String(string(stripe.InvoiceCollectionMethodChargeAutomatically))
+	}
+
+	// Set due date only for send_invoice collection method
+	if flexInvoice.DueDate != nil && collectionMethod == types.CollectionMethodSendInvoice {
+		params.DueDate = stripe.Int64(flexInvoice.DueDate.Unix())
+	}
+
+	// Create the invoice
+	stripeInvoice, err := stripeClient.V1Invoices.Create(context.Background(), params)
+	if err != nil {
+		s.Logger.Errorw("failed to create draft invoice in Stripe",
+			"error", err,
+			"invoice_id", flexInvoice.ID)
+		return "", ierr.NewError("failed to create Stripe invoice").
+			WithHint("Unable to create draft invoice in Stripe").
+			WithReportableDetails(map[string]interface{}{
+				"invoice_id": flexInvoice.ID,
+				"error":      err.Error(),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	s.Logger.Infow("created draft invoice in Stripe",
+		"invoice_id", flexInvoice.ID,
+		"stripe_invoice_id", stripeInvoice.ID)
+
+	return stripeInvoice.ID, nil
+}
+
+// syncLineItemsToStripe adds all line items to the Stripe invoice
+func (s *StripeInvoiceSyncService) syncLineItemsToStripe(ctx context.Context, flexInvoice *invoice.Invoice, stripeInvoiceID string) error {
+	if len(flexInvoice.LineItems) == 0 {
+		s.Logger.Infow("no line items to sync", "invoice_id", flexInvoice.ID)
+		return nil
+	}
+
+	stripeClient, err := s.getStripeClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.Logger.Infow("syncing line items to Stripe",
+		"invoice_id", flexInvoice.ID,
+		"stripe_invoice_id", stripeInvoiceID,
+		"line_items_count", len(flexInvoice.LineItems))
+
+	// Add each line item to Stripe invoice
+	for _, lineItem := range flexInvoice.LineItems {
+		if err := s.addLineItemToStripeInvoice(ctx, stripeClient, stripeInvoiceID, lineItem, flexInvoice); err != nil {
+			return err
+		}
+	}
+
+	s.Logger.Infow("successfully synced all line items to Stripe",
+		"invoice_id", flexInvoice.ID,
+		"stripe_invoice_id", stripeInvoiceID)
+
+	return nil
+}
+
+// addLineItemToStripeInvoice adds a single line item to Stripe invoice
+func (s *StripeInvoiceSyncService) addLineItemToStripeInvoice(ctx context.Context, stripeClient *stripe.Client, stripeInvoiceID string, lineItem *invoice.InvoiceLineItem, flexInvoice *invoice.Invoice) error {
+	// Convert amount to cents (Stripe uses cents)
+	amountCents := lineItem.Amount.Mul(decimal.NewFromInt(100)).IntPart()
+
+	// Get customer ID from the invoice
+	customerID, err := s.getStripeCustomerID(ctx, flexInvoice.CustomerID)
+	if err != nil {
+		s.Logger.Errorw("failed to get Stripe customer ID",
+			"error", err,
+			"customer_id", flexInvoice.CustomerID,
+			"line_item_id", lineItem.ID)
+		return ierr.NewError("failed to get Stripe customer ID").
+			WithHint("Unable to find Stripe customer mapping").
+			WithReportableDetails(map[string]interface{}{
+				"customer_id":  flexInvoice.CustomerID,
+				"line_item_id": lineItem.ID,
+				"error":        err.Error(),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	params := &stripe.InvoiceItemCreateParams{
+		Customer:    stripe.String(customerID),
+		Invoice:     stripe.String(stripeInvoiceID),
+		Currency:    stripe.String(strings.ToLower(lineItem.Currency)),
+		Description: stripe.String(lo.FromPtr(lineItem.DisplayName)),
+		Metadata: map[string]string{
+			"flexprice_line_item_id": lineItem.ID,
+			"flexprice_price_id":     lo.FromPtr(lineItem.PriceID),
+			"sync_source":            "flexprice",
+		},
+	}
+
+	// Stripe only allows either Amount OR Quantity, not both
+	// For now, we'll always use Amount since it's simpler and works for all cases
+	params.Amount = stripe.Int64(amountCents)
+
+	invoiceItem, err := stripeClient.V1InvoiceItems.Create(context.Background(), params)
+	if err != nil {
+		s.Logger.Errorw("failed to add line item to Stripe invoice",
+			"error", err,
+			"line_item_id", lineItem.ID,
+			"stripe_invoice_id", stripeInvoiceID)
+		return ierr.NewError("failed to add line item to Stripe").
+			WithHint("Unable to add line item to Stripe invoice").
+			WithReportableDetails(map[string]interface{}{
+				"line_item_id":      lineItem.ID,
+				"stripe_invoice_id": stripeInvoiceID,
+				"error":             err.Error(),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	s.Logger.Debugw("added line item to Stripe invoice",
+		"line_item_id", lineItem.ID,
+		"stripe_invoice_id", stripeInvoiceID,
+		"stripe_item_id", invoiceItem.ID)
+
+	return nil
+}
+
+// finalizeStripeInvoice finalizes the invoice in Stripe
+func (s *StripeInvoiceSyncService) finalizeStripeInvoice(ctx context.Context, stripeInvoiceID string, collectionMethod types.CollectionMethod) (*stripe.Invoice, error) {
+	stripeClient, err := s.getStripeClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	s.Logger.Infow("finalizing Stripe invoice",
+		"stripe_invoice_id", stripeInvoiceID,
+		"collection_method", collectionMethod)
+
+	// Finalize the invoice
+	params := &stripe.InvoiceFinalizeInvoiceParams{
+		AutoAdvance: stripe.Bool(false), // Let Stripe handle payment intent creation and sending
+	}
+
+	finalizedInvoice, err := stripeClient.V1Invoices.FinalizeInvoice(context.Background(), stripeInvoiceID, params)
+	if err != nil {
+		s.Logger.Errorw("failed to finalize Stripe invoice",
+			"error", err,
+			"stripe_invoice_id", stripeInvoiceID)
+		return nil, ierr.NewError("failed to finalize Stripe invoice").
+			WithHint("Unable to finalize invoice in Stripe").
+			WithReportableDetails(map[string]interface{}{
+				"stripe_invoice_id": stripeInvoiceID,
+				"error":             err.Error(),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	s.Logger.Infow("successfully finalized Stripe invoice",
+		"stripe_invoice_id", stripeInvoiceID,
+		"status", finalizedInvoice.Status,
+		"total", finalizedInvoice.Total)
+
+	// Send invoice if collection method is send_invoice
+	if collectionMethod == types.CollectionMethodSendInvoice {
+		s.Logger.Infow("sending invoice to customer via Stripe",
+			"stripe_invoice_id", stripeInvoiceID,
+			"collection_method", collectionMethod)
+
+		_, err = stripeClient.V1Invoices.SendInvoice(context.Background(), stripeInvoiceID, &stripe.InvoiceSendInvoiceParams{})
+		if err != nil {
+			s.Logger.Errorw("failed to send Stripe invoice",
+				"error", err,
+				"stripe_invoice_id", stripeInvoiceID)
+			// Don't fail the entire sync if sending fails, just log the error
+		} else {
+			s.Logger.Infow("successfully sent Stripe invoice to customer",
+				"stripe_invoice_id", stripeInvoiceID)
+		}
+	}
+
+	return finalizedInvoice, nil
+}
+
+// SyncPaymentToStripe syncs a FlexPrice payment to Stripe as an external payment
+func (s *StripeInvoiceSyncService) SyncPaymentToStripe(ctx context.Context, invoiceID string, paymentAmount decimal.Decimal, paymentSource string, metadata map[string]string) error {
+	// Get Stripe invoice ID from mapping
+	mapping, err := s.getExistingStripeMapping(ctx, invoiceID)
+	if err != nil {
+		return ierr.WithError(err).WithHint("Invoice not synced to Stripe").Mark(ierr.ErrNotFound)
+	}
+
+	stripeClient, err := s.getStripeClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	stripeInvoiceID := mapping.ProviderEntityID
+	amountCents := paymentAmount.Mul(decimal.NewFromInt(100)).IntPart()
+
+	s.Logger.Infow("syncing external payment to Stripe",
+		"invoice_id", invoiceID,
+		"stripe_invoice_id", stripeInvoiceID,
+		"amount", paymentAmount,
+		"source", paymentSource)
+
+	// Get the invoice to check current status
+	stripeInvoice, err := stripeClient.V1Invoices.Retrieve(context.Background(), stripeInvoiceID, nil)
+	if err != nil {
+		return ierr.NewError("failed to retrieve Stripe invoice").
+			WithHint("Unable to get invoice from Stripe").
+			Mark(ierr.ErrSystem)
+	}
+
+	// Only proceed if invoice is finalized and not fully paid
+	if stripeInvoice.Status != stripe.InvoiceStatusOpen {
+		s.Logger.Infow("Stripe invoice not in open status, skipping payment sync",
+			"stripe_invoice_id", stripeInvoiceID,
+			"status", stripeInvoice.Status)
+		return nil
+	}
+
+	// For external payments (like FlexPrice credits), mark as paid out of band
+	// This indicates the payment was processed outside of Stripe
+
+	// Create simple params without metadata to avoid Stripe SDK conflicts
+	payParams := &stripe.InvoicePayParams{
+		PaidOutOfBand: stripe.Bool(true),
+	}
+
+	s.Logger.Infow("marking external payment as paid out of band in Stripe",
+		"stripe_invoice_id", stripeInvoiceID,
+		"amount_cents", amountCents,
+		"payment_source", paymentSource)
+
+	updatedInvoice, err := stripeClient.V1Invoices.Pay(context.Background(), stripeInvoiceID, payParams)
+	if err != nil {
+		s.Logger.Errorw("failed to mark payment as paid out of band",
+			"error", err,
+			"stripe_invoice_id", stripeInvoiceID,
+			"amount_cents", amountCents)
+		return ierr.NewError("failed to mark payment as paid out of band").
+			WithHint("Unable to record external payment in Stripe").
+			WithReportableDetails(map[string]interface{}{
+				"stripe_invoice_id": stripeInvoiceID,
+				"payment_amount":    paymentAmount.String(),
+				"error":             err.Error(),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	// Update Stripe invoice metadata to track FlexPrice credit payments
+	err = s.updateStripeInvoiceMetadata(ctx, stripeClient, stripeInvoiceID, paymentAmount, paymentSource, metadata)
+	if err != nil {
+		s.Logger.Errorw("failed to update Stripe invoice metadata",
+			"error", err,
+			"stripe_invoice_id", stripeInvoiceID,
+			"amount", paymentAmount)
+		// Don't fail the whole operation, just log the error
+	}
+
+	s.Logger.Infow("successfully synced payment to Stripe",
+		"invoice_id", invoiceID,
+		"stripe_invoice_id", stripeInvoiceID,
+		"amount", paymentAmount,
+		"new_status", updatedInvoice.Status)
+
+	return nil
+}
+
+// Helper methods
+
+// hasStripeConnection checks if Stripe connection is available
+func (s *StripeInvoiceSyncService) hasStripeConnection(ctx context.Context) bool {
+	conn, err := s.ConnectionRepo.GetByProvider(ctx, types.SecretProviderStripe)
+	return err == nil && conn != nil
+}
+
+// getStripeClient gets an authenticated Stripe client
+func (s *StripeInvoiceSyncService) getStripeClient(ctx context.Context) (*stripe.Client, error) {
+	conn, err := s.ConnectionRepo.GetByProvider(ctx, types.SecretProviderStripe)
+	if err != nil {
+		return nil, ierr.NewError("failed to get Stripe connection").
+			WithHint("Stripe connection not configured").
+			Mark(ierr.ErrNotFound)
+	}
+
+	stripeConfig, err := s.stripeService.GetDecryptedStripeConfig(conn)
+	if err != nil {
+		return nil, ierr.NewError("failed to get Stripe configuration").
+			WithHint("Invalid Stripe configuration").
+			Mark(ierr.ErrValidation)
+	}
+
+	return stripe.NewClient(stripeConfig.SecretKey, nil), nil
+}
+
+// getStripeCustomerID gets the Stripe customer ID for a FlexPrice customer
+func (s *StripeInvoiceSyncService) getStripeCustomerID(ctx context.Context, customerID string) (string, error) {
+	customerService := NewCustomerService(s.ServiceParams)
+	customerResp, err := customerService.GetCustomer(ctx, customerID)
+	if err != nil {
+		return "", err
+	}
+
+	stripeCustomerID, exists := customerResp.Customer.Metadata["stripe_customer_id"]
+	if !exists || stripeCustomerID == "" {
+		return "", ierr.NewError("customer not synced to Stripe").
+			WithHint("Customer must be synced to Stripe before invoice sync").
+			WithReportableDetails(map[string]interface{}{
+				"customer_id": customerID,
+			}).
+			Mark(ierr.ErrNotFound)
+	}
+
+	return stripeCustomerID, nil
+}
+
+// getExistingStripeMapping gets existing Stripe mapping for an invoice
+func (s *StripeInvoiceSyncService) getExistingStripeMapping(ctx context.Context, invoiceID string) (*entityintegrationmapping.EntityIntegrationMapping, error) {
+	mappingService := NewEntityIntegrationMappingService(s.ServiceParams)
+
+	filter := &types.EntityIntegrationMappingFilter{
+		EntityID:      invoiceID,
+		EntityType:    types.IntegrationEntityTypeInvoice,
+		ProviderTypes: []string{"stripe"},
+		QueryFilter:   types.NewDefaultQueryFilter(),
+	}
+
+	mappings, err := mappingService.GetEntityIntegrationMappings(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(mappings.Items) == 0 {
+		return nil, ierr.NewError("mapping not found").Mark(ierr.ErrNotFound)
+	}
+
+	// Convert response to domain model
+	mappingResp := mappings.Items[0]
+	return &entityintegrationmapping.EntityIntegrationMapping{
+		ID:               mappingResp.ID,
+		EntityID:         mappingResp.EntityID,
+		EntityType:       mappingResp.EntityType,
+		ProviderType:     mappingResp.ProviderType,
+		ProviderEntityID: mappingResp.ProviderEntityID,
+		EnvironmentID:    mappingResp.EnvironmentID,
+	}, nil
+}
+
+// createInvoiceMapping creates a new entity integration mapping for the invoice
+func (s *StripeInvoiceSyncService) createInvoiceMapping(ctx context.Context, invoiceID, stripeInvoiceID string) error {
+	mappingService := NewEntityIntegrationMappingService(s.ServiceParams)
+
+	createReq := dto.CreateEntityIntegrationMappingRequest{
+		EntityID:         invoiceID,
+		EntityType:       types.IntegrationEntityTypeInvoice,
+		ProviderType:     "stripe",
+		ProviderEntityID: stripeInvoiceID,
+		Metadata: map[string]interface{}{
+			"sync_timestamp": time.Now().Unix(),
+			"sync_source":    "flexprice",
+		},
+	}
+
+	_, err := mappingService.CreateEntityIntegrationMapping(ctx, createReq)
+	return err
+}
+
+// updateFlexPriceInvoiceFromStripe updates FlexPrice invoice with data from Stripe
+func (s *StripeInvoiceSyncService) updateFlexPriceInvoiceFromStripe(ctx context.Context, flexInvoice *invoice.Invoice, stripeInvoice *stripe.Invoice) error {
+	// Update invoice with Stripe data if needed
+	updated := false
+
+	// Update total if Stripe calculated taxes
+	if stripeInvoice.Total > 0 {
+		stripeTotal := decimal.NewFromInt(stripeInvoice.Total).Div(decimal.NewFromInt(100))
+		if !flexInvoice.Total.Equal(stripeTotal) {
+			flexInvoice.Total = stripeTotal
+			flexInvoice.AmountDue = stripeTotal
+			updated = true
+		}
+	}
+
+	// Update hosted invoice URL
+	if stripeInvoice.HostedInvoiceURL != "" {
+		if flexInvoice.Metadata == nil {
+			flexInvoice.Metadata = make(types.Metadata)
+		}
+		flexInvoice.Metadata["stripe_hosted_invoice_url"] = stripeInvoice.HostedInvoiceURL
+		updated = true
+	}
+
+	// Update PDF URL
+	if stripeInvoice.InvoicePDF != "" {
+		flexInvoice.InvoicePDFURL = &stripeInvoice.InvoicePDF
+		updated = true
+	}
+
+	if updated {
+		return s.InvoiceRepo.Update(ctx, flexInvoice)
+	}
+
+	return nil
+}
+
+// updateStripeInvoiceMetadata updates the Stripe invoice metadata to track FlexPrice credit payments
+func (s *StripeInvoiceSyncService) updateStripeInvoiceMetadata(ctx context.Context, stripeClient *stripe.Client, stripeInvoiceID string, paymentAmount decimal.Decimal, paymentSource string, paymentMetadata map[string]string) error {
+	// Get current invoice to read existing metadata
+	currentInvoice, err := stripeClient.V1Invoices.Retrieve(context.Background(), stripeInvoiceID, nil)
+	if err != nil {
+		return err
+	}
+
+	// Track total FlexPrice credit amount paid (only this field needed)
+	totalCreditsKey := "flexprice_credits_paid_cents"
+	currentCreditsStr := ""
+	if currentInvoice.Metadata != nil {
+		currentCreditsStr = currentInvoice.Metadata[totalCreditsKey]
+	}
+
+	// Parse existing credits amount (keep everything in decimal for accuracy)
+	var currentCredits decimal.Decimal
+	if currentCreditsStr != "" {
+		if parsed, err := decimal.NewFromString(currentCreditsStr); err == nil {
+			currentCredits = parsed
+		}
+	}
+
+	// Add new payment amount (convert to cents as decimal for precision)
+	paymentAmountCents := paymentAmount.Mul(decimal.NewFromInt(100))
+	newTotalCredits := currentCredits.Add(paymentAmountCents)
+
+	// Update the invoice metadata with only the credits total
+	updateParams := &stripe.InvoiceUpdateParams{}
+	updateParams.AddMetadata(totalCreditsKey, newTotalCredits.String())
+
+	s.Logger.Infow("updating Stripe invoice metadata with total credit amount",
+		"stripe_invoice_id", stripeInvoiceID,
+		"payment_amount_cents", paymentAmountCents.String(),
+		"new_total_credits_cents", newTotalCredits.String())
+
+	_, err = stripeClient.V1Invoices.Update(context.Background(), stripeInvoiceID, updateParams)
+	if err != nil {
+		return err
+	}
+
+	s.Logger.Infow("successfully updated Stripe invoice metadata",
+		"stripe_invoice_id", stripeInvoiceID,
+		"total_credits_paid_cents", newTotalCredits.String())
+
+	return nil
+}

--- a/internal/service/subscription_payment_processor.go
+++ b/internal/service/subscription_payment_processor.go
@@ -447,6 +447,17 @@ func (s *subscriptionPaymentProcessor) processPayment(
 				flowType,
 			)
 
+			// If invoice is synced to Stripe, don't allow partial payments
+			if s.isInvoiceSyncedToStripe(ctx, inv.ID) {
+				s.Logger.Warnw("card payment failed, invoice is synced to Stripe - not allowing partial wallet payment",
+					"subscription_id", sub.ID,
+					"invoice_id", inv.ID,
+					"attempted_card_amount", cardAmount,
+					"wallet_amount_available", walletAmount,
+				)
+				allowPartialWallet = false
+			}
+
 			if !allowPartialWallet {
 				// Card payment failed - do not attempt wallet payment
 				// The invoice cannot be fully paid, so we stop here
@@ -906,4 +917,27 @@ func (s *subscriptionPaymentProcessor) checkAvailableCredits(
 	)
 
 	return totalAvailable
+}
+
+// isInvoiceSyncedToStripe checks if an invoice is synced to Stripe by looking up entity integration mapping
+func (s *subscriptionPaymentProcessor) isInvoiceSyncedToStripe(ctx context.Context, invoiceID string) bool {
+	filter := &types.EntityIntegrationMappingFilter{
+		EntityID:      invoiceID,
+		EntityType:    "invoice",
+		ProviderTypes: []string{"stripe"},
+	}
+
+	mappings, err := s.EntityIntegrationMappingRepo.List(ctx, filter)
+
+	if err != nil {
+		s.Logger.Errorw("failed to check invoice Stripe sync status",
+			"error", err,
+			"invoice_id", invoiceID,
+		)
+		// In case of error, assume not synced to be safe
+		return false
+	}
+
+	// If we have any mappings, the invoice is synced to Stripe
+	return len(mappings) > 0
 }

--- a/internal/types/payment_gateway.go
+++ b/internal/types/payment_gateway.go
@@ -59,7 +59,8 @@ func (w WebhookEventType) Validate() error {
 		WebhookEventTypeCheckoutSessionAsyncPaymentFailed,
 		WebhookEventTypeCheckoutSessionExpired,
 		WebhookEventTypeCustomerCreated,
-		WebhookEventTypePaymentIntentPaymentFailed:
+		WebhookEventTypePaymentIntentPaymentFailed,
+		WebhookEventTypeInvoicePaymentPaid:
 		return nil
 	default:
 		return ierr.NewError("invalid webhook event type").
@@ -72,6 +73,7 @@ func (w WebhookEventType) Validate() error {
 					WebhookEventTypeCheckoutSessionExpired,
 					WebhookEventTypeCustomerCreated,
 					WebhookEventTypePaymentIntentPaymentFailed,
+					WebhookEventTypeInvoicePaymentPaid,
 				},
 			}).
 			Mark(ierr.ErrValidation)

--- a/internal/types/payment_gateway.go
+++ b/internal/types/payment_gateway.go
@@ -48,6 +48,7 @@ const (
 	WebhookEventTypeCheckoutSessionExpired               WebhookEventType = "checkout.session.expired"
 	WebhookEventTypeCustomerCreated                      WebhookEventType = "customer.created"
 	WebhookEventTypePaymentIntentPaymentFailed           WebhookEventType = "payment_intent.payment_failed"
+	WebhookEventTypeInvoicePaymentPaid                   WebhookEventType = "invoice_payment.paid"
 )
 
 // Validate validates the webhook event type


### PR DESCRIPTION
… and API calls throughout the service.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade Stripe Go SDK from v79 to v82, updating client initialization and API calls across the service.
> 
>   - **Dependencies**:
>     - Upgrade `github.com/stripe/stripe-go` from v79 to v82 in `go.mod` and `go.sum`.
>   - **Client Initialization**:
>     - Replace `client.API{}` with `stripe.NewClient()` in `webhook.go`, `integration.go`, and `stripe.go`.
>   - **API Calls**:
>     - Update API calls to use `V1Customers`, `V1CheckoutSessions`, `V1PaymentMethods`, and `V1PaymentIntents` in `webhook.go`, `integration.go`, and `stripe.go`.
>     - Modify iteration over list results to use function callbacks instead of `Next()` in `webhook.go` and `stripe.go`.
>   - **Parameter Changes**:
>     - Update parameter structs to new versions, e.g., `CheckoutSessionCreateParams` in `stripe.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 9ee1d0ee0b6c315eae09619bfc8f68e0fae3931b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->