### PR TITLE
chore: update SDK versioning to 1.0.48 and refactor package names for…

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 go:
-  version: 2.0.3
+  version: 1.0.48
   additionalDependencies: {}
   baseErrorName: FlexPriceError
   clientServerStatusCodesAsErrors: true
@@ -63,7 +63,7 @@ go:
   templateVersion: v2
   unionStrategy: populated-fields
 python:
-  version: 2.0.3
+  version: 1.0.48
   additionalDependencies: {}
   allowedRedefinedBuiltins:
     - id
@@ -110,7 +110,7 @@ python:
   sseFlatResponse: false
   templateVersion: v2
 typescript:
-  version: 2.0.3
+  version: 1.0.48
   acceptHeaderEnum: true
   additionalDependencies: {}
   additionalPackageJSON: {}

--- a/api/custom/go/async.go
+++ b/api/custom/go/async.go
@@ -14,7 +14,7 @@ and can be ignored. The file will compile correctly when copied to the SDK.
 */
 
 // nolint
-package v2
+package gosdktemp
 
 import (
 	"context"
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/flexprice/go-sdk-temp/v2/models/components"
+	"github.com/flexprice/go-sdk-temp/models/components"
 )
 
 // Note: This file is meant to be included in the FlexPrice Go SDK

--- a/api/custom/go/helpers.go
+++ b/api/custom/go/helpers.go
@@ -1,4 +1,4 @@
-package v2
+package gosdktemp
 
 import (
 	"fmt"


### PR DESCRIPTION
… Go SDK

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update SDK version to 1.0.48 and refactor package names from `v2` to `gosdktemp` in Go SDK files.
> 
>   - **SDK Versioning**:
>     - Update SDK version to `1.0.48` in `.speakeasy/gen.yaml` for Go, Python, and TypeScript.
>   - **Package Refactoring**:
>     - Change package name from `v2` to `gosdktemp` in `api/custom/go/async.go` and `api/custom/go/helpers.go`.
>     - Update import path in `api/custom/go/async.go` from `github.com/flexprice/go-sdk-temp/v2/models/components` to `github.com/flexprice/go-sdk-temp/models/components`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for e824cf88fa5c4aff8f43acca217c0314c7544cb7. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK versions for Go, Python, and TypeScript.
  * Restructured internal SDK package organization for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->