### PR TITLE
feat(invoice-pdf): add billing adddres empty values

### DIFF
--- a/assets/typst-templates/default.typ
+++ b/assets/typst-templates/default.typ
@@ -161,7 +161,6 @@
       #text(fill: styling.secondary-color)[#biller.at("address", default: (:)).at("street", default: "--")] \
       #text(fill: styling.secondary-color)[#biller.at("address", default: (:)).at("city", default: "--")] \
       #text(fill: styling.secondary-color)[#biller.at("address", default: (:)).at("postal-code", default: "--")]
-
     ],
     [
       #text(weight: "semibold", size: 12pt)[Bill to]

--- a/internal/domain/tenant/model.go
+++ b/internal/domain/tenant/model.go
@@ -1,6 +1,7 @@
 package tenant
 
 import (
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/ent"
@@ -104,5 +105,20 @@ func (t TenantAddress) ToSchema() schema.TenantAddress {
 		State:      t.State,
 		PostalCode: t.PostalCode,
 		Country:    t.Country,
+	}
+}
+
+func (t TenantAddress) FormatAddressLines() string {
+	line1 := strings.TrimSpace(t.Line1)
+	line2 := strings.TrimSpace(t.Line2)
+	switch {
+	case line1 != "" && line2 != "":
+		return line1 + "\n" + line2
+	case line1 != "":
+		return line1
+	case line2 != "":
+		return line2
+	default:
+		return ""
 	}
 }

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -1654,12 +1653,8 @@ func (s *invoiceService) getBillerInfo(t *tenant.Tenant) *pdf.BillerInfo {
 	}
 
 	billerInfo := pdf.BillerInfo{
-		Name: t.Name,
-		Address: pdf.AddressInfo{
-			Street:     "--",
-			City:       "--",
-			PostalCode: "--",
-		},
+		Name:    t.Name,
+		Address: pdf.AddressInfo{},
 	}
 
 	if t.BillingDetails != (tenant.TenantBillingDetails{}) {
@@ -1668,8 +1663,9 @@ func (s *invoiceService) getBillerInfo(t *tenant.Tenant) *pdf.BillerInfo {
 		// billerInfo.Website = billingDetails.Website //TODO: Add this
 		billerInfo.HelpEmail = billingDetails.HelpEmail
 		// billerInfo.PaymentInstructions = billingDetails.PaymentInstructions //TODO: Add this
+
 		billerInfo.Address = pdf.AddressInfo{
-			Street:     strings.Join([]string{billingDetails.Address.Line1, billingDetails.Address.Line2}, "\n"),
+			Street:     billingDetails.Address.FormatAddressLines(),
 			City:       billingDetails.Address.City,
 			PostalCode: billingDetails.Address.PostalCode,
 			Country:    billingDetails.Address.Country,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `FormatAddressLines()` to handle empty billing address values in invoice PDFs and update `getBillerInfo()` to use it.
> 
>   - **Behavior**:
>     - `FormatAddressLines()` added to `TenantAddress` in `model.go` to format address lines, handling empty values.
>     - `getBillerInfo()` in `invoice.go` updated to use `FormatAddressLines()` for `Street` field.
>     - Removed default placeholders for address fields in `default.typ`.
>   - **Misc**:
>     - Removed unused import `strings` from `invoice.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 29b45028f52786c2e66051ab2d36d259b43ad6ab. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->