### PR TITLE
feat(plan): add endpoint to synchronize plan prices with active subsc…

### DIFF
--- a/internal/api/v1/plan.go
+++ b/internal/api/v1/plan.go
@@ -263,6 +263,19 @@ func priceSyncLockKey(planID string) string {
 	return cache.PrefixPriceSyncLock + planID
 }
 
+// @Summary Synchronize plan prices
+// @Description Synchronize current plan prices with all existing active subscriptions
+// @Tags Plans
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "Plan ID"
+// @Success 200 {object} models.TemporalWorkflowResult
+// @Failure 400 {object} ierr.ErrorResponse
+// @Failure 404 {object} ierr.ErrorResponse
+// @Failure 422 {object} ierr.ErrorResponse
+// @Failure 500 {object} ierr.ErrorResponse
+// @Router /plans/{id}/sync/subscriptions [post]
 func (h *PlanHandler) SyncPlanPrices(c *gin.Context) {
 
 	id := c.Param("id")


### PR DESCRIPTION
…riptions

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `SyncPlanPrices` endpoint to synchronize plan prices with active subscriptions, handling lock acquisition and workflow initiation.
> 
>   - **New Endpoint**:
>     - Adds `SyncPlanPrices` function in `internal/api/v1/plan.go` to synchronize plan prices with active subscriptions.
>     - Endpoint defined at `/plans/{id}/sync/subscriptions` with POST method.
>   - **Functionality**:
>     - Validates plan ID and checks plan existence.
>     - Acquires lock using Redis with 2-hour TTL to prevent concurrent syncs.
>     - Initiates Temporal workflow for price synchronization.
>     - Returns success message with workflow ID and run ID.
>   - **Error Handling**:
>     - Handles errors for missing plan ID, lock acquisition failure, and plan non-existence.
>     - Logs errors and provides user-friendly error messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for a4fe4c704c2d7fad5be8535a44dc52d357327c3e. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new API endpoint to synchronize plan prices with built-in protections against concurrent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->