### PR TITLE
fix(subscription): update validation to prevent quantity setting for usage-based prices

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1114,7 +1114,7 @@ func (r *OverrideLineItemRequest) Validate(
 		// Quantity can only be set for fixed prices, not usage-based prices
 		if priceMap != nil {
 			if price, exists := priceMap[r.PriceID]; exists && price != nil {
-				if price.Type == types.PRICE_TYPE_USAGE {
+				if price.Type == types.PRICE_TYPE_USAGE && r.Quantity.GreaterThan(decimal.Zero) {
 					return ierr.NewError("quantity cannot be set for usage-based prices").
 						WithHint("Quantity overrides are only allowed for fixed prices. Usage-based prices track quantity automatically from meter events").
 						WithReportableDetails(map[string]interface{}{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `OverrideLineItemRequest.Validate()` to prevent setting `Quantity` for usage-based prices in `subscription.go`.
> 
>   - **Validation Update**:
>     - In `OverrideLineItemRequest.Validate()`, added check to prevent setting `Quantity` for usage-based prices.
>     - Ensures `Quantity` is not greater than zero for `PRICE_TYPE_USAGE` in `subscription.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for f3ce477ed1a36174f92edc0aa5577ad098c49bec. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined validation for subscription line item quantity overrides on usage-based pricing to allow zero and negative quantities, restricting errors to positive quantities only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->