### PR TITLE
fix: use correct target names for speakeasy bump

### DIFF
--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -51,17 +51,17 @@ jobs:
             # Manual version override
             VERSION="${{ github.event.inputs.version }}"
             echo "🎯 Using manual version: $VERSION"
-            speakeasy bump -t flexprice-go -v "$VERSION"
+            speakeasy bump -t go -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
             # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
             echo "🎯 Using release version: $VERSION"
-            speakeasy bump -t flexprice-go -v "$VERSION"
+            speakeasy bump -t go -v "$VERSION"
           else
             # Auto-bump patch version
             echo "🔼 Auto-bumping patch version..."
-            speakeasy bump patch -t flexprice-go
+            speakeasy bump patch -t go
           fi
           
           # Read the bumped version from gen.yaml

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -52,17 +52,17 @@ jobs:
             # Manual version override
             VERSION="${{ github.event.inputs.version }}"
             echo "🎯 Using manual version: $VERSION"
-            speakeasy bump -t flexprice-typescript -v "$VERSION"
+            speakeasy bump -t typescript -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
             # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
             echo "🎯 Using release version: $VERSION"
-            speakeasy bump -t flexprice-typescript -v "$VERSION"
+            speakeasy bump -t typescript -v "$VERSION"
           else
             # Auto-bump patch version
             echo "🔼 Auto-bumping patch version..."
-            speakeasy bump patch -t flexprice-typescript
+            speakeasy bump patch -t typescript
           fi
           
           # Read the bumped version from gen.yaml

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -51,17 +51,17 @@ jobs:
             # Manual version override
             VERSION="${{ github.event.inputs.version }}"
             echo "🎯 Using manual version: $VERSION"
-            speakeasy bump -t flexprice-python -v "$VERSION"
+            speakeasy bump -t python -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
             # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
             echo "🎯 Using release version: $VERSION"
-            speakeasy bump -t flexprice-python -v "$VERSION"
+            speakeasy bump -t python -v "$VERSION"
           else
             # Auto-bump patch version
             echo "🔼 Auto-bumping patch version..."
-            speakeasy bump patch -t flexprice-python
+            speakeasy bump patch -t python
           fi
           
           # Read the bumped version from gen.yaml


### PR DESCRIPTION
Changed from workflow target names (flexprice-go, flexprice-python, flexprice-typescript) to language target names (go, python, typescript) as required by speakeasy bump command.

The -t flag expects the language identifier from gen.yaml, not the workflow target name.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `speakeasy bump` target names in GitHub Actions workflows to use language identifiers from `gen.yaml`.
> 
>   - **Workflows**:
>     - In `publish-go-sdk.yml`, change `speakeasy bump -t flexprice-go` to `speakeasy bump -t go`.
>     - In `publish-js-sdk.yml`, change `speakeasy bump -t flexprice-typescript` to `speakeasy bump -t typescript`.
>     - In `publish-python-sdk.yml`, change `speakeasy bump -t flexprice-python` to `speakeasy bump -t python`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 51ee126f0460836b909977449107e1abca4d9a57. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->