### PR TITLE
fix/listsubs: list only active subscriptions

### DIFF
--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -867,6 +867,11 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 		"limit", filter.GetLimit(),
 		"offset", filter.GetOffset())
 
+	// Add active status to filter
+	if filter.SubscriptionStatus == nil {
+		filter.SubscriptionStatus = append(filter.SubscriptionStatus, types.SubscriptionStatusActive)
+	}
+
 	subscriptions, err := s.SubRepo.List(ctx, filter)
 	if err != nil {
 		s.Logger.Errorw("failed to list subscriptions from repository", "error", err, "filter", filter)

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -3118,18 +3118,18 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions() {
 		wantErr   bool
 	}{
 		{
-			name:      "list_all_subscriptions",
+			name:      "list_subscriptions_defaults_to_active_only",
 			input:     &types.SubscriptionFilter{QueryFilter: types.NewDefaultQueryFilter()},
-			wantCount: 3, // 2 new + 1 from setupTestData
+			wantCount: 2, // Only active subscriptions (1 from setupTestData + 1 from test)
 			wantErr:   false,
 		},
 		{
-			name: "filter_by_customer",
+			name: "filter_by_customer_defaults_to_active_only",
 			input: &types.SubscriptionFilter{
 				QueryFilter: types.NewDefaultQueryFilter(),
 				CustomerID:  s.testData.customer.ID,
 			},
-			wantCount: 3,
+			wantCount: 2, // Only active subscriptions for this customer (1 from setupTestData + 1 from test)
 			wantErr:   false,
 		},
 		{
@@ -3148,6 +3148,18 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions() {
 				SubscriptionStatus: []types.SubscriptionStatus{types.SubscriptionStatusCancelled},
 			},
 			wantCount: 1,
+			wantErr:   false,
+		},
+		{
+			name: "filter_by_all_statuses_explicitly",
+			input: &types.SubscriptionFilter{
+				QueryFilter: types.NewDefaultQueryFilter(),
+				SubscriptionStatus: []types.SubscriptionStatus{
+					types.SubscriptionStatusActive,
+					types.SubscriptionStatusCancelled,
+				},
+			},
+			wantCount: 3, // All subscriptions when explicitly requesting all statuses
 			wantErr:   false,
 		},
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `ListSubscriptions` to default to listing only active subscriptions and update tests accordingly.
> 
>   - **Behavior**:
>     - Modify `ListSubscriptions` in `subscription.go` to default to listing only active subscriptions if no status filter is provided.
>   - **Tests**:
>     - Update `TestListSubscriptions` in `subscription_test.go` to reflect default behavior of listing only active subscriptions.
>     - Add test case for explicit status filtering to ensure all statuses can be listed when specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 044a31e65f761ca9ebd7efea1bafaf07d4a4eba0. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->