### PR TITLE
fix(costsheet-analytics): persists feature_ids to analytics api

### DIFF
--- a/internal/api/dto/costsheet_analytics.go
+++ b/internal/api/dto/costsheet_analytics.go
@@ -20,7 +20,7 @@ type GetCostAnalyticsRequest struct {
 	ExternalCustomerID string `json:"external_customer_id,omitempty"` // Optional - for specific customer
 
 	// Additional filters
-	MeterIDs []string `json:"meter_ids,omitempty"`
+	FeatureIDs []string `json:"feature_ids,omitempty"`
 
 	// Expand options - specify which entities to expand
 	Expand []string `json:"expand,omitempty"` // "meter", "price"

--- a/internal/service/revenue_analytics.go
+++ b/internal/service/revenue_analytics.go
@@ -231,11 +231,6 @@ func (s *revenueAnalyticsService) buildMeterUsageRequests(
 			continue
 		}
 
-		// Apply meter ID filter if specified
-		if len(req.MeterIDs) > 0 && !lo.Contains(req.MeterIDs, price.MeterID) {
-			continue
-		}
-
 		usageRequest := &dto.GetUsageByMeterRequest{
 			MeterID:            price.MeterID,
 			PriceID:            price.ID,
@@ -390,6 +385,7 @@ func (s *revenueAnalyticsService) buildEmptyResponse(costsheetID string, req *dt
 func (s *revenueAnalyticsService) buildRevenueRequest(req *dto.GetCostAnalyticsRequest) *dto.GetUsageAnalyticsRequest {
 	return &dto.GetUsageAnalyticsRequest{
 		ExternalCustomerID: req.ExternalCustomerID,
+		FeatureIDs:         req.FeatureIDs,
 		StartTime:          req.StartTime,
 		EndTime:            req.EndTime,
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `MeterIDs` with `FeatureIDs` in cost analytics requests and updates service logic accordingly.
> 
>   - **DTO Changes**:
>     - In `costsheet_analytics.go`, `GetCostAnalyticsRequest` now uses `FeatureIDs` instead of `MeterIDs`.
>   - **Service Changes**:
>     - In `revenue_analytics.go`, `buildRevenueRequest()` now includes `FeatureIDs` in the request.
>     - Removed `MeterIDs` filtering logic from `buildMeterUsageRequests()`.
>   - **Behavior**:
>     - Analytics API now persists and processes `FeatureIDs` instead of `MeterIDs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 611960b17d1a1e3e67388e532504419bed8c1a8c. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cost analytics API now filters results by features instead of meters
  * Revenue analytics requests now include feature-level filtering information, replacing meter-based filtering
  * Updated analytics request format to use feature identifiers for improved query organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->