### PR TITLE
fix(analytics): Add config based execution of api

### DIFF
--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -12,6 +12,7 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/service"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
 )
@@ -341,7 +342,8 @@ func (h *EventsHandler) GetUsageAnalytics(c *gin.Context) {
 
 	// Call the appropriate service based on feature flag
 	var response *dto.GetUsageAnalyticsResponse
-	if !h.config.FeatureFlag.EnableFeatureUsageForAnalytics {
+
+	if !h.config.FeatureFlag.EnableFeatureUsageForAnalytics || h.config.FeatureFlag.ForceV1ForTenant == types.GetTenantID(ctx) {
 		// Use v1 (eventPostProcessingService) when flag is disabled
 		response, err = h.eventPostProcessingService.GetDetailedUsageAnalytics(ctx, &req)
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,7 +184,8 @@ type EnvAccessConfig struct {
 }
 
 type FeatureFlagConfig struct {
-	EnableFeatureUsageForAnalytics bool `mapstructure:"enable_feature_usage_for_analytics" validate:"required"`
+	EnableFeatureUsageForAnalytics bool   `mapstructure:"enable_feature_usage_for_analytics" validate:"required"`
+	ForceV1ForTenant               string `mapstructure:"force_v1_for_tenant" validate:"omitempty"`
 }
 
 func NewConfig() (*Configuration, error) {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -160,3 +160,5 @@ feature_usage_tracking:
 feature_flag:
   # This flag is used to enable/disable feature usage for analytics
   enable_feature_usage_for_analytics: true # TODO: cleanup by 15th October 2025
+  # Tenant ID to force use v1 analytics service (empty string means no tenant is forced to v1)
+  force_v1_for_tenant: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-level override to route usage analytics to the legacy service when specified, providing per-tenant control regardless of the global analytics feature setting.

* **Documentation**
  * Updated configuration reference and sample to include force_v1_for_tenant under feature_flag, with guidance on usage and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add config option to force v1 analytics service for specific tenants in `GetUsageAnalytics`.
> 
>   - **Behavior**:
>     - Update `GetUsageAnalytics` in `events.go` to use v1 analytics service if `ForceV1ForTenant` matches the tenant ID.
>   - **Configuration**:
>     - Add `ForceV1ForTenant` to `FeatureFlagConfig` in `config.go` and `config.yaml` to specify tenant ID for v1 service.
>   - **Misc**:
>     - Import `types` in `events.go` for tenant ID retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ff552d915a89391e3a81139008f988a23f97b95b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->