### PR TITLE
Hotfix/grouping schema

### DIFF
--- a/ent/client.go
+++ b/ent/client.go
@@ -3484,22 +3484,6 @@ func (c *GroupClient) GetX(ctx context.Context, id string) *Group {
 	return obj
 }
 
-// QueryPrices queries the prices edge of a Group.
-func (c *GroupClient) QueryPrices(gr *Group) *PriceQuery {
-	query := (&PriceClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := gr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(group.Table, group.FieldID, id),
-			sqlgraph.To(price.Table, price.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, group.PricesTable, group.PricesColumn),
-		)
-		fromV = sqlgraph.Neighbors(gr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
 // Hooks returns the client hooks.
 func (c *GroupClient) Hooks() []Hook {
 	return c.hooks.Group
@@ -4685,22 +4669,6 @@ func (c *PriceClient) QueryPriceUnitEdge(pr *Price) *PriceUnitQuery {
 			sqlgraph.From(price.Table, price.FieldID, id),
 			sqlgraph.To(priceunit.Table, priceunit.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, price.PriceUnitEdgeTable, price.PriceUnitEdgeColumn),
-		)
-		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryGroup queries the group edge of a Price.
-func (c *PriceClient) QueryGroup(pr *Price) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(price.Table, price.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, price.GroupTable, price.GroupColumn),
 		)
 		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
 		return fromV, nil

--- a/ent/group.go
+++ b/ent/group.go
@@ -39,29 +39,8 @@ type Group struct {
 	// EntityType holds the value of the "entity_type" field.
 	EntityType string `json:"entity_type,omitempty"`
 	// Idempotency key for group creation
-	LookupKey string `json:"lookup_key,omitempty"`
-	// Edges holds the relations/edges for other nodes in the graph.
-	// The values are being populated by the GroupQuery when eager-loading is set.
-	Edges        GroupEdges `json:"edges"`
+	LookupKey    string `json:"lookup_key,omitempty"`
 	selectValues sql.SelectValues
-}
-
-// GroupEdges holds the relations/edges for other nodes in the graph.
-type GroupEdges struct {
-	// Prices holds the value of the prices edge.
-	Prices []*Price `json:"prices,omitempty"`
-	// loadedTypes holds the information for reporting if a
-	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [1]bool
-}
-
-// PricesOrErr returns the Prices value or an error if the edge
-// was not loaded in eager-loading.
-func (e GroupEdges) PricesOrErr() ([]*Price, error) {
-	if e.loadedTypes[0] {
-		return e.Prices, nil
-	}
-	return nil, &NotLoadedError{edge: "prices"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -175,11 +154,6 @@ func (gr *Group) assignValues(columns []string, values []any) error {
 // This includes values selected through modifiers, order, etc.
 func (gr *Group) Value(name string) (ent.Value, error) {
 	return gr.selectValues.Get(name)
-}
-
-// QueryPrices queries the "prices" edge of the Group entity.
-func (gr *Group) QueryPrices() *PriceQuery {
-	return NewGroupClient(gr.config).QueryPrices(gr)
 }
 
 // Update returns a builder for updating this Group.

--- a/ent/group/group.go
+++ b/ent/group/group.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
-	"entgo.io/ent/dialect/sql/sqlgraph"
 )
 
 const (
@@ -36,17 +35,8 @@ const (
 	FieldEntityType = "entity_type"
 	// FieldLookupKey holds the string denoting the lookup_key field in the database.
 	FieldLookupKey = "lookup_key"
-	// EdgePrices holds the string denoting the prices edge name in mutations.
-	EdgePrices = "prices"
 	// Table holds the table name of the group in the database.
 	Table = "groups"
-	// PricesTable is the table that holds the prices relation/edge.
-	PricesTable = "prices"
-	// PricesInverseTable is the table name for the Price entity.
-	// It exists in this package in order to avoid circular dependency with the "price" package.
-	PricesInverseTable = "prices"
-	// PricesColumn is the table column denoting the prices relation/edge.
-	PricesColumn = "group_id"
 )
 
 // Columns holds all SQL columns for group fields.
@@ -150,25 +140,4 @@ func ByEntityType(opts ...sql.OrderTermOption) OrderOption {
 // ByLookupKey orders the results by the lookup_key field.
 func ByLookupKey(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLookupKey, opts...).ToFunc()
-}
-
-// ByPricesCount orders the results by prices count.
-func ByPricesCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newPricesStep(), opts...)
-	}
-}
-
-// ByPrices orders the results by prices terms.
-func ByPrices(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newPricesStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
-func newPricesStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(PricesInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, true, PricesTable, PricesColumn),
-	)
 }

--- a/ent/group/where.go
+++ b/ent/group/where.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
-	"entgo.io/ent/dialect/sql/sqlgraph"
 	"github.com/flexprice/flexprice/ent/predicate"
 )
 
@@ -763,29 +762,6 @@ func LookupKeyEqualFold(v string) predicate.Group {
 // LookupKeyContainsFold applies the ContainsFold predicate on the "lookup_key" field.
 func LookupKeyContainsFold(v string) predicate.Group {
 	return predicate.Group(sql.FieldContainsFold(FieldLookupKey, v))
-}
-
-// HasPrices applies the HasEdge predicate on the "prices" edge.
-func HasPrices() predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, true, PricesTable, PricesColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasPricesWith applies the HasEdge predicate on the "prices" edge with a given conditions (other predicates).
-func HasPricesWith(preds ...predicate.Price) predicate.Group {
-	return predicate.Group(func(s *sql.Selector) {
-		step := newPricesStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
 }
 
 // And groups predicates with the AND operator between them.

--- a/ent/group_create.go
+++ b/ent/group_create.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/group"
-	"github.com/flexprice/flexprice/ent/price"
 )
 
 // GroupCreate is the builder for creating a Group entity.
@@ -155,21 +154,6 @@ func (gc *GroupCreate) SetNillableLookupKey(s *string) *GroupCreate {
 func (gc *GroupCreate) SetID(s string) *GroupCreate {
 	gc.mutation.SetID(s)
 	return gc
-}
-
-// AddPriceIDs adds the "prices" edge to the Price entity by IDs.
-func (gc *GroupCreate) AddPriceIDs(ids ...string) *GroupCreate {
-	gc.mutation.AddPriceIDs(ids...)
-	return gc
-}
-
-// AddPrices adds the "prices" edges to the Price entity.
-func (gc *GroupCreate) AddPrices(p ...*Price) *GroupCreate {
-	ids := make([]string, len(p))
-	for i := range p {
-		ids[i] = p[i].ID
-	}
-	return gc.AddPriceIDs(ids...)
 }
 
 // Mutation returns the GroupMutation object of the builder.
@@ -337,22 +321,6 @@ func (gc *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := gc.mutation.LookupKey(); ok {
 		_spec.SetField(group.FieldLookupKey, field.TypeString, value)
 		_node.LookupKey = value
-	}
-	if nodes := gc.mutation.PricesIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec
 }

--- a/ent/group_update.go
+++ b/ent/group_update.go
@@ -13,7 +13,6 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/group"
 	"github.com/flexprice/flexprice/ent/predicate"
-	"github.com/flexprice/flexprice/ent/price"
 )
 
 // GroupUpdate is the builder for updating Group entities.
@@ -115,45 +114,9 @@ func (gu *GroupUpdate) ClearLookupKey() *GroupUpdate {
 	return gu
 }
 
-// AddPriceIDs adds the "prices" edge to the Price entity by IDs.
-func (gu *GroupUpdate) AddPriceIDs(ids ...string) *GroupUpdate {
-	gu.mutation.AddPriceIDs(ids...)
-	return gu
-}
-
-// AddPrices adds the "prices" edges to the Price entity.
-func (gu *GroupUpdate) AddPrices(p ...*Price) *GroupUpdate {
-	ids := make([]string, len(p))
-	for i := range p {
-		ids[i] = p[i].ID
-	}
-	return gu.AddPriceIDs(ids...)
-}
-
 // Mutation returns the GroupMutation object of the builder.
 func (gu *GroupUpdate) Mutation() *GroupMutation {
 	return gu.mutation
-}
-
-// ClearPrices clears all "prices" edges to the Price entity.
-func (gu *GroupUpdate) ClearPrices() *GroupUpdate {
-	gu.mutation.ClearPrices()
-	return gu
-}
-
-// RemovePriceIDs removes the "prices" edge to Price entities by IDs.
-func (gu *GroupUpdate) RemovePriceIDs(ids ...string) *GroupUpdate {
-	gu.mutation.RemovePriceIDs(ids...)
-	return gu
-}
-
-// RemovePrices removes "prices" edges to Price entities.
-func (gu *GroupUpdate) RemovePrices(p ...*Price) *GroupUpdate {
-	ids := make([]string, len(p))
-	for i := range p {
-		ids[i] = p[i].ID
-	}
-	return gu.RemovePriceIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -246,51 +209,6 @@ func (gu *GroupUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if gu.mutation.LookupKeyCleared() {
 		_spec.ClearField(group.FieldLookupKey, field.TypeString)
-	}
-	if gu.mutation.PricesCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := gu.mutation.RemovedPricesIDs(); len(nodes) > 0 && !gu.mutation.PricesCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := gu.mutation.PricesIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if n, err = sqlgraph.UpdateNodes(ctx, gu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
@@ -398,45 +316,9 @@ func (guo *GroupUpdateOne) ClearLookupKey() *GroupUpdateOne {
 	return guo
 }
 
-// AddPriceIDs adds the "prices" edge to the Price entity by IDs.
-func (guo *GroupUpdateOne) AddPriceIDs(ids ...string) *GroupUpdateOne {
-	guo.mutation.AddPriceIDs(ids...)
-	return guo
-}
-
-// AddPrices adds the "prices" edges to the Price entity.
-func (guo *GroupUpdateOne) AddPrices(p ...*Price) *GroupUpdateOne {
-	ids := make([]string, len(p))
-	for i := range p {
-		ids[i] = p[i].ID
-	}
-	return guo.AddPriceIDs(ids...)
-}
-
 // Mutation returns the GroupMutation object of the builder.
 func (guo *GroupUpdateOne) Mutation() *GroupMutation {
 	return guo.mutation
-}
-
-// ClearPrices clears all "prices" edges to the Price entity.
-func (guo *GroupUpdateOne) ClearPrices() *GroupUpdateOne {
-	guo.mutation.ClearPrices()
-	return guo
-}
-
-// RemovePriceIDs removes the "prices" edge to Price entities by IDs.
-func (guo *GroupUpdateOne) RemovePriceIDs(ids ...string) *GroupUpdateOne {
-	guo.mutation.RemovePriceIDs(ids...)
-	return guo
-}
-
-// RemovePrices removes "prices" edges to Price entities.
-func (guo *GroupUpdateOne) RemovePrices(p ...*Price) *GroupUpdateOne {
-	ids := make([]string, len(p))
-	for i := range p {
-		ids[i] = p[i].ID
-	}
-	return guo.RemovePriceIDs(ids...)
 }
 
 // Where appends a list predicates to the GroupUpdate builder.
@@ -559,51 +441,6 @@ func (guo *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error
 	}
 	if guo.mutation.LookupKeyCleared() {
 		_spec.ClearField(group.FieldLookupKey, field.TypeString)
-	}
-	if guo.mutation.PricesCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := guo.mutation.RemovedPricesIDs(); len(nodes) > 0 && !guo.mutation.PricesCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := guo.mutation.PricesIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: true,
-			Table:   group.PricesTable,
-			Columns: []string{group.PricesColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(price.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	_node = &Group{config: guo.config}
 	_spec.Assign = _node.assignValues

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1322,9 +1322,9 @@ var (
 		{Name: "parent_price_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "start_date", Type: field.TypeTime, Nullable: true},
 		{Name: "end_date", Type: field.TypeTime, Nullable: true},
+		{Name: "group_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "addon_prices", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "price_unit_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
-		{Name: "group_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
 	// PricesTable holds the schema information for the "prices" table.
 	PricesTable = &schema.Table{
@@ -1334,20 +1334,14 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "prices_addons_prices",
-				Columns:    []*schema.Column{PricesColumns[37]},
+				Columns:    []*schema.Column{PricesColumns[38]},
 				RefColumns: []*schema.Column{AddonsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "prices_price_unit_price_unit_edge",
-				Columns:    []*schema.Column{PricesColumns[38]},
-				RefColumns: []*schema.Column{PriceUnitColumns[0]},
-				OnDelete:   schema.SetNull,
-			},
-			{
-				Symbol:     "prices_groups_group",
 				Columns:    []*schema.Column{PricesColumns[39]},
-				RefColumns: []*schema.Column{GroupsColumns[0]},
+				RefColumns: []*schema.Column{PriceUnitColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
@@ -1371,14 +1365,9 @@ var (
 				Columns: []*schema.Column{PricesColumns[35], PricesColumns[36]},
 			},
 			{
-				Name:    "price_group_id",
-				Unique:  false,
-				Columns: []*schema.Column{PricesColumns[39]},
-			},
-			{
 				Name:    "price_tenant_id_environment_id_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[39]},
+				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[37]},
 			},
 		},
 	}
@@ -2284,7 +2273,6 @@ func init() {
 	PaymentAttemptsTable.ForeignKeys[0].RefTable = PaymentsTable
 	PricesTable.ForeignKeys[0].RefTable = AddonsTable
 	PricesTable.ForeignKeys[1].RefTable = PriceUnitTable
-	PricesTable.ForeignKeys[2].RefTable = GroupsTable
 	PriceUnitTable.Annotation = &entsql.Annotation{
 		Table: "price_unit",
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -24048,9 +24048,6 @@ type GroupMutation struct {
 	entity_type    *string
 	lookup_key     *string
 	clearedFields  map[string]struct{}
-	prices         map[string]struct{}
-	removedprices  map[string]struct{}
-	clearedprices  bool
 	done           bool
 	oldValue       func(context.Context) (*Group, error)
 	predicates     []predicate.Group
@@ -24621,60 +24618,6 @@ func (m *GroupMutation) ResetLookupKey() {
 	delete(m.clearedFields, group.FieldLookupKey)
 }
 
-// AddPriceIDs adds the "prices" edge to the Price entity by ids.
-func (m *GroupMutation) AddPriceIDs(ids ...string) {
-	if m.prices == nil {
-		m.prices = make(map[string]struct{})
-	}
-	for i := range ids {
-		m.prices[ids[i]] = struct{}{}
-	}
-}
-
-// ClearPrices clears the "prices" edge to the Price entity.
-func (m *GroupMutation) ClearPrices() {
-	m.clearedprices = true
-}
-
-// PricesCleared reports if the "prices" edge to the Price entity was cleared.
-func (m *GroupMutation) PricesCleared() bool {
-	return m.clearedprices
-}
-
-// RemovePriceIDs removes the "prices" edge to the Price entity by IDs.
-func (m *GroupMutation) RemovePriceIDs(ids ...string) {
-	if m.removedprices == nil {
-		m.removedprices = make(map[string]struct{})
-	}
-	for i := range ids {
-		delete(m.prices, ids[i])
-		m.removedprices[ids[i]] = struct{}{}
-	}
-}
-
-// RemovedPrices returns the removed IDs of the "prices" edge to the Price entity.
-func (m *GroupMutation) RemovedPricesIDs() (ids []string) {
-	for id := range m.removedprices {
-		ids = append(ids, id)
-	}
-	return
-}
-
-// PricesIDs returns the "prices" edge IDs in the mutation.
-func (m *GroupMutation) PricesIDs() (ids []string) {
-	for id := range m.prices {
-		ids = append(ids, id)
-	}
-	return
-}
-
-// ResetPrices resets all changes to the "prices" edge.
-func (m *GroupMutation) ResetPrices() {
-	m.prices = nil
-	m.clearedprices = false
-	m.removedprices = nil
-}
-
 // Where appends a list predicates to the GroupMutation builder.
 func (m *GroupMutation) Where(ps ...predicate.Group) {
 	m.predicates = append(m.predicates, ps...)
@@ -25011,85 +24954,49 @@ func (m *GroupMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *GroupMutation) AddedEdges() []string {
-	edges := make([]string, 0, 1)
-	if m.prices != nil {
-		edges = append(edges, group.EdgePrices)
-	}
+	edges := make([]string, 0, 0)
 	return edges
 }
 
 // AddedIDs returns all IDs (to other nodes) that were added for the given edge
 // name in this mutation.
 func (m *GroupMutation) AddedIDs(name string) []ent.Value {
-	switch name {
-	case group.EdgePrices:
-		ids := make([]ent.Value, 0, len(m.prices))
-		for id := range m.prices {
-			ids = append(ids, id)
-		}
-		return ids
-	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *GroupMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 1)
-	if m.removedprices != nil {
-		edges = append(edges, group.EdgePrices)
-	}
+	edges := make([]string, 0, 0)
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *GroupMutation) RemovedIDs(name string) []ent.Value {
-	switch name {
-	case group.EdgePrices:
-		ids := make([]ent.Value, 0, len(m.removedprices))
-		for id := range m.removedprices {
-			ids = append(ids, id)
-		}
-		return ids
-	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *GroupMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 1)
-	if m.clearedprices {
-		edges = append(edges, group.EdgePrices)
-	}
+	edges := make([]string, 0, 0)
 	return edges
 }
 
 // EdgeCleared returns a boolean which indicates if the edge with the given name
 // was cleared in this mutation.
 func (m *GroupMutation) EdgeCleared(name string) bool {
-	switch name {
-	case group.EdgePrices:
-		return m.clearedprices
-	}
 	return false
 }
 
 // ClearEdge clears the value of the edge with the given name. It returns an error
 // if that edge is not defined in the schema.
 func (m *GroupMutation) ClearEdge(name string) error {
-	switch name {
-	}
 	return fmt.Errorf("unknown Group unique edge %s", name)
 }
 
 // ResetEdge resets all changes to the edge with the given name in this mutation.
 // It returns an error if the edge is not defined in the schema.
 func (m *GroupMutation) ResetEdge(name string) error {
-	switch name {
-	case group.EdgePrices:
-		m.ResetPrices()
-		return nil
-	}
 	return fmt.Errorf("unknown Group edge %s", name)
 }
 
@@ -36402,11 +36309,10 @@ type PriceMutation struct {
 	parent_price_id           *string
 	start_date                *time.Time
 	end_date                  *time.Time
+	group_id                  *string
 	clearedFields             map[string]struct{}
 	price_unit_edge           *string
 	clearedprice_unit_edge    bool
-	group                     *string
-	clearedgroup              bool
 	done                      bool
 	oldValue                  func(context.Context) (*Price, error)
 	predicates                []predicate.Price
@@ -38283,12 +38189,12 @@ func (m *PriceMutation) ResetEndDate() {
 
 // SetGroupID sets the "group_id" field.
 func (m *PriceMutation) SetGroupID(s string) {
-	m.group = &s
+	m.group_id = &s
 }
 
 // GroupID returns the value of the "group_id" field in the mutation.
 func (m *PriceMutation) GroupID() (r string, exists bool) {
-	v := m.group
+	v := m.group_id
 	if v == nil {
 		return
 	}
@@ -38314,7 +38220,7 @@ func (m *PriceMutation) OldGroupID(ctx context.Context) (v *string, err error) {
 
 // ClearGroupID clears the value of the "group_id" field.
 func (m *PriceMutation) ClearGroupID() {
-	m.group = nil
+	m.group_id = nil
 	m.clearedFields[price.FieldGroupID] = struct{}{}
 }
 
@@ -38326,7 +38232,7 @@ func (m *PriceMutation) GroupIDCleared() bool {
 
 // ResetGroupID resets all changes to the "group_id" field.
 func (m *PriceMutation) ResetGroupID() {
-	m.group = nil
+	m.group_id = nil
 	delete(m.clearedFields, price.FieldGroupID)
 }
 
@@ -38368,33 +38274,6 @@ func (m *PriceMutation) PriceUnitEdgeIDs() (ids []string) {
 func (m *PriceMutation) ResetPriceUnitEdge() {
 	m.price_unit_edge = nil
 	m.clearedprice_unit_edge = false
-}
-
-// ClearGroup clears the "group" edge to the Group entity.
-func (m *PriceMutation) ClearGroup() {
-	m.clearedgroup = true
-	m.clearedFields[price.FieldGroupID] = struct{}{}
-}
-
-// GroupCleared reports if the "group" edge to the Group entity was cleared.
-func (m *PriceMutation) GroupCleared() bool {
-	return m.GroupIDCleared() || m.clearedgroup
-}
-
-// GroupIDs returns the "group" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// GroupID instead. It exists only for internal usage by the builders.
-func (m *PriceMutation) GroupIDs() (ids []string) {
-	if id := m.group; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetGroup resets all changes to the "group" edge.
-func (m *PriceMutation) ResetGroup() {
-	m.group = nil
-	m.clearedgroup = false
 }
 
 // Where appends a list predicates to the PriceMutation builder.
@@ -38543,7 +38422,7 @@ func (m *PriceMutation) Fields() []string {
 	if m.end_date != nil {
 		fields = append(fields, price.FieldEndDate)
 	}
-	if m.group != nil {
+	if m.group_id != nil {
 		fields = append(fields, price.FieldGroupID)
 	}
 	return fields
@@ -39369,12 +39248,9 @@ func (m *PriceMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *PriceMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 1)
 	if m.price_unit_edge != nil {
 		edges = append(edges, price.EdgePriceUnitEdge)
-	}
-	if m.group != nil {
-		edges = append(edges, price.EdgeGroup)
 	}
 	return edges
 }
@@ -39387,17 +39263,13 @@ func (m *PriceMutation) AddedIDs(name string) []ent.Value {
 		if id := m.price_unit_edge; id != nil {
 			return []ent.Value{*id}
 		}
-	case price.EdgeGroup:
-		if id := m.group; id != nil {
-			return []ent.Value{*id}
-		}
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *PriceMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 1)
 	return edges
 }
 
@@ -39409,12 +39281,9 @@ func (m *PriceMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *PriceMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 1)
 	if m.clearedprice_unit_edge {
 		edges = append(edges, price.EdgePriceUnitEdge)
-	}
-	if m.clearedgroup {
-		edges = append(edges, price.EdgeGroup)
 	}
 	return edges
 }
@@ -39425,8 +39294,6 @@ func (m *PriceMutation) EdgeCleared(name string) bool {
 	switch name {
 	case price.EdgePriceUnitEdge:
 		return m.clearedprice_unit_edge
-	case price.EdgeGroup:
-		return m.clearedgroup
 	}
 	return false
 }
@@ -39438,9 +39305,6 @@ func (m *PriceMutation) ClearEdge(name string) error {
 	case price.EdgePriceUnitEdge:
 		m.ClearPriceUnitEdge()
 		return nil
-	case price.EdgeGroup:
-		m.ClearGroup()
-		return nil
 	}
 	return fmt.Errorf("unknown Price unique edge %s", name)
 }
@@ -39451,9 +39315,6 @@ func (m *PriceMutation) ResetEdge(name string) error {
 	switch name {
 	case price.EdgePriceUnitEdge:
 		m.ResetPriceUnitEdge()
-		return nil
-	case price.EdgeGroup:
-		m.ResetGroup()
 		return nil
 	}
 	return fmt.Errorf("unknown Price edge %s", name)

--- a/ent/price.go
+++ b/ent/price.go
@@ -10,7 +10,6 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
-	"github.com/flexprice/flexprice/ent/group"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/priceunit"
 	"github.com/flexprice/flexprice/internal/types"
@@ -108,11 +107,9 @@ type Price struct {
 type PriceEdges struct {
 	// PriceUnitEdge holds the value of the price_unit_edge edge.
 	PriceUnitEdge *PriceUnit `json:"price_unit_edge,omitempty"`
-	// Group holds the value of the group edge.
-	Group *Group `json:"group,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [1]bool
 }
 
 // PriceUnitEdgeOrErr returns the PriceUnitEdge value or an error if the edge
@@ -124,17 +121,6 @@ func (e PriceEdges) PriceUnitEdgeOrErr() (*PriceUnit, error) {
 		return nil, &NotFoundError{label: priceunit.Label}
 	}
 	return nil, &NotLoadedError{edge: "price_unit_edge"}
-}
-
-// GroupOrErr returns the Group value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e PriceEdges) GroupOrErr() (*Group, error) {
-	if e.Group != nil {
-		return e.Group, nil
-	} else if e.loadedTypes[1] {
-		return nil, &NotFoundError{label: group.Label}
-	}
-	return nil, &NotLoadedError{edge: "group"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -444,11 +430,6 @@ func (pr *Price) Value(name string) (ent.Value, error) {
 // QueryPriceUnitEdge queries the "price_unit_edge" edge of the Price entity.
 func (pr *Price) QueryPriceUnitEdge() *PriceUnitQuery {
 	return NewPriceClient(pr.config).QueryPriceUnitEdge(pr)
-}
-
-// QueryGroup queries the "group" edge of the Price entity.
-func (pr *Price) QueryGroup() *GroupQuery {
-	return NewPriceClient(pr.config).QueryGroup(pr)
 }
 
 // Update returns a builder for updating this Price.

--- a/ent/price/price.go
+++ b/ent/price/price.go
@@ -92,8 +92,6 @@ const (
 	FieldGroupID = "group_id"
 	// EdgePriceUnitEdge holds the string denoting the price_unit_edge edge name in mutations.
 	EdgePriceUnitEdge = "price_unit_edge"
-	// EdgeGroup holds the string denoting the group edge name in mutations.
-	EdgeGroup = "group"
 	// Table holds the table name of the price in the database.
 	Table = "prices"
 	// PriceUnitEdgeTable is the table that holds the price_unit_edge relation/edge.
@@ -103,13 +101,6 @@ const (
 	PriceUnitEdgeInverseTable = "price_unit"
 	// PriceUnitEdgeColumn is the table column denoting the price_unit_edge relation/edge.
 	PriceUnitEdgeColumn = "price_unit_id"
-	// GroupTable is the table that holds the group relation/edge.
-	GroupTable = "prices"
-	// GroupInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	GroupInverseTable = "groups"
-	// GroupColumn is the table column denoting the group relation/edge.
-	GroupColumn = "group_id"
 )
 
 // Columns holds all SQL columns for price fields.
@@ -394,24 +385,10 @@ func ByPriceUnitEdgeField(field string, opts ...sql.OrderTermOption) OrderOption
 		sqlgraph.OrderByNeighborTerms(s, newPriceUnitEdgeStep(), sql.OrderByField(field, opts...))
 	}
 }
-
-// ByGroupField orders the results by group field.
-func ByGroupField(field string, opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newGroupStep(), sql.OrderByField(field, opts...))
-	}
-}
 func newPriceUnitEdgeStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(PriceUnitEdgeInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, false, PriceUnitEdgeTable, PriceUnitEdgeColumn),
-	)
-}
-func newGroupStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(GroupInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, false, GroupTable, GroupColumn),
 	)
 }

--- a/ent/price/where.go
+++ b/ent/price/where.go
@@ -2413,29 +2413,6 @@ func HasPriceUnitEdgeWith(preds ...predicate.PriceUnit) predicate.Price {
 	})
 }
 
-// HasGroup applies the HasEdge predicate on the "group" edge.
-func HasGroup() predicate.Price {
-	return predicate.Price(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, GroupTable, GroupColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasGroupWith applies the HasEdge predicate on the "group" edge with a given conditions (other predicates).
-func HasGroupWith(preds ...predicate.Group) predicate.Price {
-	return predicate.Price(func(s *sql.Selector) {
-		step := newGroupStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Price) predicate.Price {
 	return predicate.Price(sql.AndPredicates(predicates...))

--- a/ent/price_create.go
+++ b/ent/price_create.go
@@ -10,7 +10,6 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/flexprice/flexprice/ent/group"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/priceunit"
 	"github.com/flexprice/flexprice/internal/types"
@@ -476,11 +475,6 @@ func (pc *PriceCreate) SetPriceUnitEdge(p *PriceUnit) *PriceCreate {
 	return pc.SetPriceUnitEdgeID(p.ID)
 }
 
-// SetGroup sets the "group" edge to the Group entity.
-func (pc *PriceCreate) SetGroup(g *Group) *PriceCreate {
-	return pc.SetGroupID(g.ID)
-}
-
 // Mutation returns the PriceMutation object of the builder.
 func (pc *PriceCreate) Mutation() *PriceMutation {
 	return pc.mutation
@@ -818,6 +812,10 @@ func (pc *PriceCreate) createSpec() (*Price, *sqlgraph.CreateSpec) {
 		_spec.SetField(price.FieldEndDate, field.TypeTime, value)
 		_node.EndDate = &value
 	}
+	if value, ok := pc.mutation.GroupID(); ok {
+		_spec.SetField(price.FieldGroupID, field.TypeString, value)
+		_node.GroupID = &value
+	}
 	if nodes := pc.mutation.PriceUnitEdgeIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -833,23 +831,6 @@ func (pc *PriceCreate) createSpec() (*Price, *sqlgraph.CreateSpec) {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.PriceUnitID = nodes[0]
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := pc.mutation.GroupIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   price.GroupTable,
-			Columns: []string{price.GroupColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.GroupID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/ent/price_query.go
+++ b/ent/price_query.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/flexprice/flexprice/ent/group"
 	"github.com/flexprice/flexprice/ent/predicate"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/priceunit"
@@ -25,7 +24,6 @@ type PriceQuery struct {
 	inters            []Interceptor
 	predicates        []predicate.Price
 	withPriceUnitEdge *PriceUnitQuery
-	withGroup         *GroupQuery
 	withFKs           bool
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
@@ -78,28 +76,6 @@ func (pq *PriceQuery) QueryPriceUnitEdge() *PriceUnitQuery {
 			sqlgraph.From(price.Table, price.FieldID, selector),
 			sqlgraph.To(priceunit.Table, priceunit.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, false, price.PriceUnitEdgeTable, price.PriceUnitEdgeColumn),
-		)
-		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
-}
-
-// QueryGroup chains the current query on the "group" edge.
-func (pq *PriceQuery) QueryGroup() *GroupQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := pq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := pq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(price.Table, price.FieldID, selector),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, false, price.GroupTable, price.GroupColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
 		return fromU, nil
@@ -300,7 +276,6 @@ func (pq *PriceQuery) Clone() *PriceQuery {
 		inters:            append([]Interceptor{}, pq.inters...),
 		predicates:        append([]predicate.Price{}, pq.predicates...),
 		withPriceUnitEdge: pq.withPriceUnitEdge.Clone(),
-		withGroup:         pq.withGroup.Clone(),
 		// clone intermediate query.
 		sql:  pq.sql.Clone(),
 		path: pq.path,
@@ -315,17 +290,6 @@ func (pq *PriceQuery) WithPriceUnitEdge(opts ...func(*PriceUnitQuery)) *PriceQue
 		opt(query)
 	}
 	pq.withPriceUnitEdge = query
-	return pq
-}
-
-// WithGroup tells the query-builder to eager-load the nodes that are connected to
-// the "group" edge. The optional arguments are used to configure the query builder of the edge.
-func (pq *PriceQuery) WithGroup(opts ...func(*GroupQuery)) *PriceQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	pq.withGroup = query
 	return pq
 }
 
@@ -408,9 +372,8 @@ func (pq *PriceQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Price,
 		nodes       = []*Price{}
 		withFKs     = pq.withFKs
 		_spec       = pq.querySpec()
-		loadedTypes = [2]bool{
+		loadedTypes = [1]bool{
 			pq.withPriceUnitEdge != nil,
-			pq.withGroup != nil,
 		}
 	)
 	if withFKs {
@@ -437,12 +400,6 @@ func (pq *PriceQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Price,
 	if query := pq.withPriceUnitEdge; query != nil {
 		if err := pq.loadPriceUnitEdge(ctx, query, nodes, nil,
 			func(n *Price, e *PriceUnit) { n.Edges.PriceUnitEdge = e }); err != nil {
-			return nil, err
-		}
-	}
-	if query := pq.withGroup; query != nil {
-		if err := pq.loadGroup(ctx, query, nodes, nil,
-			func(n *Price, e *Group) { n.Edges.Group = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -478,38 +435,6 @@ func (pq *PriceQuery) loadPriceUnitEdge(ctx context.Context, query *PriceUnitQue
 	}
 	return nil
 }
-func (pq *PriceQuery) loadGroup(ctx context.Context, query *GroupQuery, nodes []*Price, init func(*Price), assign func(*Price, *Group)) error {
-	ids := make([]string, 0, len(nodes))
-	nodeids := make(map[string][]*Price)
-	for i := range nodes {
-		if nodes[i].GroupID == nil {
-			continue
-		}
-		fk := *nodes[i].GroupID
-		if _, ok := nodeids[fk]; !ok {
-			ids = append(ids, fk)
-		}
-		nodeids[fk] = append(nodeids[fk], nodes[i])
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-	query.Where(group.IDIn(ids...))
-	neighbors, err := query.All(ctx)
-	if err != nil {
-		return err
-	}
-	for _, n := range neighbors {
-		nodes, ok := nodeids[n.ID]
-		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "group_id" returned %v`, n.ID)
-		}
-		for i := range nodes {
-			assign(nodes[i], n)
-		}
-	}
-	return nil
-}
 
 func (pq *PriceQuery) sqlCount(ctx context.Context) (int, error) {
 	_spec := pq.querySpec()
@@ -538,9 +463,6 @@ func (pq *PriceQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if pq.withPriceUnitEdge != nil {
 			_spec.Node.AddColumnOnce(price.FieldPriceUnitID)
-		}
-		if pq.withGroup != nil {
-			_spec.Node.AddColumnOnce(price.FieldGroupID)
 		}
 	}
 	if ps := pq.predicates; len(ps) > 0 {

--- a/ent/price_update.go
+++ b/ent/price_update.go
@@ -12,7 +12,6 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
-	"github.com/flexprice/flexprice/ent/group"
 	"github.com/flexprice/flexprice/ent/predicate"
 	"github.com/flexprice/flexprice/ent/price"
 	"github.com/flexprice/flexprice/ent/priceunit"
@@ -565,11 +564,6 @@ func (pu *PriceUpdate) SetPriceUnitEdge(p *PriceUnit) *PriceUpdate {
 	return pu.SetPriceUnitEdgeID(p.ID)
 }
 
-// SetGroup sets the "group" edge to the Group entity.
-func (pu *PriceUpdate) SetGroup(g *Group) *PriceUpdate {
-	return pu.SetGroupID(g.ID)
-}
-
 // Mutation returns the PriceMutation object of the builder.
 func (pu *PriceUpdate) Mutation() *PriceMutation {
 	return pu.mutation
@@ -578,12 +572,6 @@ func (pu *PriceUpdate) Mutation() *PriceMutation {
 // ClearPriceUnitEdge clears the "price_unit_edge" edge to the PriceUnit entity.
 func (pu *PriceUpdate) ClearPriceUnitEdge() *PriceUpdate {
 	pu.mutation.ClearPriceUnitEdge()
-	return pu
-}
-
-// ClearGroup clears the "group" edge to the Group entity.
-func (pu *PriceUpdate) ClearGroup() *PriceUpdate {
-	pu.mutation.ClearGroup()
 	return pu
 }
 
@@ -849,6 +837,12 @@ func (pu *PriceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if pu.mutation.EndDateCleared() {
 		_spec.ClearField(price.FieldEndDate, field.TypeTime)
 	}
+	if value, ok := pu.mutation.GroupID(); ok {
+		_spec.SetField(price.FieldGroupID, field.TypeString, value)
+	}
+	if pu.mutation.GroupIDCleared() {
+		_spec.ClearField(price.FieldGroupID, field.TypeString)
+	}
 	if pu.mutation.PriceUnitEdgeCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -871,35 +865,6 @@ func (pu *PriceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(priceunit.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if pu.mutation.GroupCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   price.GroupTable,
-			Columns: []string{price.GroupColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.GroupIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   price.GroupTable,
-			Columns: []string{price.GroupColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -1460,11 +1425,6 @@ func (puo *PriceUpdateOne) SetPriceUnitEdge(p *PriceUnit) *PriceUpdateOne {
 	return puo.SetPriceUnitEdgeID(p.ID)
 }
 
-// SetGroup sets the "group" edge to the Group entity.
-func (puo *PriceUpdateOne) SetGroup(g *Group) *PriceUpdateOne {
-	return puo.SetGroupID(g.ID)
-}
-
 // Mutation returns the PriceMutation object of the builder.
 func (puo *PriceUpdateOne) Mutation() *PriceMutation {
 	return puo.mutation
@@ -1473,12 +1433,6 @@ func (puo *PriceUpdateOne) Mutation() *PriceMutation {
 // ClearPriceUnitEdge clears the "price_unit_edge" edge to the PriceUnit entity.
 func (puo *PriceUpdateOne) ClearPriceUnitEdge() *PriceUpdateOne {
 	puo.mutation.ClearPriceUnitEdge()
-	return puo
-}
-
-// ClearGroup clears the "group" edge to the Group entity.
-func (puo *PriceUpdateOne) ClearGroup() *PriceUpdateOne {
-	puo.mutation.ClearGroup()
 	return puo
 }
 
@@ -1774,6 +1728,12 @@ func (puo *PriceUpdateOne) sqlSave(ctx context.Context) (_node *Price, err error
 	if puo.mutation.EndDateCleared() {
 		_spec.ClearField(price.FieldEndDate, field.TypeTime)
 	}
+	if value, ok := puo.mutation.GroupID(); ok {
+		_spec.SetField(price.FieldGroupID, field.TypeString, value)
+	}
+	if puo.mutation.GroupIDCleared() {
+		_spec.ClearField(price.FieldGroupID, field.TypeString)
+	}
 	if puo.mutation.PriceUnitEdgeCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -1796,35 +1756,6 @@ func (puo *PriceUpdateOne) sqlSave(ctx context.Context) (_node *Price, err error
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(priceunit.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if puo.mutation.GroupCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   price.GroupTable,
-			Columns: []string{price.GroupColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.GroupIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: false,
-			Table:   price.GroupTable,
-			Columns: []string{price.GroupColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/ent/schema/group.go
+++ b/ent/schema/group.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/entsql"
-	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	baseMixin "github.com/flexprice/flexprice/ent/schema/mixin"
@@ -51,14 +50,6 @@ func (Group) Fields() []ent.Field {
 			}).
 			Optional().
 			Comment("Idempotency key for group creation"),
-	}
-}
-
-// Edges of the Group.
-func (Group) Edges() []ent.Edge {
-	return []ent.Edge{
-		edge.From("prices", Price.Type).
-			Ref("group"),
 	}
 }
 

--- a/ent/schema/price.go
+++ b/ent/schema/price.go
@@ -219,9 +219,6 @@ func (Price) Edges() []ent.Edge {
 		edge.To("price_unit_edge", PriceUnit.Type).
 			Field("price_unit_id").
 			Unique(),
-		edge.To("group", Group.Type).
-			Field("group_id").
-			Unique(),
 	}
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds HubSpot deal synchronization workflow and activities, updates temporal service, and enhances webhook payloads with customer data.
> 
>   - **HubSpot Integration**:
>     - Introduces `HubSpotDealSyncWorkflow` in `hubspot_deal_sync_workflow.go` to orchestrate HubSpot deal synchronization.
>     - Adds `DealSyncActivities` in `deal_sync_activities.go` for creating line items and updating deal amounts in HubSpot.
>     - Updates `temporal.go` and `temporal/registration.go` to register the new workflow and activities.
>   - **Data Structures**:
>     - Adds `HubSpotDealSyncWorkflowInput` in `hubspot_deal_sync.go` for workflow input validation.
>     - Updates `connection.go` to include `HubSpotConnectionMetadata` for storing HubSpot-specific connection details.
>   - **Testing and Utilities**:
>     - Modifies `inmemory_price_store.go` to support group ID operations for testing.
>   - **Webhooks**:
>     - Updates `alert.go` and `wallet.go` in `webhook/dto` to include customer information in webhook payloads.
>     - Modifies `alert.go` and `wallet.go` in `webhook/payload` to fetch and include customer data in payloads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c5e16a62d753ec7ec57d6df519d0b99c41993505. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed edge-based query helpers for navigating between Group and Price relationships; relationship navigation methods are no longer available through convenience accessors.
  * Removed eager-loading support for Group-Price edge relationships in queries.
  * Group relationships are now managed exclusively through direct field references instead of edge-based mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->