### PR TITLE
fix(onboarding): orgName precedence over default

### DIFF
--- a/internal/api/dto/tenant.go
+++ b/internal/api/dto/tenant.go
@@ -115,7 +115,7 @@ func NewTenantResponse(t *tenant.Tenant) *TenantResponse {
 }
 
 type UpdateTenantRequest struct {
-	Name           string                `json:"name,omitempty"`
+	Name           *string               `json:"name,omitempty"`
 	BillingDetails *TenantBillingDetails `json:"billing_details,omitempty"`
 	Metadata       *types.Metadata       `json:"metadata,omitempty"`
 }

--- a/internal/service/tenant.go
+++ b/internal/service/tenant.go
@@ -233,9 +233,9 @@ func (s *tenantService) UpdateTenant(ctx context.Context, id string, req dto.Upd
 	}
 	existingTenant.BillingDetails = billingDetails
 
-	// Update the name if it is provided
-	if req.Name != "" {
-		existingTenant.Name = req.Name
+	// Update the name only if it is explicitly provided (not nil), not empty, and different from existing
+	if req.Name != nil && *req.Name != "" && *req.Name != existingTenant.Name {
+		existingTenant.Name = *req.Name
 	}
 
 	if req.Metadata != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `UpdateTenantRequest.Name` to a pointer and update logic to modify tenant name only if explicitly provided, not empty, and different.
> 
>   - **DTO Changes**:
>     - Change `Name` field in `UpdateTenantRequest` to `*string` in `internal/api/dto/tenant.go`.
>   - **Service Logic**:
>     - Update `UpdateTenant` in `internal/service/tenant.go` to modify tenant name only if `Name` is not nil, not empty, and different from existing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 2ecf32a8a571916dbaaabda7b94a09f066429058. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Tenant name field is now optional when updating tenant information. Name updates are only applied when a new, different value is provided, preventing unnecessary updates and enabling selective field modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->