### PR TITLE
fix: ensure Poetry packaging includes source code in pyproject.toml

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -79,15 +79,27 @@ jobs:
             echo "✓ Copied async_utils.py"
           fi
 
-      - name: Fix pyproject.toml README reference
+      - name: Fix pyproject.toml for Poetry packaging
         working-directory: api/python
         run: |
-          echo "📝 Fixing README reference in pyproject.toml..."
-          # Speakeasy generates README-PYPI.md reference but the file is README.md
+          echo "📝 Fixing pyproject.toml for proper packaging..."
+          
+          # Fix README reference
           if [ ! -f "README-PYPI.md" ] && [ -f "README.md" ]; then
             sed -i 's/readme = "README-PYPI.md"/readme = "README.md"/' pyproject.toml
             echo "✓ Fixed README reference to README.md"
           fi
+          
+          # Ensure [tool.poetry] section has repository field
+          if ! grep -q "^\[tool.poetry\]" pyproject.toml; then
+            echo "⚠️ [tool.poetry] section missing!"
+          elif ! grep -A5 "^\[tool.poetry\]" pyproject.toml | grep -q "^repository ="; then
+            # Add repository field after [tool.poetry]
+            sed -i '/^\[tool.poetry\]/a repository = "https://github.com/flexprice/flexprice.git"' pyproject.toml
+            echo "✓ Added repository field to [tool.poetry]"
+          fi
+          
+          echo "✓ pyproject.toml ready for packaging"
 
       - name: Update version in pyproject.toml
         working-directory: api/python


### PR DESCRIPTION
Issue: Speakeasy regenerates pyproject.toml without the repository field in [tool.poetry] section, causing Poetry to not include source files in wheel.

Fix: Added workflow step to inject repository field after Speakeasy generation.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `pyproject.toml` in GitHub Actions workflow to include `repository` field for proper Poetry packaging.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/publish-python-sdk.yml`, added a step to ensure `repository` field is present in `pyproject.toml` under `[tool.poetry]`.
>     - Fixes README reference in `pyproject.toml` from `README-PYPI.md` to `README.md` if necessary.
>   - **Behavior**:
>     - Ensures `pyproject.toml` is correctly configured for Poetry packaging by adding the `repository` field if missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 497f9bbbcc903c4a69fbba29af5761965f17d319. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->