### PR TITLE
Moved v2 analytics function to the main analytics api

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -121,8 +121,8 @@ func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logg
 			events.POST("/query", handlers.Events.QueryEvents)
 			events.POST("/usage", handlers.Events.GetUsage)
 			events.POST("/usage/meter", handlers.Events.GetUsageByMeter)
-			events.POST("/analytics", handlers.Events.GetUsageAnalytics)
-			events.POST("/analytics-v2", handlers.Events.GetUsageAnalyticsV2)
+			events.POST("/analytics", handlers.Events.GetUsageAnalyticsV2)
+			events.POST("/analytics-v1", handlers.Events.GetUsageAnalytics)
 		}
 
 		meters := v1Private.Group("/meters")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Swapped analytics endpoints in `router.go` to use `GetUsageAnalyticsV2` for `/analytics` and `GetUsageAnalytics` for `/analytics-v1`.
> 
>   - **API Routing**:
>     - In `router.go`, changed `/analytics` endpoint to use `GetUsageAnalyticsV2`.
>     - Changed `/analytics-v1` endpoint to use `GetUsageAnalytics`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for e7df3b0015836fb4945a68e33064d1acd5634927. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->