### PR TITLE
fix(setting): segregate the sequence and due date setting workflow

### DIFF
--- a/internal/api/dto/settings.go
+++ b/internal/api/dto/settings.go
@@ -26,20 +26,7 @@ type SettingResponse struct {
 func ConvertToInvoiceConfig(value map[string]interface{}) (*types.InvoiceConfig, error) {
 
 	invoiceConfig := &types.InvoiceConfig{}
-	if dueDateDaysRaw, exists := value["due_date_days"]; exists {
-		switch v := dueDateDaysRaw.(type) {
-		case int:
-			dueDateDays := v
-			invoiceConfig.DueDateDays = &dueDateDays
-		case float64:
-			dueDateDays := int(v)
-			invoiceConfig.DueDateDays = &dueDateDays
-		}
-	} else {
-		// Get default value and convert to pointer
-		defaultDays := types.GetDefaultSettings()[types.SettingKeyInvoiceConfig].DefaultValue["due_date_days"].(int)
-		invoiceConfig.DueDateDays = &defaultDays
-	}
+	// Note: DueDateDays is no longer set here - it should be retrieved from invoice_due_date_config setting
 
 	if invoiceNumberPrefix, ok := value["prefix"].(string); ok {
 		invoiceConfig.InvoiceNumberPrefix = invoiceNumberPrefix
@@ -73,6 +60,25 @@ func ConvertToInvoiceConfig(value map[string]interface{}) (*types.InvoiceConfig,
 	}
 
 	return invoiceConfig, nil
+}
+
+func ConvertToDueDateConfig(value map[string]interface{}) (*types.DueDateConfig, error) {
+	dueDateConfig := &types.DueDateConfig{}
+
+	if dueDateDaysRaw, exists := value["due_date_days"]; exists {
+		switch v := dueDateDaysRaw.(type) {
+		case int:
+			dueDateConfig.DueDateDays = v
+		case float64:
+			dueDateConfig.DueDateDays = int(v)
+		}
+	} else {
+		// Get default value
+		defaultDays := types.GetDefaultSettings()[types.SettingKeyInvoiceDueDateConfig].DefaultValue["due_date_days"].(int)
+		dueDateConfig.DueDateDays = defaultDays
+	}
+
+	return dueDateConfig, nil
 }
 
 // CreateSettingRequest represents the request to create a new setting

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1000,23 +1000,23 @@ func (s *billingService) CreateInvoiceRequestForCharges(
 	description string, // mark optional
 	metadata types.Metadata, // mark optional
 ) (*dto.CreateInvoiceRequest, error) {
-	// Get invoice config for tenant
+	// Get invoice due date config for tenant
 	settingsService := NewSettingsService(s.ServiceParams)
-	invoiceConfigResponse, err := settingsService.GetSettingByKey(ctx, types.SettingKeyInvoiceConfig.String())
+	dueDateConfigResponse, err := settingsService.GetSettingByKey(ctx, types.SettingKeyInvoiceDueDateConfig.String())
 	if err != nil {
 		return nil, err
 	}
 
-	// Use the safe conversion function
-	invoiceConfig, err := dto.ConvertToInvoiceConfig(invoiceConfigResponse.Value)
+	// Use the safe conversion function for due date config
+	dueDateConfig, err := dto.ConvertToDueDateConfig(dueDateConfigResponse.Value)
 	if err != nil {
 		return nil, ierr.WithError(err).
-			WithHint("Failed to parse invoice configuration").
+			WithHint("Failed to parse invoice due date configuration").
 			Mark(ierr.ErrValidation)
 	}
 
 	// Prepare invoice due date using tenant's configuration
-	invoiceDueDate := periodEnd.Add(24 * time.Hour * time.Duration(*invoiceConfig.DueDateDays))
+	invoiceDueDate := periodEnd.Add(24 * time.Hour * time.Duration(dueDateConfig.DueDateDays))
 
 	if result == nil {
 		// prepare result for zero amount invoice

--- a/internal/types/invoice.go
+++ b/internal/types/invoice.go
@@ -254,7 +254,6 @@ type InvoiceConfig struct {
 	InvoiceNumberTimezone      string              `json:"timezone,omitempty"`
 	InvoiceNumberSeparator     string              `json:"separator,omitempty"`
 	InvoiceNumberSuffixLength  int                 `json:"suffix_length,omitempty"`
-	DueDateDays                *int                `json:"due_date_days,omitempty"` // Number of days after period end when payment is due
 }
 
 // InvoiceFilter represents the filter options for listing invoices


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Segregates invoice sequence and due date settings into separate workflows with new `DueDateConfig` type and validation logic.
> 
>   - **Behavior**:
>     - Segregates invoice sequence and due date settings into separate workflows.
>     - Introduces `DueDateConfig` in `internal/types/settings.go` for handling due date settings.
>     - Updates `ConvertToInvoiceConfig` in `internal/api/dto/settings.go` to exclude due date handling.
>     - Adds `ConvertToDueDateConfig` in `internal/api/dto/settings.go` for due date handling.
>     - Modifies `CreateInvoiceRequestForCharges` in `internal/service/billing.go` to use `DueDateConfig`.
>   - **Validation**:
>     - Adds `ValidateDueDateConfig` in `internal/types/settings.go` for due date settings validation.
>     - Updates `ValidateSettingValue` in `internal/types/settings.go` to include due date config validation.
>   - **Constants and Types**:
>     - Adds `SettingKeyInvoiceDueDateConfig` to `SettingKey` constants in `internal/types/settings.go`.
>     - Removes `DueDateDays` from `InvoiceConfig` in `internal/types/invoice.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6f3cf69607c244d53c7348701fec28d82e5ee577. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->