### PR TITLE
fix: use full path to speakeasy binary

### DIFF
--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -30,13 +30,6 @@ jobs:
       - name: Install Speakeasy CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/main/install.sh | sh
-          echo "$HOME/.speakeasy/bin" >> $GITHUB_PATH
-          
-      - name: Authenticate Speakeasy
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-        run: |
-          echo "Speakeasy will use SPEAKEASY_API_KEY environment variable"
           
       - name: Get version
         id: get_version
@@ -64,9 +57,11 @@ jobs:
           fi
           
       - name: Generate Go SDK with Speakeasy
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
         run: |
           echo "🔨 Generating Go SDK..."
-          speakeasy run --target flexprice-go
+          /usr/local/bin/speakeasy run --target flexprice-go
           echo "✓ Go SDK generated"
           
       - name: Copy custom files to SDK

--- a/.github/workflows/test-go-sdk-generation.yml
+++ b/.github/workflows/test-go-sdk-generation.yml
@@ -31,13 +31,6 @@ jobs:
       - name: Install Speakeasy CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/main/install.sh | sh
-          echo "$HOME/.speakeasy/bin" >> $GITHUB_PATH
-          
-      - name: Authenticate Speakeasy
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-        run: |
-          echo "Speakeasy will use SPEAKEASY_API_KEY environment variable"
           
       - name: Generate Swagger
         run: |
@@ -47,9 +40,11 @@ jobs:
           fi
           
       - name: Generate Go SDK with Speakeasy
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
         run: |
           echo "🔨 Generating Go SDK..."
-          speakeasy run --target flexprice-go
+          /usr/local/bin/speakeasy run --target flexprice-go
           echo "✓ Go SDK generated"
           
       - name: Copy custom files to SDK


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes the path to the Speakeasy binary in GitHub Actions workflows to ensure correct execution.
> 
>   - **Workflows**:
>     - In `.github/workflows/publish-go-sdk.yml` and `.github/workflows/test-go-sdk-generation.yml`, change `speakeasy run` to `/usr/local/bin/speakeasy run` to use the full path to the Speakeasy binary.
>   - **Environment**:
>     - Move `SPEAKEASY_API_KEY` environment variable to the `Generate Go SDK with Speakeasy` step in both workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 25861a999fdb8e537470728162498816e1fd3629. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->