### PR TITLE
fix(coupons): remove discount from overage usage

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1088,8 +1088,7 @@ func (s *billingService) CreateInvoiceRequestForCharges(
 		if lineItem.PriceID == nil {
 			continue
 		}
-		metadata := lineItem.Metadata
-		if metadata["is_overage"] == "true" {
+		if lineItem.Metadata != nil && lineItem.Metadata["is_overage"] == "true" {
 			continue
 		}
 		subLineItem, ok := priceIDtoSubLineItemMap[*lineItem.PriceID]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip applying coupons to overage line items in `CreateInvoiceRequestForCharges` in `billing.go`.
> 
>   - **Behavior**:
>     - In `CreateInvoiceRequestForCharges` in `billing.go`, skip applying coupons to line items with `metadata["is_overage"] == "true"`.
>   - **Misc**:
>     - No changes to function signatures or other logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 21d2316dc4b3324d4828cb9cc9a1ef50bba19c75. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice generation now excludes overage line items from coupon and promotion application, so discounts apply only to standard charges.
  * This prevents incorrect discounting of overage fees and ensures more accurate billing totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->