### PR TITLE
fix(makefile): postgreSQL migration path in docker-compose volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_DB: flexprice
     volumes:
       - ./init-temporal-db.sh:/docker-entrypoint-initdb.d/init-temporal-db.sh
-      - ./migrations:/docker-entrypoint-initdb.d/migration
+      - ./migrations/postgres:/docker-entrypoint-initdb.d/
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
       test: pg_isready -U flexprice -d flexprice


### PR DESCRIPTION
This PR fixes the docker volume path for PostgreSQL migrations (#677 )

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes PostgreSQL migration volume path in `docker-compose.yml` to ensure correct initialization.
> 
>   - **Docker Compose**:
>     - Fixes PostgreSQL migration volume path in `docker-compose.yml` from `./migrations` to `./migrations/postgres` to ensure correct initialization of migrations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for e877dd185158e11a9b95c6463bfba7ced42c3686. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database initialization script loading path in container configuration to reflect the reorganized migrations directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->