### PR TITLE
Add PG → ClickHouse sync for dimension tables

### DIFF
--- a/migrations/clickhouse-postgres-sync/001_schema_prices.sql
+++ b/migrations/clickhouse-postgres-sync/001_schema_prices.sql
@@ -1,0 +1,52 @@
+-- ClickHouse schema for prices (synced from PostgreSQL)
+-- Primary join: feature_usage.price_id -> prices.id
+
+CREATE TABLE IF NOT EXISTS flexprice.prices (
+    id                        String NOT NULL,
+    tenant_id                 String NOT NULL,
+    environment_id            String NOT NULL,
+    status                    LowCardinality(String) NOT NULL,
+    display_name              Nullable(String),
+    amount                    Decimal(25,15) NOT NULL,
+    currency                  LowCardinality(String) NOT NULL,
+    display_amount            Nullable(String),
+    price_unit_type           LowCardinality(String) NOT NULL,
+    price_unit                Nullable(String),
+    price_unit_id             Nullable(String),
+    price_unit_amount         Nullable(Decimal(25,15)),
+    display_price_unit_amount Nullable(String),
+    conversion_rate           Nullable(Decimal(25,15)),
+    min_quantity              Nullable(Decimal(20,8)),
+    type                      LowCardinality(String) NOT NULL,
+    billing_period            LowCardinality(String) NOT NULL,
+    billing_period_count      Int64 NOT NULL,
+    billing_model             LowCardinality(String) NOT NULL,
+    billing_cadence           LowCardinality(String) NOT NULL,
+    invoice_cadence           Nullable(String),
+    trial_period              Int64 NOT NULL DEFAULT 0,
+    meter_id                  Nullable(String),
+    filter_values             Nullable(String) CODEC(ZSTD),
+    tier_mode                 Nullable(String),
+    tiers                     Nullable(String) CODEC(ZSTD),
+    price_unit_tiers          Nullable(String) CODEC(ZSTD),
+    transform_quantity        Nullable(String) CODEC(ZSTD),
+    lookup_key                Nullable(String),
+    description               Nullable(String),
+    metadata                  Nullable(String) CODEC(ZSTD),
+    entity_type               LowCardinality(String) NOT NULL,
+    entity_id                 String NOT NULL,
+    parent_price_id           Nullable(String),
+    start_date                Nullable(DateTime64(3)),
+    end_date                  Nullable(DateTime64(3)),
+    group_id                  Nullable(String),
+    created_at                DateTime64(3) NOT NULL,
+    updated_at                DateTime64(3) NOT NULL,
+    version                   UInt64 NOT NULL DEFAULT toUnixTimestamp64Milli(now64())
+)
+ENGINE = ReplacingMergeTree(version)
+ORDER BY (tenant_id, environment_id, id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE flexprice.prices
+    ADD INDEX IF NOT EXISTS bf_meter_id meter_id TYPE bloom_filter(0.01) GRANULARITY 64,
+    ADD INDEX IF NOT EXISTS bf_entity_id entity_id TYPE bloom_filter(0.01) GRANULARITY 64;

--- a/migrations/clickhouse-postgres-sync/002_schema_subscriptions.sql
+++ b/migrations/clickhouse-postgres-sync/002_schema_subscriptions.sql
@@ -1,0 +1,55 @@
+-- ClickHouse schema for subscriptions (synced from PostgreSQL)
+-- Primary join: feature_usage.subscription_id -> subscriptions.id
+-- Note: PG column `version` (business field) kept as-is; RMT version column is `_version`
+
+CREATE TABLE IF NOT EXISTS flexprice.subscriptions (
+    id                        String NOT NULL,
+    tenant_id                 String NOT NULL,
+    environment_id            String NOT NULL,
+    status                    LowCardinality(String) NOT NULL,
+    lookup_key                Nullable(String),
+    customer_id               String NOT NULL,
+    plan_id                   String NOT NULL,
+    subscription_status       LowCardinality(String) NOT NULL,
+    currency                  LowCardinality(String) NOT NULL,
+    billing_anchor            DateTime64(3) NOT NULL,
+    start_date                DateTime64(3) NOT NULL,
+    end_date                  Nullable(DateTime64(3)),
+    current_period_start      DateTime64(3) NOT NULL,
+    current_period_end        DateTime64(3) NOT NULL,
+    cancelled_at              Nullable(DateTime64(3)),
+    cancel_at                 Nullable(DateTime64(3)),
+    cancel_at_period_end      Bool NOT NULL DEFAULT false,
+    trial_start               Nullable(DateTime64(3)),
+    trial_end                 Nullable(DateTime64(3)),
+    billing_cadence           LowCardinality(String) NOT NULL,
+    billing_period            LowCardinality(String) NOT NULL,
+    billing_period_count      Int64 NOT NULL DEFAULT 1,
+    version                   Int64 NOT NULL DEFAULT 1,
+    metadata                  Nullable(String) CODEC(ZSTD),
+    pause_status              LowCardinality(String) NOT NULL,
+    active_pause_id           Nullable(String),
+    billing_cycle             LowCardinality(String) NOT NULL,
+    commitment_amount         Nullable(Decimal(20,6)),
+    overage_factor            Nullable(Decimal(10,6)),
+    payment_behavior          LowCardinality(String) NOT NULL,
+    collection_method         LowCardinality(String) NOT NULL,
+    gateway_payment_method_id Nullable(String),
+    customer_timezone         String NOT NULL DEFAULT 'UTC',
+    proration_behavior        LowCardinality(String) NOT NULL,
+    enable_true_up            Bool NOT NULL DEFAULT false,
+    invoicing_customer_id     Nullable(String),
+    commitment_duration       Nullable(String),
+    parent_subscription_id    Nullable(String),
+    payment_terms             Nullable(String),
+    created_at                DateTime64(3) NOT NULL,
+    updated_at                DateTime64(3) NOT NULL,
+    _version                  UInt64 NOT NULL DEFAULT toUnixTimestamp64Milli(now64())
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY (tenant_id, environment_id, customer_id, id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE flexprice.subscriptions
+    ADD INDEX IF NOT EXISTS bf_plan_id plan_id TYPE bloom_filter(0.01) GRANULARITY 64,
+    ADD INDEX IF NOT EXISTS bf_sub_status subscription_status TYPE set(0) GRANULARITY 64;

--- a/migrations/clickhouse-postgres-sync/003_schema_subscription_line_items.sql
+++ b/migrations/clickhouse-postgres-sync/003_schema_subscription_line_items.sql
@@ -1,0 +1,50 @@
+-- ClickHouse schema for subscription_line_items (synced from PostgreSQL)
+-- Primary join: feature_usage.sub_line_item_id -> subscription_line_items.id
+-- This is the largest table (~120M+ rows), sync incrementally via --after flag
+
+CREATE TABLE IF NOT EXISTS flexprice.subscription_line_items (
+    id                        String NOT NULL,
+    tenant_id                 String NOT NULL,
+    environment_id            String NOT NULL,
+    status                    LowCardinality(String) NOT NULL,
+    subscription_id           String NOT NULL,
+    customer_id               String NOT NULL,
+    entity_id                 Nullable(String),
+    entity_type               LowCardinality(String) NOT NULL,
+    plan_display_name         Nullable(String),
+    price_id                  String NOT NULL,
+    price_type                Nullable(String),
+    meter_id                  Nullable(String),
+    meter_display_name        Nullable(String),
+    price_unit_id             Nullable(String),
+    price_unit                Nullable(String),
+    display_name              Nullable(String),
+    quantity                  Decimal(20,8) NOT NULL,
+    currency                  LowCardinality(String) NOT NULL,
+    billing_period            LowCardinality(String) NOT NULL,
+    billing_period_count      Int64 NOT NULL DEFAULT 1,
+    invoice_cadence           Nullable(String),
+    trial_period              Int64 NOT NULL DEFAULT 0,
+    start_date                Nullable(DateTime64(3)),
+    end_date                  Nullable(DateTime64(3)),
+    subscription_phase_id     Nullable(String),
+    metadata                  Nullable(String) CODEC(ZSTD),
+    commitment_amount         Nullable(Decimal(20,8)),
+    commitment_quantity       Nullable(Decimal(20,8)),
+    commitment_type           Nullable(String),
+    commitment_overage_factor Nullable(Decimal(10,4)),
+    commitment_true_up_enabled Bool NOT NULL DEFAULT false,
+    commitment_windowed       Bool NOT NULL DEFAULT false,
+    commitment_duration       Nullable(String),
+    created_at                DateTime64(3) NOT NULL,
+    updated_at                DateTime64(3) NOT NULL,
+    version                   UInt64 NOT NULL DEFAULT toUnixTimestamp64Milli(now64())
+)
+ENGINE = ReplacingMergeTree(version)
+ORDER BY (tenant_id, environment_id, subscription_id, id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE flexprice.subscription_line_items
+    ADD INDEX IF NOT EXISTS bf_price_id price_id TYPE bloom_filter(0.01) GRANULARITY 64,
+    ADD INDEX IF NOT EXISTS bf_customer_id customer_id TYPE bloom_filter(0.01) GRANULARITY 64,
+    ADD INDEX IF NOT EXISTS bf_meter_id meter_id TYPE bloom_filter(0.01) GRANULARITY 64;

--- a/migrations/clickhouse-postgres-sync/README.md
+++ b/migrations/clickhouse-postgres-sync/README.md
@@ -1,0 +1,71 @@
+# ClickHouse <-> PostgreSQL Sync
+
+Syncs dimension tables (prices, subscriptions, subscription_line_items) from PostgreSQL to ClickHouse
+so analytics queries can JOIN them with `feature_usage` / `events_processed` without round-tripping to PG.
+
+## Tables
+
+| Table | PG Rows (approx) | Join key in feature_usage | CH RMT version col |
+|-------|-------------------|--------------------------|---------------------|
+| prices | ~thousands | `price_id` | `version` |
+| subscriptions | ~thousands | `subscription_id` | `_version` (PG `version` is a business field) |
+| subscription_line_items | ~120M+ | `sub_line_item_id` | `version` |
+
+## Setup
+
+1. Create tables in ClickHouse:
+   ```bash
+   clickhouse-client --multiquery < 001_schema_prices.sql
+   clickhouse-client --multiquery < 002_schema_subscriptions.sql
+   clickhouse-client --multiquery < 003_schema_subscription_line_items.sql
+   ```
+
+2. Set environment variables:
+   ```bash
+   export FLEXPRICE_POSTGRES_HOST=localhost
+   export FLEXPRICE_POSTGRES_PORT=5432
+   export FLEXPRICE_POSTGRES_DBNAME=flexprice
+   export FLEXPRICE_POSTGRES_USER=flexprice
+   export FLEXPRICE_POSTGRES_PASSWORD=flexprice
+   ```
+
+3. Run sync:
+   ```bash
+   # Full sync (first time)
+   ./sync.sh
+
+   # Incremental sync (only rows updated after a date)
+   ./sync.sh --after "2026-01-01 00:00:00"
+
+   # Sync a specific table only
+   ./sync.sh --table prices
+   ./sync.sh --table subscription_line_items --after "2026-03-01 00:00:00"
+
+   # Dry run (prints commands without executing)
+   ./sync.sh --dry-run
+   ```
+
+## Scalability
+
+- **prices & subscriptions**: Small tables, synced in a single `INSERT...SELECT FROM postgresql()` pass
+- **subscription_line_items (~120M+ rows)**: Batched by monthly `updated_at` windows to avoid OOM on both PG and CH sides. Each batch is `WHERE updated_at >= X AND updated_at < Y` with ~1 month intervals.
+
+## How it works
+
+- Uses ClickHouse `postgresql()` table function to read directly from PG
+- `ReplacingMergeTree(version)` handles upserts: re-syncing the same row is safe, newer version wins
+- Re-running sync is idempotent — no need to TRUNCATE before re-sync
+- Use `SELECT ... FROM table FINAL` for reads, or `OPTIMIZE TABLE table FINAL` after sync
+
+## Manual sync (without sync.sh)
+
+If the `postgresql()` table function isn't available or you prefer direct queries:
+
+```sql
+-- Example: sync prices directly
+INSERT INTO flexprice.prices (...)
+SELECT ...
+FROM postgresql('PG_HOST:5432', 'DB_NAME', 'prices', 'USER', 'PASS');
+```
+
+See `sync_prices.sql`, `sync_subscriptions.sql`, `sync_subscription_line_items.sql` for the full column lists.

--- a/migrations/clickhouse-postgres-sync/sync.sh
+++ b/migrations/clickhouse-postgres-sync/sync.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# =============================================================================
+# PG -> ClickHouse Sync Script
+#
+# Syncs prices, subscriptions, subscription_line_items from PostgreSQL to CH.
+# subscription_line_items (~120M+ rows) is batched by monthly updated_at windows.
+# prices and subscriptions are synced in a single pass.
+#
+# Required env vars:
+#   FLEXPRICE_POSTGRES_HOST, FLEXPRICE_POSTGRES_PORT, FLEXPRICE_POSTGRES_DBNAME,
+#   FLEXPRICE_POSTGRES_USER, FLEXPRICE_POSTGRES_PASSWORD
+#
+# Optional env vars:
+#   CLICKHOUSE_HOST     (default: localhost)
+#   CLICKHOUSE_PORT     (default: 9000)
+#   CLICKHOUSE_USER     (default: flexprice)
+#   CLICKHOUSE_PASSWORD (default: flexprice123)
+#   CLICKHOUSE_DB       (default: flexprice)
+#
+# Usage:
+#   ./sync.sh                                    # Full sync, all tables
+#   ./sync.sh --after "2026-01-01 00:00:00"      # Incremental sync
+#   ./sync.sh --table prices                     # Single table
+#   ./sync.sh --table subscription_line_items --after "2026-03-01 00:00:00"
+#   ./sync.sh --dry-run                          # Print commands without executing
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- PG connection (required) ---
+PG_HOST="${FLEXPRICE_POSTGRES_HOST:?Set FLEXPRICE_POSTGRES_HOST}"
+PG_PORT="${FLEXPRICE_POSTGRES_PORT:?Set FLEXPRICE_POSTGRES_PORT}"
+PG_DB="${FLEXPRICE_POSTGRES_DBNAME:?Set FLEXPRICE_POSTGRES_DBNAME}"
+PG_USER="${FLEXPRICE_POSTGRES_USER:?Set FLEXPRICE_POSTGRES_USER}"
+PG_PASS="${FLEXPRICE_POSTGRES_PASSWORD:?Set FLEXPRICE_POSTGRES_PASSWORD}"
+
+# --- CH connection (optional, defaults for local dev) ---
+CH_HOST="${CLICKHOUSE_HOST:-localhost}"
+CH_PORT="${CLICKHOUSE_PORT:-9000}"
+CH_USER="${CLICKHOUSE_USER:-flexprice}"
+CH_PASS="${CLICKHOUSE_PASSWORD:-flexprice123}"
+CH_DB="${CLICKHOUSE_DB:-flexprice}"
+
+# --- Parse args ---
+AFTER="1970-01-01 00:00:00"
+TABLE="all"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --after)  AFTER="$2"; shift 2 ;;
+        --table)  TABLE="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+# --- Helpers ---
+ch_client() {
+    clickhouse-client \
+        --host "$CH_HOST" \
+        --port "$CH_PORT" \
+        --user "$CH_USER" \
+        --password "$CH_PASS" \
+        --database "$CH_DB" \
+        "$@"
+}
+
+run_sql() {
+    local sql_file="$1"
+    shift
+    local params=(
+        --multiquery
+        --param_pg_host="$PG_HOST"
+        --param_pg_port="$PG_PORT"
+        --param_pg_db="$PG_DB"
+        --param_pg_user="$PG_USER"
+        --param_pg_pass="$PG_PASS"
+        "$@"
+    )
+
+    if $DRY_RUN; then
+        echo "[DRY RUN] clickhouse-client ${params[*]} < $sql_file"
+    else
+        ch_client "${params[@]}" < "$sql_file"
+    fi
+}
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# --- Sync functions ---
+
+sync_prices() {
+    log "Syncing prices (after: $AFTER)..."
+    run_sql "$SCRIPT_DIR/sync_prices.sql" --param_after="$AFTER"
+    log "Prices sync complete."
+}
+
+sync_subscriptions() {
+    log "Syncing subscriptions (after: $AFTER)..."
+    run_sql "$SCRIPT_DIR/sync_subscriptions.sql" --param_after="$AFTER"
+    log "Subscriptions sync complete."
+}
+
+sync_subscription_line_items() {
+    log "Syncing subscription_line_items (after: $AFTER) in monthly batches..."
+
+    # Determine date range: from AFTER to now+1month, chunked by month
+    # Use portable date parsing (macOS + Linux)
+    if date -j -f "%Y-%m-%d %H:%M:%S" "$AFTER" "+%Y" &>/dev/null; then
+        # macOS
+        start_year=$(date -j -f "%Y-%m-%d %H:%M:%S" "$AFTER" "+%Y")
+        start_month=$(date -j -f "%Y-%m-%d %H:%M:%S" "$AFTER" "+%m")
+    else
+        # Linux
+        start_year=$(date -d "$AFTER" "+%Y")
+        start_month=$(date -d "$AFTER" "+%m")
+    fi
+
+    end_year=$(date "+%Y")
+    end_month=$(date "+%m")
+    # Go one month past current to catch everything
+    end_month=$((10#$end_month + 1))
+    if [ "$end_month" -gt 12 ]; then
+        end_month=1
+        end_year=$((end_year + 1))
+    fi
+
+    local cur_year=$((10#$start_year))
+    local cur_month=$((10#$start_month))
+    local batch=0
+
+    while true; do
+        local next_month=$((cur_month + 1))
+        local next_year=$cur_year
+        if [ "$next_month" -gt 12 ]; then
+            next_month=1
+            next_year=$((next_year + 1))
+        fi
+
+        local batch_after
+        local batch_before
+        batch_after=$(printf "%04d-%02d-01 00:00:00" "$cur_year" "$cur_month")
+        batch_before=$(printf "%04d-%02d-01 00:00:00" "$next_year" "$next_month")
+
+        # For the first batch, use the actual AFTER timestamp
+        if [ "$batch" -eq 0 ]; then
+            batch_after="$AFTER"
+        fi
+
+        batch=$((batch + 1))
+        log "  Batch $batch: [$batch_after, $batch_before)"
+
+        run_sql "$SCRIPT_DIR/sync_subscription_line_items.sql" \
+            --param_after="$batch_after" \
+            --param_before="$batch_before"
+
+        # Check if we've passed the end
+        if [ "$next_year" -gt "$end_year" ] || \
+           { [ "$next_year" -eq "$end_year" ] && [ "$next_month" -gt "$end_month" ]; }; then
+            break
+        fi
+
+        cur_year=$next_year
+        cur_month=$next_month
+    done
+
+    log "Subscription line items sync complete ($batch batches)."
+}
+
+# --- Main ---
+
+log "=== PG -> ClickHouse Sync ==="
+log "PG: $PG_USER@$PG_HOST:$PG_PORT/$PG_DB"
+log "CH: $CH_USER@$CH_HOST:$CH_PORT/$CH_DB"
+log "After: $AFTER | Table: $TABLE"
+log ""
+
+case "$TABLE" in
+    all)
+        sync_prices
+        sync_subscriptions
+        sync_subscription_line_items
+        ;;
+    prices)
+        sync_prices
+        ;;
+    subscriptions)
+        sync_subscriptions
+        ;;
+    subscription_line_items)
+        sync_subscription_line_items
+        ;;
+    *)
+        echo "Unknown table: $TABLE"
+        echo "Options: prices, subscriptions, subscription_line_items, all"
+        exit 1
+        ;;
+esac
+
+log ""
+log "=== Sync finished ==="
+log "Tip: run 'OPTIMIZE TABLE flexprice.<table> FINAL' if you need immediate dedup."

--- a/migrations/clickhouse-postgres-sync/sync_prices.sql
+++ b/migrations/clickhouse-postgres-sync/sync_prices.sql
@@ -1,0 +1,38 @@
+-- Sync prices from PostgreSQL to ClickHouse
+-- Small table — single pass, filtered by updated_at >= {after:String}
+-- Pass '1970-01-01 00:00:00' for full sync.
+
+INSERT INTO flexprice.prices (
+    id, tenant_id, environment_id, status, display_name,
+    amount, currency, display_amount, price_unit_type, price_unit,
+    price_unit_id, price_unit_amount, display_price_unit_amount, conversion_rate, min_quantity,
+    type, billing_period, billing_period_count, billing_model, billing_cadence,
+    invoice_cadence, trial_period, meter_id,
+    filter_values, tier_mode, tiers, price_unit_tiers, transform_quantity,
+    lookup_key, description, metadata,
+    entity_type, entity_id, parent_price_id, start_date, end_date, group_id,
+    created_at, updated_at
+)
+SELECT
+    id, tenant_id, environment_id, status, display_name,
+    amount, currency, display_amount, price_unit_type, price_unit,
+    price_unit_id, price_unit_amount, display_price_unit_amount, conversion_rate, min_quantity,
+    type, billing_period, billing_period_count, billing_model, billing_cadence,
+    invoice_cadence, trial_period, meter_id,
+    CAST(filter_values AS Nullable(String)),
+    tier_mode,
+    CAST(tiers AS Nullable(String)),
+    CAST(price_unit_tiers AS Nullable(String)),
+    CAST(transform_quantity AS Nullable(String)),
+    lookup_key, description,
+    CAST(metadata AS Nullable(String)),
+    entity_type, entity_id, parent_price_id, start_date, end_date, group_id,
+    created_at, updated_at
+FROM postgresql(
+    {pg_host:String} || ':' || {pg_port:String},
+    {pg_db:String},
+    'prices',
+    {pg_user:String},
+    {pg_pass:String}
+)
+WHERE updated_at >= toDateTime64({after:String}, 3);

--- a/migrations/clickhouse-postgres-sync/sync_subscription_line_items.sql
+++ b/migrations/clickhouse-postgres-sync/sync_subscription_line_items.sql
@@ -1,0 +1,36 @@
+-- Sync subscription_line_items from PostgreSQL to ClickHouse
+-- LARGE table (~120M+ rows) — sync.sh batches this by monthly updated_at windows
+-- Parameters: {after:String} inclusive lower bound, {before:String} exclusive upper bound
+
+INSERT INTO flexprice.subscription_line_items (
+    id, tenant_id, environment_id, status, subscription_id, customer_id,
+    entity_id, entity_type, plan_display_name, price_id, price_type,
+    meter_id, meter_display_name, price_unit_id, price_unit,
+    display_name, quantity, currency,
+    billing_period, billing_period_count, invoice_cadence, trial_period,
+    start_date, end_date, subscription_phase_id,
+    metadata, commitment_amount, commitment_quantity,
+    commitment_type, commitment_overage_factor,
+    commitment_true_up_enabled, commitment_windowed, commitment_duration,
+    created_at, updated_at
+)
+SELECT
+    id, tenant_id, environment_id, status, subscription_id, customer_id,
+    entity_id, entity_type, plan_display_name, price_id, price_type,
+    meter_id, meter_display_name, price_unit_id, price_unit,
+    display_name, quantity, currency,
+    billing_period, billing_period_count, invoice_cadence, trial_period,
+    start_date, end_date, subscription_phase_id,
+    CAST(metadata AS Nullable(String)), commitment_amount, commitment_quantity,
+    commitment_type, commitment_overage_factor,
+    commitment_true_up_enabled, commitment_windowed, commitment_duration,
+    created_at, updated_at
+FROM postgresql(
+    {pg_host:String} || ':' || {pg_port:String},
+    {pg_db:String},
+    'subscription_line_items',
+    {pg_user:String},
+    {pg_pass:String}
+)
+WHERE updated_at >= toDateTime64({after:String}, 3)
+  AND updated_at <  toDateTime64({before:String}, 3);

--- a/migrations/clickhouse-postgres-sync/sync_subscriptions.sql
+++ b/migrations/clickhouse-postgres-sync/sync_subscriptions.sql
@@ -1,0 +1,41 @@
+-- Sync subscriptions from PostgreSQL to ClickHouse
+-- Moderate table — single pass, filtered by updated_at >= {after:String}
+-- Pass '1970-01-01 00:00:00' for full sync.
+
+INSERT INTO flexprice.subscriptions (
+    id, tenant_id, environment_id, status, lookup_key,
+    customer_id, plan_id, subscription_status, currency,
+    billing_anchor, start_date, end_date,
+    current_period_start, current_period_end,
+    cancelled_at, cancel_at, cancel_at_period_end,
+    trial_start, trial_end,
+    billing_cadence, billing_period, billing_period_count,
+    version, metadata, pause_status, active_pause_id,
+    billing_cycle, commitment_amount, overage_factor,
+    payment_behavior, collection_method, gateway_payment_method_id,
+    customer_timezone, proration_behavior, enable_true_up,
+    invoicing_customer_id, commitment_duration, parent_subscription_id, payment_terms,
+    created_at, updated_at
+)
+SELECT
+    id, tenant_id, environment_id, status, lookup_key,
+    customer_id, plan_id, subscription_status, currency,
+    billing_anchor, start_date, end_date,
+    current_period_start, current_period_end,
+    cancelled_at, cancel_at, cancel_at_period_end,
+    trial_start, trial_end,
+    billing_cadence, billing_period, billing_period_count,
+    version, CAST(metadata AS Nullable(String)), pause_status, active_pause_id,
+    billing_cycle, commitment_amount, overage_factor,
+    payment_behavior, collection_method, gateway_payment_method_id,
+    customer_timezone, proration_behavior, enable_true_up,
+    invoicing_customer_id, commitment_duration, parent_subscription_id, payment_terms,
+    created_at, updated_at
+FROM postgresql(
+    {pg_host:String} || ':' || {pg_port:String},
+    {pg_db:String},
+    'subscriptions',
+    {pg_user:String},
+    {pg_pass:String}
+)
+WHERE updated_at >= toDateTime64({after:String}, 3);


### PR DESCRIPTION
## Summary
Adds migrations and sync tooling to replicate pricing and subscription dimension tables from PostgreSQL to ClickHouse for analytical queries.

## Changes

### Schema Migrations
- **001_schema_prices.sql**: ClickHouse table for prices with bloom filter indexes on `meter_id` and `entity_id`
- **002_schema_subscriptions.sql**: ClickHouse table for subscriptions with bloom filters on `plan_id` and `subscription_status`
- **003_schema_subscription_line_items.sql**: ClickHouse table for subscription line items (~120M+ rows) with bloom filters on `price_id`, `customer_id`, and `meter_id`

All tables use `ReplacingMergeTree` engine for idempotent upserts based on version timestamps.

### Sync Scripts
- **sync.sh**: Main orchestration script supporting:
  - Full and incremental syncs (via `--after` flag)
  - Per-table syncing (via `--table` flag)
  - Dry-run mode
  - Automatic monthly batching for large tables to avoid OOM

- **sync_prices.sql**, **sync_subscriptions.sql**, **sync_subscription_line_items.sql**: Individual sync queries using ClickHouse `postgresql()` table function

### Documentation
- **README.md**: Setup instructions, usage examples, scalability notes, and manual sync guidance

## Key Features
- Supports incremental syncs with temporal filtering
- Automatically batches ~120M row subscription_line_items table by monthly windows
- Idempotent — safe to re-run without truncation
- Environment variable driven for flexible deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled PostgreSQL to ClickHouse data synchronization for pricing, subscriptions, and subscription line items
  * Added sync tools supporting full, incremental, and table-specific synchronization with dry-run mode
  * Included documentation for configuring and running data migration workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->