### PR TITLE
feat(invoice): move inv recalculation to temporal

### DIFF
--- a/internal/api/v1/invoice.go
+++ b/internal/api/v1/invoice.go
@@ -9,6 +9,9 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/service"
+	"github.com/flexprice/flexprice/internal/temporal/models"
+	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
+	temporalservice "github.com/flexprice/flexprice/internal/temporal/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
@@ -202,14 +205,14 @@ func (h *InvoiceHandler) VoidInvoice(c *gin.Context) {
 }
 
 // RecalculateInvoice godoc
-// @Summary Recalculate invoice (default: voided invoice)
+// @Summary Recalculate invoice (voided invoice)
 // @ID recalculateInvoice
-// @Description Creates a fresh replacement invoice for a voided SUBSCRIPTION invoice covering the same billing period. The original voided invoice is linked to the new invoice via recalculated_invoice_id. Can only be called once per voided invoice.
+// @Description Starts an async workflow that creates a fresh replacement invoice for a voided SUBSCRIPTION invoice (same billing period). Returns workflow_id and run_id; poll workflow status or GET the new invoice via recalculated_invoice_id after completion.
 // @Tags Invoices
 // @Produce json
 // @Security ApiKeyAuth
 // @Param id path string true "Invoice ID"
-// @Success 200 {object} dto.InvoiceResponse
+// @Success 202 {object} models.TemporalWorkflowResult
 // @Failure 400 {object} ierr.ErrorResponse "Invalid request or invoice already recalculated"
 // @Failure 404 {object} ierr.ErrorResponse "Invoice not found"
 // @Failure 500 {object} ierr.ErrorResponse "Server error"
@@ -221,14 +224,35 @@ func (h *InvoiceHandler) RecalculateInvoice(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.invoiceService.RecalculateInvoice(c.Request.Context(), id)
+	temporalSvc := temporalservice.GetGlobalTemporalService()
+	if temporalSvc == nil {
+		h.logger.Errorw("temporal service not available for recalculate invoice", "invoice_id", id)
+		c.Error(ierr.NewError("temporal service not available").
+			WithHint("Try again later.").
+			Mark(ierr.ErrServiceUnavailable))
+		return
+	}
+
+	ctx := c.Request.Context()
+	workflowInput := invoiceModels.RecalculateInvoiceWorkflowInput{
+		InvoiceID:     id,
+		TenantID:      types.GetTenantID(ctx),
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		UserID:        types.GetUserID(ctx),
+	}
+
+	workflowRun, err := temporalSvc.ExecuteWorkflow(ctx, types.TemporalRecalculateInvoiceWorkflow, workflowInput)
 	if err != nil {
-		h.logger.Errorw("failed to recalculate invoice", "error", err, "invoice_id", id)
+		h.logger.Errorw("failed to start recalculate invoice workflow", "error", err, "invoice_id", id)
 		c.Error(err)
 		return
 	}
 
-	c.JSON(http.StatusOK, resp)
+	c.JSON(http.StatusAccepted, models.TemporalWorkflowResult{
+		Message:    "recalculate invoice workflow started",
+		WorkflowID: workflowRun.GetID(),
+		RunID:      workflowRun.GetRunID(),
+	})
 }
 
 // UpdatePaymentStatus godoc

--- a/internal/temporal/activities/invoice/invoice_activities.go
+++ b/internal/temporal/activities/invoice/invoice_activities.go
@@ -118,3 +118,40 @@ func (s *InvoiceActivities) AttemptInvoicePaymentActivity(
 		Success: true,
 	}, nil
 }
+
+// RecalculateInvoiceActivity recalculates a voided subscription invoice by creating a replacement invoice (same billing period).
+func (s *InvoiceActivities) RecalculateInvoiceActivity(
+	ctx context.Context,
+	input invoiceModels.RecalculateInvoiceActivityInput,
+) (*invoiceModels.RecalculateInvoiceActivityOutput, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	ctx = types.SetTenantID(ctx, input.TenantID)
+	ctx = types.SetEnvironmentID(ctx, input.EnvironmentID)
+	ctx = types.SetUserID(ctx, input.UserID)
+
+	invSvc := service.NewInvoiceService(s.serviceParams)
+
+	newInv, err := invSvc.RecalculateInvoice(ctx, input.InvoiceID)
+	if err != nil {
+		s.logger.Errorw("failed to recalculate invoice",
+			"invoice_id", input.InvoiceID,
+			"error", err)
+		return nil, err
+	}
+
+	outID := input.InvoiceID
+	if newInv != nil {
+		outID = newInv.ID
+	}
+	s.logger.Infow("recalculated invoice successfully",
+		"invoice_id", input.InvoiceID,
+		"new_invoice_id", outID)
+
+	return &invoiceModels.RecalculateInvoiceActivityOutput{
+		Success:   true,
+		InvoiceID: outID,
+	}, nil
+}

--- a/internal/temporal/models/invoice/recalculate_invoice.go
+++ b/internal/temporal/models/invoice/recalculate_invoice.go
@@ -1,0 +1,81 @@
+package invoice
+
+import (
+	"time"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+// ===================== Recalculate Invoice (voided) Workflow Models =====================
+
+// RecalculateInvoiceWorkflowInput represents the input for recalculating a voided subscription invoice (creates replacement invoice).
+type RecalculateInvoiceWorkflowInput struct {
+	InvoiceID     string `json:"invoice_id"`
+	TenantID      string `json:"tenant_id"`
+	EnvironmentID string `json:"environment_id"`
+	UserID        string `json:"user_id"`
+}
+
+// Validate validates the recalculate invoice workflow input
+func (i *RecalculateInvoiceWorkflowInput) Validate() error {
+	if i.InvoiceID == "" {
+		return ierr.NewError("invoice_id is required").
+			WithHint("Invoice ID is required").
+			Mark(ierr.ErrValidation)
+	}
+	if i.TenantID == "" {
+		return ierr.NewError("tenant_id is required").
+			WithHint("Tenant ID is required").
+			Mark(ierr.ErrValidation)
+	}
+	if i.EnvironmentID == "" {
+		return ierr.NewError("environment_id is required").
+			WithHint("Environment ID is required").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+// RecalculateInvoiceWorkflowResult represents the result of recalculating a voided invoice.
+type RecalculateInvoiceWorkflowResult struct {
+	Success     bool      `json:"success"`
+	Error       *string   `json:"error,omitempty"`
+	CompletedAt time.Time `json:"completed_at"`
+	InvoiceID   string    `json:"invoice_id,omitempty"`
+}
+
+// ===================== Recalculate Invoice Activity Models =====================
+
+// RecalculateInvoiceActivityInput represents the input for the recalculate invoice (voided) activity
+type RecalculateInvoiceActivityInput struct {
+	InvoiceID     string `json:"invoice_id"`
+	TenantID      string `json:"tenant_id"`
+	EnvironmentID string `json:"environment_id"`
+	UserID        string `json:"user_id"`
+}
+
+// Validate validates the recalculate invoice activity input
+func (i *RecalculateInvoiceActivityInput) Validate() error {
+	if i.InvoiceID == "" {
+		return ierr.NewError("invoice_id is required").
+			WithHint("Invoice ID is required").
+			Mark(ierr.ErrValidation)
+	}
+	if i.TenantID == "" {
+		return ierr.NewError("tenant_id is required").
+			WithHint("Tenant ID is required").
+			Mark(ierr.ErrValidation)
+	}
+	if i.EnvironmentID == "" {
+		return ierr.NewError("environment_id is required").
+			WithHint("Environment ID is required").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+// RecalculateInvoiceActivityOutput represents the output for the recalculate invoice activity
+type RecalculateInvoiceActivityOutput struct {
+	Success   bool   `json:"success"`
+	InvoiceID string `json:"invoice_id,omitempty"`
+}

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -237,6 +237,7 @@ func buildWorkerConfig(
 			workflowsList,
 			subscriptionWorkflows.ScheduleSubscriptionBillingWorkflow,
 			subscriptionWorkflows.ProcessSubscriptionBillingWorkflow,
+			invoiceWorkflows.RecalculateInvoiceWorkflow,
 		)
 		activitiesList = append(activitiesList,
 			// Schedule billing activities
@@ -249,6 +250,8 @@ func buildWorkerConfig(
 			billingActivities.CheckCancellationActivity,
 			billingActivities.ProcessPendingPlanChangesActivity,
 			billingActivities.TriggerInvoiceWorkflowActivity,
+			// Invoice recalculation (v2)
+			invoiceActs.RecalculateInvoiceActivity,
 		)
 
 	case types.TemporalTaskQueueInvoice:

--- a/internal/temporal/service/service.go
+++ b/internal/temporal/service/service.go
@@ -397,6 +397,11 @@ func (s *temporalService) extractWorkflowContextID(workflowType types.TemporalWo
 		if input, ok := params.(invoiceModels.ProcessInvoiceWorkflowInput); ok {
 			return input.InvoiceID
 		}
+	case types.TemporalRecalculateInvoiceWorkflow:
+		// Extract invoice ID from RecalculateInvoiceWorkflowInput
+		if input, ok := params.(invoiceModels.RecalculateInvoiceWorkflowInput); ok {
+			return input.InvoiceID
+		}
 	case types.TemporalPrepareProcessedEventsWorkflow:
 		// Extract event ID from PrepareProcessedEventsWorkflowInput
 		if input, ok := params.(*models.PrepareProcessedEventsWorkflowInput); ok {
@@ -498,6 +503,8 @@ func (s *temporalService) buildWorkflowInput(ctx context.Context, workflowType t
 		return s.buildPrepareProcessedEventsInput(ctx, tenantID, environmentID, userID, params)
 	case types.TemporalProcessInvoiceWorkflow:
 		return s.buildProcessInvoiceInput(ctx, tenantID, environmentID, params)
+	case types.TemporalRecalculateInvoiceWorkflow:
+		return s.buildRecalculateInvoiceInput(ctx, tenantID, environmentID, userID, params)
 	case types.TemporalReprocessEventsWorkflow:
 		return s.buildReprocessEventsInput(ctx, tenantID, environmentID, userID, params)
 	case types.TemporalReprocessRawEventsWorkflow:
@@ -752,6 +759,49 @@ func (s *temporalService) buildProcessInvoiceInput(_ context.Context, tenantID, 
 
 	return nil, errors.NewError("invalid input for process invoice workflow").
 		WithHint("Provide ProcessInvoiceWorkflowInput with invoice_id, tenant_id, and environment_id").
+		Mark(errors.ErrValidation)
+}
+
+// buildRecalculateInvoiceInput builds input for recalculate invoice (voided) workflow
+func (s *temporalService) buildRecalculateInvoiceInput(_ context.Context, tenantID, environmentID, userID string, params interface{}) (interface{}, error) {
+	if input, ok := params.(invoiceModels.RecalculateInvoiceWorkflowInput); ok {
+		input.TenantID = tenantID
+		input.EnvironmentID = environmentID
+		input.UserID = userID
+		return input, nil
+	}
+	if input, ok := params.(*invoiceModels.RecalculateInvoiceWorkflowInput); ok {
+		input.TenantID = tenantID
+		input.EnvironmentID = environmentID
+		input.UserID = userID
+		return *input, nil
+	}
+	// Handle string input (invoice ID)
+	if invoiceID, ok := params.(string); ok && invoiceID != "" {
+		return invoiceModels.RecalculateInvoiceWorkflowInput{
+			InvoiceID:     invoiceID,
+			TenantID:      tenantID,
+			EnvironmentID: environmentID,
+			UserID:        userID,
+		}, nil
+	}
+	// Handle map input (e.g. from API with invoice_id)
+	if paramsMap, ok := params.(map[string]interface{}); ok {
+		invoiceID, _ := paramsMap["invoice_id"].(string)
+		if invoiceID == "" {
+			return nil, errors.NewError("invoice_id is required").
+				WithHint("Provide invoice_id in params").
+				Mark(errors.ErrValidation)
+		}
+		return invoiceModels.RecalculateInvoiceWorkflowInput{
+			InvoiceID:     invoiceID,
+			TenantID:      tenantID,
+			EnvironmentID: environmentID,
+			UserID:        userID,
+		}, nil
+	}
+	return nil, errors.NewError("invalid input for recalculate invoice workflow").
+		WithHint("Provide RecalculateInvoiceWorkflowInput with invoice_id, or invoice_id string, or map with invoice_id").
 		Mark(errors.ErrValidation)
 }
 

--- a/internal/temporal/workflows/invoice/recalculate_invoice_workflow.go
+++ b/internal/temporal/workflows/invoice/recalculate_invoice_workflow.go
@@ -1,0 +1,70 @@
+package invoice
+
+import (
+	"time"
+
+	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	// WorkflowRecalculateInvoice is the workflow name - must match the function name
+	WorkflowRecalculateInvoice = "RecalculateInvoiceWorkflow"
+	// ActivityRecalculateInvoice is the activity name - must match the registered method name
+	ActivityRecalculateInvoice = "RecalculateInvoiceActivity"
+)
+
+// RecalculateInvoiceWorkflow recalculates a voided subscription invoice by creating a replacement invoice via a single activity.
+// Heavy work (CreateSubscriptionInvoice, etc.) runs in the activity with a long timeout to avoid blocking the API.
+func RecalculateInvoiceWorkflow(
+	ctx workflow.Context,
+	input invoiceModels.RecalculateInvoiceWorkflowInput,
+) (*invoiceModels.RecalculateInvoiceWorkflowResult, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting recalculate invoice workflow (voided)",
+		"invoice_id", input.InvoiceID,
+		"tenant_id", input.TenantID,
+		"environment_id", input.EnvironmentID)
+
+	if err := input.Validate(); err != nil {
+		logger.Error("Invalid workflow input", "error", err)
+		return nil, err
+	}
+
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second * 10,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute * 5,
+			MaximumAttempts:    2,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	activityInput := invoiceModels.RecalculateInvoiceActivityInput{
+		InvoiceID:     input.InvoiceID,
+		TenantID:      input.TenantID,
+		EnvironmentID: input.EnvironmentID,
+		UserID:        input.UserID,
+	}
+
+	var activityOutput invoiceModels.RecalculateInvoiceActivityOutput
+	err := workflow.ExecuteActivity(ctx, ActivityRecalculateInvoice, activityInput).Get(ctx, &activityOutput)
+	if err != nil {
+		logger.Error("Failed to recalculate invoice",
+			"error", err,
+			"invoice_id", input.InvoiceID)
+		return nil, err
+	}
+
+	logger.Info("Successfully recalculated invoice",
+		"invoice_id", input.InvoiceID)
+
+	return &invoiceModels.RecalculateInvoiceWorkflowResult{
+		Success:     activityOutput.Success,
+		CompletedAt: workflow.Now(ctx),
+		InvoiceID:   activityOutput.InvoiceID,
+	}, nil
+}

--- a/internal/types/temporal.go
+++ b/internal/types/temporal.go
@@ -68,6 +68,7 @@ const (
 	TemporalScheduleSubscriptionBillingWorkflow TemporalWorkflowType = "ScheduleSubscriptionBillingWorkflow"
 	TemporalProcessSubscriptionBillingWorkflow  TemporalWorkflowType = "ProcessSubscriptionBillingWorkflow"
 	TemporalProcessInvoiceWorkflow              TemporalWorkflowType = "ProcessInvoiceWorkflow"
+	TemporalRecalculateInvoiceWorkflow          TemporalWorkflowType = "RecalculateInvoiceWorkflow"
 	TemporalReprocessEventsWorkflow             TemporalWorkflowType = "ReprocessEventsWorkflow"
 	TemporalReprocessRawEventsWorkflow          TemporalWorkflowType = "ReprocessRawEventsWorkflow"
 	TemporalReprocessEventsForPlanWorkflow      TemporalWorkflowType = "ReprocessEventsForPlanWorkflow"
@@ -112,6 +113,7 @@ func (w TemporalWorkflowType) Validate() error {
 		TemporalScheduleSubscriptionBillingWorkflow, // "ScheduleSubscriptionBillingWorkflow"
 		TemporalProcessSubscriptionBillingWorkflow,  // "ProcessSubscriptionBillingWorkflow"
 		TemporalProcessInvoiceWorkflow,              // "ProcessInvoiceWorkflow"
+		TemporalRecalculateInvoiceWorkflow,          // "RecalculateInvoiceWorkflow"
 		TemporalReprocessEventsWorkflow,             // "ReprocessEventsWorkflow"
 		TemporalReprocessRawEventsWorkflow,          // "ReprocessRawEventsWorkflow"
 		TemporalReprocessEventsForPlanWorkflow,      // "ReprocessEventsForPlanWorkflow"
@@ -137,6 +139,8 @@ func (w TemporalWorkflowType) TaskQueue() TemporalTaskQueue {
 	case TemporalScheduleSubscriptionBillingWorkflow:
 		return TemporalTaskQueueSubscription
 	case TemporalProcessSubscriptionBillingWorkflow:
+		return TemporalTaskQueueSubscription
+	case TemporalRecalculateInvoiceWorkflow:
 		return TemporalTaskQueueSubscription
 	case TemporalProcessInvoiceWorkflow:
 		return TemporalTaskQueueInvoice
@@ -184,6 +188,7 @@ func GetWorkflowsForTaskQueue(taskQueue TemporalTaskQueue) []TemporalWorkflowTyp
 		return []TemporalWorkflowType{
 			TemporalScheduleSubscriptionBillingWorkflow,
 			TemporalProcessSubscriptionBillingWorkflow,
+			TemporalRecalculateInvoiceWorkflow,
 		}
 	case TemporalTaskQueueInvoice:
 		return []TemporalWorkflowType{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice recalculation operations now execute asynchronously in the background, providing immediate acknowledgment with unique tracking identifiers for monitoring progress instead of blocking client requests.
  * HTTP response status updated from 200 (OK) to 202 (Accepted) to indicate asynchronous processing, with response payload containing identifiers to track the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->