### PR TITLE
feat(custom-analytics): update applyCustomRule to use response total …

### DIFF
--- a/internal/service/feature_usage_tracking_custom_analytics_test.go
+++ b/internal/service/feature_usage_tracking_custom_analytics_test.go
@@ -121,7 +121,9 @@ func TestCustomAnalytics_ApplyCustomRule(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := service.applyCustomRule(tt.rule, tt.sourceItem)
+			// Use source item's cost as response total cost (single-item case)
+			responseTotalCost := tt.sourceItem.TotalCost
+			result := service.applyCustomRule(tt.rule, tt.sourceItem, responseTotalCost)
 
 			if tt.expectNil {
 				assert.Nil(t, result, "Expected nil result")


### PR DESCRIPTION
…cost for calculations

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `applyCustomRule` to use response total cost for 'Revenue per Minute' calculations and adjust tests accordingly.
> 
>   - **Behavior**:
>     - Update `applyCustomRule` in `feature_usage_tracking.go` to use `responseTotalCost` for calculations.
>     - Specifically affects 'Revenue per Minute' rule calculation.
>   - **Tests**:
>     - Update `TestCustomAnalytics_ApplyCustomRule` in `feature_usage_tracking_custom_analytics_test.go` to pass `responseTotalCost` as `sourceItem.TotalCost`.
>     - Ensure tests cover zero usage, unknown rule ID, and various usage scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 3425c28bd2b859dadb8d6adf68957cf5478093ee. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed division by zero error in custom analytics calculations.
  * Resolved issue where multiple analytics rules could be applied to the same item.

* **Improvements**
  * Enhanced accuracy of revenue calculations in custom analytics by using top-level cost data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->