### PR TITLE
feat(wallet): remove config from create wallet req

### DIFF
--- a/internal/api/dto/wallet.go
+++ b/internal/api/dto/wallet.go
@@ -19,13 +19,16 @@ type CreateWalletRequest struct {
 	CustomerID string `json:"customer_id,omitempty"`
 
 	// external_customer_id is the customer id in the external system
-	ExternalCustomerID string              `json:"external_customer_id,omitempty"`
-	Name               string              `json:"-"`
-	Currency           string              `json:"currency" binding:"required"`
-	Description        string              `json:"description,omitempty"`
-	Metadata           types.Metadata      `json:"metadata,omitempty"`
-	WalletType         types.WalletType    `json:"wallet_type"`
-	Config             *types.WalletConfig `json:"config,omitempty"`
+	ExternalCustomerID string           `json:"external_customer_id,omitempty"`
+	Name               string           `json:"-"`
+	Currency           string           `json:"currency" binding:"required"`
+	Description        string           `json:"description,omitempty"`
+	Metadata           types.Metadata   `json:"metadata,omitempty"`
+	WalletType         types.WalletType `json:"wallet_type"`
+
+	// config is the configuration for the wallet (optional)
+	// currently config only have allowed_price_types field which isnt used by api, but is used by service
+	Config *types.WalletConfig `json:"-"`
 
 	// amount in the currency =  number of credits * conversion_rate
 	// ex if conversion_rate is 1, then 1 USD = 1 credit


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `Config` from JSON serialization in `CreateWalletRequest` and update `ToWallet` function in `wallet.go`.
> 
>   - **Behavior**:
>     - Remove `Config` field from JSON serialization in `CreateWalletRequest` in `wallet.go`.
>     - `Config` is still used internally by the service but not exposed in API requests.
>   - **Functionality**:
>     - Update `ToWallet` function to ensure `AllowedPriceTypes` are set based on `WalletType` in `wallet.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 18fba7a7d913cbf67a4e085c3a6fb38bc0f47048. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet creation to ensure allowed price types are correctly assigned based on the wallet type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->