### PR TITLE
fix: reduce default invoice finalization delay from 5 days to 2 hours

### DIFF
--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -371,7 +371,7 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 		InvoiceNumberSuffixLength:              5,
 		DueDateDays:                            lo.ToPtr(1),
 		AutoCompletePurchasedCreditTransaction: false,
-		FinalizationDelaySeconds:               432000, // 5 days
+		FinalizationDelaySeconds:               7200, // 2 hours
 	}
 
 	defaultSubscriptionConfig := SubscriptionConfig{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The default invoice finalization delay has been reduced from 5 days to 2 hours, enabling faster invoice processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->