### PR TITLE
feat(temporal): increased the start to close timeout of price-sync workflow

### DIFF
--- a/internal/temporal/workflows/price_sync_workflow.go
+++ b/internal/temporal/workflows/price_sync_workflow.go
@@ -33,7 +33,7 @@ func PriceSyncWorkflow(ctx workflow.Context, in models.PriceSyncWorkflowInput) (
 	}
 
 	ao := workflow.ActivityOptions{
-		StartToCloseTimeout: time.Minute * 30,
+		StartToCloseTimeout: time.Hour * 1,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:    time.Second,
 			BackoffCoefficient: 2.0,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increased `StartToCloseTimeout` for `PriceSyncWorkflow` to 1 hour in `price_sync_workflow.go`.
> 
>   - **Behavior**:
>     - Increased `StartToCloseTimeout` from 30 minutes to 1 hour in `PriceSyncWorkflow` in `price_sync_workflow.go`.
>     - Affects the `SyncPlanPrices` activity execution time limit.
>   - **Misc**:
>     - No other changes or additions in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for ad9080b7ef10ca15456c6ab63dc5fafa49e1af69. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Increased timeout duration for price synchronization operations to improve reliability and reduce failures during extended sync processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->