### PR TITLE
feat(sentry): remove span from repo layer of db and clickhouse

### DIFF
--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -90,6 +90,7 @@ func (s *Service) CaptureException(err error) {
 
 // AddBreadcrumb adds a breadcrumb to the current scope
 func (s *Service) AddBreadcrumb(category, message string, data map[string]interface{}) {
+	return
 	if !s.IsEnabled() {
 		return
 	}
@@ -111,6 +112,8 @@ func (s *Service) Flush(timeout uint) bool {
 
 // StartDBSpan starts a new database span in the current transaction
 func (s *Service) StartDBSpan(ctx context.Context, operation string, params map[string]interface{}) (*sentry.Span, context.Context) {
+	return nil, ctx
+
 	if !s.IsEnabled() {
 		return nil, ctx
 	}
@@ -130,6 +133,7 @@ func (s *Service) StartDBSpan(ctx context.Context, operation string, params map[
 
 // StartClickHouseSpan starts a new ClickHouse span in the current transaction
 func (s *Service) StartClickHouseSpan(ctx context.Context, operation string, params map[string]interface{}) (*sentry.Span, context.Context) {
+	return nil, ctx
 	if !s.cfg.Sentry.Enabled {
 		return nil, ctx
 	}
@@ -205,6 +209,8 @@ func (s *Service) MonitorEventProcessing(ctx context.Context, eventName string, 
 
 // StartTransaction creates a new transaction or returns an existing one from context
 func (s *Service) StartTransaction(ctx context.Context, name string, options ...sentry.SpanOption) (*sentry.Span, context.Context) {
+	return nil, ctx
+
 	if !s.cfg.Sentry.Enabled {
 		return nil, ctx
 	}
@@ -238,6 +244,8 @@ func (f *SpanFinisher) Finish() {
 
 // StartRepositorySpan creates a span for a repository operation
 func (s *Service) StartRepositorySpan(ctx context.Context, repository, operation string, params map[string]interface{}) (*sentry.Span, context.Context) {
+	return nil, ctx
+
 	if !s.cfg.Sentry.Enabled {
 		return nil, ctx
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable span creation in repository layer for DB and ClickHouse in `sentry.go`.
> 
>   - **Behavior**:
>     - `StartDBSpan`, `StartClickHouseSpan`, `StartTransaction`, and `StartRepositorySpan` in `sentry.go` now immediately return `nil` and `ctx`, disabling span creation.
>   - **Functions**:
>     - `AddBreadcrumb` in `sentry.go` now immediately returns, effectively disabling breadcrumb addition.
>   - **Misc**:
>     - No changes to configuration or external dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6ada34d2a4bc7f2e650feba84a0f09cfa9c9a968. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled Sentry breadcrumb and span recording. Methods for database operations, ClickHouse queries, transactions, and repository operations now return early without performing their intended operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->