### PR TITLE
chore: Bump SDK versions to 2.0.2 to force fresh release

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 go:
-  version: 2.0.1
+  version: 2.0.2
   additionalDependencies: {}
   baseErrorName: FlexPriceError
   clientServerStatusCodesAsErrors: true
@@ -63,7 +63,7 @@ go:
   templateVersion: v2
   unionStrategy: populated-fields
 python:
-  version: 2.0.0
+  version: 2.0.2
   additionalDependencies: {}
   allowedRedefinedBuiltins:
     - id
@@ -110,7 +110,7 @@ python:
   sseFlatResponse: false
   templateVersion: v2
 typescript:
-  version: 2.0.0
+  version: 2.0.2
   acceptHeaderEnum: true
   additionalDependencies: {}
   additionalPackageJSON: {}


### PR DESCRIPTION
All SDKs bumped from 2.0.0/2.0.1 → 2.0.2 to trigger Speakeasy to create PRs and publish even without API changes.

This is needed for initial SDK rollout.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump SDK versions to 2.0.2 in `.speakeasy/gen.yaml` to trigger a fresh release by Speakeasy.
> 
>   - **SDK Version Update**:
>     - Bump Go SDK version from 2.0.1 to 2.0.2 in `.speakeasy/gen.yaml`.
>     - Bump Python SDK version from 2.0.0 to 2.0.2 in `.speakeasy/gen.yaml`.
>     - Bump TypeScript SDK version from 2.0.0 to 2.0.2 in `.speakeasy/gen.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 5db51c20f9fe674c19070c5f1ea19e99e8d4e85b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK generator versions to latest patches for Go, Python, and TypeScript to improve stability and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->