### PR TITLE
fix: remove registry locations causing workspace mismatch

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -6,8 +6,6 @@ sources:
             - location: ./docs/swagger/swagger-3-0.json
         overlays:
             - location: .speakeasy/overlays.yaml
-        registry:
-            location: registry.speakeasyapi.dev/flexprice/staging-nyv/flexprice-api
 targets:
     flexprice-go:
         target: go
@@ -18,8 +16,6 @@ targets:
                 owner: flexprice
                 repo: go-sdk-temp
         codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/flexprice/staging-nyv/flexprice-api-go-code-samples
             labelOverride:
                 fixedValue: Go (SDK)
             blocking: false
@@ -32,8 +28,6 @@ targets:
                 packageName: flexprice-sdk-test
                 token: $PYPI_TOKEN
         codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/flexprice/staging-nyv/flexprice-api-python-code-samples
             labelOverride:
                 fixedValue: Python (SDK)
             blocking: false
@@ -47,8 +41,6 @@ targets:
                 access: public
                 token: $NPM_TOKEN
         codeSamples:
-            registry:
-                location: registry.speakeasyapi.dev/flexprice/staging-nyv/flexprice-api-typescript-code-samples
             labelOverride:
                 fixedValue: TypeScript (SDK)
             blocking: false


### PR DESCRIPTION
- Remove source registry location that doesn't match authenticated workspace
- Remove codeSamples registry locations causing 500 errors
- This should allow publishing to proceed without registry tagging errors

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove registry locations from `.speakeasy/workflow.yaml` to fix workspace mismatches and 500 errors.
> 
>   - **Behavior**:
>     - Remove registry locations from `.speakeasy/workflow.yaml` that caused workspace mismatches and 500 errors.
>     - Affects `flexprice-go`, `flexprice-python`, and `flexprice-typescript` targets.
>   - **Misc**:
>     - This change should allow publishing to proceed without registry tagging errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 2cff5c51ca29ea147bff1f1a568f0f8497d9bcab. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workflow configuration to remove redundant setup references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->