### PR TITLE
feat(subscription): add cancel immediately invoice policy

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -387,8 +387,8 @@ type CancelSubscriptionRequest struct {
 	// CancellationType determines when the cancellation takes effect
 	CancellationType types.CancellationType `json:"cancellation_type" validate:"required"`
 
-	// InvoiceOnImmediateCancellationPolicy controls whether to generate a final invoice on immediate cancellation. Defaults to skip.
-	InvoiceOnImmediateCancellationPolicy types.InvoiceOnImmediateCancellationPolicy `json:"invoice_on_immediate_cancellation_policy,omitempty"`
+	// CancelImmediatelyInvoicePolicy controls whether to generate a final invoice on immediate cancellation. Defaults to skip.
+	CancelImmediatelyInvoicePolicy types.CancelImmediatelyInvoicePolicy `json:"cancel_immediately_inovice_policy,omitempty"`
 
 	// Reason for cancellation (for audit and business intelligence)
 	Reason string `json:"reason,omitempty"`
@@ -438,10 +438,10 @@ func (r *CancelSubscriptionRequest) Validate() error {
 	if r.ProrationBehavior == "" {
 		r.ProrationBehavior = types.ProrationBehaviorNone
 	}
-	// Set default invoice on immediate cancellation policy if not provided or empty (default: skip = do not generate invoice)
-	if r.InvoiceOnImmediateCancellationPolicy == "" {
-		r.InvoiceOnImmediateCancellationPolicy = types.InvoiceOnImmediateCancellationPolicySkip
-	} else if err := r.InvoiceOnImmediateCancellationPolicy.Validate(); err != nil {
+	// Set default cancel immediately invoice policy if not provided or empty (default: skip = do not generate invoice)
+	if r.CancelImmediatelyInvoicePolicy == "" {
+		r.CancelImmediatelyInvoicePolicy = types.CancelImmediatelyInvoicePolicySkip
+	} else if err := r.CancelImmediatelyInvoicePolicy.Validate(); err != nil {
 		return err
 	}
 

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1622,12 +1622,12 @@ func (s *subscriptionService) CancelSubscription(
 		}
 
 		// Default to skip (no final invoice) when policy is empty; only generate when explicitly requested
-		invoicePolicy := req.InvoiceOnImmediateCancellationPolicy
+		invoicePolicy := req.CancelImmediatelyInvoicePolicy
 		if invoicePolicy == "" {
-			invoicePolicy = types.InvoiceOnImmediateCancellationPolicySkip
+			invoicePolicy = types.CancelImmediatelyInvoicePolicySkip
 		}
 		shouldCreateInvoice := req.CancellationType != types.CancellationTypeEndOfPeriod &&
-			invoicePolicy == types.InvoiceOnImmediateCancellationPolicyGenerateInvoice
+			invoicePolicy == types.CancelImmediatelyInvoicePolicyGenerateInvoice
 		if shouldCreateInvoice {
 			invoiceService := NewInvoiceService(s.ServiceParams)
 			paymentParams := dto.NewPaymentParametersFromSubscription(subscription.CollectionMethod, subscription.PaymentBehavior, subscription.GatewayPaymentMethodID)

--- a/internal/types/proration.go
+++ b/internal/types/proration.go
@@ -81,24 +81,24 @@ func (c CancellationType) String() string {
 	return string(c)
 }
 
-// InvoiceOnImmediateCancellationPolicy controls whether to generate a final invoice on immediate subscription cancellation.
-type InvoiceOnImmediateCancellationPolicy string
+// CancelImmediatelyInvoicePolicy controls whether to generate a final invoice on immediate subscription cancellation.
+type CancelImmediatelyInvoicePolicy string
 
 const (
-	InvoiceOnImmediateCancellationPolicyGenerateInvoice InvoiceOnImmediateCancellationPolicy = "generate_invoice"
-	InvoiceOnImmediateCancellationPolicySkip            InvoiceOnImmediateCancellationPolicy = "skip"
+	CancelImmediatelyInvoicePolicyGenerateInvoice CancelImmediatelyInvoicePolicy = "generate_invoice"
+	CancelImmediatelyInvoicePolicySkip            CancelImmediatelyInvoicePolicy = "skip"
 )
 
-func (p InvoiceOnImmediateCancellationPolicy) Validate() error {
+func (p CancelImmediatelyInvoicePolicy) Validate() error {
 
-	allowedValues := []InvoiceOnImmediateCancellationPolicy{
-		InvoiceOnImmediateCancellationPolicyGenerateInvoice,
-		InvoiceOnImmediateCancellationPolicySkip,
+	allowedValues := []CancelImmediatelyInvoicePolicy{
+		CancelImmediatelyInvoicePolicyGenerateInvoice,
+		CancelImmediatelyInvoicePolicySkip,
 	}
 
 	if !lo.Contains(allowedValues, p) {
-		return ierr.NewError("invalid invoice on immediate cancellation policy").
-			WithHint("Invoice on immediate cancellation policy must be generate_invoice or skip").
+		return ierr.NewError("invalid cancel immediately invoice policy").
+			WithHint("Cancel immediately invoice policy must be generate_invoice or skip").
 			WithReportableDetails(map[string]any{
 				"allowed_values": allowedValues,
 				"provided_value": p,
@@ -108,7 +108,7 @@ func (p InvoiceOnImmediateCancellationPolicy) Validate() error {
 	return nil
 }
 
-func (p InvoiceOnImmediateCancellationPolicy) String() string {
+func (p CancelImmediatelyInvoicePolicy) String() string {
 	return string(p)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `InvoiceOnImmediateCancellationPolicy` to `CancelImmediatelyInvoicePolicy` across DTOs, services, and types for subscription cancellation.
> 
>   - **Behavior**:
>     - Renames `InvoiceOnImmediateCancellationPolicy` to `CancelImmediatelyInvoicePolicy` in `CancelSubscriptionRequest` in `subscription.go`.
>     - Updates logic in `CancelSubscription` in `subscription.go` to use `CancelImmediatelyInvoicePolicy`.
>   - **Types**:
>     - Renames `InvoiceOnImmediateCancellationPolicy` to `CancelImmediatelyInvoicePolicy` in `proration.go`.
>     - Updates `Validate()` function to reflect new policy name in `proration.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for c745800203956ae2b5a958ca9e9ffe6a5ac0ed2a. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->