### PR TITLE
feat(billing): reverted FINAL keyword in feature usage repo

### DIFF
--- a/internal/repository/clickhouse/feature_usage.go
+++ b/internal/repository/clickhouse/feature_usage.go
@@ -2020,7 +2020,7 @@ func (r *FeatureUsageRepository) GetFeatureUsageBySubscription(ctx context.Conte
 			meter_id,
 			price_id,
 			%s
-		FROM feature_usage FINAL
+		FROM feature_usage
 		WHERE 
 			subscription_id = ?
 			AND customer_id = ?
@@ -2344,7 +2344,7 @@ func (r *FeatureUsageRepository) getWindowedQuery(ctx context.Context, params *e
 					%s as bucket_start,
 					%s as group_key,
 					%s(qty_total) as group_value
-				FROM feature_usage FINAL
+				FROM feature_usage
 				PREWHERE tenant_id = '%s'
 					AND environment_id = '%s'
 					AND sign != 0

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1547,7 +1547,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			return zeroAmountInvoice, nil
 		}
 
-		calculationResult, err = s.calculateFeatureUsageCharges(
+		calculationResult, err = s.CalculateCharges(
 			ctx,
 			sub,
 			advanceLineItems,
@@ -1582,7 +1582,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		}
 
 		// For current period arrear charges
-		arrearResult, err := s.calculateFeatureUsageCharges(
+		arrearResult, err := s.CalculateCharges(
 			ctx,
 			sub,
 			arrearLineItems,
@@ -1595,7 +1595,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		}
 
 		// For next period advance charges
-		advanceResult, err := s.calculateFeatureUsageCharges(
+		advanceResult, err := s.CalculateCharges(
 			ctx,
 			sub,
 			advanceLineItems,
@@ -1665,7 +1665,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		}
 
 		// For current period arrear charges
-		arrearResult, err := s.calculateFeatureUsageCharges(
+		arrearResult, err := s.CalculateCharges(
 			ctx,
 			sub,
 			arrearLineItems,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `FINAL` keyword from SQL queries in `feature_usage.go` and rename `calculateFeatureUsageCharges` to `CalculateCharges` in `billing.go`.
> 
>   - **SQL Query Changes**:
>     - Remove `FINAL` keyword from SQL queries in `feature_usage.go` at lines 2020 and 2344, affecting data selection from `feature_usage` table.
>   - **Function Renaming**:
>     - Rename `calculateFeatureUsageCharges` to `CalculateCharges` in `billing.go` at lines 1547, 1582, 1598, and 1668.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 55dac2ccf174ffc6a102796801762a135f7736e0. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal query processing for feature usage tracking.
  * Improved charge calculation logic for billing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->