### PR TITLE
Revert "feat(feature): add support for not contains filter with dsl approach"

### DIFF
--- a/internal/dsl/dsl.go
+++ b/internal/dsl/dsl.go
@@ -161,10 +161,6 @@ func predicateFromFilter(f *types.FilterCondition, fi string) Predicate {
 		if v := valueString(f); v != nil {
 			return func(sel *sql.Selector) { sel.Where(sql.ContainsFold(fi, *v)) }
 		}
-	case types.NOT_CONTAINS:
-		if v := valueString(f); v != nil {
-			return func(sel *sql.Selector) { sel.Where(sql.Not(sql.ContainsFold(fi, *v))) }
-		}
 	case types.GREATER_THAN:
 		if num := valueNumber(f); num != nil {
 			return func(sel *sql.Selector) { sel.Where(sql.GT(fi, *num)) }

--- a/internal/repository/ent/feature.go
+++ b/internal/repository/ent/feature.go
@@ -456,6 +456,10 @@ func (o FeatureQueryOptions) applyEntityQueryOptions(ctx context.Context, f *typ
 		query = query.Where(feature.LookupKeyIn(f.LookupKeys...))
 	}
 
+	if f.NameContains != "" {
+		query = query.Where(feature.NameContainsFold(f.NameContains))
+	}
+
 	// Apply time range filters if specified
 	if f.TimeRangeFilter != nil {
 		if f.StartTime != nil {

--- a/internal/testutil/inmemory_feature_store.go
+++ b/internal/testutil/inmemory_feature_store.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"strings"
 
 	"github.com/flexprice/flexprice/internal/domain/feature"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -61,6 +62,13 @@ func featureFilterFn(ctx context.Context, f *feature.Feature, filter interface{}
 	// Filter by lookup key
 	if filter_.LookupKey != "" {
 		if f.LookupKey != filter_.LookupKey {
+			return false
+		}
+	}
+
+	// Filter by name contains
+	if filter_.NameContains != "" {
+		if !strings.Contains(strings.ToLower(f.Name), strings.ToLower(filter_.NameContains)) {
 			return false
 		}
 	}
@@ -236,6 +244,7 @@ func (s *InMemoryFeatureStore) ListAll(ctx context.Context, filter *types.Featur
 		TimeRangeFilter: filter.TimeRangeFilter,
 		FeatureIDs:      filter.FeatureIDs,
 		LookupKey:       filter.LookupKey,
+		NameContains:    filter.NameContains,
 	}
 
 	return s.List(ctx, unlimitedFilter)

--- a/internal/types/feature.go
+++ b/internal/types/feature.go
@@ -52,10 +52,11 @@ type FeatureFilter struct {
 	Sort    []*SortCondition   `json:"sort,omitempty" form:"sort" validate:"omitempty"`
 
 	// Feature specific filters
-	FeatureIDs []string `form:"feature_ids" json:"feature_ids"`
-	MeterIDs   []string `form:"meter_ids" json:"meter_ids"`
-	LookupKey  string   `form:"lookup_key" json:"lookup_key"`
-	LookupKeys []string `form:"lookup_keys" json:"lookup_keys"`
+	FeatureIDs   []string `form:"feature_ids" json:"feature_ids"`
+	MeterIDs     []string `form:"meter_ids" json:"meter_ids"`
+	LookupKey    string   `form:"lookup_key" json:"lookup_key"`
+	LookupKeys   []string `form:"lookup_keys" json:"lookup_keys"`
+	NameContains string   `form:"name_contains" json:"name_contains"`
 }
 
 func NewDefaultFeatureFilter() *FeatureFilter {

--- a/internal/types/search_filter.go
+++ b/internal/types/search_filter.go
@@ -33,9 +33,9 @@ const (
 	EQUAL FilterOperatorType = "eq"
 
 	// string
-	CONTAINS     FilterOperatorType = "contains"
-	NOT_CONTAINS FilterOperatorType = "not_contains"
+	CONTAINS FilterOperatorType = "contains"
 	// TODO: add these operators
+	// NOT_CONTAINS FilterOperatorType = "NOT_CONTAINS"
 	// STARTS_WITH  FilterOperatorType = "STARTS_WITH"
 	// ENDS_WITH    FilterOperatorType = "ENDS_WITH"
 


### PR DESCRIPTION
Reverts flexprice/flexprice#1040
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts "not contains" filter feature, removing related logic from DSL, repository, and test utilities.
> 
>   - **Revert "not contains" filter**:
>     - Remove `NOT_CONTAINS` case from `predicateFromFilter()` in `dsl.go`.
>     - Remove `NOT_CONTAINS` from `FilterOperatorType` in `search_filter.go`.
>   - **Feature Query Adjustments**:
>     - Remove handling of `NameContains` in `applyEntityQueryOptions()` in `feature.go`.
>     - Adjust `featureFilterFn()` in `inmemory_feature_store.go` to remove `NameContains` logic.
>   - **Misc**:
>     - Remove `NameContains` from `FeatureFilter` in `feature.go` and `inmemory_feature_store.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for b657c63e912d826bb6c281ae7b8a7bc6d621917a. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added name-based filtering for features, enabling case-insensitive substring search by feature name.

* **Chores**
  * Removed unsupported NOT_CONTAINS filter operator to reduce API surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->