### PR TITLE
hotfix(wallet-cron): Change wallet balance function to v1 to v2

### DIFF
--- a/internal/api/cron/wallet.go
+++ b/internal/api/cron/wallet.go
@@ -198,7 +198,7 @@ func (h *WalletCronHandler) CheckAlerts(c *gin.Context) {
 				}
 
 				// Get real-time balance
-				balance, err := h.walletService.GetWalletBalance(ctx, wallet.ID)
+				balance, err := h.walletService.GetWalletBalanceV2(ctx, wallet.ID)
 				if err != nil {
 					h.logger.Errorw("failed to get wallet balance",
 						"wallet_id", wallet.ID,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `CheckAlerts` in `wallet.go` to use `GetWalletBalanceV2` for wallet balance retrieval.
> 
>   - **Function Update**:
>     - In `internal/api/cron/wallet.go`, `CheckAlerts` method now uses `GetWalletBalanceV2` instead of `GetWalletBalance` for fetching wallet balance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 57a984ddd6ceaf299b74f31ddb1f8a9212403bc7. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->