### PR TITLE
     fix(invoice): adjust unpaid usage charges calculation to account for prepaid credits and discounts

### DIFF
--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -1772,7 +1772,8 @@ func (s *invoiceService) GetUnpaidInvoicesToBePaid(ctx context.Context, req dto.
 
 		for _, item := range inv.LineItems {
 			if lo.FromPtr(item.PriceType) == string(types.PRICE_TYPE_USAGE) {
-				unpaidUsageCharges = unpaidUsageCharges.Add(item.Amount).Sub(item.PrepaidCreditsApplied).Sub(item.LineItemDiscount).Sub(item.InvoiceLevelDiscount)
+				usageCharge := item.Amount.Sub(item.PrepaidCreditsApplied).Sub(item.LineItemDiscount).Sub(item.InvoiceLevelDiscount)
+				unpaidUsageCharges = unpaidUsageCharges.Add(decimal.Max(decimal.Zero, usageCharge))
 			} else {
 				unpaidFixedCharges = unpaidFixedCharges.Add(item.Amount)
 			}

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -1772,7 +1772,7 @@ func (s *invoiceService) GetUnpaidInvoicesToBePaid(ctx context.Context, req dto.
 
 		for _, item := range inv.LineItems {
 			if lo.FromPtr(item.PriceType) == string(types.PRICE_TYPE_USAGE) {
-				unpaidUsageCharges = unpaidUsageCharges.Add(item.Amount).Sub(item.PrepaidCreditsApplied).Sub(item.LineItemDiscount)
+				unpaidUsageCharges = unpaidUsageCharges.Add(item.Amount).Sub(item.PrepaidCreditsApplied).Sub(item.LineItemDiscount).Sub(item.InvoiceLevelDiscount)
 			} else {
 				unpaidFixedCharges = unpaidFixedCharges.Add(item.Amount)
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts `unpaidUsageCharges` calculation in `GetUnpaidInvoicesToBePaid()` to account for prepaid credits and discounts.
> 
>   - **Behavior**:
>     - Adjusts calculation of `unpaidUsageCharges` in `GetUnpaidInvoicesToBePaid()` in `invoice.go` to subtract `PrepaidCreditsApplied` and `LineItemDiscount` from `item.Amount`.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 48ba45686d9cd70ea4908eace4c11b5754c36877. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Clone Plan API to duplicate plans (prices, entitlements, credits).
  * Added billing_period_count on plans, subscriptions and line items to support multi-unit billing periods.
  * Added monthly window size support for usage/windowing.

* **Bug Fixes**
  * Corrected unpaid invoice calculations so usage charges exclude prepaid credits and discounts and cannot reduce usage below zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->