### PR TITLE
feat(subscription): add scheduled_date cancellation type with guard v…

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -411,6 +411,10 @@ type CancelSubscriptionRequest struct {
 	// Reason for cancellation (for audit and business intelligence)
 	Reason string `json:"reason,omitempty"`
 
+	// CancelAt is the custom date to cancel the subscription.
+	// Required when CancellationType is "scheduled_date". Must be in the future.
+	CancelAt *time.Time `json:"cancel_at,omitempty"`
+
 	//SuppressWebhook is an internal flag to suppress webhook events during cancellation.
 	SuppressWebhook bool `json:"-,omitempty"`
 }
@@ -452,6 +456,21 @@ func (r *CancelSubscriptionRequest) Validate() error {
 	if err := r.CancellationType.Validate(); err != nil {
 		return err
 	}
+
+	// Validate scheduled_date specific fields
+	if r.CancellationType == types.CancellationTypeScheduledDate {
+		if r.CancelAt == nil {
+			return ierr.NewError("cancel_at is required for scheduled_date cancellation type").
+				WithHint("Provide a future date in cancel_at when using scheduled_date cancellation type").
+				Mark(ierr.ErrValidation)
+		}
+		if !r.CancelAt.After(time.Now().UTC()) {
+			return ierr.NewError("cancel_at must be in the future").
+				WithHint("Provide a future date in cancel_at").
+				Mark(ierr.ErrValidation)
+		}
+	}
+
 	// Set default proration behavior if not provided
 	if r.ProrationBehavior == "" {
 		r.ProrationBehavior = types.ProrationBehaviorNone

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4795,6 +4795,13 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 	effectiveDate time.Time,
 	reason string,
 ) error {
+	now := time.Now().UTC()
+
+	// Update cancellation fields
+	// For immediate cancellations, cancelled_at is the time of the subscription cancellation
+	// For scheduled cancellations, cancelled_at is the time when the cancellation was scheduled (not when it will be executed)
+	subscription.CancelledAt = &now
+
 	// Add cancellation metadata
 	if subscription.Metadata == nil {
 		subscription.Metadata = make(map[string]string)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1804,7 +1804,7 @@ func (s *subscriptionService) CancelSubscription(
 
 	if !req.SuppressWebhook {
 		// Step 10: Publish events
-		s.publishCancellationEvents(ctx, subscription)
+		s.publishCancellationEvents(ctx, subscription, req.CancellationType)
 	}
 
 	// Step 11: Build response
@@ -4702,6 +4702,11 @@ func (s *subscriptionService) determineEffectiveDate(
 		return subscription.CurrentPeriodEnd, nil
 
 	case types.CancellationTypeScheduledDate:
+		if customDate == nil {
+			return time.Time{}, ierr.NewError("cancel_at is required for scheduled_date").
+				WithHint("Provide a future date in cancel_at").
+				Mark(ierr.ErrValidation)
+		}
 		return customDate.UTC(), nil
 
 	default:
@@ -4837,14 +4842,17 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 // publishCancellationEvents publishes webhook events for cancellation
 func (s *subscriptionService) publishCancellationEvents(
 	ctx context.Context,
-	subscription *subscription.Subscription,
+	sub *subscription.Subscription,
+	cancellationType types.CancellationType,
 ) {
-	// Publish standard subscription events
-	s.publishInternalWebhookEvent(ctx, types.WebhookEventSubscriptionUpdated, subscription.ID)
-	s.publishInternalWebhookEvent(ctx, types.WebhookEventSubscriptionCancelled, subscription.ID)
-
+	// Always emit updated — subscription state has changed regardless of cancellation type
+	s.publishInternalWebhookEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
+	// scheduled_date only schedules a future cancellation; emit cancelled when it actually fires
+	if cancellationType != types.CancellationTypeScheduledDate {
+		s.publishInternalWebhookEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
+	}
 	s.Logger.Debugw("subscription cancellation events published",
-		"subscription_id", subscription.ID)
+		"subscription_id", sub.ID)
 }
 
 // generateCancellationMessage creates a user-friendly message for the response

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1662,19 +1662,11 @@ func (s *subscriptionService) CancelSubscription(
 			Mark(ierr.ErrValidation)
 	}
 
-	// Step 3b: Additional validations for scheduled_date cancellations
-	if req.CancellationType == types.CancellationTypeScheduledDate {
-		// Reject if end_date is already set — avoid silent overwrites
-		if subscription.EndDate != nil {
-			return nil, ierr.NewError("subscription already has an end date set").
-				WithHint("The subscription already has an end date.").
-				WithReportableDetails(map[string]interface{}{
-					"subscription_id":   subscriptionID,
-					"existing_end_date": subscription.EndDate.Format(time.RFC3339),
-				}).
-				Mark(ierr.ErrValidation)
-		}
-		// Reject if cancel_at is already set — subscription is already scheduled to cancel
+	// Step 3b: Guard against double-scheduling
+	// Both end_of_period and scheduled_date schedule a future cancellation via cancel_at.
+	// Reject if one is already in place to prevent silent overwrites.
+	if req.CancellationType == types.CancellationTypeScheduledDate ||
+		req.CancellationType == types.CancellationTypeEndOfPeriod {
 		if subscription.CancelAt != nil {
 			return nil, ierr.NewError("subscription is already scheduled to cancel").
 				WithHint("The subscription already has a scheduled cancellation. Cancel the existing schedule before setting a new one.").
@@ -1698,11 +1690,6 @@ func (s *subscriptionService) CancelSubscription(
 	// Step 5: Execute in transaction
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 
-		// For scheduled_date cancellations, only mark end_date — skip all side-effects.
-		if req.CancellationType == types.CancellationTypeScheduledDate {
-			return s.updateSubscriptionForCancellation(ctx, subscription, req.CancellationType, effectiveDate, req.Reason)
-		}
-
 		// Step 6: Calculate proration using unified function
 		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations {
 			prorationService := NewProrationService(s.ServiceParams)
@@ -1721,7 +1708,11 @@ func (s *subscriptionService) CancelSubscription(
 		if invoicePolicy == "" {
 			invoicePolicy = types.CancelImmediatelyInvoicePolicySkip
 		}
-		shouldCreateInvoice := req.CancellationType != types.CancellationTypeEndOfPeriod &&
+		// Scheduled cancellations (end_of_period and scheduled_date) do not generate an
+		// immediate invoice — billing continues until the effective date.
+		isScheduled := req.CancellationType == types.CancellationTypeEndOfPeriod ||
+			req.CancellationType == types.CancellationTypeScheduledDate
+		shouldCreateInvoice := !isScheduled &&
 			invoicePolicy == types.CancelImmediatelyInvoicePolicyGenerateInvoice
 		if shouldCreateInvoice {
 			invoiceService := NewInvoiceService(s.ServiceParams)
@@ -1745,9 +1736,10 @@ func (s *subscriptionService) CancelSubscription(
 
 		}
 
-		// Step 6.5: Capture original state BEFORE modification (for end_of_period cancellations)
+		// Step 6.5: Capture original state BEFORE modification (for scheduled cancellations)
 		var originalState *subscriptionOriginalState
-		if req.CancellationType == types.CancellationTypeEndOfPeriod {
+		if req.CancellationType == types.CancellationTypeEndOfPeriod ||
+			req.CancellationType == types.CancellationTypeScheduledDate {
 			originalState = &subscriptionOriginalState{
 				CancelAtPeriodEnd: subscription.CancelAtPeriodEnd,
 				CancelAt:          subscription.CancelAt,
@@ -1766,8 +1758,9 @@ func (s *subscriptionService) CancelSubscription(
 			return err
 		}
 
-		// Step 7b: Handle scheduling for end_of_period cancellation
-		if req.CancellationType == types.CancellationTypeEndOfPeriod {
+		// Step 7b: Handle scheduling for future cancellations (end_of_period and scheduled_date)
+		if req.CancellationType == types.CancellationTypeEndOfPeriod ||
+			req.CancellationType == types.CancellationTypeScheduledDate {
 			// Cancel all pending schedules (especially plan changes) before creating cancellation schedule
 			if err := s.cancelAllPendingSchedules(ctx, subscription.ID); err != nil {
 				logger.Errorw("failed to cancel pending schedules", "error", err)
@@ -4818,14 +4811,11 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 		subscription.CancelAtPeriodEnd = false
 		subscription.EndDate = &effectiveDate
 
-	case types.CancellationTypeEndOfPeriod:
-		// Don't change status immediately - will be cancelled at period end
+	case types.CancellationTypeEndOfPeriod, types.CancellationTypeScheduledDate:
+		// Don't change status immediately — actual cancellation runs when the schedule fires.
+		// EndDate is NOT set here; it will be set by the cancellation schedule processor.
 		subscription.CancelAtPeriodEnd = true
 		subscription.CancelAt = &effectiveDate
-		// EndDate should NOT be set - will be set when actually cancelled at period end
-
-	case types.CancellationTypeScheduledDate:
-		subscription.EndDate = &effectiveDate
 
 	default:
 		return ierr.NewError("invalid cancellation type").

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1662,8 +1662,32 @@ func (s *subscriptionService) CancelSubscription(
 			Mark(ierr.ErrValidation)
 	}
 
+	// Step 3b: Additional validations for scheduled_date cancellations
+	if req.CancellationType == types.CancellationTypeScheduledDate {
+		// Reject if end_date is already set — avoid silent overwrites
+		if subscription.EndDate != nil {
+			return nil, ierr.NewError("subscription already has an end date set").
+				WithHint("The subscription already has an end date.").
+				WithReportableDetails(map[string]interface{}{
+					"subscription_id":   subscriptionID,
+					"existing_end_date": subscription.EndDate.Format(time.RFC3339),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		// Reject if cancel_at is already set — subscription is already scheduled to cancel
+		if subscription.CancelAt != nil {
+			return nil, ierr.NewError("subscription is already scheduled to cancel").
+				WithHint("The subscription already has a scheduled cancellation. Cancel the existing schedule before setting a new one.").
+				WithReportableDetails(map[string]interface{}{
+					"subscription_id":    subscriptionID,
+					"existing_cancel_at": subscription.CancelAt.Format(time.RFC3339),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
 	// Step 4: Determine effective cancellation date
-	effectiveDate, err := s.determineEffectiveDate(subscription, req.CancellationType)
+	effectiveDate, err := s.determineEffectiveDate(subscription, req.CancellationType, req.CancelAt)
 	if err != nil {
 		return nil, err
 	}
@@ -1673,6 +1697,11 @@ func (s *subscriptionService) CancelSubscription(
 
 	// Step 5: Execute in transaction
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
+
+		// For scheduled_date cancellations, only mark end_date — skip all side-effects.
+		if req.CancellationType == types.CancellationTypeScheduledDate {
+			return s.updateSubscriptionForCancellation(ctx, subscription, req.CancellationType, effectiveDate, req.Reason)
+		}
 
 		// Step 6: Calculate proration using unified function
 		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations {
@@ -4663,10 +4692,12 @@ func (s *subscriptionService) ProcessAutoCancellationSubscriptions(ctx context.C
 
 // Helper functions for enhanced cancellation
 
-// determineEffectiveDate calculates the actual effective date based on cancellation type
+// determineEffectiveDate calculates the actual effective date based on cancellation type.
+// customDate is used when cancellationType is CancellationTypeScheduledDate.
 func (s *subscriptionService) determineEffectiveDate(
 	subscription *subscription.Subscription,
 	cancellationType types.CancellationType,
+	customDate *time.Time,
 ) (time.Time, error) {
 	now := time.Now().UTC()
 
@@ -4676,6 +4707,10 @@ func (s *subscriptionService) determineEffectiveDate(
 
 	case types.CancellationTypeEndOfPeriod:
 		return subscription.CurrentPeriodEnd, nil
+
+	case types.CancellationTypeScheduledDate:
+		return customDate.UTC(), nil
+
 	default:
 		return time.Time{}, ierr.NewError("invalid cancellation type").
 			WithHintf("Unsupported cancellation type: %s", cancellationType).
@@ -4760,13 +4795,6 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 	effectiveDate time.Time,
 	reason string,
 ) error {
-	now := time.Now().UTC()
-
-	// Update cancellation fields
-	// For immediate cancellations, cancelled_at is the time of the subscription cancellation
-	// For scheduled cancellations, cancelled_at is the time when the cancellation was scheduled (not when it will be executed)
-	subscription.CancelledAt = &now
-
 	// Add cancellation metadata
 	if subscription.Metadata == nil {
 		subscription.Metadata = make(map[string]string)
@@ -4788,6 +4816,10 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 		subscription.CancelAtPeriodEnd = true
 		subscription.CancelAt = &effectiveDate
 		// EndDate should NOT be set - will be set when actually cancelled at period end
+
+	case types.CancellationTypeScheduledDate:
+		subscription.EndDate = &effectiveDate
+
 	default:
 		return ierr.NewError("invalid cancellation type").
 			WithHintf("Unsupported cancellation type: %s", cancellationType).
@@ -4835,6 +4867,9 @@ func (s *subscriptionService) generateCancellationMessage(
 	case types.CancellationTypeEndOfPeriod:
 		return fmt.Sprintf("Subscription will be cancelled at the end of the current period (%s)",
 			effectiveDate.Format("2006-01-02"))
+
+	case types.CancellationTypeScheduledDate:
+		return fmt.Sprintf("Subscription end date set to %s", effectiveDate.Format("2006-01-02"))
 
 	default:
 		return "Subscription cancelled successfully"

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -3500,7 +3500,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 		return sub
 	}
 
-	s.Run("sets only end_date, nothing else changes", func() {
+	s.Run("mirrors end_of_period: sets cancel_at, cancel_at_period_end, cancelled_at; status stays active", func() {
 		sub := newActiveSub("sub_sched_basic")
 
 		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
@@ -3512,18 +3512,19 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 
 		updated, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
 		s.NoError(err)
-		// Only end_date should be touched
-		s.NotNil(updated.EndDate, "end_date must be set")
-		s.WithinDuration(futureDate, *updated.EndDate, time.Second)
-		// Everything else must be untouched
+		// Effective date is pinned to the custom cancel_at
+		s.NotNil(updated.CancelAt, "cancel_at must be set to the requested date")
+		s.WithinDuration(futureDate, *updated.CancelAt, time.Second)
+		// Mirrors end_of_period: subscription stays active, cancel_at_period_end flagged
 		s.Equal(types.SubscriptionStatusActive, updated.SubscriptionStatus, "status must stay active")
-		s.Nil(updated.CancelAt, "cancel_at must NOT be set")
-		s.Nil(updated.CancelledAt, "cancelled_at must NOT be set")
-		s.False(updated.CancelAtPeriodEnd, "cancel_at_period_end must be false")
-		s.T().Logf("✅ scheduled_date: only end_date is set, all other fields untouched")
+		s.True(updated.CancelAtPeriodEnd, "cancel_at_period_end must be true")
+		s.NotNil(updated.CancelledAt, "cancelled_at must be set (time the cancellation was scheduled)")
+		// end_date is NOT set here — the schedule processor sets it when it fires
+		s.Nil(updated.EndDate, "end_date must NOT be set at scheduling time")
+		s.T().Logf("✅ scheduled_date: same fields as end_of_period, effective date = custom cancel_at")
 	})
 
-	s.Run("metadata records cancellation details but cancel_at stays nil", func() {
+	s.Run("metadata records cancellation details and cancel_at is set", func() {
 		sub := newActiveSub("sub_sched_metadata")
 
 		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
@@ -3538,9 +3539,8 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 		s.Equal("scheduled_date", updated.Metadata["cancellation_type"])
 		s.Equal("user_request", updated.Metadata["cancellation_reason"])
 		s.NotEmpty(updated.Metadata["effective_date"])
-		// Scheduling must not flip cancel_at
-		s.Nil(updated.CancelAt, "cancel_at must remain nil after scheduled_date cancel")
-		s.T().Logf("✅ scheduled_date: metadata recorded, cancel_at remains nil")
+		s.NotNil(updated.CancelAt, "cancel_at must be set to effective date")
+		s.T().Logf("✅ scheduled_date: metadata recorded, cancel_at set to requested date")
 	})
 
 	s.Run("no invoice created for scheduled_date", func() {
@@ -3587,42 +3587,12 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 		s.T().Logf("✅ scheduled_date: past cancel_at rejected")
 	})
 
-	s.Run("errors if end_date is already set", func() {
-		existingEndDate := s.testData.now.Add(10 * 24 * time.Hour)
-		sub := &subscription.Subscription{
-			ID:                 "sub_sched_existing_enddate",
-			CustomerID:         s.testData.customer.ID,
-			PlanID:             s.testData.plan.ID,
-			SubscriptionStatus: types.SubscriptionStatusActive,
-			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
-			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
-			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
-			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-			BillingPeriodCount: 1,
-			Currency:           "usd",
-			EndDate:            &existingEndDate, // already set
-			BaseModel:          types.GetDefaultBaseModel(ctx),
-		}
-		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
-
-		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
-			CancellationType: types.CancellationTypeScheduledDate,
-			CancelAt:         &futureDate,
-		})
-		s.Error(err)
-		s.Contains(err.Error(), "end date")
-
-		// Confirm end_date was NOT overwritten
-		updated, fetchErr := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
-		s.NoError(fetchErr)
-		s.WithinDuration(existingEndDate, *updated.EndDate, time.Second, "existing end_date must not be overwritten")
-		s.T().Logf("✅ scheduled_date: existing end_date is protected from overwrite")
-	})
-
-	s.Run("errors if subscription is already scheduled to cancel (cancel_at set)", func() {
+	s.Run("errors if subscription is already scheduled to cancel via end_of_period", func() {
+		// Simulates: user first scheduled end_of_period, then tries scheduled_date again.
+		// The guard covers both types, so this must be rejected.
 		existingCancelAt := s.testData.now.Add(5 * 24 * time.Hour)
 		sub := &subscription.Subscription{
-			ID:                 "sub_sched_already_scheduled",
+			ID:                 "sub_sched_eop_already_set",
 			CustomerID:         s.testData.customer.ID,
 			PlanID:             s.testData.plan.ID,
 			SubscriptionStatus: types.SubscriptionStatusActive,
@@ -3632,7 +3602,8 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			Currency:           "usd",
-			CancelAt:           &existingCancelAt, // already scheduled
+			CancelAt:           &existingCancelAt,
+			CancelAtPeriodEnd:  true,
 			BaseModel:          types.GetDefaultBaseModel(ctx),
 		}
 		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
@@ -3648,7 +3619,65 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 		updated, fetchErr := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
 		s.NoError(fetchErr)
 		s.WithinDuration(existingCancelAt, *updated.CancelAt, time.Second, "existing cancel_at must not be overwritten")
+		s.T().Logf("✅ scheduled_date: rejects when end_of_period cancel_at is already set")
+	})
+
+	s.Run("errors if subscription is already scheduled to cancel (cancel_at set)", func() {
+		existingCancelAt := s.testData.now.Add(5 * 24 * time.Hour)
+		sub := &subscription.Subscription{
+			ID:                 "sub_sched_already_scheduled",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			CancelAt:           &existingCancelAt,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "already scheduled")
+
+		updated, fetchErr := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+		s.NoError(fetchErr)
+		s.WithinDuration(existingCancelAt, *updated.CancelAt, time.Second, "existing cancel_at must not be overwritten")
 		s.T().Logf("✅ scheduled_date: existing cancel_at is protected from overwrite")
+	})
+
+	s.Run("guard also blocks end_of_period when cancel_at is already set", func() {
+		existingCancelAt := s.testData.now.Add(5 * 24 * time.Hour)
+		sub := &subscription.Subscription{
+			ID:                 "sub_eop_already_scheduled",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			CancelAt:           &existingCancelAt,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:  types.CancellationTypeEndOfPeriod,
+			ProrationBehavior: types.ProrationBehaviorNone,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "already scheduled")
+		s.T().Logf("✅ end_of_period: same guard blocks double-scheduling")
 	})
 
 	s.Run("already cancelled subscription is rejected", func() {

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -3570,6 +3570,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			// CancelAt intentionally omitted
 		})
 		s.Error(err)
+		s.True(ierr.IsValidation(err), "expected validation error")
 		s.Contains(err.Error(), "cancel_at")
 		s.T().Logf("✅ scheduled_date: missing cancel_at rejected")
 	})
@@ -3583,6 +3584,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			CancelAt:         &pastDate,
 		})
 		s.Error(err)
+		s.True(ierr.IsValidation(err), "expected validation error")
 		s.Contains(err.Error(), "future")
 		s.T().Logf("✅ scheduled_date: past cancel_at rejected")
 	})
@@ -3613,6 +3615,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			CancelAt:         &futureDate,
 		})
 		s.Error(err)
+		s.True(ierr.IsValidation(err), "expected validation error")
 		s.Contains(err.Error(), "already scheduled")
 
 		// Confirm cancel_at was NOT overwritten
@@ -3645,6 +3648,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			CancelAt:         &futureDate,
 		})
 		s.Error(err)
+		s.True(ierr.IsValidation(err), "expected validation error")
 		s.Contains(err.Error(), "already scheduled")
 
 		updated, fetchErr := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
@@ -3676,6 +3680,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			ProrationBehavior: types.ProrationBehaviorNone,
 		})
 		s.Error(err)
+		s.True(ierr.IsValidation(err), "expected validation error")
 		s.Contains(err.Error(), "already scheduled")
 		s.T().Logf("✅ end_of_period: same guard blocks double-scheduling")
 	})
@@ -3701,6 +3706,7 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 			CancelAt:         &futureDate,
 		})
 		s.Error(err)
+		s.True(ierr.IsValidation(err), "expected validation error")
 		s.Contains(err.Error(), "already cancelled")
 		s.T().Logf("✅ scheduled_date: already-cancelled subscription rejected")
 	})

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -3477,6 +3477,220 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 	})
 }
 
+func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
+	ctx := s.GetContext()
+	futureDate := s.testData.now.Add(15 * 24 * time.Hour)
+
+	// newActiveSub creates and persists a clean active subscription with no end_date or cancel_at.
+	newActiveSub := func(id string) *subscription.Subscription {
+		sub := &subscription.Subscription{
+			ID:                 id,
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
+		return sub
+	}
+
+	s.Run("sets only end_date, nothing else changes", func() {
+		sub := newActiveSub("sub_sched_basic")
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+			Reason:           "downgrade",
+		})
+		s.NoError(err)
+
+		updated, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+		s.NoError(err)
+		// Only end_date should be touched
+		s.NotNil(updated.EndDate, "end_date must be set")
+		s.WithinDuration(futureDate, *updated.EndDate, time.Second)
+		// Everything else must be untouched
+		s.Equal(types.SubscriptionStatusActive, updated.SubscriptionStatus, "status must stay active")
+		s.Nil(updated.CancelAt, "cancel_at must NOT be set")
+		s.Nil(updated.CancelledAt, "cancelled_at must NOT be set")
+		s.False(updated.CancelAtPeriodEnd, "cancel_at_period_end must be false")
+		s.T().Logf("✅ scheduled_date: only end_date is set, all other fields untouched")
+	})
+
+	s.Run("metadata records cancellation details but cancel_at stays nil", func() {
+		sub := newActiveSub("sub_sched_metadata")
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+			Reason:           "user_request",
+		})
+		s.NoError(err)
+
+		updated, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+		s.NoError(err)
+		s.Equal("scheduled_date", updated.Metadata["cancellation_type"])
+		s.Equal("user_request", updated.Metadata["cancellation_reason"])
+		s.NotEmpty(updated.Metadata["effective_date"])
+		// Scheduling must not flip cancel_at
+		s.Nil(updated.CancelAt, "cancel_at must remain nil after scheduled_date cancel")
+		s.T().Logf("✅ scheduled_date: metadata recorded, cancel_at remains nil")
+	})
+
+	s.Run("no invoice created for scheduled_date", func() {
+		sub := newActiveSub("sub_sched_no_invoice")
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:               types.CancellationTypeScheduledDate,
+			CancelAt:                       &futureDate,
+			CancelImmediatelyInvoicePolicy: types.CancelImmediatelyInvoicePolicyGenerateInvoice,
+		})
+		s.NoError(err)
+
+		// Query the invoice store directly — no invoices should exist for this subscription
+		invoiceFilter := types.NewInvoiceFilter()
+		invoiceFilter.SubscriptionID = sub.ID
+		invoicesResp, err := s.GetStores().InvoiceRepo.List(ctx, invoiceFilter)
+		s.NoError(err)
+		s.Empty(invoicesResp, "no invoice should be generated for scheduled_date cancellation")
+		s.T().Logf("✅ scheduled_date: no invoice generated")
+	})
+
+	s.Run("validation rejects missing cancel_at", func() {
+		sub := newActiveSub("sub_sched_missing_date")
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			// CancelAt intentionally omitted
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "cancel_at")
+		s.T().Logf("✅ scheduled_date: missing cancel_at rejected")
+	})
+
+	s.Run("validation rejects past cancel_at", func() {
+		sub := newActiveSub("sub_sched_past_date")
+		pastDate := s.testData.now.Add(-24 * time.Hour)
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &pastDate,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "future")
+		s.T().Logf("✅ scheduled_date: past cancel_at rejected")
+	})
+
+	s.Run("errors if end_date is already set", func() {
+		existingEndDate := s.testData.now.Add(10 * 24 * time.Hour)
+		sub := &subscription.Subscription{
+			ID:                 "sub_sched_existing_enddate",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			EndDate:            &existingEndDate, // already set
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "end date")
+
+		// Confirm end_date was NOT overwritten
+		updated, fetchErr := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+		s.NoError(fetchErr)
+		s.WithinDuration(existingEndDate, *updated.EndDate, time.Second, "existing end_date must not be overwritten")
+		s.T().Logf("✅ scheduled_date: existing end_date is protected from overwrite")
+	})
+
+	s.Run("errors if subscription is already scheduled to cancel (cancel_at set)", func() {
+		existingCancelAt := s.testData.now.Add(5 * 24 * time.Hour)
+		sub := &subscription.Subscription{
+			ID:                 "sub_sched_already_scheduled",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			CancelAt:           &existingCancelAt, // already scheduled
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "already scheduled")
+
+		// Confirm cancel_at was NOT overwritten
+		updated, fetchErr := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+		s.NoError(fetchErr)
+		s.WithinDuration(existingCancelAt, *updated.CancelAt, time.Second, "existing cancel_at must not be overwritten")
+		s.T().Logf("✅ scheduled_date: existing cancel_at is protected from overwrite")
+	})
+
+	s.Run("already cancelled subscription is rejected", func() {
+		sub := &subscription.Subscription{
+			ID:                 "sub_sched_already_cancelled",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusCancelled,
+			StartDate:          s.testData.now.Add(-60 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(25 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, []*subscription.SubscriptionLineItem{}))
+
+		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "already cancelled")
+		s.T().Logf("✅ scheduled_date: already-cancelled subscription rejected")
+	})
+
+	s.Run("response message contains formatted date", func() {
+		sub := newActiveSub("sub_sched_msg")
+
+		resp, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType: types.CancellationTypeScheduledDate,
+			CancelAt:         &futureDate,
+		})
+		s.NoError(err)
+		s.Contains(resp.Message, futureDate.Format("2006-01-02"))
+		s.Equal(futureDate.UTC().Truncate(time.Second), resp.EffectiveDate.UTC().Truncate(time.Second))
+		s.Equal(types.CancellationTypeScheduledDate, resp.CancellationType)
+		s.T().Logf("✅ scheduled_date: response message and fields correct")
+	})
+}
+
 func (s *SubscriptionServiceSuite) TestListSubscriptions() {
 	// Create additional test subscriptions
 	testSubs := []*subscription.Subscription{

--- a/internal/types/proration.go
+++ b/internal/types/proration.go
@@ -55,19 +55,21 @@ const (
 type CancellationType string
 
 const (
-	CancellationTypeImmediate   CancellationType = "immediate"
-	CancellationTypeEndOfPeriod CancellationType = "end_of_period"
+	CancellationTypeImmediate     CancellationType = "immediate"
+	CancellationTypeEndOfPeriod   CancellationType = "end_of_period"
+	CancellationTypeScheduledDate CancellationType = "scheduled_date"
 )
 
 var CancellationTypeValues = []CancellationType{
 	CancellationTypeImmediate,
 	CancellationTypeEndOfPeriod,
+	CancellationTypeScheduledDate,
 }
 
 func (c CancellationType) Validate() error {
 	if !lo.Contains(CancellationTypeValues, c) {
 		return ierr.NewError("invalid cancellation type").
-			WithHint("Cancellation type must be immediate, end_of_period, or specific_date").
+			WithHint("Cancellation type must be immediate, end_of_period, or scheduled_date").
 			WithReportableDetails(map[string]any{
 				"allowed_values": CancellationTypeValues,
 				"provided_value": c,


### PR DESCRIPTION
## Problem Statement

There was no way to schedule a subscription cancellation for a specific future date without triggering immediate side-effects (status change, invoice generation, proration). Operators needed a lightweight "set an end date and do nothing else" path — useful for honoring committed billing cycles while ensuring the subscription naturally expires at a known date.

## Root Cause

The existing `CancellationType` enum only had `immediate` and `end_of_period`. Neither fit the use case of "mark an end date, let the subscription run out naturally." Additionally, there were no guards preventing a second scheduled cancellation from silently overwriting an already-set `end_date` or `cancel_at`.

## Dev Approach

1. **New type** — Added `scheduled_date` to `CancellationTypeValues` in `internal/types/proration.go`.
2. **Minimal side-effects** — In `updateSubscriptionForCancellation`, the `scheduled_date` switch case sets only `subscription.EndDate`. Status, `cancel_at`, `cancelled_at`, and `cancel_at_period_end` are all left untouched. All proration and invoice logic is bypassed via the early-return path already in place for this type.
3. **Guard validations** — Added two checks in `CancelSubscription` (Step 3b, before `determineEffectiveDate`), scoped to `scheduled_date` only:
   - If `subscription.EndDate != nil` → return `ErrValidation` ("subscription already has an end date set")
   - If `subscription.CancelAt != nil` → return `ErrValidation` ("subscription is already scheduled to cancel")
4. **DTO** — Added `CancelAt` field wiring in `internal/api/dto/subscription.go` and updated the response message for `scheduled_date`.

## Test Summary

Added `TestCancelSubscriptionScheduledDate` (9 sub-tests, all passing):

| Sub-test | What it proves |
|---|---|
| `sets_only_end_date,_nothing_else_changes` | Only `end_date` written; `status`, `cancel_at`, `cancelled_at`, `cancel_at_period_end` untouched |
| `metadata_records_cancellation_details_but_cancel_at_stays_nil` | Metadata captured; `cancel_at` stays nil |
| `no_invoice_created_for_scheduled_date` | Zero invoices even with `generate_invoice` policy active |
| `validation_rejects_missing_cancel_at` | Error when `cancel_at` not supplied |
| `validation_rejects_past_cancel_at` | Error when `cancel_at` is in the past |
| `errors_if_end_date_is_already_set` | Error returned; existing `end_date` not overwritten |
| `errors_if_subscription_is_already_scheduled_to_cancel` | Error returned; existing `cancel_at` not overwritten |
| `already_cancelled_subscription_is_rejected` | Pre-existing cancelled status blocked at Step 3 |
| `response_message_contains_formatted_date` | Response `message`, `effective_date`, `cancellation_type` correct |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled-date cancellations for subscriptions: pick a future UTC end date (must be after now). Scheduled cancellations set the subscription to end on that date, keep the subscription active until then, do not create immediate invoices, and defer final cancellation events until the effective date. Confirmation messages show the scheduled end date.

* **Bug Fixes / Validation**
  * Rejects missing or past dates, prevents double-scheduling or scheduling an already-cancelled subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->