### PR TITLE
fix(subscription): remove version checks from update

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1599,34 +1599,6 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[17], SubscriptionsColumns[11], SubscriptionsColumns[2]},
 			},
-			{
-				Name:    "subscription_tenant_id_environment_id_pause_status_status",
-				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[28], SubscriptionsColumns[2]},
-			},
-			{
-				Name:    "subscription_tenant_id_environment_id_active_pause_id_status",
-				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[29], SubscriptionsColumns[2]},
-			},
-			{
-				Name:    "subscription_tenant_id_environment_id_payment_behavior_status",
-				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[33], SubscriptionsColumns[2]},
-			},
-			{
-				Name:    "subscription_tenant_id_environment_id_collection_method_status",
-				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[34], SubscriptionsColumns[2]},
-			},
-			{
-				Name:    "subscription_tenant_id_environment_id_subscription_status_collection_method_status",
-				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[11], SubscriptionsColumns[34], SubscriptionsColumns[2]},
-				Annotation: &entsql.IndexAnnotation{
-					Where: "subscription_status IN ('incomplete', 'past_due')",
-				},
-			},
 		},
 	}
 	// SubscriptionLineItemsColumns holds the columns for the "subscription_line_items" table.

--- a/ent/schema/subscription.go
+++ b/ent/schema/subscription.go
@@ -180,15 +180,5 @@ func (Subscription) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "subscription_status", "status"),
 		// For billing period updates
 		index.Fields("tenant_id", "environment_id", "current_period_end", "subscription_status", "status"),
-		// For pause-related queries
-		index.Fields("tenant_id", "environment_id", "pause_status", "status"),
-		index.Fields("tenant_id", "environment_id", "active_pause_id", "status"),
-		// For payment behavior queries
-		index.Fields("tenant_id", "environment_id", "payment_behavior", "status"),
-		index.Fields("tenant_id", "environment_id", "collection_method", "status"),
-
-		// For incomplete subscription queries
-		index.Fields("tenant_id", "environment_id", "subscription_status", "collection_method", "status").
-			Annotations(entsql.IndexWhere("subscription_status IN ('incomplete', 'past_due')")),
 	}
 }

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -160,7 +160,6 @@ func (r *subscriptionRepository) Update(ctx context.Context, sub *domainSub.Subs
 			subscription.TenantID(types.GetTenantID(ctx)),
 			subscription.Status(string(types.StatusPublished)),
 			subscription.EnvironmentID(types.GetEnvironmentID(ctx)),
-			subscription.Version(sub.Version), // Version check for optimistic locking
 		)
 
 	// Set all fields
@@ -177,8 +176,7 @@ func (r *subscriptionRepository) Update(ctx context.Context, sub *domainSub.Subs
 		SetCollectionMethod(subscription.CollectionMethod(sub.CollectionMethod)).
 		SetNillableGatewayPaymentMethodID(sub.GatewayPaymentMethodID).
 		SetUpdatedAt(now).
-		SetUpdatedBy(types.GetUserID(ctx)).
-		AddVersion(1) // Increment version atomically
+		SetUpdatedBy(types.GetUserID(ctx))
 
 	if sub.ActivePauseID != nil {
 		query.SetActivePauseID(*sub.ActivePauseID)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove version checks from subscription update logic and related indexes in schema and repository.
> 
>   - **Schema Changes**:
>     - Removed version checks from `subscription` update logic in `subscription.go`.
>     - Removed related indexes in `schema.go`.
>   - **Repository Changes**:
>     - Removed `subscription.Version(sub.Version)` from `Update()` in `subscriptionRepository` in `subscription.go`.
>     - Removed `AddVersion(1)` from `Update()` in `subscriptionRepository` in `subscription.go`.
>   - **Migration Changes**:
>     - Removed version-related indexes from `schema.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8388bf96e9f3927a13f6fb4e7815395d0e794309. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed subscription table indexes for enhanced performance optimization and reduced database overhead.
  * Simplified update logic by removing version-based concurrency control mechanisms, streamlining internal update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->