### PR TITLE
feat(invoice): reverted true-up changes

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -663,7 +663,7 @@ func (s *billingService) CalculateUsageChargesForPreview(
 
 			// Handle bucketed max meters first - this should always be checked regardless of entitlements
 			// But skip overage charges as they already have the correct amount with overage factor applied
-			if !matchingCharge.IsOverage && meter.IsBucketedMaxMeter() && matchingCharge.Price != nil {
+			if meter.IsBucketedMaxMeter() && matchingCharge.Price != nil {
 				// Get usage with bucketed values
 				usageRequest := &events.FeatureUsageParams{
 					PriceID: item.PriceID,
@@ -859,7 +859,7 @@ func (s *billingService) CalculateUsageChargesForPreview(
 					quantityForCalculation = decimal.Zero
 					matchingCharge.Amount = 0
 				}
-			} else if !matchingCharge.IsOverage && !meter.IsBucketedMaxMeter() && matchingCharge.Price != nil {
+			} else if !meter.IsBucketedMaxMeter() && matchingCharge.Price != nil {
 				// For non-bucketed meters without entitlements (but not overage charges),
 				// calculate cost normally. Overage charges already have the correct amount
 				// calculated by GetFeatureUsageBySubscription with the overage factor applied.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove commitment true-up charges from billing calculations and ensure consistent usage handling in `billing.go`.
> 
>   - **Behavior**:
>     - Remove commitment true-up charges from `CalculateUsageCharges` and `CalculateUsageChargesForPreview` in `billing.go`.
>     - Ensure previewed bills match regular billing behavior for usage and charge calculations.
>   - **Usage Calculation**:
>     - Consistent calculation of bucketed usage, affecting capped/tiered usage totals.
>     - Predictable application of entitlement-based usage limits across meter types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 5d462db9ab4ee3ae419c479d6a2a63969e80bd57. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commitment true-up charges are no longer applied to billing calculations or previews.
  * Previewed bills now match regular billing behavior for usage and charge calculations.

* **Behavioral Changes**
  * Bucketed usage is calculated more consistently, affecting how capped/ tiered usage is totaled.
  * Entitlement-based usage limits are applied more predictably across meter types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->