### PR TITLE
feat(subscription): enhance subscription model with billing anchor an…

### DIFF
--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -367,7 +367,9 @@ func (s *SubscriptionServiceSuite) setupTestData() {
 		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
 		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
 		CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+		BillingAnchor:      s.testData.now.Add(-30 * 24 * time.Hour),
 		Currency:           "usd",
+		BillingCycle:       types.BillingCycleAnniversary,
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
@@ -3200,6 +3202,8 @@ func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod() {
 
 	sub.CurrentPeriodStart = periodStart
 	sub.CurrentPeriodEnd = periodEnd
+	// Set billing anchor to align with the period start for anniversary billing
+	sub.BillingAnchor = periodStart
 
 	// Update the subscription in the repository
 	err := s.GetStores().SubscriptionRepo.Update(s.GetContext(), sub)


### PR DESCRIPTION
…d cycle for anniversary billing

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance subscription model with `BillingAnchor` and `BillingCycle` for anniversary billing in `subscription_test.go`.
> 
>   - **Enhancements**:
>     - Add `BillingAnchor` and `BillingCycle` fields to subscription setup in `subscription_test.go` for anniversary billing.
>   - **Tests**:
>     - Update `TestProcessSubscriptionPeriod` to align `BillingAnchor` with period start for anniversary billing.
>     - Ensure correct handling of anniversary billing cycles in test scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 8279780e52946800a9e154a8ac2e30f6c012610e. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced subscription billing period tests to properly initialize and validate billing anchor and cycle values during period processing.

**Note:** This release includes internal testing improvements with no user-facing changes or impact to existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->