### PR TITLE
fix make test

### DIFF
--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -1219,9 +1219,9 @@ func (s *walletService) GetWalletBalance(ctx context.Context, walletID string) (
 	}
 
 	if lo.Contains(w.Config.AllowedPriceTypes, types.WalletConfigPriceTypeAll) && lo.Contains(w.Config.AllowedPriceTypes, types.WalletConfigPriceTypeFixed) {
-		totalPendingCharges = totalPendingCharges.Add(resp.TotalUnpaidAmount)
+		totalPendingCharges = currentPeriodUsage.Add(resp.TotalUnpaidAmount)
 	} else {
-		totalPendingCharges = totalPendingCharges.Add(resp.TotalUnpaidUsageCharges).Sub(resp.TotalPaidInvoiceAmount)
+		totalPendingCharges = currentPeriodUsage.Add(resp.TotalUnpaidUsageCharges).Sub(resp.TotalPaidInvoiceAmount)
 	}
 
 	// Calculate real-time balance


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `totalPendingCharges` calculation in `GetWalletBalance` in `wallet.go` for specific wallet price type configurations.
> 
>   - **Behavior**:
>     - In `GetWalletBalance` in `wallet.go`, change `totalPendingCharges` calculation to use `currentPeriodUsage` instead of `totalPendingCharges`.
>     - Affects wallets with `AllowedPriceTypes` including `WalletConfigPriceTypeAll` and `WalletConfigPriceTypeFixed`.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 116881e080dcece22b534091ee010591509fb4d0. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->