### PR TITLE
fix(billing): correct calendar billing period end for quarterly and half-yearly subscriptions

### DIFF
--- a/internal/types/date.go
+++ b/internal/types/date.go
@@ -88,6 +88,20 @@ func NextBillingDate(currentPeriodStart, billingAnchor time.Time, unit int, peri
 			Mark(ierr.ErrValidation)
 	}
 
+	// For calendar billing with QUARTERLY and HALF_YEARLY periods, the billingAnchor
+	// is set to the start of the next calendar boundary (e.g. April 1 for a
+	// subscription starting mid-Q1). If currentPeriodStart is before the anchor,
+	// we are still in the partial first period and the next billing date IS
+	// the anchor itself. MONTHLY and ANNUAL already handle this correctly via
+	// their own month/year arithmetic.
+	if (period == BILLING_PERIOD_QUARTER || period == BILLING_PERIOD_HALF_YEAR) &&
+		currentPeriodStart.Before(billingAnchor) {
+		if subscriptionEndDate != nil && billingAnchor.After(*subscriptionEndDate) {
+			return *subscriptionEndDate, nil
+		}
+		return billingAnchor, nil
+	}
+
 	// Get the current year and month
 	y, m, _ := currentPeriodStart.Date()
 	// get the time always from anchor because

--- a/internal/types/date_test.go
+++ b/internal/types/date_test.go
@@ -1066,6 +1066,84 @@ func TestNextBillingDate_HalfYearly_Calendar(t *testing.T) {
 	}
 }
 
+// TestNextBillingDate_Quarterly_Calendar_EndDateCliff exercises the subscriptionEndDate
+// clamp branch inside the new early-return guard for QUARTERLY calendar billing.
+func TestNextBillingDate_Quarterly_Calendar_EndDateCliff(t *testing.T) {
+	tests := []struct {
+		name    string
+		current time.Time
+		anchor  time.Time
+		endDate time.Time
+		want    time.Time
+	}{
+		{
+			name:    "end date before anchor cliffs to end date",
+			current: time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC),
+			anchor:  time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			endDate: time.Date(2026, time.March, 28, 0, 0, 0, 0, time.UTC),
+			want:    time.Date(2026, time.March, 28, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "end date after anchor returns anchor",
+			current: time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC),
+			anchor:  time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			endDate: time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC),
+			want:    time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NextBillingDate(tt.current, tt.anchor, 1, BILLING_PERIOD_QUARTER, &tt.endDate)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNextBillingDate_HalfYearly_Calendar_EndDateCliff exercises the subscriptionEndDate
+// clamp branch inside the new early-return guard for HALF_YEAR calendar billing.
+func TestNextBillingDate_HalfYearly_Calendar_EndDateCliff(t *testing.T) {
+	tests := []struct {
+		name    string
+		current time.Time
+		anchor  time.Time
+		endDate time.Time
+		want    time.Time
+	}{
+		{
+			name:    "end date before anchor cliffs to end date",
+			current: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
+			anchor:  time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			endDate: time.Date(2026, time.May, 31, 0, 0, 0, 0, time.UTC),
+			want:    time.Date(2026, time.May, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "end date after anchor returns anchor",
+			current: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
+			anchor:  time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			endDate: time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC),
+			want:    time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NextBillingDate(tt.current, tt.anchor, 1, BILLING_PERIOD_HALF_YEAR, &tt.endDate)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // Helper function to check if a string contains another string
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && s[0:len(substr)] == substr

--- a/internal/types/date_test.go
+++ b/internal/types/date_test.go
@@ -820,6 +820,252 @@ func TestNextBillingDate_Daily_CalendarBilling(t *testing.T) {
 	}
 }
 
+// TestNextBillingDate_Quarterly_Calendar tests quarterly calendar billing period calculations.
+// Calendar billing aligns periods with calendar quarter boundaries (Q1: Jan-Mar, Q2: Apr-Jun, etc.)
+func TestNextBillingDate_Quarterly_Calendar(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentPeriod time.Time
+		billingAnchor time.Time
+		unit          int
+		want          time.Time
+	}{
+		{
+			// Sub starts March 22. Calendar anchor = April 1 (start of Q2).
+			// First period: March 22 → April 1 (partial Q1 tail).
+			name:          "partial first period: mid-Q1 start (Mar 22) → Apr 1",
+			currentPeriod: time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_QUARTER),
+			unit:          1,
+			want:          time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Second full period: April 1 → July 1.
+			name:          "full Q2 period: Apr 1 → Jul 1",
+			currentPeriod: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_QUARTER),
+			unit:          1,
+			want:          time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Third full period: July 1 → October 1.
+			name:          "full Q3 period: Jul 1 → Oct 1",
+			currentPeriod: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_QUARTER),
+			unit:          1,
+			want:          time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Q4 period: October 1 → January 1.
+			name:          "full Q4 period: Oct 1 → Jan 1",
+			currentPeriod: time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_QUARTER),
+			unit:          1,
+			want:          time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Sub starts exactly on a quarter boundary (April 1). Anchor = July 1.
+			// First (full) period: April 1 → July 1.
+			name:          "start exactly on quarter boundary: Apr 1 → Jul 1",
+			currentPeriod: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_QUARTER),
+			unit:          1,
+			want:          time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Anniversary quarterly: anchor = start date. No calendar alignment.
+			name:          "anniversary quarterly: Mar 22, anchor Mar 22 → Jun 22",
+			currentPeriod: time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.March, 22, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2026, time.June, 22, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("currentPeriod: %v, billingAnchor: %v, unit: %d", tt.currentPeriod, tt.billingAnchor, tt.unit)
+			got, err := NextBillingDateLegacy(tt.currentPeriod, tt.billingAnchor, tt.unit, BILLING_PERIOD_QUARTER)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNextBillingDate_Quarterly_Calendar_BackwardCompat verifies that existing subscriptions
+// whose first period was calculated with the OLD behavior (e.g. March 22 → June 1 instead of
+// March 22 → April 1) continue to advance consistently and are NOT realigned.
+// We must not break existing subscriptions — only new ones get the corrected calendar alignment.
+func TestNextBillingDate_Quarterly_Calendar_BackwardCompat(t *testing.T) {
+	// Simulate an existing subscription:
+	//   subscriptionStart = March 22 (created before the fix)
+	//   billingAnchor     = April 1  (correctly stored on creation)
+	//   OLD first period  : March 22 → June 1  (was the wrong end date)
+	//
+	// After June 1 the cron advances currentPeriodStart to June 1 and calls
+	// NextBillingDate(June 1, April 1, ...). Since June 1 > April 1 the new
+	// guard does NOT fire; we simply add 3 months → September 1, keeping the
+	// existing cadence intact.
+	tests := []struct {
+		name          string
+		currentPeriod time.Time
+		billingAnchor time.Time
+		unit          int
+		want          time.Time
+	}{
+		{
+			name:          "2nd period of old sub: Jun 1 (old wrong end) → Sep 1",
+			currentPeriod: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:          "3rd period of old sub: Sep 1 → Dec 1",
+			currentPeriod: time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:          "4th period of old sub: Dec 1 → Mar 1 2027",
+			currentPeriod: time.Date(2026, time.December, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NextBillingDateLegacy(tt.currentPeriod, tt.billingAnchor, tt.unit, BILLING_PERIOD_QUARTER)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNextBillingDate_HalfYearly_Calendar_BackwardCompat mirrors the quarterly backward-compat
+// test for half-yearly subscriptions created before the fix.
+func TestNextBillingDate_HalfYearly_Calendar_BackwardCompat(t *testing.T) {
+	// Old sub: started March 15, anchor = July 1 (day=1).
+	// OLD first period: March 15 → September 1
+	//   (targetD = billingAnchor.Day() = 1, targetM = March+6 = September)
+	// OLD second period: September 1 → March 1 2027
+	// Since all these currentPeriodStarts are > billingAnchor, the new guard
+	// does NOT fire and the cadence is preserved as-is.
+	tests := []struct {
+		name          string
+		currentPeriod time.Time
+		billingAnchor time.Time
+		unit          int
+		want          time.Time
+	}{
+		{
+			name:          "2nd period of old half-yearly sub: Sep 1 → Mar 1 2027",
+			currentPeriod: time.Date(2026, time.September, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:          "3rd period of old half-yearly sub: Mar 1 2027 → Sep 1 2027",
+			currentPeriod: time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2027, time.September, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NextBillingDateLegacy(tt.currentPeriod, tt.billingAnchor, tt.unit, BILLING_PERIOD_HALF_YEAR)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNextBillingDate_HalfYearly_Calendar tests half-yearly calendar billing period calculations.
+// Calendar billing aligns periods with half-year boundaries (H1: Jan-Jun, H2: Jul-Dec).
+func TestNextBillingDate_HalfYearly_Calendar(t *testing.T) {
+	tests := []struct {
+		name          string
+		currentPeriod time.Time
+		billingAnchor time.Time
+		unit          int
+		want          time.Time
+	}{
+		{
+			// Sub starts March 15. Anchor = July 1 (start of H2).
+			// First period: March 15 → July 1 (partial H1 tail).
+			name:          "partial first period: mid-H1 start (Mar 15) → Jul 1",
+			currentPeriod: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_HALF_YEAR),
+			unit:          1,
+			want:          time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Second full period: July 1 → January 1.
+			name:          "full H2 period: Jul 1 → Jan 1",
+			currentPeriod: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_HALF_YEAR),
+			unit:          1,
+			want:          time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Third full period: January 1 → July 1.
+			name:          "full H1 period: Jan 1 2027 → Jul 1 2027",
+			currentPeriod: time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_HALF_YEAR),
+			unit:          1,
+			want:          time.Date(2027, time.July, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Sub starts October 5 (H2). Anchor = January 1.
+			// First period: Oct 5 → Jan 1 (partial H2 tail).
+			name:          "partial first period: mid-H2 start (Oct 5) → Jan 1",
+			currentPeriod: time.Date(2026, time.October, 5, 0, 0, 0, 0, time.UTC),
+			billingAnchor: CalculateCalendarBillingAnchor(time.Date(2026, time.October, 5, 0, 0, 0, 0, time.UTC), BILLING_PERIOD_HALF_YEAR),
+			unit:          1,
+			want:          time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// Anniversary half-yearly: anchor = start date.
+			name:          "anniversary half-yearly: Mar 15, anchor Mar 15 → Sep 15",
+			currentPeriod: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
+			billingAnchor: time.Date(2026, time.March, 15, 0, 0, 0, 0, time.UTC),
+			unit:          1,
+			want:          time.Date(2026, time.September, 15, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("currentPeriod: %v, billingAnchor: %v, unit: %d", tt.currentPeriod, tt.billingAnchor, tt.unit)
+			got, err := NextBillingDateLegacy(tt.currentPeriod, tt.billingAnchor, tt.unit, BILLING_PERIOD_HALF_YEAR)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // Helper function to check if a string contains another string
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && s[0:len(substr)] == substr


### PR DESCRIPTION
## Problem Statement

Calendar billing for **quarterly** and **half-yearly** subscriptions was computing the first billing period end date incorrectly.

**Example:** A subscription starting **March 22** with quarterly calendar billing:
- **Expected:** `current_period_end = April 1` (start of Q2 — the next calendar quarter boundary)
- **Actual (buggy):** `current_period_end = June 1` (March + 3 months, ignoring calendar alignment)

Similarly, a half-yearly subscription starting **March 15**:
- **Expected:** `current_period_end = July 1` (start of H2)
- **Actual (buggy):** `current_period_end = September 1` (March + 6 months)

Calendar quarter boundaries: Q1 Jan–Mar, Q2 Apr–Jun, Q3 Jul–Sep, Q4 Oct–Dec.  
Calendar half-year boundaries: H1 Jan–Jun, H2 Jul–Dec.

Monthly and annual calendar billing were **not affected** (working correctly).

---

## Root Cause

`NextBillingDate` in `internal/types/date.go` computes the next period end by adding months to `currentPeriodStart.Month()` and taking the day from `billingAnchor.Day()`. For `QUARTERLY` and `HALF_YEARLY`, this formula adds 3 or 6 months from the subscription start date, without checking whether the subscription started mid-period and the first true calendar boundary is already stored in `billingAnchor`.

`CalculateCalendarBillingAnchor` correctly computes the anchor (e.g. April 1 for a March 22 start), but `NextBillingDate` ignored it for the first period.

`MONTHLY` accidentally works because `currentMonth + 1` lands on the same month as the anchor. `ANNUAL` works because it explicitly uses `billingAnchor.Month()` as the target month.

---

## Dev Approach

Added a targeted guard in `NextBillingDate` (`internal/types/date.go`):

```go
// For calendar billing with QUARTERLY and HALF_YEARLY periods, the billingAnchor
// is set to the start of the next calendar boundary (e.g. April 1 for a
// subscription starting mid-Q1). If currentPeriodStart is before the anchor,
// we are still in the partial first period and the next billing date IS
// the anchor itself.
if (period == BILLING_PERIOD_QUARTER || period == BILLING_PERIOD_HALF_YEAR) &&
    currentPeriodStart.Before(billingAnchor) {
    if subscriptionEndDate != nil && billingAnchor.After(*subscriptionEndDate) {
        return *subscriptionEndDate, nil
    }
    return billingAnchor, nil
}
```

**Why only QUARTERLY/HALF_YEARLY?**
- `MONTHLY`: already works (month+1 == anchor month, day=1)
- `ANNUAL`: already works (uses `billingAnchor.Month()` explicitly)
- `WEEKLY`/`DAILY`: handled in a separate code path before this guard

**Backward compatibility:** The guard only fires when `currentPeriodStart < billingAnchor`. For existing subscriptions that have already advanced their period (so `currentPeriodStart ≥ anchor`), the guard never triggers and the old cadence is preserved exactly — e.g. an old sub whose first period ended June 1 (wrong) continues June 1 → Sep 1 → Dec 1 without realignment.

---

## Test Summary

**New test functions in `internal/types/date_test.go`:**

| Test | Cases | What it covers |
|------|-------|----------------|
| `TestNextBillingDate_Quarterly_Calendar` | 6 | Partial first period (Mar 22→Apr 1), all 4 full quarter transitions, exact Q-start subscription, anniversary mode unchanged |
| `TestNextBillingDate_Quarterly_Calendar_BackwardCompat` | 3 | Existing subscriptions with old period-end dates (Jun 1, Sep 1…) advance by 3 months normally — **no realignment** |
| `TestNextBillingDate_HalfYearly_Calendar` | 5 | Partial H1/H2 first periods, full H1↔H2 transitions, anniversary mode unchanged |
| `TestNextBillingDate_HalfYearly_Calendar_BackwardCompat` | 2 | Existing half-yearly subscriptions advance normally without disruption |

**E2E verified via live local API:**

| Scenario | `current_period_end` | Expected | ✅ |
|----------|---------------------|---------|---|
| Quarterly calendar, starts Mar 22 | Apr 1 | Apr 1 | ✅ |
| Quarterly calendar, starts Jan 1 (exact boundary) | Apr 1 | Apr 1 | ✅ |
| Half-yearly calendar, starts Mar 15 | Jul 1 | Jul 1 | ✅ |
| Quarterly anniversary, starts Mar 22 | Jun 22 | Jun 22 (unchanged) | ✅ |

All existing tests in `internal/types/` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected next billing date behavior for quarterly and half-year billing so dates align to the billing anchor and are clamped to the subscription end date where applicable.

* **Tests**
  * Added tests covering quarter and half-year calendar alignment, clamping to subscription end dates, and backward-compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->