### PR TITLE
feat(schema): add new indexes for invoice and subscription line items based on subscription_id and status

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1102,6 +1102,11 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{InvoiceLineItemsColumns[24], InvoiceLineItemsColumns[25]},
 			},
+			{
+				Name:    "invoicelineitem_subscription_id_status",
+				Unique:  false,
+				Columns: []*schema.Column{InvoiceLineItemsColumns[9], InvoiceLineItemsColumns[2]},
+			},
 		},
 	}
 	// InvoiceSequencesColumns holds the columns for the "invoice_sequences" table.
@@ -1691,6 +1696,11 @@ var (
 				Name:    "subscriptionlineitem_start_date_end_date",
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionLineItemsColumns[24], SubscriptionLineItemsColumns[25]},
+			},
+			{
+				Name:    "subscriptionlineitem_subscription_id_status",
+				Unique:  false,
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[34], SubscriptionLineItemsColumns[2]},
 			},
 		},
 	}

--- a/ent/schema/invoice_line_item.go
+++ b/ent/schema/invoice_line_item.go
@@ -179,5 +179,6 @@ func (InvoiceLineItem) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "price_id", "status"),
 		index.Fields("tenant_id", "environment_id", "meter_id", "status"),
 		index.Fields("period_start", "period_end"),
+		index.Fields("subscription_id", "status"),
 	}
 }

--- a/ent/schema/subscription_line_item.go
+++ b/ent/schema/subscription_line_item.go
@@ -190,5 +190,6 @@ func (SubscriptionLineItem) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "price_id", "status"),
 		index.Fields("tenant_id", "environment_id", "meter_id", "status"),
 		index.Fields("start_date", "end_date"),
+		index.Fields("subscription_id", "status"),
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add indexes for `subscription_id` and `status` to `InvoiceLineItems` and `SubscriptionLineItems` for improved query performance.
> 
>   - **Indexes**:
>     - Added index `invoicelineitem_subscription_id_status` to `InvoiceLineItems` in `schema.go` and `invoice_line_item.go`.
>     - Added index `subscriptionlineitem_subscription_id_status` to `SubscriptionLineItems` in `schema.go` and `subscription_line_item.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 4c169fe8893455bcdbe1f7324a69a5a9d176db15. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->