### PR TITLE
feat(wallets): calculate wallet balance based on allowed price type

### DIFF
--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -1242,7 +1242,7 @@ func (s *invoiceService) GetUnpaidInvoicesToBePaid(ctx context.Context, customer
 	containsPriceTypeFixed := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeFixed)
 	containsPriceTypeUsage := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeUsage)
 
-	if containsPriceTypeAll && containsPriceTypeFixed || containsPriceTypeAll {
+	if containsPriceTypeUsage && containsPriceTypeFixed || containsPriceTypeAll {
 		// All allowed, include all
 		unpaidAmount = usageAmountTotal.Add(fixedAmountTotal)
 	} else if containsPriceTypeUsage {

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -1238,16 +1238,17 @@ func (s *invoiceService) GetUnpaidInvoicesToBePaid(ctx context.Context, customer
 	var unpaidAmount decimal.Decimal
 
 	// Check if we need to filter by price type
-	hasUsage := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeUsage)
-	hasFixed := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeFixed)
+	containsPriceTypeAll := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeAll)
+	containsPriceTypeFixed := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeFixed)
+	containsPriceTypeUsage := lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeUsage)
 
-	if hasUsage && hasFixed || lo.Contains(allowedPriceTypes, types.WalletConfigPriceTypeAll) {
-		// Both types allowed, include all
+	if containsPriceTypeAll && containsPriceTypeFixed || containsPriceTypeAll {
+		// All allowed, include all
 		unpaidAmount = usageAmountTotal.Add(fixedAmountTotal)
-	} else if hasUsage {
+	} else if containsPriceTypeUsage {
 		// Usage-only wallet
 		unpaidAmount = usageAmountTotal
-	} else if hasFixed {
+	} else if containsPriceTypeFixed {
 		// Fixed-only wallet
 		unpaidAmount = fixedAmountTotal
 	} else {

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -440,7 +440,14 @@ func (s *walletService) GetWalletBalance(ctx context.Context, walletID string) (
 	// STEP 1: Get all unpaid invoices for the customer
 	// This includes any previously generated invoices that haven't been paid
 	invoiceService := NewInvoiceService(s.ServiceParams)
-	_, unpaidInvoiceAmountToBePaid, err := invoiceService.GetUnpaidInvoicesToBePaid(ctx, w.CustomerID, w.Currency)
+
+	// Pass allowed price types from wallet configuration
+	_, unpaidInvoiceAmountToBePaid, err := invoiceService.GetUnpaidInvoicesToBePaid(
+		ctx,
+		w.CustomerID,
+		w.Currency,
+		w.Config.AllowedPriceTypes,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -469,36 +476,30 @@ func (s *walletService) GetWalletBalance(ctx context.Context, walletID string) (
 
 	// Calculate total pending charges (usage)
 	totalPendingCharges := decimal.Zero
-	for _, sub := range filteredSubscriptions {
-		// Get current period
-		periodStart := sub.CurrentPeriodStart
-		periodEnd := sub.CurrentPeriodEnd
 
-		// Get usage data for current period
-		subscriptionService := NewSubscriptionService(s.ServiceParams)
+	// Only calculate usage charges if wallet allows usage price type
+	if lo.Contains(w.Config.AllowedPriceTypes, types.WalletConfigPriceTypeUsage) ||
+		lo.Contains(w.Config.AllowedPriceTypes, types.WalletConfigPriceTypeAll) {
 
-		usage, err := subscriptionService.GetUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
-			SubscriptionID: sub.ID,
-			StartTime:      periodStart,
-			EndTime:        periodEnd,
-		})
+		for _, sub := range filteredSubscriptions {
+			subscriptionService := NewSubscriptionService(s.ServiceParams)
+			usage, err := subscriptionService.GetUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
+				SubscriptionID: sub.ID,
+				StartTime:      sub.CurrentPeriodStart,
+				EndTime:        sub.CurrentPeriodEnd,
+			})
+			if err != nil {
+				return nil, err
+			}
 
-		if err != nil {
-			return nil, err
+			_, usageTotal, err := billingService.CalculateUsageCharges(
+				ctx, sub, usage, sub.CurrentPeriodStart, sub.CurrentPeriodEnd)
+			if err != nil {
+				return nil, err
+			}
+
+			totalPendingCharges = totalPendingCharges.Add(usageTotal)
 		}
-
-		// Calculate usage charges
-		usageCharges, usageTotal, err := billingService.CalculateUsageCharges(ctx, sub, usage, periodStart, periodEnd)
-		if err != nil {
-			return nil, err
-		}
-
-		s.Logger.Infow("subscription charges details",
-			"subscription_id", sub.ID,
-			"usage_total", usageTotal,
-			"num_usage_charges", len(usageCharges))
-
-		totalPendingCharges = totalPendingCharges.Add(usageTotal)
 	}
 
 	// Calculate real-time balance
@@ -510,7 +511,8 @@ func (s *walletService) GetWalletBalance(ctx context.Context, walletID string) (
 		"unpaid_invoices", unpaidInvoiceAmountToBePaid,
 		"pending_charges", totalPendingCharges,
 		"real_time_balance", realTimeBalance,
-		"credit_balance", w.CreditBalance)
+		"credit_balance", w.CreditBalance,
+		"allowed_price_types", w.Config.AllowedPriceTypes)
 
 	// Convert real-time balance to credit balance
 	realTimeCreditBalance := s.GetCreditsFromCurrencyAmount(realTimeBalance, w.ConversionRate)
@@ -1485,7 +1487,14 @@ func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string)
 	// STEP 1: Get all unpaid invoices for the customer
 	// This includes any previously generated invoices that haven't been paid
 	invoiceService := NewInvoiceService(s.ServiceParams)
-	_, unpaidInvoiceAmountToBePaid, err := invoiceService.GetUnpaidInvoicesToBePaid(ctx, w.CustomerID, w.Currency)
+
+	// Pass allowed price types from wallet configuration
+	_, unpaidInvoiceAmountToBePaid, err := invoiceService.GetUnpaidInvoicesToBePaid(
+		ctx,
+		w.CustomerID,
+		w.Currency,
+		w.Config.AllowedPriceTypes,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Wallet balances now respect configured price types (fixed, usage, or both) when calculating unpaid amounts and pending charges.
  - Balance responses include the wallet’s allowed_price_types for greater transparency.
  - Unpaid invoice totals are computed per line item and filtered by price type, improving accuracy.
  - Backward compatibility: wallets with legacy/empty configs are treated as allowing all price types.

- Refactor
  - Streamlined usage and pending-charge calculation flow per subscription for consistency and clearer error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->