### PR TITLE
fix(billing): cap periodEnd to now() in preview and wallet balance paths

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1962,6 +1962,12 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		// For preview, include both current period arrear and next period advance
 		// but don't filter out already invoiced items
 
+		// Cap periodEnd to now() so commitment/true-up is only calculated for elapsed time
+		now := time.Now()
+		if periodEnd.After(now) {
+			periodEnd = now
+		}
+
 		// For current period arrear charges
 		arrearResult, err := s.calculateFeatureUsageCharges(
 			ctx,

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -1787,6 +1787,13 @@ func (s *invoiceService) GetPreviewInvoice(ctx context.Context, req dto.GetPrevi
 		req.PeriodEnd = &sub.CurrentPeriodEnd
 	}
 
+	// Cap periodEnd to now() so commitment/true-up is only calculated for elapsed time
+	now := time.Now()
+	if req.PeriodEnd.After(now) {
+		cappedEnd := now
+		req.PeriodEnd = &cappedEnd
+	}
+
 	// Prepare invoice request using billing service with the preview reference point
 	invReq, err := billingService.PrepareSubscriptionInvoiceRequest(
 		ctx, sub, *req.PeriodStart, *req.PeriodEnd, types.ReferencePointPreview)

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -1198,6 +1198,12 @@ func (s *walletService) GetWalletBalance(ctx context.Context, walletID string) (
 			periodStart := sub.CurrentPeriodStart
 			periodEnd := sub.CurrentPeriodEnd
 
+			// Cap periodEnd to now() so commitment/true-up is only calculated for elapsed time
+			now := time.Now()
+			if periodEnd.After(now) {
+				periodEnd = now
+			}
+
 			usage, err := subscriptionService.GetUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
 				SubscriptionID: sub.ID,
 				StartTime:      periodStart,
@@ -2402,6 +2408,12 @@ func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string)
 			periodStart := sub.CurrentPeriodStart
 			periodEnd := sub.CurrentPeriodEnd
 
+			// Cap periodEnd to now() so commitment/true-up is only calculated for elapsed time
+			now := time.Now()
+			if periodEnd.After(now) {
+				periodEnd = now
+			}
+
 			// Get usage data for current period using feature usage table
 			usage, err := subscriptionService.GetFeatureUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
 				SubscriptionID: sub.ID,
@@ -2559,6 +2571,12 @@ func (s *walletService) GetWalletBalanceFromCache(ctx context.Context, walletID 
 			// Get current period
 			periodStart := sub.CurrentPeriodStart
 			periodEnd := sub.CurrentPeriodEnd
+
+			// Cap periodEnd to now() so commitment/true-up is only calculated for elapsed time
+			now := time.Now()
+			if periodEnd.After(now) {
+				periodEnd = now
+			}
 
 			/*
 				// Get usage for subscription using raw events table


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice preview calculations now correctly limit commitment and true-up charges to elapsed time, capping the billing period to the current moment instead of extending into future dates. This ensures accurate preview amounts.
  * Wallet balance calculations across all methods now similarly restrict charges to elapsed time, providing consistent and accurate balance reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->