### PR TITLE
feat(billing): add script for billing cycle migration

### DIFF
--- a/scripts/internal/migrate_billing_cycle.go
+++ b/scripts/internal/migrate_billing_cycle.go
@@ -130,7 +130,7 @@ func migrateBillingCycle(params MigrateBillingCycleParams) error {
 		// Calculate new current period end using the subscription start date and new billing anchor
 		// This ensures we get the correct period end for calendar billing
 		newCurrentPeriodEnd, err := types.NextBillingDate(
-			sub.StartDate,
+			sub.CurrentPeriodStart,
 			newBillingAnchor,
 			sub.BillingPeriodCount,
 			sub.BillingPeriod,

--- a/scripts/internal/migrate_billing_cycle.go
+++ b/scripts/internal/migrate_billing_cycle.go
@@ -1,0 +1,188 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	domainSub "github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
+	"github.com/flexprice/flexprice/internal/repository/ent"
+	"github.com/flexprice/flexprice/internal/sentry"
+	_ "github.com/flexprice/flexprice/internal/sentry"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// MigrateBillingCycleParams holds parameters for billing cycle migration
+type MigrateBillingCycleParams struct {
+	TenantID      string
+	EnvironmentID string
+	DryRun        bool
+}
+
+// MigrateBillingCycle migrates subscriptions from anniversary to calendar billing cycle
+func MigrateBillingCycle() error {
+	tenantID := os.Getenv("TENANT_ID")
+	environmentID := os.Getenv("ENVIRONMENT_ID")
+	dryRunStr := os.Getenv("DRY_RUN")
+
+	if tenantID == "" || environmentID == "" {
+		return fmt.Errorf("TENANT_ID and ENVIRONMENT_ID are required")
+	}
+
+	dryRun := dryRunStr == "true" || dryRunStr == "1"
+
+	params := MigrateBillingCycleParams{
+		TenantID:      tenantID,
+		EnvironmentID: environmentID,
+		DryRun:        dryRun,
+	}
+
+	return migrateBillingCycle(params)
+}
+
+func migrateBillingCycle(params MigrateBillingCycleParams) error {
+	fmt.Printf("Starting billing cycle migration...\n")
+	fmt.Printf("Tenant ID: %s\n", params.TenantID)
+	fmt.Printf("Environment ID: %s\n", params.EnvironmentID)
+	fmt.Printf("Dry Run: %t\n", params.DryRun)
+	fmt.Println(strings.Repeat("=", 50))
+
+	// Load configuration
+	cfg, err := config.NewConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Create logger
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create logger: %w", err)
+	}
+
+	// Create database client
+	entClient, err := postgres.NewEntClient(cfg, log)
+	if err != nil {
+		return fmt.Errorf("failed to create ent client: %w", err)
+	}
+	defer entClient.Close()
+
+	// Create postgres client
+	dbClient := postgres.NewClient(entClient, log, sentry.NewSentryService(cfg, log))
+
+	// Create repository
+	subscriptionRepo := ent.NewSubscriptionRepository(dbClient, log, nil)
+
+	// Create context with tenant and environment
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.CtxTenantID, params.TenantID)
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, params.EnvironmentID)
+
+	// Create filter to get subscriptions with anniversary billing cycle
+	filter := &types.SubscriptionFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		// We'll filter by billing cycle in the service layer
+	}
+
+	// Get all subscriptions for the tenant and environment
+	subscriptions, err := subscriptionRepo.List(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	// Filter subscriptions with anniversary billing cycle
+	var anniversarySubscriptions []*domainSub.Subscription
+	for _, sub := range subscriptions {
+		if sub.BillingCycle == types.BillingCycleAnniversary {
+			anniversarySubscriptions = append(anniversarySubscriptions, sub)
+		}
+	}
+
+	fmt.Printf("Found %d subscriptions with anniversary billing cycle\n", len(anniversarySubscriptions))
+
+	if len(anniversarySubscriptions) == 0 {
+		fmt.Println("No subscriptions found with anniversary billing cycle. Migration complete.")
+		return nil
+	}
+
+	// Process each subscription
+	successCount := 0
+	errorCount := 0
+
+	for i, sub := range anniversarySubscriptions {
+		fmt.Printf("\nProcessing subscription %d/%d: %s\n", i+1, len(anniversarySubscriptions), sub.ID)
+		fmt.Printf("  Current billing cycle: %s\n", sub.BillingCycle)
+		fmt.Printf("  Current billing anchor: %s\n", sub.BillingAnchor.Format(time.RFC3339))
+		fmt.Printf("  Current period start: %s\n", sub.CurrentPeriodStart.Format(time.RFC3339))
+		fmt.Printf("  Current period end: %s\n", sub.CurrentPeriodEnd.Format(time.RFC3339))
+
+		// Calculate new billing anchor for calendar billing
+		newBillingAnchor := types.CalculateCalendarBillingAnchor(sub.StartDate, sub.BillingPeriod)
+		fmt.Printf("  New billing anchor (calendar): %s\n", newBillingAnchor.Format(time.RFC3339))
+
+		// Calculate new current period end using the subscription start date and new billing anchor
+		// This ensures we get the correct period end for calendar billing
+		newCurrentPeriodEnd, err := types.NextBillingDate(
+			sub.StartDate,
+			newBillingAnchor,
+			sub.BillingPeriodCount,
+			sub.BillingPeriod,
+			sub.EndDate,
+		)
+		if err != nil {
+			fmt.Printf("  ERROR: Failed to calculate new period end: %v\n", err)
+			errorCount++
+			continue
+		}
+
+		fmt.Printf("  New current period end: %s\n", newCurrentPeriodEnd.Format(time.RFC3339))
+
+		if params.DryRun {
+			fmt.Printf("  [DRY RUN] Would update subscription:\n")
+			fmt.Printf("    - Billing cycle: %s -> %s\n", sub.BillingCycle, types.BillingCycleCalendar)
+			fmt.Printf("    - Billing anchor: %s -> %s\n", sub.BillingAnchor.Format(time.RFC3339), newBillingAnchor.Format(time.RFC3339))
+			fmt.Printf("    - Current period end: %s -> %s\n", sub.CurrentPeriodEnd.Format(time.RFC3339), newCurrentPeriodEnd.Format(time.RFC3339))
+			successCount++
+		} else {
+			// Update the subscription
+			sub.BillingCycle = types.BillingCycleCalendar
+			sub.BillingAnchor = newBillingAnchor
+			sub.CurrentPeriodEnd = newCurrentPeriodEnd
+
+			// Update in database
+			err = subscriptionRepo.Update(ctx, sub)
+			if err != nil {
+				fmt.Printf("  ERROR: Failed to update subscription: %v\n", err)
+				errorCount++
+				continue
+			}
+
+			fmt.Printf("  SUCCESS: Updated subscription successfully\n")
+			successCount++
+		}
+	}
+
+	// Print summary
+	fmt.Println("\n" + strings.Repeat("=", 50))
+	fmt.Printf("Migration Summary:\n")
+	fmt.Printf("  Total subscriptions processed: %d\n", len(anniversarySubscriptions))
+	fmt.Printf("  Successful: %d\n", successCount)
+	fmt.Printf("  Errors: %d\n", errorCount)
+
+	if params.DryRun {
+		fmt.Printf("  Mode: DRY RUN (no actual changes made)\n")
+	} else {
+		fmt.Printf("  Mode: LIVE (changes applied to database)\n")
+	}
+
+	if errorCount > 0 {
+		return fmt.Errorf("migration completed with %d errors", errorCount)
+	}
+
+	fmt.Println("Migration completed successfully!")
+	return nil
+}

--- a/scripts/internal/migrate_billing_cycle.go
+++ b/scripts/internal/migrate_billing_cycle.go
@@ -24,6 +24,7 @@ type MigrateBillingCycleParams struct {
 	DryRun        bool
 }
 
+// NOTE: It does not handle proration for subscriptions when changing the billing date.
 // MigrateBillingCycle migrates subscriptions from anniversary to calendar billing cycle
 func MigrateBillingCycle() error {
 	tenantID := os.Getenv("TENANT_ID")

--- a/scripts/internal/migrate_billing_cycle.go
+++ b/scripts/internal/migrate_billing_cycle.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/config"
 	domainSub "github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -74,8 +75,11 @@ func migrateBillingCycle(params MigrateBillingCycleParams) error {
 	// Create postgres client
 	dbClient := postgres.NewClient(entClient, log, sentry.NewSentryService(cfg, log))
 
+	// Create cache
+	cache := cache.NewInMemoryCache()
+
 	// Create repository
-	subscriptionRepo := ent.NewSubscriptionRepository(dbClient, log, nil)
+	subscriptionRepo := ent.NewSubscriptionRepository(dbClient, log, cache)
 
 	// Create context with tenant and environment
 	ctx := context.Background()

--- a/scripts/main.go
+++ b/scripts/main.go
@@ -98,6 +98,11 @@ var commands = []Command{
 		Description: "Migrate to addon",
 		Run:         internal.CopyPlanChargesToAddons,
 	},
+	{
+		Name:        "migrate-billing-cycle",
+		Description: "Migrate subscriptions from anniversary to calendar billing cycle",
+		Run:         internal.MigrateBillingCycle,
+	},
 }
 
 // runBulkReprocessEventsCommand wraps the bulk reprocess events with command line parameters
@@ -149,6 +154,7 @@ func main() {
 		startTime          string
 		endTime            string
 		batchSize          string
+		dryRun             string
 	)
 
 	flag.BoolVar(&listCommands, "list", false, "List all available commands")
@@ -169,6 +175,7 @@ func main() {
 	flag.StringVar(&startTime, "start-time", "", "Start time for reprocessing (ISO-8601 format)")
 	flag.StringVar(&endTime, "end-time", "", "End time for reprocessing (ISO-8601 format)")
 	flag.StringVar(&batchSize, "batch-size", "100", "Batch size for reprocessing")
+	flag.StringVar(&dryRun, "dry-run", "false", "Dry run mode (true/false)")
 	flag.Parse()
 
 	if listCommands {
@@ -231,6 +238,9 @@ func main() {
 	}
 	if batchSize != "" {
 		os.Setenv("BATCH_SIZE", batchSize)
+	}
+	if dryRun != "" {
+		os.Setenv("DRY_RUN", dryRun)
 	}
 
 	// Find and run the command


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a script for migrating billing cycles from anniversary to calendar with dry-run support and registers it as a command.
> 
>   - **New Script**:
>     - Adds `migrate_billing_cycle.go` to `scripts/internal` for migrating billing cycles from anniversary to calendar.
>     - Handles dry-run and live modes, processing subscriptions and updating the database.
>     - Uses direct SQL for updates due to immutability in ent schema.
>   - **Command Registration**:
>     - Registers `migrate-billing-cycle` command in `scripts/main.go`.
>     - Adds `dryRun` flag to command line options in `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d33c6429ac35731ce22ab6f8da959bec274584d0. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->