### PR TITLE
deveDevelop

### DIFF
--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -83,8 +83,10 @@ jobs:
         working-directory: api/javascript
         run: |
           echo "📝 Updating version in package.json..."
-          npm version ${{ env.VERSION }} --no-git-tag-version
+          # Use sed to update version directly
+          sed -i "s/\"version\": \".*\"/\"version\": \"${{ env.VERSION }}\"/" package.json
           echo "✓ Version updated to ${{ env.VERSION }}"
+          cat package.json | grep version
 
       - name: Install dependencies and build
         working-directory: api/javascript


### PR DESCRIPTION
Issue: npm version command fails with 'Version not changed' error even when trying to set a different version.

Solution: Use sed to directly update the version field in package.json, same approach as we use for Python's pyproject.toml and Go's gen.yaml.

This ensures version updates work reliably in CI environment.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `npm version` with `sed` in `publish-js-sdk.yml` to update `package.json` version reliably in CI.
> 
>   - **Behavior**:
>     - Replaces `npm version` command with `sed` to update version in `package.json` in `.github/workflows/publish-js-sdk.yml`.
>     - Ensures version updates work reliably in CI environments.
>   - **Misc**:
>     - Adds a `grep` command to verify version update in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 145717125664af433ede77d58302bc0514ff464d. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->