### PR TITLE
fix(analytics): added addon_id in response when the prices in addon is overriden

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,7 +122,7 @@ type ClickHouseConfig struct {
 type LoggingConfig struct {
 	Level   types.LogLevel `mapstructure:"level" validate:"required"`
 	DBLevel types.LogLevel `mapstructure:"db_level" validate:"required"`
-	
+
 	// Fluentd configuration
 	FluentdEnabled bool   `mapstructure:"fluentd_enabled" default:"false"`
 	FluentdHost    string `mapstructure:"fluentd_host" validate:"omitempty"`

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -2936,8 +2936,11 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 					// Parent price should already be fetched in fetchSubscriptionPrices
 					if price.ParentPriceID != "" {
 						if parentPrice, ok := data.PriceResponses[price.ParentPriceID]; ok {
-							if parentPrice.EntityType == types.PRICE_ENTITY_TYPE_PLAN {
+							switch parentPrice.EntityType {
+							case types.PRICE_ENTITY_TYPE_PLAN:
 								item.PlanID = parentPrice.EntityID
+							case types.PRICE_ENTITY_TYPE_ADDON:
+								item.AddOnID = parentPrice.EntityID
 							}
 						}
 					}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `addon_id` to response in `ToGetUsageAnalyticsResponseDTO()` when prices in an addon are overridden.
> 
>   - **Behavior**:
>     - In `ToGetUsageAnalyticsResponseDTO()` in `feature_usage_tracking.go`, add `addon_id` to response when `EntityType` is `PRICE_ENTITY_TYPE_ADDON`.
>   - **Misc**:
>     - Minor whitespace change in `config.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6bb3599a793f9e3117619e5b364f98503f89f7f0. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of usage analytics by correctly resolving add-on pricing information when displaying subscription override details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->