### PR TITLE
    fix(creditgrant): update expiry date calculation for recurring grants to use current time

### DIFF
--- a/internal/service/creditgrant.go
+++ b/internal/service/creditgrant.go
@@ -428,7 +428,7 @@ func (s *creditGrantService) ApplyCreditGrantToWallet(ctx context.Context, grant
 	// IMPORTANT: For recurring grants, expiry should be calculated from when the credit is actually granted,
 	// not from subscription start date. This ensures each grant has its own expiry timeline.
 	var expiryDate *time.Time
-	now := time.Now().UTC()
+	scheduledFor := cga.ScheduledFor
 
 	if grant.ExpirationType == types.CreditGrantExpiryTypeNever {
 		expiryDate = nil
@@ -440,16 +440,16 @@ func (s *creditGrantService) ApplyCreditGrantToWallet(ctx context.Context, grant
 			// This ensures recurring grants each have their own expiry timeline
 			switch lo.FromPtr(grant.ExpirationDurationUnit) {
 			case types.CreditGrantExpiryDurationUnitDays:
-				expiry := now.AddDate(0, 0, lo.FromPtr(grant.ExpirationDuration))
+				expiry := scheduledFor.AddDate(0, 0, lo.FromPtr(grant.ExpirationDuration))
 				expiryDate = &expiry
 			case types.CreditGrantExpiryDurationUnitWeeks:
-				expiry := now.AddDate(0, 0, lo.FromPtr(grant.ExpirationDuration)*7)
+				expiry := scheduledFor.AddDate(0, 0, lo.FromPtr(grant.ExpirationDuration)*7)
 				expiryDate = &expiry
 			case types.CreditGrantExpiryDurationUnitMonths:
-				expiry := now.AddDate(0, lo.FromPtr(grant.ExpirationDuration), 0)
+				expiry := scheduledFor.AddDate(0, lo.FromPtr(grant.ExpirationDuration), 0)
 				expiryDate = &expiry
 			case types.CreditGrantExpiryDurationUnitYears:
-				expiry := now.AddDate(lo.FromPtr(grant.ExpirationDuration), 0, 0)
+				expiry := scheduledFor.AddDate(lo.FromPtr(grant.ExpirationDuration), 0, 0)
 				expiryDate = &expiry
 			default:
 				return ierr.NewError("invalid expiration duration unit").

--- a/internal/types/subscription.go
+++ b/internal/types/subscription.go
@@ -80,6 +80,7 @@ func (s SubscriptionStatus) Validate() error {
 		SubscriptionStatusPastDue,
 		SubscriptionStatusTrialing,
 		SubscriptionStatusUnpaid,
+		SubscriptionStatusIncompleteExpired,
 		SubscriptionStatusDraft,
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update expiry date calculation for recurring credit grants to use current time in `ApplyCreditGrantToWallet` in `creditgrant.go`.
> 
>   - **Behavior**:
>     - Update expiry date calculation for recurring grants in `ApplyCreditGrantToWallet` in `creditgrant.go` to use current time instead of subscription start date.
>     - Adds logging for calculated expiry date and billing cycle expiry date.
>   - **Logging**:
>     - Logs duration-based expiry date details including `grant_id`, `subscription_id`, `expiry_type`, `duration`, `duration_unit`, `grant_time`, and `expiry_date`.
>     - Logs billing cycle expiry date details including `grant_id`, `subscription_id`, `expiry_type`, `current_period_end`, and `expiry_date`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d176dd9454a6ffa71ea565150eb36517cd99f952. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duration-based credits now expire relative to when the grant is applied, fixing incorrect expiry timing.
  * Billing-cycle credits remain aligned to the subscription period end for recurring grants.

* **Improvements**
  * Consistent and predictable expiry behavior across duration- and billing-based credits.

* **Documentation**
  * Added clarifying comments around expiry handling and billing-cycle behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->