### PR TITLE
feat(events): add event ingestion filter + raw bulk ingest API

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,130 @@
+# =============================================================================
+# .env.local — Local development overrides
+# =============================================================================
+# This file is loaded AFTER .env and takes precedence over it.
+# It is committed to the repo so all developers and AI agents get a working
+# local setup out of the box with zero manual configuration.
+#
+# Usage:
+#   Just run the server — config.go loads .env then overrides with .env.local.
+#   No extra flags or env exports needed.
+#
+# Pre-configured local test API key (ready to use immediately):
+#   Key:  sk_local_flexprice_test_key
+#   Tenant: 00000000-0000-0000-0000-000000000000  (Default Tenant)
+#   Env:    00000000-0000-0000-0000-000000000000  (Sandbox)
+#
+#   curl http://localhost:8080/v1/meters \
+#     -H "x-api-key: sk_local_flexprice_test_key" \
+#     -H "x-environment-id: 00000000-0000-0000-0000-000000000000"
+# =============================================================================
+
+# =============================================================================
+# Deployment
+# =============================================================================
+FLEXPRICE_DEPLOYMENT_MODE="local"
+
+# =============================================================================
+# Server
+# =============================================================================
+FLEXPRICE_SERVER_ADDRESS=":8080"
+
+# =============================================================================
+# PostgreSQL — local Docker service
+# =============================================================================
+FLEXPRICE_POSTGRES_HOST="localhost"
+FLEXPRICE_POSTGRES_PORT="5432"
+FLEXPRICE_POSTGRES_USER="flexprice"
+FLEXPRICE_POSTGRES_PASSWORD="flexprice123"
+FLEXPRICE_POSTGRES_DBNAME="flexprice"
+FLEXPRICE_POSTGRES_SSLMODE="disable"
+FLEXPRICE_POSTGRES_READER_HOST="localhost"
+
+# =============================================================================
+# ClickHouse — local Docker service
+# =============================================================================
+FLEXPRICE_CLICKHOUSE_ADDRESS="localhost:9000"
+FLEXPRICE_CLICKHOUSE_USERNAME="flexprice"
+FLEXPRICE_CLICKHOUSE_PASSWORD="flexprice123"
+FLEXPRICE_CLICKHOUSE_DATABASE="flexprice"
+
+# =============================================================================
+# Kafka — local Docker service (external port 29092)
+# =============================================================================
+FLEXPRICE_KAFKA_BROKERS="localhost:29092"
+FLEXPRICE_KAFKA_USE_SASL="false"
+FLEXPRICE_KAFKA_SASL_MECHANISM=""
+FLEXPRICE_KAFKA_SASL_USER=""
+FLEXPRICE_KAFKA_SASL_PASSWORD=""
+FLEXPRICE_KAFKA_TOPIC="events"
+FLEXPRICE_KAFKA_TOPIC_LAZY="events_lazy"
+FLEXPRICE_KAFKA_CONSUMER_GROUP="local_events_consumer"
+
+# =============================================================================
+# Raw Event Consumption
+# =============================================================================
+FLEXPRICE_RAW_EVENT_CONSUMPTION_ENABLED="true"
+FLEXPRICE_RAW_EVENT_CONSUMPTION_TOPIC="raw_events"
+FLEXPRICE_RAW_EVENT_CONSUMPTION_OUTPUT_TOPIC="events"
+FLEXPRICE_RAW_EVENT_CONSUMPTION_CONSUMER_GROUP="local_raw_events_consumer"
+FLEXPRICE_RAW_EVENT_CONSUMPTION_RATE_LIMIT="100"
+
+# =============================================================================
+# Event Processing Consumer Groups
+# =============================================================================
+FLEXPRICE_EVENT_PROCESSING_CONSUMER_GROUP="local_events_consumer"
+FLEXPRICE_EVENT_PROCESSING_LAZY_CONSUMER_GROUP="local_events_lazy_consumer"
+
+# =============================================================================
+# Auth — API key mode (no Supabase needed locally)
+# =============================================================================
+# Pre-hashed API keys (SHA-256 of the raw key → tenant/env mapping).
+# The key below is the hash of: sk_local_flexprice_test_key
+# Add more keys as needed: {"<sha256_of_key>": {"tenant_id": "...", ...}}
+FLEXPRICE_AUTH_PROVIDER="api_key"
+FLEXPRICE_AUTH_API_KEY_HEADER="x-api-key"
+FLEXPRICE_AUTH_API_KEY_KEYS="{\"0cfd568f22158887f8b77bc019fb245b1f14077b80936342b052985efa7de46c\":{\"tenant_id\":\"00000000-0000-0000-0000-000000000000\",\"user_id\":\"local-dev-user\",\"name\":\"local-dev-key\",\"is_active\":true}}"
+
+# Disable Supabase (not needed for local API-key-only auth)
+FLEXPRICE_AUTH_SUPABASE_BASE_URL=""
+FLEXPRICE_AUTH_SUPABASE_SERVICE_KEY=""
+
+# JWT secret still needed for token parsing — keep a dummy value locally
+FLEXPRICE_AUTH_SECRET="local-dev-secret-not-used-in-api-key-mode"
+
+# =============================================================================
+# Billing seed IDs (match the default seed records created by migrations)
+# =============================================================================
+FLEXPRICE_BILLING_TENANT_ID="00000000-0000-0000-0000-000000000000"
+FLEXPRICE_BILLING_ENVIRONMENT_ID="00000000-0000-0000-0000-000000000000"
+
+# =============================================================================
+# Disable production-only integrations
+# =============================================================================
+# Cache
+FLEXPRICE_CACHE_ENABLED="false"
+
+# Email — disable so no real emails are sent
+FLEXPRICE_EMAIL_ENABLED="false"
+FLEXPRICE_EMAIL_RESEND_API_KEY=""
+
+# Sentry — disable locally
+FLEXPRICE_SENTRY_ENABLED="false"
+FLEXPRICE_SENTRY_DSN=""
+
+# Pyroscope profiling — disable locally
+FLEXPRICE_PYROSCOPE_ENABLED="false"
+
+# DynamoDB — not used locally
+FLEXPRICE_DYNAMODB_IN_USE="false"
+
+# Temporal — disable if not running locally
+# (set to true and point to localhost:7233 if you need workflow support)
+FLEXPRICE_TEMPORAL_ENABLED="false"
+FLEXPRICE_TEMPORAL_ADDRESS="localhost:7233"
+
+# Svix webhooks — disable locally
+FLEXPRICE_SVIX_API_KEY=""
+
+# Encryption key — local dummy (32-byte hex)
+FLEXPRICE_ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000001"

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ coverage.html
 .env*
 !.env.project
 !.env.vault
+!.env.local
 .flaskenv*
 .secrets
 .secrets.git

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,0 +1,287 @@
+# Local Testing Guide for AI Agents
+
+This guide covers everything needed to run Flexprice locally and do end-to-end validation of changes — particularly for features involving Kafka consumers, event ingestion, and settings.
+
+---
+
+## Prerequisites
+
+- **OrbStack** (or Docker Desktop) installed and running
+- **Go 1.23+** installed
+- Production `.env` file present at the repo root (contains secrets — never commit it)
+
+---
+
+## Step 1: Start OrbStack / Docker
+
+```bash
+open -a OrbStack
+# Wait ~5 seconds, then verify:
+docker ps
+```
+
+---
+
+## Step 2: Copy `.env` to Your Worktree
+
+The production `.env` lives at the repo root. If working in a git worktree, copy it over:
+
+```bash
+cp /path/to/flexprice/.env /path/to/flexprice/.claude/worktrees/<your-worktree>/.env
+```
+
+> **Important:** The production `.env` points to production Kafka, Postgres, and ClickHouse. You must override these for local testing (see Step 4).
+
+---
+
+## Step 3: Start Local Infrastructure
+
+```bash
+docker compose up -d postgres kafka clickhouse
+```
+
+Wait ~10 seconds for Kafka to fully start before creating topics.
+
+**Verify Kafka is ready:**
+```bash
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --list
+# Should return empty output (no error)
+```
+
+---
+
+## Step 4: Create Required Kafka Topics
+
+The local Kafka starts with no topics. Create all the ones the app needs:
+
+```bash
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic raw_events --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events_lazy --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events_post_processing --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events_backfill --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic system_events --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic onboarding_events --partitions 3 --replication-factor 1
+docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic balance_alert --partitions 3 --replication-factor 1
+```
+
+> If you skip any topic the consumer subscribes to, you'll see non-fatal `kafka server: Request was for a topic or partition that does not exist` errors in the consumer logs. The app keeps retrying and won't crash, but it's noisy.
+
+---
+
+## Step 5: Run Migrations
+
+Run both Postgres and ClickHouse migrations **with local env overrides** (critical — the Makefile commands pick up the production `.env` by default):
+
+**Postgres (SQL migrations):**
+```bash
+make migrate-postgres
+# This one reads from the .env file correctly for local because it uses
+# the docker-compose postgres service exposed on localhost:5432
+```
+
+**Ent schema migrations (adds new tables):**
+```bash
+FLEXPRICE_POSTGRES_HOST=localhost \
+FLEXPRICE_POSTGRES_PORT=5432 \
+FLEXPRICE_POSTGRES_USER=flexprice \
+FLEXPRICE_POSTGRES_PASSWORD=flexprice123 \
+FLEXPRICE_POSTGRES_DBNAME=flexprice \
+FLEXPRICE_POSTGRES_SSLMODE=disable \
+go run ./cmd/migrate/main.go
+```
+
+> **Warning:** `make migrate-ent` uses the `.env` file and will run against production if you don't override env vars explicitly. Always use the `go run` form above with explicit local overrides.
+
+**ClickHouse migrations:**
+```bash
+make migrate-clickhouse
+```
+
+---
+
+## Step 6: Build the Binary
+
+```bash
+go build -o /tmp/flexprice-local ./cmd/server/main.go
+```
+
+---
+
+## Step 7: Define Local Environment Variables
+
+The production `.env` must be overridden for all infrastructure endpoints. Use this block in every terminal that runs the binary:
+
+```bash
+# Local infrastructure overrides
+export FLEXPRICE_KAFKA_BROKERS="localhost:29092"
+export FLEXPRICE_KAFKA_USE_SASL="false"
+export FLEXPRICE_KAFKA_SASL_MECHANISM=""
+export FLEXPRICE_KAFKA_SASL_USER=""
+export FLEXPRICE_KAFKA_SASL_PASSWORD=""
+export FLEXPRICE_KAFKA_TOPIC="events"
+export FLEXPRICE_KAFKA_TOPIC_LAZY="events_lazy"
+export FLEXPRICE_KAFKA_CONSUMER_GROUP="local_events_consumer"
+
+export FLEXPRICE_CLICKHOUSE_ADDRESS="localhost:9000"
+export FLEXPRICE_CLICKHOUSE_USERNAME="flexprice"
+export FLEXPRICE_CLICKHOUSE_PASSWORD="flexprice123"
+export FLEXPRICE_CLICKHOUSE_DATABASE="flexprice"
+
+export FLEXPRICE_POSTGRES_HOST="localhost"
+export FLEXPRICE_POSTGRES_PORT="5432"
+export FLEXPRICE_POSTGRES_USER="flexprice"
+export FLEXPRICE_POSTGRES_PASSWORD="flexprice123"
+export FLEXPRICE_POSTGRES_DBNAME="flexprice"
+export FLEXPRICE_POSTGRES_SSLMODE="disable"
+export FLEXPRICE_POSTGRES_READER_HOST="localhost"
+
+export FLEXPRICE_RAW_EVENT_CONSUMPTION_ENABLED="true"
+export FLEXPRICE_RAW_EVENT_CONSUMPTION_TOPIC="raw_events"
+export FLEXPRICE_RAW_EVENT_CONSUMPTION_OUTPUT_TOPIC="events"
+export FLEXPRICE_RAW_EVENT_CONSUMPTION_CONSUMER_GROUP="local_raw_events_consumer"
+export FLEXPRICE_RAW_EVENT_CONSUMPTION_RATE_LIMIT="100"
+
+export FLEXPRICE_EVENT_PROCESSING_CONSUMER_GROUP="local_events_consumer"
+export FLEXPRICE_EVENT_PROCESSING_LAZY_CONSUMER_GROUP="local_events_lazy_consumer"
+```
+
+> **Local Kafka broker port:** The docker-compose Kafka advertises on `kafka:9092` internally and `localhost:29092` externally. Always use `localhost:29092` from the host machine.
+
+---
+
+## Step 8: Set Up a Test API Key
+
+API key validation works in two modes: config-based (fast, no DB) or DB-based (via secrets table). For local testing, use **config-based** by injecting the SHA-256 hash of your test key.
+
+**Compute the hash of any key you want to use:**
+```bash
+echo -n "your-test-api-key" | sha256sum
+# e.g. sk_01KM416QMD5N07GPKRR3QXQYFB → 155f941ce338505f9e9fa1ed85776da0433b2e16f47ae26a016049984437c632
+```
+
+**Build the JSON config and export it:**
+```bash
+API_KEY_HASH="155f941ce338505f9e9fa1ed85776da0433b2e16f47ae26a016049984437c632"
+export FLEXPRICE_AUTH_API_KEY_KEYS="{\"${API_KEY_HASH}\":{\"tenant_id\":\"00000000-0000-0000-0000-000000000000\",\"user_id\":\"test-user\",\"name\":\"local-test-key\",\"is_active\":true}}"
+export FLEXPRICE_AUTH_API_KEY_HEADER="x-api-key"
+```
+
+> The `tenant_id` `00000000-0000-0000-0000-000000000000` and environment `00000000-0000-0000-0000-000000000000` are the default seed records that migrations create. Use these for local testing.
+
+---
+
+## Step 9: Run API Server (Terminal 1)
+
+```bash
+# (with all the env vars above already exported)
+FLEXPRICE_DEPLOYMENT_MODE=api \
+FLEXPRICE_SERVER_ADDRESS=":8081" \
+/tmp/flexprice-local
+```
+
+> **Port conflict:** Port `8080` may already be in use (another local server). Use `:8081` or any free port.
+
+**Verify:**
+```bash
+curl -s http://localhost:8081/health
+# → {"status":"ok"}
+```
+
+---
+
+## Step 10: Run Consumer (Terminal 2)
+
+```bash
+# (with all the env vars above already exported)
+FLEXPRICE_DEPLOYMENT_MODE=consumer \
+/tmp/flexprice-local
+```
+
+**Verify raw event consumer is active:**
+```bash
+grep "raw_event_consumption_handler\|Subscribing to Kafka topic.*raw" /tmp/consumer.log
+# Should show:
+# Adding handler  handler_name=raw_event_consumption_handler topic=raw_events
+# Subscribing to Kafka topic ... topic=raw_events
+```
+
+---
+
+## Step 11: Authenticate API Calls
+
+All private API calls need:
+- `x-api-key: <your-test-key>` header
+- `x-environment-id: 00000000-0000-0000-0000-000000000000` header
+
+```bash
+curl -s http://localhost:8081/v1/meters \
+  -H "x-api-key: sk_01KM416QMD5N07GPKRR3QXQYFB" \
+  -H "x-environment-id: 00000000-0000-0000-0000-000000000000"
+```
+
+---
+
+## Useful Local DB Access
+
+```bash
+# PostgreSQL
+docker compose exec postgres psql -U flexprice -d flexprice
+
+# ClickHouse
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice
+
+# Check events in ClickHouse
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice \
+  --query="SELECT id, external_customer_id, event_name FROM events ORDER BY timestamp DESC LIMIT 10 FORMAT PrettyCompact"
+
+# Check raw_events in ClickHouse
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice \
+  --query="SELECT count() FROM raw_events"
+```
+
+---
+
+## Shutdown
+
+```bash
+# Kill the Go processes
+pkill -f "flexprice-local"
+
+# Stop all Docker services
+docker compose down
+```
+
+---
+
+## Common Pitfalls
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `listen tcp :8080: address already in use` | Another server on port 8080 | Use `FLEXPRICE_SERVER_ADDRESS=":8081"` |
+| `make migrate-ent` runs against production | Makefile loads `.env` first | Use `go run ./cmd/migrate/main.go` with explicit env overrides |
+| Consumer errors: `topic does not exist` | Not all topics created | Run the full topic creation block in Step 4 |
+| `{"error":"Unauthorized"}` on every request | API key not wired into config | Set `FLEXPRICE_AUTH_API_KEY_KEYS` JSON (Step 8) |
+| Settings lookup returns "not found" | Wrong tenant/env in context | Always pass `x-environment-id` header; check that env vars have the right tenant/env |
+| ClickHouse `raw_events` table is empty | The consumer doesn't write there directly | Raw events are stored in ClickHouse `raw_events` by the Bento collector; the Go consumer reads from Kafka `raw_events` topic and writes transformed events to ClickHouse `events` table |
+| Consumer log flooded with `balance_alert` errors | Topic not created | Create it: `kafka-topics --create --topic balance_alert ...` |
+| `go build` fails on `api/custom/go/...` | Generated SDK has broken dep | Use `go build ./internal/... ./cmd/...` instead of `./...` |
+
+---
+
+## Local Credentials Reference
+
+| Service | Host | Port | User | Password | DB |
+|---------|------|------|------|----------|----|
+| PostgreSQL | localhost | 5432 | flexprice | flexprice123 | flexprice |
+| ClickHouse | localhost | 9000 | flexprice | flexprice123 | flexprice |
+| Kafka (external) | localhost | 29092 | — | — | — |
+| Kafka (internal) | kafka | 9092 | — | — | — |
+
+Default seed data:
+- Tenant ID: `00000000-0000-0000-0000-000000000000`
+- Environment ID (Sandbox): `00000000-0000-0000-0000-000000000000`
+- Environment ID (Production): `00000000-0000-0000-0000-000000000001`

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,28 +1,32 @@
-# Local Testing Guide for AI Agents
+# Local Testing Guide
 
-Everything needed to run Flexprice locally and validate changes end-to-end.
-**No manual env var exports or configuration required** — `.env.local` is committed and wired in automatically.
-
----
-
-## Prerequisites
-
-- **OrbStack** (or Docker Desktop) installed
-- **Go 1.23+** installed
+Step-by-step guide to running Flexprice locally and validating changes end-to-end.
+Works for humans and AI agents alike — no manual env var configuration needed.
 
 ---
 
 ## Pre-configured Local API Key
 
-Use this key for all local API calls — no setup needed:
+Use this key for all local API calls — it's baked into `.env.local`:
 
 ```
-x-api-key: sk_local_flexprice_test_key
+x-api-key:        sk_local_flexprice_test_key
 x-environment-id: 00000000-0000-0000-0000-000000000000
 ```
 
-Tenant ID: `00000000-0000-0000-0000-000000000000` (Default Tenant)
-Environment ID: `00000000-0000-0000-0000-000000000000` (Sandbox)
+Tenant ID: `00000000-0000-0000-0000-000000000000` · Environment: Sandbox
+
+---
+
+## How local config works
+
+`.env.local` is a committed file that contains all local infrastructure settings.
+When you run via `make run-local*` targets, the Makefile sources `.env` first
+then `.env.local` on top — so local Docker endpoints override any production
+settings in `.env`, without modifying that file.
+
+**Never add** `godotenv.Load(".env.local")` to application code — that would
+affect production deployments.
 
 ---
 
@@ -38,15 +42,16 @@ open -a OrbStack && sleep 3
 
 ```bash
 docker compose up -d postgres kafka clickhouse
-sleep 10  # wait for Kafka to fully initialize
+sleep 10   # wait for Kafka to fully initialise
 ```
 
 ### 3. Create Kafka topics
 
-Run once (safe to repeat — fails gracefully if topics exist):
+Run once (idempotent — safe to repeat):
 
 ```bash
-for topic in raw_events events events_lazy events_post_processing events_backfill system_events onboarding_events balance_alert; do
+for topic in raw_events events events_lazy events_post_processing \
+             events_backfill system_events onboarding_events balance_alert; do
   docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 \
     --create --topic $topic --partitions 3 --replication-factor 1 2>/dev/null || true
 done
@@ -55,50 +60,43 @@ done
 ### 4. Run migrations
 
 ```bash
-# PostgreSQL SQL migrations
+# Postgres SQL migrations (reads docker-compose defaults, safe to run as-is)
 make migrate-postgres
 
-# Ent schema migrations (local postgres — explicit overrides required!)
-FLEXPRICE_POSTGRES_HOST=localhost \
-FLEXPRICE_POSTGRES_PORT=5432 \
-FLEXPRICE_POSTGRES_USER=flexprice \
-FLEXPRICE_POSTGRES_PASSWORD=flexprice123 \
-FLEXPRICE_POSTGRES_DBNAME=flexprice \
-FLEXPRICE_POSTGRES_SSLMODE=disable \
-go run ./cmd/migrate/main.go
+# Ent schema migrations against local Postgres (uses .env.local)
+make migrate-local
 
 # ClickHouse migrations
 make migrate-clickhouse
 ```
 
-> **Warning:** `make migrate-ent` reads `.env` first and will run against production if that file points there. Always use `go run ./cmd/migrate/main.go` with explicit local overrides as shown above.
+> **Warning:** `make migrate-ent` reads `.env` and will run against production
+> if that file points there. Always use `make migrate-local` instead.
 
-### 5. Build and run
+### 5. Run the server
 
-**Terminal 1 — API server:**
+**Two separate terminals (mirrors production deployment):**
+
 ```bash
-go build -o /tmp/flexprice-local ./cmd/server/main.go
-FLEXPRICE_DEPLOYMENT_MODE=api /tmp/flexprice-local
+# Terminal 1 — API server
+make run-local-api
+
+# Terminal 2 — Kafka consumer
+make run-local-consumer
 ```
 
-**Terminal 2 — Consumer:**
-```bash
-FLEXPRICE_DEPLOYMENT_MODE=consumer /tmp/flexprice-local
-```
+**Or everything in one process (quickest for local dev):**
 
-Or run everything in a single process (API + consumer + worker):
 ```bash
-FLEXPRICE_DEPLOYMENT_MODE=local /tmp/flexprice-local
+make run-local
 ```
 
 ### 6. Verify
 
 ```bash
-# Health check
 curl http://localhost:8080/health
 # → {"status":"ok"}
 
-# Auth check
 curl http://localhost:8080/v1/meters \
   -H "x-api-key: sk_local_flexprice_test_key" \
   -H "x-environment-id: 00000000-0000-0000-0000-000000000000"
@@ -107,57 +105,19 @@ curl http://localhost:8080/v1/meters \
 
 ---
 
-## How `.env.local` Works
-
-`config.go` loads env files in this order (later wins):
-
-```
-.env          ← production/shared defaults (gitignored, contains real secrets)
-.env.local    ← local overrides (committed, safe — no real secrets)
-```
-
-`.env.local` overrides all infra endpoints to local Docker, disables Supabase/Sentry/email/DynamoDB, and wires the pre-configured API key. You never need to manually export env vars.
-
----
-
-## End-to-End Test Example
+## Shutdown
 
 ```bash
-BASE="http://localhost:8080/v1"
-KEY="sk_local_flexprice_test_key"
-ENV_HDR="x-environment-id: 00000000-0000-0000-0000-000000000000"
+# Stop Go processes (Ctrl+C in each terminal, or:)
+pkill -f "go run cmd/server"
 
-# 1. Create a customer
-curl -s -X POST $BASE/customers \
-  -H "x-api-key: $KEY" -H "$ENV_HDR" -H "Content-Type: application/json" \
-  -d '{"external_id": "org_test_001", "name": "Test Org"}'
-
-# 2. Configure event ingestion filter
-curl -s -X PUT $BASE/settings/event_ingestion_filter \
-  -H "x-api-key: $KEY" -H "$ENV_HDR" -H "Content-Type: application/json" \
-  -d '{"value": {"enabled": true, "allowed_external_customer_ids": ["org_test_001"]}}'
-
-# 3. Ingest raw events (Bento format → raw_events Kafka topic)
-curl -s -X POST $BASE/events/raw/bulk \
-  -H "x-api-key: $KEY" -H "$ENV_HDR" -H "Content-Type: application/json" \
-  -d '{
-    "events": [
-      {"id":"evt-001","orgId":"org_test_001","methodName":"api_call","providerName":"openai","createdAt":"2026-01-01T00:00:00Z","data":{}},
-      {"id":"evt-002","orgId":"org_blocked_001","methodName":"api_call","providerName":"openai","createdAt":"2026-01-01T00:00:00Z","data":{}}
-    ]
-  }'
-# → {"batch_size":2,"message":"Raw events accepted for processing"}
-# Consumer will process: success_count=1, skip_count=1
-
-# 4. Verify in ClickHouse — only the allowed org's event should appear
-docker compose exec clickhouse clickhouse-client \
-  --user=flexprice --password=flexprice123 --database=flexprice \
-  --query="SELECT id, external_customer_id, event_name FROM events ORDER BY timestamp DESC LIMIT 5 FORMAT PrettyCompact"
+# Stop Docker services
+docker compose down
 ```
 
 ---
 
-## Useful Commands
+## Useful DB Commands
 
 ```bash
 # PostgreSQL shell
@@ -167,12 +127,10 @@ docker compose exec postgres psql -U flexprice -d flexprice
 docker compose exec clickhouse clickhouse-client \
   --user=flexprice --password=flexprice123 --database=flexprice
 
-# Watch consumer logs (filter to signal lines)
-tail -f /tmp/consumer.log | grep -E "processing|completed|filter|error"
-
-# Stop everything
-pkill -f flexprice-local
-docker compose down
+# Quick ClickHouse queries
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice \
+  --query="SELECT id, external_customer_id, event_name FROM events ORDER BY timestamp DESC LIMIT 10 FORMAT PrettyCompact"
 ```
 
 ---
@@ -185,23 +143,11 @@ docker compose down
 | ClickHouse | `localhost:9000` | `flexprice` | `flexprice123` | `flexprice` |
 | Kafka | `localhost:29092` | — | — | — |
 
-| Entity | ID |
-|--------|----|
+| Seed record | ID |
+|-------------|----|
 | Default Tenant | `00000000-0000-0000-0000-000000000000` |
 | Sandbox Environment | `00000000-0000-0000-0000-000000000000` |
 | Production Environment | `00000000-0000-0000-0000-000000000001` |
-
----
-
-## Adding a New Local API Key
-
-```bash
-# 1. Pick any key string and compute its SHA-256
-echo -n "sk_my_new_key" | sha256sum | awk '{print $1}'
-
-# 2. Add to FLEXPRICE_AUTH_API_KEY_KEYS in .env.local:
-# {"<hash>": {"tenant_id": "00000000-...", "user_id": "dev", "name": "my-key", "is_active": true}}
-```
 
 ---
 
@@ -209,9 +155,15 @@ echo -n "sk_my_new_key" | sha256sum | awk '{print $1}'
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
-| `make migrate-ent` hits production | Makefile loads `.env` before overrides | Use `go run ./cmd/migrate/main.go` with explicit env vars (Step 4) |
-| `listen tcp :8080: address already in use` | Another process on 8080 | `lsof -ti:8080 | xargs kill` or use `FLEXPRICE_SERVER_ADDRESS=":8081"` |
-| Consumer: `topic does not exist` errors | Topic not created yet | Run the topic creation loop in Step 3 |
-| `{"error":"Unauthorized"}` | API key not matching | Use `sk_local_flexprice_test_key` — it's pre-wired in `.env.local` |
-| ClickHouse `raw_events` table empty | Consumer doesn't write there | The consumer writes to ClickHouse `events`, not `raw_events` (Bento writes raw_events directly) |
-| Settings lookup fails with "not found" | Missing `x-environment-id` header | Always include `-H "x-environment-id: 00000000-0000-0000-0000-000000000000"` |
+| `make migrate-ent` or `make migrate-local` hits production | `.env` loaded, not `.env.local` | Always use `make migrate-local` |
+| `address already in use :8080` | Another process on 8080 | `lsof -ti:8080 \| xargs kill` |
+| Consumer: `topic does not exist` errors | Topic not created | Run the topic creation loop in Step 3 |
+| `{"error":"Unauthorized"}` | Wrong API key | Use `sk_local_flexprice_test_key` from `.env.local` |
+| ClickHouse `raw_events` table is empty | Consumer writes to `events`, not `raw_events` | Check the `events` table — that's where transformed events land |
+| Settings lookup fails | Missing `x-environment-id` header | Always send `-H "x-environment-id: 00000000-0000-0000-0000-000000000000"` |
+
+---
+
+## See also
+
+- [`SANITY_CHECK.md`](SANITY_CHECK.md) — standard pre-validation checklist to run before every PR

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,87 +1,64 @@
 # Local Testing Guide for AI Agents
 
-This guide covers everything needed to run Flexprice locally and do end-to-end validation of changes — particularly for features involving Kafka consumers, event ingestion, and settings.
+Everything needed to run Flexprice locally and validate changes end-to-end.
+**No manual env var exports or configuration required** — `.env.local` is committed and wired in automatically.
 
 ---
 
 ## Prerequisites
 
-- **OrbStack** (or Docker Desktop) installed and running
+- **OrbStack** (or Docker Desktop) installed
 - **Go 1.23+** installed
-- Production `.env` file present at the repo root (contains secrets — never commit it)
 
 ---
 
-## Step 1: Start OrbStack / Docker
+## Pre-configured Local API Key
 
-```bash
-open -a OrbStack
-# Wait ~5 seconds, then verify:
-docker ps
+Use this key for all local API calls — no setup needed:
+
+```
+x-api-key: sk_local_flexprice_test_key
+x-environment-id: 00000000-0000-0000-0000-000000000000
 ```
 
+Tenant ID: `00000000-0000-0000-0000-000000000000` (Default Tenant)
+Environment ID: `00000000-0000-0000-0000-000000000000` (Sandbox)
+
 ---
 
-## Step 2: Copy `.env` to Your Worktree
+## Quick Start
 
-The production `.env` lives at the repo root. If working in a git worktree, copy it over:
+### 1. Start OrbStack
 
 ```bash
-cp /path/to/flexprice/.env /path/to/flexprice/.claude/worktrees/<your-worktree>/.env
+open -a OrbStack && sleep 3
 ```
 
-> **Important:** The production `.env` points to production Kafka, Postgres, and ClickHouse. You must override these for local testing (see Step 4).
-
----
-
-## Step 3: Start Local Infrastructure
+### 2. Start local infrastructure
 
 ```bash
 docker compose up -d postgres kafka clickhouse
+sleep 10  # wait for Kafka to fully initialize
 ```
 
-Wait ~10 seconds for Kafka to fully start before creating topics.
+### 3. Create Kafka topics
 
-**Verify Kafka is ready:**
+Run once (safe to repeat — fails gracefully if topics exist):
+
 ```bash
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --list
-# Should return empty output (no error)
+for topic in raw_events events events_lazy events_post_processing events_backfill system_events onboarding_events balance_alert; do
+  docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 \
+    --create --topic $topic --partitions 3 --replication-factor 1 2>/dev/null || true
+done
 ```
 
----
-
-## Step 4: Create Required Kafka Topics
-
-The local Kafka starts with no topics. Create all the ones the app needs:
+### 4. Run migrations
 
 ```bash
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic raw_events --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events_lazy --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events_post_processing --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic events_backfill --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic system_events --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic onboarding_events --partitions 3 --replication-factor 1
-docker compose exec kafka kafka-topics --bootstrap-server kafka:9092 --create --topic balance_alert --partitions 3 --replication-factor 1
-```
-
-> If you skip any topic the consumer subscribes to, you'll see non-fatal `kafka server: Request was for a topic or partition that does not exist` errors in the consumer logs. The app keeps retrying and won't crash, but it's noisy.
-
----
-
-## Step 5: Run Migrations
-
-Run both Postgres and ClickHouse migrations **with local env overrides** (critical — the Makefile commands pick up the production `.env` by default):
-
-**Postgres (SQL migrations):**
-```bash
+# PostgreSQL SQL migrations
 make migrate-postgres
-# This one reads from the .env file correctly for local because it uses
-# the docker-compose postgres service exposed on localhost:5432
-```
 
-**Ent schema migrations (adds new tables):**
-```bash
+# Ent schema migrations (local postgres — explicit overrides required!)
 FLEXPRICE_POSTGRES_HOST=localhost \
 FLEXPRICE_POSTGRES_PORT=5432 \
 FLEXPRICE_POSTGRES_USER=flexprice \
@@ -89,170 +66,141 @@ FLEXPRICE_POSTGRES_PASSWORD=flexprice123 \
 FLEXPRICE_POSTGRES_DBNAME=flexprice \
 FLEXPRICE_POSTGRES_SSLMODE=disable \
 go run ./cmd/migrate/main.go
-```
 
-> **Warning:** `make migrate-ent` uses the `.env` file and will run against production if you don't override env vars explicitly. Always use the `go run` form above with explicit local overrides.
-
-**ClickHouse migrations:**
-```bash
+# ClickHouse migrations
 make migrate-clickhouse
 ```
 
----
+> **Warning:** `make migrate-ent` reads `.env` first and will run against production if that file points there. Always use `go run ./cmd/migrate/main.go` with explicit local overrides as shown above.
 
-## Step 6: Build the Binary
+### 5. Build and run
 
+**Terminal 1 — API server:**
 ```bash
 go build -o /tmp/flexprice-local ./cmd/server/main.go
+FLEXPRICE_DEPLOYMENT_MODE=api /tmp/flexprice-local
 ```
 
----
-
-## Step 7: Define Local Environment Variables
-
-The production `.env` must be overridden for all infrastructure endpoints. Use this block in every terminal that runs the binary:
-
+**Terminal 2 — Consumer:**
 ```bash
-# Local infrastructure overrides
-export FLEXPRICE_KAFKA_BROKERS="localhost:29092"
-export FLEXPRICE_KAFKA_USE_SASL="false"
-export FLEXPRICE_KAFKA_SASL_MECHANISM=""
-export FLEXPRICE_KAFKA_SASL_USER=""
-export FLEXPRICE_KAFKA_SASL_PASSWORD=""
-export FLEXPRICE_KAFKA_TOPIC="events"
-export FLEXPRICE_KAFKA_TOPIC_LAZY="events_lazy"
-export FLEXPRICE_KAFKA_CONSUMER_GROUP="local_events_consumer"
-
-export FLEXPRICE_CLICKHOUSE_ADDRESS="localhost:9000"
-export FLEXPRICE_CLICKHOUSE_USERNAME="flexprice"
-export FLEXPRICE_CLICKHOUSE_PASSWORD="flexprice123"
-export FLEXPRICE_CLICKHOUSE_DATABASE="flexprice"
-
-export FLEXPRICE_POSTGRES_HOST="localhost"
-export FLEXPRICE_POSTGRES_PORT="5432"
-export FLEXPRICE_POSTGRES_USER="flexprice"
-export FLEXPRICE_POSTGRES_PASSWORD="flexprice123"
-export FLEXPRICE_POSTGRES_DBNAME="flexprice"
-export FLEXPRICE_POSTGRES_SSLMODE="disable"
-export FLEXPRICE_POSTGRES_READER_HOST="localhost"
-
-export FLEXPRICE_RAW_EVENT_CONSUMPTION_ENABLED="true"
-export FLEXPRICE_RAW_EVENT_CONSUMPTION_TOPIC="raw_events"
-export FLEXPRICE_RAW_EVENT_CONSUMPTION_OUTPUT_TOPIC="events"
-export FLEXPRICE_RAW_EVENT_CONSUMPTION_CONSUMER_GROUP="local_raw_events_consumer"
-export FLEXPRICE_RAW_EVENT_CONSUMPTION_RATE_LIMIT="100"
-
-export FLEXPRICE_EVENT_PROCESSING_CONSUMER_GROUP="local_events_consumer"
-export FLEXPRICE_EVENT_PROCESSING_LAZY_CONSUMER_GROUP="local_events_lazy_consumer"
+FLEXPRICE_DEPLOYMENT_MODE=consumer /tmp/flexprice-local
 ```
 
-> **Local Kafka broker port:** The docker-compose Kafka advertises on `kafka:9092` internally and `localhost:29092` externally. Always use `localhost:29092` from the host machine.
-
----
-
-## Step 8: Set Up a Test API Key
-
-API key validation works in two modes: config-based (fast, no DB) or DB-based (via secrets table). For local testing, use **config-based** by injecting the SHA-256 hash of your test key.
-
-**Compute the hash of any key you want to use:**
+Or run everything in a single process (API + consumer + worker):
 ```bash
-echo -n "your-test-api-key" | sha256sum
-# e.g. sk_01KM416QMD5N07GPKRR3QXQYFB → 155f941ce338505f9e9fa1ed85776da0433b2e16f47ae26a016049984437c632
+FLEXPRICE_DEPLOYMENT_MODE=local /tmp/flexprice-local
 ```
 
-**Build the JSON config and export it:**
-```bash
-API_KEY_HASH="155f941ce338505f9e9fa1ed85776da0433b2e16f47ae26a016049984437c632"
-export FLEXPRICE_AUTH_API_KEY_KEYS="{\"${API_KEY_HASH}\":{\"tenant_id\":\"00000000-0000-0000-0000-000000000000\",\"user_id\":\"test-user\",\"name\":\"local-test-key\",\"is_active\":true}}"
-export FLEXPRICE_AUTH_API_KEY_HEADER="x-api-key"
-```
-
-> The `tenant_id` `00000000-0000-0000-0000-000000000000` and environment `00000000-0000-0000-0000-000000000000` are the default seed records that migrations create. Use these for local testing.
-
----
-
-## Step 9: Run API Server (Terminal 1)
+### 6. Verify
 
 ```bash
-# (with all the env vars above already exported)
-FLEXPRICE_DEPLOYMENT_MODE=api \
-FLEXPRICE_SERVER_ADDRESS=":8081" \
-/tmp/flexprice-local
-```
-
-> **Port conflict:** Port `8080` may already be in use (another local server). Use `:8081` or any free port.
-
-**Verify:**
-```bash
-curl -s http://localhost:8081/health
+# Health check
+curl http://localhost:8080/health
 # → {"status":"ok"}
-```
 
----
-
-## Step 10: Run Consumer (Terminal 2)
-
-```bash
-# (with all the env vars above already exported)
-FLEXPRICE_DEPLOYMENT_MODE=consumer \
-/tmp/flexprice-local
-```
-
-**Verify raw event consumer is active:**
-```bash
-grep "raw_event_consumption_handler\|Subscribing to Kafka topic.*raw" /tmp/consumer.log
-# Should show:
-# Adding handler  handler_name=raw_event_consumption_handler topic=raw_events
-# Subscribing to Kafka topic ... topic=raw_events
-```
-
----
-
-## Step 11: Authenticate API Calls
-
-All private API calls need:
-- `x-api-key: <your-test-key>` header
-- `x-environment-id: 00000000-0000-0000-0000-000000000000` header
-
-```bash
-curl -s http://localhost:8081/v1/meters \
-  -H "x-api-key: sk_01KM416QMD5N07GPKRR3QXQYFB" \
+# Auth check
+curl http://localhost:8080/v1/meters \
+  -H "x-api-key: sk_local_flexprice_test_key" \
   -H "x-environment-id: 00000000-0000-0000-0000-000000000000"
+# → {"items":[],"pagination":{...}}
 ```
 
 ---
 
-## Useful Local DB Access
+## How `.env.local` Works
+
+`config.go` loads env files in this order (later wins):
+
+```
+.env          ← production/shared defaults (gitignored, contains real secrets)
+.env.local    ← local overrides (committed, safe — no real secrets)
+```
+
+`.env.local` overrides all infra endpoints to local Docker, disables Supabase/Sentry/email/DynamoDB, and wires the pre-configured API key. You never need to manually export env vars.
+
+---
+
+## End-to-End Test Example
 
 ```bash
-# PostgreSQL
+BASE="http://localhost:8080/v1"
+KEY="sk_local_flexprice_test_key"
+ENV_HDR="x-environment-id: 00000000-0000-0000-0000-000000000000"
+
+# 1. Create a customer
+curl -s -X POST $BASE/customers \
+  -H "x-api-key: $KEY" -H "$ENV_HDR" -H "Content-Type: application/json" \
+  -d '{"external_id": "org_test_001", "name": "Test Org"}'
+
+# 2. Configure event ingestion filter
+curl -s -X PUT $BASE/settings/event_ingestion_filter \
+  -H "x-api-key: $KEY" -H "$ENV_HDR" -H "Content-Type: application/json" \
+  -d '{"value": {"enabled": true, "allowed_external_customer_ids": ["org_test_001"]}}'
+
+# 3. Ingest raw events (Bento format → raw_events Kafka topic)
+curl -s -X POST $BASE/events/raw/bulk \
+  -H "x-api-key: $KEY" -H "$ENV_HDR" -H "Content-Type: application/json" \
+  -d '{
+    "events": [
+      {"id":"evt-001","orgId":"org_test_001","methodName":"api_call","providerName":"openai","createdAt":"2026-01-01T00:00:00Z","data":{}},
+      {"id":"evt-002","orgId":"org_blocked_001","methodName":"api_call","providerName":"openai","createdAt":"2026-01-01T00:00:00Z","data":{}}
+    ]
+  }'
+# → {"batch_size":2,"message":"Raw events accepted for processing"}
+# Consumer will process: success_count=1, skip_count=1
+
+# 4. Verify in ClickHouse — only the allowed org's event should appear
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice \
+  --query="SELECT id, external_customer_id, event_name FROM events ORDER BY timestamp DESC LIMIT 5 FORMAT PrettyCompact"
+```
+
+---
+
+## Useful Commands
+
+```bash
+# PostgreSQL shell
 docker compose exec postgres psql -U flexprice -d flexprice
 
-# ClickHouse
+# ClickHouse shell
 docker compose exec clickhouse clickhouse-client \
   --user=flexprice --password=flexprice123 --database=flexprice
 
-# Check events in ClickHouse
-docker compose exec clickhouse clickhouse-client \
-  --user=flexprice --password=flexprice123 --database=flexprice \
-  --query="SELECT id, external_customer_id, event_name FROM events ORDER BY timestamp DESC LIMIT 10 FORMAT PrettyCompact"
+# Watch consumer logs (filter to signal lines)
+tail -f /tmp/consumer.log | grep -E "processing|completed|filter|error"
 
-# Check raw_events in ClickHouse
-docker compose exec clickhouse clickhouse-client \
-  --user=flexprice --password=flexprice123 --database=flexprice \
-  --query="SELECT count() FROM raw_events"
+# Stop everything
+pkill -f flexprice-local
+docker compose down
 ```
 
 ---
 
-## Shutdown
+## Local Infrastructure Reference
+
+| Service | Host:Port | User | Password | DB |
+|---------|-----------|------|----------|----|
+| PostgreSQL | `localhost:5432` | `flexprice` | `flexprice123` | `flexprice` |
+| ClickHouse | `localhost:9000` | `flexprice` | `flexprice123` | `flexprice` |
+| Kafka | `localhost:29092` | — | — | — |
+
+| Entity | ID |
+|--------|----|
+| Default Tenant | `00000000-0000-0000-0000-000000000000` |
+| Sandbox Environment | `00000000-0000-0000-0000-000000000000` |
+| Production Environment | `00000000-0000-0000-0000-000000000001` |
+
+---
+
+## Adding a New Local API Key
 
 ```bash
-# Kill the Go processes
-pkill -f "flexprice-local"
+# 1. Pick any key string and compute its SHA-256
+echo -n "sk_my_new_key" | sha256sum | awk '{print $1}'
 
-# Stop all Docker services
-docker compose down
+# 2. Add to FLEXPRICE_AUTH_API_KEY_KEYS in .env.local:
+# {"<hash>": {"tenant_id": "00000000-...", "user_id": "dev", "name": "my-key", "is_active": true}}
 ```
 
 ---
@@ -261,27 +209,9 @@ docker compose down
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
-| `listen tcp :8080: address already in use` | Another server on port 8080 | Use `FLEXPRICE_SERVER_ADDRESS=":8081"` |
-| `make migrate-ent` runs against production | Makefile loads `.env` first | Use `go run ./cmd/migrate/main.go` with explicit env overrides |
-| Consumer errors: `topic does not exist` | Not all topics created | Run the full topic creation block in Step 4 |
-| `{"error":"Unauthorized"}` on every request | API key not wired into config | Set `FLEXPRICE_AUTH_API_KEY_KEYS` JSON (Step 8) |
-| Settings lookup returns "not found" | Wrong tenant/env in context | Always pass `x-environment-id` header; check that env vars have the right tenant/env |
-| ClickHouse `raw_events` table is empty | The consumer doesn't write there directly | Raw events are stored in ClickHouse `raw_events` by the Bento collector; the Go consumer reads from Kafka `raw_events` topic and writes transformed events to ClickHouse `events` table |
-| Consumer log flooded with `balance_alert` errors | Topic not created | Create it: `kafka-topics --create --topic balance_alert ...` |
-| `go build` fails on `api/custom/go/...` | Generated SDK has broken dep | Use `go build ./internal/... ./cmd/...` instead of `./...` |
-
----
-
-## Local Credentials Reference
-
-| Service | Host | Port | User | Password | DB |
-|---------|------|------|------|----------|----|
-| PostgreSQL | localhost | 5432 | flexprice | flexprice123 | flexprice |
-| ClickHouse | localhost | 9000 | flexprice | flexprice123 | flexprice |
-| Kafka (external) | localhost | 29092 | — | — | — |
-| Kafka (internal) | kafka | 9092 | — | — | — |
-
-Default seed data:
-- Tenant ID: `00000000-0000-0000-0000-000000000000`
-- Environment ID (Sandbox): `00000000-0000-0000-0000-000000000000`
-- Environment ID (Production): `00000000-0000-0000-0000-000000000001`
+| `make migrate-ent` hits production | Makefile loads `.env` before overrides | Use `go run ./cmd/migrate/main.go` with explicit env vars (Step 4) |
+| `listen tcp :8080: address already in use` | Another process on 8080 | `lsof -ti:8080 | xargs kill` or use `FLEXPRICE_SERVER_ADDRESS=":8081"` |
+| Consumer: `topic does not exist` errors | Topic not created yet | Run the topic creation loop in Step 3 |
+| `{"error":"Unauthorized"}` | API key not matching | Use `sk_local_flexprice_test_key` — it's pre-wired in `.env.local` |
+| ClickHouse `raw_events` table empty | Consumer doesn't write there | The consumer writes to ClickHouse `events`, not `raw_events` (Bento writes raw_events directly) |
+| Settings lookup fails with "not found" | Missing `x-environment-id` header | Always include `-H "x-environment-id: 00000000-0000-0000-0000-000000000000"` |

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,35 @@ run-server-local: run-server
 .PHONY: run
 run: run-server
 
+# ---------------------------------------------------------------------------
+# Local development targets — load .env.local on top of .env so local Docker
+# infra overrides take effect without touching production config.
+# ---------------------------------------------------------------------------
+
+# Run API server locally (loads .env then .env.local)
+.PHONY: run-local-api
+run-local-api:
+	@set -a && [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
+	FLEXPRICE_DEPLOYMENT_MODE=api go run cmd/server/main.go
+
+# Run Kafka consumer locally (loads .env then .env.local)
+.PHONY: run-local-consumer
+run-local-consumer:
+	@set -a && [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
+	FLEXPRICE_DEPLOYMENT_MODE=consumer go run cmd/server/main.go
+
+# Run all services in a single process locally (loads .env then .env.local)
+.PHONY: run-local
+run-local:
+	@set -a && [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
+	FLEXPRICE_DEPLOYMENT_MODE=local go run cmd/server/main.go
+
+# Run Ent schema migrations against local Docker postgres
+.PHONY: migrate-local
+migrate-local:
+	@set -a && [ -f .env.local ] && . ./.env.local; set +a; \
+	go run cmd/migrate/main.go
+
 .PHONY: test test-verbose test-coverage
 
 # Run all tests

--- a/SANITY_CHECK.md
+++ b/SANITY_CHECK.md
@@ -1,0 +1,247 @@
+# Local Sanity Check
+
+Run this before every PR to catch regressions early.
+Follow [`LOCAL_TESTING.md`](LOCAL_TESTING.md) first to get the server running.
+
+All commands assume:
+```bash
+BASE="http://localhost:8080/v1"
+KEY="sk_local_flexprice_test_key"
+ENV="-H 'x-environment-id: 00000000-0000-0000-0000-000000000000'"
+AUTH="-H 'x-api-key: sk_local_flexprice_test_key' -H 'x-environment-id: 00000000-0000-0000-0000-000000000000'"
+```
+
+---
+
+## 0. Health
+
+```bash
+curl -s http://localhost:8080/health
+# ✅ {"status":"ok"}
+```
+
+---
+
+## 1. Customer
+
+```bash
+# Create
+CUSTOMER=$(curl -s -X POST $BASE/customers \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{"external_id": "sanity-customer-001", "name": "Sanity Test Customer", "email": "sanity@test.local"}')
+echo $CUSTOMER | python3 -m json.tool
+CUSTOMER_ID=$(echo $CUSTOMER | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "Customer ID: $CUSTOMER_ID"
+# ✅ customer created with id, tenant_id, environment_id populated
+
+# Fetch by external ID
+curl -s "$BASE/customers/external/sanity-customer-001" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  | python3 -m json.tool
+# ✅ returns same customer
+```
+
+---
+
+## 2. Meter
+
+```bash
+METER=$(curl -s -X POST $BASE/meters \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "API Calls",
+    "event_name": "api_call",
+    "aggregation": {"type": "COUNT"},
+    "filters": []
+  }')
+echo $METER | python3 -m json.tool
+METER_ID=$(echo $METER | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "Meter ID: $METER_ID"
+# ✅ meter created with id
+```
+
+---
+
+## 3. Plan + Price
+
+```bash
+# Create plan
+PLAN=$(curl -s -X POST $BASE/plans \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Sanity Plan", "description": "Local sanity test plan"}')
+echo $PLAN | python3 -m json.tool
+PLAN_ID=$(echo $PLAN | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "Plan ID: $PLAN_ID"
+
+# Create price on the plan
+PRICE=$(curl -s -X POST $BASE/prices \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"plan_id\": \"$PLAN_ID\",
+    \"currency\": \"USD\",
+    \"amount\": \"0.001\",
+    \"type\": \"usage\",
+    \"billing_period\": \"monthly\",
+    \"billing_period_count\": 1,
+    \"billing_cadence\": \"recurring\",
+    \"billing_model\": \"per_unit\",
+    \"meter_id\": \"$METER_ID\"
+  }")
+echo $PRICE | python3 -m json.tool
+PRICE_ID=$(echo $PRICE | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "Price ID: $PRICE_ID"
+# ✅ price created, linked to plan and meter
+```
+
+---
+
+## 4. Subscription
+
+```bash
+SUBSCRIPTION=$(curl -s -X POST $BASE/subscriptions \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"customer_id\": \"$CUSTOMER_ID\",
+    \"plan_id\": \"$PLAN_ID\",
+    \"currency\": \"USD\",
+    \"start_date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+  }")
+echo $SUBSCRIPTION | python3 -m json.tool
+SUB_ID=$(echo $SUBSCRIPTION | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+echo "Subscription ID: $SUB_ID"
+# ✅ subscription created with status active/draft
+```
+
+---
+
+## 5. Event Ingestion (standard path)
+
+```bash
+# Single event
+curl -s -X POST $BASE/events \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"event_name\": \"api_call\",
+    \"external_customer_id\": \"sanity-customer-001\",
+    \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+    \"properties\": {\"endpoint\": \"/v1/test\"}
+  }"
+# ✅ {"message":"Event accepted for processing","event_id":"..."}
+
+sleep 2
+
+# Verify event landed in ClickHouse
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice \
+  --query="SELECT id, external_customer_id, event_name FROM events WHERE external_customer_id='sanity-customer-001' ORDER BY timestamp DESC LIMIT 3 FORMAT PrettyCompact"
+# ✅ row visible
+```
+
+---
+
+## 6. Usage Query
+
+```bash
+curl -s -X POST "$BASE/events/usage/meter" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"meter_id\": \"$METER_ID\",
+    \"external_customer_id\": \"sanity-customer-001\",
+    \"start_time\": \"$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)\",
+    \"end_time\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+  }" | python3 -m json.tool
+# ✅ value >= 1 (the event we just ingested)
+```
+
+---
+
+## 7. Raw Event Ingestion + Filter (VAPI flow)
+
+```bash
+# 7a. No filter — all events forwarded
+curl -s -X POST "$BASE/events/raw/bulk" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "events": [
+      {"id":"sanity-raw-001","orgId":"sanity-customer-001","methodName":"synthesizer","providerName":"deepgram","createdAt":"2026-01-01T00:00:00Z","data":{"durationMS":1000},"dataInterface":"DURATION_DATA","referenceType":"call","targetItemId":"ref-001","targetItemType":"call"},
+      {"id":"sanity-raw-002","orgId":"blocked-org-999","methodName":"synthesizer","providerName":"deepgram","createdAt":"2026-01-01T00:00:01Z","data":{"durationMS":500},"dataInterface":"DURATION_DATA","referenceType":"call","targetItemId":"ref-002","targetItemType":"call"}
+    ]
+  }'
+# ✅ {"batch_size":2,"message":"Raw events accepted for processing"}
+
+sleep 2
+# Consumer log should show: success_count=2, skip_count=0
+
+# 7b. Enable filter — only sanity-customer-001 allowed
+curl -s -X PUT "$BASE/settings/event_ingestion_filter" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{"value": {"enabled": true, "allowed_external_customer_ids": ["sanity-customer-001"]}}'
+# ✅ setting saved
+
+# Re-send same batch — should filter blocked-org-999
+curl -s -X POST "$BASE/events/raw/bulk" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "events": [
+      {"id":"sanity-raw-003","orgId":"sanity-customer-001","methodName":"synthesizer","providerName":"deepgram","createdAt":"2026-01-01T00:01:00Z","data":{"durationMS":1000},"dataInterface":"DURATION_DATA","referenceType":"call","targetItemId":"ref-003","targetItemType":"call"},
+      {"id":"sanity-raw-004","orgId":"blocked-org-999","methodName":"synthesizer","providerName":"deepgram","createdAt":"2026-01-01T00:01:01Z","data":{"durationMS":500},"dataInterface":"DURATION_DATA","referenceType":"call","targetItemId":"ref-004","targetItemType":"call"}
+    ]
+  }'
+
+sleep 2
+# ✅ Consumer log: success_count=1, skip_count=1
+
+# Verify only allowed IDs in ClickHouse
+docker compose exec clickhouse clickhouse-client \
+  --user=flexprice --password=flexprice123 --database=flexprice \
+  --query="SELECT id, external_customer_id FROM events WHERE id IN ('sanity-raw-003','sanity-raw-004') FORMAT PrettyCompact"
+# ✅ only sanity-raw-003 appears; sanity-raw-004 (blocked) is absent
+
+# 7c. Disable filter (clean up)
+curl -s -X PUT "$BASE/settings/event_ingestion_filter" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  -H "Content-Type: application/json" \
+  -d '{"value": {"enabled": false, "allowed_external_customer_ids": []}}'
+```
+
+---
+
+## 8. Settings Round-trip
+
+```bash
+# GET
+curl -s "$BASE/settings/event_ingestion_filter" \
+  -H "x-api-key: $KEY" -H "x-environment-id: 00000000-0000-0000-0000-000000000000" \
+  | python3 -m json.tool
+# ✅ enabled: false (from step 7c cleanup)
+```
+
+---
+
+## Checklist
+
+Copy this into your PR description or review notes:
+
+```
+- [ ] 0. Health check passes
+- [ ] 1. Customer create + fetch
+- [ ] 2. Meter create
+- [ ] 3. Plan + price create
+- [ ] 4. Subscription create
+- [ ] 5. Event ingested → visible in ClickHouse
+- [ ] 6. Usage query returns correct count
+- [ ] 7. Raw bulk ingest — no filter (success_count=2)
+- [ ] 7. Raw bulk ingest — filter enabled (success_count=1, skip_count=1)
+- [ ] 7. ClickHouse confirms only allowed event present
+- [ ] 8. Settings GET round-trip correct
+```

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -332,6 +332,7 @@ func provideHandlers(
 	subscriptionScheduleService service.SubscriptionScheduleService,
 	featureUsageTrackingService service.FeatureUsageTrackingService,
 	rawEventsReprocessingService service.RawEventsReprocessingService,
+	rawEventConsumptionService service.RawEventConsumptionService,
 	alertLogsService service.AlertLogsService,
 	groupService service.GroupService,
 	integrationFactory *integration.Factory,
@@ -345,7 +346,7 @@ func provideHandlers(
 	workflowService service.WorkflowService,
 ) api.Handlers {
 	return api.Handlers{
-		Events:                   v1.NewEventsHandler(eventService, eventPostProcessingService, featureUsageTrackingService, rawEventsReprocessingService, cfg, logger),
+		Events:                   v1.NewEventsHandler(eventService, eventPostProcessingService, featureUsageTrackingService, rawEventsReprocessingService, rawEventConsumptionService, cfg, logger),
 		Meter:                    v1.NewMeterHandler(meterService, logger),
 		Auth:                     v1.NewAuthHandler(cfg, authService, logger),
 		User:                     v1.NewUserHandler(userService, logger),

--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"context"
+	"encoding/json"
 	"slices"
 	"strings"
 	"time"
@@ -42,6 +43,27 @@ type BulkIngestEventRequest struct {
 
 func (r *BulkIngestEventRequest) Validate() error {
 	return validator.ValidateRequest(r)
+}
+
+// BulkIngestRawEventRequest is the request body for POST /v1/events/raw/bulk.
+// Each element in Events is a raw Bento-format event JSON object — the same
+// format that the Bento collector writes to the raw_events Kafka topic.
+type BulkIngestRawEventRequest struct {
+	Events []json.RawMessage `json:"events" validate:"required,min=1,max=1000"`
+}
+
+func (r *BulkIngestRawEventRequest) Validate() error {
+	if len(r.Events) == 0 {
+		return ierr.NewError("events is required").
+			WithHint("Provide at least one raw event").
+			Mark(ierr.ErrValidation)
+	}
+	if len(r.Events) > 1000 {
+		return ierr.NewError("too many events").
+			WithHint("Maximum 1000 events per batch").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
 }
 
 func (r *IngestEventRequest) ToEvent(ctx context.Context) *events.Event {

--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"slices"
@@ -62,6 +63,15 @@ func (r *BulkIngestRawEventRequest) Validate() error {
 		return ierr.NewError("too many events").
 			WithHint("Maximum 1000 events per batch").
 			Mark(ierr.ErrValidation)
+	}
+	// Ensure every element is a JSON object — reject nulls, arrays, strings, etc.
+	for i, raw := range r.Events {
+		trimmed := bytes.TrimSpace(raw)
+		if len(trimmed) == 0 || trimmed[0] != '{' {
+			return ierr.NewErrorf("events[%d] is not a JSON object", i).
+				WithHint("Each event must be a JSON object {}").
+				Mark(ierr.ErrValidation)
+		}
 	}
 	return nil
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -156,6 +156,8 @@ func NewRouter(handlers Handlers, cfg *config.Configuration, logger *logger.Logg
 			events.POST("/benchmark/v2", handlers.Events.BenchmarkV2)
 			// Reprocess events endpoint
 			events.POST("/reprocess", handlers.Events.ReprocessEvents)
+			// Raw event ingestion (Bento-format, publishes directly to raw_events topic)
+			events.POST("/raw/bulk", permissionMW.RequirePermission("event", "write"), handlers.Events.BulkIngestRawEvent)
 			// Reprocess raw events endpoints
 			events.POST("/raw/reprocess/all", handlers.Events.ReprocessRawEvents)
 			events.POST("/raw/reprocess/pending", handlers.Events.ReprocessUnprocessedRawEvents)

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -22,16 +22,18 @@ type EventsHandler struct {
 	eventPostProcessingService   service.EventPostProcessingService
 	featureUsageTrackingService  service.FeatureUsageTrackingService
 	rawEventsReprocessingService service.RawEventsReprocessingService
+	rawEventConsumptionService   service.RawEventConsumptionService
 	config                       *config.Configuration
 	log                          *logger.Logger
 }
 
-func NewEventsHandler(eventService service.EventService, eventPostProcessingService service.EventPostProcessingService, featureUsageTrackingService service.FeatureUsageTrackingService, rawEventsReprocessingService service.RawEventsReprocessingService, config *config.Configuration, log *logger.Logger) *EventsHandler {
+func NewEventsHandler(eventService service.EventService, eventPostProcessingService service.EventPostProcessingService, featureUsageTrackingService service.FeatureUsageTrackingService, rawEventsReprocessingService service.RawEventsReprocessingService, rawEventConsumptionService service.RawEventConsumptionService, config *config.Configuration, log *logger.Logger) *EventsHandler {
 	return &EventsHandler{
 		eventService:                 eventService,
 		eventPostProcessingService:   eventPostProcessingService,
 		featureUsageTrackingService:  featureUsageTrackingService,
 		rawEventsReprocessingService: rawEventsReprocessingService,
+		rawEventConsumptionService:   rawEventConsumptionService,
 		config:                       config,
 		log:                          log,
 	}
@@ -106,6 +108,46 @@ func (h *EventsHandler) BulkIngestEvent(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusAccepted, gin.H{"message": "Events accepted for processing"})
+}
+
+// @Summary Bulk ingest raw events
+// @ID ingestRawEventsBulk
+// @Description Publishes a batch of raw Bento-format event payloads directly to the raw_events Kafka topic. The raw-event consumer processes them identically to events produced by the Bento collector — useful for testing, backfills, and retrying filtered events.
+// @Tags Events
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param request body dto.BulkIngestRawEventRequest true "Raw event batch"
+// @Success 202 {object} map[string]interface{} "message:Raw events accepted for processing"
+// @Failure 400 {object} ierr.ErrorResponse "Invalid request"
+// @Failure 500 {object} ierr.ErrorResponse "Server error"
+// @Router /events/raw/bulk [post]
+func (h *EventsHandler) BulkIngestRawEvent(c *gin.Context) {
+	ctx := c.Request.Context()
+	var req dto.BulkIngestRawEventRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.log.Error("Failed to bind JSON", "error", err)
+		c.Error(ierr.WithError(err).
+			WithHint("Invalid request payload").
+			Mark(ierr.ErrValidation))
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		c.Error(err)
+		return
+	}
+
+	if err := h.rawEventConsumptionService.BulkIngestRawEvents(ctx, req.Events); err != nil {
+		h.log.Error("Failed to bulk ingest raw events", "error", err)
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"message":    "Raw events accepted for processing",
+		"batch_size": len(req.Events),
+	})
 }
 
 // @Summary Get usage by meter

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -110,18 +110,9 @@ func (h *EventsHandler) BulkIngestEvent(c *gin.Context) {
 	c.JSON(http.StatusAccepted, gin.H{"message": "Events accepted for processing"})
 }
 
-// @Summary Bulk ingest raw events
-// @ID ingestRawEventsBulk
-// @Description Publishes a batch of raw Bento-format event payloads directly to the raw_events Kafka topic. The raw-event consumer processes them identically to events produced by the Bento collector — useful for testing, backfills, and retrying filtered events.
-// @Tags Events
-// @Accept json
-// @Produce json
-// @Security ApiKeyAuth
-// @Param request body dto.BulkIngestRawEventRequest true "Raw event batch"
-// @Success 202 {object} map[string]interface{} "message:Raw events accepted for processing"
-// @Failure 400 {object} ierr.ErrorResponse "Invalid request"
-// @Failure 500 {object} ierr.ErrorResponse "Server error"
-// @Router /events/raw/bulk [post]
+// BulkIngestRawEvent publishes a batch of raw Bento-format event payloads directly to the
+// raw_events Kafka topic (POST /v1/events/raw/bulk). Intentionally excluded from Swagger/SDK
+// — this is an internal endpoint for testing and backfills, not part of the public API.
 func (h *EventsHandler) BulkIngestRawEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.BulkIngestRawEventRequest

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -348,11 +348,8 @@ type RedisConfig struct {
 func NewConfig() (*Configuration, error) {
 	v := viper.New()
 
-	// Step 1: Load env files in order of increasing precedence.
-	// `.env` holds shared/production defaults; `.env.local` overrides them
-	// for local development without modifying tracked files.
+	// Step 1: Load `.env` if it exists
 	_ = godotenv.Load()
-	_ = godotenv.Overload(".env.local")
 
 	// Step 2: Initialize Viper
 	v.SetConfigName("config")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -348,8 +348,11 @@ type RedisConfig struct {
 func NewConfig() (*Configuration, error) {
 	v := viper.New()
 
-	// Step 1: Load `.env` if it exists
+	// Step 1: Load env files in order of increasing precedence.
+	// `.env` holds shared/production defaults; `.env.local` overrides them
+	// for local development without modifying tracked files.
 	_ = godotenv.Load()
+	_ = godotenv.Overload(".env.local")
 
 	// Step 2: Initialize Viper
 	v.SetConfigName("config")

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -23,8 +23,13 @@ import (
 
 // RawEventConsumptionService handles consuming raw event batches from Kafka and transforming them
 type RawEventConsumptionService interface {
-	// Register message handler with the router
+	// RegisterHandler registers the message handler with the router (consumer side)
 	RegisterHandler(router *pubsubRouter.Router, cfg *config.Configuration)
+
+	// BulkIngestRawEvents publishes a batch of raw Bento-format event payloads directly
+	// to the raw_events Kafka topic. The consumer (processMessage) will pick them up
+	// exactly as it would if Bento had written them.
+	BulkIngestRawEvents(ctx context.Context, events []json.RawMessage) error
 }
 
 type rawEventConsumptionService struct {
@@ -289,6 +294,43 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		return fmt.Errorf("failed to process %d events in batch, retrying entire batch", errorCount)
 	}
 
+	return nil
+}
+
+// BulkIngestRawEvents publishes a batch of raw Bento-format event payloads to the
+// raw_events Kafka topic. The consumer picks them up in the same format as events
+// produced by the Bento collector — there is no difference from the consumer's perspective.
+func (s *rawEventConsumptionService) BulkIngestRawEvents(ctx context.Context, events []json.RawMessage) error {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	batch := RawEventBatch{
+		Data:          events,
+		TenantID:      tenantID,
+		EnvironmentID: environmentID,
+	}
+
+	payload, err := json.Marshal(batch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal raw event batch: %w", err)
+	}
+
+	uniqueID := fmt.Sprintf("%s-%d-%d", types.GenerateUUID(), time.Now().UnixNano(), rand.Int63())
+	msg := message.NewMessage(uniqueID, payload)
+	msg.Metadata.Set("tenant_id", tenantID)
+	msg.Metadata.Set("environment_id", environmentID)
+
+	topic := s.Config.RawEventConsumption.Topic
+	if err := s.pubSub.Publish(ctx, topic, msg); err != nil {
+		return fmt.Errorf("failed to publish raw event batch: %w", err)
+	}
+
+	s.Logger.Infow("published raw event batch to kafka",
+		"batch_size", len(events),
+		"tenant_id", tenantID,
+		"environment_id", environmentID,
+		"topic", topic,
+	)
 	return nil
 }
 

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -139,16 +139,11 @@ func (s *rawEventConsumptionService) loadIngestionFilter(ctx context.Context) (e
 
 // processMessage processes a batch of raw events from Kafka
 func (s *rawEventConsumptionService) processMessage(msg *message.Message) error {
-	ctx := context.Background()
-
 	s.Logger.Debugw("processing raw event batch from message queue",
 		"message_uuid", msg.UUID,
 	)
 
-	// Fetch the ingestion filter once per batch (one DB read per Kafka message).
-	filterEnabled, allowlist := s.loadIngestionFilter(ctx)
-
-	// Unmarshal the batch
+	// Unmarshal the batch first so we have tenant/environment IDs.
 	var batch RawEventBatch
 	if err := json.Unmarshal(msg.Payload, &batch); err != nil {
 		s.Logger.Errorw("failed to unmarshal raw event batch",
@@ -186,6 +181,13 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 			return "config"
 		}(),
 	)
+
+	// Build a context carrying tenant/environment so the settings repo can filter correctly.
+	ctx := types.SetTenantID(context.Background(), tenantID)
+	ctx = types.SetEnvironmentID(ctx, environmentID)
+
+	// Fetch the ingestion filter once per batch (one DB read per Kafka message).
+	filterEnabled, allowlist := s.loadIngestionFilter(ctx)
 
 	// Counters for tracking
 	successCount := 0

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -107,23 +107,31 @@ func (s *rawEventConsumptionService) RegisterHandler(
 }
 
 // loadIngestionFilter fetches the EventIngestionFilterConfig from the settings DB
-// and returns a ready-to-use allowlist map. When the setting is absent or the filter
-// is disabled it returns (false, nil) so the caller skips filtering entirely.
-func (s *rawEventConsumptionService) loadIngestionFilter(ctx context.Context) (enabled bool, allowlist map[string]struct{}) {
+// and returns a ready-to-use allowlist map.
+//
+// Error handling:
+//   - Setting absent (ErrNotFound) → filter disabled, returns (false, nil, nil)
+//   - Any other repo error → returns the error so the caller can fail the batch and retry
+//   - Parsing failure → same: error is returned for retry
+//   - Setting present but enabled=false → returns (false, nil, nil)
+func (s *rawEventConsumptionService) loadIngestionFilter(ctx context.Context) (enabled bool, allowlist map[string]struct{}, err error) {
 	setting, err := s.SettingsRepo.GetByKey(ctx, types.SettingKeyEventIngestionFilter)
 	if err != nil {
-		// Setting not configured → filter disabled, pass everything through
-		return false, nil
+		if ierr.IsNotFound(err) {
+			// Setting not configured is expected — filter simply disabled.
+			return false, nil, nil
+		}
+		// Transient DB or other operational error — bubble up so the batch retries.
+		return false, nil, fmt.Errorf("failed to load event ingestion filter setting: %w", err)
 	}
 
 	cfg, err := utils.ToStruct[types.EventIngestionFilterConfig](setting.Value)
 	if err != nil {
-		s.Logger.Errorw("failed to parse event ingestion filter config, filter disabled", "error", err)
-		return false, nil
+		return false, nil, fmt.Errorf("failed to parse event ingestion filter config: %w", err)
 	}
 
 	if !cfg.Enabled {
-		return false, nil
+		return false, nil, nil
 	}
 
 	allowlist = make(map[string]struct{}, len(cfg.AllowedExternalCustomerIDs))
@@ -134,7 +142,7 @@ func (s *rawEventConsumptionService) loadIngestionFilter(ctx context.Context) (e
 	s.Logger.Infow("event ingestion filter loaded",
 		"allowlist_size", len(allowlist),
 	)
-	return true, allowlist
+	return true, allowlist, nil
 }
 
 // processMessage processes a batch of raw events from Kafka
@@ -182,12 +190,22 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		}(),
 	)
 
-	// Build a context carrying tenant/environment so the settings repo can filter correctly.
-	ctx := types.SetTenantID(context.Background(), tenantID)
+	// Build a context from the message's own context so cancellation/tracing propagates,
+	// then attach tenant and environment IDs so the settings repo can scope its query.
+	ctx := types.SetTenantID(msg.Context(), tenantID)
 	ctx = types.SetEnvironmentID(ctx, environmentID)
 
 	// Fetch the ingestion filter once per batch (one DB read per Kafka message).
-	filterEnabled, allowlist := s.loadIngestionFilter(ctx)
+	// On a real settings-store error (not ErrNotFound) we fail the batch so Kafka retries it.
+	filterEnabled, allowlist, err := s.loadIngestionFilter(ctx)
+	if err != nil {
+		s.Logger.Errorw("failed to load ingestion filter, failing batch for retry",
+			"tenant_id", tenantID,
+			"environment_id", environmentID,
+			"error", err,
+		)
+		return fmt.Errorf("ingestion filter load error: %w", err)
+	}
 
 	// Counters for tracking
 	successCount := 0

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -251,7 +251,6 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 			if _, ok := allowlist[transformedEvent.ExternalCustomerID]; !ok {
 				skipCount++
 				s.Logger.Debugw("event filtered by ingestion allowlist - skipped",
-					"external_customer_id", transformedEvent.ExternalCustomerID,
 					"batch_position", i+1,
 				)
 				continue
@@ -303,6 +302,10 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 func (s *rawEventConsumptionService) BulkIngestRawEvents(ctx context.Context, events []json.RawMessage) error {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
+
+	if tenantID == "" || environmentID == "" {
+		return fmt.Errorf("BulkIngestRawEvents: tenant_id and environment_id must be set in context (got tenant=%q env=%q)", tenantID, environmentID)
+	}
 
 	batch := RawEventBatch{
 		Data:          events,

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -17,6 +17,8 @@ import (
 	"github.com/flexprice/flexprice/internal/pubsub/kafka"
 	pubsubRouter "github.com/flexprice/flexprice/internal/pubsub/router"
 	"github.com/flexprice/flexprice/internal/sentry"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/flexprice/flexprice/internal/utils"
 )
 
 // RawEventConsumptionService handles consuming raw event batches from Kafka and transforming them
@@ -104,11 +106,47 @@ func (s *rawEventConsumptionService) RegisterHandler(
 	)
 }
 
+// loadIngestionFilter fetches the EventIngestionFilterConfig from the settings DB
+// and returns a ready-to-use allowlist map. When the setting is absent or the filter
+// is disabled it returns (false, nil) so the caller skips filtering entirely.
+func (s *rawEventConsumptionService) loadIngestionFilter(ctx context.Context) (enabled bool, allowlist map[string]struct{}) {
+	setting, err := s.SettingsRepo.GetByKey(ctx, types.SettingKeyEventIngestionFilter)
+	if err != nil {
+		// Setting not configured → filter disabled, pass everything through
+		return false, nil
+	}
+
+	cfg, err := utils.ToStruct[types.EventIngestionFilterConfig](setting.Value)
+	if err != nil {
+		s.Logger.Errorw("failed to parse event ingestion filter config, filter disabled", "error", err)
+		return false, nil
+	}
+
+	if !cfg.Enabled {
+		return false, nil
+	}
+
+	allowlist = make(map[string]struct{}, len(cfg.AllowedExternalCustomerIDs))
+	for _, id := range cfg.AllowedExternalCustomerIDs {
+		allowlist[id] = struct{}{}
+	}
+
+	s.Logger.Infow("event ingestion filter loaded",
+		"allowlist_size", len(allowlist),
+	)
+	return true, allowlist
+}
+
 // processMessage processes a batch of raw events from Kafka
 func (s *rawEventConsumptionService) processMessage(msg *message.Message) error {
+	ctx := context.Background()
+
 	s.Logger.Debugw("processing raw event batch from message queue",
 		"message_uuid", msg.UUID,
 	)
+
+	// Fetch the ingestion filter once per batch (one DB read per Kafka message).
+	filterEnabled, allowlist := s.loadIngestionFilter(ctx)
 
 	// Unmarshal the batch
 	var batch RawEventBatch
@@ -182,8 +220,21 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 			continue
 		}
 
+		// Apply ingestion filter: skip events for customer IDs not in the allowlist.
+		// Raw event is still stored upstream; we only skip forwarding to the events topic.
+		if filterEnabled {
+			if _, ok := allowlist[transformedEvent.ExternalCustomerID]; !ok {
+				skipCount++
+				s.Logger.Debugw("event filtered by ingestion allowlist - skipped",
+					"external_customer_id", transformedEvent.ExternalCustomerID,
+					"batch_position", i+1,
+				)
+				continue
+			}
+		}
+
 		// Publish the transformed event to events topic
-		if err := s.publishTransformedEvent(context.Background(), transformedEvent); err != nil {
+		if err := s.publishTransformedEvent(ctx, transformedEvent); err != nil {
 			errorCount++
 			s.Logger.Errorw("failed to publish transformed event",
 				"event_id", transformedEvent.ID,

--- a/internal/service/raw_event_consumption_test.go
+++ b/internal/service/raw_event_consumption_test.go
@@ -2,24 +2,27 @@ package service
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	domainSettings "github.com/flexprice/flexprice/internal/domain/settings"
+	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/sentry"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 // ---------------------------------------------------------------------------
-// Suite setup
+// Suite
 // ---------------------------------------------------------------------------
 
 type RawEventConsumptionSuite struct {
 	testutil.BaseServiceTestSuite
-	svc         *rawEventConsumptionService
+	svc          *rawEventConsumptionService
 	outputPubSub *testutil.InMemoryPubSub
 	settingsRepo *testutil.InMemorySettingsStore
 }
@@ -46,10 +49,13 @@ func (s *RawEventConsumptionSuite) SetupTest() {
 		outputPubSub:  s.outputPubSub,
 		sentryService: sentry.NewSentryService(s.GetConfig(), s.GetLogger()),
 	}
+
+	// Default output topic
+	s.GetConfig().RawEventConsumption.OutputTopic = testOutputTopic
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Constants
 // ---------------------------------------------------------------------------
 
 const (
@@ -58,15 +64,13 @@ const (
 	testOutputTopic   = "events"
 )
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 // validBentoPayload returns a minimal valid Bento event JSON for the given orgID.
 func validBentoPayload(orgID, eventID string) string {
-	return `{
-		"orgId":"` + orgID + `",
-		"id":"` + eventID + `",
-		"methodName":"CHAT_COMPLETION",
-		"providerName":"openai",
-		"createdAt":"2024-01-15T10:00:00Z"
-	}`
+	return `{"orgId":"` + orgID + `","id":"` + eventID + `","methodName":"CHAT_COMPLETION","providerName":"openai","createdAt":"2024-01-15T10:00:00Z"}`
 }
 
 // buildBatchMsg serialises a RawEventBatch into a Watermill message.
@@ -76,14 +80,16 @@ func buildBatchMsg(batch RawEventBatch) *message.Message {
 }
 
 // makeFilterSetting stores an EventIngestionFilterConfig in the in-memory settings
-// repo under the test tenant+environment.
+// repo under the test tenant + environment. Fails the test immediately on any error.
 func (s *RawEventConsumptionSuite) makeFilterSetting(enabled bool, allowedIDs []string) {
-	value, _ := json.Marshal(types.EventIngestionFilterConfig{
+	value, err := json.Marshal(types.EventIngestionFilterConfig{
 		Enabled:                    enabled,
 		AllowedExternalCustomerIDs: allowedIDs,
 	})
+	require.NoError(s.T(), err, "marshal filter config")
+
 	var valueMap map[string]interface{}
-	_ = json.Unmarshal(value, &valueMap)
+	require.NoError(s.T(), json.Unmarshal(value, &valueMap), "unmarshal filter config to map")
 
 	setting := &domainSettings.Setting{
 		ID:            types.GenerateUUID(),
@@ -97,163 +103,188 @@ func (s *RawEventConsumptionSuite) makeFilterSetting(enabled bool, allowedIDs []
 	setting.UpdatedAt = time.Now()
 
 	ctx := testutil.SetupContext()
-	_ = s.settingsRepo.Create(ctx, setting)
+	require.NoError(s.T(), s.settingsRepo.Create(ctx, setting), "create filter setting")
 }
 
-// publishedCount returns how many messages landed on the output topic.
-func (s *RawEventConsumptionSuite) publishedCount() int {
-	return len(s.outputPubSub.GetMessages(testOutputTopic))
-}
-
-// configure the output topic on the embedded config
-func (s *RawEventConsumptionSuite) setOutputTopic(topic string) {
-	s.svc.Config.RawEventConsumption.OutputTopic = topic
+// publishedExternalIDs decodes all messages published to the output topic and
+// returns the sorted list of ExternalCustomerID values.
+func (s *RawEventConsumptionSuite) publishedExternalIDs() []string {
+	msgs := s.outputPubSub.GetMessages(testOutputTopic)
+	ids := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		var evt events.Event
+		if err := json.Unmarshal(m.Payload, &evt); err == nil {
+			ids = append(ids, evt.ExternalCustomerID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Table-driven filter tests
 // ---------------------------------------------------------------------------
 
-// TestFilterDisabled_AllEventsForwarded — setting absent, all events pass through.
-func (s *RawEventConsumptionSuite) TestFilterDisabled_AllEventsForwarded() {
-	s.setOutputTopic(testOutputTopic)
-
-	batch := RawEventBatch{
-		TenantID:      testTenantID,
-		EnvironmentID: testEnvironmentID,
-		Data: []json.RawMessage{
-			json.RawMessage(validBentoPayload("org_001", "evt_001")),
-			json.RawMessage(validBentoPayload("org_002", "evt_002")),
-			json.RawMessage(validBentoPayload("org_003", "evt_003")),
+func (s *RawEventConsumptionSuite) TestProcessMessage_FilterBehavior() {
+	tests := []struct {
+		name           string
+		setupFilter    func()
+		inputOrgIDs    []string // one event per org ID
+		wantForwarded  []string // sorted expected ExternalCustomerIDs that reach the output topic
+		wantErr        bool
+	}{
+		{
+			name:        "no filter setting → all events forwarded",
+			setupFilter: func() { /* no setting created */ },
+			inputOrgIDs: []string{"org_001", "org_002", "org_003"},
+			wantForwarded: []string{"org_001", "org_002", "org_003"},
+		},
+		{
+			name: "filter enabled=false → all events forwarded regardless of list",
+			setupFilter: func() {
+				s.makeFilterSetting(false, []string{"org_001"})
+			},
+			inputOrgIDs:   []string{"org_001", "org_999"},
+			wantForwarded: []string{"org_001", "org_999"},
+		},
+		{
+			name: "filter enabled → only allowlisted IDs forwarded",
+			setupFilter: func() {
+				s.makeFilterSetting(true, []string{"org_001", "org_002"})
+			},
+			inputOrgIDs:   []string{"org_001", "org_002", "org_003", "org_004"},
+			wantForwarded: []string{"org_001", "org_002"},
+		},
+		{
+			name: "filter enabled → no IDs match, nothing forwarded",
+			setupFilter: func() {
+				s.makeFilterSetting(true, []string{"org_allowed"})
+			},
+			inputOrgIDs:   []string{"org_not_in_list", "org_also_not"},
+			wantForwarded: []string{},
+		},
+		{
+			name: "filter enabled with empty allowlist → everything blocked",
+			setupFilter: func() {
+				s.makeFilterSetting(true, []string{})
+			},
+			inputOrgIDs:   []string{"org_001"},
+			wantForwarded: []string{},
 		},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
-	s.NoError(err)
-	s.Equal(3, s.publishedCount(), "all 3 events should be forwarded when filter is absent")
-}
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			// Reset state between sub-tests
+			s.settingsRepo.Clear()
+			s.outputPubSub.ClearMessages()
 
-// TestFilterEnabled_AllowlistedIDsForwarded — only IDs in the allowlist pass.
-func (s *RawEventConsumptionSuite) TestFilterEnabled_AllowlistedIDsForwarded() {
-	s.setOutputTopic(testOutputTopic)
-	s.makeFilterSetting(true, []string{"org_001", "org_002"})
+			tc.setupFilter()
 
-	batch := RawEventBatch{
-		TenantID:      testTenantID,
-		EnvironmentID: testEnvironmentID,
-		Data: []json.RawMessage{
-			json.RawMessage(validBentoPayload("org_001", "evt_001")), // allowed
-			json.RawMessage(validBentoPayload("org_002", "evt_002")), // allowed
-			json.RawMessage(validBentoPayload("org_003", "evt_003")), // filtered out
-			json.RawMessage(validBentoPayload("org_004", "evt_004")), // filtered out
-		},
+			data := make([]json.RawMessage, len(tc.inputOrgIDs))
+			for i, orgID := range tc.inputOrgIDs {
+				data[i] = json.RawMessage(validBentoPayload(orgID, "evt_"+orgID))
+			}
+
+			batch := RawEventBatch{
+				TenantID:      testTenantID,
+				EnvironmentID: testEnvironmentID,
+				Data:          data,
+			}
+
+			err := s.svc.processMessage(buildBatchMsg(batch))
+
+			if tc.wantErr {
+				s.Error(err)
+				return
+			}
+			s.NoError(err)
+
+			got := s.publishedExternalIDs()
+			wantSorted := append([]string{}, tc.wantForwarded...)
+			sort.Strings(wantSorted)
+
+			s.Equal(wantSorted, got,
+				"forwarded ExternalCustomerIDs should exactly match allowlist")
+		})
 	}
-
-	err := s.svc.processMessage(buildBatchMsg(batch))
-	s.NoError(err)
-	s.Equal(2, s.publishedCount(), "only org_001 and org_002 should be forwarded")
 }
 
-// TestFilterEnabled_NoAllowlistedIDs — filter is on but the batch has no matching IDs.
-func (s *RawEventConsumptionSuite) TestFilterEnabled_NoAllowlistedIDs() {
-	s.setOutputTopic(testOutputTopic)
-	s.makeFilterSetting(true, []string{"org_allowed"})
+// ---------------------------------------------------------------------------
+// Edge-case tests (kept separate as they need special setup)
+// ---------------------------------------------------------------------------
 
-	batch := RawEventBatch{
-		TenantID:      testTenantID,
-		EnvironmentID: testEnvironmentID,
-		Data: []json.RawMessage{
-			json.RawMessage(validBentoPayload("org_not_in_list", "evt_001")),
-			json.RawMessage(validBentoPayload("org_also_not",    "evt_002")),
-		},
-	}
-
-	err := s.svc.processMessage(buildBatchMsg(batch))
-	s.NoError(err)
-	s.Equal(0, s.publishedCount(), "no events should be forwarded when no IDs match")
-}
-
-// TestFilterEnabledFalse_AllEventsForwarded — setting exists but enabled=false, all pass.
-func (s *RawEventConsumptionSuite) TestFilterEnabledFalse_AllEventsForwarded() {
-	s.setOutputTopic(testOutputTopic)
-	s.makeFilterSetting(false, []string{"org_001"}) // disabled
-
-	batch := RawEventBatch{
-		TenantID:      testTenantID,
-		EnvironmentID: testEnvironmentID,
-		Data: []json.RawMessage{
-			json.RawMessage(validBentoPayload("org_001", "evt_001")),
-			json.RawMessage(validBentoPayload("org_999", "evt_002")), // would be blocked if enabled
-		},
-	}
-
-	err := s.svc.processMessage(buildBatchMsg(batch))
-	s.NoError(err)
-	s.Equal(2, s.publishedCount(), "all events should pass when filter is disabled")
-}
-
-// TestFilterEnabled_EmptyAllowlist — filter on with empty list blocks everything.
-func (s *RawEventConsumptionSuite) TestFilterEnabled_EmptyAllowlist() {
-	s.setOutputTopic(testOutputTopic)
-	s.makeFilterSetting(true, []string{}) // enabled but empty
-
-	batch := RawEventBatch{
-		TenantID:      testTenantID,
-		EnvironmentID: testEnvironmentID,
-		Data: []json.RawMessage{
-			json.RawMessage(validBentoPayload("org_001", "evt_001")),
-		},
-	}
-
-	err := s.svc.processMessage(buildBatchMsg(batch))
-	s.NoError(err)
-	s.Equal(0, s.publishedCount(), "empty allowlist should block all events")
-}
-
-// TestInvalidEvent_Skipped — events that fail transformer validation are counted as skips,
-// not errors, regardless of filter state.
-func (s *RawEventConsumptionSuite) TestInvalidEvent_Skipped() {
-	s.setOutputTopic(testOutputTopic)
+// TestInvalidBentoEvent_SkippedBeforeFilterCheck — invalid events are dropped before the
+// filter check; a valid+allowed event in the same batch still gets through.
+func (s *RawEventConsumptionSuite) TestInvalidBentoEvent_SkippedBeforeFilterCheck() {
 	s.makeFilterSetting(true, []string{"org_001"})
 
-	invalidPayload := `{"orgId":"org_001"}` // missing required fields (methodName, providerName, id, createdAt)
+	// Missing required fields (methodName, providerName, id, createdAt)
+	invalidPayload := json.RawMessage(`{"orgId":"org_001"}`)
 
 	batch := RawEventBatch{
 		TenantID:      testTenantID,
 		EnvironmentID: testEnvironmentID,
 		Data: []json.RawMessage{
-			json.RawMessage(invalidPayload),
-			json.RawMessage(validBentoPayload("org_001", "evt_002")),
+			invalidPayload,
+			json.RawMessage(validBentoPayload("org_001", "evt_valid")),
 		},
 	}
 
 	err := s.svc.processMessage(buildBatchMsg(batch))
 	s.NoError(err)
-	// Invalid event is dropped before filter check; valid+allowed event goes through
-	s.Equal(1, s.publishedCount())
+	s.Equal([]string{"org_001"}, s.publishedExternalIDs())
 }
 
-// TestMalformedBatchPayload_ReturnsError — a non-JSON batch returns a non-retriable error.
-func (s *RawEventConsumptionSuite) TestMalformedBatchPayload_ReturnsError() {
-	// sentryService is nil, but we guard against panics by catching the error path
+// TestMalformedBatchPayload_ReturnsNonRetriableError — a completely non-JSON batch payload
+// returns an immediate non-retriable error (no retries would help).
+func (s *RawEventConsumptionSuite) TestMalformedBatchPayload_ReturnsNonRetriableError() {
 	msg := message.NewMessage("test-uuid", []byte("not-json"))
 	err := s.svc.processMessage(msg)
 	s.Error(err)
 	s.Contains(err.Error(), "non-retriable unmarshal error")
 }
 
-// TestTenantFallbackFromConfig — when batch has no tenant/env, config values are used
-// and the filter setting stored under config tenant/env is picked up correctly.
-func (s *RawEventConsumptionSuite) TestTenantFallbackFromConfig() {
-	s.setOutputTopic(testOutputTopic)
+// TestSettingsRepoError_FailsBatchForRetry — a transient settings-store error (not ErrNotFound)
+// must propagate so Watermill retries the entire batch.
+func (s *RawEventConsumptionSuite) TestSettingsRepoError_FailsBatchForRetry() {
+	// Replace the settings repo with one that always returns an operational error
+	// for GetByKey. We do this by pre-populating a setting with a corrupted value
+	// that causes a parse failure (which is treated as a hard error).
+	ctx := testutil.SetupContext()
+	corruptSetting := &domainSettings.Setting{
+		ID:            types.GenerateUUID(),
+		Key:           types.SettingKeyEventIngestionFilter,
+		Value:         map[string]interface{}{"enabled": "not-a-bool", "allowed_external_customer_ids": "also-wrong"},
+		EnvironmentID: testEnvironmentID,
+	}
+	corruptSetting.TenantID = testTenantID
+	corruptSetting.Status = types.StatusPublished
+	corruptSetting.CreatedAt = time.Now()
+	corruptSetting.UpdatedAt = time.Now()
+	require.NoError(s.T(), s.settingsRepo.Create(ctx, corruptSetting))
 
-	// Config tenant/env is what SetupContext uses (DefaultTenantID / env_sandbox)
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data:          []json.RawMessage{json.RawMessage(validBentoPayload("org_001", "evt_001"))},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.Error(err, "corrupt setting value should fail the batch for retry")
+	s.Equal(0, len(s.outputPubSub.GetMessages(testOutputTopic)),
+		"no events should be forwarded when filter config is unreadable")
+}
+
+// TestTenantFallbackFromConfig — when the batch omits tenant/env, config fallback values
+// are used to scope the settings lookup and the filter activates correctly.
+func (s *RawEventConsumptionSuite) TestTenantFallbackFromConfig() {
 	s.GetConfig().Billing.TenantID = testTenantID
 	s.GetConfig().Billing.EnvironmentID = testEnvironmentID
 	s.makeFilterSetting(true, []string{"org_001"})
 
 	batch := RawEventBatch{
-		// TenantID and EnvironmentID intentionally omitted → falls back to config
+		// TenantID and EnvironmentID intentionally omitted → config fallback
 		Data: []json.RawMessage{
 			json.RawMessage(validBentoPayload("org_001", "evt_001")), // allowed
 			json.RawMessage(validBentoPayload("org_002", "evt_002")), // filtered
@@ -262,5 +293,5 @@ func (s *RawEventConsumptionSuite) TestTenantFallbackFromConfig() {
 
 	err := s.svc.processMessage(buildBatchMsg(batch))
 	s.NoError(err)
-	s.Equal(1, s.publishedCount())
+	s.Equal([]string{"org_001"}, s.publishedExternalIDs())
 }

--- a/internal/service/raw_event_consumption_test.go
+++ b/internal/service/raw_event_consumption_test.go
@@ -1,0 +1,266 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	domainSettings "github.com/flexprice/flexprice/internal/domain/settings"
+	"github.com/flexprice/flexprice/internal/sentry"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/suite"
+)
+
+// ---------------------------------------------------------------------------
+// Suite setup
+// ---------------------------------------------------------------------------
+
+type RawEventConsumptionSuite struct {
+	testutil.BaseServiceTestSuite
+	svc         *rawEventConsumptionService
+	outputPubSub *testutil.InMemoryPubSub
+	settingsRepo *testutil.InMemorySettingsStore
+}
+
+func TestRawEventConsumptionService(t *testing.T) {
+	suite.Run(t, new(RawEventConsumptionSuite))
+}
+
+func (s *RawEventConsumptionSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+
+	s.outputPubSub = testutil.NewInMemoryPubSub()
+	s.settingsRepo = s.GetStores().SettingsRepo.(*testutil.InMemorySettingsStore)
+
+	params := ServiceParams{
+		Logger:       s.GetLogger(),
+		Config:       s.GetConfig(),
+		DB:           s.GetDB(),
+		SettingsRepo: s.settingsRepo,
+	}
+
+	s.svc = &rawEventConsumptionService{
+		ServiceParams: params,
+		outputPubSub:  s.outputPubSub,
+		sentryService: sentry.NewSentryService(s.GetConfig(), s.GetLogger()),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const (
+	testTenantID      = types.DefaultTenantID
+	testEnvironmentID = "env_sandbox"
+	testOutputTopic   = "events"
+)
+
+// validBentoPayload returns a minimal valid Bento event JSON for the given orgID.
+func validBentoPayload(orgID, eventID string) string {
+	return `{
+		"orgId":"` + orgID + `",
+		"id":"` + eventID + `",
+		"methodName":"CHAT_COMPLETION",
+		"providerName":"openai",
+		"createdAt":"2024-01-15T10:00:00Z"
+	}`
+}
+
+// buildBatchMsg serialises a RawEventBatch into a Watermill message.
+func buildBatchMsg(batch RawEventBatch) *message.Message {
+	payload, _ := json.Marshal(batch)
+	return message.NewMessage("test-uuid", payload)
+}
+
+// makeFilterSetting stores an EventIngestionFilterConfig in the in-memory settings
+// repo under the test tenant+environment.
+func (s *RawEventConsumptionSuite) makeFilterSetting(enabled bool, allowedIDs []string) {
+	value, _ := json.Marshal(types.EventIngestionFilterConfig{
+		Enabled:                    enabled,
+		AllowedExternalCustomerIDs: allowedIDs,
+	})
+	var valueMap map[string]interface{}
+	_ = json.Unmarshal(value, &valueMap)
+
+	setting := &domainSettings.Setting{
+		ID:            types.GenerateUUID(),
+		Key:           types.SettingKeyEventIngestionFilter,
+		Value:         valueMap,
+		EnvironmentID: testEnvironmentID,
+	}
+	setting.TenantID = testTenantID
+	setting.Status = types.StatusPublished
+	setting.CreatedAt = time.Now()
+	setting.UpdatedAt = time.Now()
+
+	ctx := testutil.SetupContext()
+	_ = s.settingsRepo.Create(ctx, setting)
+}
+
+// publishedCount returns how many messages landed on the output topic.
+func (s *RawEventConsumptionSuite) publishedCount() int {
+	return len(s.outputPubSub.GetMessages(testOutputTopic))
+}
+
+// configure the output topic on the embedded config
+func (s *RawEventConsumptionSuite) setOutputTopic(topic string) {
+	s.svc.Config.RawEventConsumption.OutputTopic = topic
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestFilterDisabled_AllEventsForwarded — setting absent, all events pass through.
+func (s *RawEventConsumptionSuite) TestFilterDisabled_AllEventsForwarded() {
+	s.setOutputTopic(testOutputTopic)
+
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data: []json.RawMessage{
+			json.RawMessage(validBentoPayload("org_001", "evt_001")),
+			json.RawMessage(validBentoPayload("org_002", "evt_002")),
+			json.RawMessage(validBentoPayload("org_003", "evt_003")),
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	s.Equal(3, s.publishedCount(), "all 3 events should be forwarded when filter is absent")
+}
+
+// TestFilterEnabled_AllowlistedIDsForwarded — only IDs in the allowlist pass.
+func (s *RawEventConsumptionSuite) TestFilterEnabled_AllowlistedIDsForwarded() {
+	s.setOutputTopic(testOutputTopic)
+	s.makeFilterSetting(true, []string{"org_001", "org_002"})
+
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data: []json.RawMessage{
+			json.RawMessage(validBentoPayload("org_001", "evt_001")), // allowed
+			json.RawMessage(validBentoPayload("org_002", "evt_002")), // allowed
+			json.RawMessage(validBentoPayload("org_003", "evt_003")), // filtered out
+			json.RawMessage(validBentoPayload("org_004", "evt_004")), // filtered out
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	s.Equal(2, s.publishedCount(), "only org_001 and org_002 should be forwarded")
+}
+
+// TestFilterEnabled_NoAllowlistedIDs — filter is on but the batch has no matching IDs.
+func (s *RawEventConsumptionSuite) TestFilterEnabled_NoAllowlistedIDs() {
+	s.setOutputTopic(testOutputTopic)
+	s.makeFilterSetting(true, []string{"org_allowed"})
+
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data: []json.RawMessage{
+			json.RawMessage(validBentoPayload("org_not_in_list", "evt_001")),
+			json.RawMessage(validBentoPayload("org_also_not",    "evt_002")),
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	s.Equal(0, s.publishedCount(), "no events should be forwarded when no IDs match")
+}
+
+// TestFilterEnabledFalse_AllEventsForwarded — setting exists but enabled=false, all pass.
+func (s *RawEventConsumptionSuite) TestFilterEnabledFalse_AllEventsForwarded() {
+	s.setOutputTopic(testOutputTopic)
+	s.makeFilterSetting(false, []string{"org_001"}) // disabled
+
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data: []json.RawMessage{
+			json.RawMessage(validBentoPayload("org_001", "evt_001")),
+			json.RawMessage(validBentoPayload("org_999", "evt_002")), // would be blocked if enabled
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	s.Equal(2, s.publishedCount(), "all events should pass when filter is disabled")
+}
+
+// TestFilterEnabled_EmptyAllowlist — filter on with empty list blocks everything.
+func (s *RawEventConsumptionSuite) TestFilterEnabled_EmptyAllowlist() {
+	s.setOutputTopic(testOutputTopic)
+	s.makeFilterSetting(true, []string{}) // enabled but empty
+
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data: []json.RawMessage{
+			json.RawMessage(validBentoPayload("org_001", "evt_001")),
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	s.Equal(0, s.publishedCount(), "empty allowlist should block all events")
+}
+
+// TestInvalidEvent_Skipped — events that fail transformer validation are counted as skips,
+// not errors, regardless of filter state.
+func (s *RawEventConsumptionSuite) TestInvalidEvent_Skipped() {
+	s.setOutputTopic(testOutputTopic)
+	s.makeFilterSetting(true, []string{"org_001"})
+
+	invalidPayload := `{"orgId":"org_001"}` // missing required fields (methodName, providerName, id, createdAt)
+
+	batch := RawEventBatch{
+		TenantID:      testTenantID,
+		EnvironmentID: testEnvironmentID,
+		Data: []json.RawMessage{
+			json.RawMessage(invalidPayload),
+			json.RawMessage(validBentoPayload("org_001", "evt_002")),
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	// Invalid event is dropped before filter check; valid+allowed event goes through
+	s.Equal(1, s.publishedCount())
+}
+
+// TestMalformedBatchPayload_ReturnsError — a non-JSON batch returns a non-retriable error.
+func (s *RawEventConsumptionSuite) TestMalformedBatchPayload_ReturnsError() {
+	// sentryService is nil, but we guard against panics by catching the error path
+	msg := message.NewMessage("test-uuid", []byte("not-json"))
+	err := s.svc.processMessage(msg)
+	s.Error(err)
+	s.Contains(err.Error(), "non-retriable unmarshal error")
+}
+
+// TestTenantFallbackFromConfig — when batch has no tenant/env, config values are used
+// and the filter setting stored under config tenant/env is picked up correctly.
+func (s *RawEventConsumptionSuite) TestTenantFallbackFromConfig() {
+	s.setOutputTopic(testOutputTopic)
+
+	// Config tenant/env is what SetupContext uses (DefaultTenantID / env_sandbox)
+	s.GetConfig().Billing.TenantID = testTenantID
+	s.GetConfig().Billing.EnvironmentID = testEnvironmentID
+	s.makeFilterSetting(true, []string{"org_001"})
+
+	batch := RawEventBatch{
+		// TenantID and EnvironmentID intentionally omitted → falls back to config
+		Data: []json.RawMessage{
+			json.RawMessage(validBentoPayload("org_001", "evt_001")), // allowed
+			json.RawMessage(validBentoPayload("org_002", "evt_002")), // filtered
+		},
+	}
+
+	err := s.svc.processMessage(buildBatchMsg(batch))
+	s.NoError(err)
+	s.Equal(1, s.publishedCount())
+}

--- a/internal/service/raw_event_consumption_test.go
+++ b/internal/service/raw_event_consumption_test.go
@@ -35,7 +35,9 @@ func (s *RawEventConsumptionSuite) SetupTest() {
 	s.BaseServiceTestSuite.SetupTest()
 
 	s.outputPubSub = testutil.NewInMemoryPubSub()
-	s.settingsRepo = s.GetStores().SettingsRepo.(*testutil.InMemorySettingsStore)
+	var ok bool
+	s.settingsRepo, ok = s.GetStores().SettingsRepo.(*testutil.InMemorySettingsStore)
+	require.True(s.T(), ok, "SettingsRepo must be *testutil.InMemorySettingsStore, got %T", s.GetStores().SettingsRepo)
 
 	params := ServiceParams{
 		Logger:       s.GetLogger(),
@@ -113,9 +115,9 @@ func (s *RawEventConsumptionSuite) publishedExternalIDs() []string {
 	ids := make([]string, 0, len(msgs))
 	for _, m := range msgs {
 		var evt events.Event
-		if err := json.Unmarshal(m.Payload, &evt); err == nil {
-			ids = append(ids, evt.ExternalCustomerID)
-		}
+		require.NoError(s.T(), json.Unmarshal(m.Payload, &evt),
+			"publishedExternalIDs: failed to unmarshal published payload: %s", string(m.Payload))
+		ids = append(ids, evt.ExternalCustomerID)
 	}
 	sort.Strings(ids)
 	return ids

--- a/internal/service/settings.go
+++ b/internal/service/settings.go
@@ -231,6 +231,8 @@ func (s *settingsService) GetSettingByKey(ctx context.Context, key types.Setting
 		return getSettingByKey[types.AlertSettings](s, ctx, key)
 	case types.SettingKeyCustomerPortalConfig:
 		return getSettingByKey[types.CustomerPortalConfig](s, ctx, key)
+	case types.SettingKeyEventIngestionFilter:
+		return getSettingByKey[types.EventIngestionFilterConfig](s, ctx, key)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).
@@ -273,6 +275,8 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 		return updateSettingByKey[*types.AlertSettings](s, ctx, key, req)
 	case types.SettingKeyCustomerPortalConfig:
 		return updateSettingByKey[types.CustomerPortalConfig](s, ctx, key, req)
+	case types.SettingKeyEventIngestionFilter:
+		return updateSettingByKey[types.EventIngestionFilterConfig](s, ctx, key, req)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -28,6 +28,7 @@ const (
 	SettingKeyPrepareProcessedEvents   SettingKey = "prepare_processed_events_config"
 	SettingKeyCustomAnalytics          SettingKey = "custom_analytics_config"
 	SettingKeyCustomerPortalConfig     SettingKey = "customer_portal_config"
+	SettingKeyEventIngestionFilter     SettingKey = "event_ingestion_filter"
 )
 
 func (s *SettingKey) Validate() error {
@@ -42,6 +43,7 @@ func (s *SettingKey) Validate() error {
 		SettingKeyPrepareProcessedEvents,
 		SettingKeyCustomAnalytics,
 		SettingKeyCustomerPortalConfig,
+		SettingKeyEventIngestionFilter,
 	}
 
 	if !lo.Contains(allowedKeys, *s) {
@@ -333,6 +335,22 @@ type CustomerPortalMetricCards struct {
 	ShowRevenueMetric bool `json:"show_revenue_metric"`
 }
 
+// EventIngestionFilterConfig controls which external customer IDs are allowed through
+// the raw-event → events transformation pipeline. When Enabled is true, only events
+// whose ExternalCustomerID appears in AllowedExternalCustomerIDs are forwarded; all
+// others are stored in raw_events but silently dropped at the enqueue step.
+// This is useful for large-volume pilots where only a subset of customers need live
+// billing (e.g. 400 out of 60 000 VAPI orgs).
+type EventIngestionFilterConfig struct {
+	Enabled                    bool     `json:"enabled"`
+	AllowedExternalCustomerIDs []string `json:"allowed_external_customer_ids"`
+}
+
+// Validate implements SettingConfig interface
+func (c EventIngestionFilterConfig) Validate() error {
+	return validator.ValidateRequest(c)
+}
+
 // GetDefaultSettings returns the default settings configuration for all setting keys
 // Uses typed structs and converts them to maps using ToMap utility from conversion.go
 func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
@@ -478,6 +496,15 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 		return nil, err
 	}
 
+	defaultEventIngestionFilterConfig := EventIngestionFilterConfig{
+		Enabled:                    false,
+		AllowedExternalCustomerIDs: []string{},
+	}
+	defaultEventIngestionFilterConfigMap, err := utils.ToMap(defaultEventIngestionFilterConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[SettingKey]DefaultSettingValue{
 		SettingKeyInvoiceConfig: {
 			Key:          SettingKeyInvoiceConfig,
@@ -525,6 +552,11 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			Key:          SettingKeyCustomerPortalConfig,
 			DefaultValue: defaultCustomerPortalConfigMap,
 			Description:  "Configuration for the customer self-service portal (branding, allowed sections, permissions)",
+		},
+		SettingKeyEventIngestionFilter: {
+			Key:          SettingKeyEventIngestionFilter,
+			DefaultValue: defaultEventIngestionFilterConfigMap,
+			Description:  "Controls which external customer IDs are forwarded from raw events to the events pipeline (pilot allowlist)",
 		},
 	}, nil
 }
@@ -620,6 +652,13 @@ func ValidateSettingValue(key SettingKey, value map[string]interface{}) error {
 
 	case SettingKeyCustomerPortalConfig:
 		config, err := utils.ToStruct[CustomerPortalConfig](value)
+		if err != nil {
+			return err
+		}
+		return config.Validate()
+
+	case SettingKeyEventIngestionFilter:
+		config, err := utils.ToStruct[EventIngestionFilterConfig](value)
 		if err != nil {
 			return err
 		}

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -346,8 +346,15 @@ type EventIngestionFilterConfig struct {
 	AllowedExternalCustomerIDs []string `json:"allowed_external_customer_ids"`
 }
 
-// Validate implements SettingConfig interface
+// Validate implements SettingConfig interface.
+// It rejects the combination of Enabled=true with an empty allowlist because
+// that would silently drop every event — an almost certainly unintentional
+// configuration. Use Enabled=false to disable filtering entirely.
 func (c EventIngestionFilterConfig) Validate() error {
+	if c.Enabled && len(c.AllowedExternalCustomerIDs) == 0 {
+		return ierr.NewError("event_ingestion_filter: enabled is true but allowed_external_customer_ids is empty — this would block all events; set enabled=false to disable filtering").
+			Mark(ierr.ErrValidation)
+	}
 	return validator.ValidateRequest(c)
 }
 


### PR DESCRIPTION
## Summary

Implements per-tenant event ingestion filtering for large-volume pilots where only a subset of customers need live billing (e.g. 400 out of 60,000 VAPI orgs sending 500M events/month).

- **Ingestion filter**: per-tenant-per-env setting (`event_ingestion_filter`) that allowlists `external_customer_id` values. The raw-event consumer reads the setting once per Kafka batch, skips non-allowlisted events at the enqueue step (they are still stored in `raw_events`), and logs skip counts.
- **Raw bulk ingest API** (`POST /v1/events/raw/bulk`): publishes Bento-format event payloads directly to the `raw_events` Kafka topic using the exact same `RawEventBatch` struct the consumer already parses. Enables testing the filter without a live Bento collector and retrying previously-filtered events for newly allowlisted orgs.
- **Local dev tooling**: committed `.env.local` with all Docker infra overrides and a pre-configured test API key; `make run-local-api / run-local-consumer / run-local / migrate-local` targets.

## Changes

| Area | What changed |
|------|-------------|
| `internal/types/settings.go` | `SettingKeyEventIngestionFilter`, `EventIngestionFilterConfig` (with Validate guard: enabled+empty allowlist is rejected), default setting, `ValidateSettingValue` case |
| `internal/service/settings.go` | `GetSettingByKey` / `UpdateSettingByKey` cases for the new key |
| `internal/service/raw_event_consumption.go` | `loadIngestionFilter(ctx)` — one DB read per batch, `ierr.IsNotFound` → filter disabled, other errors → fail batch for retry; per-event allowlist check; `BulkIngestRawEvents` with tenant/env validation |
| `internal/service/raw_event_consumption_test.go` | Table-driven suite: 5 filter scenarios + malformed batch + settings error + tenant fallback; comma-ok type assertion; `require.NoError` on unmarshal |
| `internal/api/dto/events.go` | `BulkIngestRawEventRequest` with per-element JSON-object validation |
| `internal/api/v1/events.go` | `BulkIngestRawEvent` handler (no Swagger annotations — internal endpoint) |
| `internal/api/router.go` | `POST /v1/events/raw/bulk` (event:write permission) |
| `cmd/server/main.go` | Wire `rawEventConsumptionService` into `provideHandlers` |
| `.env.local` | Committed local dev config (Docker infra + test API key) |
| `Makefile` | `run-local-api`, `run-local-consumer`, `run-local`, `migrate-local` |
| `LOCAL_TESTING.md` | End-to-end local setup guide |
| `SANITY_CHECK.md` | Standard pre-PR validation checklist |

## Key design decisions

- **One DB read per Kafka batch** (not per-event, not cached): simple and correct; settings load is O(1) per message not per event
- **`ierr.IsNotFound` → filter disabled**: setting not configured = pass-through with zero overhead; any other error = fail batch for Watermill retry
- **Context propagation**: `msg.Context()` enriched with tenant/env from the batch payload before settings lookup — no `context.Background()`
- **`BulkIngestRawEvents`**: publishes the exact `RawEventBatch` struct so the consumer sees no difference between API-sourced and Bento-sourced events
- **Internal endpoint**: `POST /v1/events/raw/bulk` has no Swagger annotations — excluded from public docs/SDKs

## Linear task

[FLP-XXXX](https://linear.app/flexprice) — assigned to @tsage

## Test plan

- [x] Unit tests: 9 table-driven cases covering filter on/off/empty, malformed batch, settings repo error, tenant fallback
- [x] E2E local sanity: health → customer → ingest raw batch (no filter, success_count=2) → enable filter → ingest (success_count=1, skip_count=1) → verify ClickHouse has only allowed event
- [x] `go build ./internal/... ./cmd/...` clean
- [x] `go test ./internal/service/... -run TestRawEventConsumption -race` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk raw event ingestion API endpoint for batch event processing
  * Added event ingestion filter to selectively control which customer events are processed

* **Documentation**
  * Added local testing guide with step-by-step setup instructions
  * Added sanity check guide for end-to-end regression testing

* **Tests**
  * Added comprehensive test suite for raw event consumption

<!-- end of auto-generated comment: release notes by coderabbit.ai -->