### PR TITLE
refactor(email): simplify template path resolution in readTemplate function

### DIFF
--- a/internal/email/service.go
+++ b/internal/email/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"os"
-	"path/filepath"
 
 	"go.uber.org/zap"
 )
@@ -158,16 +157,7 @@ func (s *Email) SendEmailWithTemplate(ctx context.Context, req SendEmailWithTemp
 
 // readTemplate reads an HTML template from the file system
 func (s *Email) readTemplate(templatePath string) (string, error) {
-	// If the path is relative, resolve it from the assets directory
-	if !filepath.IsAbs(templatePath) {
-		// Get the current working directory
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("failed to get working directory: %w", err)
-		}
-		templatePath = filepath.Join(cwd, "assets", "email-templates", templatePath)
-	}
-
+	templatePath = fmt.Sprintf("./assets/email-templates/%s", templatePath)
 	content, err := os.ReadFile(templatePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read template file: %w", err)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies template path resolution in `readTemplate` function by directly formatting path, ensuring all templates are resolved from `./assets/email-templates/`.
> 
>   - **Behavior**:
>     - Simplifies template path resolution in `readTemplate` function in `service.go` by removing relative path check and directly formatting path.
>     - Ensures all template paths are resolved from `./assets/email-templates/` directory.
>   - **Misc**:
>     - Removes unused `filepath` import from `service.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ae5248785b6b21fff5b3734bb363b2401bfe6553. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved email template path resolution by using a fixed asset path, reducing dependency on working directory configuration and enhancing reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->