### PR TITLE
fix: Python SDK packaging - correct README and package name

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -74,9 +74,19 @@ jobs:
         run: |
           echo "📋 Copying custom files..."
           if [ -f "api/custom/python/async_utils.py" ]; then
-            mkdir -p api/python/src/flexprice_test_sdk
-            cp api/custom/python/async_utils.py api/python/src/flexprice_test_sdk/
+            mkdir -p api/python/src/flexprice_sdk_test
+            cp api/custom/python/async_utils.py api/python/src/flexprice_sdk_test/
             echo "✓ Copied async_utils.py"
+          fi
+
+      - name: Fix pyproject.toml README reference
+        working-directory: api/python
+        run: |
+          echo "📝 Fixing README reference in pyproject.toml..."
+          # Speakeasy generates README-PYPI.md reference but the file is README.md
+          if [ ! -f "README-PYPI.md" ] && [ -f "README.md" ]; then
+            sed -i 's/readme = "README-PYPI.md"/readme = "README.md"/' pyproject.toml
+            echo "✓ Fixed README reference to README.md"
           fi
 
       - name: Update version in pyproject.toml

--- a/api/python/.genignore
+++ b/api/python/.genignore
@@ -2,8 +2,5 @@
 src/flexprice/async_utils.py
 examples/
 
-# Preserve pyproject.toml package configuration
-pyproject.toml
-
 
 

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -4,7 +4,7 @@ name = "flexprice-sdk-test"
 version = "2.0.2"
 description = "Python SDK for FlexPrice API"
 authors = [{ name = "Speakeasy" },]
-readme = "README-PYPI.md"
+readme = "README.md"
 requires-python = ">=3.9.2"
 dependencies = [
     "httpcore >=1.0.9",
@@ -15,12 +15,12 @@ dependencies = [
 [tool.poetry]
 repository = "https://github.com/flexprice/flexprice.git"
 packages = [
-    { include = "flexprice_test_sdk", from = "src" }
+    { include = "flexprice_sdk_test", from = "src" }
 ]
-include = ["py.typed", "src/flexprice_test_sdk/py.typed"]
+include = ["py.typed", "src/flexprice_sdk_test/py.typed"]
 
 [tool.setuptools.package-data]
-"*" = ["py.typed", "src/flexprice_test_sdk/py.typed"]
+"*" = ["py.typed", "src/flexprice_sdk_test/py.typed"]
 
 [virtualenvs]
 in-project = true


### PR DESCRIPTION
Issues fixed:
1. README-PYPI.md doesn't exist - changed to README.md
2. Package name was flexprice_test_sdk but Speakeasy generates flexprice_sdk_test
3. Added workflow step to fix README reference after Speakeasy generation
4. Removed pyproject.toml from .genignore (Speakeasy needs to regenerate it)

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Python SDK packaging by correcting README reference and package name, and updating workflow and configuration files accordingly.
> 
>   - **Workflow Changes**:
>     - In `publish-python-sdk.yml`, change package directory from `flexprice_test_sdk` to `flexprice_sdk_test`.
>     - Add step to fix `README` reference in `pyproject.toml` from `README-PYPI.md` to `README.md`.
>   - **Configuration Changes**:
>     - In `pyproject.toml`, update `name` to `flexprice-sdk-test` and `packages` to include `flexprice_sdk_test`.
>     - Update `include` and `package-data` paths to `flexprice_sdk_test`.
>   - **Misc**:
>     - Remove `pyproject.toml` from `.genignore` to allow regeneration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for e29a7e6b2bb343764e975e1c251f81a65a1a31c1. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->