### PR TITLE
feat(subscription): added new api for get subscription by id with minimal response and expand params

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -444,6 +444,34 @@ type SubscriptionResponse struct {
 // ListSubscriptionsResponse represents the response for listing subscriptions
 type ListSubscriptionsResponse = types.ListResponse[*SubscriptionResponse]
 
+// SubscriptionResponseV2 represents the V2 response for a subscription
+// with optional expanded fields based on the request expand parameter
+type SubscriptionResponseV2 struct {
+	*subscription.Subscription
+
+	// Plan is expanded only if "plan" is in expand parameter
+	Plan *PlanResponse `json:"plan,omitempty"`
+
+	// Customer is expanded only if "customer" is in expand parameter
+	Customer *CustomerResponse `json:"customer,omitempty"`
+
+	// LineItems is expanded only if "subscription_line_items" is in expand parameter
+	// Each line item can optionally include expanded price data
+	LineItems []*SubscriptionLineItemResponse `json:"line_items,omitempty"`
+
+	// CouponAssociations are included when "coupon_associations" is in expand parameter
+	CouponAssociations []*CouponAssociationResponse `json:"coupon_associations,omitempty"`
+
+	// Phases are included when "phases" is in expand parameter
+	Phases []*SubscriptionPhaseResponse `json:"phases,omitempty"`
+
+	// CreditGrants are included when "credit_grants" is in expand parameter
+	CreditGrants []*CreditGrantResponse `json:"credit_grants,omitempty"`
+
+	// Pauses are included when subscription has pause status
+	Pauses []*subscription.SubscriptionPause `json:"pauses,omitempty"`
+}
+
 func (r *CreateSubscriptionRequest) Validate() error {
 	// Case- Both are absent
 	if r.CustomerID == "" && r.ExternalCustomerID == "" {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -257,6 +257,7 @@ func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logg
 			subscription.POST("", handlers.Subscription.CreateSubscription)
 			subscription.GET("", handlers.Subscription.GetSubscriptions)
 			subscription.GET("/:id", handlers.Subscription.GetSubscription)
+			subscription.GET("/:id/v2", handlers.Subscription.GetSubscriptionV2)
 			subscription.POST("/:id/activate", handlers.Subscription.ActivateDraftSubscription)
 			subscription.POST("/:id/cancel", handlers.Subscription.CancelSubscription)
 			subscription.POST("/usage", handlers.Subscription.GetUsageBySubscription)

--- a/internal/api/v1/subscription.go
+++ b/internal/api/v1/subscription.go
@@ -80,6 +80,40 @@ func (h *SubscriptionHandler) GetSubscription(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// @Summary Get subscription V2
+// @Description Get a subscription by ID with optional expand parameters
+// @Tags Subscriptions
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "Subscription ID"
+// @Param expand query string false "Comma-separated list of fields to expand (e.g., 'subscription_line_items,prices,plan')"
+// @Success 200 {object} dto.SubscriptionResponseV2
+// @Failure 400 {object} ierr.ErrorResponse
+// @Failure 500 {object} ierr.ErrorResponse
+// @Router /subscriptions/{id}/v2 [get]
+func (h *SubscriptionHandler) GetSubscriptionV2(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.Error(ierr.NewError("subscription ID is required").
+			WithHint("Please provide a valid subscription ID").
+			Mark(ierr.ErrValidation))
+		return
+	}
+
+	// Parse expand query parameter
+	expandStr := c.Query("expand")
+	expand := types.NewExpand(expandStr)
+
+	resp, err := h.service.GetSubscriptionV2(c.Request.Context(), id, expand)
+	if err != nil {
+		h.log.Error("Failed to get subscription v2", "error", err)
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
 // @Summary List subscriptions
 // @Description Get subscriptions with optional filtering
 // @Tags Subscriptions

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -77,6 +77,7 @@ type RevenueAnalyticsService interface {
 type SubscriptionService interface {
 	CreateSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*dto.SubscriptionResponse, error)
 	GetSubscription(ctx context.Context, id string) (*dto.SubscriptionResponse, error)
+	GetSubscriptionV2(ctx context.Context, id string, expand types.Expand) (*dto.SubscriptionResponseV2, error)
 	UpdateSubscription(ctx context.Context, subscriptionID string, req dto.UpdateSubscriptionRequest) (*dto.SubscriptionResponse, error)
 	CancelSubscription(ctx context.Context, subscriptionID string, req *dto.CancelSubscriptionRequest) (*dto.CancelSubscriptionResponse, error)
 	ActivateIncompleteSubscription(ctx context.Context, subscriptionID string) error

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -38,6 +38,7 @@ const (
 	ExpandParentCustomer            ExpandableField = "parent_customer"
 	ExpandCreatedByUser             ExpandableField = "created_by_user"
 	ExpandCreditsAvailableBreakdown ExpandableField = "credits_available_breakdown"
+	ExpandSubscriptionLineItems     ExpandableField = "subscription_line_items"
 )
 
 // ExpandConfig defines which fields can be expanded and their nested expansions
@@ -75,13 +76,14 @@ var (
 
 	// SubscriptionExpandConfig defines what can be expanded on a subscription
 	SubscriptionExpandConfig = ExpandConfig{
-		AllowedFields: []ExpandableField{ExpandPlan, ExpandCustomer, ExpandPrices, ExpandMeters, ExpandSchedule, ExpandCouponAssociations, ExpandCoupon},
+		AllowedFields: []ExpandableField{ExpandPlan, ExpandCustomer, ExpandPrices, ExpandMeters, ExpandSchedule, ExpandCouponAssociations, ExpandCoupon, ExpandSubscriptionLineItems},
 		NestedExpands: map[ExpandableField][]ExpandableField{
-			ExpandPlan:               {ExpandPrices},
-			ExpandCustomer:           {},
-			ExpandPrices:             {ExpandMeters},
-			ExpandSchedule:           {},
-			ExpandCouponAssociations: {ExpandCoupon},
+			ExpandPlan:                  {ExpandPrices},
+			ExpandCustomer:              {},
+			ExpandPrices:                {ExpandMeters},
+			ExpandSchedule:              {},
+			ExpandCouponAssociations:    {ExpandCoupon},
+			ExpandSubscriptionLineItems: {ExpandPrices},
 		},
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GetSubscriptionV2` API to fetch subscription details with optional expanded fields using expand parameters.
> 
>   - **API Changes**:
>     - Add `GetSubscriptionV2` endpoint in `router.go` and `subscription.go` for fetching subscription by ID with expand parameters.
>   - **DTOs**:
>     - Add `SubscriptionResponseV2` in `dto/subscription.go` to support expanded fields.
>   - **Service Layer**:
>     - Implement `GetSubscriptionV2` in `subscriptionService` in `subscription.go` to handle expanded fields logic.
>     - Update `SubscriptionService` interface in `service.go` to include `GetSubscriptionV2` method.
>   - **Expand Logic**:
>     - Add `ExpandSubscriptionLineItems` to `expand.go` and update `SubscriptionExpandConfig` to include nested expand options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 0380d7ae9054e20c4bd035f82bf4830e39c9b461. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new subscription retrieval endpoint with enhanced data expansion capabilities. Optional query parameters enable retrieval of related plan, customer, line items, coupon associations, phases, credit grants, and pause information in a single request.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->