### PR TITLE
revert: back to manual registry-based versioning

### DIFF
--- a/.github/workflows/publish-go-sdk.yml
+++ b/.github/workflows/publish-go-sdk.yml
@@ -34,41 +34,52 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/main/install.sh | sh
           
-      - name: Bump version with Speakeasy
-        id: bump_version
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+      - name: Get version
+        id: get_version
         run: |
-          # Ensure we're in the repo root where .speakeasy/ exists
-          cd $GITHUB_WORKSPACE
-          
-          # Debug: Show current directory and files
-          echo "📂 Current directory: $(pwd)"
-          echo "📋 Checking for .speakeasy files:"
-          ls -la .speakeasy/ || echo "⚠️  .speakeasy directory not found!"
-          
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Manual version override
             VERSION="${{ github.event.inputs.version }}"
-            echo "🎯 Using manual version: $VERSION"
-            speakeasy bump -t go -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
-            # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
-            echo "🎯 Using release version: $VERSION"
-            speakeasy bump -t go -v "$VERSION"
           else
-            # Auto-bump patch version
-            echo "🔼 Auto-bumping patch version..."
-            speakeasy bump patch -t go
+            # Fetch latest version from GitHub releases and increment patch version
+            echo "📡 Fetching latest version from GitHub..."
+            LATEST_TAG=$(git ls-remote --tags --refs --sort="v:refname" https://github.com/flexprice/go-sdk-temp.git | tail -n1 | sed 's/.*\///' | sed 's/^v//')
+            
+            if [ -z "$LATEST_TAG" ]; then
+              # No tags found, start with 2.0.0
+              VERSION="2.0.0"
+              echo "⚠️  No previous tags found, starting with $VERSION"
+            else
+              echo "Latest version: $LATEST_TAG"
+              # Extract major, minor, patch
+              MAJOR=$(echo $LATEST_TAG | cut -d. -f1)
+              MINOR=$(echo $LATEST_TAG | cut -d. -f2)
+              PATCH=$(echo $LATEST_TAG | cut -d. -f3)
+              
+              # Check if PATCH is a valid number (not timestamp)
+              if [[ "$PATCH" =~ ^[0-9]{1,3}$ ]]; then
+                # Valid patch number (1-3 digits), increment it
+                NEW_PATCH=$((PATCH + 1))
+                VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+                echo "🔼 Incrementing patch version: $LATEST_TAG → $VERSION"
+              else
+                # Patch is timestamp or invalid, reset to 2.0.0
+                VERSION="2.0.0"
+                echo "⚠️  Previous version uses timestamp format ($LATEST_TAG), resetting to $VERSION"
+              fi
+            fi
           fi
-          
-          # Read the bumped version from gen.yaml
-          VERSION=$(grep -A 50 '^go:' .speakeasy/gen.yaml | grep -m 1 'version:' | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "📦 Publishing Go SDK version: ${VERSION}"
+          
+      - name: Update version in gen.yaml
+        run: |
+          # Update Go SDK version in gen.yaml
+          sed -i '/^go:/,/^[a-z]/ { /^  version:/ s/version: .*/version: ${{ env.VERSION }}/; }' .speakeasy/gen.yaml
+          echo "✓ Updated Go SDK version to ${{ env.VERSION }}"
           
       - name: Generate Swagger
         run: |

--- a/.github/workflows/publish-js-sdk.yml
+++ b/.github/workflows/publish-js-sdk.yml
@@ -35,41 +35,51 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/main/install.sh | sh
 
-      - name: Bump version with Speakeasy
-        id: bump_version
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+      - name: Get version
+        id: get_version
         run: |
-          # Ensure we're in the repo root where .speakeasy/ exists
-          cd $GITHUB_WORKSPACE
-          
-          # Debug: Show current directory and files
-          echo "📂 Current directory: $(pwd)"
-          echo "📋 Checking for .speakeasy files:"
-          ls -la .speakeasy/ || echo "⚠️  .speakeasy directory not found!"
-          
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Manual version override
             VERSION="${{ github.event.inputs.version }}"
-            echo "🎯 Using manual version: $VERSION"
-            speakeasy bump -t typescript -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
-            # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
-            echo "🎯 Using release version: $VERSION"
-            speakeasy bump -t typescript -v "$VERSION"
           else
-            # Auto-bump patch version
-            echo "🔼 Auto-bumping patch version..."
-            speakeasy bump patch -t typescript
+            # Fetch latest version from npm and increment patch version
+            echo "📡 Fetching latest version from npm..."
+            LATEST_VERSION=$(npm view flexprice-sdk-test version 2>/dev/null || echo "")
+            
+            if [ -z "$LATEST_VERSION" ]; then
+              # No version found on npm, start with 2.0.0
+              VERSION="2.0.0"
+              echo "⚠️  No previous version found on npm, starting with $VERSION"
+            else
+              echo "Latest version: $LATEST_VERSION"
+              # Extract major, minor, patch
+              MAJOR=$(echo $LATEST_VERSION | cut -d. -f1)
+              MINOR=$(echo $LATEST_VERSION | cut -d. -f2)
+              PATCH=$(echo $LATEST_VERSION | cut -d. -f3)
+              
+              # Check if PATCH is a valid number (not timestamp)
+              if [[ "$PATCH" =~ ^[0-9]{1,3}$ ]]; then
+                # Valid patch number (1-3 digits), increment it
+                NEW_PATCH=$((PATCH + 1))
+                VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+                echo "🔼 Incrementing patch version: $LATEST_VERSION → $VERSION"
+              else
+                # Patch is timestamp or invalid, reset to 2.0.0
+                VERSION="2.0.0"
+                echo "⚠️  Previous version uses timestamp format ($LATEST_VERSION), resetting to $VERSION"
+              fi
+            fi
           fi
-          
-          # Read the bumped version from gen.yaml
-          VERSION=$(grep -A 50 '^typescript:' .speakeasy/gen.yaml | grep -m 1 'version:' | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "📦 Publishing JavaScript SDK version: ${VERSION}"
+
+      - name: Update version in gen.yaml
+        run: |
+          sed -i '/^typescript:/,/^[a-z]/ { /^  version:/ s/version: .*/version: ${{ env.VERSION }}/; }' .speakeasy/gen.yaml
+          echo "✓ Updated TypeScript SDK version to ${{ env.VERSION }}"
 
       - name: Generate Swagger
         run: |

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -34,41 +34,51 @@ jobs:
         run: |
           curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/main/install.sh | sh
 
-      - name: Bump version with Speakeasy
-        id: bump_version
-        env:
-          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+      - name: Get version
+        id: get_version
         run: |
-          # Ensure we're in the repo root where .speakeasy/ exists
-          cd $GITHUB_WORKSPACE
-          
-          # Debug: Show current directory and files
-          echo "📂 Current directory: $(pwd)"
-          echo "📋 Checking for .speakeasy files:"
-          ls -la .speakeasy/ || echo "⚠️  .speakeasy directory not found!"
-          
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            # Manual version override
             VERSION="${{ github.event.inputs.version }}"
-            echo "🎯 Using manual version: $VERSION"
-            speakeasy bump -t python -v "$VERSION"
           elif [ "${{ github.event_name }}" == "release" ]; then
-            # Use release tag version
             VERSION="${{ github.event.release.tag_name }}"
             VERSION="${VERSION#v}"
-            echo "🎯 Using release version: $VERSION"
-            speakeasy bump -t python -v "$VERSION"
           else
-            # Auto-bump patch version
-            echo "🔼 Auto-bumping patch version..."
-            speakeasy bump patch -t python
+            # Fetch latest version from PyPI and increment patch version
+            echo "📡 Fetching latest version from PyPI..."
+            LATEST_VERSION=$(curl -s https://pypi.org/pypi/flexprice-sdk-test/json | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4 || echo "")
+            
+            if [ -z "$LATEST_VERSION" ]; then
+              # No version found on PyPI, start with 2.0.0
+              VERSION="2.0.0"
+              echo "⚠️  No previous version found on PyPI, starting with $VERSION"
+            else
+              echo "Latest version: $LATEST_VERSION"
+              # Extract major, minor, patch
+              MAJOR=$(echo $LATEST_VERSION | cut -d. -f1)
+              MINOR=$(echo $LATEST_VERSION | cut -d. -f2)
+              PATCH=$(echo $LATEST_VERSION | cut -d. -f3)
+              
+              # Check if PATCH is a valid number (not timestamp)
+              if [[ "$PATCH" =~ ^[0-9]{1,3}$ ]]; then
+                # Valid patch number (1-3 digits), increment it
+                NEW_PATCH=$((PATCH + 1))
+                VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
+                echo "🔼 Incrementing patch version: $LATEST_VERSION → $VERSION"
+              else
+                # Patch is timestamp or invalid, reset to 2.0.0
+                VERSION="2.0.0"
+                echo "⚠️  Previous version uses timestamp format ($LATEST_VERSION), resetting to $VERSION"
+              fi
+            fi
           fi
-          
-          # Read the bumped version from gen.yaml
-          VERSION=$(grep -A 50 '^python:' .speakeasy/gen.yaml | grep -m 1 'version:' | awk '{print $2}')
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
           echo "📦 Publishing Python SDK version: ${VERSION}"
+
+      - name: Update version in gen.yaml
+        run: |
+          sed -i '/^python:/,/^[a-z]/ { /^  version:/ s/version: .*/version: ${{ env.VERSION }}/; }' .speakeasy/gen.yaml
+          echo "✓ Updated Python SDK version to ${{ env.VERSION }}"
 
       - name: Generate Swagger
         run: |


### PR DESCRIPTION
Reverted Speakeasy bump command approach due to TTY issues in CI. Restored original logic that:
- Fetches latest version from PyPI/npm/GitHub
- Handles timestamp → semver transition (2.0.YYYYMMDDHHMMSS → 2.0.0)
- Increments patch version for valid semver (2.0.4 → 2.0.5)
- Uses curl for PyPI instead of pip index (more reliable)

Tested locally and confirmed working.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts to manual registry-based versioning for Go, JavaScript, and Python SDKs due to CI issues with Speakeasy CLI.
> 
>   - **Behavior**:
>     - Reverts version bumping from Speakeasy CLI to manual registry-based approach in `publish-go-sdk.yml`, `publish-js-sdk.yml`, and `publish-python-sdk.yml`.
>     - Fetches latest version from GitHub for Go, npm for JavaScript, and PyPI for Python.
>     - Handles transition from timestamp to semver and increments patch version if valid.
>   - **Workflows**:
>     - Updates `publish-go-sdk.yml` to fetch and increment version from GitHub.
>     - Updates `publish-js-sdk.yml` to fetch and increment version from npm.
>     - Updates `publish-python-sdk.yml` to fetch and increment version from PyPI.
>   - **Misc**:
>     - Uses `curl` for PyPI version fetching instead of `pip index` for reliability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 172ff4dd0f516e180e89914fdb56656a34b5428c. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->