### PR TITLE
chore: 🐝 Update SDK - Generate & Publish SDKs [develop]

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -6,7 +6,7 @@ sources:
         sourceBlobDigest: sha256:bb4b9ed078b71cb6aee4b72c3c6a831899049bd466c6cf9ec321108bacdfc01c
         tags:
             - latest
-            - speakeasy-sdk-regen-develop-1767449149
+            - speakeasy-sdk-regen-develop-1767451153
             - "1.0"
 targets:
     flexprice-go:
@@ -15,21 +15,21 @@ targets:
         sourceRevisionDigest: sha256:038fb757329ecadf37790c1134f995838e703e0bad216cc5a81a99b3ffa8432b
         sourceBlobDigest: sha256:bb4b9ed078b71cb6aee4b72c3c6a831899049bd466c6cf9ec321108bacdfc01c
         codeSamplesNamespace: flexprice-api-go-code-samples
-        codeSamplesRevisionDigest: sha256:54ec9e9200f7cb9faa152d9d7adb954c3b851d9f32fa9c09825c0dda68c0892e
+        codeSamplesRevisionDigest: sha256:6ac68f4883ecf525ea3a90b1387c8478f9523af4e9acd9fee770953520ab9920
     flexprice-python:
         source: flexprice-api
         sourceNamespace: flexprice-api
         sourceRevisionDigest: sha256:038fb757329ecadf37790c1134f995838e703e0bad216cc5a81a99b3ffa8432b
         sourceBlobDigest: sha256:bb4b9ed078b71cb6aee4b72c3c6a831899049bd466c6cf9ec321108bacdfc01c
         codeSamplesNamespace: flexprice-api-python-code-samples
-        codeSamplesRevisionDigest: sha256:d1aafdad817d301bc4892265b86e1cb22fa8781f41eae1793ad33658a2a7cfe0
+        codeSamplesRevisionDigest: sha256:aa3fbe77a9f165f1bc7d101613022f6fa5cf42fb71516f60e7c84eb04747cf61
     flexprice-typescript:
         source: flexprice-api
         sourceNamespace: flexprice-api
         sourceRevisionDigest: sha256:038fb757329ecadf37790c1134f995838e703e0bad216cc5a81a99b3ffa8432b
         sourceBlobDigest: sha256:bb4b9ed078b71cb6aee4b72c3c6a831899049bd466c6cf9ec321108bacdfc01c
         codeSamplesNamespace: flexprice-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:6b0ea825c9c64d7914d8e4ba634558f4bf23ebb7be495129af2f0377074ee205
+        codeSamplesRevisionDigest: sha256:9b222d574591e27428be910f488ef1516a65fff12f433dc1d8057f175aef759f
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,3 +34,15 @@ Based on:
 ### Releases
 - [PyPI v2.0.0] https://pypi.org/project/flexprice-sdk-test/2.0.0 - api/python
 - [NPM v2.0.0] https://www.npmjs.com/package/flexprice-sdk-test/v/2.0.0 - api/javascript
+
+## 2026-01-03 19:36:07
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.680.11 (2.788.15) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [python v2.0.2] api/python
+- [typescript v2.0.2] api/javascript
+### Releases
+- [PyPI v2.0.2] https://pypi.org/project/flexprice-sdk-test/2.0.2 - api/python
+- [NPM v2.0.2] https://www.npmjs.com/package/flexprice-sdk-test/v/2.0.2 - api/javascript

--- a/api/javascript/package-lock.json
+++ b/api/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flexprice-sdk-test",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flexprice-sdk-test",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       },

--- a/api/javascript/package.json
+++ b/api/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flexprice-sdk-test",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "author": "FlexPrice",
   "main": "./index.js",
   "sideEffects": false,

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "flexprice-sdk-test"
-version = "2.0.0"
+version = "2.0.2"
 description = "Python SDK for FlexPrice API"
 authors = [{ name = "Speakeasy" },]
 readme = "README-PYPI.md"


### PR DESCRIPTION
> [!IMPORTANT]
> Linting report available at: <https://app.speakeasy.com/org/flexprice/staging-nyv/linting-report/ea5232dccc4583045003b8599829a7e6>
> OpenAPI Change report available at: <https://app.speakeasy.com/org/flexprice/staging-nyv/changes-report/0c9405248ab2a16ef27215f45ee9c8e9>
# SDK update
<details open>
<summary>OpenAPI Change Summary</summary>
No specification changes
</details>


Based on [Speakeasy CLI](https://github.com/speakeasy-api/speakeasy) 1.680.11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Patch version 2.0.2 is now available for Python packages on PyPI, bringing the latest updates to users
- Patch version 2.0.2 is now available for JavaScript and TypeScript packages on NPM with the latest improvements
- Release documentation and version tracking updated across all platforms to reflect the new 2.0.2 patch release

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->