### PR TITLE
fix(grouping): add update group_id while updating price

### DIFF
--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -297,6 +297,7 @@ func (r *priceRepository) Update(ctx context.Context, p *domainPrice.Price) erro
 		SetMetadata(map[string]string(p.Metadata)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
+		SetNillableGroupID(lo.ToPtr(p.GroupID)).
 		Save(ctx)
 
 	if err != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `Update()` in `price.go` to set `GroupID` when updating a price, handling it as a nullable field.
> 
>   - **Behavior**:
>     - Update `Update()` in `price.go` to set `GroupID` when updating a price.
>     - Handles `GroupID` as a nullable field using `SetNillableGroupID()`.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for a998d31a9fc36c782ab359f480cec3e3801a5423. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Price group assignments can now be properly updated after initial creation, with behavior consistent across all operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->