### PR TITLE
Fix: Making billing_period_count optional in all apis

### DIFF
--- a/internal/api/dto/price.go
+++ b/internal/api/dto/price.go
@@ -23,7 +23,7 @@ type CreatePriceRequest struct {
 	Type               types.PriceType          `json:"type" validate:"required"`
 	PriceUnitType      types.PriceUnitType      `json:"price_unit_type" validate:"required"`
 	BillingPeriod      types.BillingPeriod      `json:"billing_period" validate:"required"`
-	BillingPeriodCount int                      `json:"billing_period_count" validate:"required,min=1"`
+	BillingPeriodCount int                      `json:"billing_period_count"`
 	BillingModel       types.BillingModel       `json:"billing_model" validate:"required"`
 	BillingCadence     types.BillingCadence     `json:"billing_cadence" validate:"required"`
 	MeterID            string                   `json:"meter_id,omitempty"`
@@ -74,6 +74,11 @@ func (r *CreatePriceRequest) Validate() error {
 	// Set default price unit type to FIAT if not provided
 	if r.PriceUnitType == "" {
 		r.PriceUnitType = types.PRICE_UNIT_TYPE_FIAT
+	}
+
+	// Set default value to Billing Period Count if not provided
+	if r.BillingPeriodCount == 0 {
+		r.BillingPeriodCount = 1
 	}
 
 	// Base validations

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -32,7 +32,7 @@ type CreateSubscriptionRequest struct {
 	TrialEnd           *time.Time           `json:"trial_end,omitempty"`
 	BillingCadence     types.BillingCadence `json:"billing_cadence" validate:"required"`
 	BillingPeriod      types.BillingPeriod  `json:"billing_period" validate:"required"`
-	BillingPeriodCount int                  `json:"billing_period_count" validate:"required,min=1"`
+	BillingPeriodCount int                  `json:"billing_period_count"`
 	Metadata           map[string]string    `json:"metadata,omitempty"`
 	// BillingCycle is the cycle of the billing anchor.
 	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
@@ -241,6 +241,11 @@ func (r *CreateSubscriptionRequest) Validate() error {
 	if r.PaymentBehavior == nil {
 		defaultPaymentBehavior := types.PaymentBehaviorDefaultActive
 		r.PaymentBehavior = &defaultPaymentBehavior
+	}
+
+	// Set default value to Billing Period Count if not provided
+	if r.BillingPeriodCount == 0 {
+		r.BillingPeriodCount = 1
 	}
 
 	// Validate payment behavior and collection method combination

--- a/internal/api/dto/subscription_change.go
+++ b/internal/api/dto/subscription_change.go
@@ -30,7 +30,7 @@ type SubscriptionChangeRequest struct {
 	BillingPeriod types.BillingPeriod `json:"billing_period" validate:"required" binding:"required"`
 
 	// billing_period_count is the billing period count for the new subscription
-	BillingPeriodCount int `json:"billing_period_count" validate:"required" binding:"required"`
+	BillingPeriodCount int `json:"billing_period_count" binding:"required"`
 
 	// billing_cycle is the billing cycle for the new subscription
 	BillingCycle types.BillingCycle `json:"billing_cycle" validate:"required" binding:"required"`
@@ -41,6 +41,11 @@ func (r *SubscriptionChangeRequest) Validate() error {
 	// Validate using struct tags first
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
+	}
+
+	// Set default value to Billing Period Count if not provided
+	if r.BillingPeriodCount == 0 {
+		r.BillingPeriodCount = 1
 	}
 
 	// Validate proration behavior


### PR DESCRIPTION
Fixes #520 

The changes will be reflected inthe  following APIs'
- create plan
- update plan
- create price
- create subscription
- execute subscription plan change
- preview subscription plan change