### PR TITLE
feat(invoice): change the name for true up line item

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -551,16 +551,25 @@ func (s *billingService) CalculateUsageCharges(
 
 		if remainingCommitment.GreaterThan(decimal.Zero) {
 			commitmentUtilized := commitmentAmount.Sub(remainingCommitment)
+			// Get plan display name from line items
+			planDisplayName := ""
+			for _, item := range sub.LineItems {
+				if item.PlanDisplayName != "" {
+					planDisplayName = item.PlanDisplayName
+					break
+				}
+			}
 			trueUpLineItem := dto.CreateInvoiceLineItemRequest{
-				EntityID:    lo.ToPtr(sub.PlanID),
-				EntityType:  lo.ToPtr(string(types.SubscriptionLineItemEntityTypePlan)),
-				PriceType:   lo.ToPtr(string(types.PRICE_TYPE_FIXED)),
-				DisplayName: lo.ToPtr("Commitment Shortfall"),
-				Amount:      remainingCommitment,
-				Quantity:    decimal.NewFromInt(1),
-				PeriodStart: &periodStart,
-				PeriodEnd:   &periodEnd,
-				PriceID:     lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)),
+				EntityID:        lo.ToPtr(sub.PlanID),
+				EntityType:      lo.ToPtr(string(types.SubscriptionLineItemEntityTypePlan)),
+				PriceType:       lo.ToPtr(string(types.PRICE_TYPE_FIXED)),
+				PlanDisplayName: lo.ToPtr(planDisplayName),
+				DisplayName:     lo.ToPtr(fmt.Sprintf("%s True Up", planDisplayName)), // Plan display name with true up suffix
+				Amount:          remainingCommitment,
+				Quantity:        decimal.NewFromInt(1),
+				PeriodStart:     &periodStart,
+				PeriodEnd:       &periodEnd,
+				PriceID:         lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)),
 				Metadata: types.Metadata{
 					"is_commitment_trueup": "true",
 					"description":          "Remaining commitment amount for billing period",
@@ -988,18 +997,25 @@ func (s *billingService) CalculateUsageChargesForPreview(
 		remainingCommitment := s.calculateRemainingCommitment(usage, commitmentAmount)
 
 		if remainingCommitment.GreaterThan(decimal.Zero) {
-
+			planDisplayName := ""
+			for _, item := range sub.LineItems {
+				if item.PlanDisplayName != "" {
+					planDisplayName = item.PlanDisplayName
+					break
+				}
+			}
 			commitmentUtilized := commitmentAmount.Sub(remainingCommitment)
 			trueUpLineItem := dto.CreateInvoiceLineItemRequest{
-				EntityID:    lo.ToPtr(sub.PlanID),
-				EntityType:  lo.ToPtr(string(types.SubscriptionLineItemEntityTypePlan)),
-				PriceType:   lo.ToPtr(string(types.PRICE_TYPE_FIXED)),
-				DisplayName: lo.ToPtr("Commitment Shortfall"),
-				Amount:      remainingCommitment,
-				Quantity:    decimal.NewFromInt(1),
-				PeriodStart: &periodStart,
-				PeriodEnd:   &periodEnd,
-				PriceID:     lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)),
+				EntityID:        lo.ToPtr(sub.PlanID),
+				EntityType:      lo.ToPtr(string(types.SubscriptionLineItemEntityTypePlan)),
+				PriceType:       lo.ToPtr(string(types.PRICE_TYPE_FIXED)),
+				PlanDisplayName: lo.ToPtr(planDisplayName),
+				DisplayName:     lo.ToPtr(fmt.Sprintf("%s True Up", planDisplayName)), // Plan display name with true up suffix
+				Amount:          remainingCommitment,
+				Quantity:        decimal.NewFromInt(1),
+				PeriodStart:     &periodStart,
+				PeriodEnd:       &periodEnd,
+				PriceID:         lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)),
 				Metadata: types.Metadata{
 					"is_commitment_trueup": "true",
 					"description":          "Remaining commitment amount for billing period",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update true-up line item display name in `billing.go` to include plan display name with "True Up" suffix.
> 
>   - **Behavior**:
>     - Update `CalculateUsageCharges` and `CalculateUsageChargesForPreview` in `billing.go` to change true-up line item display name to include plan display name.
>     - Extracts `planDisplayName` from subscription line items and appends "True Up" suffix.
>   - **Misc**:
>     - No changes to logic or functionality beyond display name update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 1100a599cc8bc10b16f50b75671f0760b2a02565. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Billing line items now display with plan-specific names instead of generic labels, providing clearer and more contextual billing information to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->