### PR TITLE
feat(razorpay): add support for Razorpay connection metadata encrypti…

### DIFF
--- a/internal/repository/ent/connection.go
+++ b/internal/repository/ent/connection.go
@@ -263,6 +263,18 @@ func convertConnectionMetadataToMap(encryptedSecretData types.ConnectionMetadata
 			}
 			return result
 		}
+	case types.SecretProviderRazorpay:
+		if encryptedSecretData.Razorpay != nil {
+			result := map[string]interface{}{
+				"key_id":     encryptedSecretData.Razorpay.KeyID,
+				"secret_key": encryptedSecretData.Razorpay.SecretKey,
+			}
+			// Add webhook_secret if present (optional)
+			if encryptedSecretData.Razorpay.WebhookSecret != "" {
+				result["webhook_secret"] = encryptedSecretData.Razorpay.WebhookSecret
+			}
+			return result
+		}
 	default:
 		// For other providers or unknown types, use generic format
 		if encryptedSecretData.Generic != nil {

--- a/internal/service/connection.go
+++ b/internal/service/connection.go
@@ -148,6 +148,33 @@ func (s *connectionService) encryptMetadata(encryptedSecretData types.Connection
 			}
 		}
 
+	case types.SecretProviderRazorpay:
+		if encryptedSecretData.Razorpay != nil {
+			encryptedKeyID, err := s.encryptionService.Encrypt(encryptedSecretData.Razorpay.KeyID)
+			if err != nil {
+				return types.ConnectionMetadata{}, err
+			}
+			encryptedSecretKey, err := s.encryptionService.Encrypt(encryptedSecretData.Razorpay.SecretKey)
+			if err != nil {
+				return types.ConnectionMetadata{}, err
+			}
+
+			// Encrypt webhook secret if provided (optional)
+			var encryptedWebhookSecret string
+			if encryptedSecretData.Razorpay.WebhookSecret != "" {
+				encryptedWebhookSecret, err = s.encryptionService.Encrypt(encryptedSecretData.Razorpay.WebhookSecret)
+				if err != nil {
+					return types.ConnectionMetadata{}, err
+				}
+			}
+
+			encryptedMetadata.Razorpay = &types.RazorpayConnectionMetadata{
+				KeyID:         encryptedKeyID,
+				SecretKey:     encryptedSecretKey,
+				WebhookSecret: encryptedWebhookSecret,
+			}
+		}
+
 	default:
 		// For other providers or unknown types, use generic format
 		if encryptedSecretData.Generic != nil {


### PR DESCRIPTION
…on and mapping

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for Razorpay connection metadata encryption and mapping in `connection.go`.
> 
>   - **Behavior**:
>     - Adds support for Razorpay connection metadata encryption in `encryptMetadata()` in `connection.go`.
>     - Adds Razorpay case to `convertConnectionMetadataToMap()` in `connection.go` for metadata mapping.
>   - **Encryption**:
>     - Encrypts `KeyID`, `SecretKey`, and optional `WebhookSecret` for Razorpay in `encryptMetadata()`.
>   - **Mapping**:
>     - Maps `KeyID`, `SecretKey`, and optional `WebhookSecret` for Razorpay in `convertConnectionMetadataToMap()`.
>   - **Misc**:
>     - Updates `connectionService` and `connectionRepository` to handle Razorpay metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 27614f1c215713da72238ddab065f6aefc651b1a. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Razorpay as a payment provider with encrypted credential storage for API keys and webhook secrets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->