### PR TITLE
fix(scheduled_task): increase workflow timeout

### DIFF
--- a/internal/service/scheduled_task.go
+++ b/internal/service/scheduled_task.go
@@ -396,9 +396,9 @@ func (s *scheduledTaskService) startScheduledTask(ctx context.Context, task *sch
 			},
 		},
 		TaskQueue:                string(types.TemporalTaskQueueExport),
-		WorkflowExecutionTimeout: 15 * time.Minute,
-		WorkflowRunTimeout:       15 * time.Minute,
-		WorkflowTaskTimeout:      15 * time.Minute,
+		WorkflowExecutionTimeout: 60 * time.Minute,
+		WorkflowRunTimeout:       60 * time.Minute,
+		WorkflowTaskTimeout:      60 * time.Minute,
 	}
 
 	scheduleOptions := models.CreateScheduleOptions{
@@ -572,9 +572,9 @@ func (s *scheduledTaskService) triggerForceRun(ctx context.Context, taskID strin
 	workflowOptions := models.StartWorkflowOptions{
 		ID:                       workflowID,
 		TaskQueue:                string(types.TemporalTaskQueueExport),
-		WorkflowExecutionTimeout: 15 * time.Minute, // 15 minutes for export tasks
-		WorkflowRunTimeout:       15 * time.Minute, // 15 minutes for single workflow run
-		WorkflowTaskTimeout:      15 * time.Minute, // 15 minute for workflow task processing
+		WorkflowExecutionTimeout: 60 * time.Minute, // 60 minutes for export tasks
+		WorkflowRunTimeout:       60 * time.Minute, // 60 minutes for single workflow run
+		WorkflowTaskTimeout:      60 * time.Minute, // 60 minutes for workflow task processing
 	}
 
 	input := exportWorkflows.ExecuteExportWorkflowInput{


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase workflow timeouts from 15 to 60 minutes in `scheduled_task.go` for scheduled tasks and force run exports.
> 
>   - **Timeout Increase**:
>     - In `scheduled_task.go`, increase `WorkflowExecutionTimeout`, `WorkflowRunTimeout`, and `WorkflowTaskTimeout` from 15 to 60 minutes in `startScheduledTask()` and `triggerForceRun()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for fcf6210719d3d5b9bbebf44e399067e550a5bf06. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for scheduled task execution and manual force execution operations from 15 to 60 minutes, providing more time for longer-running workflows to complete without premature failure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->