### PR TITLE
feat(kafka): add sentry span over monitoring api

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -339,6 +339,7 @@ func provideHandlers(
 		ScheduledTask:            v1.NewScheduledTaskHandler(scheduledTaskService, logger),
 		AlertLogsHandler:         v1.NewAlertLogsHandler(alertLogsService, customerService, walletService, featureService, logger),
 		RBAC:                     v1.NewRBACHandler(rbacService, userService, logger),
+		CronKafkaLagMonitoring:   cron.NewKafkaLagMonitoringHandler(logger, eventService),
 	}
 }
 

--- a/internal/api/cron/kafka_lag_monitoting.go
+++ b/internal/api/cron/kafka_lag_monitoting.go
@@ -1,0 +1,44 @@
+package cron
+
+import (
+	"net/http"
+
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// KafkaLagMonitoringHandler handles periodic Kafka consumer lag monitoring for cron jobs.
+// It monitors lag metrics across event consumption and post-processing pipelines.
+type KafkaLagMonitoringHandler struct {
+	logger       *logger.Logger
+	eventService service.EventService
+}
+
+// NewKafkaLagMonitoringHandler creates a new handler for Kafka lag monitoring cron jobs.
+func NewKafkaLagMonitoringHandler(log *logger.Logger, eventService service.EventService) *KafkaLagMonitoringHandler {
+	return &KafkaLagMonitoringHandler{
+		logger:       log,
+		eventService: eventService,
+	}
+}
+
+// HandleKafkaLagMonitoring is the HTTP handler for the Kafka lag monitoring cron endpoint.
+// It triggers lag monitoring across all configured Kafka consumer groups and reports metrics to Sentry.
+func (h *KafkaLagMonitoringHandler) HandleKafkaLagMonitoring(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	h.logger.Infow("kafka lag monitoring job started")
+
+	if err := h.eventService.MonitorKafkaLag(ctx); err != nil {
+		h.logger.Errorw("kafka lag monitoring job failed", "error", err)
+		c.Error(err)
+		return
+	}
+
+	h.logger.Infow("kafka lag monitoring job completed successfully")
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "success",
+		"message": "kafka lag monitoring completed",
+	})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -56,10 +56,11 @@ type Handlers struct {
 	// Portal handlers
 	Onboarding *v1.OnboardingHandler
 	// Cron jobs : TODO: move crons out of API based architecture
-	CronSubscription *cron.SubscriptionHandler
-	CronWallet       *cron.WalletCronHandler
-	CronCreditGrant  *cron.CreditGrantCronHandler
-	CronInvoice      *cron.InvoiceHandler
+	CronSubscription       *cron.SubscriptionHandler
+	CronWallet             *cron.WalletCronHandler
+	CronCreditGrant        *cron.CreditGrantCronHandler
+	CronInvoice            *cron.InvoiceHandler
+	CronKafkaLagMonitoring *cron.KafkaLagMonitoringHandler
 }
 
 func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logger, secretService service.SecretService, envAccessService service.EnvAccessService, rbacService *rbac.RBACService) *gin.Engine {
@@ -521,6 +522,11 @@ func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logg
 	invoiceGroup := cron.Group("/invoices")
 	{
 		invoiceGroup.POST("/void-old-pending", handlers.CronInvoice.VoidOldPendingInvoices)
+	}
+	// Kafka lag monitoring related cron jobs
+	kafkaLagMonitoringGroup := cron.Group("/events")
+	{
+		kafkaLagMonitoringGroup.POST("/monitoring", handlers.CronKafkaLagMonitoring.HandleKafkaLagMonitoring)
 	}
 
 	// Settings routes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kafka lag monitoring capability to track consumer lag metrics across event consumption pipelines.
  * New API endpoint (`POST /invoices/events/monitoring`) to trigger Kafka lag monitoring jobs.
  * Enhanced observability with specialized monitoring spans to support filtering and alerting on Kafka lag data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->