### PR TITLE
fix: add Makefile to workflow trigger paths

### DIFF
--- a/.github/workflows/test-go-sdk-generation.yml
+++ b/.github/workflows/test-go-sdk-generation.yml
@@ -9,7 +9,9 @@ on:
       - 'docs/swagger/**'
       - '.speakeasy/**'
       - 'api/custom/go/**'
+      - 'Makefile'
       - '.github/workflows/test-go-sdk-generation.yml'
+      - '.github/workflows/publish-go-sdk.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `Makefile` and `.github/workflows/publish-go-sdk.yml` to workflow trigger paths in `test-go-sdk-generation.yml`.
> 
>   - **Workflow Trigger Paths**:
>     - Add `Makefile` to trigger paths in `.github/workflows/test-go-sdk-generation.yml`.
>     - Add `.github/workflows/publish-go-sdk.yml` to trigger paths in `.github/workflows/test-go-sdk-generation.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for d269bf98e9255a60e827911139dcde51d2050bd4. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->