### PR TITLE
refactor(feature_usage): update COUNT aggregation logic to ensure consistent event count retrieval

### DIFF
--- a/internal/repository/clickhouse/feature_usage.go
+++ b/internal/repository/clickhouse/feature_usage.go
@@ -68,11 +68,11 @@ func buildConditionalAggregationColumns(aggTypes []types.AggregationType) []stri
 		columns = append(columns, "toUInt64(0) AS count_unique_usage")
 	}
 
-	// COUNT aggregation (event_count) - count distinct event IDs - returns UInt64
+	// event_count: for COUNT aggregation use distinct event count; otherwise use total event count
 	if aggSet[types.AggregationCount] {
 		columns = append(columns, "COUNT(DISTINCT id) AS event_count")
 	} else {
-		columns = append(columns, "toUInt64(0) AS event_count")
+		columns = append(columns, "COUNT(id) AS event_count")
 	}
 
 	return columns
@@ -103,13 +103,6 @@ func buildConditionalAggregationColumnsForSubscription(aggTypes []types.Aggregat
 		columns = append(columns, "toDecimal128(0, 9) AS max_total")
 	}
 
-	// COUNT aggregation (count_distinct_ids) - returns UInt64
-	if aggSet[types.AggregationCount] {
-		columns = append(columns, "count(DISTINCT id) AS count_distinct_ids")
-	} else {
-		columns = append(columns, "toUInt64(0) AS count_distinct_ids")
-	}
-
 	// COUNT_UNIQUE aggregation (count_unique_qty) - returns UInt64
 	if aggSet[types.AggregationCountUnique] {
 		columns = append(columns, "count(DISTINCT unique_hash) AS count_unique_qty")
@@ -123,6 +116,10 @@ func buildConditionalAggregationColumnsForSubscription(aggTypes []types.Aggregat
 	} else {
 		columns = append(columns, "toDecimal128(0, 9) AS latest_qty")
 	}
+
+	// COUNT aggregation (count_distinct_ids) - returns UInt64 always
+	// This is done to ensure that the count_distinct_ids is always returned and not affected by the aggregation types
+	columns = append(columns, "count(DISTINCT id) AS count_distinct_ids")
 
 	return columns
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `feature_usage.go` to update COUNT aggregation logic for consistent event count retrieval, ensuring `count_distinct_ids` is always returned in subscription queries.
> 
>   - **Behavior**:
>     - Update `buildConditionalAggregationColumns` in `feature_usage.go` to use `COUNT(id)` for non-distinct event counts when `COUNT` aggregation is not specified.
>     - Ensure `count_distinct_ids` is always returned in `buildConditionalAggregationColumnsForSubscription` regardless of aggregation types.
>   - **Functions**:
>     - Modify `buildConditionalAggregationColumns` to handle `COUNT` aggregation by distinguishing between distinct and total event counts.
>     - Remove redundant `COUNT` logic in `buildConditionalAggregationColumnsForSubscription` and ensure consistent return of `count_distinct_ids`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for b3819170ad7cef294dbbf5c2f36e722fb855b9cb. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and determinism of feature usage aggregation calculations, ensuring metrics are calculated reliably regardless of aggregation type selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->