### PR TITLE
Feat/sum with window

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -323,6 +323,7 @@ type UsageAnalyticItem struct {
 	Points               []UsageAnalyticPoint               `json:"points,omitempty"`
 	AddOnID              string                             `json:"add_on_id,omitempty"`
 	PlanID               string                             `json:"plan_id,omitempty"`
+	WindowSize           types.WindowSize                   `json:"window_size,omitempty"` // Window size for bucketed meters (only set if meter is bucketed)
 }
 
 // UsageAnalyticPoint represents a point in the time series data

--- a/internal/service/billing_commitment.go
+++ b/internal/service/billing_commitment.go
@@ -89,9 +89,9 @@ func (c *commitmentCalculator) applyCommitmentToLineItem(
 		overageCharge := overage.Mul(overageFactor)
 		finalCharge = commitmentAmount.Add(overageCharge)
 
-		info.Utilized = commitmentAmount
-		info.Overage = overageCharge
-		info.TrueUp = decimal.Zero
+		info.ComputedCommitmentUtilizedAmount = commitmentAmount
+		info.ComputedOverageAmount = overageCharge
+		info.ComputedTrueUpAmount = decimal.Zero
 
 		c.logger.Debugw("usage exceeds commitment, applying overage",
 			"line_item_id", lineItem.ID,
@@ -105,22 +105,22 @@ func (c *commitmentCalculator) applyCommitmentToLineItem(
 		if lineItem.CommitmentTrueUpEnabled {
 			// Charge full commitment (true-up)
 			finalCharge = commitmentAmount
-			info.Utilized = usageCost
-			info.Overage = decimal.Zero
-			info.TrueUp = commitmentAmount.Sub(usageCost)
+			info.ComputedCommitmentUtilizedAmount = usageCost
+			info.ComputedOverageAmount = decimal.Zero
+			info.ComputedTrueUpAmount = commitmentAmount.Sub(usageCost)
 
 			c.logger.Debugw("usage below commitment, applying true-up",
 				"line_item_id", lineItem.ID,
 				"usage_cost", usageCost,
 				"commitment_amount", commitmentAmount,
-				"true_up", info.TrueUp,
+				"true_up", info.ComputedTrueUpAmount,
 				"final_charge", finalCharge)
 		} else {
 			// Charge only actual usage (no true-up)
 			finalCharge = usageCost
-			info.Utilized = usageCost
-			info.Overage = decimal.Zero
-			info.TrueUp = decimal.Zero
+			info.ComputedCommitmentUtilizedAmount = usageCost
+			info.ComputedOverageAmount = decimal.Zero
+			info.ComputedTrueUpAmount = decimal.Zero
 
 			c.logger.Debugw("usage below commitment, no true-up",
 				"line_item_id", lineItem.ID,
@@ -224,9 +224,9 @@ func (c *commitmentCalculator) applyWindowCommitmentToLineItem(
 		totalCharge = totalCharge.Add(windowCharge)
 	}
 
-	info.Utilized = totalCommitmentUtilized
-	info.Overage = totalOverage
-	info.TrueUp = totalTrueUp
+	info.ComputedCommitmentUtilizedAmount = totalCommitmentUtilized
+	info.ComputedOverageAmount = totalOverage
+	info.ComputedTrueUpAmount = totalTrueUp
 
 	c.logger.Infow("window commitment applied to line item",
 		"line_item_id", lineItem.ID,

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -2260,6 +2260,22 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 			}
 		}
 
+		// Set window size: use meter's bucket size if bucketed, otherwise use request window size
+		if analytic.MeterID != "" {
+			if meter, ok := data.Meters[analytic.MeterID]; ok {
+				if meter.HasBucketSize() {
+					// For bucketed meters, use the meter's bucket size
+					item.WindowSize = meter.Aggregation.BucketSize
+				} else if req.WindowSize != "" {
+					// For non-bucketed meters, use the request window size if provided
+					item.WindowSize = req.WindowSize
+				}
+			}
+		} else if req.WindowSize != "" {
+			// If no meter ID, still use request window size if provided
+			item.WindowSize = req.WindowSize
+		}
+
 		if expandMap["feature"] && analytic.FeatureID != "" {
 			if feature, ok := data.Features[analytic.FeatureID]; ok {
 				item.Feature = feature
@@ -2615,5 +2631,3 @@ func (s *featureUsageTrackingService) applyLineItemCommitment(
 	s.Logger.Warnw("failed to apply commitment", "error", err, "line_item_id", lineItem.ID)
 	return rawCost
 }
-
-// updateItemProperties is removed as it is no longer used for commitment info

--- a/internal/types/commitment.go
+++ b/internal/types/commitment.go
@@ -29,15 +29,14 @@ func (ct CommitmentType) String() string {
 
 // CommitmentInfo holds information about a commitment
 type CommitmentInfo struct {
-	Type             CommitmentType   `json:"type"`
-	Amount           decimal.Decimal  `json:"amount" swaggertype:"string"`
-	Quantity         decimal.Decimal  `json:"quantity,omitempty" swaggertype:"string"`
-	Utilized         decimal.Decimal  `json:"computed_utilized_amount" swaggertype:"string"`
-	Overage          decimal.Decimal  `json:"computed_overage_amount" swaggertype:"string"`
-	TrueUp           decimal.Decimal  `json:"computed_true_up_amount" swaggertype:"string"`
-	OverageFactor    *decimal.Decimal `json:"overage_factor,omitempty" swaggertype:"string"`
-	TrueUpEnabled    bool             `json:"true_up_enabled"`
-	IsWindowed       bool             `json:"is_windowed"`
-	WindowSize       *string          `json:"window_size,omitempty"`
-	UsageResetPeriod string           `json:"usage_reset_period,omitempty"`
+	Type          CommitmentType   `json:"type"`
+	Amount        decimal.Decimal  `json:"amount" swaggertype:"string"`
+	Quantity      decimal.Decimal  `json:"quantity,omitempty" swaggertype:"string"` // Only used for quantity-based commitments
+	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty" swaggertype:"string"`
+	TrueUpEnabled bool             `json:"true_up_enabled"`
+	IsWindowed    bool             `json:"is_windowed"`
+	// total_cost = computed_commitment_utilized_amount + computed_overage_amount + computed_true_up_amount
+	ComputedTrueUpAmount             decimal.Decimal `json:"computed_true_up_amount" swaggertype:"string"`
+	ComputedOverageAmount            decimal.Decimal `json:"computed_overage_amount" swaggertype:"string"`
+	ComputedCommitmentUtilizedAmount decimal.Decimal `json:"computed_commitment_utilized_amount" swaggertype:"string"`
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for windowed commitments in billing calculations, including DTO updates and service logic enhancements.
> 
>   - **Behavior**:
>     - Adds `WindowSize` to `UsageAnalyticItem` in `events.go` for bucketed meters.
>     - Implements windowed commitment logic in `applyWindowCommitmentToLineItem()` in `billing_commitment.go`.
>     - Updates `calculateRegularCost()` in `feature_usage_tracking.go` to support windowed commitments if points exist.
>   - **Models**:
>     - Renames fields in `CommitmentInfo` in `commitment.go` to `ComputedCommitmentUtilizedAmount`, `ComputedOverageAmount`, and `ComputedTrueUpAmount`.
>   - **Misc**:
>     - Removes unused `updateItemProperties` function in `feature_usage_tracking.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for a4f9d08103d7e5c811350ea867f604855d3f0c5e. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Usage analytics now include window size information, providing clearer context for time-period bucketing.
  * Enhanced support for bucketed time windows in usage and commitment calculations.

* **Improvements**
  * Commitment totals are now explicitly labeled as computed amounts in API responses (utilized, overage, and true-up values) for improved transparency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->