### PR TITLE
feat(email): enhance template loading logic and add email templates to Dockerfile

### DIFF
--- a/Dockerfile.ecs
+++ b/Dockerfile.ecs
@@ -48,6 +48,7 @@ COPY --from=typst /bin/typst /usr/local/bin/
 COPY internal/config ./config
 COPY assets/fonts ./assets/fonts
 COPY assets/typst-templates ./assets/typst-templates
+COPY assets/email-templates ./assets/email-templates
 
 RUN chmod +x /app/server
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances email template loading logic with multiple fallback paths and includes email templates in Docker image.
> 
>   - **Enhancements**:
>     - `readTemplate` in `internal/email/service.go` now checks multiple paths for email templates: Docker path, current working directory, and executable location.
>     - Adds `assets/email-templates` to `Dockerfile.ecs` to include email templates in the Docker image.
>   - **Error Handling**:
>     - Improved error messages in `readTemplate` to specify the file path causing the error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d9de3696ccbcdcf6866a2485ff45d53be0957e74. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email templates are now included in Docker container images.
  * Email template path resolution now checks multiple locations: Docker container paths, local development paths, and executable installation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->