### PR TITLE
fix(plan): add support for source plan id in cloned plan metadata

### DIFF
--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -851,10 +851,17 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 	if req.Description != nil {
 		description = *req.Description
 	}
-	metadata := sourcePlan.Metadata
-	if req.Metadata != nil {
-		metadata = req.Metadata
+	// Merge metadata: source plan first, then req overlay (req overwrites/adds), then source_plan_id
+	merged := make(types.Metadata, len(sourcePlan.Metadata)+len(req.Metadata)+1)
+	for k, v := range sourcePlan.Metadata {
+		merged[k] = v
 	}
+	for k, v := range req.Metadata {
+		merged[k] = v
+	}
+	merged["source_plan_id"] = id
+	metadata := merged
+
 	displayOrder := sourcePlan.DisplayOrder
 	if req.DisplayOrder != nil {
 		displayOrder = req.DisplayOrder


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `source_plan_id` to metadata in `ClonePlan` in `plan.go`.
> 
>   - **Behavior**:
>     - In `ClonePlan` in `plan.go`, metadata is now merged to include `source_plan_id` from the original plan.
>     - Metadata merging prioritizes request metadata over source plan metadata, then adds `source_plan_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 6b4aab2a31d195a051ddc53fbe0a5de86da99cfb. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced plan cloning to better preserve metadata. When cloning a plan, existing metadata is now retained and intelligently merged with any newly provided metadata, ensuring no data is lost during the cloning process. The cloned plan ID is automatically included in the resulting metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->