### PR TITLE
feat: optimise raw events consumption by kafka msg consumer batching

### DIFF
--- a/docs/prds/spec.md
+++ b/docs/prds/spec.md
@@ -1,0 +1,118 @@
+# Watermill Kafka Batch Consumer – Specification
+
+## Overview
+- Goal: Implement efficient application-level batching for Watermill Kafka consumers while tuning Sarama for buffered fetches.
+- Context: Watermill delivers messages singly via channel; Sarama can fetch in batches internally. We accumulate messages with size/timeout and process as a batch.
+
+## Scope
+- In-scope: Batch accumulation loop, ack/nack strategy, error handling, configuration tuning, observability.
+- Out-of-scope: Replacing Watermill with direct Sarama consumption, multi-topic orchestration, cross-service refactors.
+
+## Objectives
+- Reduce per-message overhead by processing batches.
+- Preserve ordering within a partition and correctness of acks/nacks.
+- Provide tunable batch size and timeout to balance latency and throughput.
+
+## Non-Goals
+- Exactly-once processing guarantees (keep at-least-once with Watermill semantics).
+- Sophisticated backpressure beyond basic buffering.
+
+## Functional Requirements
+- Batch accumulation:
+  - Accumulate up to `batchSize` messages or flush on `batchTimeout`.
+  - On channel close, flush remaining messages.
+- Processing:
+  - Invoke `processBatch([]*message.Message)` for each flushed batch.
+  - On success, `Ack()` all messages in the batch.
+  - On partial failures, configurable policy: either `Nack()` entire batch or implement per-message fallback (default: nack entire batch for simplicity).
+- Configuration:
+  - App-level: `batchSize` (int), `batchTimeout` (duration).
+  - Sarama/Watermill: `Consumer.Fetch.MinBytes`, `Consumer.Fetch.MaxWaitTime`, `ChannelBufferSize`.
+- Observability:
+  - Log batch flushes with size and age.
+  - Metrics: batch size distribution, flush count, processing latency, ack/nack counts.
+
+## Design
+- Data flow:
+  - Kafka -> Sarama fetch (buffered) -> Watermill subscriber -> `msgs <-chan *message.Message` -> batch accumulator -> `processBatch` -> ack/nack.
+- Accumulator algorithm:
+  - Maintain slice `batch` and timer `batchTimeout`.
+  - On each message: append; if `len(batch) >= batchSize` then flush.
+  - On timer: flush partial batch if not empty; reset timer.
+- Concurrency:
+  - Single accumulator per partition subscription to preserve ordering; multiple goroutines can be used per partition if ordering is not required, but default keeps ordering.
+
+## Configuration Tuning (Sarama via Watermill)
+- `Consumer.Fetch.MinBytes`: set to a higher value (e.g., 10KiB) to encourage batch fetches.
+- `Consumer.Fetch.MaxWaitTime`: small wait (e.g., 1s) to coalesce fetches.
+- `ChannelBufferSize`: increase (e.g., 512) to allow buffering before the app loop drains messages.
+- These are set on `saramaConfig := kafka.DefaultSaramaSubscriberConfig()` prior to creating the subscriber.
+
+## Error Handling
+- Batch processing error:
+  - Default: `Nack()` all messages in the batch to allow redelivery.
+  - Optional enhancement: Retry `processBatch` with exponential backoff up to N attempts; if still failing, nack.
+- Message-level anomalies:
+  - If `processBatch` returns per-message results, consider granular ack/nack; otherwise keep batch-level simplicity.
+
+## Observability & Metrics
+- Emit logs at `INFO` for batch flushes: size, elapsed since first message.
+- Metrics (Prometheus style):
+  - `batch_flush_total` (counter), `batch_size` (histogram), `batch_flush_age_ms` (histogram), `batch_process_latency_ms` (histogram).
+  - `messages_acked_total`, `messages_nacked_total`.
+
+## Pseudocode
+```go
+const batchSize = 100
+const batchTimeout = 500 * time.Millisecond
+
+func processBatch(batch []*message.Message) error { /* implement */ return nil }
+
+func consumeInBatches(msgs <-chan *message.Message) {
+    batch := make([]*message.Message, 0, batchSize)
+    timer := time.NewTimer(batchTimeout)
+    defer timer.Stop()
+
+    flush := func() {
+        if len(batch) == 0 { return }
+        start := time.Now()
+        if err := processBatch(batch); err != nil {
+            for _, m := range batch { m.Nack() }
+        } else {
+            for _, m := range batch { m.Ack() }
+        }
+        _ = start // record latency metric
+        batch = batch[:0]
+        timer.Reset(batchTimeout)
+    }
+
+    for {
+        select {
+        case msg, ok := <-msgs:
+            if !ok { flush(); return }
+            batch = append(batch, msg)
+            if len(batch) >= batchSize { flush() }
+        case <-timer.C:
+            flush()
+        }
+    }
+}
+```
+
+## Performance Targets (initial)
+- Throughput: 2–5x improvement over per-message processing in equivalent workloads.
+- Latency: p50 <= `batchTimeout` when not hitting `batchSize`.
+
+## Rollout Plan
+- Stage: enable accumulator in a test environment.
+- Validate metrics, adjust `batchSize`/`batchTimeout`.
+- Deploy gradually; monitor lag and nack rates.
+
+## Risks & Mitigations
+- Larger batches increase retry cost: start with moderate sizes; add backoff.
+- Timer drift: reset timer after each flush.
+
+## Acceptance Criteria
+- Configurable batch processing works with Watermill subscriber.
+- Passing tests for batch behavior and ack/nack semantics.
+- Metrics emitted and observed in local/integration environment.

--- a/docs/prds/tasks.md
+++ b/docs/prds/tasks.md
@@ -1,0 +1,53 @@
+# Watermill Kafka Batch Consumer – Tasks
+
+## Implementation
+- Tune Sarama via Watermill:
+  - Set `Consumer.Fetch.MinBytes` (e.g., 10KiB), `Consumer.Fetch.MaxWaitTime` (e.g., 1s), and `ChannelBufferSize` (e.g., 512) on `saramaConfig := kafka.DefaultSaramaSubscriberConfig()`.
+- Add batch accumulator:
+  - Implement `consumeInBatches(msgs <-chan *message.Message)` with `batchSize` and `batchTimeout`.
+  - Provide `processBatch([]*message.Message)` hook for domain processing.
+- Ack/Nack policy:
+  - Default: on batch success `Ack()` all, on failure `Nack()` all.
+  - Optional: future enhancement for per-message fallback.
+- Configuration plumbing:
+  - Read `batchSize` and `batchTimeout` from application configuration or environment.
+  - Document runtime overrides.
+
+## Testing
+- Unit tests:
+  - Accumulator flushes on size threshold.
+  - Accumulator flushes on timeout when not reaching `batchSize`.
+  - Channel close flushes remaining messages.
+  - Ack/Nack behavior: success acks all; failure nacks all.
+- Integration tests:
+  - Subscriber receives from Watermill channel; accumulator processes batches; verify metrics and logs.
+  - Backpressure sanity: increased `ChannelBufferSize` avoids drops; no message loss.
+
+## Observability
+- Logging:
+  - Log batch flush with size and age.
+- Metrics:
+  - Counters: `batch_flush_total`, `messages_acked_total`, `messages_nacked_total`.
+  - Histograms: `batch_size`, `batch_flush_age_ms`, `batch_process_latency_ms`.
+
+## Performance & Tuning
+- Baseline:
+  - Measure throughput and latency before batching.
+- Tuning runs:
+  - Experiment with `batchSize` and `batchTimeout` values; record impacts.
+  - Adjust Sarama fetch settings to balance lag and throughput.
+
+## Rollout
+- Enable in staging with conservative defaults.
+- Monitor lag, nack rates, and processing latency.
+- Incrementally increase `batchSize` as confidence grows.
+
+## Deliverables
+- Code changes implementing accumulator and config tuning.
+- Tests covering accumulator behavior.
+- Documentation for configuration knobs and operational guidance.
+
+## Acceptance Criteria
+- All tests pass; batch behavior correct under size and timeout.
+- End-to-end consumption with Watermill works; no message loss observed.
+- Metrics available and provide visibility into batching performance.


### PR DESCRIPTION
Add detailed design documents for the Watermill Kafka batch consumer implementation. Includes:
- Specification document covering design, requirements, and configuration
- Tasks document outlining implementation steps, testing, and rollout plan

Fixes #<issue-number> TODO: @nkmishra1997


## 📝 Description
- This PR targets end‑to‑end optimisation of the existing Watermill Kafka consumer to significantly improve throughput and reduce per‑message overhead while preserving correctness.

---

## 🔨 Changes Made
- Design:
  - Application-level batching on msgs <-chan *message.Message with batchSize and batchTimeout .
  - Default ack/nack policy: ack all on success, nack all on failure; per-message fallback noted as future enhancement.
  - Single accumulator per partition subscription to preserve ordering; performance-focused, low-risk changes aligned with current stack.
- Configuration:
  - App-level batchSize (int) and batchTimeout (duration string) documented; env var mapping via Viper described.
  - Sarama tuning guidance: Consumer.Fetch.MinBytes , Consumer.Fetch.MaxWaitTime , ChannelBufferSize .
- Observability:
  - Logging plan for batch flush size/age.
  - Metrics: batch_flush_total , batch_size , batch_flush_age_ms , batch_process_latency_ms , messages_acked_total , messages_nacked_total .
- Pseudocode:
  - Reference implementation for consumeInBatches with time-based and size-based flush triggers.
- Acceptance Criteria:
  - Correct batch behavior under size and timeout.
  - Watermill end-to-end consumption without message loss.
  - Metrics available and actionable.

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [x] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce batch processing for Watermill Kafka consumers with Sarama tuning, detailed in new design and task documents.
> 
>   - **Design Documents**:
>     - Add `spec.md` detailing design, requirements, and configuration for Watermill Kafka batch consumer.
>     - Add `tasks.md` outlining implementation steps, testing, and rollout plan.
>   - **Batch Processing**:
>     - Implement `consumeInBatches(msgs <-chan *message.Message)` with `batchSize` and `batchTimeout`.
>     - Use `processBatch([]*message.Message)` for domain processing.
>     - Default ack/nack policy: `Ack()` on success, `Nack()` on failure.
>   - **Configuration**:
>     - Tune Sarama via Watermill: `Consumer.Fetch.MinBytes`, `Consumer.Fetch.MaxWaitTime`, `ChannelBufferSize`.
>     - Read `batchSize` and `batchTimeout` from config or environment.
>   - **Testing & Observability**:
>     - Unit and integration tests for batch behavior and ack/nack semantics.
>     - Log batch flushes; metrics for batch size, flush count, processing latency.
>   - **Rollout Plan**:
>     - Enable in staging, monitor metrics, incrementally adjust `batchSize`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8447a284ac85e712a6f1ee81475a0064cb3dc366. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added specification documentation for Kafka batch consumer functionality, covering batch accumulation, configuration parameters, error handling, observability, and performance targets.
* Added implementation and rollout guidance including testing requirements, performance tuning recommendations, and acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->