### PR TITLE
fix(event-ingestion): skip pushing events to the post-processing topi…

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -510,7 +510,7 @@ func registerRouterHandlers(
 
 	// Only register processing handlers when needed
 	if includeProcessingHandlers {
-		// Register post-processing handlers
+		// Register handlers
 		eventConsumptionSvc.RegisterHandler(router, cfg)
 		eventConsumptionSvc.RegisterHandlerLazy(router, cfg)
 		eventPostProcessingSvc.RegisterHandler(router, cfg)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify event processing to only publish events for post-processing for specific tenants in `event_consumption.go`.
> 
>   - **Behavior**:
>     - Modify `processMessage()` and `ProcessRawEvent()` in `event_consumption.go` to only publish events to post-processing for tenants forced to v1.
>   - **Misc**:
>     - Update comment in `main.go` to clarify handler registration logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 71d02de577964d790a59db8ccc161a7e5c9f6451. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal comment for clarity.

* **Internal Changes**
  * Modified event publishing behavior to be conditional based on tenant configuration, ensuring events are only published to post-processing when specific tenant criteria are met. Existing error handling and retry logic remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->