### PR TITLE
feat(event-post-processing): add a flag to exclude non v1 tenants

### DIFF
--- a/internal/service/event_post_processing.go
+++ b/internal/service/event_post_processing.go
@@ -210,6 +210,14 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
+	if s.Config.FeatureFlag.ForceV1ForTenant != "" && tenantID != s.Config.FeatureFlag.ForceV1ForTenant {
+		s.Logger.Debugw("skipping event post-processing for tenant as its not a part of v1 pipeline",
+			"tenant_id", tenantID,
+			"force_v1_for_tenant", s.Config.FeatureFlag.ForceV1ForTenant,
+		)
+		return nil
+	}
+
 	s.Logger.Debugw("processing event from message queue",
 		"message_uuid", msg.UUID,
 		"partition_key", partitionKey,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add feature flag to skip event post-processing for non-v1 tenants in `processMessage()` of `event_post_processing.go`.
> 
>   - **Behavior**:
>     - Adds a feature flag `ForceV1ForTenant` in `processMessage()` in `event_post_processing.go` to skip event post-processing for non-v1 tenants.
>     - Logs a debug message when skipping event processing due to the feature flag.
>   - **Logging**:
>     - Adds debug logging for skipped events in `processMessage()` when tenant is not part of v1 pipeline.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for cafb2a9f4074c0bccced3484017adb5d321393c1. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated message post-processing logic to include tenant-based configuration checks, allowing selective processing based on tenant settings in non-backfill paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->