### PR TITLE
feat(subscription): add commitment fields to create and update 

### DIFF
--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -106,6 +106,13 @@ func (r *subscriptionLineItemRepository) Create(ctx context.Context, item *subsc
 		SetInvoiceCadence(item.InvoiceCadence).
 		SetTrialPeriod(item.TrialPeriod).
 		SetMetadata(item.Metadata).
+		// Commitment fields
+		SetNillableCommitmentAmount(item.CommitmentAmount).
+		SetNillableCommitmentQuantity(item.CommitmentQuantity).
+		SetNillableCommitmentType(types.ToNillableString(string(item.CommitmentType))).
+		SetNillableCommitmentOverageFactor(item.CommitmentOverageFactor).
+		SetCommitmentTrueUpEnabled(item.CommitmentTrueUpEnabled).
+		SetCommitmentWindowed(item.CommitmentWindowed).
 		SetTenantID(item.TenantID).
 		SetEnvironmentID(item.EnvironmentID).
 		SetStatus(string(item.Status)).
@@ -233,6 +240,13 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 		SetNillableStartDate(types.ToNillableTime(item.StartDate)).
 		SetNillableEndDate(types.ToNillableTime(item.EndDate)).
 		SetMetadata(item.Metadata).
+		// Commitment fields
+		SetNillableCommitmentAmount(item.CommitmentAmount).
+		SetNillableCommitmentQuantity(item.CommitmentQuantity).
+		SetNillableCommitmentType(types.ToNillableString(string(item.CommitmentType))).
+		SetNillableCommitmentOverageFactor(item.CommitmentOverageFactor).
+		SetCommitmentTrueUpEnabled(item.CommitmentTrueUpEnabled).
+		SetCommitmentWindowed(item.CommitmentWindowed).
 		SetStatus(string(item.Status)).
 		SetUpdatedBy(item.UpdatedBy).
 		SetUpdatedAt(time.Now()).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add commitment fields to `Create` and `Update` methods in `subscription_line_item.go`.
> 
>   - **Behavior**:
>     - Add commitment fields to `Create` and `Update` methods in `subscription_line_item.go`.
>     - Fields include `CommitmentAmount`, `CommitmentQuantity`, `CommitmentType`, `CommitmentOverageFactor`, `CommitmentTrueUpEnabled`, and `CommitmentWindowed`.
>     - Use `SetNillable` methods for optional fields.
>   - **Misc**:
>     - No changes to other methods or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 7236e9983c87c824c3f79678c6d7059e563d290b. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription line items now capture and maintain commitment-related details including amount, quantity, type, overage factor, true-up settings, and windowing parameters during creation and updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->