### PR TITLE
feat(invoice): add regenerating draft invoices schedule

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -356,6 +356,9 @@ func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logg
 			invoices.POST("/:id/recalculate", handlers.Invoice.RecalculateInvoice)
 			invoices.POST("/:id/comms/trigger", handlers.Invoice.TriggerCommunication)
 			invoices.POST("/:id/webhook/trigger", handlers.Invoice.TriggerWebhook)
+
+			// System schedule: trigger once to create 6-hour Temporal schedule
+			invoices.POST("/temporal/schedule-regenerate-draft-invoices", handlers.ScheduledTask.ScheduleRegenerateDraftInvoices)
 		}
 
 		feature := v1Private.Group("/features")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -354,7 +354,6 @@ func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logg
 			invoices.POST("/:id/payment/attempt", handlers.Invoice.AttemptPayment)
 			invoices.GET("/:id/pdf", handlers.Invoice.GetInvoicePDF)
 			invoices.POST("/:id/recalculate", handlers.Invoice.RecalculateInvoice)
-			invoices.POST("/:id/recalculate-v2", handlers.Invoice.RecalculateInvoiceV2)
 			invoices.POST("/:id/comms/trigger", handlers.Invoice.TriggerCommunication)
 			invoices.POST("/:id/webhook/trigger", handlers.Invoice.TriggerWebhook)
 		}

--- a/internal/api/v1/invoice.go
+++ b/internal/api/v1/invoice.go
@@ -442,42 +442,6 @@ func (h *InvoiceHandler) GetInvoicePDF(c *gin.Context) {
 	c.Data(http.StatusOK, "application/pdf", pdf)
 }
 
-// RecalculateInvoiceV2 godoc
-// @Summary Recalculate draft invoice (v2)
-// @ID recalculateInvoiceV2
-// @Description Recalculates a draft SUBSCRIPTION invoice in-place (replaces line items, reapplies credits/coupons/taxes). Use when subscription or usage data changed before finalizing.
-// @Tags Invoices
-// @Accept json
-// @Produce json
-// @Security ApiKeyAuth
-// @Param id path string true "Invoice ID"
-// @Param finalize query bool false "Whether to finalize the invoice after recalculation (default: true)"
-// @Success 200 {object} dto.InvoiceResponse
-// @Failure 400 {object} ierr.ErrorResponse "Invalid request"
-// @Failure 404 {object} ierr.ErrorResponse "Resource not found"
-// @Failure 500 {object} ierr.ErrorResponse "Server error"
-// @Router /invoices/{id}/recalculate-v2 [post]
-func (h *InvoiceHandler) RecalculateInvoiceV2(c *gin.Context) {
-	id := c.Param("id")
-	if id == "" {
-		c.Error(ierr.NewError("invalid invoice id").Mark(ierr.ErrValidation))
-		return
-	}
-
-	// Parse finalize query parameter (default: true)
-	finalizeParam := c.DefaultQuery("finalize", "true")
-	finalize := finalizeParam == "true"
-
-	invoice, err := h.invoiceService.RecalculateInvoiceV2(c.Request.Context(), id, finalize)
-	if err != nil {
-		h.logger.Errorw("failed to recalculate invoice v2", "error", err, "invoice_id", id)
-		c.Error(err)
-		return
-	}
-
-	c.JSON(http.StatusOK, invoice)
-}
-
 // UpdateInvoice godoc
 // @Summary Update invoice
 // @ID updateInvoice

--- a/internal/api/v1/scheduled_task.go
+++ b/internal/api/v1/scheduled_task.go
@@ -282,3 +282,22 @@ func (h *ScheduledTaskHandler) ScheduleUpdateBillingPeriod(c *gin.Context) {
 		"message": response,
 	})
 }
+
+// ScheduleRegenerateDraftInvoices godoc
+// @Summary Create schedule for regenerate draft invoices
+// @Description Creates a Temporal schedule that runs RegenerateDraftInvoicesScheduledWorkflow every 6 hours. Trigger once (e.g. deployment). Idempotent (fixed schedule ID). Same convention as POST /subscriptions/temporal/schedule-update-billing-period.
+// @Tags Invoices
+// @Produce json
+// @Security ApiKeyAuth
+// @Success 200 {object} object
+// @Failure 500 {object} ierr.ErrorResponse "Server error"
+// @Router /invoices/temporal/schedule-regenerate-draft-invoices [post]
+func (h *ScheduledTaskHandler) ScheduleRegenerateDraftInvoices(c *gin.Context) {
+	response, err := h.service.ScheduleRegenerateDraftInvoices(c.Request.Context())
+	if err != nil {
+		h.logger.Errorw("failed to create regenerate draft invoices schedule", "error", err)
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": response})
+}

--- a/internal/domain/invoice/repository.go
+++ b/internal/domain/invoice/repository.go
@@ -15,6 +15,9 @@ type Repository interface {
 	Update(ctx context.Context, inv *Invoice) error
 	Delete(ctx context.Context, id string) error
 	List(ctx context.Context, filter *types.InvoiceFilter) ([]*Invoice, error)
+	
+	// ListAllTenant lists invoices across all tenants (no tenant/env from context). For CRON/scheduled use only.
+	ListAllTenant(ctx context.Context, filter *types.InvoiceFilter) ([]*Invoice, error)
 	Count(ctx context.Context, filter *types.InvoiceFilter) (int, error)
 
 	// Edge-specific operations

--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -606,6 +606,53 @@ func (r *invoiceRepository) List(ctx context.Context, filter *types.InvoiceFilte
 	return result, nil
 }
 
+// ListAllTenant retrieves all invoices across all tenants (no tenant/env from context).
+// NOTE: Expensive operation; use only for CRON/scheduled jobs.
+func (r *invoiceRepository) ListAllTenant(ctx context.Context, filter *types.InvoiceFilter) ([]*domainInvoice.Invoice, error) {
+	span := StartRepositorySpan(ctx, "invoice", "list_all_tenant", map[string]interface{}{
+		"filter": filter,
+	})
+	defer FinishSpan(span)
+
+	if filter == nil {
+		filter = types.NewInvoiceFilter()
+	}
+	if err := filter.Validate(); err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).WithHint("invalid filter").Mark(ierr.ErrValidation)
+	}
+
+	client := r.client.Reader(ctx)
+	query := client.Invoice.Query()
+
+	// Intentionally skip ApplyQueryOptions/ApplyBaseFilters so we do not restrict by tenant or environment.
+	query, err := r.queryOpts.applyEntityQueryOptions(ctx, filter, query)
+	if err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to apply query options").
+			Mark(ierr.ErrDatabase)
+	}
+
+	query = ApplySorting(query, filter, r.queryOpts)
+	query = ApplyPagination(query, filter, r.queryOpts)
+	query = r.queryOpts.ApplyStatusFilter(query, filter.GetStatus())
+
+	invoices, err := query.All(ctx)
+	if err != nil {
+		SetSpanError(span, err)
+		r.logger.Errorw("failed to list invoices across tenants", "error", err)
+		return nil, ierr.WithError(err).WithHint("invoice list all tenant failed").Mark(ierr.ErrDatabase)
+	}
+
+	result := make([]*domainInvoice.Invoice, len(invoices))
+	for i, inv := range invoices {
+		result[i] = domainInvoice.FromEnt(inv)
+	}
+	SetSpanSuccess(span)
+	return result, nil
+}
+
 // Count returns the total number of invoices based on the filter
 func (r *invoiceRepository) Count(ctx context.Context, filter *types.InvoiceFilter) (int, error) {
 	// Start a span for this repository operation

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -49,7 +49,7 @@ type InvoiceService interface {
 	GetInvoicePDF(ctx context.Context, id string) ([]byte, error)
 	GetInvoicePDFUrl(ctx context.Context, id string) (string, error)
 	RecalculateInvoice(ctx context.Context, id string) (*dto.InvoiceResponse, error)
-	RecalculateInvoiceV2(ctx context.Context, id string, finalize bool) (*dto.InvoiceResponse, error)
+	RegenerateDraftSubscriptionInvoice(ctx context.Context, id string, finalize bool) (*dto.InvoiceResponse, error)
 	RecalculateInvoiceAmounts(ctx context.Context, invoiceID string) error
 	CalculatePriceBreakdown(ctx context.Context, inv *dto.InvoiceResponse) (map[string][]dto.SourceUsageItem, error)
 	CalculateUsageBreakdown(ctx context.Context, inv *dto.InvoiceResponse, groupBy []string, forceRealtimeRecalculation bool) (map[string][]dto.UsageBreakdownItem, error)
@@ -2600,9 +2600,17 @@ func (s *invoiceService) publishInternalWebhookEvent(ctx context.Context, eventN
 	)
 }
 
-// RecalculateInvoiceV2 recalculates a draft subscription invoice in-place (replaces line items, reapplies credits/coupons/taxes).
-func (s *invoiceService) RecalculateInvoiceV2(ctx context.Context, id string, finalize bool) (*dto.InvoiceResponse, error) {
-	s.Logger.Infow("recalculating invoice v2 (draft)", "invoice_id", id)
+// RegenerateDraftSubscriptionInvoice regenerates a draft subscription invoice in-place from current subscription and usage.
+//
+// Behavior:
+//   - Removes existing line items and recomputes them from the subscription (plan, prices, usage).
+//   - Reapplies credits, coupons, and taxes to the new line items.
+//   - Updates invoice totals, amount due, and payment status. The same invoice ID is kept.
+//
+// Use when subscription or usage data has changed after the draft was created but before finalizing.
+// If finalize is true, the invoice is finalized after regeneration; otherwise it remains in draft.
+func (s *invoiceService) RegenerateDraftSubscriptionInvoice(ctx context.Context, id string, finalize bool) (*dto.InvoiceResponse, error) {
+	s.Logger.Infow("regenerating draft subscription invoice", "invoice_id", id)
 
 	// Get the invoice
 	inv, err := s.InvoiceRepo.Get(ctx, id)
@@ -2766,38 +2774,37 @@ func (s *invoiceService) RecalculateInvoiceV2(ctx context.Context, id string, fi
 			return err
 		}
 
-		s.Logger.Infow("successfully recalculated invoice with fresh calculation",
+		s.Logger.Infow("successfully regenerated draft subscription invoice",
 			"invoice_id", inv.ID,
 			"subscription_id", *inv.SubscriptionID,
 			"old_amount_due", inv.AmountDue,
 			"new_amount_due", newInvoiceReq.AmountDue,
 			"old_line_items", len(existingLineItemIDs),
-			"new_line_items", len(newLineItems),
-			"recalculation_type", "complete_fresh_calculation")
+			"new_line_items", len(newLineItems))
 
 		return nil
 	})
 
 	if err != nil {
-		s.Logger.Errorw("failed to recalculate invoice",
+		s.Logger.Errorw("failed to regenerate draft subscription invoice",
 			"error", err,
 			"invoice_id", inv.ID,
 			"subscription_id", *inv.SubscriptionID)
 		return nil, err
 	}
 
-	// Publish webhook event for invoice recalculation
+	// Publish webhook event for invoice regeneration
 	s.publishInternalWebhookEvent(ctx, types.WebhookEventInvoiceCreateDraft, inv.ID)
 
 	// Finalize the invoice if requested
 	if finalize {
 		if err := s.FinalizeInvoice(ctx, id); err != nil {
-			s.Logger.Errorw("failed to finalize invoice after recalculation",
+			s.Logger.Errorw("failed to finalize invoice after regeneration",
 				"error", err,
 				"invoice_id", id)
 			return nil, err
 		}
-		s.Logger.Infow("successfully finalized invoice after recalculation", "invoice_id", id)
+		s.Logger.Infow("successfully finalized invoice after regeneration", "invoice_id", id)
 	}
 
 	// Return updated invoice
@@ -3134,24 +3141,6 @@ func (s *invoiceService) HandleIncompleteSubscriptionPayment(ctx context.Context
 		"subscription_id", *invoice.SubscriptionID)
 
 	return nil
-}
-
-// generateProrationInvoiceDescription creates a description for proration invoices
-func (s *invoiceService) generateProrationInvoiceDescription(cancellationType, cancellationReason string, totalAmount decimal.Decimal) string {
-	if totalAmount.IsNegative() {
-		// Credit invoice
-		switch cancellationType {
-		case "immediate":
-			return fmt.Sprintf("Credit for unused time - immediate cancellation (%s)", cancellationReason)
-		case "specific_date":
-			return fmt.Sprintf("Credit for unused time - scheduled cancellation (%s)", cancellationReason)
-		default:
-			return fmt.Sprintf("Cancellation credit (%s)", cancellationReason)
-		}
-	} else {
-		// Charge invoice (rare for cancellations, but possible)
-		return fmt.Sprintf("Proration charges - cancellation (%s)", cancellationReason)
-	}
 }
 
 // CalculateUsageBreakdown provides flexible usage breakdown with custom grouping

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -24,6 +24,7 @@ import (
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/s3"
 	"github.com/flexprice/flexprice/internal/temporal/models"
+	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
 	temporalservice "github.com/flexprice/flexprice/internal/temporal/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
@@ -60,6 +61,8 @@ type InvoiceService interface {
 
 	// Cron methods
 	SyncInvoiceToExternalVendors(ctx context.Context, invoiceID string) error
+	// TriggerRegenerateDraftInvoicesInBatches lists draft subscription invoices in batches of 500 and starts a RegenerateDraftInvoicesBatchWorkflow per batch (fire-and-forget). For use by scheduled Temporal activity only.
+	TriggerRegenerateDraftInvoicesInBatches(ctx context.Context) (batchesStarted, totalInvoices int, err error)
 
 	DistributeInvoiceLevelDiscount(ctx context.Context, lineItems []*invoice.InvoiceLineItem, invoiceDiscountAmount decimal.Decimal) error
 }
@@ -2809,6 +2812,70 @@ func (s *invoiceService) RegenerateDraftSubscriptionInvoice(ctx context.Context,
 
 	// Return updated invoice
 	return s.GetInvoice(ctx, id)
+}
+
+const regenerateDraftInvoicesBatchSize = 500
+
+// TriggerRegenerateDraftInvoicesInBatches lists draft subscription invoices in batches and starts a RegenerateDraftInvoicesBatchWorkflow per batch (fire-and-forget).
+func (s *invoiceService) TriggerRegenerateDraftInvoicesInBatches(ctx context.Context) (batchesStarted, totalInvoices int, err error) {
+	temporalSvc := temporalservice.GetGlobalTemporalService()
+	if temporalSvc == nil {
+		return 0, 0, ierr.NewError("temporal service not available").
+			WithHint("Cannot trigger regenerate draft invoices workflows").
+			Mark(ierr.ErrInternal)
+	}
+
+	queryFilter := types.NewDefaultQueryFilter()
+	queryFilter.Limit = lo.ToPtr(regenerateDraftInvoicesBatchSize)
+	filter := &types.InvoiceFilter{
+		QueryFilter:   queryFilter,
+		InvoiceStatus: []types.InvoiceStatus{types.InvoiceStatusDraft},
+		InvoiceType:   types.InvoiceTypeSubscription,
+		SkipLineItems: true,
+	}
+
+	for offset := 0; ; offset += regenerateDraftInvoicesBatchSize {
+		filter.QueryFilter.Offset = lo.ToPtr(offset)
+		invoices, listErr := s.InvoiceRepo.ListAllTenant(ctx, filter)
+		if listErr != nil {
+			s.Logger.Errorw("failed to list draft subscription invoices", "error", listErr, "offset", offset)
+			return batchesStarted, totalInvoices, listErr
+		}
+		if len(invoices) == 0 {
+			break
+		}
+
+		items := make([]invoiceModels.InvoiceTenantEnv, len(invoices))
+		for i, inv := range invoices {
+			items[i] = invoiceModels.InvoiceTenantEnv{
+				InvoiceID:     inv.ID,
+				TenantID:      inv.TenantID,
+				EnvironmentID: inv.EnvironmentID,
+			}
+		}
+		input := invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput{Invoices: items}
+		if err := input.Validate(); err != nil {
+			s.Logger.Errorw("invalid batch input for regenerate draft invoices", "error", err, "offset", offset)
+			return batchesStarted, totalInvoices, err
+		}
+
+		_, startErr := temporalSvc.ExecuteWorkflow(ctx, types.TemporalRegenerateDraftInvoicesBatchWorkflow, input)
+		if startErr != nil {
+			s.Logger.Errorw("failed to start regenerate draft invoices batch workflow", "error", startErr, "offset", offset, "batch_size", len(items))
+			return batchesStarted, totalInvoices, startErr
+		}
+
+		batchesStarted++
+		totalInvoices += len(invoices)
+		s.Logger.Infow("started regenerate draft invoices batch workflow", "offset", offset, "batch_size", len(invoices), "batches_started", batchesStarted)
+
+		if len(invoices) < regenerateDraftInvoicesBatchSize {
+			break
+		}
+	}
+
+	s.Logger.Infow("triggered regenerate draft invoices in batches", "batches_started", batchesStarted, "total_invoices", totalInvoices)
+	return batchesStarted, totalInvoices, nil
 }
 
 // RecalculateVoidedInvoice creates a fresh replacement invoice for a voided subscription invoice

--- a/internal/service/invoice_void_recalculate_test.go
+++ b/internal/service/invoice_void_recalculate_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// InvoiceVoidRecalculateSuite tests VoidInvoice, RecalculateInvoice and RecalculateInvoiceV2.
+// InvoiceVoidRecalculateSuite tests VoidInvoice, RecalculateInvoice and RegenerateDraftSubscriptionInvoice.
 type InvoiceVoidRecalculateSuite struct {
 	testutil.BaseServiceTestSuite
 	service     InvoiceService
@@ -797,10 +797,10 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoice_HappyPath() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// RecalculateInvoiceV2 tests
+// RegenerateDraftSubscriptionInvoice tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_Validation() {
+func (s *InvoiceVoidRecalculateSuite) TestRegenerateDraftSubscriptionInvoice_Validation() {
 	tests := []struct {
 		name          string
 		setup         func() string // returns invoice ID
@@ -913,19 +913,19 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_Validation() {
 			s.setupTestData()
 
 			id := tt.setup()
-			_, err := s.service.RecalculateInvoiceV2(s.GetContext(), id, false)
+			_, err := s.service.RegenerateDraftSubscriptionInvoice(s.GetContext(), id, false)
 			s.Error(err)
 			s.Contains(err.Error(), tt.expectedError)
 		})
 	}
 }
 
-func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_HappyPath_KeepDraft() {
+func (s *InvoiceVoidRecalculateSuite) TestRegenerateDraftSubscriptionInvoice_HappyPath_KeepDraft() {
 	inv := s.buildDraftInvoice("inv_v2_draft_keep")
 
-	result, err := s.service.RecalculateInvoiceV2(s.GetContext(), inv.ID, false)
+	result, err := s.service.RegenerateDraftSubscriptionInvoice(s.GetContext(), inv.ID, false)
 	if err != nil {
-		s.T().Logf("RecalculateInvoiceV2 returned error (possible mock limitation): %v", err)
+		s.T().Logf("RegenerateDraftSubscriptionInvoice returned error (possible mock limitation): %v", err)
 		return
 	}
 
@@ -935,12 +935,12 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_HappyPath_KeepDra
 		"invoice must remain DRAFT when finalize=false")
 }
 
-func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_HappyPath_Finalize() {
+func (s *InvoiceVoidRecalculateSuite) TestRegenerateDraftSubscriptionInvoice_HappyPath_Finalize() {
 	inv := s.buildDraftInvoice("inv_v2_draft_finalize")
 
-	result, err := s.service.RecalculateInvoiceV2(s.GetContext(), inv.ID, true)
+	result, err := s.service.RegenerateDraftSubscriptionInvoice(s.GetContext(), inv.ID, true)
 	if err != nil {
-		s.T().Logf("RecalculateInvoiceV2 returned error (possible mock limitation): %v", err)
+		s.T().Logf("RegenerateDraftSubscriptionInvoice returned error (possible mock limitation): %v", err)
 		return
 	}
 

--- a/internal/service/scheduled_task.go
+++ b/internal/service/scheduled_task.go
@@ -817,6 +817,12 @@ func (s *scheduledTaskService) ScheduleUpdateBillingPeriod(ctx context.Context) 
 // Schedule ID is fixed so repeated calls are idempotent (Temporal returns already exists if present).
 // Follows same convention as ScheduleUpdateBillingPeriod (resource-scoped route, trigger once). Fixed schedule ID for idempotent create.
 func (s *scheduledTaskService) ScheduleRegenerateDraftInvoices(ctx context.Context) (string, error) {
+	if s.temporalClient == nil {
+		return "", ierr.NewError("temporal client not configured").
+			WithHint("Temporal client is not available").
+			Mark(ierr.ErrInternal)
+	}
+
 	const scheduleID = "schtask_regenerate_draft_invoices"
 	// Cron: at minute 0 of every 6th hour (00:00, 06:00, 12:00, 18:00 UTC)
 	cronExpr := "0 */6 * * *"

--- a/internal/service/scheduled_task.go
+++ b/internal/service/scheduled_task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flexprice/flexprice/internal/temporal/models"
 	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
 	exportWorkflows "github.com/flexprice/flexprice/internal/temporal/workflows/export"
+	invoiceWorkflows "github.com/flexprice/flexprice/internal/temporal/workflows/invoice"
 	subscriptionWorkflows "github.com/flexprice/flexprice/internal/temporal/workflows/subscription"
 	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/api/serviceerror"
@@ -32,6 +33,7 @@ type ScheduledTaskService interface {
 
 	CalculateIntervalBoundaries(currentTime time.Time, interval types.ScheduledTaskInterval) (startTime, endTime time.Time)
 	ScheduleUpdateBillingPeriod(ctx context.Context) (string, error)
+	ScheduleRegenerateDraftInvoices(ctx context.Context) (string, error)
 }
 
 type scheduledTaskService struct {
@@ -809,4 +811,41 @@ func (s *scheduledTaskService) ScheduleUpdateBillingPeriod(ctx context.Context) 
 	}
 
 	return "Triggered update billing period workflow successfully", nil
+}
+
+// ScheduleRegenerateDraftInvoices creates a Temporal schedule that runs RegenerateDraftInvoicesScheduledWorkflow every 6 hours.
+// Schedule ID is fixed so repeated calls are idempotent (Temporal returns already exists if present).
+// Follows same convention as ScheduleUpdateBillingPeriod (resource-scoped route, trigger once). Fixed schedule ID for idempotent create.
+func (s *scheduledTaskService) ScheduleRegenerateDraftInvoices(ctx context.Context) (string, error) {
+	const scheduleID = "schtask_regenerate_draft_invoices"
+	// Cron: at minute 0 of every 6th hour (00:00, 06:00, 12:00, 18:00 UTC)
+	cronExpr := "0 */6 * * *"
+	scheduleSpec := client.ScheduleSpec{
+		CronExpressions: []string{cronExpr},
+	}
+	// Timeouts match schedule interval (6h): allow a run to complete before the next tick.
+	// Trade-off: a stuck workflow will take up to 6h to time out instead of failing sooner.
+	action := &client.ScheduleWorkflowAction{
+		Workflow:                 invoiceWorkflows.RegenerateDraftInvoicesScheduledWorkflow,
+		Args:                     []interface{}{},
+		TaskQueue:                string(types.TemporalTaskQueueInvoice),
+		WorkflowExecutionTimeout: 6 * time.Hour,
+		WorkflowRunTimeout:       6 * time.Hour,
+		WorkflowTaskTimeout:      1 * time.Hour, // workflow task is short; only activities run long
+	}
+	scheduleOptions := models.CreateScheduleOptions{
+		ID:     scheduleID,
+		Spec:   scheduleSpec,
+		Action: action,
+		Paused: false,
+	}
+	_, err := s.temporalClient.CreateSchedule(ctx, scheduleOptions)
+	if err != nil {
+		s.logger.Errorw("failed to create regenerate draft invoices schedule", "error", err)
+		return "", ierr.WithError(err).
+			WithHint("Failed to create Temporal schedule for regenerate draft invoices").
+			Mark(ierr.ErrInternal)
+	}
+	s.logger.Infow("created regenerate draft invoices schedule", "schedule_id", scheduleID, "cron", cronExpr)
+	return "Regenerate draft invoices schedule created (every 6 hours)", nil
 }

--- a/internal/temporal/activities/invoice/invoice_activities.go
+++ b/internal/temporal/activities/invoice/invoice_activities.go
@@ -155,3 +155,55 @@ func (s *InvoiceActivities) RecalculateInvoiceActivity(
 		InvoiceID: outID,
 	}, nil
 }
+
+// TriggerRegenerateDraftInvoicesActivity calls the invoice service to list draft subscription invoices in batches and start a batch workflow per batch.
+func (s *InvoiceActivities) TriggerRegenerateDraftInvoicesActivity(ctx context.Context) (*invoiceModels.TriggerRegenerateDraftInvoicesActivityOutput, error) {
+	invoiceService := service.NewInvoiceService(s.serviceParams)
+	batchesStarted, totalInvoices, err := invoiceService.TriggerRegenerateDraftInvoicesInBatches(ctx)
+	if err != nil {
+		s.logger.Errorw("failed to trigger regenerate draft invoices in batches", "error", err)
+		return nil, err
+	}
+	s.logger.Infow("triggered regenerate draft invoices in batches", "batches_started", batchesStarted, "total_invoices", totalInvoices)
+	return &invoiceModels.TriggerRegenerateDraftInvoicesActivityOutput{
+		BatchesStarted: batchesStarted,
+		TotalInvoices:  totalInvoices,
+	}, nil
+}
+
+// RegenerateDraftInvoicesBatchActivity regenerates each draft subscription invoice in the batch (per-invoice context and RegenerateDraftSubscriptionInvoice).
+func (s *InvoiceActivities) RegenerateDraftInvoicesBatchActivity(
+	ctx context.Context,
+	input invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput,
+) (*invoiceModels.RegenerateDraftInvoicesBatchWorkflowResult, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	result := &invoiceModels.RegenerateDraftInvoicesBatchWorkflowResult{
+		FailedInvoiceIDs: make([]string, 0),
+	}
+	invoiceService := service.NewInvoiceService(s.serviceParams)
+
+	for _, item := range input.Invoices {
+		result.Processed++
+		itemCtx := types.SetTenantID(ctx, item.TenantID)
+		itemCtx = types.SetEnvironmentID(itemCtx, item.EnvironmentID)
+		_, err := invoiceService.RegenerateDraftSubscriptionInvoice(itemCtx, item.InvoiceID, false)
+		if err != nil {
+			result.Failed++
+			result.FailedInvoiceIDs = append(result.FailedInvoiceIDs, item.InvoiceID)
+			s.logger.Warnw("failed to regenerate draft subscription invoice",
+				"invoice_id", item.InvoiceID,
+				"error", err)
+			continue
+		}
+		result.Succeeded++
+	}
+
+	s.logger.Infow("regenerate draft invoices batch completed",
+		"processed", result.Processed,
+		"succeeded", result.Succeeded,
+		"failed", result.Failed)
+	return result, nil
+}

--- a/internal/temporal/models/invoice/regenerate_draft_invoices.go
+++ b/internal/temporal/models/invoice/regenerate_draft_invoices.go
@@ -1,0 +1,61 @@
+package invoice
+
+import (
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+// RegenerateDraftInvoicesBatchWorkflowInput is the input for the batch workflow that regenerates draft subscription invoices.
+type RegenerateDraftInvoicesBatchWorkflowInput struct {
+	Invoices []InvoiceTenantEnv `json:"invoices"`
+}
+
+// InvoiceTenantEnv holds invoice ID with its tenant and environment for context.
+type InvoiceTenantEnv struct {
+	InvoiceID     string `json:"invoice_id"`
+	TenantID      string `json:"tenant_id"`
+	EnvironmentID string `json:"environment_id"`
+}
+
+// Validate validates the batch workflow input.
+func (i *RegenerateDraftInvoicesBatchWorkflowInput) Validate() error {
+	if len(i.Invoices) == 0 {
+		return ierr.NewError("invoices list is required and must not be empty").
+			WithHint("At least one invoice is required").
+			Mark(ierr.ErrValidation)
+	}
+	for j, inv := range i.Invoices {
+		if inv.InvoiceID == "" {
+			return ierr.NewError("invoice_id is required for each item").
+				WithHint("Invoice ID is required").
+				WithReportableDetails(map[string]interface{}{"index": j}).
+				Mark(ierr.ErrValidation)
+		}
+		if inv.TenantID == "" {
+			return ierr.NewError("tenant_id is required for each item").
+				WithHint("Tenant ID is required").
+				WithReportableDetails(map[string]interface{}{"index": j, "invoice_id": inv.InvoiceID}).
+				Mark(ierr.ErrValidation)
+		}
+		if inv.EnvironmentID == "" {
+			return ierr.NewError("environment_id is required for each item").
+				WithHint("Environment ID is required").
+				WithReportableDetails(map[string]interface{}{"index": j, "invoice_id": inv.InvoiceID}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// RegenerateDraftInvoicesBatchWorkflowResult is the result of the batch regeneration workflow/activity.
+type RegenerateDraftInvoicesBatchWorkflowResult struct {
+	Processed       int      `json:"processed"`
+	Succeeded       int      `json:"succeeded"`
+	Failed          int      `json:"failed"`
+	FailedInvoiceIDs []string `json:"failed_invoice_ids,omitempty"`
+}
+
+// TriggerRegenerateDraftInvoicesActivityOutput is the optional output of the trigger activity.
+type TriggerRegenerateDraftInvoicesActivityOutput struct {
+	BatchesStarted int `json:"batches_started"`
+	TotalInvoices  int `json:"total_invoices"`
+}

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -258,12 +258,16 @@ func buildWorkerConfig(
 		workflowsList = append(
 			workflowsList,
 			invoiceWorkflows.ProcessInvoiceWorkflow,
+			invoiceWorkflows.RegenerateDraftInvoicesScheduledWorkflow,
+			invoiceWorkflows.RegenerateDraftInvoicesBatchWorkflow,
 		)
 		activitiesList = append(activitiesList,
 			// Invoice workflow activities
 			invoiceActs.FinalizeInvoiceActivity,
 			invoiceActs.SyncInvoiceToVendorActivity,
 			invoiceActs.AttemptInvoicePaymentActivity,
+			invoiceActs.TriggerRegenerateDraftInvoicesActivity,
+			invoiceActs.RegenerateDraftInvoicesBatchActivity,
 		)
 
 	case types.TemporalTaskQueueWorkflows:

--- a/internal/temporal/service/service.go
+++ b/internal/temporal/service/service.go
@@ -810,9 +810,15 @@ func (s *temporalService) buildRecalculateInvoiceInput(_ context.Context, tenant
 // buildRegenerateDraftInvoicesBatchWorkflowInput builds input for the batch regenerate draft invoices workflow.
 func (s *temporalService) buildRegenerateDraftInvoicesBatchWorkflowInput(_ context.Context, _, _, _ string, params interface{}) (interface{}, error) {
 	if input, ok := params.(invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput); ok {
+		if err := input.Validate(); err != nil {
+			return nil, err
+		}
 		return input, nil
 	}
 	if input, ok := params.(*invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput); ok {
+		if err := input.Validate(); err != nil {
+			return nil, err
+		}
 		return *input, nil
 	}
 	return nil, errors.NewError("invalid input for regenerate draft invoices batch workflow").

--- a/internal/temporal/service/service.go
+++ b/internal/temporal/service/service.go
@@ -511,6 +511,8 @@ func (s *temporalService) buildWorkflowInput(ctx context.Context, workflowType t
 		return s.buildReprocessRawEventsInput(ctx, tenantID, environmentID, userID, params)
 	case types.TemporalReprocessEventsForPlanWorkflow:
 		return s.buildReprocessEventsForPlanInput(ctx, tenantID, environmentID, userID, params)
+	case types.TemporalRegenerateDraftInvoicesBatchWorkflow:
+		return s.buildRegenerateDraftInvoicesBatchWorkflowInput(ctx, tenantID, environmentID, userID, params)
 	default:
 		return nil, errors.NewError("unsupported workflow type").
 			WithHintf("Workflow type %s is not supported", workflowType.String()).
@@ -802,6 +804,19 @@ func (s *temporalService) buildRecalculateInvoiceInput(_ context.Context, tenant
 	}
 	return nil, errors.NewError("invalid input for recalculate invoice workflow").
 		WithHint("Provide RecalculateInvoiceWorkflowInput with invoice_id, or invoice_id string, or map with invoice_id").
+		Mark(errors.ErrValidation)
+}
+
+// buildRegenerateDraftInvoicesBatchWorkflowInput builds input for the batch regenerate draft invoices workflow.
+func (s *temporalService) buildRegenerateDraftInvoicesBatchWorkflowInput(_ context.Context, _, _, _ string, params interface{}) (interface{}, error) {
+	if input, ok := params.(invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput); ok {
+		return input, nil
+	}
+	if input, ok := params.(*invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput); ok {
+		return *input, nil
+	}
+	return nil, errors.NewError("invalid input for regenerate draft invoices batch workflow").
+		WithHint("Provide RegenerateDraftInvoicesBatchWorkflowInput with invoices list").
 		Mark(errors.ErrValidation)
 }
 

--- a/internal/temporal/workflows/invoice/regenerate_draft_invoices_workflow.go
+++ b/internal/temporal/workflows/invoice/regenerate_draft_invoices_workflow.go
@@ -26,7 +26,7 @@ func RegenerateDraftInvoicesScheduledWorkflow(ctx workflow.Context) (*invoiceMod
 			InitialInterval:    time.Second * 30,
 			BackoffCoefficient: 2.0,
 			MaximumInterval:    time.Minute * 5,
-			MaximumAttempts:    3,
+			MaximumAttempts:    1,
 		},
 	}
 	ctx = workflow.WithActivityOptions(ctx, activityOptions)

--- a/internal/temporal/workflows/invoice/regenerate_draft_invoices_workflow.go
+++ b/internal/temporal/workflows/invoice/regenerate_draft_invoices_workflow.go
@@ -1,0 +1,83 @@
+package invoice
+
+import (
+	"time"
+
+	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	WorkflowRegenerateDraftInvoicesScheduled = "RegenerateDraftInvoicesScheduledWorkflow"
+	WorkflowRegenerateDraftInvoicesBatch    = "RegenerateDraftInvoicesBatchWorkflow"
+	ActivityTriggerRegenerateDraftInvoices  = "TriggerRegenerateDraftInvoicesActivity"
+	ActivityRegenerateDraftInvoicesBatch    = "RegenerateDraftInvoicesBatchActivity"
+)
+
+// RegenerateDraftInvoicesScheduledWorkflow runs every 6 hours (via schedule). It executes a single activity that triggers the service to list draft subscription invoices in batches and start a batch workflow per batch.
+func RegenerateDraftInvoicesScheduledWorkflow(ctx workflow.Context) (*invoiceModels.TriggerRegenerateDraftInvoicesActivityOutput, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting regenerate draft invoices scheduled workflow")
+
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second * 30,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute * 5,
+			MaximumAttempts:    3,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	var output invoiceModels.TriggerRegenerateDraftInvoicesActivityOutput
+	err := workflow.ExecuteActivity(ctx, ActivityTriggerRegenerateDraftInvoices).Get(ctx, &output)
+	if err != nil {
+		logger.Error("Trigger regenerate draft invoices activity failed", "error", err)
+		return nil, err
+	}
+
+	logger.Info("Regenerate draft invoices scheduled workflow completed",
+		"batches_started", output.BatchesStarted,
+		"total_invoices", output.TotalInvoices)
+	return &output, nil
+}
+
+// RegenerateDraftInvoicesBatchWorkflow processes a batch of draft subscription invoices (up to 500), regenerating each in place via the invoice service.
+func RegenerateDraftInvoicesBatchWorkflow(
+	ctx workflow.Context,
+	input invoiceModels.RegenerateDraftInvoicesBatchWorkflowInput,
+) (*invoiceModels.RegenerateDraftInvoicesBatchWorkflowResult, error) {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting regenerate draft invoices batch workflow", "invoice_count", len(input.Invoices))
+
+	if err := input.Validate(); err != nil {
+		logger.Error("Invalid batch workflow input", "error", err)
+		return nil, err
+	}
+
+	activityOptions := workflow.ActivityOptions{
+		StartToCloseTimeout: 60 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second * 30,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute * 5,
+			MaximumAttempts:    2,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, activityOptions)
+
+	var result invoiceModels.RegenerateDraftInvoicesBatchWorkflowResult
+	err := workflow.ExecuteActivity(ctx, ActivityRegenerateDraftInvoicesBatch, input).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Regenerate draft invoices batch activity failed", "error", err)
+		return nil, err
+	}
+
+	logger.Info("Regenerate draft invoices batch workflow completed",
+		"processed", result.Processed,
+		"succeeded", result.Succeeded,
+		"failed", result.Failed)
+	return &result, nil
+}

--- a/internal/testutil/inmemory_invoice_store.go
+++ b/internal/testutil/inmemory_invoice_store.go
@@ -175,6 +175,11 @@ func (s *InMemoryInvoiceStore) List(ctx context.Context, filter *types.InvoiceFi
 	return s.InMemoryStore.List(ctx, filter, invoiceFilterFn, invoiceSortFn)
 }
 
+// ListAllTenant returns all invoices across tenants (no tenant from context). For tests only.
+func (s *InMemoryInvoiceStore) ListAllTenant(ctx context.Context, filter *types.InvoiceFilter) ([]*invoice.Invoice, error) {
+	return s.InMemoryStore.List(context.Background(), filter, invoiceFilterFn, invoiceSortFn)
+}
+
 func (s *InMemoryInvoiceStore) Count(ctx context.Context, filter *types.InvoiceFilter) (int, error) {
 	return s.InMemoryStore.Count(ctx, filter, invoiceFilterFn)
 }

--- a/internal/types/temporal.go
+++ b/internal/types/temporal.go
@@ -69,6 +69,8 @@ const (
 	TemporalProcessSubscriptionBillingWorkflow  TemporalWorkflowType = "ProcessSubscriptionBillingWorkflow"
 	TemporalProcessInvoiceWorkflow              TemporalWorkflowType = "ProcessInvoiceWorkflow"
 	TemporalRecalculateInvoiceWorkflow          TemporalWorkflowType = "RecalculateInvoiceWorkflow"
+	TemporalRegenerateDraftInvoicesScheduledWorkflow TemporalWorkflowType = "RegenerateDraftInvoicesScheduledWorkflow"
+	TemporalRegenerateDraftInvoicesBatchWorkflow    TemporalWorkflowType = "RegenerateDraftInvoicesBatchWorkflow"
 	TemporalReprocessEventsWorkflow             TemporalWorkflowType = "ReprocessEventsWorkflow"
 	TemporalReprocessRawEventsWorkflow          TemporalWorkflowType = "ReprocessRawEventsWorkflow"
 	TemporalReprocessEventsForPlanWorkflow      TemporalWorkflowType = "ReprocessEventsForPlanWorkflow"
@@ -81,6 +83,8 @@ var WorkflowTypesExcludedFromTracking = []TemporalWorkflowType{
 	TemporalScheduleSubscriptionBillingWorkflow,
 	TemporalProcessSubscriptionBillingWorkflow,
 	TemporalProcessInvoiceWorkflow,
+	TemporalRegenerateDraftInvoicesScheduledWorkflow,
+	TemporalRegenerateDraftInvoicesBatchWorkflow,
 }
 
 // ShouldTrackWorkflowType returns false if this workflow type is excluded from tracking
@@ -114,6 +118,8 @@ func (w TemporalWorkflowType) Validate() error {
 		TemporalProcessSubscriptionBillingWorkflow,  // "ProcessSubscriptionBillingWorkflow"
 		TemporalProcessInvoiceWorkflow,              // "ProcessInvoiceWorkflow"
 		TemporalRecalculateInvoiceWorkflow,          // "RecalculateInvoiceWorkflow"
+		TemporalRegenerateDraftInvoicesScheduledWorkflow,    // "RegenerateDraftInvoicesScheduledWorkflow"
+		TemporalRegenerateDraftInvoicesBatchWorkflow,       // "RegenerateDraftInvoicesBatchWorkflow"
 		TemporalReprocessEventsWorkflow,             // "ReprocessEventsWorkflow"
 		TemporalReprocessRawEventsWorkflow,          // "ReprocessRawEventsWorkflow"
 		TemporalReprocessEventsForPlanWorkflow,      // "ReprocessEventsForPlanWorkflow"
@@ -142,7 +148,7 @@ func (w TemporalWorkflowType) TaskQueue() TemporalTaskQueue {
 		return TemporalTaskQueueSubscription
 	case TemporalRecalculateInvoiceWorkflow:
 		return TemporalTaskQueueSubscription
-	case TemporalProcessInvoiceWorkflow:
+	case TemporalProcessInvoiceWorkflow, TemporalRegenerateDraftInvoicesScheduledWorkflow, TemporalRegenerateDraftInvoicesBatchWorkflow:
 		return TemporalTaskQueueInvoice
 	case TemporalCustomerOnboardingWorkflow, TemporalPrepareProcessedEventsWorkflow:
 		return TemporalTaskQueueWorkflows
@@ -193,6 +199,8 @@ func GetWorkflowsForTaskQueue(taskQueue TemporalTaskQueue) []TemporalWorkflowTyp
 	case TemporalTaskQueueInvoice:
 		return []TemporalWorkflowType{
 			TemporalProcessInvoiceWorkflow,
+			TemporalRegenerateDraftInvoicesScheduledWorkflow,
+			TemporalRegenerateDraftInvoicesBatchWorkflow,
 		}
 	case TemporalTaskQueueWorkflows:
 		return []TemporalWorkflowType{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the legacy v2 invoice recalculation endpoint.

* **New Features**
  * Automatic draft invoice regeneration added (runs every 6 hours).
  * New API endpoint to schedule on-demand draft invoice regeneration.
  * Large-scale batched regeneration processing for improved throughput, reliability and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->