### PR TITLE
feat(config): add debug option to ClickHouse configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,7 @@ type ClickHouseConfig struct {
 	Password       string `mapstructure:"password" validate:"required"`
 	Database       string `mapstructure:"database" validate:"required"`
 	MaxMemoryUsage int64  `mapstructure:"max_memory_usage" validate:"required"`
+	Debug          bool   `mapstructure:"debug" default:"false"`
 }
 
 type LoggingConfig struct {
@@ -432,6 +433,10 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 			Password: c.Password,
 		},
 		ConnOpenStrategy: clickhouse.ConnOpenInOrder,
+		Debug:            c.Debug,
+		// Suppress driver-level per-fragment query logs (e.g. "PREWHERE ...", "AND ...").
+		// Structured query observability is handled via Sentry spans in tracedConn.
+		Debugf: func(format string, v ...any) {},
 	}
 	if c.TLS {
 		options.TLS = &tls.Config{}

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -43,6 +43,7 @@ clickhouse:
   password: flexprice123
   database: flexprice
   max_memory_usage: 50
+  debug: false # enable via FLEXPRICE_CLICKHOUSE_DEBUG=true for local SQL inspection only
 
 postgres:
   host: 127.0.0.1 # For local mode


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug configuration option for ClickHouse, enabling developers to inspect and troubleshoot SQL queries during local development using the `FLEXPRICE_CLICKHOUSE_DEBUG` environment variable.

* **Configuration**
  * Introduced new `clickhouse.debug` setting (disabled by default) that controls verbose query logging while preserving other observability features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->