### PR TITLE
feat(Webhook): move to kafka with ratelimits and central consumer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -586,10 +586,10 @@ func registerRouterHandlers(
 	cfg *config.Configuration,
 	includeProcessingHandlers bool,
 ) {
-	webhookService.RegisterHandler(router)
 	onboardingService.RegisterHandler(router)
 
 	if includeProcessingHandlers {
+		webhookService.RegisterHandler(router, cfg)
 		eventConsumptionSvc.RegisterHandler(router, cfg)
 		eventConsumptionSvc.RegisterHandlerLazy(router, cfg)
 		// eventPostProcessingSvc.RegisterHandler(router, cfg)

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/resend/resend-go/v2 v2.26.0
 	github.com/samber/lo v1.47.0
+	github.com/sethvargo/go-password v0.3.1
 	github.com/shopspring/decimal v1.4.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/viper v1.19.0
@@ -168,7 +169,6 @@ require (
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	github.com/sethvargo/go-password v0.3.1 // indirect
 	github.com/sony/gobreaker v1.0.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -93,8 +93,8 @@ logging:
 webhook:
   enabled: true
   topic: "system_events"
-  pubsub: "memory"
-  consumer_group: "webhook-consumer-local"
+  consumer_group: "system-events-consumer"
+  rate_limit: 5
   max_retries: 3
   initial_interval: 1s
   max_interval: 10s

--- a/internal/config/webhook.go
+++ b/internal/config/webhook.go
@@ -13,7 +13,7 @@ type Webhook struct {
 	InitialInterval time.Duration                  `mapstructure:"initial_interval" default:"1s"`
 	MaxInterval     time.Duration                  `mapstructure:"max_interval" default:"10s"`
 	Multiplier      float64                        `mapstructure:"multiplier" default:"2.0"`
-	RateLimit       int                            `mapstructure:"rate_limit" default:"5"`
+	RateLimit       int64                          `mapstructure:"rate_limit" default:"5"`
 	MaxElapsedTime  time.Duration                  `mapstructure:"max_elapsed_time" default:"2m"`
 	Tenants         map[string]TenantWebhookConfig `mapstructure:"tenants"`
 	Svix            Svix                           `mapstructure:"svix_config"`

--- a/internal/config/webhook.go
+++ b/internal/config/webhook.go
@@ -2,20 +2,18 @@ package config
 
 import (
 	"time"
-
-	"github.com/flexprice/flexprice/internal/types"
 )
 
 // Webhook represents the configuration for the webhook system
 type Webhook struct {
 	Enabled         bool                           `mapstructure:"enabled"`
-	Topic           string                         `mapstructure:"topic" default:"webhooks"`
-	PubSub          types.PubSubType               `mapstructure:"pubsub" default:"kafka"`
-	ConsumerGroup   string                         `mapstructure:"consumer_group" default:"webhook-consumer"`
+	Topic           string                         `mapstructure:"topic" default:"system_events"`
+	ConsumerGroup   string                         `mapstructure:"consumer_group" default:"system-events-consumer"`
 	MaxRetries      int                            `mapstructure:"max_retries" default:"3"`
 	InitialInterval time.Duration                  `mapstructure:"initial_interval" default:"1s"`
 	MaxInterval     time.Duration                  `mapstructure:"max_interval" default:"10s"`
 	Multiplier      float64                        `mapstructure:"multiplier" default:"2.0"`
+	RateLimit       int                            `mapstructure:"rate_limit" default:"5"`
 	MaxElapsedTime  time.Duration                  `mapstructure:"max_elapsed_time" default:"2m"`
 	Tenants         map[string]TenantWebhookConfig `mapstructure:"tenants"`
 	Svix            Svix                           `mapstructure:"svix_config"`

--- a/internal/testutil/base_service_suite.go
+++ b/internal/testutil/base_service_suite.go
@@ -140,7 +140,7 @@ func (s *BaseServiceTestSuite) setupDependencies() {
 	eventStore := s.stores.EventRepo.(*InMemoryEventStore)
 	s.publisher = NewInMemoryEventPublisher(eventStore)
 	pubsub := NewInMemoryPubSub()
-	webhookPublisher, err := webhookPublisher.NewPublisher(pubsub, s.config, s.logger)
+	webhookPublisher, err := webhookPublisher.NewPublisherWithPublisher(pubsub.AsPublisher(), s.config, s.logger)
 	if err != nil {
 		s.T().Fatalf("failed to create webhook publisher: %v", err)
 	}
@@ -234,7 +234,7 @@ func (s *BaseServiceTestSuite) setupStores() {
 	eventStore := s.stores.EventRepo.(*InMemoryEventStore)
 	s.publisher = NewInMemoryEventPublisher(eventStore)
 	pubsub := NewInMemoryPubSub()
-	webhookPublisher, err := webhookPublisher.NewPublisher(pubsub, s.config, s.logger)
+	webhookPublisher, err := webhookPublisher.NewPublisherWithPublisher(pubsub.AsPublisher(), s.config, s.logger)
 	if err != nil {
 		s.T().Fatalf("failed to create webhook publisher: %v", err)
 	}

--- a/internal/testutil/inmemory_pubsub.go
+++ b/internal/testutil/inmemory_pubsub.go
@@ -106,3 +106,26 @@ func (ps *InMemoryPubSub) ClearMessages() {
 
 	ps.messages = make(map[string][]*message.Message)
 }
+
+// AsPublisher returns a message.Publisher adapter for use with webhook publisher
+func (ps *InMemoryPubSub) AsPublisher() message.Publisher {
+	return &inMemoryPublisherAdapter{ps: ps}
+}
+
+// inMemoryPublisherAdapter adapts InMemoryPubSub to watermill's message.Publisher interface
+type inMemoryPublisherAdapter struct {
+	ps *InMemoryPubSub
+}
+
+func (a *inMemoryPublisherAdapter) Publish(topic string, messages ...*message.Message) error {
+	for _, msg := range messages {
+		if err := a.ps.Publish(context.Background(), topic, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *inMemoryPublisherAdapter) Close() error {
+	return a.ps.Close()
+}

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -3,12 +3,15 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/httpclient"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/pubsub"
+	kafkaPubsub "github.com/flexprice/flexprice/internal/pubsub/kafka"
 	pubsubRouter "github.com/flexprice/flexprice/internal/pubsub/router"
 	"github.com/flexprice/flexprice/internal/sentry"
 	"github.com/flexprice/flexprice/internal/svix"
@@ -18,10 +21,10 @@ import (
 
 // Handler interface for processing webhook events
 type Handler interface {
-	RegisterHandler(router *pubsubRouter.Router)
+	RegisterHandler(router *pubsubRouter.Router, cfg *config.Configuration)
 }
 
-// handler implements handler.Handler using watermill's gochannel
+// handler implements Handler using a dedicated Kafka consumer
 type handler struct {
 	pubSub     pubsub.PubSub
 	config     *config.Webhook
@@ -32,9 +35,8 @@ type handler struct {
 	svixClient *svix.Client
 }
 
-// NewHandler creates a new memory-based handler
+// NewHandler creates a new webhook handler with its own Kafka consumer
 func NewHandler(
-	pubSub pubsub.PubSub,
 	cfg *config.Configuration,
 	factory payload.PayloadBuilderFactory,
 	client httpclient.Client,
@@ -42,8 +44,13 @@ func NewHandler(
 	sentry *sentry.Service,
 	svixClient *svix.Client,
 ) (Handler, error) {
+	ps, err := kafkaPubsub.NewPubSubFromConfig(cfg, logger, cfg.Webhook.ConsumerGroup)
+	if err != nil {
+		return nil, err
+	}
+
 	return &handler{
-		pubSub:     pubSub,
+		pubSub:     ps,
 		config:     &cfg.Webhook,
 		factory:    factory,
 		client:     client,
@@ -53,12 +60,30 @@ func NewHandler(
 	}, nil
 }
 
-func (h *handler) RegisterHandler(router *pubsubRouter.Router) {
+func (h *handler) RegisterHandler(router *pubsubRouter.Router, cfg *config.Configuration) {
+	if !cfg.Webhook.Enabled {
+		h.logger.Infow("webhook handler disabled by configuration")
+		return
+	}
+
+	rateLimit := cfg.Webhook.RateLimit
+	if rateLimit <= 0 {
+		rateLimit = 5
+	}
+
+	throttle := middleware.NewThrottle(rateLimit, time.Second)
+
 	router.AddNoPublishHandler(
 		"webhook_handler",
 		h.config.Topic,
 		h.pubSub,
 		h.processMessage,
+		throttle.Middleware,
+	)
+
+	h.logger.Infow("registered webhook handler",
+		"topic", h.config.Topic,
+		"rate_limit", rateLimit,
 	)
 }
 

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -1,14 +1,8 @@
 package webhook
 
 import (
-	"github.com/flexprice/flexprice/internal/config"
-	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/pubsub"
-	"github.com/flexprice/flexprice/internal/pubsub/kafka"
-	"github.com/flexprice/flexprice/internal/pubsub/memory"
 	"github.com/flexprice/flexprice/internal/sentry"
 	"github.com/flexprice/flexprice/internal/service"
-	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/webhook/handler"
 	"github.com/flexprice/flexprice/internal/webhook/payload"
 	"github.com/flexprice/flexprice/internal/webhook/publisher"
@@ -17,18 +11,11 @@ import (
 
 // Module provides all webhook-related dependencies
 var Module = fx.Options(
-	// Core dependencies
 	fx.Provide(
-		// PubSub for sending webhook events
-		providePubSub,
-	),
-
-	// Webhook components
-	fx.Provide(
-		// Publisher for sending webhook events
+		// Publisher for sending webhook events (uses shared Kafka producer)
 		publisher.NewPublisher,
 
-		// Handler for processing webhook events
+		// Handler for processing webhook events (creates its own Kafka consumer)
 		handler.NewHandler,
 
 		// Payload builder factory and services
@@ -67,23 +54,4 @@ func providePayloadBuilderFactory(
 		creditNoteService,
 	)
 	return payload.NewPayloadBuilderFactory(services)
-}
-
-func providePubSub(
-	cfg *config.Configuration,
-	logger *logger.Logger,
-) pubsub.PubSub {
-	switch cfg.Webhook.PubSub {
-	case types.MemoryPubSub:
-		return memory.NewPubSub(cfg, logger)
-	case types.KafkaPubSub:
-		pubsub, err := kafka.NewPubSubFromConfig(cfg, logger, cfg.Webhook.ConsumerGroup)
-		if err != nil {
-			logger.Fatalw("failed to create kafka pubsub for webhooks", "error", err)
-		}
-		return pubsub
-	default:
-		logger.Fatalw("unsupported webhook pubsub type", "type", cfg.Webhook.PubSub)
-	}
-	return nil
 }

--- a/internal/webhook/publisher/publisher.go
+++ b/internal/webhook/publisher/publisher.go
@@ -20,14 +20,31 @@ type WebhookPublisher interface {
 
 // webhookPublisher publishes webhook events to Kafka
 type webhookPublisher struct {
-	producer *kafka.Producer
+	producer message.Publisher
 	config   *config.Webhook
 	logger   *logger.Logger
 }
 
-// NewPublisher creates a new Kafka-backed webhook publisher
+// NewPublisher creates a new Kafka-backed webhook publisher using the shared Kafka producer
 func NewPublisher(
 	producer *kafka.Producer,
+	cfg *config.Configuration,
+	logger *logger.Logger,
+) (WebhookPublisher, error) {
+	return newPublisher(producer, cfg, logger)
+}
+
+// NewPublisherWithPublisher creates a webhook publisher with a custom message.Publisher (useful for testing)
+func NewPublisherWithPublisher(
+	producer message.Publisher,
+	cfg *config.Configuration,
+	logger *logger.Logger,
+) (WebhookPublisher, error) {
+	return newPublisher(producer, cfg, logger)
+}
+
+func newPublisher(
+	producer message.Publisher,
 	cfg *config.Configuration,
 	logger *logger.Logger,
 ) (WebhookPublisher, error) {

--- a/internal/webhook/publisher/publisher.go
+++ b/internal/webhook/publisher/publisher.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/pubsub"
 	"github.com/flexprice/flexprice/internal/types"
 )
 
@@ -18,23 +18,23 @@ type WebhookPublisher interface {
 	Close() error
 }
 
-// Handler implements handler.Handler using watermill's gochannel
+// webhookPublisher publishes webhook events to Kafka
 type webhookPublisher struct {
-	pubSub pubsub.PubSub
-	config *config.Webhook
-	logger *logger.Logger
+	producer *kafka.Producer
+	config   *config.Webhook
+	logger   *logger.Logger
 }
 
-// NewHandler creates a new memory-based handler
+// NewPublisher creates a new Kafka-backed webhook publisher
 func NewPublisher(
-	pubSub pubsub.PubSub,
+	producer *kafka.Producer,
 	cfg *config.Configuration,
 	logger *logger.Logger,
 ) (WebhookPublisher, error) {
 	return &webhookPublisher{
-		pubSub: pubSub,
-		config: &cfg.Webhook,
-		logger: logger,
+		producer: producer,
+		config:   &cfg.Webhook,
+		logger:   logger,
 	}, nil
 }
 
@@ -62,7 +62,7 @@ func (p *webhookPublisher) PublishWebhook(ctx context.Context, event *types.Webh
 		"payload", string(payload),
 	)
 
-	if err := p.pubSub.Publish(ctx, p.config.Topic, msg); err != nil {
+	if err := p.producer.Publish(p.config.Topic, msg); err != nil {
 		p.logger.Errorw("failed to publish webhook event",
 			"error", err,
 			"event_id", event.ID,
@@ -81,7 +81,7 @@ func (p *webhookPublisher) PublishWebhook(ctx context.Context, event *types.Webh
 	return nil
 }
 
-// Close closes the publisher
+// Close is a no-op since the Kafka producer is shared and managed globally
 func (p *webhookPublisher) Close() error {
-	return p.pubSub.Close()
+	return nil
 }

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/flexprice/flexprice/internal/config"
@@ -42,22 +41,9 @@ func NewWebhookService(
 	}
 }
 
-// RegisterHandler registers the webhook handler with the router
-func (s *WebhookService) RegisterHandler(router *pubsubRouter.Router) {
-	s.handler.RegisterHandler(router)
-}
-
-// Start starts the webhook service
-func (s *WebhookService) Start(ctx context.Context) error {
-	if !s.config.Webhook.Enabled {
-		s.logger.Info("webhook service disabled")
-		return nil
-	}
-
-	s.logger.Debug("starting webhook service")
-
-	s.logger.Info("webhook service started successfully")
-	return nil
+// RegisterHandler registers the webhook handler with the router (consumer side)
+func (s *WebhookService) RegisterHandler(router *pubsubRouter.Router, cfg *config.Configuration) {
+	s.handler.RegisterHandler(router, cfg)
 }
 
 // Stop stops the webhook service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook rate limiting added with configurable threshold (default: 5 requests)

* **Improvements**
  * Webhook handling can be enabled/disabled via configuration; registration is now conditional
  * Delivery switched to a Kafka-backed publisher
  * Default webhook topic renamed to "system_events" and consumer group updated to "system-events-consumer"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->