### PR TITLE
fix: always force SDK generation and publishing

### DIFF
--- a/.github/workflows/speakeasy.yml
+++ b/.github/workflows/speakeasy.yml
@@ -37,7 +37,7 @@ jobs:
           github_access_token: ${{ secrets.SDK_DEPLOY_GIT_TOKEN }}
           speakeasy_version: latest
           mode: direct
-          force: ${{ github.event.inputs.force || 'false' }}
+          force: ${{ github.event.inputs.force || 'true' }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Changed force default from 'false' to 'true' to ensure SDKs are always regenerated and published on every push to develop, even without spec changes.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changes `force` default to `true` in `.github/workflows/speakeasy.yml` to always regenerate and publish SDKs on every push to `develop`.
> 
>   - **Behavior**:
>     - Changes `force` default from `'false'` to `'true'` in `.github/workflows/speakeasy.yml` to ensure SDKs are always regenerated and published on every push to `develop`.
>   - **Misc**:
>     - Addresses issue #<issue-number>.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for bbcc3403ed0ddc33dea64fae22993047aa83503b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->