### PR TITLE
    fix(subscription): truncate StartDate to milliseconds for consistency

### DIFF
--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -138,9 +138,9 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 
 	// Setup subscription dates
 	if sub.StartDate.IsZero() {
-		sub.StartDate = time.Now().UTC()
+		sub.StartDate = time.Now().UTC().Truncate(time.Millisecond)
 	} else {
-		sub.StartDate = sub.StartDate.UTC()
+		sub.StartDate = sub.StartDate.UTC().Truncate(time.Millisecond)
 	}
 	if req.BillingAnchor != nil {
 		sub.BillingAnchor = *req.BillingAnchor


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Truncate `StartDate` to milliseconds in `CreateSubscription()` for consistent date handling.
> 
>   - **Behavior**:
>     - Truncate `StartDate` to milliseconds in `CreateSubscription()` in `subscription.go` for both default and provided dates.
>   - **Misc**:
>     - Ensures consistent date precision across subscription creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 1af70e2c575301b435ffbea852330533f36529e9. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved consistency in subscription timestamp precision by normalizing start dates to millisecond-level accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->