### PR TITLE
 docs: update Go SDK README to reflect version 2.0 import paths and types

### DIFF
--- a/api/custom/go/README.md
+++ b/api/custom/go/README.md
@@ -9,13 +9,13 @@ Type-safe Go client for the FlexPrice API: billing, metering, and subscription m
 ## Installation
 
 ```bash
-go get github.com/flexprice/flexprice-go
+go get github.com/flexprice/flexprice-go/v2
 ```
 
 Then in your code:
 
 ```go
-import "github.com/flexprice/flexprice-go"
+import "github.com/flexprice/flexprice-go/v2"
 ```
 
 ## Quick start
@@ -32,8 +32,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/flexprice/flexprice-go"
-	"github.com/flexprice/flexprice-go/models/components"
+	"github.com/flexprice/flexprice-go/v2"
+	"github.com/flexprice/flexprice-go/v2/models/types"
 	"github.com/joho/godotenv"
 )
 
@@ -56,7 +56,7 @@ func main() {
 	customerID := fmt.Sprintf("sample-customer-%d", time.Now().Unix())
 
 	// Ingest an event
-	req := components.DtoIngestEventRequest{
+	req := types.DtoIngestEventRequest{
 		EventName:          "Sample Event",
 		ExternalCustomerID: customerID,
 		Properties:         map[string]string{"source": "sample_app", "environment": "test"},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Go SDK README to reflect version 2.0 import paths and types.
> 
>   - **Import Path Updates**:
>     - Change import path from `github.com/flexprice/flexprice-go` to `github.com/flexprice/flexprice-go/v2` in `README.md`.
>   - **Type Changes**:
>     - Update type from `components.DtoIngestEventRequest` to `types.DtoIngestEventRequest` in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 0ec072645d3e6debc1ef1e5f45ddc80b541e51f4. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated README with v2 module import paths in code examples
- Adjusted API type references to reflect the reorganized package structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->