### PR TITLE
feat(subscription): limit the workflow trigger to 500 max in temporal

### DIFF
--- a/internal/service/scheduled_task.go
+++ b/internal/service/scheduled_task.go
@@ -774,8 +774,10 @@ func (s *scheduledTaskService) CalculateIntervalBoundaries(currentTime time.Time
 func (s *scheduledTaskService) ScheduleUpdateBillingPeriod(ctx context.Context) (string, error) {
 
 	scheduleID := types.GenerateUUIDWithPrefix("schtask_billing")
-	cronExpr := s.getCronExpression(types.ScheduledTaskIntervalEvery15Minutes)
+	// Subscription billing schedule runs every 10 minutes; cap at 500 workflows per run
 
+	// get cron expression
+	cronExpr := s.getCronExpression(types.ScheduledTaskIntervalEvery10Minutes)
 	scheduleSpec := client.ScheduleSpec{
 		CronExpressions: []string{cronExpr},
 	}
@@ -784,7 +786,8 @@ func (s *scheduledTaskService) ScheduleUpdateBillingPeriod(ctx context.Context) 
 		Workflow: subscriptionWorkflows.ScheduleSubscriptionBillingWorkflow,
 		Args: []interface{}{
 			subscriptionModels.ScheduleSubscriptionBillingWorkflowInput{
-				BatchSize: types.DEFAULT_BATCH_SIZE,
+				BatchSize:    types.DEFAULT_BATCH_SIZE,
+				MaxWorkflows: types.DEFAULT_MAX_SUBSCRIPTION_BILLING_WORKFLOWS,
 			},
 		},
 		TaskQueue:                string(types.TemporalTaskQueueSubscription),

--- a/internal/service/scheduled_task.go
+++ b/internal/service/scheduled_task.go
@@ -777,7 +777,7 @@ func (s *scheduledTaskService) ScheduleUpdateBillingPeriod(ctx context.Context) 
 	// Subscription billing schedule runs every 10 minutes; cap at 500 workflows per run
 
 	// get cron expression
-	cronExpr := s.getCronExpression(types.ScheduledTaskIntervalEvery10Minutes)
+	cronExpr := s.getCronExpression(types.ScheduledTaskIntervalCustom)
 	scheduleSpec := client.ScheduleSpec{
 		CronExpressions: []string{cronExpr},
 	}

--- a/internal/temporal/activities/subscription/schedule_subscription_billing_activities.go
+++ b/internal/temporal/activities/subscription/schedule_subscription_billing_activities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/service"
 	temporalService "github.com/flexprice/flexprice/internal/temporal/service"
 	"github.com/flexprice/flexprice/internal/types"
@@ -13,116 +14,113 @@ import (
 	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
 )
 
-const ActivityPrefix = "SubscriptionActivities"
-
 const (
-	// Workflow name - must match the function name
+	ActivityPrefix                     = "SubscriptionActivities"
 	WorkflowProcessSubscriptionBilling = "ProcessSubscriptionBillingWorkflow"
 )
 
-// SubscriptionActivities contains all subscription-related activities
-// When registered with Temporal, methods will be called as "SubscriptionActivities.ScheduleBillingActivity"
 type SubscriptionActivities struct {
 	subscriptionService service.SubscriptionService
 }
 
-// NewSubscriptionActivities creates a new SubscriptionActivities instance
 func NewSubscriptionActivities(subscriptionService service.SubscriptionService) *SubscriptionActivities {
-	return &SubscriptionActivities{
-		subscriptionService: subscriptionService,
-	}
+	return &SubscriptionActivities{subscriptionService: subscriptionService}
 }
 
-// ScheduleBillingActivity schedules billing workflows for subscriptions
-// This method will be registered as "ScheduleBillingActivity" in Temporal
-func (s *SubscriptionActivities) ScheduleBillingActivity(ctx context.Context, input subscriptionModels.ScheduleSubscriptionBillingWorkflowInput) (*subscriptionModels.ScheduleSubscriptionBillingWorkflowResult, error) {
+// ScheduleBillingActivity fetches active subscriptions in batches and starts a billing
+// workflow for each. Processing stops when MaxWorkflows is reached; the next cron run
+// picks up remaining subscriptions.
+func (a *SubscriptionActivities) ScheduleBillingActivity(
+	ctx context.Context,
+	input subscriptionModels.ScheduleSubscriptionBillingWorkflowInput,
+) (*subscriptionModels.ScheduleSubscriptionBillingWorkflowResult, error) {
 	logger := activity.GetLogger(ctx)
-	response := &subscriptionModels.ScheduleSubscriptionBillingWorkflowResult{
-		SubscriptionIDs: make([]string, 0),
-	}
 
-	// Validate input
 	if err := input.Validate(); err != nil {
-		return response, err
+		return &subscriptionModels.ScheduleSubscriptionBillingWorkflowResult{}, err
 	}
 
+	temporalSvc := temporalService.GetGlobalTemporalService()
 	now := time.Now().UTC()
+
+	var scheduledIDs []string
 	offset := 0
-	batchSize := input.BatchSize
-	totalProcessed := 0
 
-	// Loop through all subscriptions with pagination
-	for {
-		filter := &types.SubscriptionFilter{
-			QueryFilter: &types.QueryFilter{
-				Limit:  lo.ToPtr(batchSize),
-				Offset: lo.ToPtr(offset),
-				Status: lo.ToPtr(types.StatusPublished),
-			},
-			SubscriptionStatus: []types.SubscriptionStatus{types.SubscriptionStatusActive},
-			TimeRangeFilter: &types.TimeRangeFilter{
-				EndTime: &now,
-			},
-		}
-
-		subs, err := s.subscriptionService.ListAllTenantSubscriptions(ctx, filter)
+	for len(scheduledIDs) < input.MaxWorkflows {
+		// Fetch next batch of subscriptions.
+		subs, err := a.listActiveSubscriptions(ctx, now, input.BatchSize, offset)
 		if err != nil {
 			logger.Error("Failed to list subscriptions", "offset", offset, "error", err)
-			return response, err
+			return &subscriptionModels.ScheduleSubscriptionBillingWorkflowResult{SubscriptionIDs: scheduledIDs}, err
 		}
-
-		// No more subscriptions to process
-		if len(subs.Items) == 0 {
+		if len(subs) == 0 {
 			break
 		}
 
-		logger.Info("Processing subscription batch",
-			"offset", offset,
-			"batch_size", len(subs.Items),
-			"total_processed", totalProcessed)
+		logger.Info("Processing batch", "offset", offset, "batch_size", len(subs), "scheduled_so_far", len(scheduledIDs))
 
-		temporalSvc := temporalService.GetGlobalTemporalService()
-		subItems := subs.Items
-		for _, sub := range subItems {
-			// update context to include the tenant id
-			ctx = context.WithValue(ctx, types.CtxTenantID, sub.TenantID)
-			ctx = context.WithValue(ctx, types.CtxEnvironmentID, sub.EnvironmentID)
-			ctx = context.WithValue(ctx, types.CtxUserID, sub.CreatedBy)
+		// Start workflows for each subscription in this batch.
+		for _, sub := range subs {
+			if len(scheduledIDs) >= input.MaxWorkflows {
+				break
+			}
 
-			// Here we need to launch a new workflow to update the billing period
-			_, err := temporalSvc.ExecuteWorkflow(
-				ctx,
-				WorkflowProcessSubscriptionBilling,
-				subscriptionModels.ProcessSubscriptionBillingWorkflowInput{
-					SubscriptionID: sub.ID,
-					TenantID:       sub.TenantID,
-					EnvironmentID:  sub.EnvironmentID,
-					UserID:         sub.CreatedBy,
-					PeriodStart:    sub.CurrentPeriodStart,
-					PeriodEnd:      sub.CurrentPeriodEnd,
-				},
-			)
-			if err != nil {
-				// Log error but continue processing other subscriptions
-				logger.Error("Failed to start workflow for subscription",
-					"subscription_id", sub.ID,
-					"error", err)
+			workflowCtx := a.buildWorkflowContext(ctx, sub)
+			workflowInput := subscriptionModels.ProcessSubscriptionBillingWorkflowInput{
+				SubscriptionID: sub.ID,
+				TenantID:       sub.TenantID,
+				EnvironmentID:  sub.EnvironmentID,
+				UserID:         sub.CreatedBy,
+				PeriodStart:    sub.CurrentPeriodStart,
+				PeriodEnd:      sub.CurrentPeriodEnd,
+			}
+
+			if _, err := temporalSvc.ExecuteWorkflow(workflowCtx, WorkflowProcessSubscriptionBilling, workflowInput); err != nil {
+				logger.Error("Failed to start workflow", "subscription_id", sub.ID, "error", err)
 				continue
 			}
-			response.SubscriptionIDs = append(response.SubscriptionIDs, sub.ID)
-			totalProcessed++
+			scheduledIDs = append(scheduledIDs, sub.ID)
 		}
 
-		// Check if we got fewer results than batch size (last page)
-		if len(subs.Items) < batchSize {
-			logger.Info("Reached last page of subscriptions", "total_processed", totalProcessed)
+		// Exit if this was the last page.
+		if len(subs) < input.BatchSize {
 			break
 		}
-
-		// Move to next page
-		offset += batchSize
+		offset += input.BatchSize
 	}
 
-	logger.Info("Completed processing all subscriptions", "total_processed", totalProcessed)
-	return response, nil
+	// Log completion summary.
+	if len(scheduledIDs) >= input.MaxWorkflows {
+		logger.Info("Hit workflow cap; remaining subscriptions deferred to next cron", "scheduled", len(scheduledIDs), "max", input.MaxWorkflows)
+	} else {
+		logger.Info("Processed all eligible subscriptions", "scheduled", len(scheduledIDs))
+	}
+
+	return &subscriptionModels.ScheduleSubscriptionBillingWorkflowResult{SubscriptionIDs: scheduledIDs}, nil
+}
+
+// listActiveSubscriptions returns a page of active subscriptions whose current billing period has ended.
+func (a *SubscriptionActivities) listActiveSubscriptions(ctx context.Context, now time.Time, limit, offset int) ([]*dto.SubscriptionResponse, error) {
+	filter := &types.SubscriptionFilter{
+		QueryFilter: &types.QueryFilter{
+			Limit:  lo.ToPtr(limit),
+			Offset: lo.ToPtr(offset),
+			Status: lo.ToPtr(types.StatusPublished),
+		},
+		SubscriptionStatus: []types.SubscriptionStatus{types.SubscriptionStatusActive},
+		TimeRangeFilter:    &types.TimeRangeFilter{EndTime: &now},
+	}
+	resp, err := a.subscriptionService.ListAllTenantSubscriptions(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
+// buildWorkflowContext attaches tenant, environment, and user IDs to the context.
+func (a *SubscriptionActivities) buildWorkflowContext(ctx context.Context, sub *dto.SubscriptionResponse) context.Context {
+	ctx = context.WithValue(ctx, types.CtxTenantID, sub.TenantID)
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, sub.EnvironmentID)
+	ctx = context.WithValue(ctx, types.CtxUserID, sub.CreatedBy)
+	return ctx
 }

--- a/internal/temporal/models/subscription/schedule_update_billing_period.go
+++ b/internal/temporal/models/subscription/schedule_update_billing_period.go
@@ -3,13 +3,17 @@ package subscription
 import "github.com/flexprice/flexprice/internal/types"
 
 type ScheduleSubscriptionBillingWorkflowInput struct {
-	BatchSize int `json:"batch_size"`
+	BatchSize    int `json:"batch_size"`
+	MaxWorkflows int `json:"max_workflows"`
 }
 
 // Validate validates the schedule subscription billing workflow input
 func (i *ScheduleSubscriptionBillingWorkflowInput) Validate() error {
 	if i.BatchSize <= 0 {
 		i.BatchSize = types.DEFAULT_BATCH_SIZE
+	}
+	if i.MaxWorkflows <= 0 {
+		i.MaxWorkflows = types.DEFAULT_MAX_SUBSCRIPTION_BILLING_WORKFLOWS
 	}
 	return nil
 }

--- a/internal/temporal/workflows/subscription/schedule_subscription_billing_workflow.go
+++ b/internal/temporal/workflows/subscription/schedule_subscription_billing_workflow.go
@@ -40,7 +40,8 @@ func ScheduleSubscriptionBillingWorkflow(ctx workflow.Context, input subscriptio
 	var result subscriptionModels.ScheduleSubscriptionBillingWorkflowResult
 
 	activityInput := subscriptionModels.ScheduleSubscriptionBillingWorkflowInput{
-		BatchSize: input.BatchSize,
+		BatchSize:    input.BatchSize,
+		MaxWorkflows: input.MaxWorkflows,
 	}
 	err := workflow.ExecuteActivity(ctx, ActivityScheduleBilling, activityInput).Get(ctx, &result)
 

--- a/internal/types/price.go
+++ b/internal/types/price.go
@@ -203,6 +203,9 @@ const (
 
 	// DEFAULT_BATCH_SIZE is the default batch size for fetching subscriptions
 	DEFAULT_BATCH_SIZE = 100
+
+	// DEFAULT_MAX_SUBSCRIPTION_BILLING_WORKFLOWS is the maximum number of subscription billing workflows to start per scheduler run
+	DEFAULT_MAX_SUBSCRIPTION_BILLING_WORKFLOWS = 500
 )
 
 func (b BillingCadence) Validate() error {

--- a/internal/types/scheduled_task.go
+++ b/internal/types/scheduled_task.go
@@ -9,7 +9,6 @@ type ScheduledTaskInterval string
 
 const (
 	ScheduledTaskIntervalEvery15Minutes ScheduledTaskInterval = "15MIN"
-	ScheduledTaskIntervalEvery10Minutes ScheduledTaskInterval = "10MIN"
 	ScheduledTaskIntervalCustom         ScheduledTaskInterval = "custom"
 	ScheduledTaskIntervalHourly         ScheduledTaskInterval = "hourly"
 	ScheduledTaskIntervalDaily          ScheduledTaskInterval = "daily"
@@ -19,7 +18,6 @@ const (
 func (s ScheduledTaskInterval) Validate() error {
 	allowedIntervals := []ScheduledTaskInterval{
 		ScheduledTaskIntervalEvery15Minutes,
-		ScheduledTaskIntervalEvery10Minutes,
 		ScheduledTaskIntervalCustom,
 		ScheduledTaskIntervalHourly,
 		ScheduledTaskIntervalDaily,
@@ -35,7 +33,7 @@ func (s ScheduledTaskInterval) Validate() error {
 		}
 	}
 	return ierr.NewError("invalid scheduled task interval").
-		WithHint("Interval must be one of: 15MIN, 10MIN, custom, hourly, daily").
+		WithHint("Interval must be one of: 15MIN, custom, hourly, daily").
 		Mark(ierr.ErrValidation)
 }
 

--- a/internal/types/scheduled_task.go
+++ b/internal/types/scheduled_task.go
@@ -9,7 +9,8 @@ type ScheduledTaskInterval string
 
 const (
 	ScheduledTaskIntervalEvery15Minutes ScheduledTaskInterval = "15MIN"
-	ScheduledTaskIntervalCustom         ScheduledTaskInterval = "custom" // 10 minutes for testing
+	ScheduledTaskIntervalEvery10Minutes ScheduledTaskInterval = "10MIN"
+	ScheduledTaskIntervalCustom         ScheduledTaskInterval = "custom"
 	ScheduledTaskIntervalHourly         ScheduledTaskInterval = "hourly"
 	ScheduledTaskIntervalDaily          ScheduledTaskInterval = "daily"
 )
@@ -18,6 +19,7 @@ const (
 func (s ScheduledTaskInterval) Validate() error {
 	allowedIntervals := []ScheduledTaskInterval{
 		ScheduledTaskIntervalEvery15Minutes,
+		ScheduledTaskIntervalEvery10Minutes,
 		ScheduledTaskIntervalCustom,
 		ScheduledTaskIntervalHourly,
 		ScheduledTaskIntervalDaily,
@@ -33,7 +35,7 @@ func (s ScheduledTaskInterval) Validate() error {
 		}
 	}
 	return ierr.NewError("invalid scheduled task interval").
-		WithHint("Interval must be one of: 15MIN, custom, hourly, daily").
+		WithHint("Interval must be one of: 15MIN, 10MIN, custom, hourly, daily").
 		Mark(ierr.ErrValidation)
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limit subscription billing workflows to 500 per run and change billing schedule interval to every 10 minutes.
> 
>   - **Behavior**:
>     - Limit subscription billing workflows to 500 per run in `scheduled_task.go` and `schedule_subscription_billing_activities.go`.
>     - Change billing schedule interval to every 10 minutes in `scheduled_task.go`.
>   - **Models**:
>     - Add `MaxWorkflows` to `ScheduleSubscriptionBillingWorkflowInput` in `schedule_update_billing_period.go`.
>     - Update `Validate()` in `schedule_update_billing_period.go` to set default `MaxWorkflows`.
>   - **Constants**:
>     - Add `DEFAULT_MAX_SUBSCRIPTION_BILLING_WORKFLOWS` in `price.go`.
>     - Add `ScheduledTaskIntervalEvery10Minutes` in `scheduled_task.go`.
>   - **Misc**:
>     - Update cron expression logic in `scheduled_task.go` to use 10-minute intervals.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for b7465c6b8225d31df16881c905cd5d5666e4b39e. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription billing now runs on a 10-minute cadence (was 15 minutes) for quicker updates.
  * Enforced a maximum of 500 billing workflows per scheduler run to improve stability.

* **Improvements**
  * Billing processing now batches subscriptions and reports progress, with clearer completion logging and partial-result handling on listing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->