### PR TITLE
feat(analytics): handled case where the req.window_size < feature.window_size

### DIFF
--- a/internal/types/window_size.go
+++ b/internal/types/window_size.go
@@ -68,3 +68,56 @@ func (w WindowSize) Validate() error {
 
 	return nil
 }
+
+// ToMinutes converts a WindowSize to its duration in minutes
+// This is used for comparing window sizes. For MONTH, we use 30 days as approximation.
+func (w WindowSize) ToMinutes() int {
+	switch w {
+	case WindowSizeMinute:
+		return 1
+	case WindowSize15Min:
+		return 15
+	case WindowSize30Min:
+		return 30
+	case WindowSizeHour:
+		return 60
+	case WindowSize3Hour:
+		return 180
+	case WindowSize6Hour:
+		return 360
+	case WindowSize12Hour:
+		return 720
+	case WindowSizeDay:
+		return 1440
+	case WindowSizeWeek:
+		return 10080
+	case WindowSizeMonth:
+		return 43200 // 30 days
+	default:
+		return 0
+	}
+}
+
+// IsLargerThan returns true if the current window size is larger than the other window size
+func (w WindowSize) IsLargerThan(other WindowSize) bool {
+	if w == "" || other == "" {
+		return false
+	}
+	return w.ToMinutes() > other.ToMinutes()
+}
+
+// Max returns the larger of two window sizes
+// If either is empty, returns the non-empty one
+// If both are empty, returns empty
+func (w WindowSize) Max(other WindowSize) WindowSize {
+	if w == "" {
+		return other
+	}
+	if other == "" {
+		return w
+	}
+	if w.ToMinutes() > other.ToMinutes() {
+		return w
+	}
+	return other
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure analytics use the larger of request or bucket window size to maintain proper granularity in `feature_usage.go`.
> 
>   - **Behavior**:
>     - In `feature_usage.go`, `getMaxBucketPointsForGroup` and `getSumBucketPointsForGroup` now use the larger of `params.WindowSize` or `featureInfo.BucketSize` to ensure proper granularity.
>   - **Functions**:
>     - Add `ToMinutes()`, `IsLargerThan()`, and `Max()` to `WindowSize` in `window_size.go` for window size comparison and selection.
>   - **Misc**:
>     - Adjusts window size handling to prevent generating points at a granularity smaller than the bucket size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 74439eb4bd40560bc14596cbab1facaa3d783e88. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-window alignment for bucketed features to prevent granularity finer than the configured bucket size, resulting in more consistent per-group time-series data points.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->