### PR TITLE
fix(wallet): revert allowed_price_types removal

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -2258,6 +2258,9 @@ var (
 		{Name: "workflow_type", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(100)"}},
 		{Name: "task_queue", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(100)"}},
 		{Name: "start_time", Type: field.TypeTime},
+		{Name: "end_time", Type: field.TypeTime, Nullable: true},
+		{Name: "duration_ms", Type: field.TypeInt64, Nullable: true},
+		{Name: "workflow_status", Type: field.TypeString, Default: "Unknown", SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 	}
 	// WorkflowExecutionsTable holds the schema information for the "workflow_executions" table.
@@ -2287,9 +2290,19 @@ var (
 				Columns: []*schema.Column{WorkflowExecutionsColumns[12]},
 			},
 			{
+				Name:    "idx_workflow_executions_end_time",
+				Unique:  false,
+				Columns: []*schema.Column{WorkflowExecutionsColumns[13]},
+			},
+			{
 				Name:    "idx_workflow_executions_tenant_env_time",
 				Unique:  false,
 				Columns: []*schema.Column{WorkflowExecutionsColumns[1], WorkflowExecutionsColumns[7], WorkflowExecutionsColumns[12]},
+			},
+			{
+				Name:    "idx_workflow_executions_tenant_env_status",
+				Unique:  false,
+				Columns: []*schema.Column{WorkflowExecutionsColumns[1], WorkflowExecutionsColumns[7], WorkflowExecutionsColumns[15]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -65969,26 +65969,30 @@ func (m *WalletTransactionMutation) ResetEdge(name string) error {
 // WorkflowExecutionMutation represents an operation that mutates the WorkflowExecution nodes in the graph.
 type WorkflowExecutionMutation struct {
 	config
-	op             Op
-	typ            string
-	id             *string
-	tenant_id      *string
-	status         *string
-	created_at     *time.Time
-	updated_at     *time.Time
-	created_by     *string
-	updated_by     *string
-	environment_id *string
-	workflow_id    *string
-	run_id         *string
-	workflow_type  *string
-	task_queue     *string
-	start_time     *time.Time
-	metadata       *map[string]interface{}
-	clearedFields  map[string]struct{}
-	done           bool
-	oldValue       func(context.Context) (*WorkflowExecution, error)
-	predicates     []predicate.WorkflowExecution
+	op              Op
+	typ             string
+	id              *string
+	tenant_id       *string
+	status          *string
+	created_at      *time.Time
+	updated_at      *time.Time
+	created_by      *string
+	updated_by      *string
+	environment_id  *string
+	workflow_id     *string
+	run_id          *string
+	workflow_type   *string
+	task_queue      *string
+	start_time      *time.Time
+	end_time        *time.Time
+	duration_ms     *int64
+	addduration_ms  *int64
+	workflow_status *types.WorkflowExecutionStatus
+	metadata        *map[string]interface{}
+	clearedFields   map[string]struct{}
+	done            bool
+	oldValue        func(context.Context) (*WorkflowExecution, error)
+	predicates      []predicate.WorkflowExecution
 }
 
 var _ ent.Mutation = (*WorkflowExecutionMutation)(nil)
@@ -66566,6 +66570,161 @@ func (m *WorkflowExecutionMutation) ResetStartTime() {
 	m.start_time = nil
 }
 
+// SetEndTime sets the "end_time" field.
+func (m *WorkflowExecutionMutation) SetEndTime(t time.Time) {
+	m.end_time = &t
+}
+
+// EndTime returns the value of the "end_time" field in the mutation.
+func (m *WorkflowExecutionMutation) EndTime() (r time.Time, exists bool) {
+	v := m.end_time
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldEndTime returns the old "end_time" field's value of the WorkflowExecution entity.
+// If the WorkflowExecution object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *WorkflowExecutionMutation) OldEndTime(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldEndTime is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldEndTime requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldEndTime: %w", err)
+	}
+	return oldValue.EndTime, nil
+}
+
+// ClearEndTime clears the value of the "end_time" field.
+func (m *WorkflowExecutionMutation) ClearEndTime() {
+	m.end_time = nil
+	m.clearedFields[workflowexecution.FieldEndTime] = struct{}{}
+}
+
+// EndTimeCleared returns if the "end_time" field was cleared in this mutation.
+func (m *WorkflowExecutionMutation) EndTimeCleared() bool {
+	_, ok := m.clearedFields[workflowexecution.FieldEndTime]
+	return ok
+}
+
+// ResetEndTime resets all changes to the "end_time" field.
+func (m *WorkflowExecutionMutation) ResetEndTime() {
+	m.end_time = nil
+	delete(m.clearedFields, workflowexecution.FieldEndTime)
+}
+
+// SetDurationMs sets the "duration_ms" field.
+func (m *WorkflowExecutionMutation) SetDurationMs(i int64) {
+	m.duration_ms = &i
+	m.addduration_ms = nil
+}
+
+// DurationMs returns the value of the "duration_ms" field in the mutation.
+func (m *WorkflowExecutionMutation) DurationMs() (r int64, exists bool) {
+	v := m.duration_ms
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDurationMs returns the old "duration_ms" field's value of the WorkflowExecution entity.
+// If the WorkflowExecution object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *WorkflowExecutionMutation) OldDurationMs(ctx context.Context) (v *int64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDurationMs is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDurationMs requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDurationMs: %w", err)
+	}
+	return oldValue.DurationMs, nil
+}
+
+// AddDurationMs adds i to the "duration_ms" field.
+func (m *WorkflowExecutionMutation) AddDurationMs(i int64) {
+	if m.addduration_ms != nil {
+		*m.addduration_ms += i
+	} else {
+		m.addduration_ms = &i
+	}
+}
+
+// AddedDurationMs returns the value that was added to the "duration_ms" field in this mutation.
+func (m *WorkflowExecutionMutation) AddedDurationMs() (r int64, exists bool) {
+	v := m.addduration_ms
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearDurationMs clears the value of the "duration_ms" field.
+func (m *WorkflowExecutionMutation) ClearDurationMs() {
+	m.duration_ms = nil
+	m.addduration_ms = nil
+	m.clearedFields[workflowexecution.FieldDurationMs] = struct{}{}
+}
+
+// DurationMsCleared returns if the "duration_ms" field was cleared in this mutation.
+func (m *WorkflowExecutionMutation) DurationMsCleared() bool {
+	_, ok := m.clearedFields[workflowexecution.FieldDurationMs]
+	return ok
+}
+
+// ResetDurationMs resets all changes to the "duration_ms" field.
+func (m *WorkflowExecutionMutation) ResetDurationMs() {
+	m.duration_ms = nil
+	m.addduration_ms = nil
+	delete(m.clearedFields, workflowexecution.FieldDurationMs)
+}
+
+// SetWorkflowStatus sets the "workflow_status" field.
+func (m *WorkflowExecutionMutation) SetWorkflowStatus(tes types.WorkflowExecutionStatus) {
+	m.workflow_status = &tes
+}
+
+// WorkflowStatus returns the value of the "workflow_status" field in the mutation.
+func (m *WorkflowExecutionMutation) WorkflowStatus() (r types.WorkflowExecutionStatus, exists bool) {
+	v := m.workflow_status
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldWorkflowStatus returns the old "workflow_status" field's value of the WorkflowExecution entity.
+// If the WorkflowExecution object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *WorkflowExecutionMutation) OldWorkflowStatus(ctx context.Context) (v types.WorkflowExecutionStatus, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldWorkflowStatus is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldWorkflowStatus requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldWorkflowStatus: %w", err)
+	}
+	return oldValue.WorkflowStatus, nil
+}
+
+// ResetWorkflowStatus resets all changes to the "workflow_status" field.
+func (m *WorkflowExecutionMutation) ResetWorkflowStatus() {
+	m.workflow_status = nil
+}
+
 // SetMetadata sets the "metadata" field.
 func (m *WorkflowExecutionMutation) SetMetadata(value map[string]interface{}) {
 	m.metadata = &value
@@ -66649,7 +66808,7 @@ func (m *WorkflowExecutionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *WorkflowExecutionMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 16)
 	if m.tenant_id != nil {
 		fields = append(fields, workflowexecution.FieldTenantID)
 	}
@@ -66686,6 +66845,15 @@ func (m *WorkflowExecutionMutation) Fields() []string {
 	if m.start_time != nil {
 		fields = append(fields, workflowexecution.FieldStartTime)
 	}
+	if m.end_time != nil {
+		fields = append(fields, workflowexecution.FieldEndTime)
+	}
+	if m.duration_ms != nil {
+		fields = append(fields, workflowexecution.FieldDurationMs)
+	}
+	if m.workflow_status != nil {
+		fields = append(fields, workflowexecution.FieldWorkflowStatus)
+	}
 	if m.metadata != nil {
 		fields = append(fields, workflowexecution.FieldMetadata)
 	}
@@ -66721,6 +66889,12 @@ func (m *WorkflowExecutionMutation) Field(name string) (ent.Value, bool) {
 		return m.TaskQueue()
 	case workflowexecution.FieldStartTime:
 		return m.StartTime()
+	case workflowexecution.FieldEndTime:
+		return m.EndTime()
+	case workflowexecution.FieldDurationMs:
+		return m.DurationMs()
+	case workflowexecution.FieldWorkflowStatus:
+		return m.WorkflowStatus()
 	case workflowexecution.FieldMetadata:
 		return m.Metadata()
 	}
@@ -66756,6 +66930,12 @@ func (m *WorkflowExecutionMutation) OldField(ctx context.Context, name string) (
 		return m.OldTaskQueue(ctx)
 	case workflowexecution.FieldStartTime:
 		return m.OldStartTime(ctx)
+	case workflowexecution.FieldEndTime:
+		return m.OldEndTime(ctx)
+	case workflowexecution.FieldDurationMs:
+		return m.OldDurationMs(ctx)
+	case workflowexecution.FieldWorkflowStatus:
+		return m.OldWorkflowStatus(ctx)
 	case workflowexecution.FieldMetadata:
 		return m.OldMetadata(ctx)
 	}
@@ -66851,6 +67031,27 @@ func (m *WorkflowExecutionMutation) SetField(name string, value ent.Value) error
 		}
 		m.SetStartTime(v)
 		return nil
+	case workflowexecution.FieldEndTime:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetEndTime(v)
+		return nil
+	case workflowexecution.FieldDurationMs:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDurationMs(v)
+		return nil
+	case workflowexecution.FieldWorkflowStatus:
+		v, ok := value.(types.WorkflowExecutionStatus)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetWorkflowStatus(v)
+		return nil
 	case workflowexecution.FieldMetadata:
 		v, ok := value.(map[string]interface{})
 		if !ok {
@@ -66865,13 +67066,21 @@ func (m *WorkflowExecutionMutation) SetField(name string, value ent.Value) error
 // AddedFields returns all numeric fields that were incremented/decremented during
 // this mutation.
 func (m *WorkflowExecutionMutation) AddedFields() []string {
-	return nil
+	var fields []string
+	if m.addduration_ms != nil {
+		fields = append(fields, workflowexecution.FieldDurationMs)
+	}
+	return fields
 }
 
 // AddedField returns the numeric value that was incremented/decremented on a field
 // with the given name. The second boolean return value indicates that this field
 // was not set, or was not defined in the schema.
 func (m *WorkflowExecutionMutation) AddedField(name string) (ent.Value, bool) {
+	switch name {
+	case workflowexecution.FieldDurationMs:
+		return m.AddedDurationMs()
+	}
 	return nil, false
 }
 
@@ -66880,6 +67089,13 @@ func (m *WorkflowExecutionMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *WorkflowExecutionMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case workflowexecution.FieldDurationMs:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddDurationMs(v)
+		return nil
 	}
 	return fmt.Errorf("unknown WorkflowExecution numeric field %s", name)
 }
@@ -66896,6 +67112,12 @@ func (m *WorkflowExecutionMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(workflowexecution.FieldEnvironmentID) {
 		fields = append(fields, workflowexecution.FieldEnvironmentID)
+	}
+	if m.FieldCleared(workflowexecution.FieldEndTime) {
+		fields = append(fields, workflowexecution.FieldEndTime)
+	}
+	if m.FieldCleared(workflowexecution.FieldDurationMs) {
+		fields = append(fields, workflowexecution.FieldDurationMs)
 	}
 	if m.FieldCleared(workflowexecution.FieldMetadata) {
 		fields = append(fields, workflowexecution.FieldMetadata)
@@ -66922,6 +67144,12 @@ func (m *WorkflowExecutionMutation) ClearField(name string) error {
 		return nil
 	case workflowexecution.FieldEnvironmentID:
 		m.ClearEnvironmentID()
+		return nil
+	case workflowexecution.FieldEndTime:
+		m.ClearEndTime()
+		return nil
+	case workflowexecution.FieldDurationMs:
+		m.ClearDurationMs()
 		return nil
 	case workflowexecution.FieldMetadata:
 		m.ClearMetadata()
@@ -66969,6 +67197,15 @@ func (m *WorkflowExecutionMutation) ResetField(name string) error {
 		return nil
 	case workflowexecution.FieldStartTime:
 		m.ResetStartTime()
+		return nil
+	case workflowexecution.FieldEndTime:
+		m.ResetEndTime()
+		return nil
+	case workflowexecution.FieldDurationMs:
+		m.ResetDurationMs()
+		return nil
+	case workflowexecution.FieldWorkflowStatus:
+		m.ResetWorkflowStatus()
 		return nil
 	case workflowexecution.FieldMetadata:
 		m.ResetMetadata()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -2308,6 +2308,10 @@ func init() {
 	workflowexecutionDescTaskQueue := workflowexecutionFields[4].Descriptor()
 	// workflowexecution.TaskQueueValidator is a validator for the "task_queue" field. It is called by the builders before save.
 	workflowexecution.TaskQueueValidator = workflowexecutionDescTaskQueue.Validators[0].(func(string) error)
+	// workflowexecutionDescWorkflowStatus is the schema descriptor for workflow_status field.
+	workflowexecutionDescWorkflowStatus := workflowexecutionFields[8].Descriptor()
+	// workflowexecution.DefaultWorkflowStatus holds the default value on creation for the workflow_status field.
+	workflowexecution.DefaultWorkflowStatus = types.WorkflowExecutionStatus(workflowexecutionDescWorkflowStatus.Default.(string))
 	// workflowexecutionDescID is the schema descriptor for id field.
 	workflowexecutionDescID := workflowexecutionFields[0].Descriptor()
 	// workflowexecution.DefaultID holds the default value on creation for the id field.

--- a/ent/workflowexecution.go
+++ b/ent/workflowexecution.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent/workflowexecution"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // WorkflowExecution is the model entity for the WorkflowExecution schema.
@@ -43,6 +44,12 @@ type WorkflowExecution struct {
 	TaskQueue string `json:"task_queue,omitempty"`
 	// Workflow execution start time
 	StartTime time.Time `json:"start_time,omitempty"`
+	// Workflow execution end time (when workflow completed/failed)
+	EndTime *time.Time `json:"end_time,omitempty"`
+	// Total workflow execution duration in milliseconds
+	DurationMs *int64 `json:"duration_ms,omitempty"`
+	// Temporal workflow run status (Running, Completed, Failed, etc.)
+	WorkflowStatus types.WorkflowExecutionStatus `json:"workflow_status,omitempty"`
 	// Custom metadata (e.g., customer_id, plan, etc.)
 	Metadata     map[string]interface{} `json:"metadata,omitempty"`
 	selectValues sql.SelectValues
@@ -55,9 +62,11 @@ func (*WorkflowExecution) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case workflowexecution.FieldMetadata:
 			values[i] = new([]byte)
-		case workflowexecution.FieldID, workflowexecution.FieldTenantID, workflowexecution.FieldStatus, workflowexecution.FieldCreatedBy, workflowexecution.FieldUpdatedBy, workflowexecution.FieldEnvironmentID, workflowexecution.FieldWorkflowID, workflowexecution.FieldRunID, workflowexecution.FieldWorkflowType, workflowexecution.FieldTaskQueue:
+		case workflowexecution.FieldDurationMs:
+			values[i] = new(sql.NullInt64)
+		case workflowexecution.FieldID, workflowexecution.FieldTenantID, workflowexecution.FieldStatus, workflowexecution.FieldCreatedBy, workflowexecution.FieldUpdatedBy, workflowexecution.FieldEnvironmentID, workflowexecution.FieldWorkflowID, workflowexecution.FieldRunID, workflowexecution.FieldWorkflowType, workflowexecution.FieldTaskQueue, workflowexecution.FieldWorkflowStatus:
 			values[i] = new(sql.NullString)
-		case workflowexecution.FieldCreatedAt, workflowexecution.FieldUpdatedAt, workflowexecution.FieldStartTime:
+		case workflowexecution.FieldCreatedAt, workflowexecution.FieldUpdatedAt, workflowexecution.FieldStartTime, workflowexecution.FieldEndTime:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -152,6 +161,26 @@ func (we *WorkflowExecution) assignValues(columns []string, values []any) error 
 			} else if value.Valid {
 				we.StartTime = value.Time
 			}
+		case workflowexecution.FieldEndTime:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field end_time", values[i])
+			} else if value.Valid {
+				we.EndTime = new(time.Time)
+				*we.EndTime = value.Time
+			}
+		case workflowexecution.FieldDurationMs:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field duration_ms", values[i])
+			} else if value.Valid {
+				we.DurationMs = new(int64)
+				*we.DurationMs = value.Int64
+			}
+		case workflowexecution.FieldWorkflowStatus:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field workflow_status", values[i])
+			} else if value.Valid {
+				we.WorkflowStatus = types.WorkflowExecutionStatus(value.String)
+			}
 		case workflowexecution.FieldMetadata:
 			if value, ok := values[i].(*[]byte); !ok {
 				return fmt.Errorf("unexpected type %T for field metadata", values[i])
@@ -231,6 +260,19 @@ func (we *WorkflowExecution) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("start_time=")
 	builder.WriteString(we.StartTime.Format(time.ANSIC))
+	builder.WriteString(", ")
+	if v := we.EndTime; v != nil {
+		builder.WriteString("end_time=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := we.DurationMs; v != nil {
+		builder.WriteString("duration_ms=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	builder.WriteString("workflow_status=")
+	builder.WriteString(fmt.Sprintf("%v", we.WorkflowStatus))
 	builder.WriteString(", ")
 	builder.WriteString("metadata=")
 	builder.WriteString(fmt.Sprintf("%v", we.Metadata))

--- a/ent/workflowexecution/where.go
+++ b/ent/workflowexecution/where.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent/predicate"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // ID filters vertices based on their ID field.
@@ -122,6 +123,22 @@ func TaskQueue(v string) predicate.WorkflowExecution {
 // StartTime applies equality check predicate on the "start_time" field. It's identical to StartTimeEQ.
 func StartTime(v time.Time) predicate.WorkflowExecution {
 	return predicate.WorkflowExecution(sql.FieldEQ(FieldStartTime, v))
+}
+
+// EndTime applies equality check predicate on the "end_time" field. It's identical to EndTimeEQ.
+func EndTime(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldEQ(FieldEndTime, v))
+}
+
+// DurationMs applies equality check predicate on the "duration_ms" field. It's identical to DurationMsEQ.
+func DurationMs(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldEQ(FieldDurationMs, v))
+}
+
+// WorkflowStatus applies equality check predicate on the "workflow_status" field. It's identical to WorkflowStatusEQ.
+func WorkflowStatus(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldEQ(FieldWorkflowStatus, vc))
 }
 
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
@@ -857,6 +874,190 @@ func StartTimeLT(v time.Time) predicate.WorkflowExecution {
 // StartTimeLTE applies the LTE predicate on the "start_time" field.
 func StartTimeLTE(v time.Time) predicate.WorkflowExecution {
 	return predicate.WorkflowExecution(sql.FieldLTE(FieldStartTime, v))
+}
+
+// EndTimeEQ applies the EQ predicate on the "end_time" field.
+func EndTimeEQ(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldEQ(FieldEndTime, v))
+}
+
+// EndTimeNEQ applies the NEQ predicate on the "end_time" field.
+func EndTimeNEQ(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldNEQ(FieldEndTime, v))
+}
+
+// EndTimeIn applies the In predicate on the "end_time" field.
+func EndTimeIn(vs ...time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldIn(FieldEndTime, vs...))
+}
+
+// EndTimeNotIn applies the NotIn predicate on the "end_time" field.
+func EndTimeNotIn(vs ...time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldNotIn(FieldEndTime, vs...))
+}
+
+// EndTimeGT applies the GT predicate on the "end_time" field.
+func EndTimeGT(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldGT(FieldEndTime, v))
+}
+
+// EndTimeGTE applies the GTE predicate on the "end_time" field.
+func EndTimeGTE(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldGTE(FieldEndTime, v))
+}
+
+// EndTimeLT applies the LT predicate on the "end_time" field.
+func EndTimeLT(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldLT(FieldEndTime, v))
+}
+
+// EndTimeLTE applies the LTE predicate on the "end_time" field.
+func EndTimeLTE(v time.Time) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldLTE(FieldEndTime, v))
+}
+
+// EndTimeIsNil applies the IsNil predicate on the "end_time" field.
+func EndTimeIsNil() predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldIsNull(FieldEndTime))
+}
+
+// EndTimeNotNil applies the NotNil predicate on the "end_time" field.
+func EndTimeNotNil() predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldNotNull(FieldEndTime))
+}
+
+// DurationMsEQ applies the EQ predicate on the "duration_ms" field.
+func DurationMsEQ(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldEQ(FieldDurationMs, v))
+}
+
+// DurationMsNEQ applies the NEQ predicate on the "duration_ms" field.
+func DurationMsNEQ(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldNEQ(FieldDurationMs, v))
+}
+
+// DurationMsIn applies the In predicate on the "duration_ms" field.
+func DurationMsIn(vs ...int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldIn(FieldDurationMs, vs...))
+}
+
+// DurationMsNotIn applies the NotIn predicate on the "duration_ms" field.
+func DurationMsNotIn(vs ...int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldNotIn(FieldDurationMs, vs...))
+}
+
+// DurationMsGT applies the GT predicate on the "duration_ms" field.
+func DurationMsGT(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldGT(FieldDurationMs, v))
+}
+
+// DurationMsGTE applies the GTE predicate on the "duration_ms" field.
+func DurationMsGTE(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldGTE(FieldDurationMs, v))
+}
+
+// DurationMsLT applies the LT predicate on the "duration_ms" field.
+func DurationMsLT(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldLT(FieldDurationMs, v))
+}
+
+// DurationMsLTE applies the LTE predicate on the "duration_ms" field.
+func DurationMsLTE(v int64) predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldLTE(FieldDurationMs, v))
+}
+
+// DurationMsIsNil applies the IsNil predicate on the "duration_ms" field.
+func DurationMsIsNil() predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldIsNull(FieldDurationMs))
+}
+
+// DurationMsNotNil applies the NotNil predicate on the "duration_ms" field.
+func DurationMsNotNil() predicate.WorkflowExecution {
+	return predicate.WorkflowExecution(sql.FieldNotNull(FieldDurationMs))
+}
+
+// WorkflowStatusEQ applies the EQ predicate on the "workflow_status" field.
+func WorkflowStatusEQ(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldEQ(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusNEQ applies the NEQ predicate on the "workflow_status" field.
+func WorkflowStatusNEQ(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldNEQ(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusIn applies the In predicate on the "workflow_status" field.
+func WorkflowStatusIn(vs ...types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = string(vs[i])
+	}
+	return predicate.WorkflowExecution(sql.FieldIn(FieldWorkflowStatus, v...))
+}
+
+// WorkflowStatusNotIn applies the NotIn predicate on the "workflow_status" field.
+func WorkflowStatusNotIn(vs ...types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = string(vs[i])
+	}
+	return predicate.WorkflowExecution(sql.FieldNotIn(FieldWorkflowStatus, v...))
+}
+
+// WorkflowStatusGT applies the GT predicate on the "workflow_status" field.
+func WorkflowStatusGT(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldGT(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusGTE applies the GTE predicate on the "workflow_status" field.
+func WorkflowStatusGTE(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldGTE(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusLT applies the LT predicate on the "workflow_status" field.
+func WorkflowStatusLT(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldLT(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusLTE applies the LTE predicate on the "workflow_status" field.
+func WorkflowStatusLTE(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldLTE(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusContains applies the Contains predicate on the "workflow_status" field.
+func WorkflowStatusContains(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldContains(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusHasPrefix applies the HasPrefix predicate on the "workflow_status" field.
+func WorkflowStatusHasPrefix(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldHasPrefix(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusHasSuffix applies the HasSuffix predicate on the "workflow_status" field.
+func WorkflowStatusHasSuffix(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldHasSuffix(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusEqualFold applies the EqualFold predicate on the "workflow_status" field.
+func WorkflowStatusEqualFold(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldEqualFold(FieldWorkflowStatus, vc))
+}
+
+// WorkflowStatusContainsFold applies the ContainsFold predicate on the "workflow_status" field.
+func WorkflowStatusContainsFold(v types.WorkflowExecutionStatus) predicate.WorkflowExecution {
+	vc := string(v)
+	return predicate.WorkflowExecution(sql.FieldContainsFold(FieldWorkflowStatus, vc))
 }
 
 // MetadataIsNil applies the IsNil predicate on the "metadata" field.

--- a/ent/workflowexecution/workflowexecution.go
+++ b/ent/workflowexecution/workflowexecution.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 const (
@@ -37,6 +38,12 @@ const (
 	FieldTaskQueue = "task_queue"
 	// FieldStartTime holds the string denoting the start_time field in the database.
 	FieldStartTime = "start_time"
+	// FieldEndTime holds the string denoting the end_time field in the database.
+	FieldEndTime = "end_time"
+	// FieldDurationMs holds the string denoting the duration_ms field in the database.
+	FieldDurationMs = "duration_ms"
+	// FieldWorkflowStatus holds the string denoting the workflow_status field in the database.
+	FieldWorkflowStatus = "workflow_status"
 	// FieldMetadata holds the string denoting the metadata field in the database.
 	FieldMetadata = "metadata"
 	// Table holds the table name of the workflowexecution in the database.
@@ -58,6 +65,9 @@ var Columns = []string{
 	FieldWorkflowType,
 	FieldTaskQueue,
 	FieldStartTime,
+	FieldEndTime,
+	FieldDurationMs,
+	FieldWorkflowStatus,
 	FieldMetadata,
 }
 
@@ -92,6 +102,8 @@ var (
 	WorkflowTypeValidator func(string) error
 	// TaskQueueValidator is a validator for the "task_queue" field. It is called by the builders before save.
 	TaskQueueValidator func(string) error
+	// DefaultWorkflowStatus holds the default value on creation for the "workflow_status" field.
+	DefaultWorkflowStatus types.WorkflowExecutionStatus
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -162,4 +174,19 @@ func ByTaskQueue(opts ...sql.OrderTermOption) OrderOption {
 // ByStartTime orders the results by the start_time field.
 func ByStartTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStartTime, opts...).ToFunc()
+}
+
+// ByEndTime orders the results by the end_time field.
+func ByEndTime(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldEndTime, opts...).ToFunc()
+}
+
+// ByDurationMs orders the results by the duration_ms field.
+func ByDurationMs(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDurationMs, opts...).ToFunc()
+}
+
+// ByWorkflowStatus orders the results by the workflow_status field.
+func ByWorkflowStatus(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldWorkflowStatus, opts...).ToFunc()
 }

--- a/ent/workflowexecution_create.go
+++ b/ent/workflowexecution_create.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/workflowexecution"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // WorkflowExecutionCreate is the builder for creating a WorkflowExecution entity.
@@ -140,6 +141,48 @@ func (wec *WorkflowExecutionCreate) SetStartTime(t time.Time) *WorkflowExecution
 	return wec
 }
 
+// SetEndTime sets the "end_time" field.
+func (wec *WorkflowExecutionCreate) SetEndTime(t time.Time) *WorkflowExecutionCreate {
+	wec.mutation.SetEndTime(t)
+	return wec
+}
+
+// SetNillableEndTime sets the "end_time" field if the given value is not nil.
+func (wec *WorkflowExecutionCreate) SetNillableEndTime(t *time.Time) *WorkflowExecutionCreate {
+	if t != nil {
+		wec.SetEndTime(*t)
+	}
+	return wec
+}
+
+// SetDurationMs sets the "duration_ms" field.
+func (wec *WorkflowExecutionCreate) SetDurationMs(i int64) *WorkflowExecutionCreate {
+	wec.mutation.SetDurationMs(i)
+	return wec
+}
+
+// SetNillableDurationMs sets the "duration_ms" field if the given value is not nil.
+func (wec *WorkflowExecutionCreate) SetNillableDurationMs(i *int64) *WorkflowExecutionCreate {
+	if i != nil {
+		wec.SetDurationMs(*i)
+	}
+	return wec
+}
+
+// SetWorkflowStatus sets the "workflow_status" field.
+func (wec *WorkflowExecutionCreate) SetWorkflowStatus(tes types.WorkflowExecutionStatus) *WorkflowExecutionCreate {
+	wec.mutation.SetWorkflowStatus(tes)
+	return wec
+}
+
+// SetNillableWorkflowStatus sets the "workflow_status" field if the given value is not nil.
+func (wec *WorkflowExecutionCreate) SetNillableWorkflowStatus(tes *types.WorkflowExecutionStatus) *WorkflowExecutionCreate {
+	if tes != nil {
+		wec.SetWorkflowStatus(*tes)
+	}
+	return wec
+}
+
 // SetMetadata sets the "metadata" field.
 func (wec *WorkflowExecutionCreate) SetMetadata(m map[string]interface{}) *WorkflowExecutionCreate {
 	wec.mutation.SetMetadata(m)
@@ -211,6 +254,10 @@ func (wec *WorkflowExecutionCreate) defaults() {
 		v := workflowexecution.DefaultEnvironmentID
 		wec.mutation.SetEnvironmentID(v)
 	}
+	if _, ok := wec.mutation.WorkflowStatus(); !ok {
+		v := workflowexecution.DefaultWorkflowStatus
+		wec.mutation.SetWorkflowStatus(v)
+	}
 	if _, ok := wec.mutation.ID(); !ok {
 		v := workflowexecution.DefaultID()
 		wec.mutation.SetID(v)
@@ -270,6 +317,9 @@ func (wec *WorkflowExecutionCreate) check() error {
 	}
 	if _, ok := wec.mutation.StartTime(); !ok {
 		return &ValidationError{Name: "start_time", err: errors.New(`ent: missing required field "WorkflowExecution.start_time"`)}
+	}
+	if _, ok := wec.mutation.WorkflowStatus(); !ok {
+		return &ValidationError{Name: "workflow_status", err: errors.New(`ent: missing required field "WorkflowExecution.workflow_status"`)}
 	}
 	return nil
 }
@@ -353,6 +403,18 @@ func (wec *WorkflowExecutionCreate) createSpec() (*WorkflowExecution, *sqlgraph.
 	if value, ok := wec.mutation.StartTime(); ok {
 		_spec.SetField(workflowexecution.FieldStartTime, field.TypeTime, value)
 		_node.StartTime = value
+	}
+	if value, ok := wec.mutation.EndTime(); ok {
+		_spec.SetField(workflowexecution.FieldEndTime, field.TypeTime, value)
+		_node.EndTime = &value
+	}
+	if value, ok := wec.mutation.DurationMs(); ok {
+		_spec.SetField(workflowexecution.FieldDurationMs, field.TypeInt64, value)
+		_node.DurationMs = &value
+	}
+	if value, ok := wec.mutation.WorkflowStatus(); ok {
+		_spec.SetField(workflowexecution.FieldWorkflowStatus, field.TypeString, value)
+		_node.WorkflowStatus = value
 	}
 	if value, ok := wec.mutation.Metadata(); ok {
 		_spec.SetField(workflowexecution.FieldMetadata, field.TypeJSON, value)

--- a/ent/workflowexecution_update.go
+++ b/ent/workflowexecution_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/predicate"
 	"github.com/flexprice/flexprice/ent/workflowexecution"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // WorkflowExecutionUpdate is the builder for updating WorkflowExecution entities.
@@ -134,6 +135,67 @@ func (weu *WorkflowExecutionUpdate) SetStartTime(t time.Time) *WorkflowExecution
 func (weu *WorkflowExecutionUpdate) SetNillableStartTime(t *time.Time) *WorkflowExecutionUpdate {
 	if t != nil {
 		weu.SetStartTime(*t)
+	}
+	return weu
+}
+
+// SetEndTime sets the "end_time" field.
+func (weu *WorkflowExecutionUpdate) SetEndTime(t time.Time) *WorkflowExecutionUpdate {
+	weu.mutation.SetEndTime(t)
+	return weu
+}
+
+// SetNillableEndTime sets the "end_time" field if the given value is not nil.
+func (weu *WorkflowExecutionUpdate) SetNillableEndTime(t *time.Time) *WorkflowExecutionUpdate {
+	if t != nil {
+		weu.SetEndTime(*t)
+	}
+	return weu
+}
+
+// ClearEndTime clears the value of the "end_time" field.
+func (weu *WorkflowExecutionUpdate) ClearEndTime() *WorkflowExecutionUpdate {
+	weu.mutation.ClearEndTime()
+	return weu
+}
+
+// SetDurationMs sets the "duration_ms" field.
+func (weu *WorkflowExecutionUpdate) SetDurationMs(i int64) *WorkflowExecutionUpdate {
+	weu.mutation.ResetDurationMs()
+	weu.mutation.SetDurationMs(i)
+	return weu
+}
+
+// SetNillableDurationMs sets the "duration_ms" field if the given value is not nil.
+func (weu *WorkflowExecutionUpdate) SetNillableDurationMs(i *int64) *WorkflowExecutionUpdate {
+	if i != nil {
+		weu.SetDurationMs(*i)
+	}
+	return weu
+}
+
+// AddDurationMs adds i to the "duration_ms" field.
+func (weu *WorkflowExecutionUpdate) AddDurationMs(i int64) *WorkflowExecutionUpdate {
+	weu.mutation.AddDurationMs(i)
+	return weu
+}
+
+// ClearDurationMs clears the value of the "duration_ms" field.
+func (weu *WorkflowExecutionUpdate) ClearDurationMs() *WorkflowExecutionUpdate {
+	weu.mutation.ClearDurationMs()
+	return weu
+}
+
+// SetWorkflowStatus sets the "workflow_status" field.
+func (weu *WorkflowExecutionUpdate) SetWorkflowStatus(tes types.WorkflowExecutionStatus) *WorkflowExecutionUpdate {
+	weu.mutation.SetWorkflowStatus(tes)
+	return weu
+}
+
+// SetNillableWorkflowStatus sets the "workflow_status" field if the given value is not nil.
+func (weu *WorkflowExecutionUpdate) SetNillableWorkflowStatus(tes *types.WorkflowExecutionStatus) *WorkflowExecutionUpdate {
+	if tes != nil {
+		weu.SetWorkflowStatus(*tes)
 	}
 	return weu
 }
@@ -260,6 +322,24 @@ func (weu *WorkflowExecutionUpdate) sqlSave(ctx context.Context) (n int, err err
 	}
 	if value, ok := weu.mutation.StartTime(); ok {
 		_spec.SetField(workflowexecution.FieldStartTime, field.TypeTime, value)
+	}
+	if value, ok := weu.mutation.EndTime(); ok {
+		_spec.SetField(workflowexecution.FieldEndTime, field.TypeTime, value)
+	}
+	if weu.mutation.EndTimeCleared() {
+		_spec.ClearField(workflowexecution.FieldEndTime, field.TypeTime)
+	}
+	if value, ok := weu.mutation.DurationMs(); ok {
+		_spec.SetField(workflowexecution.FieldDurationMs, field.TypeInt64, value)
+	}
+	if value, ok := weu.mutation.AddedDurationMs(); ok {
+		_spec.AddField(workflowexecution.FieldDurationMs, field.TypeInt64, value)
+	}
+	if weu.mutation.DurationMsCleared() {
+		_spec.ClearField(workflowexecution.FieldDurationMs, field.TypeInt64)
+	}
+	if value, ok := weu.mutation.WorkflowStatus(); ok {
+		_spec.SetField(workflowexecution.FieldWorkflowStatus, field.TypeString, value)
 	}
 	if value, ok := weu.mutation.Metadata(); ok {
 		_spec.SetField(workflowexecution.FieldMetadata, field.TypeJSON, value)
@@ -393,6 +473,67 @@ func (weuo *WorkflowExecutionUpdateOne) SetStartTime(t time.Time) *WorkflowExecu
 func (weuo *WorkflowExecutionUpdateOne) SetNillableStartTime(t *time.Time) *WorkflowExecutionUpdateOne {
 	if t != nil {
 		weuo.SetStartTime(*t)
+	}
+	return weuo
+}
+
+// SetEndTime sets the "end_time" field.
+func (weuo *WorkflowExecutionUpdateOne) SetEndTime(t time.Time) *WorkflowExecutionUpdateOne {
+	weuo.mutation.SetEndTime(t)
+	return weuo
+}
+
+// SetNillableEndTime sets the "end_time" field if the given value is not nil.
+func (weuo *WorkflowExecutionUpdateOne) SetNillableEndTime(t *time.Time) *WorkflowExecutionUpdateOne {
+	if t != nil {
+		weuo.SetEndTime(*t)
+	}
+	return weuo
+}
+
+// ClearEndTime clears the value of the "end_time" field.
+func (weuo *WorkflowExecutionUpdateOne) ClearEndTime() *WorkflowExecutionUpdateOne {
+	weuo.mutation.ClearEndTime()
+	return weuo
+}
+
+// SetDurationMs sets the "duration_ms" field.
+func (weuo *WorkflowExecutionUpdateOne) SetDurationMs(i int64) *WorkflowExecutionUpdateOne {
+	weuo.mutation.ResetDurationMs()
+	weuo.mutation.SetDurationMs(i)
+	return weuo
+}
+
+// SetNillableDurationMs sets the "duration_ms" field if the given value is not nil.
+func (weuo *WorkflowExecutionUpdateOne) SetNillableDurationMs(i *int64) *WorkflowExecutionUpdateOne {
+	if i != nil {
+		weuo.SetDurationMs(*i)
+	}
+	return weuo
+}
+
+// AddDurationMs adds i to the "duration_ms" field.
+func (weuo *WorkflowExecutionUpdateOne) AddDurationMs(i int64) *WorkflowExecutionUpdateOne {
+	weuo.mutation.AddDurationMs(i)
+	return weuo
+}
+
+// ClearDurationMs clears the value of the "duration_ms" field.
+func (weuo *WorkflowExecutionUpdateOne) ClearDurationMs() *WorkflowExecutionUpdateOne {
+	weuo.mutation.ClearDurationMs()
+	return weuo
+}
+
+// SetWorkflowStatus sets the "workflow_status" field.
+func (weuo *WorkflowExecutionUpdateOne) SetWorkflowStatus(tes types.WorkflowExecutionStatus) *WorkflowExecutionUpdateOne {
+	weuo.mutation.SetWorkflowStatus(tes)
+	return weuo
+}
+
+// SetNillableWorkflowStatus sets the "workflow_status" field if the given value is not nil.
+func (weuo *WorkflowExecutionUpdateOne) SetNillableWorkflowStatus(tes *types.WorkflowExecutionStatus) *WorkflowExecutionUpdateOne {
+	if tes != nil {
+		weuo.SetWorkflowStatus(*tes)
 	}
 	return weuo
 }
@@ -549,6 +690,24 @@ func (weuo *WorkflowExecutionUpdateOne) sqlSave(ctx context.Context) (_node *Wor
 	}
 	if value, ok := weuo.mutation.StartTime(); ok {
 		_spec.SetField(workflowexecution.FieldStartTime, field.TypeTime, value)
+	}
+	if value, ok := weuo.mutation.EndTime(); ok {
+		_spec.SetField(workflowexecution.FieldEndTime, field.TypeTime, value)
+	}
+	if weuo.mutation.EndTimeCleared() {
+		_spec.ClearField(workflowexecution.FieldEndTime, field.TypeTime)
+	}
+	if value, ok := weuo.mutation.DurationMs(); ok {
+		_spec.SetField(workflowexecution.FieldDurationMs, field.TypeInt64, value)
+	}
+	if value, ok := weuo.mutation.AddedDurationMs(); ok {
+		_spec.AddField(workflowexecution.FieldDurationMs, field.TypeInt64, value)
+	}
+	if weuo.mutation.DurationMsCleared() {
+		_spec.ClearField(workflowexecution.FieldDurationMs, field.TypeInt64)
+	}
+	if value, ok := weuo.mutation.WorkflowStatus(); ok {
+		_spec.SetField(workflowexecution.FieldWorkflowStatus, field.TypeString, value)
 	}
 	if value, ok := weuo.mutation.Metadata(); ok {
 		_spec.SetField(workflowexecution.FieldMetadata, field.TypeJSON, value)

--- a/internal/api/dto/workflow.go
+++ b/internal/api/dto/workflow.go
@@ -47,10 +47,17 @@ type WorkflowTimelineItemDTO struct {
 
 // ListWorkflowsRequest represents the request parameters for listing workflows
 type ListWorkflowsRequest struct {
-	WorkflowType string `form:"workflow_type"`
-	TaskQueue    string `form:"task_queue"`
-	PageSize     int    `form:"page_size"`
-	Page         int    `form:"page"`
+	WorkflowID     string `form:"workflow_id"` // Filter by specific workflow ID
+	WorkflowType   string `form:"workflow_type"`
+	TaskQueue      string `form:"task_queue"`
+	WorkflowStatus string `form:"workflow_status"` // e.g. Running, Completed, Failed
+
+	// Metadata filters - specific fields for common use cases
+	Entity   string `form:"entity"`    // e.g. "plan", "customer", "invoice"
+	EntityID string `form:"entity_id"` // e.g. "plan_01ABC123"
+
+	PageSize int `form:"page_size"`
+	Page     int `form:"page"`
 }
 
 // ListWorkflowsResponse represents the response for listing workflows

--- a/internal/api/v1/workflow.go
+++ b/internal/api/v1/workflow.go
@@ -67,12 +67,16 @@ func (h *WorkflowHandler) ListWorkflows(c *gin.Context) {
 
 	// Query database for workflow executions
 	filters := &service.ListWorkflowExecutionsFilters{
-		TenantID:      tenantID,
-		EnvironmentID: environmentID,
-		WorkflowType:  req.WorkflowType,
-		TaskQueue:     req.TaskQueue,
-		PageSize:      req.PageSize,
-		Page:          req.Page,
+		TenantID:       tenantID,
+		EnvironmentID:  environmentID,
+		WorkflowID:     req.WorkflowID,
+		WorkflowType:   req.WorkflowType,
+		TaskQueue:      req.TaskQueue,
+		WorkflowStatus: req.WorkflowStatus,
+		Entity:         req.Entity,
+		EntityID:       req.EntityID,
+		PageSize:       req.PageSize,
+		Page:           req.Page,
 	}
 
 	executions, total, err := h.workflowExecService.ListWorkflowExecutions(c.Request.Context(), filters)
@@ -89,7 +93,10 @@ func (h *WorkflowHandler) ListWorkflows(c *gin.Context) {
 			RunID:        exec.RunID,
 			WorkflowType: exec.WorkflowType,
 			TaskQueue:    exec.TaskQueue,
+			Status:       string(exec.WorkflowStatus),
 			StartTime:    exec.StartTime,
+			CloseTime:    exec.EndTime,    // Map end_time to CloseTime
+			DurationMs:   exec.DurationMs, // Include duration
 			CreatedBy:    exec.CreatedBy,
 		}
 	}

--- a/internal/domain/workflowexecution/repository.go
+++ b/internal/domain/workflowexecution/repository.go
@@ -2,8 +2,10 @@ package workflowexecution
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/ent"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // Repository defines the interface for workflow execution data access
@@ -12,14 +14,22 @@ type Repository interface {
 	Get(ctx context.Context, workflowID, runID string) (*ent.WorkflowExecution, error)
 	List(ctx context.Context, filter *ListFilter) ([]*ent.WorkflowExecution, int, error)
 	Delete(ctx context.Context, id string) error
+	UpdateStatus(ctx context.Context, workflowID, runID string, status types.WorkflowExecutionStatus, errorMessage string, endTime *time.Time, durationMs *int64) error
 }
 
 // ListFilter defines filters for listing workflow executions
 type ListFilter struct {
-	TenantID      string
-	EnvironmentID string
-	WorkflowType  string
-	TaskQueue     string
-	PageSize      int
-	Page          int
+	TenantID       string
+	EnvironmentID  string
+	WorkflowID     string // Filter by specific workflow ID
+	WorkflowType   string
+	TaskQueue      string
+	WorkflowStatus string // e.g. Running, Completed, Failed
+
+	// Metadata filters - specific fields
+	Entity   string // Filter by entity type in metadata
+	EntityID string // Filter by entity_id in metadata
+
+	PageSize int
+	Page     int
 }

--- a/internal/repository/ent/workflow_execution.go
+++ b/internal/repository/ent/workflow_execution.go
@@ -2,13 +2,16 @@ package ent
 
 import (
 	"context"
+	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/workflowexecution"
 	domainWorkflowExecution "github.com/flexprice/flexprice/internal/domain/workflowexecution"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/postgres"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 type workflowExecutionRepository struct {
@@ -42,6 +45,7 @@ func (r *workflowExecutionRepository) Create(ctx context.Context, exec *ent.Work
 		SetEnvironmentID(exec.EnvironmentID).
 		SetCreatedBy(exec.CreatedBy).
 		SetStatus(exec.Status).
+		SetWorkflowStatus(exec.WorkflowStatus).
 		SetCreatedAt(exec.CreatedAt).
 		SetUpdatedAt(exec.UpdatedAt).
 		SetUpdatedBy(exec.UpdatedBy)
@@ -104,11 +108,35 @@ func (r *workflowExecutionRepository) List(ctx context.Context, filter *domainWo
 	if filter.EnvironmentID != "" {
 		query = query.Where(workflowexecution.EnvironmentID(filter.EnvironmentID))
 	}
+	if filter.WorkflowID != "" {
+		query = query.Where(workflowexecution.WorkflowID(filter.WorkflowID))
+	}
 	if filter.WorkflowType != "" {
 		query = query.Where(workflowexecution.WorkflowType(filter.WorkflowType))
 	}
 	if filter.TaskQueue != "" {
 		query = query.Where(workflowexecution.TaskQueue(filter.TaskQueue))
+	}
+	if filter.WorkflowStatus != "" {
+		query = query.Where(workflowexecution.WorkflowStatus(types.WorkflowExecutionStatus(filter.WorkflowStatus)))
+	}
+
+	// Metadata filters - JSONB queries
+	if filter.Entity != "" {
+		query = query.Where(func(s *sql.Selector) {
+			s.Where(sql.P(func(b *sql.Builder) {
+				b.WriteString("metadata->>'entity' = ")
+				b.Arg(filter.Entity)
+			}))
+		})
+	}
+	if filter.EntityID != "" {
+		query = query.Where(func(s *sql.Selector) {
+			s.Where(sql.P(func(b *sql.Builder) {
+				b.WriteString("metadata->>'entity_id' = ")
+				b.Arg(filter.EntityID)
+			}))
+		})
 	}
 
 	// Get total count
@@ -167,6 +195,76 @@ func (r *workflowExecutionRepository) Delete(ctx context.Context, id string) err
 			WithHint("Failed to delete workflow execution").
 			Mark(ierr.ErrDatabase)
 	}
+
+	return nil
+}
+
+func (r *workflowExecutionRepository) UpdateStatus(
+	ctx context.Context,
+	workflowID string,
+	runID string,
+	status types.WorkflowExecutionStatus,
+	errorMessage string,
+	endTime *time.Time,
+	durationMs *int64,
+) error {
+	client := r.client.Writer(ctx)
+
+	r.log.Debugw("updating workflow execution status",
+		"workflow_id", workflowID,
+		"run_id", runID,
+		"status", status,
+		"has_end_time", endTime != nil,
+		"has_duration", durationMs != nil,
+	)
+
+	// Find the workflow execution
+	exec, err := r.Get(ctx, workflowID, runID)
+	if err != nil {
+		return err
+	}
+
+	// Build update query
+	updateQuery := client.WorkflowExecution.
+		UpdateOne(exec).
+		SetWorkflowStatus(status).
+		SetUpdatedAt(exec.UpdatedAt) // Will be auto-updated by the hook
+
+	// Set end time if provided
+	if endTime != nil {
+		updateQuery = updateQuery.SetEndTime(*endTime)
+	}
+
+	// Set duration if provided
+	if durationMs != nil {
+		updateQuery = updateQuery.SetDurationMs(*durationMs)
+	}
+
+	// Store error message in metadata if provided
+	if errorMessage != "" {
+		metadata := exec.Metadata
+		if metadata == nil {
+			metadata = make(map[string]interface{})
+		}
+		metadata["error"] = errorMessage
+		updateQuery = updateQuery.SetMetadata(metadata)
+	}
+
+	// Execute update
+	_, err = updateQuery.Save(ctx)
+	if err != nil {
+		return ierr.WithError(err).
+			WithHintf("Failed to update workflow execution status: %s/%s", workflowID, runID).
+			Mark(ierr.ErrDatabase)
+	}
+
+	r.log.Infow("successfully updated workflow execution status",
+		"workflow_id", workflowID,
+		"run_id", runID,
+		"status", status,
+		"end_time", endTime,
+		"duration_ms", durationMs,
+	)
 
 	return nil
 }

--- a/internal/temporal/activities/workflow/tracking_activity.go
+++ b/internal/temporal/activities/workflow/tracking_activity.go
@@ -33,7 +33,19 @@ func NewWorkflowTrackingActivities(
 // TrackWorkflowStart performs the workflow tracking activity
 // This is registered as a local activity and saves workflow metadata to the database
 // It uses the TrackWorkflowStartActivityInput type from the tracking package
+// This function is panic-safe and will never crash the workflow
 func (a *WorkflowTrackingActivities) TrackWorkflowStart(ctx context.Context, input tracking.TrackWorkflowStartActivityInput) error {
+	// CRITICAL: Panic recovery to ensure tracking failures never crash workflows
+	defer func() {
+		if r := recover(); r != nil {
+			a.logger.Error("Panic recovered in TrackWorkflowStart - workflow will continue",
+				"panic", r,
+				"workflow_id", input.WorkflowID,
+				"run_id", input.RunID)
+			// Workflow continues despite panic
+		}
+	}()
+
 	// Set context values for proper multi-tenancy
 	ctx = types.SetTenantID(ctx, input.TenantID)
 	ctx = types.SetEnvironmentID(ctx, input.EnvironmentID)
@@ -70,6 +82,56 @@ func (a *WorkflowTrackingActivities) TrackWorkflowStart(ctx context.Context, inp
 	a.logger.Info("Successfully tracked workflow start",
 		"workflow_id", input.WorkflowID,
 		"run_id", input.RunID)
+
+	return nil
+}
+
+// TrackWorkflowEnd performs the workflow end tracking activity
+// This is registered as a local activity and updates workflow status in the database
+// It uses the TrackWorkflowEndActivityInput type from the tracking package
+// This function is panic-safe and will never crash the workflow
+func (a *WorkflowTrackingActivities) TrackWorkflowEnd(ctx context.Context, input tracking.TrackWorkflowEndActivityInput) error {
+	// CRITICAL: Panic recovery to ensure tracking failures never crash workflows
+	defer func() {
+		if r := recover(); r != nil {
+			a.logger.Error("Panic recovered in TrackWorkflowEnd - workflow will continue",
+				"panic", r,
+				"workflow_id", input.WorkflowID,
+				"run_id", input.RunID)
+			// Workflow continues despite panic
+		}
+	}()
+
+	a.logger.Info("Tracking workflow end",
+		"workflow_id", input.WorkflowID,
+		"run_id", input.RunID,
+		"status", input.WorkflowStatus,
+		"has_end_time", input.EndTime != nil,
+		"has_duration", input.DurationMs != nil)
+
+	// Update workflow execution status in database
+	err := a.workflowExecRepo.UpdateStatus(
+		ctx,
+		input.WorkflowID,
+		input.RunID,
+		input.WorkflowStatus,
+		input.ErrorMessage,
+		input.EndTime,
+		input.DurationMs,
+	)
+
+	if err != nil {
+		a.logger.Error("Failed to update workflow status", "error", err)
+		// Don't fail the workflow if tracking fails - just log the error
+		return nil
+	}
+
+	a.logger.Info("Successfully tracked workflow end",
+		"workflow_id", input.WorkflowID,
+		"run_id", input.RunID,
+		"status", input.WorkflowStatus,
+		"end_time", input.EndTime,
+		"duration_ms", input.DurationMs)
 
 	return nil
 }

--- a/internal/temporal/interceptor/workflow_tracking_interceptor.go
+++ b/internal/temporal/interceptor/workflow_tracking_interceptor.go
@@ -1,0 +1,249 @@
+package interceptor
+
+import (
+	"reflect"
+	"strings"
+	"unicode"
+
+	"github.com/flexprice/flexprice/internal/temporal/tracking"
+	"github.com/flexprice/flexprice/internal/types"
+	"go.temporal.io/sdk/interceptor"
+	"go.temporal.io/sdk/workflow"
+)
+
+// WorkflowTrackingInterceptor provides workflow execution tracking
+// It automatically tracks workflow start and end status in the database
+type WorkflowTrackingInterceptor struct {
+	interceptor.InterceptorBase
+}
+
+// NewWorkflowTrackingInterceptor creates a new workflow tracking interceptor
+func NewWorkflowTrackingInterceptor() *WorkflowTrackingInterceptor {
+	return &WorkflowTrackingInterceptor{}
+}
+
+// InterceptWorkflow creates a workflow inbound interceptor
+func (w *WorkflowTrackingInterceptor) InterceptWorkflow(
+	ctx workflow.Context,
+	next interceptor.WorkflowInboundInterceptor,
+) interceptor.WorkflowInboundInterceptor {
+	return &workflowTrackingInboundInterceptor{
+		WorkflowInboundInterceptorBase: interceptor.WorkflowInboundInterceptorBase{
+			Next: next,
+		},
+	}
+}
+
+// workflowTrackingInboundInterceptor intercepts workflow executions to track status
+type workflowTrackingInboundInterceptor struct {
+	interceptor.WorkflowInboundInterceptorBase
+}
+
+// ExecuteWorkflow intercepts workflow execution to track completion status and timing
+func (w *workflowTrackingInboundInterceptor) ExecuteWorkflow(
+	ctx workflow.Context,
+	in *interceptor.ExecuteWorkflowInput,
+) (interface{}, error) {
+	logger := workflow.GetLogger(ctx)
+	workflowInfo := workflow.GetInfo(ctx)
+
+	// Track workflow start automatically
+	trackWorkflowStart(ctx, *workflowInfo, in)
+
+	// Capture start time from workflow info
+	startTime := workflowInfo.WorkflowStartTime
+
+	logger.Debug("Workflow tracking interceptor: workflow starting",
+		"workflow_type", workflowInfo.WorkflowType.Name,
+		"workflow_id", workflowInfo.WorkflowExecution.ID,
+		"run_id", workflowInfo.WorkflowExecution.RunID,
+		"start_time", startTime,
+	)
+
+	// Execute the workflow
+	result, err := w.Next.ExecuteWorkflow(ctx, in)
+
+	// Capture end time and calculate duration
+	endTime := workflow.Now(ctx)
+	durationMs := endTime.Sub(startTime).Milliseconds()
+
+	// After workflow completes (success or failure), update status
+	status := types.WorkflowExecutionStatusCompleted
+	errorMsg := ""
+
+	if err != nil {
+		status = types.WorkflowExecutionStatusFailed
+		errorMsg = err.Error()
+		logger.Info("Workflow tracking interceptor: workflow failed, tracking status",
+			"workflow_type", workflowInfo.WorkflowType.Name,
+			"workflow_id", workflowInfo.WorkflowExecution.ID,
+			"status", status,
+			"duration_ms", durationMs,
+		)
+	} else {
+		logger.Info("Workflow tracking interceptor: workflow completed, tracking status",
+			"workflow_type", workflowInfo.WorkflowType.Name,
+			"workflow_id", workflowInfo.WorkflowExecution.ID,
+			"status", status,
+			"duration_ms", durationMs,
+		)
+	}
+
+	// Execute local activity to update workflow status in database with timing
+	// This is non-blocking and won't fail the workflow if tracking fails
+	tracking.ExecuteTrackWorkflowEnd(ctx, tracking.TrackWorkflowEndInput{
+		WorkflowStatus: status,
+		Error:          errorMsg,
+		EndTime:        endTime,
+		DurationMs:     durationMs,
+	})
+
+	return result, err
+
+}
+
+// trackWorkflowStart automatically tracks workflow start by extracting metadata from input
+// This function is panic-safe and will never crash the workflow
+func trackWorkflowStart(ctx workflow.Context, info workflow.Info, in *interceptor.ExecuteWorkflowInput) {
+	logger := workflow.GetLogger(ctx)
+
+	// CRITICAL: Panic recovery to ensure tracking failures never crash workflows
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Panic recovered in trackWorkflowStart - workflow will continue",
+				"panic", r,
+				"workflow_id", info.WorkflowExecution.ID,
+				"workflow_type", info.WorkflowType.Name)
+			// Workflow continues despite panic
+		}
+	}()
+
+	// Extract tenant/environment and metadata from workflow input
+	tenantID, environmentID, metadata := extractWorkflowContext(in.Args)
+
+	logger.Debug("Tracking workflow start",
+		"workflow_type", info.WorkflowType.Name,
+		"workflow_id", info.WorkflowExecution.ID,
+		"task_queue", info.TaskQueueName,
+		"tenant_id", tenantID,
+		"environment_id", environmentID,
+	)
+
+	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
+		WorkflowType:  info.WorkflowType.Name,
+		TaskQueue:     info.TaskQueueName,
+		TenantID:      tenantID,
+		EnvironmentID: environmentID,
+		UserID:        "", // Can be extracted from metadata if needed
+		Metadata:      metadata,
+	})
+}
+
+// extractWorkflowContext extracts TenantID, EnvironmentID, and metadata from workflow input
+// This function is panic-safe and will return empty values if extraction fails
+func extractWorkflowContext(args []interface{}) (tenantID, environmentID string, metadata map[string]interface{}) {
+	// CRITICAL: Panic recovery to ensure reflection errors never crash workflows
+	defer func() {
+		if r := recover(); r != nil {
+			// Return empty values on panic - workflow will continue
+			tenantID = ""
+			environmentID = ""
+			metadata = nil
+		}
+	}()
+
+	if len(args) == 0 {
+		return "", "", nil
+	}
+
+	metadata = make(map[string]interface{})
+	input := args[0]
+
+	// Use reflection to extract fields
+	val := reflect.ValueOf(input)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return "", "", nil
+	}
+
+	typ := val.Type()
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		fieldVal := val.Field(i)
+
+		// Skip unexported fields
+		if !fieldVal.CanInterface() {
+			continue
+		}
+
+		// Extract TenantID
+		if field.Name == "TenantID" && fieldVal.Kind() == reflect.String {
+			tenantID = fieldVal.String()
+			continue
+		}
+
+		// Extract EnvironmentID (handles both EnvironmentID and EnvID field names)
+		if (field.Name == "EnvironmentID" || field.Name == "EnvID") && fieldVal.Kind() == reflect.String {
+			environmentID = fieldVal.String()
+			continue
+		}
+
+		// Add other fields to metadata (skip empty values)
+		if !isZeroValue(fieldVal) {
+			metadata[toSnakeCase(field.Name)] = fieldVal.Interface()
+		}
+	}
+
+	return tenantID, environmentID, metadata
+}
+
+// isZeroValue checks if a reflect.Value is the zero value for its type
+func isZeroValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.String:
+		return v.String() == ""
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Ptr, reflect.Interface, reflect.Slice, reflect.Map:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
+// toSnakeCase converts a string from CamelCase to snake_case
+// Handles acronyms correctly: UserID -> user_id, ScheduledTaskID -> scheduled_task_id
+func toSnakeCase(s string) string {
+	var result strings.Builder
+	for i, r := range s {
+		if unicode.IsUpper(r) {
+			// Don't add underscore at the start
+			if i > 0 {
+				// Check if previous char was lowercase or if next char is lowercase
+				// This handles acronyms: UserID -> user_id (not user_i_d)
+				prevIsLower := i > 0 && unicode.IsLower(rune(s[i-1]))
+				nextIsLower := i+1 < len(s) && unicode.IsLower(rune(s[i+1]))
+
+				// Add underscore if:
+				// - Previous char was lowercase (camelCase boundary)
+				// - OR current is uppercase but next is lowercase (end of acronym: HTMLParser -> html_parser)
+				if prevIsLower || (i > 0 && nextIsLower && unicode.IsUpper(rune(s[i-1]))) {
+					result.WriteRune('_')
+				}
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}

--- a/internal/temporal/interceptor/workflow_tracking_interceptor_test.go
+++ b/internal/temporal/interceptor/workflow_tracking_interceptor_test.go
@@ -1,0 +1,48 @@
+package interceptor
+
+import (
+	"testing"
+)
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Regular camelCase
+		{"userName", "user_name"},
+		{"firstName", "first_name"},
+
+		// With ID suffix (acronym)
+		{"UserID", "user_id"},
+		{"TenantID", "tenant_id"},
+		{"ScheduledTaskID", "scheduled_task_id"},
+		{"EnvironmentID", "environment_id"},
+
+		// With ID in middle
+		{"UserIDName", "user_id_name"},
+
+		// Multiple acronyms
+		{"HTMLURL", "htmlurl"},
+		{"HTMLParser", "html_parser"},
+
+		// Already snake_case
+		{"user_name", "user_name"},
+
+		// Single word
+		{"User", "user"},
+		{"ID", "id"},
+
+		// Empty
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := toSnakeCase(tt.input)
+			if result != tt.expected {
+				t.Errorf("toSnakeCase(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -183,6 +183,7 @@ func buildWorkerConfig(
 	// Add tracking activity to all task queues
 	activitiesList := []interface{}{
 		workflowTrackingActivities.TrackWorkflowStart,
+		workflowTrackingActivities.TrackWorkflowEnd,
 	}
 
 	switch taskQueue {

--- a/internal/temporal/service/service.go
+++ b/internal/temporal/service/service.go
@@ -234,11 +234,16 @@ func (s *temporalService) RegisterWorkflow(taskQueue types.TemporalTaskQueue, wo
 			Mark(errors.ErrValidation)
 	}
 
-	// Create worker options with Sentry interceptor
+	// Create worker options with Sentry and Workflow Tracking interceptors
 	options := models.DefaultWorkerOptions()
 	if s.sentry != nil && s.sentry.IsEnabled() {
 		options.Interceptors = []interceptor.WorkerInterceptor{
 			temporalInterceptor.NewSentryInterceptor(s.sentry),
+			temporalInterceptor.NewWorkflowTrackingInterceptor(),
+		}
+	} else {
+		options.Interceptors = []interceptor.WorkerInterceptor{
+			temporalInterceptor.NewWorkflowTrackingInterceptor(),
 		}
 	}
 
@@ -265,11 +270,16 @@ func (s *temporalService) RegisterActivity(taskQueue types.TemporalTaskQueue, ac
 			Mark(errors.ErrValidation)
 	}
 
-	// Create worker options with Sentry interceptor
+	// Create worker options with Sentry and Workflow Tracking interceptors
 	options := models.DefaultWorkerOptions()
 	if s.sentry != nil && s.sentry.IsEnabled() {
 		options.Interceptors = []interceptor.WorkerInterceptor{
 			temporalInterceptor.NewSentryInterceptor(s.sentry),
+			temporalInterceptor.NewWorkflowTrackingInterceptor(),
+		}
+	} else {
+		options.Interceptors = []interceptor.WorkerInterceptor{
+			temporalInterceptor.NewWorkflowTrackingInterceptor(),
 		}
 	}
 

--- a/internal/temporal/tracking/workflow_tracking.go
+++ b/internal/temporal/tracking/workflow_tracking.go
@@ -3,6 +3,7 @@ package tracking
 import (
 	"time"
 
+	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -15,6 +16,24 @@ type TrackWorkflowStartInput struct {
 	EnvironmentID string
 	UserID        string
 	Metadata      map[string]interface{}
+}
+
+// TrackWorkflowEndInput contains the parameters for tracking a workflow end
+type TrackWorkflowEndInput struct {
+	WorkflowStatus types.WorkflowExecutionStatus
+	Error          string
+	EndTime        time.Time
+	DurationMs     int64
+}
+
+// TrackWorkflowEndActivityInput is the input for the end tracking activity
+type TrackWorkflowEndActivityInput struct {
+	WorkflowID     string
+	RunID          string
+	WorkflowStatus types.WorkflowExecutionStatus
+	ErrorMessage   string
+	EndTime        *time.Time
+	DurationMs     *int64
 }
 
 // TrackWorkflowStartActivityInput is the input for the tracking activity
@@ -75,4 +94,49 @@ func ExecuteTrackWorkflowStart(ctx workflow.Context, input TrackWorkflowStartInp
 	}
 
 	logger.Info("Successfully tracked workflow start", "workflow_id", workflowID, "run_id", runID)
+}
+
+// ExecuteTrackWorkflowEnd is a helper function to be called at the end of each workflow
+// It executes a local activity to update the workflow execution status in the database
+func ExecuteTrackWorkflowEnd(ctx workflow.Context, input TrackWorkflowEndInput) {
+	logger := workflow.GetLogger(ctx)
+	info := workflow.GetInfo(ctx)
+
+	// Extract workflow execution details
+	workflowID := info.WorkflowExecution.ID
+	runID := info.WorkflowExecution.RunID
+
+	logger.Info("Tracking workflow end",
+		"workflow_id", workflowID,
+		"run_id", runID,
+		"status", input.WorkflowStatus)
+
+	// Prepare activity input
+	activityInput := TrackWorkflowEndActivityInput{
+		WorkflowID:     workflowID,
+		RunID:          runID,
+		WorkflowStatus: input.WorkflowStatus,
+		ErrorMessage:   input.Error,
+		EndTime:        &input.EndTime,
+		DurationMs:     &input.DurationMs,
+	}
+
+	// Execute as local activity (fast, doesn't need to be in history)
+	localActivityOptions := workflow.LocalActivityOptions{
+		StartToCloseTimeout: 10 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			MaximumAttempts: 3,
+		},
+	}
+
+	ctx = workflow.WithLocalActivityOptions(ctx, localActivityOptions)
+
+	// Execute local activity by name (activity is registered in registration.go)
+	err := workflow.ExecuteLocalActivity(ctx, "TrackWorkflowEnd", activityInput).Get(ctx, nil)
+	if err != nil {
+		logger.Error("Failed to execute end tracking activity", "error", err)
+		// Don't fail the workflow - tracking is non-critical
+	}
+
+	logger.Info("Successfully tracked workflow end", "workflow_id", workflowID, "run_id", runID)
 }

--- a/internal/temporal/workflows/customer_onboarding_workflow.go
+++ b/internal/temporal/workflows/customer_onboarding_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -30,19 +28,6 @@ func CustomerOnboardingWorkflow(ctx workflow.Context, input models.CustomerOnboa
 	logger.Info("Starting customer onboarding workflow",
 		"customer_id", input.CustomerID,
 		"action_count", len(input.WorkflowConfig.Actions))
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowCustomerOnboarding,
-		TaskQueue:     string(types.TemporalTaskQueueWorkflows),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        input.UserID,
-		Metadata: map[string]interface{}{
-			"customer_id":  input.CustomerID,
-			"action_count": len(input.WorkflowConfig.Actions),
-		},
-	})
 
 	// Define activity options
 	ao := workflow.ActivityOptions{

--- a/internal/temporal/workflows/events/reprocess_events_workflow.go
+++ b/internal/temporal/workflows/events/reprocess_events_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	models "github.com/flexprice/flexprice/internal/temporal/models/events"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -30,19 +28,6 @@ func ReprocessEventsWorkflow(ctx workflow.Context, input models.ReprocessEventsW
 		"event_name", input.EventName,
 		"start_date", input.StartDate,
 		"end_date", input.EndDate)
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowReprocessEvents,
-		TaskQueue:     string(types.TemporalTaskQueueReprocessEvents),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        input.UserID,
-		Metadata: map[string]interface{}{
-			"external_customer_id": input.ExternalCustomerID,
-			"event_name":           input.EventName,
-		},
-	})
 
 	// Define activity options with extended timeouts for large batch processing
 	// Activity timeout set to 10 hours to allow for long-running reprocessing

--- a/internal/temporal/workflows/events/reprocess_raw_events_workflow.go
+++ b/internal/temporal/workflows/events/reprocess_raw_events_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	models "github.com/flexprice/flexprice/internal/temporal/models/events"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -30,19 +28,6 @@ func ReprocessRawEventsWorkflow(ctx workflow.Context, input models.ReprocessRawE
 		"event_name", input.EventName,
 		"start_date", input.StartDate,
 		"end_date", input.EndDate)
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowReprocessRawEvents,
-		TaskQueue:     string(types.TemporalTaskQueueReprocessEvents),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        input.UserID,
-		Metadata: map[string]interface{}{
-			"external_customer_id": input.ExternalCustomerID,
-			"event_name":           input.EventName,
-		},
-	})
 
 	// Define activity options with 1 hour timeout as requested
 	// Activity timeout set to 55 minutes to leave buffer for workflow

--- a/internal/temporal/workflows/export/export_workflow.go
+++ b/internal/temporal/workflows/export/export_workflow.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/activities/export"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
 	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
@@ -44,18 +43,6 @@ func ExecuteExportWorkflow(ctx workflow.Context, input ExecuteExportWorkflowInpu
 		"scheduled_task_id", input.ScheduledTaskID,
 		"tenant_id", input.TenantID,
 		"env_id", input.EnvID)
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  "ExecuteExportWorkflow",
-		TaskQueue:     string(types.TemporalTaskQueueExport),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvID,
-		UserID:        input.UserID,
-		Metadata: map[string]interface{}{
-			"scheduled_task_id": input.ScheduledTaskID,
-		},
-	})
 
 	// Activity options for lightweight operations (fetching config, updating status)
 	lightweightActivityOptions := workflow.ActivityOptions{

--- a/internal/temporal/workflows/hubspot_deal_sync_workflow.go
+++ b/internal/temporal/workflows/hubspot_deal_sync_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -36,18 +34,6 @@ func HubSpotDealSyncWorkflow(ctx workflow.Context, input models.HubSpotDealSyncW
 		logger.Error("Invalid workflow input", "error", err)
 		return err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowHubSpotDealSync,
-		TaskQueue:     string(types.TemporalTaskQueueTask),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "", // System workflow, no specific user
-		Metadata: map[string]interface{}{
-			"subscription_id": input.SubscriptionID,
-		},
-	})
 
 	// Configure activity options
 	activityOptions := workflow.ActivityOptions{

--- a/internal/temporal/workflows/hubspot_invoice_sync_workflow.go
+++ b/internal/temporal/workflows/hubspot_invoice_sync_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -34,19 +32,6 @@ func HubSpotInvoiceSyncWorkflow(ctx workflow.Context, input models.HubSpotInvoic
 		logger.Error("Invalid workflow input", "error", err)
 		return err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowHubSpotInvoiceSync,
-		TaskQueue:     string(types.TemporalTaskQueueTask),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "", // System workflow, no specific user
-		Metadata: map[string]interface{}{
-			"invoice_id":  input.InvoiceID,
-			"customer_id": input.CustomerID,
-		},
-	})
 
 	activityOptions := workflow.ActivityOptions{
 		StartToCloseTimeout: 5 * time.Minute,

--- a/internal/temporal/workflows/hubspot_quote_sync_workflow.go
+++ b/internal/temporal/workflows/hubspot_quote_sync_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -33,18 +31,6 @@ func HubSpotQuoteSyncWorkflow(ctx workflow.Context, input models.HubSpotQuoteSyn
 		logger.Error("Invalid workflow input", "error", err)
 		return err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowHubSpotQuoteSync,
-		TaskQueue:     string(types.TemporalTaskQueueTask),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "", // System workflow, no specific user
-		Metadata: map[string]interface{}{
-			"subscription_id": input.SubscriptionID,
-		},
-	})
 
 	// Configure activity options
 	activityOptions := workflow.ActivityOptions{

--- a/internal/temporal/workflows/invoice/process_invoice_workflow.go
+++ b/internal/temporal/workflows/invoice/process_invoice_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -40,18 +38,6 @@ func ProcessInvoiceWorkflow(
 		logger.Error("Invalid workflow input", "error", err)
 		return nil, err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowProcessInvoice,
-		TaskQueue:     string(types.TemporalTaskQueueInvoice),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "",
-		Metadata: map[string]interface{}{
-			"invoice_id": input.InvoiceID,
-		},
-	})
 
 	// Define activity options
 	activityOptions := workflow.ActivityOptions{

--- a/internal/temporal/workflows/moyasar_invoice_sync_workflow.go
+++ b/internal/temporal/workflows/moyasar_invoice_sync_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -34,19 +32,6 @@ func MoyasarInvoiceSyncWorkflow(ctx workflow.Context, input models.MoyasarInvoic
 		logger.Error("Invalid workflow input", "error", err)
 		return err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowMoyasarInvoiceSync,
-		TaskQueue:     string(types.TemporalTaskQueueTask),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "", // System workflow, no specific user
-		Metadata: map[string]interface{}{
-			"invoice_id":  input.InvoiceID,
-			"customer_id": input.CustomerID,
-		},
-	})
 
 	activityOptions := workflow.ActivityOptions{
 		StartToCloseTimeout: 5 * time.Minute,

--- a/internal/temporal/workflows/nomod_invoice_sync_workflow.go
+++ b/internal/temporal/workflows/nomod_invoice_sync_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -34,19 +32,6 @@ func NomodInvoiceSyncWorkflow(ctx workflow.Context, input models.NomodInvoiceSyn
 		logger.Error("Invalid workflow input", "error", err)
 		return err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowNomodInvoiceSync,
-		TaskQueue:     string(types.TemporalTaskQueueTask),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "", // System workflow, no specific user
-		Metadata: map[string]interface{}{
-			"invoice_id":  input.InvoiceID,
-			"customer_id": input.CustomerID,
-		},
-	})
 
 	activityOptions := workflow.ActivityOptions{
 		StartToCloseTimeout: 5 * time.Minute,

--- a/internal/temporal/workflows/price_sync_workflow.go
+++ b/internal/temporal/workflows/price_sync_workflow.go
@@ -7,8 +7,6 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	planActivities "github.com/flexprice/flexprice/internal/temporal/activities/plan"
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -25,18 +23,6 @@ func PriceSyncWorkflow(ctx workflow.Context, in models.PriceSyncWorkflowInput) (
 	if err := in.Validate(); err != nil {
 		return nil, err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowPriceSync,
-		TaskQueue:     string(types.TemporalTaskQueuePrice),
-		TenantID:      in.TenantID,
-		EnvironmentID: in.EnvironmentID,
-		UserID:        in.UserID,
-		Metadata: map[string]interface{}{
-			"plan_id": in.PlanID,
-		},
-	})
 
 	// Create activity input with context
 	activityInput := planActivities.SyncPlanPricesInput{

--- a/internal/temporal/workflows/quickbooks_price_sync_workflow.go
+++ b/internal/temporal/workflows/quickbooks_price_sync_workflow.go
@@ -5,8 +5,6 @@ import (
 
 	qbActivities "github.com/flexprice/flexprice/internal/temporal/activities/quickbooks"
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -23,19 +21,6 @@ func QuickBooksPriceSyncWorkflow(ctx workflow.Context, in models.QuickBooksPrice
 	if err := in.Validate(); err != nil {
 		return nil, err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowQuickBooksPriceSync,
-		TaskQueue:     string(types.TemporalTaskQueuePrice),
-		TenantID:      in.TenantID,
-		EnvironmentID: in.EnvironmentID,
-		UserID:        in.UserID,
-		Metadata: map[string]interface{}{
-			"price_id": in.PriceID,
-			"plan_id":  in.PlanID,
-		},
-	})
 
 	// Create activity input with context
 	activityInput := qbActivities.SyncPriceToQuickBooksInput{

--- a/internal/temporal/workflows/subscription/process_subscription_billing_workflow.go
+++ b/internal/temporal/workflows/subscription/process_subscription_billing_workflow.go
@@ -6,8 +6,6 @@ import (
 	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
 	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
 	"github.com/flexprice/flexprice/internal/temporal/searchattr"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -51,18 +49,6 @@ func ProcessSubscriptionBillingWorkflow(
 		logger.Error("Invalid workflow input", "error", err)
 		return nil, err
 	}
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowProcessSubscriptionBilling,
-		TaskQueue:     string(types.TemporalTaskQueueSubscription),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "",
-		Metadata: map[string]interface{}{
-			"subscription_id": input.SubscriptionID,
-		},
-	})
 
 	// Upsert workflow search attributes for better discoverability
 	searchattr.UpsertWorkflowSearchAttributes(ctx, map[string]interface{}{

--- a/internal/temporal/workflows/subscription/schedule_subscription_billing_workflow.go
+++ b/internal/temporal/workflows/subscription/schedule_subscription_billing_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -25,18 +23,6 @@ func ScheduleSubscriptionBillingWorkflow(ctx workflow.Context, input subscriptio
 	}
 
 	logger := workflow.GetLogger(ctx)
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowScheduleSubscriptionBilling,
-		TaskQueue:     string(types.TemporalTaskQueueSubscription),
-		TenantID:      "",
-		EnvironmentID: "",
-		UserID:        "",
-		Metadata: map[string]interface{}{
-			"batch_size": input.BatchSize,
-		},
-	})
 
 	// Define activity options with extended timeouts for large batch processing
 	ao := workflow.ActivityOptions{

--- a/internal/temporal/workflows/task_workflow.go
+++ b/internal/temporal/workflows/task_workflow.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/temporal/models"
-	"github.com/flexprice/flexprice/internal/temporal/tracking"
-	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )
@@ -26,18 +24,6 @@ func TaskProcessingWorkflow(ctx workflow.Context, input models.TaskProcessingWor
 
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Starting task processing workflow", "task_id", input.TaskID)
-
-	// Track workflow execution start
-	tracking.ExecuteTrackWorkflowStart(ctx, tracking.TrackWorkflowStartInput{
-		WorkflowType:  WorkflowTaskProcessing,
-		TaskQueue:     string(types.TemporalTaskQueueTask),
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		UserID:        "",
-		Metadata: map[string]interface{}{
-			"task_id": input.TaskID,
-		},
-	})
 
 	// Define activity options with extended timeouts for large file processing
 	ao := workflow.ActivityOptions{

--- a/internal/types/temporal.go
+++ b/internal/types/temporal.go
@@ -202,3 +202,19 @@ func GetAllTaskQueues() []TemporalTaskQueue {
 		TemporalTaskQueueReprocessEvents,
 	}
 }
+
+// WorkflowExecutionStatus represents the execution state of a Temporal workflow run.
+// Values align with Temporal's workflow execution status.
+type WorkflowExecutionStatus string
+
+const (
+	WorkflowExecutionStatusRunning         WorkflowExecutionStatus = "Running"
+	WorkflowExecutionStatusCompleted      WorkflowExecutionStatus = "Completed"
+	WorkflowExecutionStatusFailed         WorkflowExecutionStatus = "Failed"
+	WorkflowExecutionStatusCanceled       WorkflowExecutionStatus = "Canceled"
+	WorkflowExecutionStatusTerminated     WorkflowExecutionStatus = "Terminated"
+	WorkflowExecutionStatusContinuedAsNew WorkflowExecutionStatus = "ContinuedAsNew"
+	WorkflowExecutionStatusTimedOut       WorkflowExecutionStatus = "TimedOut"
+	// WorkflowExecutionStatusUnknown is used when we have a DB record but haven't synced status from Temporal yet
+	WorkflowExecutionStatusUnknown WorkflowExecutionStatus = "Unknown"
+)

--- a/internal/types/wallet.go
+++ b/internal/types/wallet.go
@@ -278,7 +278,7 @@ const (
 type WalletConfig struct {
 	// AllowedPriceTypes is a list of price types that are allowed for the wallet
 	// nil means all price types are allowed
-	AllowedPriceTypes []WalletConfigPriceType `json:"-"`
+	AllowedPriceTypes []WalletConfigPriceType `json:"allowed_price_types,omitempty"`
 }
 
 func GetDefaultWalletConfig() *WalletConfig {


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---
----
<!-- ELLIPSIS_HIDDEN -->
> [!IMPORTANT]
> Implemented automatic workflow execution tracking by adding database schema fields for workflow status and timing, creating a new interceptor to capture workflow lifecycle events, and removing manual tracking calls from individual workflows.
> 
>   ## Workflow Execution Schema & Data Model
>   - Added three new columns to `workflow_executions` table: `end_time` (nullable timestamp), `duration_ms` (nullable int64), and `workflow_status` (varchar(50) with default "Unknown")
>   - Added indexes on `end_time` and composite index on `(tenant_id, environment_id, workflow_status)` for efficient filtering
>   - Added `WorkflowExecutionStatus` type in `internal/types/temporal.go` with eight status constants: `Running`, `Completed`, `Failed`, `Canceled`, `Terminated`, `ContinuedAsNew`, `TimedOut`, and `Unknown`
>   - Updated `WorkflowExecution` entity with new fields and corresponding getter/setter methods in `mutation.go`, `workflowexecution.go`, `workflowexecution_create.go`, and `workflowexecution_update.go`
>   ## Workflow Tracking Infrastructure
>   - Created new `WorkflowTrackingInterceptor` in `internal/temporal/interceptor/workflow_tracking_interceptor.go` that automatically captures workflow start time, end time, duration, and completion status
>   - Interceptor uses reflection to extract tenant ID, environment ID, and metadata from workflow input arguments
>   - Added `TrackWorkflowEnd` activity and supporting functions in `internal/temporal/activities/workflow/tracking_activity.go` with panic recovery to prevent tracking failures from crashing workflows
>   - Added `ExecuteTrackWorkflowEnd` function in `internal/temporal/tracking/workflow_tracking.go` to execute local activity for workflow completion tracking
>   - Registered `WorkflowTrackingInterceptor` in `internal/temporal/service/service.go` for both Sentry-enabled and non-Sentry configurations
>   - Registered `TrackWorkflowEnd` activity in `internal/temporal/registration.go`
>   ## API & Repository Layer Updates
>   - Added filter fields to `ListWorkflowsRequest` DTO: `WorkflowID`, `WorkflowStatus`, `Entity`, and `EntityID`
>   - Added corresponding filter fields to `ListWorkflowExecutionsFilters` in API handler and service layer
>   - Added `Status`, `CloseTime`, and `DurationMs` fields to workflow execution response in `internal/api/v1/workflow.go`
>   - Added `UpdateStatus` method to `Repository` interface in `internal/domain/workflowexecution/repository.go`
>   - Implemented `UpdateStatus` method in `internal/repository/ent/workflow_execution.go` to update workflow status, end time, duration, and error message
>   - Added filtering by `WorkflowID`, `WorkflowStatus`, and metadata entity fields in repository `List` method
>   ## Workflow Cleanup
>   - Removed manual workflow execution tracking calls from 13 workflow files: `customer_onboarding_workflow.go`, `reprocess_events_workflow.go`, `reprocess_raw_events_workflow.go`, `export_workflow.go`, `hubspot_deal_sync_workflow.go`, `hubspot_invoice_sync_workflow.go`, `hubspot_quote_sync_workflow.go`, `process_invoice_workflow.go`, `moyasar_invoice_sync_workflow.go`, `nomod_invoice_sync_workflow.go`, `price_sync_workflow.go`, `quickbooks_price_sync_workflow.go`, `process_subscription_billing_workflow.go`, `schedule_subscription_billing_workflow.go`, and `task_workflow.go`
>   - Removed corresponding imports for tracking and types packages from these workflows
>   ## Other Changes
>   - Changed JSON tag for `AllowedPriceTypes` field in `WalletConfig` struct from `json:"-"` to `json:"allowed_price_types,omitempty"` to make it serializable in JSON output
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for e372aa0f6e022b48b424b9ebdb3393e185e0c4ba. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>
<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workflow execution status tracking with multiple states (Running, Completed, Failed, Canceled, Terminated, etc.)
  * Added execution duration metrics and end-time tracking for completed workflows
  * Enhanced workflow list filtering to support filtering by workflow ID, status, entity, and entity ID
  * Implemented automatic workflow lifecycle tracking for workflow start and completion events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->