### PR TITLE
chore: bump SDK versions to 2.0.3 to force initial publish

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 go:
-  version: 2.0.2
+  version: 2.0.3
   additionalDependencies: {}
   baseErrorName: FlexPriceError
   clientServerStatusCodesAsErrors: true
@@ -63,7 +63,7 @@ go:
   templateVersion: v2
   unionStrategy: populated-fields
 python:
-  version: 2.0.2
+  version: 2.0.3
   additionalDependencies: {}
   allowedRedefinedBuiltins:
     - id
@@ -110,7 +110,7 @@ python:
   sseFlatResponse: false
   templateVersion: v2
 typescript:
-  version: 2.0.2
+  version: 2.0.3
   acceptHeaderEnum: true
   additionalDependencies: {}
   additionalPackageJSON: {}


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bumps SDK versions for Go, Python, and TypeScript to 2.0.3 in `.speakeasy/gen.yaml` to force initial publish.
> 
>   - **SDK Version Update**:
>     - Bumps SDK version for `go`, `python`, and `typescript` from `2.0.2` to `2.0.3` in `.speakeasy/gen.yaml` to force initial publish.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 81340be3cb4ddc39f93c85c35d03031feb5b3959. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK generator configuration for Go, Python, and TypeScript languages to the latest version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->