### PR TITLE
fix(subscription): update subscription cancellation logic and respons…

### DIFF
--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -2112,7 +2112,6 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 			// Check for cancellation at this period end
 			if sub.CancelAtPeriodEnd && sub.CancelAt != nil && !sub.CancelAt.After(period.end) {
 				sub.SubscriptionStatus = types.SubscriptionStatusCancelled
-				sub.CancelledAt = sub.CancelAt
 				sub.EndDate = sub.CancelAt
 				break
 			}
@@ -2153,7 +2152,6 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 		// Final cancellation check
 		if sub.CancelAtPeriodEnd && sub.CancelAt != nil && !sub.CancelAt.After(newPeriod.end) {
 			sub.SubscriptionStatus = types.SubscriptionStatusCancelled
-			sub.CancelledAt = sub.CancelAt
 		}
 
 		// Check if the new period end matches the subscription end date


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update subscription cancellation logic in `subscription.go` to ensure `EndDate` is set correctly for immediate and end-of-period cancellations.
> 
>   - **Behavior**:
>     - Update `updateSubscriptionForCancellation()` in `subscription.go` to set `EndDate` for both immediate and end-of-period cancellations.
>     - Modify `processSubscriptionPeriod()` in `subscription.go` to set `EndDate` when cancelling at period end.
>   - **Misc**:
>     - Remove redundant `CancelledAt` field setting in `processSubscriptionPeriod()` in `subscription.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for f077da9f6ee535a7227b0d4714630a7630022868. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription cancellations now consistently record an End Date that reflects the effective cancellation timing (immediate or end-of-period).
  * When a cancellation includes a planned cancel date, the subscription End Date is set to that date to ensure accurate termination tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->