### PR TITLE
fix: ensure speakeasy bump runs in correct directory

### DIFF
--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -39,21 +39,29 @@ jobs:
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
         run: |
+          # Ensure we're in the repo root where .speakeasy/ exists
+          cd $GITHUB_WORKSPACE
+          
+          # Debug: Show current directory and files
+          echo "📂 Current directory: $(pwd)"
+          echo "📋 Checking for .speakeasy files:"
+          ls -la .speakeasy/ || echo "⚠️  .speakeasy directory not found!"
+          
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             # Manual version override
             VERSION="${{ github.event.inputs.version }}"
             echo "🎯 Using manual version: $VERSION"
-            /usr/local/bin/speakeasy bump -t flexprice-go -v "$VERSION"
+            speakeasy bump -t flexprice-go -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
             # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
             echo "🎯 Using release version: $VERSION"
-            /usr/local/bin/speakeasy bump -t flexprice-go -v "$VERSION"
+            speakeasy bump -t flexprice-go -v "$VERSION"
           else
             # Auto-bump patch version
             echo "🔼 Auto-bumping patch version..."
-            /usr/local/bin/speakeasy bump patch -t flexprice-go
+            speakeasy bump patch -t flexprice-go
           fi
           
           # Read the bumped version from gen.yaml

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -40,21 +40,29 @@ jobs:
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
         run: |
+          # Ensure we're in the repo root where .speakeasy/ exists
+          cd $GITHUB_WORKSPACE
+          
+          # Debug: Show current directory and files
+          echo "📂 Current directory: $(pwd)"
+          echo "📋 Checking for .speakeasy files:"
+          ls -la .speakeasy/ || echo "⚠️  .speakeasy directory not found!"
+          
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             # Manual version override
             VERSION="${{ github.event.inputs.version }}"
             echo "🎯 Using manual version: $VERSION"
-            /usr/local/bin/speakeasy bump -t flexprice-typescript -v "$VERSION"
+            speakeasy bump -t flexprice-typescript -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
             # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
             echo "🎯 Using release version: $VERSION"
-            /usr/local/bin/speakeasy bump -t flexprice-typescript -v "$VERSION"
+            speakeasy bump -t flexprice-typescript -v "$VERSION"
           else
             # Auto-bump patch version
             echo "🔼 Auto-bumping patch version..."
-            /usr/local/bin/speakeasy bump patch -t flexprice-typescript
+            speakeasy bump patch -t flexprice-typescript
           fi
           
           # Read the bumped version from gen.yaml

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -39,21 +39,29 @@ jobs:
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
         run: |
+          # Ensure we're in the repo root where .speakeasy/ exists
+          cd $GITHUB_WORKSPACE
+          
+          # Debug: Show current directory and files
+          echo "📂 Current directory: $(pwd)"
+          echo "📋 Checking for .speakeasy files:"
+          ls -la .speakeasy/ || echo "⚠️  .speakeasy directory not found!"
+          
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             # Manual version override
             VERSION="${{ github.event.inputs.version }}"
             echo "🎯 Using manual version: $VERSION"
-            /usr/local/bin/speakeasy bump -t flexprice-python -v "$VERSION"
+            speakeasy bump -t flexprice-python -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
             # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
             echo "🎯 Using release version: $VERSION"
-            /usr/local/bin/speakeasy bump -t flexprice-python -v "$VERSION"
+            speakeasy bump -t flexprice-python -v "$VERSION"
           else
             # Auto-bump patch version
             echo "🔼 Auto-bumping patch version..."
-            /usr/local/bin/speakeasy bump patch -t flexprice-python
+            speakeasy bump patch -t flexprice-python
           fi
           
           # Read the bumped version from gen.yaml


### PR DESCRIPTION
Added explicit cd to GITHUB_WORKSPACE and debug output to help diagnose path issues. Also removed /usr/local/bin prefix to use speakeasy from PATH.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `speakeasy` CLI runs in the correct directory and uses PATH in GitHub Actions workflows for Go, JavaScript, and Python SDKs.
> 
>   - **Behavior**:
>     - Adds `cd $GITHUB_WORKSPACE` to ensure the correct directory context in `publish-go-sdk.yml`, `publish-js-sdk.yml`, and `publish-python-sdk.yml`.
>     - Removes `/usr/local/bin` prefix from `speakeasy` CLI calls to use the PATH variable in the same files.
>   - **Debugging**:
>     - Adds debug output to show the current directory and check for `.speakeasy` files in all three workflow files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for bab655e7f1034d99e3fe95c0710779b4262ada13. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->