### PR TITLE
Hotfix/clickhouse timeout

### DIFF
--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -181,7 +181,7 @@ func (s *eventService) BulkGetUsageByMeter(ctx context.Context, req []*dto.GetUs
 
 	// Get configuration values or use defaults
 	maxWorkers := 5
-	timeoutDuration := 30000 * time.Millisecond
+	timeoutDuration := 15000 * time.Millisecond
 
 	// Log the configuration being used
 	s.logger.With(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `timeoutDuration` in `BulkGetUsageByMeter()` to 15000ms for extended operation time.
> 
>   - **Behavior**:
>     - Increase `timeoutDuration` from `3000ms` to `15000ms` in `BulkGetUsageByMeter()` in `event.go` to allow more time for operations to complete.
>   - **Logging**:
>     - Logs the updated `timeoutDuration` value in `BulkGetUsageByMeter()` for better traceability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 364d0971e9980a3791e6a4c6717a61aef9b3abce. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased timeout duration for bulk meter usage requests from 3 seconds to 15 seconds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->