### PR TITLE
feat(costsheet): moved from warn to debug

### DIFF
--- a/internal/service/costsheet_usage_tracking.go
+++ b/internal/service/costsheet_usage_tracking.go
@@ -300,7 +300,7 @@ func (s *costsheetUsageTrackingService) prepareProcessedEvents(ctx context.Conte
 	costSheet, err := s.getActiveCostsheetWithCache(ctx)
 	if err != nil {
 		if ierr.IsNotFound(err) {
-			s.Logger.Warnw("no active costsheet found for event, skipping",
+			s.Logger.Debugw("no active costsheet found for event, skipping",
 				"event_id", event.ID,
 				"tenant_id", event.TenantID,
 				"environment_id", event.EnvironmentID,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change log level from `Warn` to `Debug` in `prepareProcessedEvents()` for missing active costsheets in `costsheet_usage_tracking.go`.
> 
>   - **Logging**:
>     - Change log level from `Warn` to `Debug` in `prepareProcessedEvents()` in `costsheet_usage_tracking.go` when no active costsheet is found for an event.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ca4423d1ca16f77f0ec2823f6bbd243066299da3. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for cost tracking events when no active costsheet is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->