### PR TITLE
feat(subscriptions): add configurable renewal alert window with temporal workflow

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,15 @@ type Configuration struct {
 	Redis                      RedisConfig                      `mapstructure:"redis" validate:"required"`
 	RawEventsReprocessing      RawEventsReprocessingConfig      `mapstructure:"raw_events_reprocessing" validate:"required"`
 	RawEventConsumption        RawEventConsumptionConfig        `mapstructure:"raw_event_consumption" validate:"required"`
+	Subscription               SubscriptionConfig               `mapstructure:"subscription" validate:"omitempty"`
+}
+
+// SubscriptionConfig holds subscription-related configuration.
+type SubscriptionConfig struct {
+	// RenewalAlertLookAheadHours is how many hours ahead to look for subscriptions due for renewal.
+	// The query uses a ±1 hour window around (now + RenewalAlertLookAheadHours).
+	// Defaults to 24 if not set. Env var: FLEXPRICE_SUBSCRIPTION_RENEWAL_ALERT_LOOK_AHEAD_HOURS
+	RenewalAlertLookAheadHours int `mapstructure:"renewal_alert_look_ahead_hours" validate:"omitempty"`
 }
 
 type CacheConfig struct {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -147,6 +147,9 @@ billing:
   tenant_id: ""
   environment_id: ""
 
+subscription:
+  renewal_alert_look_ahead_hours: 24
+
 s3:
   enabled: false
   region: "ap-south-1"

--- a/internal/domain/subscription/repository.go
+++ b/internal/domain/subscription/repository.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/types"
 )
@@ -27,7 +28,8 @@ type Repository interface {
 	GetWithPauses(ctx context.Context, id string) (*Subscription, []*SubscriptionPause, error)
 
 	// Renewal due alert methods
-	ListSubscriptionsDueForRenewal(ctx context.Context) ([]*Subscription, error)
+	// lookAhead is the duration from now within which subscriptions are considered "due for renewal"
+	ListSubscriptionsDueForRenewal(ctx context.Context, lookAhead time.Duration) ([]*Subscription, error)
 
 	// Dashboard methods
 	GetRecentSubscriptionsByPlan(ctx context.Context) ([]types.SubscriptionPlanCount, error)

--- a/internal/domain/subscription/repository.go
+++ b/internal/domain/subscription/repository.go
@@ -28,8 +28,8 @@ type Repository interface {
 	GetWithPauses(ctx context.Context, id string) (*Subscription, []*SubscriptionPause, error)
 
 	// Renewal due alert methods
-	// lookAhead is the duration from now within which subscriptions are considered "due for renewal"
-	ListSubscriptionsDueForRenewal(ctx context.Context, lookAhead time.Duration) ([]*Subscription, error)
+	// windowStart and windowEnd define the inclusive period-end range for subscriptions considered "due for renewal"
+	ListSubscriptionsDueForRenewal(ctx context.Context, windowStart time.Time, windowEnd time.Time) ([]*Subscription, error)
 
 	// Dashboard methods
 	GetRecentSubscriptionsByPlan(ctx context.Context) ([]types.SubscriptionPlanCount, error)

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -340,12 +340,12 @@ func (r *subscriptionRepository) List(ctx context.Context, filter *types.Subscri
 	return result, nil
 }
 
-// ListActiveSubscriptionsDueForRenewal retrieves all active subscriptions that are due for renewal in 24 hours
-func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context) ([]*domainSub.Subscription, error) {
+// ListSubscriptionsDueForRenewal retrieves all active subscriptions whose current period ends
+// within a ±1-hour window centred on (now + lookAhead).
+func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context, lookAhead time.Duration) ([]*domainSub.Subscription, error) {
 	now := time.Now().UTC()
-	targetTime := now.Add(24 * time.Hour)
+	targetTime := now.Add(lookAhead)
 
-	// Create a 5-minute window around the target time
 	windowStart := targetTime.Add(-1 * time.Hour)
 	windowEnd := targetTime.Add(1 * time.Hour)
 

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -341,15 +341,8 @@ func (r *subscriptionRepository) List(ctx context.Context, filter *types.Subscri
 }
 
 // ListSubscriptionsDueForRenewal retrieves all active subscriptions whose current period ends
-// within a ±1-hour window centred on (now + lookAhead).
-func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context, lookAhead time.Duration) ([]*domainSub.Subscription, error) {
-	now := time.Now().UTC()
-	targetTime := now.Add(lookAhead)
-
-	windowStart := targetTime.Add(-1 * time.Hour)
-	windowEnd := targetTime.Add(1 * time.Hour)
-
-	// Find subscriptions ending exactly at the target time
+// within [windowStart, windowEnd].
+func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context, windowStart time.Time, windowEnd time.Time) ([]*domainSub.Subscription, error) {
 	subs, err := r.client.Reader(ctx).Subscription.Query().
 		Where(
 			subscription.And(

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -3783,8 +3783,13 @@ func (s *subscriptionService) publishInternalWebhookEvent(ctx context.Context, e
 // The look-ahead window is controlled by FLEXPRICE_SUBSCRIPTION_RENEWAL_ALERT_LOOK_AHEAD_HOURS (default 24).
 func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context) error {
 	lookAheadHours := 24
-	if s.Config != nil && s.Config.Subscription.RenewalAlertLookAheadHours > 0 {
-		lookAheadHours = s.Config.Subscription.RenewalAlertLookAheadHours
+	if s.Config != nil {
+		if s.Config.Subscription.RenewalAlertLookAheadHours < 0 {
+			return fmt.Errorf("invalid configuration: Subscription.RenewalAlertLookAheadHours must be >= 0, got %d", s.Config.Subscription.RenewalAlertLookAheadHours)
+		}
+		if s.Config.Subscription.RenewalAlertLookAheadHours > 0 {
+			lookAheadHours = s.Config.Subscription.RenewalAlertLookAheadHours
+		}
 	}
 	lookAhead := time.Duration(lookAheadHours) * time.Hour
 

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -3779,9 +3779,16 @@ func (s *subscriptionService) publishInternalWebhookEvent(ctx context.Context, e
 	}
 }
 
-// ProcessSubscriptionRenewalDueAlert processes subscriptions that are due for renewal in 24 hours
+// ProcessSubscriptionRenewalDueAlert processes subscriptions that are due for renewal.
+// The look-ahead window is controlled by FLEXPRICE_SUBSCRIPTION_RENEWAL_ALERT_LOOK_AHEAD_HOURS (default 24).
 func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context) error {
-	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx)
+	lookAheadHours := 24
+	if s.Config != nil && s.Config.Subscription.RenewalAlertLookAheadHours > 0 {
+		lookAheadHours = s.Config.Subscription.RenewalAlertLookAheadHours
+	}
+	lookAhead := time.Duration(lookAheadHours) * time.Hour
+
+	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx, lookAhead)
 	if err != nil {
 		s.Logger.ErrorwCtx(ctx, "failed to list subscriptions due for renewal", "error", err)
 		return err

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -3791,9 +3791,12 @@ func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Con
 			lookAheadHours = s.Config.Subscription.RenewalAlertLookAheadHours
 		}
 	}
-	lookAhead := time.Duration(lookAheadHours) * time.Hour
+	now := time.Now().UTC()
+	targetTime := now.Add(time.Duration(lookAheadHours) * time.Hour)
+	windowStart := targetTime.Add(-1 * time.Hour)
+	windowEnd := targetTime.Add(1 * time.Hour)
 
-	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx, lookAhead)
+	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx, windowStart, windowEnd)
 	if err != nil {
 		s.Logger.ErrorwCtx(ctx, "failed to list subscriptions due for renewal", "error", err)
 		return err

--- a/internal/service/subscription_renewal_alert_test.go
+++ b/internal/service/subscription_renewal_alert_test.go
@@ -1,0 +1,175 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// captureWebhookPublisher records every webhook event it receives.
+type captureWebhookPublisher struct {
+	events []*types.WebhookEvent
+}
+
+func (c *captureWebhookPublisher) PublishWebhook(_ context.Context, event *types.WebhookEvent) error {
+	c.events = append(c.events, event)
+	return nil
+}
+
+func (c *captureWebhookPublisher) Close() error { return nil }
+
+// buildRenewalService creates a SubscriptionService wired to the suite's stores but with a
+// caller-supplied config and webhook publisher so each sub-test can vary those independently.
+func (s *SubscriptionServiceSuite) buildRenewalService(cfg *config.Configuration, whPublisher *captureWebhookPublisher) SubscriptionService {
+	return NewSubscriptionService(ServiceParams{
+		Logger:                     s.GetLogger(),
+		Config:                     cfg,
+		DB:                         s.GetDB(),
+		TaxAssociationRepo:         s.GetStores().TaxAssociationRepo,
+		TaxRateRepo:                s.GetStores().TaxRateRepo,
+		SubRepo:                    s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo:   s.GetStores().SubscriptionLineItemRepo,
+		SubscriptionPhaseRepo:      s.GetStores().SubscriptionPhaseRepo,
+		SubScheduleRepo:            s.GetStores().SubscriptionScheduleRepo,
+		PlanRepo:                   s.GetStores().PlanRepo,
+		PriceRepo:                  s.GetStores().PriceRepo,
+		PriceUnitRepo:              s.GetStores().PriceUnitRepo,
+		EventRepo:                  s.GetStores().EventRepo,
+		MeterRepo:                  s.GetStores().MeterRepo,
+		CustomerRepo:               s.GetStores().CustomerRepo,
+		InvoiceRepo:                s.GetStores().InvoiceRepo,
+		EntitlementRepo:            s.GetStores().EntitlementRepo,
+		EnvironmentRepo:            s.GetStores().EnvironmentRepo,
+		FeatureRepo:                s.GetStores().FeatureRepo,
+		TenantRepo:                 s.GetStores().TenantRepo,
+		UserRepo:                   s.GetStores().UserRepo,
+		AuthRepo:                   s.GetStores().AuthRepo,
+		WalletRepo:                 s.GetStores().WalletRepo,
+		PaymentRepo:                s.GetStores().PaymentRepo,
+		CreditGrantRepo:            s.GetStores().CreditGrantRepo,
+		CreditGrantApplicationRepo: s.GetStores().CreditGrantApplicationRepo,
+		CouponRepo:                 s.GetStores().CouponRepo,
+		CouponAssociationRepo:      s.GetStores().CouponAssociationRepo,
+		CouponApplicationRepo:      s.GetStores().CouponApplicationRepo,
+		AddonRepo:                  testutil.NewInMemoryAddonStore(),
+		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
+		ConnectionRepo:             s.GetStores().ConnectionRepo,
+		SettingsRepo:               s.GetStores().SettingsRepo,
+		EventPublisher:             s.GetPublisher(),
+		WebhookPublisher:           whPublisher,
+		ProrationCalculator:        s.GetCalculator(),
+		FeatureUsageRepo:           s.GetStores().FeatureUsageRepo,
+		IntegrationFactory:         s.GetIntegrationFactory(),
+	})
+}
+
+func (s *SubscriptionServiceSuite) TestProcessSubscriptionRenewalDueAlert() {
+	ctx := s.GetContext()
+	now := time.Now().UTC()
+
+	// activeSub returns a minimal active, published subscription ending at periodEnd.
+	activeSub := func(id string, periodEnd time.Time, cancelAtPeriodEnd bool) *subscription.Subscription {
+		return &subscription.Subscription{
+			ID:                 id,
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			CurrentPeriodEnd:   periodEnd,
+			CancelAtPeriodEnd:  cancelAtPeriodEnd,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+	}
+
+	// With lookAheadHours=24: target = now+24h, window = [now+23h, now+25h].
+	inWindow := now.Add(24 * time.Hour)
+	outsideWindow := now.Add(48 * time.Hour)
+
+	tests := []struct {
+		name             string
+		lookAheadHours   int // 0 means use default (24)
+		subscriptions    []*subscription.Subscription
+		wantErr          bool
+		wantWebhookCount int
+		wantEventName    types.WebhookEventName
+	}{
+		{
+			name:           "negative_look_ahead_hours_returns_error",
+			lookAheadHours: -1,
+			wantErr:        true,
+		},
+		{
+			name:             "no_subscriptions_returns_no_error_no_webhooks",
+			wantWebhookCount: 0,
+		},
+		{
+			name:             "subscription_in_window_publishes_renewal_due_webhook",
+			subscriptions:    []*subscription.Subscription{activeSub("sub_in_window", inWindow, false)},
+			wantWebhookCount: 1,
+			wantEventName:    types.WebhookEventSubscriptionRenewalDue,
+		},
+		{
+			name:             "subscription_outside_window_is_excluded",
+			subscriptions:    []*subscription.Subscription{activeSub("sub_out_of_window", outsideWindow, false)},
+			wantWebhookCount: 0,
+		},
+		{
+			name:             "cancel_at_period_end_subscription_is_excluded",
+			subscriptions:    []*subscription.Subscription{activeSub("sub_cancel_at_end", inWindow, true)},
+			wantWebhookCount: 0,
+		},
+		{
+			name: "multiple_subscriptions_only_in_window_ones_get_webhook",
+			subscriptions: []*subscription.Subscription{
+				activeSub("sub_in_1", inWindow, false),
+				activeSub("sub_in_2", inWindow, false),
+				activeSub("sub_out", outsideWindow, false),
+				activeSub("sub_cancel", inWindow, true),
+			},
+			wantWebhookCount: 2,
+		},
+		{
+			name:           "custom_look_ahead_uses_correct_window",
+			lookAheadHours: 48,
+			// target = now+48h, window = [now+47h, now+49h]
+			// inWindow (now+24h) is outside this window; outsideWindow (now+48h) is inside.
+			subscriptions: []*subscription.Subscription{
+				activeSub("sub_48h", outsideWindow, false),
+				activeSub("sub_24h", inWindow, false), // outside the 48h±1h window
+			},
+			wantWebhookCount: 1,
+			wantEventName:    types.WebhookEventSubscriptionRenewalDue,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.ClearStores()
+
+			cfg := *s.GetConfig()
+			cfg.Subscription.RenewalAlertLookAheadHours = tc.lookAheadHours
+
+			capture := &captureWebhookPublisher{}
+			svc := s.buildRenewalService(&cfg, capture)
+
+			for _, sub := range tc.subscriptions {
+				s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, sub))
+			}
+
+			err := svc.ProcessSubscriptionRenewalDueAlert(ctx)
+
+			if tc.wantErr {
+				s.Error(err)
+				return
+			}
+			s.NoError(err)
+			s.Len(capture.events, tc.wantWebhookCount)
+			if tc.wantEventName != "" && len(capture.events) > 0 {
+				s.Equal(tc.wantEventName, capture.events[0].EventName)
+			}
+		})
+	}
+}

--- a/internal/temporal/activities/subscription/schedule_subscription_billing_activities.go
+++ b/internal/temporal/activities/subscription/schedule_subscription_billing_activities.go
@@ -21,6 +21,20 @@ const (
 	WorkflowProcessSubscriptionBilling = "ProcessSubscriptionBillingWorkflow"
 )
 
+// ProcessRenewalDueAlertActivity fetches all subscriptions due for renewal across all tenants
+// and publishes a webhook event for each one.
+func (s *SubscriptionActivities) ProcessRenewalDueAlertActivity(ctx context.Context, input subscriptionModels.ProcessRenewalDueAlertActivityInput) (*subscriptionModels.ProcessRenewalDueAlertActivityResult, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := s.subscriptionService.ProcessSubscriptionRenewalDueAlert(ctx); err != nil {
+		return nil, err
+	}
+
+	return &subscriptionModels.ProcessRenewalDueAlertActivityResult{}, nil
+}
+
 // SubscriptionActivities contains all subscription-related activities
 // When registered with Temporal, methods will be called as "SubscriptionActivities.ScheduleBillingActivity"
 type SubscriptionActivities struct {

--- a/internal/temporal/models/subscription/renewal_due_alert.go
+++ b/internal/temporal/models/subscription/renewal_due_alert.go
@@ -1,0 +1,27 @@
+package subscription
+
+// ProcessRenewalDueAlertWorkflowInput is the input for the subscription renewal due alert workflow.
+// No specific fields are required - the activity queries all tenants for subscriptions due for renewal.
+type ProcessRenewalDueAlertWorkflowInput struct{}
+
+// Validate validates the workflow input
+func (i *ProcessRenewalDueAlertWorkflowInput) Validate() error {
+	return nil
+}
+
+// ProcessRenewalDueAlertWorkflowResult is the result for the subscription renewal due alert workflow
+type ProcessRenewalDueAlertWorkflowResult struct {
+	Success bool    `json:"success"`
+	Error   *string `json:"error,omitempty"`
+}
+
+// ProcessRenewalDueAlertActivityInput is the input for the renewal due alert activity
+type ProcessRenewalDueAlertActivityInput struct{}
+
+// Validate validates the activity input
+func (i *ProcessRenewalDueAlertActivityInput) Validate() error {
+	return nil
+}
+
+// ProcessRenewalDueAlertActivityResult is the result for the renewal due alert activity
+type ProcessRenewalDueAlertActivityResult struct{}

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -248,11 +248,14 @@ func buildWorkerConfig(
 			workflowsList,
 			subscriptionWorkflows.ScheduleSubscriptionBillingWorkflow,
 			subscriptionWorkflows.ProcessSubscriptionBillingWorkflow,
+			subscriptionWorkflows.ProcessRenewalDueAlertWorkflow,
 			invoiceWorkflows.RecalculateInvoiceWorkflow,
 		)
 		activitiesList = append(activitiesList,
 			// Schedule billing activities
 			scheduleBillingActivities.ScheduleBillingActivity,
+			// Renewal due alert activity
+			scheduleBillingActivities.ProcessRenewalDueAlertActivity,
 			// Subscription billing period activities
 			billingActivities.CheckDraftSubscriptionActivity,
 			billingActivities.CalculatePeriodsActivity,

--- a/internal/temporal/workflows/subscription/renewal_due_alert_workflow.go
+++ b/internal/temporal/workflows/subscription/renewal_due_alert_workflow.go
@@ -1,0 +1,51 @@
+package subscription
+
+import (
+	"time"
+
+	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	WorkflowProcessRenewalDueAlert = "ProcessRenewalDueAlertWorkflow"
+	ActivityProcessRenewalDueAlert = "ProcessRenewalDueAlertActivity"
+)
+
+// ProcessRenewalDueAlertWorkflow finds all subscriptions due for renewal and sends webhook events.
+func ProcessRenewalDueAlertWorkflow(ctx workflow.Context, input subscriptionModels.ProcessRenewalDueAlertWorkflowInput) (*subscriptionModels.ProcessRenewalDueAlertWorkflowResult, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	logger := workflow.GetLogger(ctx)
+	logger.Info("Starting process renewal due alert workflow")
+
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: time.Hour,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    time.Second * 10,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    time.Minute * 5,
+			MaximumAttempts:    3,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var result subscriptionModels.ProcessRenewalDueAlertActivityResult
+	err := workflow.ExecuteActivity(ctx, ActivityProcessRenewalDueAlert, subscriptionModels.ProcessRenewalDueAlertActivityInput{}).Get(ctx, &result)
+	if err != nil {
+		logger.Error("Process renewal due alert workflow failed", "error", err)
+		errStr := err.Error()
+		return &subscriptionModels.ProcessRenewalDueAlertWorkflowResult{
+			Success: false,
+			Error:   &errStr,
+		}, nil
+	}
+
+	logger.Info("Process renewal due alert workflow completed successfully")
+	return &subscriptionModels.ProcessRenewalDueAlertWorkflowResult{
+		Success: true,
+	}, nil
+}

--- a/internal/temporal/workflows/subscription/renewal_due_alert_workflow.go
+++ b/internal/temporal/workflows/subscription/renewal_due_alert_workflow.go
@@ -37,11 +37,7 @@ func ProcessRenewalDueAlertWorkflow(ctx workflow.Context, input subscriptionMode
 	err := workflow.ExecuteActivity(ctx, ActivityProcessRenewalDueAlert, subscriptionModels.ProcessRenewalDueAlertActivityInput{}).Get(ctx, &result)
 	if err != nil {
 		logger.Error("Process renewal due alert workflow failed", "error", err)
-		errStr := err.Error()
-		return &subscriptionModels.ProcessRenewalDueAlertWorkflowResult{
-			Success: false,
-			Error:   &errStr,
-		}, nil
+		return nil, err
 	}
 
 	logger.Info("Process renewal due alert workflow completed successfully")

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -442,16 +442,15 @@ func (s *InMemorySubscriptionStore) GetWithPauses(ctx context.Context, id string
 	return sub, pauses, nil
 }
 
-// ListSubscriptionsDueForRenewal retrieves all active subscriptions that are due for renewal in 24 hours
-func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context) ([]*subscription.Subscription, error) {
-	// Create a filter for active subscriptions
+// ListSubscriptionsDueForRenewal retrieves all active subscriptions due for renewal within lookAhead
+func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, lookAhead time.Duration) ([]*subscription.Subscription, error) {
 	filter := &types.SubscriptionFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),
 		SubscriptionStatus: []types.SubscriptionStatus{
 			types.SubscriptionStatusActive,
 		},
 		TimeRangeFilter: &types.TimeRangeFilter{
-			EndTime: lo.ToPtr(time.Now().UTC().Add(24 * time.Hour)),
+			EndTime: lo.ToPtr(time.Now().UTC().Add(lookAhead)),
 		},
 	}
 

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -442,20 +442,26 @@ func (s *InMemorySubscriptionStore) GetWithPauses(ctx context.Context, id string
 	return sub, pauses, nil
 }
 
-// ListSubscriptionsDueForRenewal retrieves all active subscriptions whose period ends within [windowStart, windowEnd]
+// ListSubscriptionsDueForRenewal retrieves all active subscriptions whose period ends within [windowStart, windowEnd],
+// excluding any subscription with CancelAtPeriodEnd set. Mirrors the production ent repository logic.
 func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, windowStart time.Time, windowEnd time.Time) ([]*subscription.Subscription, error) {
-	filter := &types.SubscriptionFilter{
-		QueryFilter: types.NewNoLimitQueryFilter(),
-		SubscriptionStatus: []types.SubscriptionStatus{
-			types.SubscriptionStatusActive,
-		},
-		TimeRangeFilter: &types.TimeRangeFilter{
-			StartTime: lo.ToPtr(windowStart),
-			EndTime:   lo.ToPtr(windowEnd),
-		},
+	filterFn := func(ctx context.Context, sub *subscription.Subscription, _ interface{}) bool {
+		if sub == nil {
+			return false
+		}
+		if sub.SubscriptionStatus != types.SubscriptionStatusActive {
+			return false
+		}
+		if sub.Status != types.StatusPublished {
+			return false
+		}
+		if sub.CancelAtPeriodEnd {
+			return false
+		}
+		return !sub.CurrentPeriodEnd.Before(windowStart) && !sub.CurrentPeriodEnd.After(windowEnd)
 	}
 
-	return s.ListAll(ctx, filter)
+	return s.InMemoryStore.List(ctx, nil, filterFn, subscriptionSortFn)
 }
 
 // GetRecentSubscriptionsByPlan returns subscription counts grouped by plan for last 7 days

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -442,15 +442,16 @@ func (s *InMemorySubscriptionStore) GetWithPauses(ctx context.Context, id string
 	return sub, pauses, nil
 }
 
-// ListSubscriptionsDueForRenewal retrieves all active subscriptions due for renewal within lookAhead
-func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, lookAhead time.Duration) ([]*subscription.Subscription, error) {
+// ListSubscriptionsDueForRenewal retrieves all active subscriptions whose period ends within [windowStart, windowEnd]
+func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, windowStart time.Time, windowEnd time.Time) ([]*subscription.Subscription, error) {
 	filter := &types.SubscriptionFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),
 		SubscriptionStatus: []types.SubscriptionStatus{
 			types.SubscriptionStatusActive,
 		},
 		TimeRangeFilter: &types.TimeRangeFilter{
-			EndTime: lo.ToPtr(time.Now().UTC().Add(lookAhead)),
+			StartTime: lo.ToPtr(windowStart),
+			EndTime:   lo.ToPtr(windowEnd),
 		},
 	}
 

--- a/internal/types/temporal.go
+++ b/internal/types/temporal.go
@@ -75,6 +75,7 @@ const (
 	TemporalReprocessRawEventsWorkflow          TemporalWorkflowType = "ReprocessRawEventsWorkflow"
 	TemporalReprocessEventsForPlanWorkflow      TemporalWorkflowType = "ReprocessEventsForPlanWorkflow"
 	TemporalScheduleDraftFinalizationWorkflow   TemporalWorkflowType = "ScheduleDraftFinalizationWorkflow"
+	TemporalProcessRenewalDueAlertWorkflow      TemporalWorkflowType = "ProcessRenewalDueAlertWorkflow"
 )
 
 // WorkflowTypesExcludedFromTracking are workflow types that are not persisted to the
@@ -85,6 +86,7 @@ var WorkflowTypesExcludedFromTracking = []TemporalWorkflowType{
 	TemporalProcessSubscriptionBillingWorkflow,
 	TemporalProcessInvoiceWorkflow,
 	TemporalScheduleDraftFinalizationWorkflow,
+	TemporalProcessRenewalDueAlertWorkflow,
 }
 
 // ShouldTrackWorkflowType returns false if this workflow type is excluded from tracking
@@ -124,6 +126,7 @@ func (w TemporalWorkflowType) Validate() error {
 		TemporalReprocessRawEventsWorkflow,          // "ReprocessRawEventsWorkflow"
 		TemporalReprocessEventsForPlanWorkflow,      // "ReprocessEventsForPlanWorkflow"
 		TemporalScheduleDraftFinalizationWorkflow,   // "ScheduleDraftFinalizationWorkflow"
+		TemporalProcessRenewalDueAlertWorkflow,      // "ProcessRenewalDueAlertWorkflow"
 	}
 	if lo.Contains(allowedWorkflows, w) {
 		return nil
@@ -155,6 +158,8 @@ func (w TemporalWorkflowType) TaskQueue() TemporalTaskQueue {
 		return TemporalTaskQueueWorkflows
 	case TemporalReprocessEventsWorkflow, TemporalReprocessRawEventsWorkflow, TemporalReprocessEventsForPlanWorkflow:
 		return TemporalTaskQueueReprocessEvents
+	case TemporalProcessRenewalDueAlertWorkflow:
+		return TemporalTaskQueueSubscription
 	default:
 		return TemporalTaskQueueTask // Default fallback
 	}
@@ -197,6 +202,7 @@ func GetWorkflowsForTaskQueue(taskQueue TemporalTaskQueue) []TemporalWorkflowTyp
 			TemporalScheduleSubscriptionBillingWorkflow,
 			TemporalProcessSubscriptionBillingWorkflow,
 			TemporalRecalculateInvoiceWorkflow,
+			TemporalProcessRenewalDueAlertWorkflow,
 		}
 	case TemporalTaskQueueInvoice:
 		return []TemporalWorkflowType{


### PR DESCRIPTION
This is for my issue #1837 


## 📝 Description

Instead of fetching the renewal events for the next 24hr, now we can configure the time through the env variables.
Currently the renewal events are processed when the cron endpoint POST /subscriptions/renewal-due-alerts is called, since temporal is already being used, have added a workflow and activity for it, the client can use the temporal UI and create a schedule using any Schedule ID , Workflow Type as ProcessRenewalDueAlertsWorkflow, Task Queue as subscription and any cron duration they consider right. While the thought was to create a Schedule on server start with a const Schedule ID and ignore the error in case of schedule already being existed, I didnt want to add that cause it didnt feel right. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable subscription renewal alert timing with a customizable look‑ahead window and a new automated workflow to detect and process renewal‑due subscriptions.
  * Background task and activity added to trigger the renewal‑due alert flow.

* **Configuration**
  * Added a top-level subscription section to set the renewal alert look‑ahead period; invalid values are validated and a sensible default is applied.

* **Improvements**
  * Renewal detection now uses an explicit inclusive time window for more accurate alerting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->