### PR TITLE
feat(analytics): add invoice reconciliation command to compare analytics costs with invoice subtotals

### DIFF
--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -983,6 +983,12 @@ func (o InvoiceQueryOptions) applyEntityQueryOptions(_ context.Context, f *types
 	if f.PeriodEndLTE != nil {
 		query = query.Where(invoice.PeriodEndLTE(*f.PeriodEndLTE))
 	}
+	if f.CreatedAtGTE != nil {
+		query = query.Where(invoice.CreatedAtGTE(*f.CreatedAtGTE))
+	}
+	if f.CreatedAtLTE != nil {
+		query = query.Where(invoice.CreatedAtLTE(*f.CreatedAtLTE))
+	}
 
 	if f.Filters != nil {
 		query, err = dsl.ApplyFilters[InvoiceQuery, predicate.Invoice](

--- a/internal/types/invoice.go
+++ b/internal/types/invoice.go
@@ -357,6 +357,11 @@ type InvoiceFilter struct {
 	// period_end_lte filters invoices with period_end <= value
 	PeriodEndLTE *time.Time `json:"period_end_lte,omitempty" form:"period_end_lte" validate:"omitempty,time_rfc3339"`
 
+	// created_at_gte filters invoices created at or after the given time
+	CreatedAtGTE *time.Time `json:"created_at_gte,omitempty" form:"created_at_gte" validate:"omitempty,time_rfc3339"`
+	// created_at_lte filters invoices created at or before the given time
+	CreatedAtLTE *time.Time `json:"created_at_lte,omitempty" form:"created_at_lte" validate:"omitempty,time_rfc3339"`
+
 	// SkipLineItems if true, will not include line items in the response
 	SkipLineItems bool `json:"skip_line_items,omitempty" form:"skip_line_items"`
 }

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -139,14 +139,13 @@ func RunAnalyticsInvoiceReconciliation() error {
 	}
 	log.Printf("Summed stored invoice subtotals for %d invoices (DB-stored values only; not runtime-recalculated)", len(invoices))
 
-	// 4) Build diff rows (only where there is a meaningful difference)
+	// 4) Build diff rows (only where there is a meaningful difference).
+	// Iterate over toProcess so we only consider customers we ran analytics for (with ExternalID);
+	// avoids false diffs from customers missing from analyticsByCustomer.
 	var rows []AnalyticsInvoiceDiffRow
 	tolerance := decimal.NewFromFloat(0.0001)
 
-	for _, c := range customers {
-		if c.TenantID != tenantID || c.EnvironmentID != environmentID {
-			continue
-		}
+	for _, c := range toProcess {
 		analyticsCost := analyticsByCustomer[c.ID]
 		storedSubtotal := storedInvoiceSubtotalByCustomer[c.ID]
 		diff := analyticsCost.Sub(storedSubtotal)
@@ -181,17 +180,15 @@ func RunAnalyticsInvoiceReconciliation() error {
 		})
 	}
 
-	if len(rows) == 0 {
-		log.Printf("No differences found; no CSV written.")
-		return nil
-	}
-
 	outputFile := fmt.Sprintf("analytics_invoice_reconciliation_%s_%s.csv", tenantID, time.Now().Format("20060102_150405"))
 	if err := writeReconciliationCSV(rows, outputFile); err != nil {
 		return fmt.Errorf("write CSV: %w", err)
 	}
-
-	log.Printf("Wrote %d diff rows to %s", len(rows), outputFile)
+	if len(rows) == 0 {
+		log.Printf("No differences found; wrote CSV with header only to %s", outputFile)
+	} else {
+		log.Printf("Wrote %d diff rows to %s", len(rows), outputFile)
+	}
 	return nil
 }
 

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -31,6 +31,8 @@ const (
 	dateLayout                   = "2006-01-02"
 	defaultReconciliationWorkers = 10
 	envReconciliationWorkers     = "RECONCILIATION_WORKERS"
+	envStartTime                 = "START_TIME"
+	envEndTime                   = "END_TIME"
 )
 
 // AnalyticsInvoiceDiffRow represents one row in the reconciliation diff CSV
@@ -54,7 +56,7 @@ type analyticsInvoiceReconciliationScript struct {
 }
 
 // RunAnalyticsInvoiceReconciliation compares analytics total cost to invoice subtotals for a period and writes diffs to CSV.
-// Period is hardcoded to 1 Feb – 1 Mar. Requires TENANT_ID and ENVIRONMENT_ID.
+// Requires TENANT_ID and ENVIRONMENT_ID. Optional START_TIME and END_TIME (date 2006-01-02 or ISO-8601); default is start of current year through end of today UTC.
 // Infrastructure (Postgres, ClickHouse, Kafka) must be running.
 //
 // Invoice side uses stored subtotals only: values come from invoiceRepo.List() (inv.Subtotal).
@@ -68,8 +70,10 @@ func RunAnalyticsInvoiceReconciliation() error {
 		return fmt.Errorf("TENANT_ID and ENVIRONMENT_ID are required")
 	}
 
-	startTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
-	endTime := time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC)
+	startTime, endTime, err := parseReconciliationPeriod()
+	if err != nil {
+		return err
+	}
 
 	log.Printf("Reconciling analytics vs invoices for period %s to %s (tenant=%s, env=%s)",
 		startTime.Format(dateLayout), endTime.Format(dateLayout), tenantID, environmentID)
@@ -118,7 +122,7 @@ func RunAnalyticsInvoiceReconciliation() error {
 	header := []string{
 		"customer_id", "customer_name", "external_customer_id",
 		"analytics_total_cost", "invoice_subtotal_sum", "diff",
-		"invoice_ids", "invoice_count", "currency",
+		"invoice_ids", "invoice_count_in_period", "total_invoice_count", "currency",
 	}
 	if err := csvWriter.Write(header); err != nil {
 		return fmt.Errorf("write CSV header: %w", err)
@@ -142,6 +146,49 @@ func RunAnalyticsInvoiceReconciliation() error {
 		log.Printf("Wrote %d customer rows (diff at each customer level) to %s (completed %d/%d customers)", rowsWritten, outputFile, completed, len(toProcess))
 	}
 	return nil
+}
+
+// parseReconciliationPeriod returns start and end time for the reconciliation period.
+// Uses START_TIME and END_TIME env vars (date-only 2006-01-02 or ISO-8601). If unset,
+// defaults to start of current year and end of current day UTC so invoice/list and analytics match real data.
+func parseReconciliationPeriod() (startTime, endTime time.Time, err error) {
+	now := time.Now().UTC()
+	defaultStart := time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+	defaultEnd := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, time.UTC)
+
+	startStr := os.Getenv(envStartTime)
+	endStr := os.Getenv(envEndTime)
+
+	if startStr == "" {
+		startTime = defaultStart
+	} else {
+		startTime, err = parseTime(startStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid START_TIME %q: %w", startStr, err)
+		}
+	}
+	if endStr == "" {
+		endTime = defaultEnd
+	} else {
+		endTime, err = parseTime(endStr)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid END_TIME %q: %w", endStr, err)
+		}
+	}
+	if startTime.After(endTime) {
+		return time.Time{}, time.Time{}, fmt.Errorf("START_TIME must be before or equal to END_TIME")
+	}
+	return startTime, endTime, nil
+}
+
+func parseTime(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(dateLayout, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("use date (2006-01-02) or ISO-8601")
 }
 
 func getReconciliationWorkers() int {
@@ -245,6 +292,17 @@ func runReconciliationWorkers(
 			storedSubtotal = storedSubtotal.Add(inv.Subtotal)
 			ids = append(ids, inv.ID)
 		}
+		inPeriodCount := len(ids)
+
+		// Total invoice count for this customer (all time, same tenant/env)
+		totalFilter := types.NewNoLimitInvoiceFilter()
+		totalFilter.CustomerID = c.ID
+		totalFilter.SkipLineItems = true
+		totalInvoiceCount, countErr := script.invoiceRepo.Count(ctx, totalFilter)
+		if countErr != nil {
+			log.Printf("Warning: count invoices for customer %s: %v", c.ID, countErr)
+			totalInvoiceCount = 0
+		}
 
 		diff := analyticsCost.Sub(storedSubtotal)
 		customerName := c.Name
@@ -264,7 +322,7 @@ func runReconciliationWorkers(
 		record := []string{
 			c.ID, customerName, c.ExternalID,
 			analyticsCost.StringFixed(4), storedSubtotal.StringFixed(4), diff.StringFixed(4),
-			idList, fmt.Sprintf("%d", len(ids)), "USD",
+			idList, fmt.Sprintf("%d", inPeriodCount), fmt.Sprintf("%d", totalInvoiceCount), "USD",
 		}
 		if err := csvWriter.Write(record); err != nil {
 			log.Printf("Error writing CSV row for customer %s: %v", c.ID, err)

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -278,6 +278,7 @@ func runReconciliationWorkers(
 		invFilter.CreatedAtGTE = &startTime
 		invFilter.CreatedAtLTE = &endTime
 		invFilter.SkipLineItems = true
+		invFilter.InvoiceType = types.InvoiceTypeSubscription
 		invoices, err := script.invoiceRepo.List(ctx, invFilter)
 		if err != nil {
 			log.Printf("Warning: list invoices for customer %s: %v", c.ID, err)
@@ -298,6 +299,7 @@ func runReconciliationWorkers(
 		totalFilter := types.NewNoLimitInvoiceFilter()
 		totalFilter.CustomerID = c.ID
 		totalFilter.SkipLineItems = true
+		totalFilter.InvoiceType = types.InvoiceTypeSubscription
 		totalInvoiceCount, countErr := script.invoiceRepo.Count(ctx, totalFilter)
 		if countErr != nil {
 			log.Printf("Warning: count invoices for customer %s: %v", c.ID, countErr)

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -245,17 +245,30 @@ func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationS
 	customerRepo := entRepo.NewCustomerRepository(pgClient, logger, cacheClient)
 	invoiceRepo := entRepo.NewInvoiceRepository(pgClient, logger, cacheClient)
 	featureRepo := entRepo.NewFeatureRepository(pgClient, logger, cacheClient)
+	meterRepo := entRepo.NewMeterRepository(pgClient, logger, cacheClient)
+	priceRepo := entRepo.NewPriceRepository(pgClient, logger, cacheClient)
+	planRepo := entRepo.NewPlanRepository(pgClient, logger, cacheClient)
+	subRepo := entRepo.NewSubscriptionRepository(pgClient, logger, cacheClient)
+	subLineItemRepo := entRepo.NewSubscriptionLineItemRepository(pgClient, logger, cacheClient)
+	addonRepo := entRepo.NewAddonRepository(pgClient, logger, cacheClient)
 	eventRepo := chRepo.NewEventRepository(chStore, logger)
 	featureUsageRepo := chRepo.NewFeatureUsageRepository(chStore, logger)
 
 	serviceParams := service.ServiceParams{
-		Logger:       logger,
-		Config:       cfg,
-		DB:          pgClient,
-		CustomerRepo: customerRepo,
-		InvoiceRepo:  invoiceRepo,
-		FeatureRepo:  featureRepo,
-		EventRepo:    eventRepo,
+		Logger:                   logger,
+		Config:                   cfg,
+		DB:                       pgClient,
+		CustomerRepo:             customerRepo,
+		InvoiceRepo:              invoiceRepo,
+		FeatureRepo:              featureRepo,
+		MeterRepo:                meterRepo,
+		PriceRepo:                priceRepo,
+		PlanRepo:                 planRepo,
+		SubRepo:                  subRepo,
+		SubscriptionLineItemRepo: subLineItemRepo,
+		AddonRepo:                addonRepo,
+		EventRepo:                eventRepo,
+		FeatureUsageRepo:         featureUsageRepo,
 	}
 	featureUsageTrackingService := service.NewFeatureUsageTrackingService(serviceParams, eventRepo, featureUsageRepo)
 

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -28,7 +29,7 @@ import (
 
 const (
 	dateLayout                   = "2006-01-02"
-	defaultReconciliationWorkers = 5000
+	defaultReconciliationWorkers = 10
 	envReconciliationWorkers     = "RECONCILIATION_WORKERS"
 )
 
@@ -107,15 +108,10 @@ func RunAnalyticsInvoiceReconciliation() error {
 		}
 		toProcess = append(toProcess, c)
 	}
-	log.Printf("Processing %d customers (with external_customer_id)", len(toProcess))
-
 	workers := getReconciliationWorkers()
-	log.Printf("Using %d workers for analytics", workers)
+	log.Printf("Processing %d customers with %d parallel workers, appending diff rows to CSV as each completes", len(toProcess), workers)
 
-	// 2) For each customer: get analytics total cost via feature usage tracking (same period), in parallel
-	analyticsByCustomer := runAnalyticsWorkers(ctx, script, toProcess, startTime, endTime, workers)
-
-	// 3) List invoices in period (period_end in range), sum subtotal by customer
+	// 2) List invoices in period (period_end in range), sum subtotal by customer (needed before we iterate customers)
 	invFilter := types.NewNoLimitInvoiceFilter()
 	invFilter.PeriodEndGTE = &periodEndGTE
 	invFilter.PeriodEndLTE = &periodEndLTE
@@ -139,17 +135,133 @@ func RunAnalyticsInvoiceReconciliation() error {
 	}
 	log.Printf("Summed stored invoice subtotals for %d invoices (DB-stored values only; not runtime-recalculated)", len(invoices))
 
-	// 4) Build diff rows (only where there is a meaningful difference).
-	// Iterate over toProcess so we only consider customers we ran analytics for (with ExternalID);
-	// avoids false diffs from customers missing from analyticsByCustomer.
-	var rows []AnalyticsInvoiceDiffRow
-	tolerance := decimal.NewFromFloat(0.0001)
+	// 3) Open CSV and run N workers: each result appends a row if diff exceeds tolerance
+	outputFile := fmt.Sprintf("analytics_invoice_reconciliation_%s_%s.csv", tenantID, time.Now().Format("20060102_150405"))
+	csvFile, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("create CSV: %w", err)
+	}
+	defer csvFile.Close()
+	csvWriter := csv.NewWriter(csvFile)
+	header := []string{
+		"customer_id", "customer_name", "external_customer_id",
+		"analytics_total_cost", "invoice_subtotal_sum", "diff",
+		"invoice_ids", "invoice_count", "currency",
+	}
+	if err := csvWriter.Write(header); err != nil {
+		return fmt.Errorf("write CSV header: %w", err)
+	}
+	csvWriter.Flush()
+	if err := csvWriter.Error(); err != nil {
+		return fmt.Errorf("flush CSV header: %w", err)
+	}
 
-	for _, c := range toProcess {
-		analyticsCost := analyticsByCustomer[c.ID]
+	tolerance := decimal.NewFromFloat(0.0001)
+	rowsWritten, completed := runReconciliationWorkers(
+		ctx, script, toProcess, startTime, endTime, workers,
+		storedInvoiceSubtotalByCustomer, invoiceIDsByCustomer,
+		tolerance, csvWriter,
+	)
+	csvWriter.Flush()
+	if err := csvWriter.Error(); err != nil {
+		return fmt.Errorf("flush CSV: %w", err)
+	}
+	if rowsWritten == 0 {
+		log.Printf("No differences found; wrote CSV with header only to %s (completed %d/%d customers)", outputFile, completed, len(toProcess))
+	} else {
+		log.Printf("Wrote %d diff rows to %s (completed %d/%d customers)", rowsWritten, outputFile, completed, len(toProcess))
+	}
+	return nil
+}
+
+func getReconciliationWorkers() int {
+	s := os.Getenv(envReconciliationWorkers)
+	if s == "" {
+		return defaultReconciliationWorkers
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return defaultReconciliationWorkers
+	}
+	return n
+}
+
+type analyticsResult struct {
+	customer  *customer.Customer
+	totalCost decimal.Decimal
+	err       error
+}
+
+// runReconciliationWorkers runs GetDetailedUsageAnalytics with a worker pool; as each result
+// arrives, if the diff exceeds tolerance a row is appended to the CSV. Returns rowsWritten and completed count.
+func runReconciliationWorkers(
+	ctx context.Context,
+	script *analyticsInvoiceReconciliationScript,
+	customers []*customer.Customer,
+	startTime, endTime time.Time,
+	workers int,
+	storedInvoiceSubtotalByCustomer map[string]decimal.Decimal,
+	invoiceIDsByCustomer map[string][]string,
+	tolerance decimal.Decimal,
+	csvWriter *csv.Writer,
+) (rowsWritten, completed int) {
+	if len(customers) == 0 {
+		return 0, 0
+	}
+	if workers > len(customers) {
+		workers = len(customers)
+	}
+
+	jobCh := make(chan *customer.Customer, len(customers))
+	resultCh := make(chan analyticsResult, workers*2)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for c := range jobCh {
+				req := &dto.GetUsageAnalyticsRequest{
+					ExternalCustomerID: c.ExternalID,
+					StartTime:          startTime,
+					EndTime:            endTime,
+				}
+				resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalytics(ctx, req)
+				if err != nil {
+					resultCh <- analyticsResult{customer: c, err: err}
+					continue
+				}
+				resultCh <- analyticsResult{customer: c, totalCost: resp.TotalCost}
+			}
+		}()
+	}
+
+	go func() {
+		for _, c := range customers {
+			jobCh <- c
+		}
+		close(jobCh)
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	for r := range resultCh {
+		completed++
+		if r.err != nil {
+			log.Printf("Warning: analytics for customer %s: %v", r.customer.ID, r.err)
+			if completed%100 == 0 || completed == len(customers) {
+				log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
+			}
+			continue
+		}
+		c := r.customer
+		analyticsCost := r.totalCost
 		storedSubtotal := storedInvoiceSubtotalByCustomer[c.ID]
 		diff := analyticsCost.Sub(storedSubtotal)
 		if diff.Abs().LessThanOrEqual(tolerance) {
+			if completed%100 == 0 || completed == len(customers) {
+				log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
+			}
 			continue
 		}
 		customerName := c.Name
@@ -167,136 +279,24 @@ func RunAnalyticsInvoiceReconciliation() error {
 			}
 			idList += id
 		}
-		rows = append(rows, AnalyticsInvoiceDiffRow{
-			CustomerID:         c.ID,
-			CustomerName:       customerName,
-			ExternalCustomerID: c.ExternalID,
-			AnalyticsTotalCost: analyticsCost.StringFixed(4),
-			InvoiceSubtotalSum: storedSubtotal.StringFixed(4),
-			Diff:               diff.StringFixed(4),
-			InvoiceIDs:         idList,
-			InvoiceCount:       len(ids),
-			Currency:           "USD",
-		})
-	}
-
-	outputFile := fmt.Sprintf("analytics_invoice_reconciliation_%s_%s.csv", tenantID, time.Now().Format("20060102_150405"))
-	if err := writeReconciliationCSV(rows, outputFile); err != nil {
-		return fmt.Errorf("write CSV: %w", err)
-	}
-	if len(rows) == 0 {
-		log.Printf("No differences found; wrote CSV with header only to %s", outputFile)
-	} else {
-		log.Printf("Wrote %d diff rows to %s", len(rows), outputFile)
-	}
-	return nil
-}
-
-// getReconciliationWorkers returns RECONCILIATION_WORKERS env (default defaultReconciliationWorkers), clamped to at least 1.
-func getReconciliationWorkers() int {
-	s := os.Getenv(envReconciliationWorkers)
-	if s == "" {
-		return defaultReconciliationWorkers
-	}
-	n, err := strconv.Atoi(s)
-	if err != nil || n < 1 {
-		return defaultReconciliationWorkers
-	}
-	return n
-}
-
-type analyticsResult struct {
-	customerID string
-	totalCost  decimal.Decimal
-	err        error
-}
-
-// runAnalyticsWorkers runs GetDetailedUsageAnalyticsV2 for each customer using a worker pool.
-func runAnalyticsWorkers(
-	ctx context.Context,
-	script *analyticsInvoiceReconciliationScript,
-	customers []*customer.Customer,
-	startTime, endTime time.Time,
-	workers int,
-) map[string]decimal.Decimal {
-	if len(customers) == 0 {
-		return make(map[string]decimal.Decimal)
-	}
-	if workers > len(customers) {
-		workers = len(customers)
-	}
-
-	jobCh := make(chan *customer.Customer, len(customers))
-	resultCh := make(chan analyticsResult, workers*2)
-
-	for w := 0; w < workers; w++ {
-		go func() {
-			for c := range jobCh {
-				req := &dto.GetUsageAnalyticsRequest{
-					ExternalCustomerID: c.ExternalID,
-					StartTime:          startTime,
-					EndTime:            endTime,
-				}
-				resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalytics(ctx, req)
-				if err != nil {       
-					resultCh <- analyticsResult{customerID: c.ID, err: err}
-					continue
-				}
-				resultCh <- analyticsResult{customerID: c.ID, totalCost: resp.TotalCost}
-			}
-		}()
-	}
-
-	go func() {
-		for _, c := range customers {
-			jobCh <- c
+		record := []string{
+			c.ID, customerName, c.ExternalID,
+			analyticsCost.StringFixed(4), storedSubtotal.StringFixed(4), diff.StringFixed(4),
+			idList, fmt.Sprintf("%d", len(ids)), "USD",
 		}
-		close(jobCh)
-	}()
-
-	analyticsByCustomer := make(map[string]decimal.Decimal)
-	for i := 0; i < len(customers); i++ {
-		r := <-resultCh
-		if r.err != nil {
-			log.Printf("Warning: analytics for customer %s: %v", r.customerID, r.err)
+		if err := csvWriter.Write(record); err != nil {
+			log.Printf("Error writing CSV row for customer %s: %v", c.ID, err)
 			continue
 		}
-		analyticsByCustomer[r.customerID] = r.totalCost
-		if (i+1)%500 == 0 || i+1 == len(customers) {
-			log.Printf("Analytics progress: %d/%d customers", i+1, len(customers))
+		rowsWritten++
+		if rowsWritten%50 == 0 {
+			csvWriter.Flush()
+		}
+		if completed%100 == 0 || completed == len(customers) {
+			log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
 		}
 	}
-	return analyticsByCustomer
-}
-
-func writeReconciliationCSV(rows []AnalyticsInvoiceDiffRow, filename string) error {
-	f, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	w := csv.NewWriter(f)
-	defer w.Flush()
-
-	header := []string{
-		"customer_id", "customer_name", "external_customer_id",
-		"analytics_total_cost", "invoice_subtotal_sum", "diff",
-		"invoice_ids", "invoice_count", "currency",
-	}
-	if err := w.Write(header); err != nil {
-		return err
-	}
-	for _, r := range rows {
-		record := []string{
-			r.CustomerID, r.CustomerName, r.ExternalCustomerID,
-			r.AnalyticsTotalCost, r.InvoiceSubtotalSum, r.Diff,
-			r.InvoiceIDs, fmt.Sprintf("%d", r.InvoiceCount), r.Currency,
-		}
-		if err := w.Write(record); err != nil {
-			return err
-		}
-	}
-	return nil
+	return rowsWritten, completed
 }
 
 func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationScript, error) {

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -13,38 +14,42 @@ import (
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/postgres"
 	chRepo "github.com/flexprice/flexprice/internal/repository/clickhouse"
 	entRepo "github.com/flexprice/flexprice/internal/repository/ent"
 	"github.com/flexprice/flexprice/internal/sentry"
 	"github.com/flexprice/flexprice/internal/service"
-	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
 
-const dateLayout = "2006-01-02"
+const (
+	dateLayout                   = "2006-01-02"
+	defaultReconciliationWorkers = 1000
+	envReconciliationWorkers     = "RECONCILIATION_WORKERS"
+)
 
 // AnalyticsInvoiceDiffRow represents one row in the reconciliation diff CSV
 type AnalyticsInvoiceDiffRow struct {
 	CustomerID         string
-	CustomerName        string
-	ExternalCustomerID  string
-	AnalyticsTotalCost  string
-	InvoiceSubtotalSum  string
-	Diff                string
-	InvoiceIDs          string
-	InvoiceCount        int
-	Currency            string
+	CustomerName       string
+	ExternalCustomerID string
+	AnalyticsTotalCost string
+	InvoiceSubtotalSum string
+	Diff               string
+	InvoiceIDs         string
+	InvoiceCount       int
+	Currency           string
 }
 
 type analyticsInvoiceReconciliationScript struct {
-	log                           *logger.Logger
-	customerRepo                  customer.Repository
-	invoiceRepo                   invoice.Repository
-	featureUsageTrackingService   service.FeatureUsageTrackingService
+	log                         *logger.Logger
+	customerRepo                customer.Repository
+	invoiceRepo                 invoice.Repository
+	featureUsageTrackingService service.FeatureUsageTrackingService
 }
 
 // RunAnalyticsInvoiceReconciliation compares analytics total cost to invoice subtotals for a period and writes diffs to CSV.
@@ -87,31 +92,24 @@ func RunAnalyticsInvoiceReconciliation() error {
 
 	log.Printf("Found %d customers", len(customers))
 
-	// 2) For each customer: get analytics total cost via feature usage tracking (same period)
-	analyticsByCustomer := make(map[string]decimal.Decimal)
-	for i, c := range customers {
+	// Build list of customers to process (same tenant/env, with external_customer_id)
+	var toProcess []*customer.Customer
+	for _, c := range customers {
 		if c.TenantID != tenantID || c.EnvironmentID != environmentID {
 			continue
 		}
 		if c.ExternalID == "" {
-			log.Printf("Skip customer %s: no external_customer_id", c.ID)
 			continue
 		}
-		if i%50 == 0 && i > 0 {
-			log.Printf("Analytics progress: %d/%d customers", i, len(customers))
-		}
-		req := &dto.GetUsageAnalyticsRequest{
-			ExternalCustomerID: c.ExternalID,
-			StartTime:          startTime,
-			EndTime:            endTime,
-		}
-		resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalyticsV2(ctx, req)
-		if err != nil {
-			log.Printf("Warning: analytics for customer %s (%s): %v", c.ExternalID, c.ID, err)
-			continue
-		}
-		analyticsByCustomer[c.ID] = resp.TotalCost
+		toProcess = append(toProcess, c)
 	}
+	log.Printf("Processing %d customers (with external_customer_id)", len(toProcess))
+
+	workers := getReconciliationWorkers()
+	log.Printf("Using %d workers for analytics", workers)
+
+	// 2) For each customer: get analytics total cost via feature usage tracking (same period), in parallel
+	analyticsByCustomer := runAnalyticsWorkers(ctx, script, toProcess, startTime, endTime, workers)
 
 	// 3) List invoices in period (period_end in range), sum subtotal by customer
 	invFilter := types.NewNoLimitInvoiceFilter()
@@ -121,7 +119,7 @@ func RunAnalyticsInvoiceReconciliation() error {
 	invFilter.SkipLineItems = true
 
 	invoices, err := script.invoiceRepo.List(ctx, invFilter)
-	if err != nil { 
+	if err != nil {
 		return fmt.Errorf("list invoices: %w", err)
 	}
 
@@ -165,15 +163,15 @@ func RunAnalyticsInvoiceReconciliation() error {
 			idList += id
 		}
 		rows = append(rows, AnalyticsInvoiceDiffRow{
-			CustomerID:        c.ID,
-			CustomerName:      customerName,
+			CustomerID:         c.ID,
+			CustomerName:       customerName,
 			ExternalCustomerID: c.ExternalID,
 			AnalyticsTotalCost: analyticsCost.StringFixed(4),
 			InvoiceSubtotalSum: invoiceSubtotal.StringFixed(4),
-			Diff:              diff.StringFixed(4),
-			InvoiceIDs:        idList,
-			InvoiceCount:      len(ids),
-			Currency:          "USD",
+			Diff:               diff.StringFixed(4),
+			InvoiceIDs:         idList,
+			InvoiceCount:       len(ids),
+			Currency:           "USD",
 		})
 	}
 
@@ -189,6 +187,83 @@ func RunAnalyticsInvoiceReconciliation() error {
 
 	log.Printf("Wrote %d diff rows to %s", len(rows), outputFile)
 	return nil
+}
+
+// getReconciliationWorkers returns RECONCILIATION_WORKERS env (default defaultReconciliationWorkers), clamped to at least 1.
+func getReconciliationWorkers() int {
+	s := os.Getenv(envReconciliationWorkers)
+	if s == "" {
+		return defaultReconciliationWorkers
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return defaultReconciliationWorkers
+	}
+	return n
+}
+
+type analyticsResult struct {
+	customerID string
+	totalCost  decimal.Decimal
+	err        error
+}
+
+// runAnalyticsWorkers runs GetDetailedUsageAnalyticsV2 for each customer using a worker pool.
+func runAnalyticsWorkers(
+	ctx context.Context,
+	script *analyticsInvoiceReconciliationScript,
+	customers []*customer.Customer,
+	startTime, endTime time.Time,
+	workers int,
+) map[string]decimal.Decimal {
+	if len(customers) == 0 {
+		return make(map[string]decimal.Decimal)
+	}
+	if workers > len(customers) {
+		workers = len(customers)
+	}
+
+	jobCh := make(chan *customer.Customer, len(customers))
+	resultCh := make(chan analyticsResult, workers*2)
+
+	for w := 0; w < workers; w++ {
+		go func() {
+			for c := range jobCh {
+				req := &dto.GetUsageAnalyticsRequest{
+					ExternalCustomerID: c.ExternalID,
+					StartTime:          startTime,
+					EndTime:            endTime,
+				}
+				resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalyticsV2(ctx, req)
+				if err != nil {
+					resultCh <- analyticsResult{customerID: c.ID, err: err}
+					continue
+				}
+				resultCh <- analyticsResult{customerID: c.ID, totalCost: resp.TotalCost}
+			}
+		}()
+	}
+
+	go func() {
+		for _, c := range customers {
+			jobCh <- c
+		}
+		close(jobCh)
+	}()
+
+	analyticsByCustomer := make(map[string]decimal.Decimal)
+	for i := 0; i < len(customers); i++ {
+		r := <-resultCh
+		if r.err != nil {
+			log.Printf("Warning: analytics for customer %s: %v", r.customerID, r.err)
+			continue
+		}
+		analyticsByCustomer[r.customerID] = r.totalCost
+		if (i+1)%500 == 0 || i+1 == len(customers) {
+			log.Printf("Analytics progress: %d/%d customers", i+1, len(customers))
+		}
+	}
+	return analyticsByCustomer
 }
 
 func writeReconciliationCSV(rows []AnalyticsInvoiceDiffRow, filename string) error {

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -71,10 +71,6 @@ func RunAnalyticsInvoiceReconciliation() error {
 	startTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
 	endTime := time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC)
 
-	// End of period for invoice filter: period_end in [start, end]
-	periodEndGTE := startTime
-	periodEndLTE := endTime
-
 	log.Printf("Reconciling analytics vs invoices for period %s to %s (tenant=%s, env=%s)",
 		startTime.Format(dateLayout), endTime.Format(dateLayout), tenantID, environmentID)
 
@@ -111,11 +107,10 @@ func RunAnalyticsInvoiceReconciliation() error {
 	workers := getReconciliationWorkers()
 	log.Printf("Processing %d customers with %d parallel workers, appending diff rows to CSV as each completes", len(toProcess), workers)
 
-	// 2) List invoices in period (period_end in range), sum subtotal by customer (needed before we iterate customers)
+	// 2) List invoices created in period, sum subtotal by customer (needed before we iterate customers)
 	invFilter := types.NewNoLimitInvoiceFilter()
-	invFilter.PeriodEndGTE = &periodEndGTE
-	invFilter.PeriodEndLTE = &periodEndLTE
-	invFilter.InvoiceStatus = []types.InvoiceStatus{types.InvoiceStatusDraft, types.InvoiceStatusFinalized}
+	invFilter.CreatedAtGTE = &startTime
+	invFilter.CreatedAtLTE = &endTime
 	invFilter.SkipLineItems = true
 
 	invoices, err := script.invoiceRepo.List(ctx, invFilter)
@@ -156,11 +151,10 @@ func RunAnalyticsInvoiceReconciliation() error {
 		return fmt.Errorf("flush CSV header: %w", err)
 	}
 
-	tolerance := decimal.NewFromFloat(0.0001)
 	rowsWritten, completed := runReconciliationWorkers(
 		ctx, script, toProcess, startTime, endTime, workers,
 		storedInvoiceSubtotalByCustomer, invoiceIDsByCustomer,
-		tolerance, csvWriter,
+		csvWriter,
 	)
 	csvWriter.Flush()
 	if err := csvWriter.Error(); err != nil {
@@ -193,7 +187,8 @@ type analyticsResult struct {
 }
 
 // runReconciliationWorkers runs GetDetailedUsageAnalytics with a worker pool; as each result
-// arrives, if the diff exceeds tolerance a row is appended to the CSV. Returns rowsWritten and completed count.
+// arrives, if analytics total and invoice subtotal don't match, a row is appended to the CSV.
+// Returns rowsWritten and completed count.
 func runReconciliationWorkers(
 	ctx context.Context,
 	script *analyticsInvoiceReconciliationScript,
@@ -202,7 +197,6 @@ func runReconciliationWorkers(
 	workers int,
 	storedInvoiceSubtotalByCustomer map[string]decimal.Decimal,
 	invoiceIDsByCustomer map[string][]string,
-	tolerance decimal.Decimal,
 	csvWriter *csv.Writer,
 ) (rowsWritten, completed int) {
 	if len(customers) == 0 {
@@ -257,13 +251,13 @@ func runReconciliationWorkers(
 		c := r.customer
 		analyticsCost := r.totalCost
 		storedSubtotal := storedInvoiceSubtotalByCustomer[c.ID]
-		diff := analyticsCost.Sub(storedSubtotal)
-		if diff.Abs().LessThanOrEqual(tolerance) {
+		if analyticsCost.Equal(storedSubtotal) {
 			if completed%100 == 0 || completed == len(customers) {
 				log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
 			}
 			continue
 		}
+		diff := analyticsCost.Sub(storedSubtotal)
 		customerName := c.Name
 		if customerName == "" {
 			customerName = c.ExternalID

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -111,8 +112,15 @@ func RunAnalyticsInvoiceReconciliation() error {
 	workers := getReconciliationWorkers()
 	log.Printf("Processing %d customers with %d parallel workers, appending diff rows to CSV as each completes", len(toProcess), workers)
 
-	// 2) Open CSV and run N workers: each result fetches invoices by customer ID, then appends a row if diff
+	// 2) Run N workers: collect one row per customer, then sort by diff ascending (most negative first) and write CSV
 	outputFile := fmt.Sprintf("analytics_invoice_reconciliation_%s_%s.csv", tenantID, time.Now().Format("20060102_150405"))
+	rows, completed := runReconciliationWorkers(
+		ctx, script, toProcess, startTime, endTime, workers,
+	)
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].diff.LessThan(rows[j].diff)
+	})
+
 	csvFile, err := os.Create(outputFile)
 	if err != nil {
 		return fmt.Errorf("create CSV: %w", err)
@@ -127,23 +135,19 @@ func RunAnalyticsInvoiceReconciliation() error {
 	if err := csvWriter.Write(header); err != nil {
 		return fmt.Errorf("write CSV header: %w", err)
 	}
-	csvWriter.Flush()
-	if err := csvWriter.Error(); err != nil {
-		return fmt.Errorf("flush CSV header: %w", err)
+	for _, r := range rows {
+		if err := csvWriter.Write(r.record); err != nil {
+			return fmt.Errorf("write CSV row: %w", err)
+		}
 	}
-
-	rowsWritten, completed := runReconciliationWorkers(
-		ctx, script, toProcess, startTime, endTime, workers,
-		csvWriter,
-	)
 	csvWriter.Flush()
 	if err := csvWriter.Error(); err != nil {
 		return fmt.Errorf("flush CSV: %w", err)
 	}
-	if rowsWritten == 0 {
+	if len(rows) == 0 {
 		log.Printf("Wrote CSV with header only to %s (completed %d/%d customers)", outputFile, completed, len(toProcess))
 	} else {
-		log.Printf("Wrote %d customer rows (diff at each customer level) to %s (completed %d/%d customers)", rowsWritten, outputFile, completed, len(toProcess))
+		log.Printf("Wrote %d customer rows sorted by diff ascending to %s (completed %d/%d customers)", len(rows), outputFile, completed, len(toProcess))
 	}
 	return nil
 }
@@ -209,20 +213,24 @@ type analyticsResult struct {
 	err       error
 }
 
+// reconciliationRow holds a CSV record and its diff for sorting (ascending = most negative first).
+type reconciliationRow struct {
+	record []string
+	diff   decimal.Decimal
+}
+
 // runReconciliationWorkers runs GetDetailedUsageAnalytics with a worker pool; as each result
 // arrives, fetches invoices for that customer (by customer ID, created in period), sums subtotal,
-// and appends one row per customer with analytics total, invoice subtotal, and diff at customer level.
-// Returns rowsWritten and completed count.
+// and collects one row per customer. Returns rows (to be sorted by diff) and completed count.
 func runReconciliationWorkers(
 	ctx context.Context,
 	script *analyticsInvoiceReconciliationScript,
 	customers []*customer.Customer,
 	startTime, endTime time.Time,
 	workers int,
-	csvWriter *csv.Writer,
-) (rowsWritten, completed int) {
+) (rows []reconciliationRow, completed int) {
 	if len(customers) == 0 {
-		return 0, 0
+		return nil, 0
 	}
 	if workers > len(customers) {
 		workers = len(customers)
@@ -266,7 +274,7 @@ func runReconciliationWorkers(
 		if r.err != nil {
 			log.Printf("Warning: analytics for customer %s: %v", r.customer.ID, r.err)
 			if completed%100 == 0 || completed == len(customers) {
-				log.Printf("Progress: %d/%d customers (%d rows written)", completed, len(customers), rowsWritten)
+				log.Printf("Progress: %d/%d customers (%d rows collected)", completed, len(customers), len(rows))
 			}
 			continue
 		}
@@ -283,7 +291,7 @@ func runReconciliationWorkers(
 		if err != nil {
 			log.Printf("Warning: list invoices for customer %s: %v", c.ID, err)
 			if completed%100 == 0 || completed == len(customers) {
-				log.Printf("Progress: %d/%d customers (%d rows written)", completed, len(customers), rowsWritten)
+				log.Printf("Progress: %d/%d customers (%d rows collected)", completed, len(customers), len(rows))
 			}
 			continue
 		}
@@ -326,19 +334,12 @@ func runReconciliationWorkers(
 			analyticsCost.StringFixed(4), storedSubtotal.StringFixed(4), diff.StringFixed(4),
 			idList, fmt.Sprintf("%d", inPeriodCount), fmt.Sprintf("%d", totalInvoiceCount), "USD",
 		}
-		if err := csvWriter.Write(record); err != nil {
-			log.Printf("Error writing CSV row for customer %s: %v", c.ID, err)
-			continue
-		}
-		rowsWritten++
-		if rowsWritten%50 == 0 {
-			csvWriter.Flush()
-		}
+		rows = append(rows, reconciliationRow{record: record, diff: diff})
 		if completed%100 == 0 || completed == len(customers) {
-			log.Printf("Progress: %d/%d customers (%d rows written)", completed, len(customers), rowsWritten)
+			log.Printf("Progress: %d/%d customers (%d rows collected)", completed, len(customers), len(rows))
 		}
 	}
-	return rowsWritten, completed
+	return rows, completed
 }
 
 func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationScript, error) {

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	dateLayout                   = "2006-01-02"
-	defaultReconciliationWorkers = 1000
+	defaultReconciliationWorkers = 5000
 	envReconciliationWorkers     = "RECONCILIATION_WORKERS"
 )
 
@@ -55,6 +55,10 @@ type analyticsInvoiceReconciliationScript struct {
 // RunAnalyticsInvoiceReconciliation compares analytics total cost to invoice subtotals for a period and writes diffs to CSV.
 // Period is hardcoded to 1 Feb – 1 Mar. Requires TENANT_ID and ENVIRONMENT_ID.
 // Infrastructure (Postgres, ClickHouse, Kafka) must be running.
+//
+// Invoice side uses stored subtotals only: values come from invoiceRepo.List() (inv.Subtotal).
+// Recalculated totals from GetInvoiceWithBreakdown()/recalculateInvoiceTotals() are not used,
+// so the report may show divergence where DB-stored subtotals differ from in-memory recalculated totals.
 func RunAnalyticsInvoiceReconciliation() error {
 	tenantID := os.Getenv("TENANT_ID")
 	environmentID := os.Getenv("ENVIRONMENT_ID")
@@ -123,15 +127,17 @@ func RunAnalyticsInvoiceReconciliation() error {
 		return fmt.Errorf("list invoices: %w", err)
 	}
 
-	invoiceSubtotalByCustomer := make(map[string]decimal.Decimal)
+	// Sum stored subtotals by customer (DB values only; not recalculated via GetInvoiceWithBreakdown/recalculateInvoiceTotals)
+	storedInvoiceSubtotalByCustomer := make(map[string]decimal.Decimal)
 	invoiceIDsByCustomer := make(map[string][]string)
 	for _, inv := range invoices {
 		if inv.TenantID != tenantID || inv.EnvironmentID != environmentID {
 			continue
 		}
-		invoiceSubtotalByCustomer[inv.CustomerID] = invoiceSubtotalByCustomer[inv.CustomerID].Add(inv.Subtotal)
+		storedInvoiceSubtotalByCustomer[inv.CustomerID] = storedInvoiceSubtotalByCustomer[inv.CustomerID].Add(inv.Subtotal)
 		invoiceIDsByCustomer[inv.CustomerID] = append(invoiceIDsByCustomer[inv.CustomerID], inv.ID)
 	}
+	log.Printf("Summed stored invoice subtotals for %d invoices (DB-stored values only; not runtime-recalculated)", len(invoices))
 
 	// 4) Build diff rows (only where there is a meaningful difference)
 	var rows []AnalyticsInvoiceDiffRow
@@ -142,8 +148,8 @@ func RunAnalyticsInvoiceReconciliation() error {
 			continue
 		}
 		analyticsCost := analyticsByCustomer[c.ID]
-		invoiceSubtotal := invoiceSubtotalByCustomer[c.ID]
-		diff := analyticsCost.Sub(invoiceSubtotal)
+		storedSubtotal := storedInvoiceSubtotalByCustomer[c.ID]
+		diff := analyticsCost.Sub(storedSubtotal)
 		if diff.Abs().LessThanOrEqual(tolerance) {
 			continue
 		}
@@ -167,7 +173,7 @@ func RunAnalyticsInvoiceReconciliation() error {
 			CustomerName:       customerName,
 			ExternalCustomerID: c.ExternalID,
 			AnalyticsTotalCost: analyticsCost.StringFixed(4),
-			InvoiceSubtotalSum: invoiceSubtotal.StringFixed(4),
+			InvoiceSubtotalSum: storedSubtotal.StringFixed(4),
 			Diff:               diff.StringFixed(4),
 			InvoiceIDs:         idList,
 			InvoiceCount:       len(ids),

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -107,30 +107,7 @@ func RunAnalyticsInvoiceReconciliation() error {
 	workers := getReconciliationWorkers()
 	log.Printf("Processing %d customers with %d parallel workers, appending diff rows to CSV as each completes", len(toProcess), workers)
 
-	// 2) List invoices created in period, sum subtotal by customer (needed before we iterate customers)
-	invFilter := types.NewNoLimitInvoiceFilter()
-	invFilter.CreatedAtGTE = &startTime
-	invFilter.CreatedAtLTE = &endTime
-	invFilter.SkipLineItems = true
-
-	invoices, err := script.invoiceRepo.List(ctx, invFilter)
-	if err != nil {
-		return fmt.Errorf("list invoices: %w", err)
-	}
-
-	// Sum stored subtotals by customer (DB values only; not recalculated via GetInvoiceWithBreakdown/recalculateInvoiceTotals)
-	storedInvoiceSubtotalByCustomer := make(map[string]decimal.Decimal)
-	invoiceIDsByCustomer := make(map[string][]string)
-	for _, inv := range invoices {
-		if inv.TenantID != tenantID || inv.EnvironmentID != environmentID {
-			continue
-		}
-		storedInvoiceSubtotalByCustomer[inv.CustomerID] = storedInvoiceSubtotalByCustomer[inv.CustomerID].Add(inv.Subtotal)
-		invoiceIDsByCustomer[inv.CustomerID] = append(invoiceIDsByCustomer[inv.CustomerID], inv.ID)
-	}
-	log.Printf("Summed stored invoice subtotals for %d invoices (DB-stored values only; not runtime-recalculated)", len(invoices))
-
-	// 3) Open CSV and run N workers: each result appends a row if diff exceeds tolerance
+	// 2) Open CSV and run N workers: each result fetches invoices by customer ID, then appends a row if diff
 	outputFile := fmt.Sprintf("analytics_invoice_reconciliation_%s_%s.csv", tenantID, time.Now().Format("20060102_150405"))
 	csvFile, err := os.Create(outputFile)
 	if err != nil {
@@ -153,7 +130,6 @@ func RunAnalyticsInvoiceReconciliation() error {
 
 	rowsWritten, completed := runReconciliationWorkers(
 		ctx, script, toProcess, startTime, endTime, workers,
-		storedInvoiceSubtotalByCustomer, invoiceIDsByCustomer,
 		csvWriter,
 	)
 	csvWriter.Flush()
@@ -161,9 +137,9 @@ func RunAnalyticsInvoiceReconciliation() error {
 		return fmt.Errorf("flush CSV: %w", err)
 	}
 	if rowsWritten == 0 {
-		log.Printf("No differences found; wrote CSV with header only to %s (completed %d/%d customers)", outputFile, completed, len(toProcess))
+		log.Printf("Wrote CSV with header only to %s (completed %d/%d customers)", outputFile, completed, len(toProcess))
 	} else {
-		log.Printf("Wrote %d diff rows to %s (completed %d/%d customers)", rowsWritten, outputFile, completed, len(toProcess))
+		log.Printf("Wrote %d customer rows (diff at each customer level) to %s (completed %d/%d customers)", rowsWritten, outputFile, completed, len(toProcess))
 	}
 	return nil
 }
@@ -187,7 +163,8 @@ type analyticsResult struct {
 }
 
 // runReconciliationWorkers runs GetDetailedUsageAnalytics with a worker pool; as each result
-// arrives, if analytics total and invoice subtotal don't match, a row is appended to the CSV.
+// arrives, fetches invoices for that customer (by customer ID, created in period), sums subtotal,
+// and appends one row per customer with analytics total, invoice subtotal, and diff at customer level.
 // Returns rowsWritten and completed count.
 func runReconciliationWorkers(
 	ctx context.Context,
@@ -195,8 +172,6 @@ func runReconciliationWorkers(
 	customers []*customer.Customer,
 	startTime, endTime time.Time,
 	workers int,
-	storedInvoiceSubtotalByCustomer map[string]decimal.Decimal,
-	invoiceIDsByCustomer map[string][]string,
 	csvWriter *csv.Writer,
 ) (rowsWritten, completed int) {
 	if len(customers) == 0 {
@@ -244,19 +219,33 @@ func runReconciliationWorkers(
 		if r.err != nil {
 			log.Printf("Warning: analytics for customer %s: %v", r.customer.ID, r.err)
 			if completed%100 == 0 || completed == len(customers) {
-				log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
+				log.Printf("Progress: %d/%d customers (%d rows written)", completed, len(customers), rowsWritten)
 			}
 			continue
 		}
 		c := r.customer
 		analyticsCost := r.totalCost
-		storedSubtotal := storedInvoiceSubtotalByCustomer[c.ID]
-		if analyticsCost.Equal(storedSubtotal) {
+
+		invFilter := types.NewNoLimitInvoiceFilter()
+		invFilter.CustomerID = c.ID
+		invFilter.CreatedAtGTE = &startTime
+		invFilter.CreatedAtLTE = &endTime
+		invFilter.SkipLineItems = true
+		invoices, err := script.invoiceRepo.List(ctx, invFilter)
+		if err != nil {
+			log.Printf("Warning: list invoices for customer %s: %v", c.ID, err)
 			if completed%100 == 0 || completed == len(customers) {
-				log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
+				log.Printf("Progress: %d/%d customers (%d rows written)", completed, len(customers), rowsWritten)
 			}
 			continue
 		}
+		var storedSubtotal decimal.Decimal
+		var ids []string
+		for _, inv := range invoices {
+			storedSubtotal = storedSubtotal.Add(inv.Subtotal)
+			ids = append(ids, inv.ID)
+		}
+
 		diff := analyticsCost.Sub(storedSubtotal)
 		customerName := c.Name
 		if customerName == "" {
@@ -265,7 +254,6 @@ func runReconciliationWorkers(
 		if customerName == "" {
 			customerName = c.ID
 		}
-		ids := invoiceIDsByCustomer[c.ID]
 		idList := ""
 		for _, id := range ids {
 			if idList != "" {
@@ -287,7 +275,7 @@ func runReconciliationWorkers(
 			csvWriter.Flush()
 		}
 		if completed%100 == 0 || completed == len(customers) {
-			log.Printf("Progress: %d/%d customers (%d diff rows so far)", completed, len(customers), rowsWritten)
+			log.Printf("Progress: %d/%d customers (%d rows written)", completed, len(customers), rowsWritten)
 		}
 	}
 	return rowsWritten, completed

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -1,0 +1,275 @@
+package internal
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/cache"
+	"github.com/flexprice/flexprice/internal/clickhouse"
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
+	chRepo "github.com/flexprice/flexprice/internal/repository/clickhouse"
+	entRepo "github.com/flexprice/flexprice/internal/repository/ent"
+	"github.com/flexprice/flexprice/internal/sentry"
+	"github.com/flexprice/flexprice/internal/service"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+const dateLayout = "2006-01-02"
+
+// AnalyticsInvoiceDiffRow represents one row in the reconciliation diff CSV
+type AnalyticsInvoiceDiffRow struct {
+	CustomerID         string
+	CustomerName        string
+	ExternalCustomerID  string
+	AnalyticsTotalCost  string
+	InvoiceSubtotalSum  string
+	Diff                string
+	InvoiceIDs          string
+	InvoiceCount        int
+	Currency            string
+}
+
+type analyticsInvoiceReconciliationScript struct {
+	log                          *logger.Logger
+	customerRepo                 customer.Repository
+	invoiceRepo                  invoice.Repository
+	costSheetUsageTrackingService service.CostSheetUsageTrackingService
+}
+
+// RunAnalyticsInvoiceReconciliation compares analytics total cost to invoice subtotals for a period and writes diffs to CSV.
+// Period is hardcoded to 1 Feb – 1 Mar. Requires TENANT_ID and ENVIRONMENT_ID.
+// Infrastructure (Postgres, ClickHouse, Kafka) must be running.
+func RunAnalyticsInvoiceReconciliation() error {
+	tenantID := os.Getenv("TENANT_ID")
+	environmentID := os.Getenv("ENVIRONMENT_ID")
+
+	if tenantID == "" || environmentID == "" {
+		return fmt.Errorf("TENANT_ID and ENVIRONMENT_ID are required")
+	}
+
+	startTime := time.Date(2025, time.February, 1, 0, 0, 0, 0, time.UTC)
+	endTime := time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC)
+
+	// End of period for invoice filter: period_end in [start, end]
+	periodEndGTE := startTime
+	periodEndLTE := endTime
+
+	log.Printf("Reconciling analytics vs invoices for period %s to %s (tenant=%s, env=%s)",
+		startTime.Format(dateLayout), endTime.Format(dateLayout), tenantID, environmentID)
+
+	script, err := newAnalyticsInvoiceReconciliationScript()
+	if err != nil {
+		return fmt.Errorf("failed to initialize script: %w", err)
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
+
+	// 1) List all customers (published)
+	customerFilter := types.NewNoLimitCustomerFilter()
+	customerFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+	customers, err := script.customerRepo.ListAll(ctx, customerFilter)
+	if err != nil {
+		return fmt.Errorf("list customers: %w", err)
+	}
+
+	log.Printf("Found %d customers", len(customers))
+
+	// 2) For each customer: get analytics total cost (same period)
+	analyticsByCustomer := make(map[string]decimal.Decimal)
+	for i, c := range customers {
+		if c.TenantID != tenantID || c.EnvironmentID != environmentID {
+			continue
+		}
+		if i%50 == 0 && i > 0 {
+			log.Printf("Analytics progress: %d/%d customers", i, len(customers))
+		}
+		req := &dto.GetCostAnalyticsRequest{
+			StartTime:          startTime,
+			EndTime:            endTime,
+			ExternalCustomerID: c.ExternalID,
+		}
+		if err := req.Validate(); err != nil {
+			log.Printf("Skip customer %s: invalid analytics request: %v", c.ID, err)
+			continue
+		}
+		resp, err := script.costSheetUsageTrackingService.GetCostSheetUsageAnalytics(ctx, req)
+		if err != nil {
+			log.Printf("Warning: analytics for customer %s (%s): %v", c.ExternalID, c.ID, err)
+			continue
+		}
+		analyticsByCustomer[c.ID] = resp.TotalCost
+	}
+
+	// 3) List invoices in period (period_end in range), sum subtotal by customer
+	invFilter := types.NewNoLimitInvoiceFilter()
+	invFilter.PeriodEndGTE = &periodEndGTE
+	invFilter.PeriodEndLTE = &periodEndLTE
+	invFilter.InvoiceStatus = []types.InvoiceStatus{types.InvoiceStatusDraft, types.InvoiceStatusFinalized}
+	invFilter.SkipLineItems = true
+
+	invoices, err := script.invoiceRepo.List(ctx, invFilter)
+	if err != nil { 
+		return fmt.Errorf("list invoices: %w", err)
+	}
+
+	invoiceSubtotalByCustomer := make(map[string]decimal.Decimal)
+	invoiceIDsByCustomer := make(map[string][]string)
+	for _, inv := range invoices {
+		if inv.TenantID != tenantID || inv.EnvironmentID != environmentID {
+			continue
+		}
+		invoiceSubtotalByCustomer[inv.CustomerID] = invoiceSubtotalByCustomer[inv.CustomerID].Add(inv.Subtotal)
+		invoiceIDsByCustomer[inv.CustomerID] = append(invoiceIDsByCustomer[inv.CustomerID], inv.ID)
+	}
+
+	// 4) Build diff rows (only where there is a meaningful difference)
+	var rows []AnalyticsInvoiceDiffRow
+	tolerance := decimal.NewFromFloat(0.0001)
+
+	for _, c := range customers {
+		if c.TenantID != tenantID || c.EnvironmentID != environmentID {
+			continue
+		}
+		analyticsCost := analyticsByCustomer[c.ID]
+		invoiceSubtotal := invoiceSubtotalByCustomer[c.ID]
+		diff := analyticsCost.Sub(invoiceSubtotal)
+		if diff.Abs().LessThanOrEqual(tolerance) {
+			continue
+		}
+		customerName := c.Name
+		if customerName == "" {
+			customerName = c.ExternalID
+		}
+		if customerName == "" {
+			customerName = c.ID
+		}
+		ids := invoiceIDsByCustomer[c.ID]
+		idList := ""
+		for _, id := range ids {
+			if idList != "" {
+				idList += ";"
+			}
+			idList += id
+		}
+		rows = append(rows, AnalyticsInvoiceDiffRow{
+			CustomerID:        c.ID,
+			CustomerName:      customerName,
+			ExternalCustomerID: c.ExternalID,
+			AnalyticsTotalCost: analyticsCost.StringFixed(4),
+			InvoiceSubtotalSum: invoiceSubtotal.StringFixed(4),
+			Diff:              diff.StringFixed(4),
+			InvoiceIDs:        idList,
+			InvoiceCount:      len(ids),
+			Currency:          "USD",
+		})
+	}
+
+	if len(rows) == 0 {
+		log.Printf("No differences found; no CSV written.")
+		return nil
+	}
+
+	outputFile := fmt.Sprintf("analytics_invoice_reconciliation_%s_%s.csv", tenantID, time.Now().Format("20060102_150405"))
+	if err := writeReconciliationCSV(rows, outputFile); err != nil {
+		return fmt.Errorf("write CSV: %w", err)
+	}
+
+	log.Printf("Wrote %d diff rows to %s", len(rows), outputFile)
+	return nil
+}
+
+func writeReconciliationCSV(rows []AnalyticsInvoiceDiffRow, filename string) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	header := []string{
+		"customer_id", "customer_name", "external_customer_id",
+		"analytics_total_cost", "invoice_subtotal_sum", "diff",
+		"invoice_ids", "invoice_count", "currency",
+	}
+	if err := w.Write(header); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		record := []string{
+			r.CustomerID, r.CustomerName, r.ExternalCustomerID,
+			r.AnalyticsTotalCost, r.InvoiceSubtotalSum, r.Diff,
+			r.InvoiceIDs, fmt.Sprintf("%d", r.InvoiceCount), r.Currency,
+		}
+		if err := w.Write(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationScript, error) {
+	cfg, err := config.NewConfig()
+	if err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	logger, err := logger.NewLogger(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("logger: %w", err)
+	}
+	sentrySvc := sentry.NewSentryService(cfg, logger)
+	chStore, err := clickhouse.NewClickHouseStore(cfg, sentrySvc)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse: %w", err)
+	}
+	entClient, err := postgres.NewEntClients(cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: %w", err)
+	}
+	pgClient := postgres.NewClient(entClient, logger, sentrySvc)
+	cacheClient := cache.NewInMemoryCache()
+
+	customerRepo := entRepo.NewCustomerRepository(pgClient, logger, cacheClient)
+	invoiceRepo := entRepo.NewInvoiceRepository(pgClient, logger, cacheClient)
+	costsheetRepo := entRepo.NewCostsheetRepository(pgClient, logger, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(pgClient, logger, cacheClient)
+	meterRepo := entRepo.NewMeterRepository(pgClient, logger, cacheClient)
+	priceRepo := entRepo.NewPriceRepository(pgClient, logger, cacheClient)
+	eventRepo := chRepo.NewEventRepository(chStore, logger)
+	costUsageRepo := chRepo.NewCostSheetUsageRepository(chStore, logger)
+
+	serviceParams := service.ServiceParams{
+		Logger:             logger,
+		Config:             cfg,
+		DB:                 pgClient,
+		CustomerRepo:       customerRepo,
+		InvoiceRepo:        invoiceRepo,
+		CostSheetRepo:      costsheetRepo,
+		CostSheetUsageRepo: costUsageRepo,
+		FeatureRepo:        featureRepo,
+		MeterRepo:          meterRepo,
+		PriceRepo:          priceRepo,
+		EventRepo:          eventRepo,
+	}
+	costSheetUsageTrackingService := service.NewCostSheetUsageTrackingService(serviceParams, eventRepo, costUsageRepo)
+
+	return &analyticsInvoiceReconciliationScript{
+		log:                          logger,
+		customerRepo:                 customerRepo,
+		invoiceRepo:                  invoiceRepo,
+		costSheetUsageTrackingService: costSheetUsageTrackingService,
+	}, nil
+}

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -67,7 +67,7 @@ func RunAnalyticsInvoiceReconciliation() error {
 		return fmt.Errorf("TENANT_ID and ENVIRONMENT_ID are required")
 	}
 
-	startTime := time.Date(2025, time.February, 1, 0, 0, 0, 0, time.UTC)
+	startTime := time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC)
 	endTime := time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC)
 
 	// End of period for invoice filter: period_end in [start, end]

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -41,10 +41,10 @@ type AnalyticsInvoiceDiffRow struct {
 }
 
 type analyticsInvoiceReconciliationScript struct {
-	log                          *logger.Logger
-	customerRepo                 customer.Repository
-	invoiceRepo                  invoice.Repository
-	costSheetUsageTrackingService service.CostSheetUsageTrackingService
+	log                           *logger.Logger
+	customerRepo                  customer.Repository
+	invoiceRepo                   invoice.Repository
+	featureUsageTrackingService   service.FeatureUsageTrackingService
 }
 
 // RunAnalyticsInvoiceReconciliation compares analytics total cost to invoice subtotals for a period and writes diffs to CSV.
@@ -87,25 +87,25 @@ func RunAnalyticsInvoiceReconciliation() error {
 
 	log.Printf("Found %d customers", len(customers))
 
-	// 2) For each customer: get analytics total cost (same period)
+	// 2) For each customer: get analytics total cost via feature usage tracking (same period)
 	analyticsByCustomer := make(map[string]decimal.Decimal)
 	for i, c := range customers {
 		if c.TenantID != tenantID || c.EnvironmentID != environmentID {
 			continue
 		}
+		if c.ExternalID == "" {
+			log.Printf("Skip customer %s: no external_customer_id", c.ID)
+			continue
+		}
 		if i%50 == 0 && i > 0 {
 			log.Printf("Analytics progress: %d/%d customers", i, len(customers))
 		}
-		req := &dto.GetCostAnalyticsRequest{
+		req := &dto.GetUsageAnalyticsRequest{
+			ExternalCustomerID: c.ExternalID,
 			StartTime:          startTime,
 			EndTime:            endTime,
-			ExternalCustomerID: c.ExternalID,
 		}
-		if err := req.Validate(); err != nil {
-			log.Printf("Skip customer %s: invalid analytics request: %v", c.ID, err)
-			continue
-		}
-		resp, err := script.costSheetUsageTrackingService.GetCostSheetUsageAnalytics(ctx, req)
+		resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalyticsV2(ctx, req)
 		if err != nil {
 			log.Printf("Warning: analytics for customer %s (%s): %v", c.ExternalID, c.ID, err)
 			continue
@@ -244,32 +244,25 @@ func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationS
 
 	customerRepo := entRepo.NewCustomerRepository(pgClient, logger, cacheClient)
 	invoiceRepo := entRepo.NewInvoiceRepository(pgClient, logger, cacheClient)
-	costsheetRepo := entRepo.NewCostsheetRepository(pgClient, logger, cacheClient)
 	featureRepo := entRepo.NewFeatureRepository(pgClient, logger, cacheClient)
-	meterRepo := entRepo.NewMeterRepository(pgClient, logger, cacheClient)
-	priceRepo := entRepo.NewPriceRepository(pgClient, logger, cacheClient)
 	eventRepo := chRepo.NewEventRepository(chStore, logger)
-	costUsageRepo := chRepo.NewCostSheetUsageRepository(chStore, logger)
+	featureUsageRepo := chRepo.NewFeatureUsageRepository(chStore, logger)
 
 	serviceParams := service.ServiceParams{
-		Logger:             logger,
-		Config:             cfg,
-		DB:                 pgClient,
-		CustomerRepo:       customerRepo,
-		InvoiceRepo:        invoiceRepo,
-		CostSheetRepo:      costsheetRepo,
-		CostSheetUsageRepo: costUsageRepo,
-		FeatureRepo:        featureRepo,
-		MeterRepo:          meterRepo,
-		PriceRepo:          priceRepo,
-		EventRepo:          eventRepo,
+		Logger:       logger,
+		Config:       cfg,
+		DB:          pgClient,
+		CustomerRepo: customerRepo,
+		InvoiceRepo:  invoiceRepo,
+		FeatureRepo:  featureRepo,
+		EventRepo:    eventRepo,
 	}
-	costSheetUsageTrackingService := service.NewCostSheetUsageTrackingService(serviceParams, eventRepo, costUsageRepo)
+	featureUsageTrackingService := service.NewFeatureUsageTrackingService(serviceParams, eventRepo, featureUsageRepo)
 
 	return &analyticsInvoiceReconciliationScript{
-		log:                          logger,
-		customerRepo:                 customerRepo,
-		invoiceRepo:                  invoiceRepo,
-		costSheetUsageTrackingService: costSheetUsageTrackingService,
+		log:                         logger,
+		customerRepo:                customerRepo,
+		invoiceRepo:                 invoiceRepo,
+		featureUsageTrackingService: featureUsageTrackingService,
 	}, nil
 }

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -237,8 +237,8 @@ func runAnalyticsWorkers(
 					StartTime:          startTime,
 					EndTime:            endTime,
 				}
-				resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalyticsV2(ctx, req)
-				if err != nil {
+				resp, err := script.featureUsageTrackingService.GetDetailedUsageAnalytics(ctx, req)
+				if err != nil {       
 					resultCh <- analyticsResult{customerID: c.ID, err: err}
 					continue
 				}

--- a/scripts/internal/analytics_invoice_reconciliation.go
+++ b/scripts/internal/analytics_invoice_reconciliation.go
@@ -251,6 +251,7 @@ func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationS
 	subRepo := entRepo.NewSubscriptionRepository(pgClient, logger, cacheClient)
 	subLineItemRepo := entRepo.NewSubscriptionLineItemRepository(pgClient, logger, cacheClient)
 	addonRepo := entRepo.NewAddonRepository(pgClient, logger, cacheClient)
+	settingsRepo := entRepo.NewSettingsRepository(pgClient, logger, cacheClient)
 	eventRepo := chRepo.NewEventRepository(chStore, logger)
 	featureUsageRepo := chRepo.NewFeatureUsageRepository(chStore, logger)
 
@@ -267,6 +268,7 @@ func newAnalyticsInvoiceReconciliationScript() (*analyticsInvoiceReconciliationS
 		SubRepo:                  subRepo,
 		SubscriptionLineItemRepo: subLineItemRepo,
 		AddonRepo:                addonRepo,
+		SettingsRepo:             settingsRepo,
 		EventRepo:                eventRepo,
 		FeatureUsageRepo:         featureUsageRepo,
 	}

--- a/scripts/main.go
+++ b/scripts/main.go
@@ -123,6 +123,11 @@ var commands = []Command{
 		Description: "Sync a price to all subscriptions with the same plan and start date by creating new line items",
 		Run:         internal.SyncPriceToSubscriptions,
 	},
+	{
+		Name:        "analytics-invoice-reconciliation",
+		Description: "Compare analytics total cost vs invoice subtotals for a period (default 1 Feb–1 Mar); output CSV of diffs",
+		Run:         internal.RunAnalyticsInvoiceReconciliation,
+	},
 }
 
 // runBulkReprocessEventsCommand wraps the bulk reprocess events with command line parameters


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to run an analytics vs. invoice reconciliation for Feb 1, 2025–Mar 1, 2025 that compares per-customer analytics costs to invoice subtotals, flags discrepancies beyond a small tolerance, and generates a detailed CSV report listing affected customers, calculated totals, invoice subtotals, differences, related invoice IDs and counts; logs when no differences are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->