### PR TITLE
hotfix(stripe): Fix the subscription status

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -84,7 +84,8 @@ type CreateSubscriptionRequest struct {
 	BillingAnchor *time.Time `json:"-"`
 
 	// Workflow
-	Workflow *types.TemporalWorkflowType `json:"-"`
+	Workflow           *types.TemporalWorkflowType `json:"-"`
+	SubscriptionStatus types.SubscriptionStatus    `json:"-,omitempty"`
 }
 
 // AddAddonRequest is used by body-based endpoint /subscriptions/addon

--- a/internal/integration/stripe/subscription.go
+++ b/internal/integration/stripe/subscription.go
@@ -456,6 +456,7 @@ func (s *stripeSubscriptionService) createFlexPriceSubscription(ctx context.Cont
 		BillingAnchor:      &billingAnchor,
 		BillingPeriodCount: 1,
 		Workflow:           lo.ToPtr(types.TemporalStripeIntegrationWorkflow),
+		SubscriptionStatus: s.mapStripeStatusToFlexPrice(stripeSub.Status),
 	}
 
 	return subscriptionService.CreateSubscription(ctx, createReq)
@@ -517,6 +518,7 @@ func (s *stripeSubscriptionService) createFlexPriceSubscriptionWithoutTx(ctx con
 		BillingAnchor:      &billingAnchor,
 		BillingPeriodCount: 1,
 		Workflow:           lo.ToPtr(types.TemporalStripeIntegrationWorkflow),
+		SubscriptionStatus: s.mapStripeStatusToFlexPrice(stripeSub.Status),
 	}
 
 	// Create subscription using service (this will use the transaction context)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -228,6 +228,10 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 	// Create response object
 	response := &dto.SubscriptionResponse{Subscription: sub}
 
+	if req.SubscriptionStatus != "" {
+		sub.SubscriptionStatus = req.SubscriptionStatus
+	}
+
 	invoiceService := NewInvoiceService(s.ServiceParams)
 	var invoice *dto.InvoiceResponse
 	var updatedSub *subscription.Subscription
@@ -332,7 +336,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 
 		// if the subscription is created with incomplete status, but it doesn't create an invoice, we need to mark it as active
 		// This applies regardless of collection method - if there's no invoice to pay, the subscription should be active
-		if sub.SubscriptionStatus == types.SubscriptionStatusIncomplete && (invoice == nil || invoice.PaymentStatus == types.PaymentStatusSucceeded) {
+		if (req.Workflow != nil && *req.Workflow != types.TemporalStripeIntegrationWorkflow) && sub.SubscriptionStatus == types.SubscriptionStatusIncomplete && (invoice == nil || invoice.PaymentStatus == types.PaymentStatusSucceeded) {
 			sub.SubscriptionStatus = types.SubscriptionStatusActive
 			err = s.SubRepo.Update(ctx, sub)
 			if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix subscription status handling in Stripe integration by updating `CreateSubscriptionRequest` and related functions.
> 
>   - **Behavior**:
>     - Adds `SubscriptionStatus` to `CreateSubscriptionRequest` in `subscription.go`.
>     - Updates `createFlexPriceSubscription` and `createFlexPriceSubscriptionWithoutTx` in `stripe/subscription.go` to set `SubscriptionStatus` using `mapStripeStatusToFlexPrice()`.
>     - Modifies `CreateSubscription` in `service/subscription.go` to update `SubscriptionStatus` from request.
>     - Adjusts logic in `CreateSubscription` to mark subscriptions as active if no invoice is created, excluding Stripe workflows.
>   - **Functions**:
>     - `mapStripeStatusToFlexPrice()` maps Stripe subscription statuses to internal statuses.
>   - **Misc**:
>     - Minor formatting changes in `subscription.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ecb980f58545d13330a988d58c6a5b9209289a11. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now set the subscription status when creating a subscription.
  - For Stripe-linked subscriptions, the status is automatically synced from Stripe during creation.

- Bug Fixes
  - Adjusted auto-activation: subscriptions created via the Stripe workflow no longer auto-activate prematurely and will only activate when appropriate (no invoice or the invoice is paid).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->