### PR TITLE
feat: parse `x-max-live` header and pass its value to `GetWalletBalan…

### DIFF
--- a/internal/api/v1/wallet.go
+++ b/internal/api/v1/wallet.go
@@ -388,8 +388,16 @@ func (h *WalletHandler) GetWalletBalanceForceCached(c *gin.Context) {
 		}
 	}
 
+	// Parse optional x-max-live header (value in seconds)
+	var maxLiveSeconds *int64
+	if maxLiveStr := c.GetHeader("x-max-live"); maxLiveStr != "" {
+		if maxLive, err := strconv.ParseInt(maxLiveStr, 10, 64); err == nil && maxLive > 0 {
+			maxLiveSeconds = &maxLive
+		}
+	}
+
 	// Get wallet balance
-	balance, err := h.walletService.GetWalletBalanceFromCache(c.Request.Context(), walletID, nil)
+	balance, err := h.walletService.GetWalletBalanceFromCache(c.Request.Context(), walletID, maxLiveSeconds)
 	if err != nil {
 		h.logger.Error("Failed to get wallet balance", "error", err)
 		c.Error(err)


### PR DESCRIPTION
…ceFromCache`

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Parse `x-max-live` header in `GetWalletBalanceForceCached()` and pass its value to `GetWalletBalanceFromCache()` for optional cache duration.
> 
>   - **Behavior**:
>     - Parse `x-max-live` header in `GetWalletBalanceForceCached()` in `wallet.go`.
>     - Pass parsed `x-max-live` value to `GetWalletBalanceFromCache()`.
>     - If `x-max-live` is invalid or missing, default behavior is unchanged.
>   - **Misc**:
>     - Update `GetWalletBalanceForceCached()` to handle optional cache duration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 733a33681ee9e510fc76a18c68022b73017f1bfd. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet balance retrieval now supports optional x-max-live header, which influences cache behavior when specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->