### PR TITLE
fix(invoice): adjust unpaid usage charge calculation to account for prepaid credits and discounts

### DIFF
--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -1772,7 +1772,7 @@ func (s *invoiceService) GetUnpaidInvoicesToBePaid(ctx context.Context, req dto.
 
 		for _, item := range inv.LineItems {
 			if lo.FromPtr(item.PriceType) == string(types.PRICE_TYPE_USAGE) {
-				unpaidUsageCharges = unpaidUsageCharges.Add(item.Amount)
+				unpaidUsageCharges = unpaidUsageCharges.Add(item.Amount).Sub(item.PrepaidCreditsApplied).Sub(item.LineItemDiscount)
 			} else {
 				unpaidFixedCharges = unpaidFixedCharges.Add(item.Amount)
 			}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts unpaid usage charge calculation in `GetUnpaidInvoicesToBePaid()` to account for prepaid credits and discounts.
> 
>   - **Behavior**:
>     - Adjusts calculation of `unpaidUsageCharges` in `GetUnpaidInvoicesToBePaid()` to subtract `PrepaidCreditsApplied` and `LineItemDiscount` from `item.Amount`.
>   - **Misc**:
>     - No other changes or refactoring in the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 775cc18a9337fcd991a2f7254ffe2d2859cd134d. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invoice calculation to properly account for prepaid credits and discounts when determining unpaid usage charges, ensuring accurate total amounts owed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->