### PR TITLE
fix: skip incompatible CustomerPortal for now

### DIFF
--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -71,40 +71,27 @@ jobs:
           /usr/local/bin/speakeasy run --target flexprice-typescript
           echo "✓ JavaScript SDK generated"
 
-      - name: Ensure CustomerPortal is preserved and exported
+      - name: Remove incompatible custom files
         working-directory: api/javascript
         run: |
-          echo "📋 Setting up custom CustomerPortal..."
+          echo "📋 Cleaning up incompatible custom files..."
           
-          # Make sure .genignore preserves CustomerPortal
-          if ! grep -q "CustomerPortal.ts" .genignore 2>/dev/null; then
-            echo "src/apis/CustomerPortal.ts" >> .genignore
-            echo "✓ Added CustomerPortal to .genignore"
+          # Remove CustomerPortal.ts - it was written for old OpenAPI Generator structure
+          # and is incompatible with new Speakeasy SDK structure
+          # TODO: Rewrite CustomerPortal for Speakeasy SDK structure
+          if [ -f "src/apis/CustomerPortal.ts" ]; then
+            rm -f src/apis/CustomerPortal.ts
+            echo "✓ Removed incompatible CustomerPortal.ts (needs rewrite for Speakeasy)"
           fi
           
-          # Copy CustomerPortal if it doesn't exist
-          if [ ! -f "src/apis/CustomerPortal.ts" ]; then
-            if [ -f "$GITHUB_WORKSPACE/api/custom/javascript/src/apis/CustomerPortal.ts" ]; then
-              mkdir -p src/apis
-              cp "$GITHUB_WORKSPACE/api/custom/javascript/src/apis/CustomerPortal.ts" src/apis/
-              echo "✓ Copied CustomerPortal.ts"
-            fi
-          else
-            echo "✓ CustomerPortal.ts already exists (preserved by .genignore)"
+          # Remove empty apis directory if it exists
+          if [ -d "src/apis" ] && [ -z "$(ls -A src/apis)" ]; then
+            rmdir src/apis
+            echo "✓ Removed empty src/apis directory"
           fi
           
-          # Check current SDK structure
-          echo "📁 Checking SDK structure..."
+          echo "📁 Current SDK structure:"
           ls -la src/ || true
-          
-          # Add export to main SDK file
-          if [ -f "src/sdk/sdk.ts" ]; then
-            if ! grep -q "CustomerPortal" src/sdk/sdk.ts; then
-              echo "" >> src/sdk/sdk.ts
-              echo "export * from '../apis/CustomerPortal.js';" >> src/sdk/sdk.ts
-              echo "✓ Added CustomerPortal export to SDK"
-            fi
-          fi
 
       - name: Update version in package.json
         working-directory: api/javascript

--- a/api/javascript/.genignore
+++ b/api/javascript/.genignore
@@ -1,5 +1,7 @@
 # Preserve custom files during SDK regeneration
 # Note: Removed examples/ to allow Speakeasy to regenerate it properly
 
-# Preserve custom CustomerPortal during SDK regeneration
-src/apis/CustomerPortal.ts
+# NOTE: CustomerPortal.ts is NOT preserved because it was written for 
+# the old OpenAPI Generator structure and is incompatible with Speakeasy.
+# TODO: Rewrite CustomerPortal for Speakeasy SDK structure
+


### PR DESCRIPTION
CustomerPortal.ts was written for old OpenAPI Generator SDK structure and is incompatible with new Speakeasy SDK structure.

TODO: Rewrite CustomerPortal for Speakeasy SDK structure later

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `CustomerPortal.ts` due to incompatibility with new SDK structure and update `.genignore` accordingly.
> 
>   - **Behavior**:
>     - Removes `CustomerPortal.ts` from `api/javascript` in `publish-js-sdk.yml` due to incompatibility with Speakeasy SDK structure.
>     - Deletes empty `src/apis` directory if it exists after removal.
>   - **Configuration**:
>     - Updates `.genignore` to exclude `CustomerPortal.ts` from preservation during SDK regeneration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for da857ded610bf859915b8f1d28d34ed7ba0b8ab1. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->