### PR TITLE
feat(wallet): add buffer of 6 hrs over expiration date for expire credits cron.

### DIFF
--- a/internal/api/cron/wallet.go
+++ b/internal/api/cron/wallet.go
@@ -55,7 +55,7 @@ func (h *WalletCronHandler) ExpireCredits(c *gin.Context) {
 	filter := &types.WalletTransactionFilter{
 		Type:               lo.ToPtr(types.TransactionTypeCredit),
 		TransactionStatus:  lo.ToPtr(types.TransactionStatusCompleted),
-		ExpiryDateBefore:   lo.ToPtr(time.Now().UTC()),
+		ExpiryDateBefore:   lo.ToPtr(time.Now().UTC().Add(6 * time.Hour)),
 		CreditsAvailableGT: lo.ToPtr(decimal.Zero),
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 6-hour buffer to credit expiration in `ExpireCredits()` in `wallet.go`.
> 
>   - **Behavior**:
>     - Adds a 6-hour buffer to the `ExpiryDateBefore` filter in `ExpireCredits()` in `wallet.go`, delaying credit expiration by 6 hours.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for b9175d22e6a63c43797d3b85225a29c5e6167517. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified wallet credit expiration logic to evaluate credits against a 6-hour future timestamp rather than the current time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->