### PR TITLE
feat(plan_price_sync): add start date condition and ordering to terminate and list plan line items queries

### DIFF
--- a/internal/repository/ent/plan_price_sync.go
+++ b/internal/repository/ent/plan_price_sync.go
@@ -103,6 +103,8 @@ func (r *planPriceSyncRepository) TerminateExpiredPlanPricesLineItems(
 					AND li.status = '%s'
 					AND li.entity_type = '%s'
 					AND li.end_date IS NULL
+					AND (li.start_date IS NULL OR li.start_date <= p.end_date)
+				ORDER BY li.id
 				LIMIT $4
 			)
 		UPDATE
@@ -245,6 +247,8 @@ func (r *planPriceSyncRepository) ListPlanLineItemsToTerminate(
 			AND li.status = '%s'
 			AND li.entity_type = '%s'
 			AND li.end_date IS NULL
+			AND (li.start_date IS NULL OR li.start_date <= p.end_date)
+		ORDER BY li.start_date, li.id
 		LIMIT
 			$4
 	`,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `start_date` condition and ordering to `TerminateExpiredPlanPricesLineItems` and `ListPlanLineItemsToTerminate` queries in `plan_price_sync.go`.
> 
>   - **Behavior**:
>     - Add `start_date` condition to `TerminateExpiredPlanPricesLineItems` and `ListPlanLineItemsToTerminate` queries in `plan_price_sync.go`.
>     - Order results by `li.id` in `TerminateExpiredPlanPricesLineItems` and by `li.start_date, li.id` in `ListPlanLineItemsToTerminate`.
>   - **Functions**:
>     - Modify `TerminateExpiredPlanPricesLineItems` to include `start_date` condition and order by `li.id`.
>     - Modify `ListPlanLineItemsToTerminate` to include `start_date` condition and order by `li.start_date, li.id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6ff278574a0fa27eaa664f5790e7fe4c668290fb. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Refined the logic for identifying which plan prices and line items should be terminated, ensuring only eligible items are processed based on their relationship to plan end dates.
* Improved the ordering of plan termination operations to ensure consistent and reproducible processing across system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->