### PR TITLE
hotfix(wallet): credit amount becomes credits available

### DIFF
--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -1562,7 +1562,7 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 	// Set transaction-specific fields based on transaction type
 	if req.Type == types.TransactionTypeCredit {
 		tx.TopupConversionRate = lo.ToPtr(w.TopupConversionRate)
-		tx.CreditsAvailable = decimal.Max(decimal.Zero, tx.CreditBalanceAfter)
+		tx.CreditsAvailable = decimal.Max(decimal.Zero, tx.CreditAmount)
 		if req.ExpiryDate != nil {
 			tx.ExpiryDate = types.ParseYYYYMMDDToDate(req.ExpiryDate)
 		}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `CreditsAvailable` calculation in `processWalletOperation()` in `wallet.go` to use `CreditAmount` instead of `CreditBalanceAfter` for credit transactions.
> 
>   - **Behavior**:
>     - Fixes `CreditsAvailable` calculation in `processWalletOperation()` in `wallet.go` to use `CreditAmount` instead of `CreditBalanceAfter` for credit transactions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 27feba3e2e11fc153d7e8cca531c6329df2e6ecc. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calculation of available credits following credit transactions to ensure accurate balance reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->