### PR TITLE
feat(analytics): added sources in response

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -311,6 +311,7 @@ type UsageAnalyticItem struct {
 	FeatureName          string                             `json:"name,omitempty"`
 	EventName            string                             `json:"event_name,omitempty"`
 	Source               string                             `json:"source,omitempty"`
+	Sources              []string                           `json:"sources,omitempty"` // List of sources when not grouping by source
 	Unit                 string                             `json:"unit,omitempty"`
 	UnitPlural           string                             `json:"unit_plural,omitempty"`
 	AggregationType      types.AggregationType              `json:"aggregation_type,omitempty"`

--- a/internal/domain/events/models.go
+++ b/internal/domain/events/models.go
@@ -47,6 +47,7 @@ type DetailedUsageAnalytic struct {
 	FeatureName     string
 	EventName       string
 	Source          string
+	Sources         []string // List of distinct sources when source is not in group_by
 	MeterID         string
 	PriceID         string // Price ID used for this usage - allows tracking different prices per subscription
 	SubLineItemID   string // Subscription line item ID


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Sources` field to analytics response for distinct source listing when not grouping by source.
> 
>   - **Behavior**:
>     - Add `Sources` field to `UsageAnalyticItem` in `events.go` and `DetailedUsageAnalytic` in `models.go` to list distinct sources when not grouping by source.
>     - Update `getStandardAnalytics()` and `getMaxBucketTotals()` in `feature_usage.go` to handle `Sources` field.
>     - Update `GetDetailedUsageAnalytics()` in `processed_event.go` to include `Sources` in analytics results.
>     - Modify `aggregateAnalyticsByGrouping()` in `feature_usage_tracking.go` to merge `Sources`.
>   - **Misc**:
>     - Add logic to check if `source` is in `group_by` and adjust queries accordingly in `feature_usage.go` and `processed_event.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for be503d8941f84adc438c2c54586a48aea35f90e1. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced usage analytics API to include a comprehensive list of all distinct sources when results are not grouped by the source parameter. Users can now view all contributing sources directly in aggregated analytics metrics and reports, providing improved visibility into data lineage and source attribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->