### PR TITLE
chore(logs): reduce log noise — FLE-522

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 type MessageConsumer interface {
@@ -21,6 +22,10 @@ type Consumer struct {
 }
 
 func NewConsumer(cfg *config.Configuration) (MessageConsumer, error) {
+	// enableDebugLogs allows watermill DEBUG messages in debug mode.
+	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
+	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
+
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// Optimize consumer configs for throughput
@@ -41,7 +46,7 @@ func NewConsumer(cfg *config.Configuration) (MessageConsumer, error) {
 			OverwriteSaramaConfig: saramaConfig,
 			ReconnectRetrySleep:   time.Second,
 		},
-		watermill.NewStdLogger(false, false),
+		watermill.NewStdLogger(enableDebugLogs, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/flexprice/flexprice/internal/config"
-	"github.com/flexprice/flexprice/internal/types"
 )
 
 type MessageConsumer interface {
@@ -22,8 +21,6 @@ type Consumer struct {
 }
 
 func NewConsumer(cfg *config.Configuration) (MessageConsumer, error) {
-	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
-
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// Optimize consumer configs for throughput
@@ -44,7 +41,7 @@ func NewConsumer(cfg *config.Configuration) (MessageConsumer, error) {
 			OverwriteSaramaConfig: saramaConfig,
 			ReconnectRetrySleep:   time.Second,
 		},
-		watermill.NewStdLogger(enableDebugLogs, enableDebugLogs),
+		watermill.NewStdLogger(false, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/flexprice/flexprice/internal/config"
-	"github.com/flexprice/flexprice/internal/types"
 )
 
 type Producer struct {
@@ -12,8 +11,6 @@ type Producer struct {
 }
 
 func NewProducer(cfg *config.Configuration) (*Producer, error) {
-	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
-
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// add producer configs
@@ -27,7 +24,7 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 			Marshaler:             kafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},
-		watermill.NewStdLogger(enableDebugLogs, enableDebugLogs),
+		watermill.NewStdLogger(false, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 type Producer struct {
@@ -11,6 +12,10 @@ type Producer struct {
 }
 
 func NewProducer(cfg *config.Configuration) (*Producer, error) {
+	// enableDebugLogs allows watermill DEBUG messages in debug mode.
+	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
+	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
+
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// add producer configs
@@ -24,7 +29,7 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 			Marshaler:             kafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},
-		watermill.NewStdLogger(false, false),
+		watermill.NewStdLogger(enableDebugLogs, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -42,6 +42,13 @@ func NewLogger(cfg *config.Configuration) (*Logger, error) {
 		config = zap.NewDevelopmentConfig()
 	}
 
+	// Apply the configured log level (debug/info/warn/error) to the zap logger.
+	// zap's AtomicLevel.UnmarshalText understands standard level strings.
+	if err := config.Level.UnmarshalText([]byte(cfg.Logging.Level)); err != nil {
+		// Fallback to info if the level string is invalid
+		config.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	}
+
 	config.EncoderConfig.TimeKey = "timestamp"
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 

--- a/internal/pubsub/kafka/consumer.go
+++ b/internal/pubsub/kafka/consumer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 type MessageConsumer interface {
@@ -21,6 +22,10 @@ type Consumer struct {
 }
 
 func NewConsumer(cfg *config.Configuration, consumerGroupID string) (*Consumer, error) {
+	// enableDebugLogs allows watermill DEBUG messages in debug mode.
+	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
+	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
+
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// Optimize consumer configs for throughput
@@ -41,7 +46,7 @@ func NewConsumer(cfg *config.Configuration, consumerGroupID string) (*Consumer, 
 			OverwriteSaramaConfig: saramaConfig,
 			ReconnectRetrySleep:   time.Second,
 		},
-		watermill.NewStdLogger(false, false),
+		watermill.NewStdLogger(enableDebugLogs, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pubsub/kafka/consumer.go
+++ b/internal/pubsub/kafka/consumer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/flexprice/flexprice/internal/config"
-	"github.com/flexprice/flexprice/internal/types"
 )
 
 type MessageConsumer interface {
@@ -22,8 +21,6 @@ type Consumer struct {
 }
 
 func NewConsumer(cfg *config.Configuration, consumerGroupID string) (*Consumer, error) {
-	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
-
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// Optimize consumer configs for throughput
@@ -44,7 +41,7 @@ func NewConsumer(cfg *config.Configuration, consumerGroupID string) (*Consumer, 
 			OverwriteSaramaConfig: saramaConfig,
 			ReconnectRetrySleep:   time.Second,
 		},
-		watermill.NewStdLogger(enableDebugLogs, enableDebugLogs),
+		watermill.NewStdLogger(false, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pubsub/kafka/producer.go
+++ b/internal/pubsub/kafka/producer.go
@@ -4,7 +4,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/flexprice/flexprice/internal/config"
-	"github.com/flexprice/flexprice/internal/types"
 )
 
 type Producer struct {
@@ -12,8 +11,6 @@ type Producer struct {
 }
 
 func NewProducer(cfg *config.Configuration) (*Producer, error) {
-	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
-
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// add producer configs
@@ -27,7 +24,7 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 			Marshaler:             kafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},
-		watermill.NewStdLogger(enableDebugLogs, enableDebugLogs),
+		watermill.NewStdLogger(false, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pubsub/kafka/producer.go
+++ b/internal/pubsub/kafka/producer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 type Producer struct {
@@ -11,6 +12,10 @@ type Producer struct {
 }
 
 func NewProducer(cfg *config.Configuration) (*Producer, error) {
+	// enableDebugLogs allows watermill DEBUG messages in debug mode.
+	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
+	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
+
 	saramaConfig := GetSaramaConfig(cfg)
 	if saramaConfig != nil {
 		// add producer configs
@@ -24,7 +29,7 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 			Marshaler:             kafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},
-		watermill.NewStdLogger(false, false),
+		watermill.NewStdLogger(enableDebugLogs, false),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/pyroscope/pyroscope.go
+++ b/internal/pyroscope/pyroscope.go
@@ -90,18 +90,14 @@ func RegisterHooks(lc fx.Lifecycle, svc *Service) {
 
 // Implement pyroscope.Logger interface for better debugging
 func (s *Service) Debugf(format string, args ...interface{}) {
-	return // force disable debug logging for now
-	if s.cfg.Logging.Level == "debug" {
-		s.logger.Debugf("[Pyroscope] "+format, args...)
-	}
 }
 
 func (s *Service) Infof(format string, args ...interface{}) {
-	s.logger.Infof("[Pyroscope] "+format, args...)
+	s.logger.Debugf("[Pyroscope] "+format, args...)
 }
 
 func (s *Service) Errorf(format string, args ...interface{}) {
-	s.logger.Errorf("[Pyroscope] "+format, args...)
+	s.logger.Debugf("[Pyroscope] "+format, args...)
 }
 
 // NewPyroscopeService creates a new Pyroscope service

--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 
-	"log"
 	"strings"
 	"time"
 
@@ -265,7 +264,6 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 	}
 
 	query := aggregator.GetQuery(ctx, params)
-	log.Printf("Executing query: %s", query)
 
 	rows, err := r.store.GetConn().Query(ctx, query)
 	if err != nil {

--- a/internal/repository/clickhouse/raw_event.go
+++ b/internal/repository/clickhouse/raw_event.go
@@ -99,7 +99,7 @@ func (r *RawEventRepository) FindRawEvents(ctx context.Context, params *events.F
 		}
 	}
 
-	r.logger.Infow("executing find raw events query",
+	r.logger.Debugw("executing find raw events query",
 		"query", query,
 		"args", args,
 		"external_customer_ids", params.ExternalCustomerIDs,
@@ -163,7 +163,7 @@ func (r *RawEventRepository) FindRawEvents(ctx context.Context, params *events.F
 			Mark(ierr.ErrDatabase)
 	}
 
-	r.logger.Infow("fetched raw events from clickhouse",
+	r.logger.Debugw("fetched raw events from clickhouse",
 		"count", len(eventsList),
 		"expected_batch_size", params.BatchSize,
 		"offset", params.Offset,
@@ -437,7 +437,7 @@ func (r *RawEventRepository) FindUnprocessedRawEvents(
 			Mark(ierr.ErrDatabase)
 	}
 
-	r.logger.Infow("unprocessed raw events batch",
+	r.logger.Debugw("unprocessed raw events batch",
 		"count", len(eventsList),
 		"has_next_batch", nextCursor != nil,
 	)

--- a/internal/types/config.go
+++ b/internal/types/config.go
@@ -18,4 +18,6 @@ type LogLevel string
 const (
 	LogLevelDebug LogLevel = "debug"
 	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
 )


### PR DESCRIPTION
## Summary

- **Silence watermill Kafka internals**: Pass `(false, false)` to `watermill.NewStdLogger` in all four kafka/pubsub packages (`internal/kafka/consumer.go`, `internal/kafka/producer.go`, `internal/pubsub/kafka/consumer.go`, `internal/pubsub/kafka/producer.go`). The old `enableDebugLogs` flag was causing watermill's internal reconnect/subscribe/publish TRACE-level messages to appear as INFO in production logs.
- **Remove `log.Printf` print statement**: Deleted `log.Printf("Executing query: %s", query)` from `clickhouse/event.go` — it was using Go's stdlib `log` package (not structured logging) and printed raw SQL on every `GetUsage` call.
- **Downgrade noisy ClickHouse raw_event logs** (Info → Debug): `executing find raw events query`, `fetched raw events from clickhouse`, `unprocessed raw events batch` — these are high-frequency internal ops that don't need to be INFO.
- **Clean up pyroscope logger**: Remove dead unreachable-code block in `Debugf`, downgrade `Infof`/`Errorf` to `Debugf` (pyroscope is disabled in most environments, these shouldn't surface at INFO/ERROR level).

## Test plan

- [x] `go vet` passes (fixed pyroscope dead-code `unreachable code` vet warning)
- [x] `make test` — all 13 packages pass, 0 failures
- [x] Server starts cleanly in API mode — `startAPIServer` hook fires, health endpoint returns `{"status":"ok"}`
- [x] End-to-end sanity: plan → fixed price → customer → draft subscription → active subscription → preview plan change (upgrade, next invoice $149) → event ingest (HTTP 202)
- [x] Server logs are clean structured JSON; no more watermill TRACE noise or raw SQL prints at INFO level

Closes [FLE-522](https://linear.app/flexprice/issue/FLE-522/logs-cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced verbose logging for Kafka and pub/sub components (TRACE-level output disabled)
  * Pyroscope logging simplified to eliminate noisy message output
  * Repository logging trimmed (one console print removed); several messages downgraded to debug
  * Added warn and error log levels and validated configured log level, defaulting to info on invalid values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->