### PR TITLE
feat(feature): add archive validation for active plan associations

### DIFF
--- a/internal/service/feature.go
+++ b/internal/service/feature.go
@@ -289,19 +289,37 @@ func (s *featureService) DeleteFeature(ctx context.Context, id string) error {
 			Mark(ierr.ErrNotFound)
 	}
 
-	entitlementFilter := types.NewDefaultEntitlementFilter()
-	entitlementFilter.QueryFilter.Limit = lo.ToPtr(1)
+	// Check whether this feature is attached to any ACTIVE plans.
+	entitlementFilter := types.NewNoLimitEntitlementFilter()
 	entitlementFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+	entitlementFilter.EntityType = lo.ToPtr(types.ENTITLEMENT_ENTITY_TYPE_PLAN)
 	entitlementFilter.FeatureIDs = []string{id}
-	entitlements, err := s.EntitlementRepo.List(ctx, entitlementFilter)
 
+	entitlements, err := s.EntitlementRepo.List(ctx, entitlementFilter)
 	if err != nil {
 		return err
 	}
-	if len(entitlements) > 0 {
-		return ierr.NewError("feature is linked to some plans").
-			WithHint("Feature is linked to some plans, please remove the feature from the plans first").
-			Mark(ierr.ErrInvalidOperation)
+
+	// Check the referenced plan's status and block if active
+	for _, ent := range entitlements {
+		if ent == nil {
+			continue
+		}
+		if ent.EntityType != types.ENTITLEMENT_ENTITY_TYPE_PLAN {
+			continue
+		}
+
+		p, err := s.PlanRepo.Get(ctx, ent.EntityID)
+		if err != nil {
+			s.Logger.Debugw("skipping entitlement check - failed to get plan", "plan_id", ent.EntityID, "error", err)
+			continue
+		}
+
+		if p.Status == types.StatusPublished {
+			return ierr.NewError("feature is linked to some plans").
+				WithHint("Feature is linked to some active plans, please remove the feature from the plans first").
+				Mark(ierr.ErrInvalidOperation)
+		}
 	}
 
 	if feature.Type == types.FeatureTypeMetered {


### PR DESCRIPTION
Fixes #699


## 📝 Description
Check only active plan association when archiving.

---

## 🔨 Changes Made
- [x] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [x] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `DeleteFeature` in `feature.go` to check only active plan associations when archiving a feature.
> 
>   - **Behavior**:
>     - Update `DeleteFeature` in `feature.go` to check only active plan associations when archiving.
>     - Uses `NewNoLimitEntitlementFilter` and checks `StatusPublished` for active plans.
>     - Iterates over entitlements to verify plan status and blocks deletion if any plan is active.
>   - **Misc**:
>     - Adds debug logging for skipped entitlement checks due to plan retrieval errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8a25bc32e9574abebf9b42805b928c7d264c5042. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced feature deletion validation to more robustly check against active plans before allowing deletion.
  * Improved error messaging to clearly indicate when a feature cannot be deleted due to associated active plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->