### PR TITLE
fix: use old Poetry format in pyproject.toml for proper packaging

### DIFF
--- a/api/python/.genignore
+++ b/api/python/.genignore
@@ -2,5 +2,8 @@
 src/flexprice/async_utils.py
 examples/
 
+# Preserve pyproject.toml to maintain proper packaging configuration
+pyproject.toml
+
 
 

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -1,29 +1,20 @@
-
-[project]
+[tool.poetry]
 name = "flexprice-sdk-test"
 version = "2.0.2"
 description = "Python SDK for FlexPrice API"
-authors = [{ name = "Speakeasy" },]
+authors = ["Speakeasy"]
 readme = "README.md"
-requires-python = ">=3.9.2"
-dependencies = [
-    "httpcore >=1.0.9",
-    "httpx >=0.28.1",
-    "pydantic >=2.11.2",
-]
-
-[tool.poetry]
 repository = "https://github.com/flexprice/flexprice.git"
 packages = [
     { include = "flexprice_sdk_test", from = "src" }
 ]
 include = ["py.typed", "src/flexprice_sdk_test/py.typed"]
 
-[tool.setuptools.package-data]
-"*" = ["py.typed", "src/flexprice_sdk_test/py.typed"]
-
-[virtualenvs]
-in-project = true
+[tool.poetry.dependencies]
+python = ">=3.9.2"
+httpcore = ">=1.0.9"
+httpx = ">=0.28.1"
+pydantic = ">=2.11.2"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.15.0"
@@ -54,5 +45,3 @@ ignore_missing_imports = true
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
-
-


### PR DESCRIPTION
Issue: poetry-core with [project] table ignores [tool.poetry] packages, causing wheel to be built without source code.

Fix:
- Converted pyproject.toml to old Poetry format (no [project] table)
- Added pyproject.toml to .genignore to preserve it across generations
- Poetry will now properly include src/flexprice_sdk_test/ in wheel

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert `pyproject.toml` to old Poetry format to fix packaging issue and add it to `.genignore` to prevent overwriting.
> 
>   - **Packaging Fix**:
>     - Revert `pyproject.toml` to old Poetry format by removing `[project]` table and using `[tool.poetry]`.
>     - Ensures `src/flexprice_sdk_test/` is included in the wheel package.
>   - **File Preservation**:
>     - Add `pyproject.toml` to `.genignore` to prevent overwriting during SDK regeneration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 18625ced7cc03db2251b60e2e6f305381b4809c1. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->