### PR TITLE
 fix(wallet): add buffer for credit expiry 

### DIFF
--- a/internal/api/cron/wallet.go
+++ b/internal/api/cron/wallet.go
@@ -51,7 +51,7 @@ func (h *WalletCronHandler) ExpireCredits(c *gin.Context) {
 		return
 	}
 
-	// Create filter to find expired credits
+	// Create filter to find expired credits (expired at least 6 hours ago - grace period after expiry)
 	filter := &types.WalletTransactionFilter{
 		Type:               lo.ToPtr(types.TransactionTypeCredit),
 		TransactionStatus:  lo.ToPtr(types.TransactionStatusCompleted),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts `ExpireCredits` in `wallet.go` to include a 6-hour grace period for credit expiry.
> 
>   - **Behavior**:
>     - Adjusts `ExpireCredits` in `wallet.go` to include a 6-hour grace period for credit expiry.
>     - Changes `ExpiryDateBefore` filter to `time.Now().UTC().Add(-6 * time.Hour)` to find credits expired at least 6 hours ago.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 0734619a26ee52a9ee4744f824d3a76355fc93f3. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted credit expiration logic to enforce a 6-hour grace period, ensuring credits are marked as expired only after being expired for at least 6 hours rather than before expiration occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->