### PR TITLE
refactor(wallet): ensure correct allowed price types are set based on wallet type

### DIFF
--- a/internal/api/dto/wallet.go
+++ b/internal/api/dto/wallet.go
@@ -19,13 +19,16 @@ type CreateWalletRequest struct {
 	CustomerID string `json:"customer_id,omitempty"`
 
 	// external_customer_id is the customer id in the external system
-	ExternalCustomerID string              `json:"external_customer_id,omitempty"`
-	Name               string              `json:"-"`
-	Currency           string              `json:"currency" binding:"required"`
-	Description        string              `json:"description,omitempty"`
-	Metadata           types.Metadata      `json:"metadata,omitempty"`
-	WalletType         types.WalletType    `json:"wallet_type"`
-	Config             *types.WalletConfig `json:"config,omitempty"`
+	ExternalCustomerID string           `json:"external_customer_id,omitempty"`
+	Name               string           `json:"-"`
+	Currency           string           `json:"currency" binding:"required"`
+	Description        string           `json:"description,omitempty"`
+	Metadata           types.Metadata   `json:"metadata,omitempty"`
+	WalletType         types.WalletType `json:"wallet_type"`
+
+	// config is the configuration for the wallet (optional)
+	// currently config only have allowed_price_types field which isnt used by api, but is used by service
+	Config *types.WalletConfig `json:"-"`
 
 	// amount in the currency =  number of credits * conversion_rate
 	// ex if conversion_rate is 1, then 1 USD = 1 credit


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `CreateWalletRequest.ToWallet()` to always set `AllowedPriceTypes` based on `WalletType`.
> 
>   - **Behavior**:
>     - In `CreateWalletRequest.ToWallet()`, always set `AllowedPriceTypes` based on `WalletType`.
>     - Removes conditional check for `AllowedPriceTypes` being `nil`.
>   - **Misc**:
>     - Simplifies logic for setting `AllowedPriceTypes` in `wallet.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 69b76ba97b2449b1c78c4bb2e99e0e7c252eb5a3. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet creation now consistently applies price-type defaults for PrePaid and PostPaid wallets so pricing permissions are set automatically.

* **Chores**
  * Wallet configuration is no longer exposed in create payloads (config is hidden), simplifying the data sent during wallet creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->