### PR TITLE
hotfix: Validation fix on cancell subscription

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -162,12 +162,7 @@ func (r *CancelSubscriptionRequest) Validate() error {
 	}
 	// Set default proration behavior if not provided
 	if r.ProrationBehavior == "" {
-		r.ProrationBehavior = types.ProrationBehaviorCreateProrations
-	}
-
-	// Validate proration behavior
-	if err := r.ProrationBehavior.Validate(); err != nil {
-		return err
+		r.ProrationBehavior = types.ProrationBehaviorNone
 	}
 
 	return nil


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `ProrationBehavior` to `None` in `CancelSubscriptionRequest.Validate()` if not provided.
> 
>   - **Validation Logic**:
>     - In `CancelSubscriptionRequest.Validate()`, change default `ProrationBehavior` from `types.ProrationBehaviorCreateProrations` to `types.ProrationBehaviorNone` if not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d8195153a90fad837d9a77682e064ad8a893fdcc. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription cancellations now default to no proration when no preference is provided, ensuring cancellations complete without partial credits/charges unless explicitly requested.
  * Users can still opt in to proration by specifying it during cancellation.
  * This change provides more predictable billing outcomes for cancellations that do not require proration.
  * Previously, unspecified cancellations could result in prorated adjustments; this is no longer the default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->