### PR TITLE
Revert "fix(subscription): change action for incomplete subscriptions from defer to skip"

### DIFF
--- a/internal/service/subscription_state_handler.go
+++ b/internal/service/subscription_state_handler.go
@@ -53,8 +53,8 @@ func (h *SubscriptionStateHandler) DetermineCreditGrantAction() (StateAction, er
 		return StateActionCancel, nil
 
 	case types.SubscriptionStatusIncomplete:
-		// Skip incomplete subscriptions until they become active
-		return StateActionSkip, nil
+		// Defer incomplete subscriptions as they might become active
+		return StateActionDefer, nil
 
 	case types.SubscriptionStatusIncompleteExpired:
 		// Expired incomplete subscriptions should be cancelled


### PR DESCRIPTION
Reverts flexprice/flexprice#598
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts action for `SubscriptionStatusIncomplete` in `DetermineCreditGrantAction()` to `StateActionDefer`, allowing potential activation instead of skipping.
> 
>   - **Behavior**:
>     - Reverts action for `SubscriptionStatusIncomplete` in `DetermineCreditGrantAction()` from `StateActionSkip` to `StateActionDefer` in `subscription_state_handler.go`.
>     - Allows incomplete subscriptions to potentially become active instead of skipping them.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for fbb65b30a599526138b6dc5cd315a9f29d1139b3. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Behavior
  - Credits for accounts with incomplete subscription status are now deferred rather than skipped, ensuring they are granted once the subscription is completed.
- Bug Fixes
  - Resolves cases where credits could be missed for users with temporarily incomplete subscriptions by queuing them for later processing.
- Chores
  - Updated internal comments to reflect the revised handling of incomplete subscriptions.
- Compatibility
  - No changes to public APIs or user-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->