### PR TITLE
feat(plan): add support for multi env plan cloning

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -12099,6 +12099,10 @@ const docTemplate = `{
                 "name": {
                     "description": "Name is required and must be different from the source plan's name",
                     "type": "string"
+                },
+                "target_environment_id": {
+                    "description": "TargetEnvironmentID, when provided, clones the plan into a different environment\nwithin the same tenant. Omit or leave null to clone within the same environment.",
+                    "type": "string"
                 }
             }
         },
@@ -23395,7 +23399,6 @@ const docTemplate = `{
         "types.WindowSize": {
             "type": "string",
             "enum": [
-                "MONTH",
                 "MINUTE",
                 "15MIN",
                 "30MIN",
@@ -23405,10 +23408,10 @@ const docTemplate = `{
                 "12HOUR",
                 "DAY",
                 "WEEK",
+                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
-                "DefaultWindowSize",
                 "WindowSizeMinute",
                 "WindowSize15Min",
                 "WindowSize30Min",
@@ -23418,7 +23421,8 @@ const docTemplate = `{
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth"
+                "WindowSizeMonth",
+                "DefaultWindowSize"
             ]
         },
         "types.WorkflowExecutionFilter": {

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -14033,7 +14033,8 @@
           },
           "target_environment_id": {
             "type": "string",
-            "description": "TargetEnvironmentID, when provided, clones the plan into a different environment\nwithin the same tenant. Omit or leave null to clone within the same environment."
+            "description": "TargetEnvironmentID, when provided, clones the plan into a different environment\nwithin the same tenant. Omit or leave null to clone within the same environment.",
+            "x-nullable": true
           }
         }
       },
@@ -24890,7 +24891,6 @@
           "12HOUR",
           "DAY",
           "WEEK",
-          "MONTH",
           "MONTH"
         ],
         "x-enum-varnames": [
@@ -24903,8 +24903,7 @@
           "WindowSize12Hour",
           "WindowSizeDay",
           "WindowSizeWeek",
-          "WindowSizeMonth",
-          "DefaultWindowSize"
+          "WindowSizeMonth"
         ],
         "x-speakeasy-name-override": "WindowSize"
       },

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -14030,6 +14030,10 @@
           "name": {
             "type": "string",
             "description": "Name is required and must be different from the source plan's name"
+          },
+          "target_environment_id": {
+            "type": "string",
+            "description": "TargetEnvironmentID, when provided, clones the plan into a different environment\nwithin the same tenant. Omit or leave null to clone within the same environment."
           }
         }
       },
@@ -24877,7 +24881,6 @@
       "types.WindowSize": {
         "type": "string",
         "enum": [
-          "MONTH",
           "MINUTE",
           "15MIN",
           "30MIN",
@@ -24887,10 +24890,10 @@
           "12HOUR",
           "DAY",
           "WEEK",
+          "MONTH",
           "MONTH"
         ],
         "x-enum-varnames": [
-          "DefaultWindowSize",
           "WindowSizeMinute",
           "WindowSize15Min",
           "WindowSize30Min",
@@ -24900,7 +24903,8 @@
           "WindowSize12Hour",
           "WindowSizeDay",
           "WindowSizeWeek",
-          "WindowSizeMonth"
+          "WindowSizeMonth",
+          "DefaultWindowSize"
         ],
         "x-speakeasy-name-override": "WindowSize"
       },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -12044,6 +12044,10 @@
                 "name": {
                     "description": "Name is required and must be different from the source plan's name",
                     "type": "string"
+                },
+                "target_environment_id": {
+                    "description": "TargetEnvironmentID, when provided, clones the plan into a different environment\nwithin the same tenant. Omit or leave null to clone within the same environment.",
+                    "type": "string"
                 }
             }
         },
@@ -22904,7 +22908,6 @@
         "types.WindowSize": {
             "type": "string",
             "enum": [
-                "MONTH",
                 "MINUTE",
                 "15MIN",
                 "30MIN",
@@ -22914,10 +22917,10 @@
                 "12HOUR",
                 "DAY",
                 "WEEK",
+                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
-                "DefaultWindowSize",
                 "WindowSizeMinute",
                 "WindowSize15Min",
                 "WindowSize30Min",
@@ -22927,7 +22930,8 @@
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth"
+                "WindowSizeMonth",
+                "DefaultWindowSize"
             ]
         },
         "types.WorkflowExecutionFilter": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -12047,7 +12047,8 @@
                 },
                 "target_environment_id": {
                     "description": "TargetEnvironmentID, when provided, clones the plan into a different environment\nwithin the same tenant. Omit or leave null to clone within the same environment.",
-                    "type": "string"
+                    "type": "string",
+                    "x-nullable": true
                 }
             }
         },
@@ -22917,7 +22918,6 @@
                 "12HOUR",
                 "DAY",
                 "WEEK",
-                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
@@ -22930,8 +22930,7 @@
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth",
-                "DefaultWindowSize"
+                "WindowSizeMonth"
             ]
         },
         "types.WorkflowExecutionFilter": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -524,6 +524,11 @@ definitions:
         description: Name is required and must be different from the source plan's
           name
         type: string
+      target_environment_id:
+        description: |-
+          TargetEnvironmentID, when provided, clones the plan into a different environment
+          within the same tenant. Omit or leave null to clone within the same environment.
+        type: string
     type: object
   dto.CostAnalyticItem:
     properties:
@@ -8788,7 +8793,6 @@ definitions:
     - WalletTypePostPaid
   types.WindowSize:
     enum:
-    - MONTH
     - MINUTE
     - 15MIN
     - 30MIN
@@ -8799,9 +8803,9 @@ definitions:
     - DAY
     - WEEK
     - MONTH
+    - MONTH
     type: string
     x-enum-varnames:
-    - DefaultWindowSize
     - WindowSizeMinute
     - WindowSize15Min
     - WindowSize30Min
@@ -8812,6 +8816,7 @@ definitions:
     - WindowSizeDay
     - WindowSizeWeek
     - WindowSizeMonth
+    - DefaultWindowSize
   types.WorkflowExecutionFilter:
     properties:
       end_time:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -529,6 +529,7 @@ definitions:
           TargetEnvironmentID, when provided, clones the plan into a different environment
           within the same tenant. Omit or leave null to clone within the same environment.
         type: string
+        x-nullable: true
     type: object
   dto.CostAnalyticItem:
     properties:
@@ -8803,7 +8804,6 @@ definitions:
     - DAY
     - WEEK
     - MONTH
-    - MONTH
     type: string
     x-enum-varnames:
     - WindowSizeMinute
@@ -8816,7 +8816,6 @@ definitions:
     - WindowSizeDay
     - WindowSizeWeek
     - WindowSizeMonth
-    - DefaultWindowSize
   types.WorkflowExecutionFilter:
     properties:
       end_time:

--- a/internal/api/dto/plan.go
+++ b/internal/api/dto/plan.go
@@ -204,6 +204,9 @@ type ClonePlanRequest struct {
 	DisplayOrder *int `json:"display_order,omitempty"`
 	// Metadata overrides the source plan's metadata when provided
 	Metadata types.Metadata `json:"metadata,omitempty"`
+	// TargetEnvironmentID, when provided, clones the plan into a different environment
+	// within the same tenant. Omit or leave null to clone within the same environment.
+	TargetEnvironmentID *string `json:"target_environment_id,omitempty"`
 }
 
 func (r *ClonePlanRequest) Validate() error {

--- a/internal/api/dto/plan.go
+++ b/internal/api/dto/plan.go
@@ -220,6 +220,11 @@ func (r *ClonePlanRequest) Validate() error {
 			WithHint("Please provide a unique lookup_key for the cloned plan").
 			Mark(errors.ErrValidation)
 	}
+	if r.TargetEnvironmentID != nil && *r.TargetEnvironmentID == "" {
+		return errors.NewError("target_environment_id cannot be empty when provided").
+			WithHint("Provide a valid environment ID or omit the field entirely").
+			Mark(errors.ErrValidation)
+	}
 	return nil
 }
 

--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -807,9 +807,28 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		return nil, err
 	}
 
-	// GetByLookupKey only matches published plans, so a successful lookup means the
-	// key is already taken — covers both "same as source" and "taken by another plan".
-	existing, err := s.PlanRepo.GetByLookupKey(ctx, req.LookupKey)
+	// Determine save context and target environment ID
+	saveCtx := ctx
+	targetEnvID := types.GetEnvironmentID(ctx)
+
+	if req.TargetEnvironmentID != nil && *req.TargetEnvironmentID != "" {
+		if _, err := s.EnvironmentRepo.Get(ctx, *req.TargetEnvironmentID); err != nil {
+			if ierr.IsNotFound(err) {
+				return nil, ierr.NewError("target environment not found").
+					WithHint("Ensure target_environment_id belongs to your tenant").
+					WithReportableDetails(map[string]interface{}{
+						"target_environment_id": *req.TargetEnvironmentID,
+					}).
+					Mark(ierr.ErrNotFound)
+			}
+			return nil, err
+		}
+		targetEnvID = *req.TargetEnvironmentID
+		saveCtx = types.SetEnvironmentID(ctx, targetEnvID)
+	}
+
+	// lookup_key uniqueness check must use saveCtx (target environment)
+	existing, err := s.PlanRepo.GetByLookupKey(saveCtx, req.LookupKey)
 	if err != nil && !ierr.IsNotFound(err) {
 		return nil, err
 	}
@@ -822,7 +841,7 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 			Mark(ierr.ErrAlreadyExists)
 	}
 
-	// Active prices: published + not expired
+	// Active prices: published + not expired — read from source env context
 	sourcePrices, err := s.PriceRepo.List(ctx, types.NewNoLimitPriceFilter().
 		WithEntityIDs([]string{id}).
 		WithEntityType(types.PRICE_ENTITY_TYPE_PLAN).
@@ -832,7 +851,7 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		return nil, err
 	}
 
-	// Published entitlements — WithPlanIDs sets EntityType=PLAN + EntityIDs in one call
+	// Published entitlements
 	sourceEntitlements, err := s.EntitlementRepo.List(ctx, types.NewNoLimitEntitlementFilter().
 		WithPlanIDs([]string{id}).
 		WithStatus(types.StatusPublished))
@@ -841,7 +860,7 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		return nil, err
 	}
 
-	// Published credit grants — filter at query level, no post-loop status check needed
+	// Published credit grants
 	sourceGrants, err := s.CreditGrantRepo.List(ctx, types.NewNoLimitCreditGrantFilter().
 		WithPlanIDs([]string{id}).
 		WithStatus(types.StatusPublished).
@@ -850,6 +869,25 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		s.Logger.ErrorwCtx(ctx, "failed to fetch credit grants for plan clone", "plan_id", id, "error", err)
 		return nil, err
 	}
+
+	return s.clonePlanCore(ctx, saveCtx, sourcePlan, sourcePrices, sourceEntitlements, sourceGrants, req, targetEnvID)
+}
+
+// clonePlanCore builds and saves the cloned plan and sub-entities.
+// saveCtx carries the target environment ID — all writes and BaseModel generation use it.
+// sourcePlan, sourcePrices, sourceEntitlements, sourceGrants are pre-fetched from the source env.
+// targetEnvID is explicitly stamped on all new entities (CopyWith doesn't copy EnvironmentID).
+func (s *planService) clonePlanCore(
+	ctx context.Context,
+	saveCtx context.Context,
+	sourcePlan *plan.Plan,
+	sourcePrices []*domainPrice.Price,
+	sourceEntitlements []*domainEntitlement.Entitlement,
+	sourceGrants []*domainCreditGrant.CreditGrant,
+	req dto.ClonePlanRequest,
+	targetEnvID string,
+) (*dto.PlanResponse, error) {
+	id := sourcePlan.ID
 
 	// Resolve fields: request overrides take precedence over source values
 	description := sourcePlan.Description
@@ -877,10 +915,10 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		Name:          req.Name,
 		LookupKey:     req.LookupKey,
 		Description:   description,
-		EnvironmentID: sourcePlan.EnvironmentID,
+		EnvironmentID: targetEnvID,
 		Metadata:      metadata,
 		DisplayOrder:  displayOrder,
-		BaseModel:     types.GetDefaultBaseModel(ctx),
+		BaseModel:     types.GetDefaultBaseModel(saveCtx),
 	}
 
 	emptyLookupKey := ""
@@ -890,31 +928,37 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 
 	newPrices := make([]*domainPrice.Price, 0, len(sourcePrices))
 	for _, p := range sourcePrices {
-		newPrices = append(newPrices, p.CopyWith(ctx, &domainPrice.PriceCloneOverrides{
+		cloned := p.CopyWith(saveCtx, &domainPrice.PriceCloneOverrides{
 			ID:         lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)),
 			EntityType: &entityTypePlan,
 			EntityID:   &newPlan.ID,
 			LookupKey:  lo.ToPtr(emptyLookupKey),
-		}))
+		})
+		cloned.EnvironmentID = targetEnvID
+		newPrices = append(newPrices, cloned)
 	}
 
 	newEntitlements := make([]*domainEntitlement.Entitlement, 0, len(sourceEntitlements))
 	for _, e := range sourceEntitlements {
-		newEntitlements = append(newEntitlements, e.CopyWith(ctx, &domainEntitlement.EntitlementCloneOverrides{
+		cloned := e.CopyWith(saveCtx, &domainEntitlement.EntitlementCloneOverrides{
 			ID:         lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITLEMENT)),
 			EntityType: &entEntityTypePlan,
 			EntityID:   &newPlan.ID,
-		}))
+		})
+		cloned.EnvironmentID = targetEnvID
+		newEntitlements = append(newEntitlements, cloned)
 	}
 
 	newGrants := make([]*domainCreditGrant.CreditGrant, 0, len(sourceGrants))
 	newPlanID := newPlan.ID
 	for _, cg := range sourceGrants {
-		newGrants = append(newGrants, cg.CopyWith(ctx, &domainCreditGrant.CreditGrantCloneOverrides{
+		cloned := cg.CopyWith(saveCtx, &domainCreditGrant.CreditGrantCloneOverrides{
 			ID:     lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT)),
 			Scope:  &scopePlan,
 			PlanID: &newPlanID,
-		}))
+		})
+		cloned.EnvironmentID = targetEnvID
+		newGrants = append(newGrants, cloned)
 	}
 
 	// Batch size for bulk creates (prices, entitlements, credit grants)
@@ -923,7 +967,7 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 	// Inside tx: plan create then batched bulk creates
 	var entitlementsCreated []*domainEntitlement.Entitlement
 	var grantsCreated []*domainCreditGrant.CreditGrant
-	err = s.DB.WithTx(ctx, func(txCtx context.Context) error {
+	err := s.DB.WithTx(saveCtx, func(txCtx context.Context) error {
 		if err := s.PlanRepo.Create(txCtx, newPlan); err != nil {
 			return err
 		}

--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -811,25 +811,17 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 	saveCtx := ctx
 	targetEnvID := types.GetEnvironmentID(ctx)
 
-	if req.TargetEnvironmentID != nil && *req.TargetEnvironmentID != "" {
-		if _, err := s.EnvironmentRepo.Get(ctx, *req.TargetEnvironmentID); err != nil {
-			if ierr.IsNotFound(err) {
-				return nil, ierr.NewError("target environment not found").
-					WithHint("Ensure target_environment_id belongs to your tenant").
-					WithReportableDetails(map[string]interface{}{
-						"target_environment_id": *req.TargetEnvironmentID,
-					}).
-					Mark(ierr.ErrNotFound)
-			}
+	if req.TargetEnvironmentID != nil && lo.FromPtr(req.TargetEnvironmentID) != "" {
+		if _, err := s.EnvironmentRepo.Get(ctx, lo.FromPtr(req.TargetEnvironmentID)); err != nil {
 			return nil, err
 		}
-		targetEnvID = *req.TargetEnvironmentID
+		targetEnvID = lo.FromPtr(req.TargetEnvironmentID)
 		saveCtx = types.SetEnvironmentID(ctx, targetEnvID)
 	}
 
 	// lookup_key uniqueness check must use saveCtx (target environment)
 	existing, err := s.PlanRepo.GetByLookupKey(saveCtx, req.LookupKey)
-	if err != nil && !ierr.IsNotFound(err) {
+	if err != nil {
 		return nil, err
 	}
 	if existing != nil {

--- a/internal/service/plan.go
+++ b/internal/service/plan.go
@@ -807,9 +807,11 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		return nil, err
 	}
 
-	// Determine save context and target environment ID
+	// Determine save context and target environment ID.
+	// Default to sourcePlan.EnvironmentID (not ctx) to guarantee a non-empty value
+	// even when the caller did not stamp the context with an environment.
 	saveCtx := ctx
-	targetEnvID := types.GetEnvironmentID(ctx)
+	targetEnvID := sourcePlan.EnvironmentID
 
 	if req.TargetEnvironmentID != nil && lo.FromPtr(req.TargetEnvironmentID) != "" {
 		if _, err := s.EnvironmentRepo.Get(ctx, lo.FromPtr(req.TargetEnvironmentID)); err != nil {
@@ -819,9 +821,10 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 		saveCtx = types.SetEnvironmentID(ctx, targetEnvID)
 	}
 
-	// lookup_key uniqueness check must use saveCtx (target environment)
+	// lookup_key uniqueness check must use saveCtx (target environment).
+	// GetByLookupKey returns ErrNotFound when the key is free — treat that as success.
 	existing, err := s.PlanRepo.GetByLookupKey(saveCtx, req.LookupKey)
-	if err != nil {
+	if err != nil && !ierr.IsNotFound(err) {
 		return nil, err
 	}
 	if existing != nil {
@@ -866,9 +869,10 @@ func (s *planService) ClonePlan(ctx context.Context, id string, req dto.ClonePla
 }
 
 // clonePlanCore builds and saves the cloned plan and sub-entities.
-// saveCtx carries the target environment ID — all writes and BaseModel generation use it.
+// saveCtx carries the target environment ID for tenant/user BaseModel stamping and DB writes.
+// EnvironmentID is NOT derived from BaseModel — it must be set explicitly on every entity via
+// targetEnvID, which is why CopyWith is followed by a direct EnvironmentID assignment.
 // sourcePlan, sourcePrices, sourceEntitlements, sourceGrants are pre-fetched from the source env.
-// targetEnvID is explicitly stamped on all new entities (CopyWith doesn't copy EnvironmentID).
 func (s *planService) clonePlanCore(
 	ctx context.Context,
 	saveCtx context.Context,

--- a/internal/service/plan_test.go
+++ b/internal/service/plan_test.go
@@ -5,9 +5,11 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/environment"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
@@ -1225,5 +1227,167 @@ func (s *PlanServiceSuite) TestSyncPlanPrices_Timing_And_Edge_Cases() {
 		s.Equal(testPlan.ID, testPrice.EntityID)
 		s.Equal(testPlan.ID, testSub.PlanID)
 		s.Equal(types.SubscriptionStatusActive, testSub.SubscriptionStatus)
+	})
+}
+
+func (s *PlanServiceSuite) TestClonePlan_CrossEnv() {
+	const (
+		sourceEnvID = "env-source"
+		targetEnvID = "env-target"
+	)
+
+	// seedEnv creates an environment in the store, ignoring already-exists errors
+	// so sub-tests that share the same IDs can each set up their own state.
+	seedEnv := func(id, name string) {
+		_ = s.GetStores().EnvironmentRepo.Create(s.GetContext(), &environment.Environment{
+			ID:   id,
+			Name: name,
+			Type: types.EnvironmentDevelopment,
+			BaseModel: types.BaseModel{
+				TenantID: types.GetTenantID(s.GetContext()),
+				Status:   types.StatusPublished,
+			},
+		})
+	}
+
+	s.Run("same_env_no_target", func() {
+		srcCtx := types.SetEnvironmentID(s.GetContext(), sourceEnvID)
+		seedEnv(sourceEnvID, "Source Env")
+
+		sourcePlan, err := s.service.CreatePlan(srcCtx, dto.CreatePlanRequest{
+			Name:      "Source Plan Same",
+			LookupKey: "src-plan-same",
+		})
+		s.Require().NoError(err)
+
+		// Clone with no TargetEnvironmentID — should stay in the same env
+		cloned, err := s.service.ClonePlan(srcCtx, sourcePlan.Plan.ID, dto.ClonePlanRequest{
+			Name:      "Cloned Plan Same",
+			LookupKey: "cloned-plan-same",
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(cloned)
+		s.Equal(sourceEnvID, cloned.Plan.EnvironmentID, "cloned plan should be in the same environment as source")
+	})
+
+	s.Run("cross_env_success", func() {
+		srcCtx := types.SetEnvironmentID(s.GetContext(), sourceEnvID)
+		seedEnv(sourceEnvID, "Source Env")
+		seedEnv(targetEnvID, "Target Env")
+
+		sourcePlan, err := s.service.CreatePlan(srcCtx, dto.CreatePlanRequest{
+			Name:      "Source Plan Cross",
+			LookupKey: "src-plan-cross",
+		})
+		s.Require().NoError(err)
+
+		// Add a price to the source plan so we can verify price env is cloned to target
+		srcPrice := &price.Price{
+			ID:                 "price-cross-src",
+			Amount:             decimal.NewFromInt(50),
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+			EntityID:           sourcePlan.Plan.ID,
+			Type:               types.PRICE_TYPE_FIXED,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			EnvironmentID:      sourceEnvID,
+			BaseModel:          types.GetDefaultBaseModel(srcCtx),
+		}
+		s.Require().NoError(s.GetStores().PriceRepo.Create(srcCtx, srcPrice))
+
+		cloned, err := s.service.ClonePlan(srcCtx, sourcePlan.Plan.ID, dto.ClonePlanRequest{
+			Name:                "Cloned Plan Cross",
+			LookupKey:           "cloned-plan-cross",
+			TargetEnvironmentID: lo.ToPtr(targetEnvID),
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(cloned)
+
+		// Plan must be in target env
+		s.Equal(targetEnvID, cloned.Plan.EnvironmentID, "cloned plan should be in the target environment")
+
+		// Every cloned price must be in target env
+		s.Require().NotEmpty(cloned.Prices, "cloned plan should have at least one price")
+		for _, p := range cloned.Prices {
+			s.Equal(targetEnvID, p.Price.EnvironmentID, "cloned price should be in the target environment")
+		}
+	})
+
+	s.Run("cross_env_invalid_target", func() {
+		srcCtx := types.SetEnvironmentID(s.GetContext(), sourceEnvID)
+		seedEnv(sourceEnvID, "Source Env")
+
+		sourcePlan, err := s.service.CreatePlan(srcCtx, dto.CreatePlanRequest{
+			Name:      "Source Plan Invalid",
+			LookupKey: "src-plan-invalid",
+		})
+		s.Require().NoError(err)
+
+		_, err = s.service.ClonePlan(srcCtx, sourcePlan.Plan.ID, dto.ClonePlanRequest{
+			Name:                "Cloned Plan Invalid",
+			LookupKey:           "cloned-plan-invalid",
+			TargetEnvironmentID: lo.ToPtr("nonexistent-env"),
+		})
+		s.Require().Error(err)
+		s.True(ierr.IsNotFound(err), "error should be ErrNotFound for nonexistent target environment, got: %v", err)
+	})
+
+	s.Run("cross_env_lookup_key_conflict_in_target", func() {
+		srcCtx := types.SetEnvironmentID(s.GetContext(), sourceEnvID)
+		tgtCtx := types.SetEnvironmentID(s.GetContext(), targetEnvID)
+		seedEnv(sourceEnvID, "Source Env")
+		seedEnv(targetEnvID, "Target Env")
+
+		const conflictKey = "conflict-key"
+
+		sourcePlan, err := s.service.CreatePlan(srcCtx, dto.CreatePlanRequest{
+			Name:      "Source Plan Conflict",
+			LookupKey: "src-plan-conflict",
+		})
+		s.Require().NoError(err)
+
+		// Pre-create a plan with the conflicting lookup_key in target env
+		_, err = s.service.CreatePlan(tgtCtx, dto.CreatePlanRequest{
+			Name:      "Existing Target Plan",
+			LookupKey: conflictKey,
+		})
+		s.Require().NoError(err)
+
+		// Cloning to target with the same lookup_key should fail with ErrAlreadyExists
+		_, err = s.service.ClonePlan(srcCtx, sourcePlan.Plan.ID, dto.ClonePlanRequest{
+			Name:                "Cloned Plan Conflict",
+			LookupKey:           conflictKey,
+			TargetEnvironmentID: lo.ToPtr(targetEnvID),
+		})
+		s.Require().Error(err)
+		s.True(ierr.IsAlreadyExists(err), "error should be ErrAlreadyExists for conflicting lookup_key in target env, got: %v", err)
+	})
+
+	s.Run("cross_env_lookup_key_ok_if_only_in_source", func() {
+		srcCtx := types.SetEnvironmentID(s.GetContext(), sourceEnvID)
+		seedEnv(sourceEnvID, "Source Env")
+		seedEnv(targetEnvID, "Target Env")
+
+		const sharedKey = "shared-key-only-source"
+
+		// Create source plan with the lookup_key in source env only (target env is empty)
+		sourcePlan, err := s.service.CreatePlan(srcCtx, dto.CreatePlanRequest{
+			Name:      "Source Plan Shared Key",
+			LookupKey: sharedKey,
+		})
+		s.Require().NoError(err)
+
+		// Clone to target env with the same lookup_key — target has no such key, so it should succeed
+		cloned, err := s.service.ClonePlan(srcCtx, sourcePlan.Plan.ID, dto.ClonePlanRequest{
+			Name:                "Cloned Plan Shared Key",
+			LookupKey:           sharedKey,
+			TargetEnvironmentID: lo.ToPtr(targetEnvID),
+		})
+		s.Require().NoError(err)
+		s.Require().NotNil(cloned)
+		s.Equal(targetEnvID, cloned.Plan.EnvironmentID, "cloned plan should be in the target environment")
+		s.Equal(sharedKey, cloned.Plan.LookupKey, "cloned plan should have the same lookup_key")
 	})
 }

--- a/internal/service/plan_test.go
+++ b/internal/service/plan_test.go
@@ -1238,8 +1238,9 @@ func (s *PlanServiceSuite) TestClonePlan_CrossEnv() {
 
 	// seedEnv creates an environment in the store, ignoring already-exists errors
 	// so sub-tests that share the same IDs can each set up their own state.
+	// Unexpected errors are logged so they don't silently mask test failures.
 	seedEnv := func(id, name string) {
-		_ = s.GetStores().EnvironmentRepo.Create(s.GetContext(), &environment.Environment{
+		err := s.GetStores().EnvironmentRepo.Create(s.GetContext(), &environment.Environment{
 			ID:   id,
 			Name: name,
 			Type: types.EnvironmentDevelopment,
@@ -1248,6 +1249,9 @@ func (s *PlanServiceSuite) TestClonePlan_CrossEnv() {
 				Status:   types.StatusPublished,
 			},
 		})
+		if err != nil && !ierr.IsAlreadyExists(err) {
+			s.T().Logf("seedEnv: unexpected error creating env %s: %v", id, err)
+		}
 	}
 
 	s.Run("same_env_no_target", func() {

--- a/internal/testutil/inmemory_environment_store.go
+++ b/internal/testutil/inmemory_environment_store.go
@@ -52,7 +52,7 @@ func (s *InMemoryEnvironmentStore) Get(ctx context.Context, id string) (*environ
 	}
 	return nil, ierr.NewError("environment not found").
 		WithHint("Environment not found").
-		Mark(ierr.ErrDatabase)
+		Mark(ierr.ErrNotFound)
 }
 
 func (s *InMemoryEnvironmentStore) List(ctx context.Context, filter types.Filter) ([]*environment.Environment, error) {

--- a/internal/testutil/inmemory_environment_store.go
+++ b/internal/testutil/inmemory_environment_store.go
@@ -34,7 +34,7 @@ func (s *InMemoryEnvironmentStore) Create(ctx context.Context, env *environment.
 	if _, exists := s.environments[env.ID]; exists {
 		return ierr.NewError("environment already exists").
 			WithHint("Environment already exists").
-			Mark(ierr.ErrDatabase)
+			Mark(ierr.ErrAlreadyExists)
 	}
 
 	env.CreatedAt = time.Now()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional target environment for plan cloning: specify a target environment to clone a plan and its associated prices/entitlements/credits into.

* **Bug Fixes**
  * Uniqueness checks and stamping now apply to the target environment; cloning to a non-existent target returns not-found and target conflicts are detected as already-exists.

* **Tests**
  * Added cross-environment cloning tests covering same-env, cross-env, missing-target, and lookup-key conflict scenarios.

* **Documentation**
  * OpenAPI/Swagger updated to document target_environment_id and adjusted enum metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->