### PR TITLE
refactor(api): deprecate customer parent hierarchy in favor of subscription-level hierarchy

### DIFF
--- a/internal/api/dto/customer.go
+++ b/internal/api/dto/customer.go
@@ -64,11 +64,14 @@ type CreateCustomerRequest struct {
 	// integration_entity_mapping contains provider integration mappings for this customer
 	IntegrationEntityMapping []*IntegrationEntityMapping `json:"integration_entity_mapping,omitempty"`
 
-	// parent_customer_id is the internal FlexPrice ID of the parent customer
+	// Deprecated: Customer parent hierarchy is deprecated in favor of subscription-level hierarchy.
+	// This field is accepted for backward compatibility but no hierarchy validations are enforced.
+	// parent_customer_id is the internal FlexPrice ID of the parent customer.
 	ParentCustomerID *string `json:"parent_customer_id,omitempty"`
 
-	// parent_customer_external_id is the external ID of the parent customer from your system
-	// Exactly one of parent_customer_id or parent_customer_external_id may be provided
+	// Deprecated: See ParentCustomerID.
+	// parent_customer_external_id is the external ID of the parent customer from your system.
+	// Exactly one of parent_customer_id or parent_customer_external_id may be provided.
 	ParentCustomerExternalID *string `json:"parent_customer_external_id,omitempty"`
 }
 
@@ -108,12 +111,15 @@ type UpdateCustomerRequest struct {
 	// integration_entity_mapping contains provider integration mappings for this customer
 	IntegrationEntityMapping []*IntegrationEntityMapping `json:"integration_entity_mapping,omitempty"`
 
-	// parent_customer_id is the internal FlexPrice ID of the parent customer
+	// Deprecated: Customer parent hierarchy is deprecated in favor of subscription-level hierarchy.
+	// This field is accepted for backward compatibility but no hierarchy validations are enforced.
+	// parent_customer_id is the internal FlexPrice ID of the parent customer.
 	ParentCustomerID *string `json:"parent_customer_id,omitempty"`
 
-	// parent_customer_external_id is the external ID of the parent customer from your system
-	// Exactly one of parent_customer_id or parent_customer_external_id may be provided
-	// If you provide the external ID, the parent customer value will be ignored
+	// Deprecated: See ParentCustomerID.
+	// parent_customer_external_id is the external ID of the parent customer from your system.
+	// Exactly one of parent_customer_id or parent_customer_external_id may be provided.
+	// If you provide the external ID, the parent customer value will be ignored.
 	ParentCustomerExternalID *string `json:"parent_customer_external_id,omitempty"`
 }
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -262,14 +262,20 @@ type CreateSubscriptionRequest struct {
 	// and must be same as what you provided as external_id while creating the customer in flexprice.
 	ExternalCustomerID string `json:"external_customer_id"`
 
-	// invoicing_customer_id is the customer ID to use for invoicing
-	// This can differ from the subscription customer (e.g., parent company invoicing for child company)
-	// This field is set internally based on InvoiceBillingConfig and is not exposed in the API
-	InvoicingCustomerID *string `json:"-"`
+	// invoicing_customer_id is the FlexPrice customer ID to use for invoicing.
+	// This can differ from the subscription customer (e.g., a billing entity invoicing on behalf of another customer).
+	// Mutually exclusive with invoicing_customer_external_id.
+	InvoicingCustomerID *string `json:"invoicing_customer_id,omitempty"`
 
-	// invoice_billing determines which customer should receive invoices for a subscription
-	// "invoice_to_parent" - Invoices are sent to the parent customer
-	// "invoice_to_self" - Invoices are sent to the subscription's customer
+	// invoicing_customer_external_id is the external ID of the customer to use for invoicing.
+	// Resolved internally to an internal customer ID via external ID lookup.
+	// Mutually exclusive with invoicing_customer_id.
+	InvoicingCustomerExternalID *string `json:"invoicing_customer_external_id,omitempty"`
+
+	// Deprecated: Use invoicing_customer_id or invoicing_customer_external_id instead.
+	// invoice_billing determines which customer should receive invoices for a subscription.
+	// Supported values: "invoice_to_parent" (uses the subscription customer's parent) or "invoice_to_self" (default).
+	// Will be removed in a future version.
 	InvoiceBilling *types.InvoiceBilling `json:"invoice_billing,omitempty"`
 
 	PlanID             string               `json:"plan_id" validate:"required"`
@@ -543,6 +549,20 @@ func (r *CreateSubscriptionRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	// invoicing_customer_id and invoicing_customer_external_id are mutually exclusive
+	if r.InvoicingCustomerID != nil && r.InvoicingCustomerExternalID != nil {
+		return ierr.NewError("only one of invoicing_customer_id or invoicing_customer_external_id may be provided").
+			WithHint("Send either invoicing_customer_id or invoicing_customer_external_id, but not both").
+			Mark(ierr.ErrValidation)
+	}
+
+	// invoice_billing (deprecated) cannot be combined with the new invoicing customer fields
+	if r.InvoiceBilling != nil && (r.InvoicingCustomerID != nil || r.InvoicingCustomerExternalID != nil) {
+		return ierr.NewError("invoice_billing cannot be used together with invoicing_customer_id or invoicing_customer_external_id").
+			WithHint("invoice_billing is deprecated; use invoicing_customer_id or invoicing_customer_external_id instead").
+			Mark(ierr.ErrValidation)
+	}
+
 	err := validator.ValidateRequest(r)
 	if err != nil {
 		return err
@@ -593,11 +613,9 @@ func (r *CreateSubscriptionRequest) Validate() error {
 		r.PaymentBehavior = &defaultPaymentBehavior
 	}
 
-	// Set default for invoice billing if not provided
-	if r.InvoiceBilling == nil {
-		r.InvoiceBilling = lo.ToPtr(types.InvoiceBillingInvoiceToSelf)
-	} else {
-		// Validate invoice billing if provided
+	// Deprecated: invoice_billing is deprecated in favor of invoicing_customer_id / invoicing_customer_external_id.
+	// Validate the value if it was explicitly provided for backward compatibility.
+	if r.InvoiceBilling != nil {
 		if err := r.InvoiceBilling.Validate(); err != nil {
 			return err
 		}

--- a/internal/domain/customer/model.go
+++ b/internal/domain/customer/model.go
@@ -20,7 +20,9 @@ type Customer struct {
 	// Email is the email of the customer
 	Email string `db:"email" json:"email"`
 
-	// ParentCustomerID is the parent customer identifier for the customer
+	// Deprecated: Customer parent hierarchy is deprecated in favor of subscription-level hierarchy.
+	// Retained for backward compatibility; no hierarchy rules are enforced at the service layer.
+	// ParentCustomerID is the parent customer identifier for the customer.
 	ParentCustomerID *string `db:"parent_customer_id" json:"parent_customer_id"`
 
 	// AddressLine1 is the first line of the customer's address

--- a/internal/service/customer.go
+++ b/internal/service/customer.go
@@ -34,29 +34,15 @@ func (s *customerService) CreateCustomer(ctx context.Context, req dto.CreateCust
 		return nil, err
 	}
 
-	// Resolve and validate parent customer if provided (by ID or external ID)
+	// Deprecated: Customer parent hierarchy is deprecated in favor of subscription-level hierarchy.
+	// Fields are still accepted for backward compatibility; no hierarchy rules are enforced.
+	// Resolve parent_customer_external_id to an internal ID if provided.
 	if req.ParentCustomerExternalID != nil {
 		parent, err := s.CustomerRepo.GetByLookupKey(ctx, *req.ParentCustomerExternalID)
 		if err != nil {
 			return nil, err
 		}
-		if parent.ParentCustomerID != nil {
-			return nil, ierr.NewError("parent customer cannot be a child").
-				WithHint("Choose a parent customer that isn't a child of another").
-				Mark(ierr.ErrInvalidOperation)
-		}
-		// Normalize to internal ID for downstream logic
 		req.ParentCustomerID = lo.ToPtr(parent.ID)
-	} else if req.ParentCustomerID != nil {
-		parentCustomer, err := s.CustomerRepo.Get(ctx, *req.ParentCustomerID)
-		if err != nil {
-			return nil, err
-		}
-		if parentCustomer.ParentCustomerID != nil {
-			return nil, ierr.NewError("parent customer cannot be a child").
-				WithHint("Choose a parent customer that isn't a child of another").
-				Mark(ierr.ErrInvalidOperation)
-		}
 	}
 
 	cust := req.ToCustomer(ctx)
@@ -354,24 +340,14 @@ func (s *customerService) UpdateCustomer(ctx context.Context, id string, req dto
 		return nil, err
 	}
 
+	// Deprecated: Customer parent hierarchy is deprecated in favor of subscription-level hierarchy.
+	// The parent_customer_id field is accepted for backward compatibility without enforcing hierarchy rules.
 	if req.ParentCustomerID != nil {
 		newParentID := strings.TrimSpace(*req.ParentCustomerID)
-		currentParentID := ""
-		if cust.ParentCustomerID != nil {
-			currentParentID = strings.TrimSpace(*cust.ParentCustomerID)
-		}
-
-		// Only run validations if the hierarchy is changing
-		if newParentID != currentParentID {
-			if err := s.validateParentCustomerAssignment(ctx, cust, newParentID); err != nil {
-				return nil, err
-			}
-
-			if newParentID == "" {
-				cust.ParentCustomerID = nil
-			} else {
-				cust.ParentCustomerID = lo.ToPtr(newParentID)
-			}
+		if newParentID == "" {
+			cust.ParentCustomerID = nil
+		} else {
+			cust.ParentCustomerID = lo.ToPtr(newParentID)
 		}
 	}
 
@@ -588,61 +564,6 @@ func (s *customerService) GetCustomerByLookupKey(ctx context.Context, lookupKey 
 	return &dto.CustomerResponse{Customer: customer}, nil
 }
 
-func (s *customerService) validateParentCustomerAssignment(ctx context.Context, cust *customer.Customer, newParentID string) error {
-	// Do not allow hierarchy changes when customer has non-cancelled subscriptions
-	subFilter := types.NewSubscriptionFilter()
-	subFilter.CustomerID = cust.ID
-	subFilter.SubscriptionStatusNotIn = []types.SubscriptionStatus{types.SubscriptionStatusCancelled}
-	subFilter.Limit = lo.ToPtr(1)
-
-	subs, err := s.SubRepo.List(ctx, subFilter)
-	if err != nil {
-		return err
-	}
-	if len(subs) > 0 {
-		return ierr.NewError("customer hierarchy cannot change with active subscriptions").
-			WithHint("Cancel or transfer subscriptions before updating parent hierarchy").
-			Mark(ierr.ErrInvalidOperation)
-	}
-
-	if newParentID == "" {
-		// Resetting parent - nothing else to validate
-		return nil
-	}
-
-	if newParentID == cust.ID {
-		return ierr.NewError("customer cannot be its own parent").
-			WithHint("Please provide a different customer as parent").
-			Mark(ierr.ErrValidation)
-	}
-
-	parentCustomer, err := s.CustomerRepo.Get(ctx, newParentID)
-	if err != nil {
-		return err
-	}
-	if parentCustomer.ParentCustomerID != nil {
-		return ierr.NewError("parent customer cannot have its own parent").
-			WithHint("Nested hierarchies are not supported; pick a top-level customer as parent").
-			Mark(ierr.ErrInvalidOperation)
-	}
-
-	// A customer that already has children cannot become a child itself
-	childFilter := types.NewCustomerFilter()
-	childFilter.ParentCustomerIDs = []string{cust.ID}
-	childFilter.Limit = lo.ToPtr(1)
-
-	children, err := s.CustomerRepo.List(ctx, childFilter)
-	if err != nil {
-		return err
-	}
-	if len(children) > 0 {
-		return ierr.NewError("customer already acts as a parent").
-			WithHint("A customer cannot be both parent and child; detach child customers first").
-			Mark(ierr.ErrInvalidOperation)
-	}
-
-	return nil
-}
 
 func (s *customerService) publishWebhookEvent(ctx context.Context, eventName types.WebhookEventName, customerID string) {
 	webhookPayload, err := json.Marshal(webhookDto.InternalCustomerEvent{

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -71,20 +71,26 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			Mark(ierr.ErrValidation)
 	}
 
-	// Handle InvoiceBilling to set InvoicingCustomerID internally
-	// The DTO layer ensures InvoiceBilling is always set (defaults to invoice_to_self)
-	// For invoice_to_self, we don't need to set InvoicingCustomerID as it defaults to subscription customer
-	if lo.FromPtr(req.InvoiceBilling) == types.InvoiceBillingInvoiceToParent {
-		if customer.ParentCustomerID == nil {
-			return nil, ierr.NewError("customer does not have a parent customer").
-				WithHint("The customer must have a parent customer to use invoice_to_parent").
-				WithReportableDetails(map[string]interface{}{"customer_id": req.CustomerID}).
-				Mark(ierr.ErrValidation)
+	// Resolve invoicing customer.
+	// Priority: invoicing_customer_external_id > invoicing_customer_id > deprecated invoice_billing fallback.
+	if req.InvoicingCustomerExternalID != nil && *req.InvoicingCustomerExternalID != "" {
+		// Resolve external ID to internal ID.
+		invoicingCustomer, err := s.CustomerRepo.GetByLookupKey(ctx, *req.InvoicingCustomerExternalID)
+		if err != nil {
+			return nil, err
 		}
-		req.InvoicingCustomerID = customer.ParentCustomerID
+		req.InvoicingCustomerID = lo.ToPtr(invoicingCustomer.ID)
+	} else if req.InvoicingCustomerID == nil || *req.InvoicingCustomerID == "" {
+		// Deprecated fallback: if invoice_to_parent was specified, attempt to resolve from the
+		// subscription customer's parent. This path exists only for backward compatibility and
+		// will be removed once invoice_billing is fully retired.
+		if lo.FromPtr(req.InvoiceBilling) == types.InvoiceBillingInvoiceToParent && customer.ParentCustomerID != nil {
+			req.InvoicingCustomerID = customer.ParentCustomerID
+		}
+		// If invoice_to_parent is set but no parent exists, silently fall back to invoice_to_self behavior.
 	}
 
-	// Validate that the invoicing customer exists and is active
+	// Validate that the resolved invoicing customer exists and is active.
 	if req.InvoicingCustomerID != nil && *req.InvoicingCustomerID != "" {
 		invoicingCustomer, err := s.CustomerRepo.Get(ctx, *req.InvoicingCustomerID)
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Customer parent hierarchy is now deprecated in favor of subscription-level hierarchy. The parent customer field is retained for backward compatibility but no longer enforced.
  * Invoicing billing field is deprecated; use new invoicing customer fields instead.

* **New Features**
  * Added optional invoicing customer fields for improved subscription creation flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->