### PR TITLE
fix(onboarding): change aggregation type to sum and add field for default meters

### DIFF
--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -502,7 +502,8 @@ func (s *onboardingService) createDefaultMeters(ctx context.Context) ([]*meter.M
 		Name:      "LLM Usage",
 		EventName: "llm_usage",
 		Aggregation: meter.Aggregation{
-			Type: types.AggregationCount,
+			Type: types.AggregationSum,
+			Field: "value",
 		},
 		Filters: modelFilters,
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change aggregation type to sum and add field for default meters in `createDefaultMeters()` in `onboarding.go`.
> 
>   - **Behavior**:
>     - Change aggregation type from `types.AggregationCount` to `types.AggregationSum` in `createDefaultMeters()` in `onboarding.go`.
>     - Add `Field: "value"` to the aggregation configuration for default meters.
>   - **Misc**:
>     - Minor adjustment to meter configuration for LLM usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8d8cca23b82b5baabeb9f53f6fc3db6a6491fdca. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->