### PR TITLE
feat(env): Add restriction over env creation

### DIFF
--- a/internal/api/dto/settings.go
+++ b/internal/api/dto/settings.go
@@ -99,9 +99,15 @@ func (r *CreateSettingRequest) Validate() error {
 }
 
 func (r *CreateSettingRequest) ToSetting(ctx context.Context) *settings.Setting {
+	// env_permit_config must be tenant-level only (no environment_id)
+	environmentID := types.GetEnvironmentID(ctx)
+	if r.Key == types.SettingKeyEnvPermitConfig {
+		environmentID = ""
+	}
+
 	return &settings.Setting{
 		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SETTING),
-		EnvironmentID: types.GetEnvironmentID(ctx),
+		EnvironmentID: environmentID,
 		BaseModel:     types.GetDefaultBaseModel(ctx),
 		Key:           r.Key.String(),
 		Value:         r.Value,

--- a/internal/api/dto/settings.go
+++ b/internal/api/dto/settings.go
@@ -99,9 +99,9 @@ func (r *CreateSettingRequest) Validate() error {
 }
 
 func (r *CreateSettingRequest) ToSetting(ctx context.Context) *settings.Setting {
-	// env_permit_config must be tenant-level only (no environment_id)
+	// env_config must be tenant-level only (no environment_id)
 	environmentID := types.GetEnvironmentID(ctx)
-	if r.Key == types.SettingKeyEnvPermitConfig {
+	if r.Key == types.SettingKeyEnvConfig {
 		environmentID = ""
 	}
 

--- a/internal/domain/environment/repository.go
+++ b/internal/domain/environment/repository.go
@@ -11,4 +11,5 @@ type Repository interface {
 	Get(ctx context.Context, id string) (*Environment, error)
 	List(ctx context.Context, filter types.Filter) ([]*Environment, error)
 	Update(ctx context.Context, environment *Environment) error
+	CountByType(ctx context.Context, envType types.EnvironmentType) (int, error)
 }

--- a/internal/domain/settings/repository.go
+++ b/internal/domain/settings/repository.go
@@ -16,6 +16,7 @@ type Repository interface {
 
 	// Operations by key
 	GetByKey(ctx context.Context, key types.SettingKey) (*Setting, error)
+	GetTenantSettingByKey(ctx context.Context, key types.SettingKey) (*Setting, error)
 	DeleteByKey(ctx context.Context, key types.SettingKey) error
 
 	// Config operations

--- a/internal/domain/settings/repository.go
+++ b/internal/domain/settings/repository.go
@@ -18,6 +18,7 @@ type Repository interface {
 	GetByKey(ctx context.Context, key types.SettingKey) (*Setting, error)
 	GetTenantSettingByKey(ctx context.Context, key types.SettingKey) (*Setting, error)
 	DeleteByKey(ctx context.Context, key types.SettingKey) error
+	DeleteTenantSettingByKey(ctx context.Context, key types.SettingKey) error
 
 	// Config operations
 	ListAllTenantEnvSettingsByKey(ctx context.Context, key types.SettingKey) ([]*types.TenantEnvConfig, error)

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -254,8 +254,7 @@ func (r *settingsRepository) GetTenantSettingByKey(ctx context.Context, key type
 		Where(
 			settings.Key(key.String()),
 			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentID(""),
-			settings.KeyEQ(string(types.SettingKeyEnvConfig)),
+			settings.EnvironmentIDIsNil(),
 			settings.Status(string(types.StatusPublished)),
 		).
 		Only(ctx)
@@ -335,8 +334,7 @@ func (r *settingsRepository) DeleteTenantSettingByKey(ctx context.Context, key t
 		Where(
 			settings.Key(key.String()),
 			settings.TenantID(types.GetTenantID(ctx)),
-			settings.KeyEQ(string(types.SettingKeyEnvConfig)),
-			settings.EnvironmentID(""), // Tenant-level setting has empty environment_id
+			settings.EnvironmentIDIsNil(), // Tenant-level setting has empty environment_id
 			settings.Status(string(types.StatusPublished)),
 		).
 		SetStatus(string(types.StatusArchived)).

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -50,7 +50,7 @@ func (r *settingsRepository) Create(ctx context.Context, s *domainSettings.Setti
 		SetUpdatedAt(s.UpdatedAt).
 		SetCreatedBy(s.CreatedBy).
 		SetUpdatedBy(s.UpdatedBy).
-		SetNillableEnvironmentID(&s.EnvironmentID).
+		SetEnvironmentID(s.EnvironmentID).
 		Save(ctx)
 
 	if err != nil {
@@ -239,7 +239,7 @@ func (r *settingsRepository) GetTenantSettingByKey(ctx context.Context, key type
 		Where(
 			settings.Key(key.String()),
 			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentIDIsNil(),
+			settings.EnvironmentID(""),
 			settings.Status(string(types.StatusPublished)),
 		).
 		Only(ctx)
@@ -319,7 +319,7 @@ func (r *settingsRepository) DeleteTenantSettingByKey(ctx context.Context, key t
 		Where(
 			settings.Key(key.String()),
 			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentIDIsNil(),
+			settings.EnvironmentID(""),
 			settings.Status(string(types.StatusPublished)),
 		).
 		SetStatus(string(types.StatusArchived)).

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -239,10 +239,7 @@ func (r *settingsRepository) GetTenantSettingByKey(ctx context.Context, key type
 		Where(
 			settings.Key(key.String()),
 			settings.TenantID(types.GetTenantID(ctx)),
-			settings.Or(
-				settings.EnvironmentIDIsNil(),
-				settings.EnvironmentID(""),
-			),
+			settings.EnvironmentIDIsNil(),
 			settings.Status(string(types.StatusPublished)),
 		).
 		Only(ctx)
@@ -322,10 +319,7 @@ func (r *settingsRepository) DeleteTenantSettingByKey(ctx context.Context, key t
 		Where(
 			settings.Key(key.String()),
 			settings.TenantID(types.GetTenantID(ctx)),
-			settings.Or(
-				settings.EnvironmentIDIsNil(),
-				settings.EnvironmentID(""),
-			),
+			settings.EnvironmentIDIsNil(),
 			settings.Status(string(types.StatusPublished)),
 		).
 		SetStatus(string(types.StatusArchived)).

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -55,7 +55,7 @@ func (s *EnvironmentServiceSuite) SetupTest() {
 	}
 }
 
-// mockSettingsService is a simple mock that returns defaults for env_permit_config
+// mockSettingsService is a simple mock that returns defaults for env_config
 type mockSettingsService struct {
 	repo *testutil.InMemorySettingsStore
 }
@@ -64,7 +64,7 @@ func (m *mockSettingsService) GetSettingByKey(ctx context.Context, key types.Set
 	// Try to get from repo first
 	setting, err := m.repo.GetByKey(ctx, key)
 	if err != nil {
-		// If not found and it's env_permit_config, return error so service can use defaults
+		// If not found and it's env_config, return error so service can use defaults
 		// For other settings, also return error
 		return nil, err
 	}

--- a/internal/service/settings.go
+++ b/internal/service/settings.go
@@ -57,11 +57,12 @@ func (s *settingsService) GetSettingByKey(ctx context.Context, key types.Setting
 					Value:     defaultSetting.DefaultValue,
 					BaseModel: types.GetDefaultBaseModel(ctx),
 				}
+				// For env_config, don't set environment_id (will be NULL in DB)
+				// For other settings, use environment_id from context
 				if !isEnvConfig {
 					defaultSettingModel.EnvironmentID = types.GetEnvironmentID(ctx)
-				} else {
-					defaultSettingModel.EnvironmentID = ""
 				}
+				// env_config: EnvironmentID remains empty (zero value), repository will set to NULL
 				return dto.SettingFromDomain(defaultSettingModel), nil
 			}
 		}
@@ -132,10 +133,8 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 		setting.Value[key] = value
 	}
 
-	// For env_config, ensure environment_id is empty
-	if key == types.SettingKeyEnvConfig {
-		setting.EnvironmentID = ""
-	}
+	// For env_config, ensure environment_id is not set (will be stored as NULL)
+	// Don't set it - repository will handle NULL conversion
 
 	return s.updateSetting(ctx, setting)
 }

--- a/internal/testutil/inmemory_environment_store.go
+++ b/internal/testutil/inmemory_environment_store.go
@@ -102,6 +102,24 @@ func (s *InMemoryEnvironmentStore) Update(ctx context.Context, env *environment.
 	return nil
 }
 
+func (s *InMemoryEnvironmentStore) CountByType(ctx context.Context, envType types.EnvironmentType) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tenantID := types.GetTenantID(ctx)
+	count := 0
+
+	for _, env := range s.environments {
+		if env.TenantID == tenantID &&
+			env.Type == envType &&
+			env.Status == types.StatusPublished {
+			count++
+		}
+	}
+
+	return count, nil
+}
+
 func (s *InMemoryEnvironmentStore) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -14,7 +14,7 @@ const (
 	SettingKeyInvoiceConfig      SettingKey = "invoice_config"
 	SettingKeySubscriptionConfig SettingKey = "subscription_config"
 	SettingKeyInvoicePDFConfig   SettingKey = "invoice_pdf_config"
-	SettingKeyEnvPermitConfig    SettingKey = "env_permit_config"
+	SettingKeyEnvConfig          SettingKey = "env_config"
 )
 
 func (s SettingKey) String() string {
@@ -136,8 +136,8 @@ func GetDefaultSettings() map[SettingKey]DefaultSettingValue {
 			Description: "Default configuration for invoice PDF generation",
 			Required:    true,
 		},
-		SettingKeyEnvPermitConfig: {
-			Key: SettingKeyEnvPermitConfig,
+		SettingKeyEnvConfig: {
+			Key: SettingKeyEnvConfig,
 			DefaultValue: map[string]interface{}{
 				string(EnvironmentProduction):  1,
 				string(EnvironmentDevelopment): 2,
@@ -167,8 +167,8 @@ func ValidateSettingValue(key string, value map[string]interface{}) error {
 		return ValidateSubscriptionConfig(value)
 	case SettingKeyInvoicePDFConfig:
 		return ValidateInvoicePDFConfig(value)
-	case SettingKeyEnvPermitConfig:
-		return ValidateEnvPermitConfig(value)
+	case SettingKeyEnvConfig:
+		return ValidateEnvConfig(value)
 	default:
 		return ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).
@@ -535,10 +535,10 @@ func validateTimezone(timezone string) error {
 	return err
 }
 
-// ValidateEnvPermitConfig validates environment permit configuration settings
-func ValidateEnvPermitConfig(value map[string]interface{}) error {
+// ValidateEnvConfig validates environment configuration settings
+func ValidateEnvConfig(value map[string]interface{}) error {
 	if value == nil {
-		return errors.New("env_permit_config value cannot be nil")
+		return errors.New("env_config value cannot be nil")
 	}
 
 	// Define valid keys - only production and development are allowed
@@ -550,64 +550,49 @@ func ValidateEnvPermitConfig(value map[string]interface{}) error {
 	// Check for invalid keys
 	for key := range value {
 		if !validKeys[key] {
-			return ierr.NewErrorf("env_permit_config: invalid key '%s'. Only '%s' and '%s' are allowed", key, EnvironmentProduction, EnvironmentDevelopment).
-				WithHintf("Environment permit config only accepts keys: '%s' and '%s'", EnvironmentProduction, EnvironmentDevelopment).
+			return ierr.NewErrorf("env_config: invalid key '%s'. Only '%s' and '%s' are allowed", key, EnvironmentProduction, EnvironmentDevelopment).
+				WithHintf("Environment config only accepts keys: '%s' and '%s'", EnvironmentProduction, EnvironmentDevelopment).
 				Mark(ierr.ErrValidation)
 		}
 	}
 
-	// Validate production environment limit if provided
-	prodEnvKey := string(EnvironmentProduction)
-	if prodEnvRaw, exists := value[prodEnvKey]; exists {
-		var prodEnv int
-		switch v := prodEnvRaw.(type) {
-		case int:
-			prodEnv = v
-		case float64:
-			if v != float64(int(v)) {
-				return ierr.NewErrorf("env_permit_config: '%s' must be a whole number", prodEnvKey).
-					WithHintf("Environment permit config for %s must be a whole number", prodEnvKey).
-					Mark(ierr.ErrValidation)
+	// Validate each environment type limit
+	envTypes := []EnvironmentType{EnvironmentProduction, EnvironmentDevelopment}
+	for _, envType := range envTypes {
+		envTypeKey := string(envType)
+		if limitRaw, exists := value[envTypeKey]; exists {
+			if err := validateEnvLimit(envTypeKey, limitRaw); err != nil {
+				return err
 			}
-			prodEnv = int(v)
-		default:
-			return ierr.NewErrorf("env_permit_config: '%s' must be an integer, got %T", prodEnvKey, prodEnvRaw).
-				WithHintf("Environment permit config for %s must be an integer, got %T", prodEnvKey, prodEnvRaw).
-				Mark(ierr.ErrValidation)
-		}
-
-		if prodEnv < 0 {
-			return ierr.NewErrorf("env_permit_config: '%s' must be greater than or equal to 0", prodEnvKey).
-				WithHintf("Environment permit config for %s must be greater than or equal to 0", prodEnvKey).
-				Mark(ierr.ErrValidation)
 		}
 	}
 
-	// Validate development (sandbox) environment limit if provided
-	sandboxEnvKey := string(EnvironmentDevelopment)
-	if sandboxEnvRaw, exists := value[sandboxEnvKey]; exists {
-		var sandboxEnv int
-		switch v := sandboxEnvRaw.(type) {
-		case int:
-			sandboxEnv = v
-		case float64:
-			if v != float64(int(v)) {
-				return ierr.NewErrorf("env_permit_config: '%s' must be a whole number", sandboxEnvKey).
-					WithHintf("Environment permit config for %s must be a whole number", sandboxEnvKey).
-					Mark(ierr.ErrValidation)
-			}
-			sandboxEnv = int(v)
-		default:
-			return ierr.NewErrorf("env_permit_config: '%s' must be an integer, got %T", sandboxEnvKey, sandboxEnvRaw).
-				WithHintf("Environment permit config for %s must be an integer, got %T", sandboxEnvKey, sandboxEnvRaw).
-				Mark(ierr.ErrValidation)
-		}
+	return nil
+}
 
-		if sandboxEnv < 0 {
-			return ierr.NewErrorf("env_permit_config: '%s' must be greater than or equal to 0", sandboxEnvKey).
-				WithHintf("Environment permit config for %s must be greater than or equal to 0", sandboxEnvKey).
+// validateEnvLimit validates a single environment limit value
+func validateEnvLimit(envTypeKey string, limitRaw interface{}) error {
+	var limit int
+	switch v := limitRaw.(type) {
+	case int:
+		limit = v
+	case float64:
+		if v != float64(int(v)) {
+			return ierr.NewErrorf("env_config: '%s' must be a whole number", envTypeKey).
+				WithHintf("Environment config for %s must be a whole number", envTypeKey).
 				Mark(ierr.ErrValidation)
 		}
+		limit = int(v)
+	default:
+		return ierr.NewErrorf("env_config: '%s' must be an integer, got %T", envTypeKey, limitRaw).
+			WithHintf("Environment config for %s must be an integer, got %T", envTypeKey, limitRaw).
+			Mark(ierr.ErrValidation)
+	}
+
+	if limit < 0 {
+		return ierr.NewErrorf("env_config: '%s' must be greater than or equal to 0", envTypeKey).
+			WithHintf("Environment config for %s must be greater than or equal to 0", envTypeKey).
+			Mark(ierr.ErrValidation)
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforce configurable environment creation limits per environment type (production/development).
  * Tenant-level "env_config" settings supported separately from environment-scoped settings, with retrieval and deletion paths.

* **Refactor**
  * Improved settings validation and defaulting for environment configuration, including per-environment limits and clearer error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds environment creation limits for `production` and `development` types, with tenant-level settings and validation support.
> 
>   - **Behavior**:
>     - Restricts environment creation by checking limits for `production` and `development` types in `CreateEnvironment()` in `environment.go`.
>     - Uses `GetSettingWithDefaults()` to fetch environment configuration limits.
>   - **Repositories**:
>     - Adds `CountByType()` to `environmentRepository` in `environment.go` to count environments by type.
>     - Adds `GetTenantSettingByKey()` and `DeleteTenantSettingByKey()` to `settingsRepository` in `settings.go` for tenant-level settings.
>   - **Validation**:
>     - Adds `ValidateEnvConfig()` in `settings.go` to validate environment configuration settings.
>   - **Testing**:
>     - Updates `EnvironmentServiceSuite` in `environment_test.go` to include tenant ID in context and test environment limits.
>     - Adds `CountByType()` to `InMemoryEnvironmentStore` in `inmemory_environment_store.go` for testing.
>     - Adds `GetTenantSettingByKey()` and `DeleteTenantSettingByKey()` to `InMemorySettingsStore` in `inmemory_settings_store.go` for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c1bbf9ff14956ef33e6872880ef828b7a670ac2d. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->