### PR TITLE
fix(wallets): add status filter in check alert cron while checking against features

### DIFF
--- a/internal/api/cron/wallet.go
+++ b/internal/api/cron/wallet.go
@@ -178,8 +178,11 @@ func (h *WalletCronHandler) CheckAlerts(c *gin.Context) {
 			)
 
 			// Get all features for this tenant+environment - we'll filter by alert settings in code
+			queryFilter := types.NewNoLimitQueryFilter()
+			queryFilter.Status = lo.ToPtr(types.StatusPublished)
+
 			features, err := h.featureService.GetFeatures(ctx, &types.FeatureFilter{
-				QueryFilter: types.NewNoLimitQueryFilter(),
+				QueryFilter: queryFilter,
 			})
 			if err != nil {
 				h.logger.Errorw("failed to get features for alert checking",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a status filter in `CheckAlerts` to only retrieve published features in `wallet.go`.
> 
>   - **Behavior**:
>     - Adds a status filter to the `CheckAlerts` function in `wallet.go` to only retrieve features with `StatusPublished`.
>   - **Misc**:
>     - Uses `lo.ToPtr` to set the status filter in the `queryFilter` object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d42ef37d86736b6c858f195cbed7ec482ee52de4. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined alert filtering to focus on published items only, improving accuracy of wallet alert notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->