### PR TITLE
fix: switch Python SDK to setuptools, tested locally and working

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -79,24 +79,15 @@ jobs:
             echo "✓ Copied async_utils.py"
           fi
 
-      - name: Fix pyproject.toml for Poetry packaging
+      - name: Fix pyproject.toml for proper packaging
         working-directory: api/python
         run: |
           echo "📝 Fixing pyproject.toml for proper packaging..."
           
-          # Fix README reference
+          # Fix README reference if needed
           if [ ! -f "README-PYPI.md" ] && [ -f "README.md" ]; then
-            sed -i 's/readme = "README-PYPI.md"/readme = "README.md"/' pyproject.toml
+            sed -i 's/readme = "README-PYPI.md"/readme = "README.md"/' pyproject.toml || true
             echo "✓ Fixed README reference to README.md"
-          fi
-          
-          # Ensure [tool.poetry] section has repository field
-          if ! grep -q "^\[tool.poetry\]" pyproject.toml; then
-            echo "⚠️ [tool.poetry] section missing!"
-          elif ! grep -A5 "^\[tool.poetry\]" pyproject.toml | grep -q "^repository ="; then
-            # Add repository field after [tool.poetry]
-            sed -i '/^\[tool.poetry\]/a repository = "https://github.com/flexprice/flexprice.git"' pyproject.toml
-            echo "✓ Added repository field to [tool.poetry]"
           fi
           
           echo "✓ pyproject.toml ready for packaging"
@@ -108,34 +99,37 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"${{ env.VERSION }}\"/" pyproject.toml
           echo "✓ Version updated to ${{ env.VERSION }}"
 
-      - name: Install Poetry
+      - name: Install build tools
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "📦 Installing build tools..."
+          pip install --upgrade build twine
+          echo "✓ Build tools installed"
 
-      - name: Install dependencies and build
+      - name: Build package
         working-directory: api/python
         run: |
-          echo "🔨 Installing dependencies..."
-          poetry install
-          echo "🏗️ Building package..."
-          poetry build
+          echo "🏗️ Building package with setuptools..."
+          python -m build
           echo "✓ Package built successfully"
 
-      - name: Verify package
+      - name: Verify package contents
         working-directory: api/python
         run: |
-          echo "🧪 Verifying package..."
+          echo "🧪 Verifying package contents..."
           ls -lh dist/
+          echo ""
+          echo "Checking wheel contents:"
+          unzip -l dist/*.whl | head -30 || true
           echo "✓ Package verified"
 
       - name: Publish to PyPI
         working-directory: api/python
         env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           echo "🚀 Publishing to PyPI..."
-          poetry publish
+          python -m twine upload dist/*
           echo "✅ Python SDK v${{ env.VERSION }} published successfully to PyPI!"
           echo "🔗 Package: https://pypi.org/project/flexprice-sdk-test/"
 

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -1,29 +1,29 @@
-[tool.poetry]
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
 name = "flexprice-sdk-test"
 version = "2.0.2"
 description = "Python SDK for FlexPrice API"
-authors = ["Speakeasy"]
 readme = "README.md"
-repository = "https://github.com/flexprice/flexprice.git"
-packages = [
-    { include = "flexprice_sdk_test", from = "src" }
+requires-python = ">=3.9.2"
+authors = [{ name = "Speakeasy" }]
+dependencies = [
+    "httpcore>=1.0.9",
+    "httpx>=0.28.1",
+    "pydantic>=2.11.2",
 ]
-include = ["py.typed", "src/flexprice_sdk_test/py.typed"]
 
-[tool.poetry.dependencies]
-python = ">=3.9.2"
-httpcore = ">=1.0.9"
-httpx = ">=0.28.1"
-pydantic = ">=2.11.2"
+[project.urls]
+Repository = "https://github.com/flexprice/flexprice"
+Homepage = "https://github.com/flexprice/flexprice"
 
-[tool.poetry.group.dev.dependencies]
-mypy = "==1.15.0"
-pylint = "==3.2.3"
-pyright = "==1.1.398"
+[tool.setuptools]
+packages = { find = { where = ["src"] } }
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch Python SDK packaging from Poetry to setuptools, updating GitHub Actions workflow and `pyproject.toml`.
> 
>   - **Build System**:
>     - Switch from Poetry to setuptools in `pyproject.toml`.
>     - Update `pyproject.toml` to use `setuptools.build_meta` as the build backend.
>     - Add `setuptools` and `wheel` to `requires` in `pyproject.toml`.
>   - **GitHub Actions Workflow**:
>     - Replace Poetry with `setuptools` and `twine` in `publish-python-sdk.yml`.
>     - Update steps to install build tools using `pip` and build package with `python -m build`.
>     - Change package publishing to use `twine upload` instead of `poetry publish`.
>   - **Misc**:
>     - Remove Poetry-specific fields from `pyproject.toml` and add `setuptools` configurations.
>     - Ensure README reference is corrected in `pyproject.toml` if needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 579458a039a46c6a21f8b903da35e79463a06536. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->