### PR TITLE
 refactor(workflow): update version resolution logic in SDK generation process

### DIFF
--- a/.github/workflows/generate-sdks.yml
+++ b/.github/workflows/generate-sdks.yml
@@ -1,7 +1,7 @@
 # Generate OpenAPI spec and all SDKs (Go, TypeScript, Python) + MCP.
 #
-# Flow: trigger -> version-check (skip if .speakeasy/sdk-version.json equals .speakeasy/gen/go.yaml version) -> generate (swagger, Speakeasy, upload artifacts) -> push to GitHub -> publish to npm/PyPI.
-# Version source: .speakeasy/sdk-version.json and .speakeasy/gen/*.yaml (central config). To release: update sdk-version.json, then trigger.
+# Flow: trigger -> version-check (resolve version from sdk-version.json vs published npm; skip if resolved equals .speakeasy/gen/go.yaml) -> generate -> push to GitHub -> publish to npm/PyPI.
+# Version: resolved in version-check (sdk-version.json vs npm); if npm greater, use bumped npm; else use sdk-version.json. All downstream jobs use this resolved version only. Skip when resolved equals gen/go.yaml.
 #
 # Triggers: push to main (path-filtered); workflow_dispatch. When version unchanged, generate and publish are skipped.
 # Required secrets: SPEAKEASY_API_KEY, SDK_DEPLOY_GIT_TOKEN (fine-grained PAT: Contents R/W + Metadata Read on target SDK repos), NPM_TOKEN, PYPI_TOKEN.
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Compare .speakeasy/sdk-version.json with .speakeasy/gen/go.yaml version; skip generate/publish if equal.
+  # Resolve version: max(sdk-version.json, published npm). If npm > sdk, use bumped npm; else use sdk. Skip if resolved equals gen/go.yaml.
   # ---------------------------------------------------------------------------
   version-check:
     runs-on: ubuntu-latest
@@ -46,30 +46,49 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Compare versions and set outputs
+      - name: Resolve version (sdk-version.json vs npm) and set outputs
         id: version-check
         run: |
           SDK_VERSION=$(jq -r .version .speakeasy/sdk-version.json 2>/dev/null || echo "")
           [ -z "$SDK_VERSION" ] || [ "$SDK_VERSION" = "null" ] && SDK_VERSION="0.0.0"
+
+          # Fetch published npm version for @flexprice/sdk (ignore failures for first publish or network)
+          NPM_VERSION=$(curl -sf "https://registry.npmjs.org/@flexprice/sdk" | jq -r '.["dist-tags"].latest // empty' 2>/dev/null || echo "")
+          [ -z "$NPM_VERSION" ] && NPM_VERSION="0.0.0"
+
+          # Semver compare: which is greater? (sort -V puts greater last)
+          GREATER=$(printf '%s\n%s\n' "$SDK_VERSION" "$NPM_VERSION" | sort -V | tail -1)
+
+          if [ "$GREATER" = "$NPM_VERSION" ] && [ "$NPM_VERSION" != "$SDK_VERSION" ]; then
+            # npm is greater: use bumped npm version (patch bump)
+            RESOLVED=$(echo "$NPM_VERSION" | awk -F. -v OFS=. '{ $3++; print $1, $2, $3 }')
+            echo "Using bumped npm version (npm=$NPM_VERSION -> $RESOLVED); sdk-version.json=$SDK_VERSION"
+          else
+            # sdk-version.json is greater or equal: use it directly
+            RESOLVED="$SDK_VERSION"
+            echo "Using sdk-version.json directly: $RESOLVED (npm=$NPM_VERSION)"
+          fi
+
           GEN_VERSION=""
           if [ -f .speakeasy/gen/go.yaml ]; then
             GEN_VERSION=$(sed -n '/^go:/,/^[a-z]/p' .speakeasy/gen/go.yaml | grep 'version:' | head -1 | sed 's/.*version:[[:space:]]*//' | xargs)
           fi
           [ -z "$GEN_VERSION" ] && GEN_VERSION=""
-          if [ "$SDK_VERSION" = "$GEN_VERSION" ]; then
+
+          if [ "$RESOLVED" = "$GEN_VERSION" ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "Version unchanged (sdk-version.json=$SDK_VERSION, gen/go.yaml=$GEN_VERSION); skipping generate and publish."
+            echo "Resolved version unchanged (resolved=$RESOLVED, gen/go.yaml=$GEN_VERSION); skipping generate and publish."
           else
             echo "skip=false" >> $GITHUB_OUTPUT
-            echo "Version changed (sdk-version.json=$SDK_VERSION, gen/go.yaml=$GEN_VERSION); will generate and publish."
+            echo "Resolved version changed (resolved=$RESOLVED, gen/go.yaml=$GEN_VERSION); will generate and publish."
           fi
-          echo "version=$SDK_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$RESOLVED" >> $GITHUB_OUTPUT
 
       - name: Skip summary
         if: steps.version-check.outputs.skip == 'true'
         run: |
           echo "## Skipped generate and publish" >> $GITHUB_STEP_SUMMARY
-          echo "Version in \`.speakeasy/sdk-version.json\` matches \`.speakeasy/gen/go.yaml\`. No generation or publish." >> $GITHUB_STEP_SUMMARY
+          echo "Resolved version matches \`.speakeasy/gen/go.yaml\`. No generation or publish." >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
   # Setup → OpenAPI → SDK tooling → Generate → Upload artifacts
@@ -132,18 +151,18 @@ jobs:
         run: |
           unset VERSION && curl -fsSL https://raw.githubusercontent.com/speakeasy-api/speakeasy/main/install.sh | sh
 
-      # SDKs: generate with version from .speakeasy/sdk-version.json (set by version-check job)
+      # SDKs: generate with resolved version only (from version-check job)
       - name: Generate SDKs and MCP
         run: make sdk-all VERSION=${{ needs.version-check.outputs.version }}
 
-      # Overwrite Speakeasy version in artifacts so publish never gets 0.0.1 (version already set in central gen before generate)
-      - name: Apply version from sdk-version.json to SDK artifacts
+      # Overwrite Speakeasy version in artifacts with resolved version only
+      - name: Apply resolved version to SDK artifacts
         run: ./scripts/force-sdk-version.sh "${{ needs.version-check.outputs.version }}"
 
       - name: Generate job summary
         run: |
           echo "## Generate SDKs" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ needs.version-check.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Resolved version:** ${{ needs.version-check.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Artifacts:** api-go, api-typescript, api-python, api-mcp" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload api-go artifact
@@ -201,7 +220,7 @@ jobs:
       SDK_PYTHON_REPO: ${{ vars.SDK_PYTHON_REPO }}
       SDK_TYPESCRIPT_REPO: ${{ vars.SDK_TYPESCRIPT_REPO }}
       SDK_MCP_REPO: ${{ vars.SDK_MCP_REPO }}
-      VERSION: ${{ needs.version-check.outputs.version }}
+      VERSION: ${{ needs.version-check.outputs.version }}  # resolved version only
     steps:
       - name: Checkout (for LICENSE)
         uses: actions/checkout@v4
@@ -223,7 +242,7 @@ jobs:
 
       - name: Push SDK to repo
         run: |
-          # Ensure VERSION is never empty so commit message and tag always include version number
+          # Use resolved version only (from version-check)
           VERSION="${{ env.VERSION }}"
           [ -z "$VERSION" ] && VERSION="0.0.0"
           git clone https://x-access-token:${{ secrets.SDK_DEPLOY_GIT_TOKEN }}@github.com/${{ env.REPO }}.git /tmp/sdk-repo
@@ -258,7 +277,7 @@ jobs:
       SDK_PYTHON_REPO: ${{ vars.SDK_PYTHON_REPO }}
       SDK_TYPESCRIPT_REPO: ${{ vars.SDK_TYPESCRIPT_REPO }}
       SDK_MCP_REPO: ${{ vars.SDK_MCP_REPO }}
-      VERSION: ${{ needs.version-check.outputs.version }}
+      VERSION: ${{ needs.version-check.outputs.version }}  # resolved version only
     steps:
       - name: Summary
         run: |
@@ -267,7 +286,7 @@ jobs:
           TS_REPO="${SDK_TYPESCRIPT_REPO:-flexprice/javascript-sdk}"
           MCP_REPO="${SDK_MCP_REPO:-flexprice/mcp-server}"
           echo "## SDKs pushed to GitHub" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Resolved version:** v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "- Go: https://github.com/$GO_REPO" >> $GITHUB_STEP_SUMMARY
           echo "- Python: https://github.com/$PY_REPO" >> $GITHUB_STEP_SUMMARY
           echo "- TypeScript: https://github.com/$TS_REPO" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactors version resolution in SDK generation workflow to compare `sdk-version.json` with npm, using the greater version consistently across jobs.
> 
>   - **Version Resolution**:
>     - Updates version resolution logic in `.github/workflows/generate-sdks.yml` to compare `sdk-version.json` with published npm version.
>     - Uses the greater version between `sdk-version.json` and npm, with a patch bump if npm is greater.
>     - Skips generation if resolved version matches `.speakeasy/gen/go.yaml`.
>   - **Workflow Changes**:
>     - Consistently uses resolved version across all jobs in the workflow.
>     - Updates job summaries and artifact handling to reflect resolved version.
>   - **Misc**:
>     - Updates comments and log messages to clarify version resolution process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=flexprice%2Fflexprice&utm_source=github&utm_medium=referral)<sup> for 4448a16fc21d4864521d496573d0a053720f40ea. You can [customize](https://app.ellipsis.dev/flexprice/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK versioning and release workflow to improve version resolution accuracy during generation and publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->