### PR TITLE
feat(events): add negative usage check

### DIFF
--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -293,6 +293,13 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 					}
 					total = safeDecimalFromFloat(totalFloat)
 					value = safeDecimalFromFloat(valueFloat)
+					// Ensure negative values are treated as zero
+					if total.LessThan(decimal.Zero) {
+						total = decimal.Zero
+					}
+					if value.LessThan(decimal.Zero) {
+						value = decimal.Zero
+					}
 					// Set the overall max/sum as the result value
 					result.Value = total
 				} else {
@@ -308,6 +315,10 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 							Mark(ierr.ErrDatabase)
 					}
 					value = safeDecimalFromFloat(floatValue)
+					// Ensure negative values are treated as zero
+					if value.LessThan(decimal.Zero) {
+						value = decimal.Zero
+					}
 				}
 			case types.AggregationAvg, types.AggregationLatest, types.AggregationSumWithMultiplier, types.AggregationWeightedSum:
 				var floatValue float64
@@ -323,8 +334,8 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 				}
 				value = safeDecimalFromFloat(floatValue)
 
-				// For Latest aggregation, return 0 if negative
-				if params.AggregationType == types.AggregationLatest && value.LessThan(decimal.Zero) {
+				// Ensure negative values are treated as zero for all aggregation types
+				if value.LessThan(decimal.Zero) {
 					value = decimal.Zero
 				}
 			default:
@@ -371,8 +382,8 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 				}
 				result.Value = safeDecimalFromFloat(value)
 
-				// For Latest aggregation, return 0 if negative
-				if params.AggregationType == types.AggregationLatest && result.Value.LessThan(decimal.Zero) {
+				// Ensure negative values are treated as zero for all aggregation types
+				if result.Value.LessThan(decimal.Zero) {
 					result.Value = decimal.Zero
 				}
 			default:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure negative values are treated as zero in `GetUsage()` for all aggregation types in `event.go`.
> 
>   - **Behavior**:
>     - In `GetUsage()` in `event.go`, negative values are now treated as zero for all aggregation types.
>     - Applies to `AggregationMax`, `AggregationSum`, `AggregationAvg`, `AggregationLatest`, `AggregationSumWithMultiplier`, and `AggregationWeightedSum`.
>   - **Implementation**:
>     - Added checks for negative values and set them to zero in `GetUsage()`.
>     - Ensures consistent handling of negative values across different aggregation scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 4eb9c31789327ba1d6e779c9cdca375703e24874. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->