### PR TITLE
fix(preview): add check over preview api

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -907,7 +907,7 @@ func (s *billingService) CalculateUsageChargesForPreview(
 					quantityForCalculation = decimal.Zero
 					matchingCharge.Amount = 0
 				}
-			} else if !meter.IsBucketedMaxMeter() && matchingCharge.Price != nil {
+			} else if !matchingCharge.IsOverage && !meter.IsBucketedMaxMeter() && matchingCharge.Price != nil {
 				// For non-bucketed meters without entitlements (but not overage charges),
 				// calculate cost normally. Overage charges already have the correct amount
 				// calculated by GetFeatureUsageBySubscription with the overage factor applied.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix in `CalculateUsageChargesForPreview` to prevent recalculation of overage charges for non-bucketed meters, aligning with existing logic.
> 
>   - **Behavior**:
>     - Fix in `CalculateUsageChargesForPreview` in `billing.go` to prevent recalculation of overage charges for non-bucketed meters.
>     - Aligns with existing logic in `CalculateUsageCharges` to ensure overage charges are handled correctly.
>   - **Misc**:
>     - Minor logic adjustment to improve consistency in charge calculations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 98b57f1331e72ba381746bfc21852918105ec587. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected billing charge calculations for metered usage with entitlements to ensure overage charges are handled properly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->