### PR TITLE
feat(invoice): consider max features also for entitlement

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -692,7 +692,7 @@ func (s *billingService) CalculateUsageChargesForPreview(
 			// 2. There is a matching entitlement
 			// 3. The entitlement is enabled
 			// 4. This is not a bucketed max meter (already handled above)
-			if !matchingCharge.IsOverage && entitlementOk && matchingEntitlement.IsEnabled && !meter.IsBucketedMaxMeter() {
+			if !matchingCharge.IsOverage && entitlementOk && matchingEntitlement.IsEnabled {
 				if matchingEntitlement.UsageLimit != nil {
 
 					// consider the usage reset period


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove bucketed max meter check from entitlement adjustments in `CalculateUsageChargesForPreview` in `billing.go`.
> 
>   - **Behavior**:
>     - Modify `CalculateUsageChargesForPreview` in `billing.go` to remove the check for bucketed max meters when applying entitlement adjustments.
>     - Ensures entitlement adjustments are applied even if the meter is bucketed max, as this is handled separately.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ea4063d616bee53abab89fed43eb51e0e4f4289e. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a billing calculation issue where entitlement adjustments were not being applied to certain meter types. Previously, this could result in inaccurate charges for some customers. Usage limits and resets now properly apply to all meter types during usage charge calculations, ensuring consistent and accurate billing outcomes for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->