### PR TITLE
fix(temporal): reduce worker concurrency defaults to prevent OOM

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -444,9 +444,9 @@ func provideTemporalWorkerManager(temporalClient client.TemporalClient, log *log
 	return worker.NewTemporalWorkerManager(temporalClient, log)
 }
 
-func provideTemporalService(temporalClient client.TemporalClient, workerManager worker.TemporalWorkerManager, log *logger.Logger, sentryService *sentry.Service) temporalservice.TemporalService {
+func provideTemporalService(temporalClient client.TemporalClient, workerManager worker.TemporalWorkerManager, log *logger.Logger, sentryService *sentry.Service, cfg *config.TemporalConfig) temporalservice.TemporalService {
 	// Initialize the global Temporal service instance with Sentry
-	temporalservice.InitializeGlobalTemporalService(temporalClient, workerManager, log, sentryService)
+	temporalservice.InitializeGlobalTemporalService(temporalClient, workerManager, log, sentryService, cfg)
 
 	// Get the global instance and start it
 	service := temporalservice.GetGlobalTemporalService()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,22 @@ type TemporalConfig struct {
 	APIKeyName             string `mapstructure:"api_key_name"`
 	TLS                    bool   `mapstructure:"tls"`
 	MaxWorkflowsPerCronRun int    `mapstructure:"max_workflows_per_cron_run"`
+	Worker                 TemporalWorkerConfig `mapstructure:"worker"`
+}
+
+type TemporalWorkerConfig struct {
+	// MaxConcurrentActivityExecutionSize is the max number of activities executed concurrently per worker.
+	// Default: 10
+	MaxConcurrentActivityExecutionSize int `mapstructure:"max_concurrent_activity_execution_size"`
+	// MaxConcurrentWorkflowTaskExecutionSize is the max number of workflow tasks executed concurrently per worker.
+	// Default: 10
+	MaxConcurrentWorkflowTaskExecutionSize int `mapstructure:"max_concurrent_workflow_task_execution_size"`
+	// WorkerActivitiesPerSecond is the rate limit for activities per second per worker. 0 means unlimited.
+	// Default: 5
+	WorkerActivitiesPerSecond float64 `mapstructure:"worker_activities_per_second"`
+	// TaskQueueActivitiesPerSecond is the rate limit for activities per second across all workers for the task queue. 0 means unlimited.
+	// Default: 0 (unlimited)
+	TaskQueueActivitiesPerSecond float64 `mapstructure:"task_queue_activities_per_second"`
 }
 
 type SecretsConfig struct {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -133,6 +133,11 @@ temporal:
     max_interval_seconds: 10
     max_attempts: 3
     backoff_coefficient: 2.0
+  worker:
+    max_concurrent_activity_execution_size: 10      # Max activities running concurrently per worker (default: 10)
+    max_concurrent_workflow_task_execution_size: 10  # Max workflow tasks running concurrently per worker (default: 10)
+    worker_activities_per_second: 5                  # Rate limit: activities dispatched per second per worker (default: 5, 0=unlimited)
+    task_queue_activities_per_second: 0              # Rate limit: activities per second across ALL workers for a task queue (default: 0=unlimited)
   connection:
     dial_timeout_seconds: 5
     retry_max_attempts: 5

--- a/internal/temporal/models/options.go
+++ b/internal/temporal/models/options.go
@@ -47,6 +47,10 @@ type WorkerOptions struct {
 	MaxConcurrentActivityExecutionSize int
 	// MaxConcurrentWorkflowTaskExecutionSize is the maximum number of workflow tasks that can be executed concurrently
 	MaxConcurrentWorkflowTaskExecutionSize int
+	// WorkerActivitiesPerSecond is the rate limit for activities per second per worker. 0 means unlimited.
+	WorkerActivitiesPerSecond float64
+	// TaskQueueActivitiesPerSecond is the rate limit for activities per second across all workers for the task queue. 0 means unlimited.
+	TaskQueueActivitiesPerSecond float64
 	// WorkerStopTimeout is the time to wait for worker to stop gracefully
 	WorkerStopTimeout time.Duration
 	// EnableLoggingInReplay enables logging in replay mode
@@ -55,11 +59,18 @@ type WorkerOptions struct {
 	Interceptors []interceptor.WorkerInterceptor
 }
 
+const (
+	DefaultMaxConcurrentActivityExecutionSize     = 10
+	DefaultMaxConcurrentWorkflowTaskExecutionSize = 10
+	DefaultWorkerActivitiesPerSecond              = 5.0
+)
+
 // DefaultWorkerOptions returns the default worker options
 func DefaultWorkerOptions() *WorkerOptions {
 	return &WorkerOptions{
-		MaxConcurrentActivityExecutionSize:     1000,
-		MaxConcurrentWorkflowTaskExecutionSize: 1000,
+		MaxConcurrentActivityExecutionSize:     DefaultMaxConcurrentActivityExecutionSize,
+		MaxConcurrentWorkflowTaskExecutionSize: DefaultMaxConcurrentWorkflowTaskExecutionSize,
+		WorkerActivitiesPerSecond:              DefaultWorkerActivitiesPerSecond,
 		WorkerStopTimeout:                      time.Second * 30,
 		EnableLoggingInReplay:                  false,
 	}
@@ -80,11 +91,13 @@ func (o *ClientOptions) ToSDKOptions() client.Options {
 // ToSDKOptions converts WorkerOptions to Temporal SDK worker.Options
 func (o *WorkerOptions) ToSDKOptions() worker.Options {
 	return worker.Options{
-		MaxConcurrentActivityExecutionSize:     o.MaxConcurrentActivityExecutionSize,
-		MaxConcurrentWorkflowTaskExecutionSize: o.MaxConcurrentWorkflowTaskExecutionSize,
-		WorkerStopTimeout:                      o.WorkerStopTimeout,
-		EnableLoggingInReplay:                  o.EnableLoggingInReplay,
-		Interceptors:                           o.Interceptors,
+		MaxConcurrentActivityExecutionSize:      o.MaxConcurrentActivityExecutionSize,
+		MaxConcurrentWorkflowTaskExecutionSize:  o.MaxConcurrentWorkflowTaskExecutionSize,
+		WorkerActivitiesPerSecond:               o.WorkerActivitiesPerSecond,
+		TaskQueueActivitiesPerSecond:            o.TaskQueueActivitiesPerSecond,
+		WorkerStopTimeout:                       o.WorkerStopTimeout,
+		EnableLoggingInReplay:                   o.EnableLoggingInReplay,
+		Interceptors:                            o.Interceptors,
 	}
 }
 

--- a/internal/temporal/service/service.go
+++ b/internal/temporal/service/service.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/sentry"
@@ -31,22 +32,24 @@ type temporalService struct {
 	workerManager worker.TemporalWorkerManager
 	logger        *logger.Logger
 	sentry        *sentry.Service
+	workerConfig  config.TemporalWorkerConfig
 }
 
 // NewTemporalService creates a new temporal service instance
-func NewTemporalService(client client.TemporalClient, workerManager worker.TemporalWorkerManager, logger *logger.Logger, sentryService *sentry.Service) TemporalService {
+func NewTemporalService(client client.TemporalClient, workerManager worker.TemporalWorkerManager, logger *logger.Logger, sentryService *sentry.Service, cfg *config.TemporalConfig) TemporalService {
 	return &temporalService{
 		client:        client,
 		workerManager: workerManager,
 		logger:        logger,
 		sentry:        sentryService,
+		workerConfig:  cfg.Worker,
 	}
 }
 
 // InitializeGlobalTemporalService initializes the global Temporal service instance
-func InitializeGlobalTemporalService(client client.TemporalClient, workerManager worker.TemporalWorkerManager, logger *logger.Logger, sentryService *sentry.Service) {
+func InitializeGlobalTemporalService(client client.TemporalClient, workerManager worker.TemporalWorkerManager, logger *logger.Logger, sentryService *sentry.Service, cfg *config.TemporalConfig) {
 	globalTemporalOnce.Do(func() {
-		globalTemporalService = NewTemporalService(client, workerManager, logger, sentryService)
+		globalTemporalService = NewTemporalService(client, workerManager, logger, sentryService, cfg)
 	})
 }
 
@@ -234,18 +237,7 @@ func (s *temporalService) RegisterWorkflow(taskQueue types.TemporalTaskQueue, wo
 			Mark(errors.ErrValidation)
 	}
 
-	// Create worker options with Sentry and Workflow Tracking interceptors
-	options := models.DefaultWorkerOptions()
-	if s.sentry != nil && s.sentry.IsEnabled() {
-		options.Interceptors = []interceptor.WorkerInterceptor{
-			temporalInterceptor.NewSentryInterceptor(s.sentry),
-			temporalInterceptor.NewWorkflowTrackingInterceptor(),
-		}
-	} else {
-		options.Interceptors = []interceptor.WorkerInterceptor{
-			temporalInterceptor.NewWorkflowTrackingInterceptor(),
-		}
-	}
+	options := s.buildWorkerOptions()
 
 	w, err := s.workerManager.GetOrCreateWorker(taskQueue, options)
 	if err != nil {
@@ -270,18 +262,7 @@ func (s *temporalService) RegisterActivity(taskQueue types.TemporalTaskQueue, ac
 			Mark(errors.ErrValidation)
 	}
 
-	// Create worker options with Sentry and Workflow Tracking interceptors
-	options := models.DefaultWorkerOptions()
-	if s.sentry != nil && s.sentry.IsEnabled() {
-		options.Interceptors = []interceptor.WorkerInterceptor{
-			temporalInterceptor.NewSentryInterceptor(s.sentry),
-			temporalInterceptor.NewWorkflowTrackingInterceptor(),
-		}
-	} else {
-		options.Interceptors = []interceptor.WorkerInterceptor{
-			temporalInterceptor.NewWorkflowTrackingInterceptor(),
-		}
-	}
+	options := s.buildWorkerOptions()
 
 	w, err := s.workerManager.GetOrCreateWorker(taskQueue, options)
 	if err != nil {
@@ -313,6 +294,39 @@ func (s *temporalService) StopWorker(taskQueue types.TemporalTaskQueue) error {
 	}
 
 	return s.workerManager.StopWorker(taskQueue)
+}
+
+// buildWorkerOptions creates worker options from config with interceptors
+func (s *temporalService) buildWorkerOptions() *models.WorkerOptions {
+	options := models.DefaultWorkerOptions()
+
+	// Apply config overrides (0 values mean use defaults)
+	if s.workerConfig.MaxConcurrentActivityExecutionSize > 0 {
+		options.MaxConcurrentActivityExecutionSize = s.workerConfig.MaxConcurrentActivityExecutionSize
+	}
+	if s.workerConfig.MaxConcurrentWorkflowTaskExecutionSize > 0 {
+		options.MaxConcurrentWorkflowTaskExecutionSize = s.workerConfig.MaxConcurrentWorkflowTaskExecutionSize
+	}
+	if s.workerConfig.WorkerActivitiesPerSecond > 0 {
+		options.WorkerActivitiesPerSecond = s.workerConfig.WorkerActivitiesPerSecond
+	}
+	if s.workerConfig.TaskQueueActivitiesPerSecond > 0 {
+		options.TaskQueueActivitiesPerSecond = s.workerConfig.TaskQueueActivitiesPerSecond
+	}
+
+	// Add interceptors
+	if s.sentry != nil && s.sentry.IsEnabled() {
+		options.Interceptors = []interceptor.WorkerInterceptor{
+			temporalInterceptor.NewSentryInterceptor(s.sentry),
+			temporalInterceptor.NewWorkflowTrackingInterceptor(),
+		}
+	} else {
+		options.Interceptors = []interceptor.WorkerInterceptor{
+			temporalInterceptor.NewWorkflowTrackingInterceptor(),
+		}
+	}
+
+	return options
 }
 
 // StopAllWorkers implements TemporalService


### PR DESCRIPTION
## Changes

- Reduced default worker concurrency limits from 1000 to 10 for both activity and workflow task execution to prevent out-of-memory kills
- Added configurable `TemporalWorkerConfig` struct with:
  - `MaxConcurrentActivityExecutionSize` (default: 10)
  - `MaxConcurrentWorkflowTaskExecutionSize` (default: 10)
  - `WorkerActivitiesPerSecond` rate limiting (default: 5)
  - `TaskQueueActivitiesPerSecond` rate limiting (default: unlimited)
- Updated config schema in `config.yaml` with new worker tuning parameters
- Refactored worker options building into dedicated `buildWorkerOptions()` method to reduce code duplication
- Connected temporal service initialization to use config values
- Added constants for default worker option values for maintainability

## Impact

This change significantly reduces memory pressure on Temporal workers by limiting concurrent execution, making the system more stable in resource-constrained environments while maintaining configurability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temporal workers can now be configured with custom concurrency limits and activity rate-limiting thresholds.

* **Chores**
  * Updated default Temporal worker concurrency and activity handling parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->