### PR TITLE
feat(stripe): Add status as archived instead of db delete

### DIFF
--- a/internal/repository/ent/entityintegrationmapping.go
+++ b/internal/repository/ent/entityintegrationmapping.go
@@ -3,6 +3,7 @@ package ent
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/entityintegrationmapping"
@@ -349,12 +350,16 @@ func (r *entityIntegrationMappingRepository) Delete(ctx context.Context, mapping
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
 
-	err := client.EntityIntegrationMapping.DeleteOneID(mapping.ID).
+	_, err := client.EntityIntegrationMapping.Update().
 		Where(
+			entityintegrationmapping.ID(mapping.ID),
 			entityintegrationmapping.TenantID(tenantID),
 			entityintegrationmapping.EnvironmentID(environmentID),
 		).
-		Exec(ctx)
+		SetStatus(string(types.StatusArchived)).
+		SetUpdatedAt(time.Now().UTC()).
+		SetUpdatedBy(types.GetUserID(ctx)).
+		Save(ctx)
 
 	if err != nil {
 		SetSpanError(span, err)

--- a/internal/service/entityintegrationmapping.go
+++ b/internal/service/entityintegrationmapping.go
@@ -205,9 +205,8 @@ func (s *entityIntegrationMappingService) DeleteEntityIntegrationMapping(ctx con
 		return err
 	}
 
-	mapping.Status = types.StatusArchived
-
-	if err := s.EntityIntegrationMappingRepo.Update(ctx, mapping); err != nil {
+	if err := s.EntityIntegrationMappingRepo.Delete(ctx, mapping); err != nil {
+		// No need to wrap the error as the repository already returns properly formatted errors
 		return err
 	}
 

--- a/internal/service/entityintegrationmapping.go
+++ b/internal/service/entityintegrationmapping.go
@@ -205,12 +205,11 @@ func (s *entityIntegrationMappingService) DeleteEntityIntegrationMapping(ctx con
 		return err
 	}
 
-	if err := s.EntityIntegrationMappingRepo.Delete(ctx, mapping); err != nil {
-		// No need to wrap the error as the repository already returns properly formatted errors
+	mapping.Status = types.StatusArchived
+
+	if err := s.EntityIntegrationMappingRepo.Update(ctx, mapping); err != nil {
 		return err
 	}
 
 	return nil
 }
-
-// Helper-specific methods removed; use GetEntityIntegrationMappings with filters instead


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `DeleteEntityIntegrationMapping` now archives records instead of deleting them in `entityintegrationmapping.go`.
> 
>   - **Behavior**:
>     - `DeleteEntityIntegrationMapping` in `entityintegrationmapping.go` now sets `Status` to `types.StatusArchived` instead of deleting the record.
>     - Preserves the record in the database with an archived status instead of removing it.
>   - **Misc**:
>     - Removed unused helper-specific methods in `entityintegrationmapping.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 87d0925715f87db98491cd5efce907926c81c8c5. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleting an Entity Integration Mapping now archives it instead of permanently removing it, preserving history and enabling review or restoration.
  * Lists and filters can include archived mappings, improving traceability and auditability.
  * Archived entries retain audit details (who/when), so change history is preserved for compliance and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->