### PR TITLE
fix: Use Speakeasy action properly with mode:direct and move it after…

### DIFF
--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -28,17 +28,13 @@ jobs:
   generate-sdks:
     name: Generate All SDKs
     runs-on: ubuntu-latest
+    # Skip if commit message starts with "ci: regenerated" to prevent loops
+    if: ${{ !startsWith(github.event.head_commit.message, 'ci: regenerated') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.SDK_DEPLOY_GIT_TOKEN }}
-
-      - name: Setup Speakeasy
-        uses: speakeasy-api/sdk-generation-action@v15
-        with:
-          speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-          github_access_token: ${{ secrets.SDK_DEPLOY_GIT_TOKEN }}
 
       - name: Generate Go SDK version
         id: go_version
@@ -86,12 +82,15 @@ jobs:
           
           echo "✅ Updated versions in gen.yaml"
 
-      - name: Generate SDKs
+      - name: Setup Speakeasy and Generate SDKs
+        uses: speakeasy-api/sdk-generation-action@v15
+        with:
+          speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+          github_access_token: ${{ secrets.SDK_DEPLOY_GIT_TOKEN }}
+          mode: direct
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          speakeasy run
 
       - name: Copy custom files to all SDKs
         run: |


### PR DESCRIPTION
… version updates

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reorders Speakeasy setup in GitHub Actions to occur after version updates and adds `mode: direct` for direct execution.
> 
>   - **Workflow Changes**:
>     - Move Speakeasy setup step after version updates in `.github/workflows/publish-sdks.yml`.
>     - Add `mode: direct` to Speakeasy setup to ensure direct execution.
>   - **Behavior**:
>     - Prevents infinite loop by skipping if commit message starts with "ci: regenerated".
>     - Ensures SDK versions are updated before SDK generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for a8b59ea8dcd719baf9992571796c0d961e08278f. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->