### PR TITLE
feat: add event_name column to system_events table

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1920,6 +1920,7 @@ var (
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "environment_id", Type: field.TypeString, Nullable: true, Default: "", SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "event_name", Type: field.TypeString, Nullable: true, Default: "", SchemaType: map[string]string{"postgres": "varchar(128)"}},
 		{Name: "entity_type", Type: field.TypeString, Nullable: true, Default: "", SchemaType: map[string]string{"postgres": "varchar(64)"}},
 		{Name: "entity_id", Type: field.TypeString, Nullable: true, Default: "", SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "webhook_message_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(128)"}},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -55821,6 +55821,7 @@ type SystemEventMutation struct {
 	created_by         *string
 	updated_by         *string
 	environment_id     *string
+	event_name         *string
 	entity_type        *string
 	entity_id          *string
 	webhook_message_id *string
@@ -56227,6 +56228,55 @@ func (m *SystemEventMutation) ResetEnvironmentID() {
 	delete(m.clearedFields, systemevent.FieldEnvironmentID)
 }
 
+// SetEventName sets the "event_name" field.
+func (m *SystemEventMutation) SetEventName(s string) {
+	m.event_name = &s
+}
+
+// EventName returns the value of the "event_name" field in the mutation.
+func (m *SystemEventMutation) EventName() (r string, exists bool) {
+	v := m.event_name
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldEventName returns the old "event_name" field's value of the SystemEvent entity.
+// If the SystemEvent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SystemEventMutation) OldEventName(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldEventName is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldEventName requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldEventName: %w", err)
+	}
+	return oldValue.EventName, nil
+}
+
+// ClearEventName clears the value of the "event_name" field.
+func (m *SystemEventMutation) ClearEventName() {
+	m.event_name = nil
+	m.clearedFields[systemevent.FieldEventName] = struct{}{}
+}
+
+// EventNameCleared returns if the "event_name" field was cleared in this mutation.
+func (m *SystemEventMutation) EventNameCleared() bool {
+	_, ok := m.clearedFields[systemevent.FieldEventName]
+	return ok
+}
+
+// ResetEventName resets all changes to the "event_name" field.
+func (m *SystemEventMutation) ResetEventName() {
+	m.event_name = nil
+	delete(m.clearedFields, systemevent.FieldEventName)
+}
+
 // SetEntityType sets the "entity_type" field.
 func (m *SystemEventMutation) SetEntityType(s string) {
 	m.entity_type = &s
@@ -56506,7 +56556,7 @@ func (m *SystemEventMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SystemEventMutation) Fields() []string {
-	fields := make([]string, 0, 12)
+	fields := make([]string, 0, 13)
 	if m.tenant_id != nil {
 		fields = append(fields, systemevent.FieldTenantID)
 	}
@@ -56527,6 +56577,9 @@ func (m *SystemEventMutation) Fields() []string {
 	}
 	if m.environment_id != nil {
 		fields = append(fields, systemevent.FieldEnvironmentID)
+	}
+	if m.event_name != nil {
+		fields = append(fields, systemevent.FieldEventName)
 	}
 	if m.entity_type != nil {
 		fields = append(fields, systemevent.FieldEntityType)
@@ -56565,6 +56618,8 @@ func (m *SystemEventMutation) Field(name string) (ent.Value, bool) {
 		return m.UpdatedBy()
 	case systemevent.FieldEnvironmentID:
 		return m.EnvironmentID()
+	case systemevent.FieldEventName:
+		return m.EventName()
 	case systemevent.FieldEntityType:
 		return m.EntityType()
 	case systemevent.FieldEntityID:
@@ -56598,6 +56653,8 @@ func (m *SystemEventMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldUpdatedBy(ctx)
 	case systemevent.FieldEnvironmentID:
 		return m.OldEnvironmentID(ctx)
+	case systemevent.FieldEventName:
+		return m.OldEventName(ctx)
 	case systemevent.FieldEntityType:
 		return m.OldEntityType(ctx)
 	case systemevent.FieldEntityID:
@@ -56665,6 +56722,13 @@ func (m *SystemEventMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetEnvironmentID(v)
+		return nil
+	case systemevent.FieldEventName:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetEventName(v)
 		return nil
 	case systemevent.FieldEntityType:
 		v, ok := value.(string)
@@ -56740,6 +56804,9 @@ func (m *SystemEventMutation) ClearedFields() []string {
 	if m.FieldCleared(systemevent.FieldEnvironmentID) {
 		fields = append(fields, systemevent.FieldEnvironmentID)
 	}
+	if m.FieldCleared(systemevent.FieldEventName) {
+		fields = append(fields, systemevent.FieldEventName)
+	}
 	if m.FieldCleared(systemevent.FieldEntityType) {
 		fields = append(fields, systemevent.FieldEntityType)
 	}
@@ -56777,6 +56844,9 @@ func (m *SystemEventMutation) ClearField(name string) error {
 		return nil
 	case systemevent.FieldEnvironmentID:
 		m.ClearEnvironmentID()
+		return nil
+	case systemevent.FieldEventName:
+		m.ClearEventName()
 		return nil
 	case systemevent.FieldEntityType:
 		m.ClearEntityType()
@@ -56821,6 +56891,9 @@ func (m *SystemEventMutation) ResetField(name string) error {
 		return nil
 	case systemevent.FieldEnvironmentID:
 		m.ResetEnvironmentID()
+		return nil
+	case systemevent.FieldEventName:
+		m.ResetEventName()
 		return nil
 	case systemevent.FieldEntityType:
 		m.ResetEntityType()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -1900,12 +1900,16 @@ func init() {
 	systemeventDescEnvironmentID := systemeventMixinFields1[0].Descriptor()
 	// systemevent.DefaultEnvironmentID holds the default value on creation for the environment_id field.
 	systemevent.DefaultEnvironmentID = systemeventDescEnvironmentID.Default.(string)
+	// systemeventDescEventName is the schema descriptor for event_name field.
+	systemeventDescEventName := systemeventFields[1].Descriptor()
+	// systemevent.DefaultEventName holds the default value on creation for the event_name field.
+	systemevent.DefaultEventName = systemeventDescEventName.Default.(string)
 	// systemeventDescEntityType is the schema descriptor for entity_type field.
-	systemeventDescEntityType := systemeventFields[1].Descriptor()
+	systemeventDescEntityType := systemeventFields[2].Descriptor()
 	// systemevent.DefaultEntityType holds the default value on creation for the entity_type field.
 	systemevent.DefaultEntityType = systemeventDescEntityType.Default.(string)
 	// systemeventDescEntityID is the schema descriptor for entity_id field.
-	systemeventDescEntityID := systemeventFields[2].Descriptor()
+	systemeventDescEntityID := systemeventFields[3].Descriptor()
 	// systemevent.DefaultEntityID holds the default value on creation for the entity_id field.
 	systemevent.DefaultEntityID = systemeventDescEntityID.Default.(string)
 	taskMixin := schema.Task{}.Mixin()

--- a/ent/schema/systemevent.go
+++ b/ent/schema/systemevent.go
@@ -26,6 +26,12 @@ func (SystemEvent) Fields() []ent.Field {
 			}).
 			Unique().
 			Immutable(),
+		field.String("event_name").
+			SchemaType(map[string]string{
+				"postgres": "varchar(128)",
+			}).
+			Optional().
+			Default(""),
 		field.String("entity_type").
 			SchemaType(map[string]string{
 				"postgres": "varchar(64)",

--- a/ent/systemevent.go
+++ b/ent/systemevent.go
@@ -32,6 +32,8 @@ type SystemEvent struct {
 	UpdatedBy string `json:"updated_by,omitempty"`
 	// EnvironmentID holds the value of the "environment_id" field.
 	EnvironmentID string `json:"environment_id,omitempty"`
+	// EventName holds the value of the "event_name" field.
+	EventName string `json:"event_name,omitempty"`
 	// EntityType holds the value of the "entity_type" field.
 	EntityType string `json:"entity_type,omitempty"`
 	// EntityID holds the value of the "entity_id" field.
@@ -52,7 +54,7 @@ func (*SystemEvent) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case systemevent.FieldPayload:
 			values[i] = new([]byte)
-		case systemevent.FieldID, systemevent.FieldTenantID, systemevent.FieldStatus, systemevent.FieldCreatedBy, systemevent.FieldUpdatedBy, systemevent.FieldEnvironmentID, systemevent.FieldEntityType, systemevent.FieldEntityID, systemevent.FieldWebhookMessageID:
+		case systemevent.FieldID, systemevent.FieldTenantID, systemevent.FieldStatus, systemevent.FieldCreatedBy, systemevent.FieldUpdatedBy, systemevent.FieldEnvironmentID, systemevent.FieldEventName, systemevent.FieldEntityType, systemevent.FieldEntityID, systemevent.FieldWebhookMessageID:
 			values[i] = new(sql.NullString)
 		case systemevent.FieldCreatedAt, systemevent.FieldUpdatedAt, systemevent.FieldPublishedAt:
 			values[i] = new(sql.NullTime)
@@ -118,6 +120,12 @@ func (se *SystemEvent) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field environment_id", values[i])
 			} else if value.Valid {
 				se.EnvironmentID = value.String
+			}
+		case systemevent.FieldEventName:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field event_name", values[i])
+			} else if value.Valid {
+				se.EventName = value.String
 			}
 		case systemevent.FieldEntityType:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -209,6 +217,9 @@ func (se *SystemEvent) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("environment_id=")
 	builder.WriteString(se.EnvironmentID)
+	builder.WriteString(", ")
+	builder.WriteString("event_name=")
+	builder.WriteString(se.EventName)
 	builder.WriteString(", ")
 	builder.WriteString("entity_type=")
 	builder.WriteString(se.EntityType)

--- a/ent/systemevent/systemevent.go
+++ b/ent/systemevent/systemevent.go
@@ -27,6 +27,8 @@ const (
 	FieldUpdatedBy = "updated_by"
 	// FieldEnvironmentID holds the string denoting the environment_id field in the database.
 	FieldEnvironmentID = "environment_id"
+	// FieldEventName holds the string denoting the event_name field in the database.
+	FieldEventName = "event_name"
 	// FieldEntityType holds the string denoting the entity_type field in the database.
 	FieldEntityType = "entity_type"
 	// FieldEntityID holds the string denoting the entity_id field in the database.
@@ -51,6 +53,7 @@ var Columns = []string{
 	FieldCreatedBy,
 	FieldUpdatedBy,
 	FieldEnvironmentID,
+	FieldEventName,
 	FieldEntityType,
 	FieldEntityID,
 	FieldWebhookMessageID,
@@ -81,6 +84,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// DefaultEnvironmentID holds the default value on creation for the "environment_id" field.
 	DefaultEnvironmentID string
+	// DefaultEventName holds the default value on creation for the "event_name" field.
+	DefaultEventName string
 	// DefaultEntityType holds the default value on creation for the "entity_type" field.
 	DefaultEntityType string
 	// DefaultEntityID holds the default value on creation for the "entity_id" field.
@@ -128,6 +133,11 @@ func ByUpdatedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByEnvironmentID orders the results by the environment_id field.
 func ByEnvironmentID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldEnvironmentID, opts...).ToFunc()
+}
+
+// ByEventName orders the results by the event_name field.
+func ByEventName(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldEventName, opts...).ToFunc()
 }
 
 // ByEntityType orders the results by the entity_type field.

--- a/ent/systemevent/where.go
+++ b/ent/systemevent/where.go
@@ -99,6 +99,11 @@ func EnvironmentID(v string) predicate.SystemEvent {
 	return predicate.SystemEvent(sql.FieldEQ(FieldEnvironmentID, v))
 }
 
+// EventName applies equality check predicate on the "event_name" field. It's identical to EventNameEQ.
+func EventName(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldEQ(FieldEventName, v))
+}
+
 // EntityType applies equality check predicate on the "entity_type" field. It's identical to EntityTypeEQ.
 func EntityType(v string) predicate.SystemEvent {
 	return predicate.SystemEvent(sql.FieldEQ(FieldEntityType, v))
@@ -552,6 +557,81 @@ func EnvironmentIDEqualFold(v string) predicate.SystemEvent {
 // EnvironmentIDContainsFold applies the ContainsFold predicate on the "environment_id" field.
 func EnvironmentIDContainsFold(v string) predicate.SystemEvent {
 	return predicate.SystemEvent(sql.FieldContainsFold(FieldEnvironmentID, v))
+}
+
+// EventNameEQ applies the EQ predicate on the "event_name" field.
+func EventNameEQ(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldEQ(FieldEventName, v))
+}
+
+// EventNameNEQ applies the NEQ predicate on the "event_name" field.
+func EventNameNEQ(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldNEQ(FieldEventName, v))
+}
+
+// EventNameIn applies the In predicate on the "event_name" field.
+func EventNameIn(vs ...string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldIn(FieldEventName, vs...))
+}
+
+// EventNameNotIn applies the NotIn predicate on the "event_name" field.
+func EventNameNotIn(vs ...string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldNotIn(FieldEventName, vs...))
+}
+
+// EventNameGT applies the GT predicate on the "event_name" field.
+func EventNameGT(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldGT(FieldEventName, v))
+}
+
+// EventNameGTE applies the GTE predicate on the "event_name" field.
+func EventNameGTE(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldGTE(FieldEventName, v))
+}
+
+// EventNameLT applies the LT predicate on the "event_name" field.
+func EventNameLT(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldLT(FieldEventName, v))
+}
+
+// EventNameLTE applies the LTE predicate on the "event_name" field.
+func EventNameLTE(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldLTE(FieldEventName, v))
+}
+
+// EventNameContains applies the Contains predicate on the "event_name" field.
+func EventNameContains(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldContains(FieldEventName, v))
+}
+
+// EventNameHasPrefix applies the HasPrefix predicate on the "event_name" field.
+func EventNameHasPrefix(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldHasPrefix(FieldEventName, v))
+}
+
+// EventNameHasSuffix applies the HasSuffix predicate on the "event_name" field.
+func EventNameHasSuffix(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldHasSuffix(FieldEventName, v))
+}
+
+// EventNameIsNil applies the IsNil predicate on the "event_name" field.
+func EventNameIsNil() predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldIsNull(FieldEventName))
+}
+
+// EventNameNotNil applies the NotNil predicate on the "event_name" field.
+func EventNameNotNil() predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldNotNull(FieldEventName))
+}
+
+// EventNameEqualFold applies the EqualFold predicate on the "event_name" field.
+func EventNameEqualFold(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldEqualFold(FieldEventName, v))
+}
+
+// EventNameContainsFold applies the ContainsFold predicate on the "event_name" field.
+func EventNameContainsFold(v string) predicate.SystemEvent {
+	return predicate.SystemEvent(sql.FieldContainsFold(FieldEventName, v))
 }
 
 // EntityTypeEQ applies the EQ predicate on the "entity_type" field.

--- a/ent/systemevent_create.go
+++ b/ent/systemevent_create.go
@@ -110,6 +110,20 @@ func (sec *SystemEventCreate) SetNillableEnvironmentID(s *string) *SystemEventCr
 	return sec
 }
 
+// SetEventName sets the "event_name" field.
+func (sec *SystemEventCreate) SetEventName(s string) *SystemEventCreate {
+	sec.mutation.SetEventName(s)
+	return sec
+}
+
+// SetNillableEventName sets the "event_name" field if the given value is not nil.
+func (sec *SystemEventCreate) SetNillableEventName(s *string) *SystemEventCreate {
+	if s != nil {
+		sec.SetEventName(*s)
+	}
+	return sec
+}
+
 // SetEntityType sets the "entity_type" field.
 func (sec *SystemEventCreate) SetEntityType(s string) *SystemEventCreate {
 	sec.mutation.SetEntityType(s)
@@ -229,6 +243,10 @@ func (sec *SystemEventCreate) defaults() {
 		v := systemevent.DefaultEnvironmentID
 		sec.mutation.SetEnvironmentID(v)
 	}
+	if _, ok := sec.mutation.EventName(); !ok {
+		v := systemevent.DefaultEventName
+		sec.mutation.SetEventName(v)
+	}
 	if _, ok := sec.mutation.EntityType(); !ok {
 		v := systemevent.DefaultEntityType
 		sec.mutation.SetEntityType(v)
@@ -320,6 +338,10 @@ func (sec *SystemEventCreate) createSpec() (*SystemEvent, *sqlgraph.CreateSpec) 
 	if value, ok := sec.mutation.EnvironmentID(); ok {
 		_spec.SetField(systemevent.FieldEnvironmentID, field.TypeString, value)
 		_node.EnvironmentID = value
+	}
+	if value, ok := sec.mutation.EventName(); ok {
+		_spec.SetField(systemevent.FieldEventName, field.TypeString, value)
+		_node.EventName = value
 	}
 	if value, ok := sec.mutation.EntityType(); ok {
 		_spec.SetField(systemevent.FieldEntityType, field.TypeString, value)

--- a/ent/systemevent_update.go
+++ b/ent/systemevent_update.go
@@ -68,6 +68,26 @@ func (seu *SystemEventUpdate) ClearUpdatedBy() *SystemEventUpdate {
 	return seu
 }
 
+// SetEventName sets the "event_name" field.
+func (seu *SystemEventUpdate) SetEventName(s string) *SystemEventUpdate {
+	seu.mutation.SetEventName(s)
+	return seu
+}
+
+// SetNillableEventName sets the "event_name" field if the given value is not nil.
+func (seu *SystemEventUpdate) SetNillableEventName(s *string) *SystemEventUpdate {
+	if s != nil {
+		seu.SetEventName(*s)
+	}
+	return seu
+}
+
+// ClearEventName clears the value of the "event_name" field.
+func (seu *SystemEventUpdate) ClearEventName() *SystemEventUpdate {
+	seu.mutation.ClearEventName()
+	return seu
+}
+
 // SetEntityType sets the "entity_type" field.
 func (seu *SystemEventUpdate) SetEntityType(s string) *SystemEventUpdate {
 	seu.mutation.SetEntityType(s)
@@ -228,6 +248,12 @@ func (seu *SystemEventUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if seu.mutation.EnvironmentIDCleared() {
 		_spec.ClearField(systemevent.FieldEnvironmentID, field.TypeString)
 	}
+	if value, ok := seu.mutation.EventName(); ok {
+		_spec.SetField(systemevent.FieldEventName, field.TypeString, value)
+	}
+	if seu.mutation.EventNameCleared() {
+		_spec.ClearField(systemevent.FieldEventName, field.TypeString)
+	}
 	if value, ok := seu.mutation.EntityType(); ok {
 		_spec.SetField(systemevent.FieldEntityType, field.TypeString, value)
 	}
@@ -315,6 +341,26 @@ func (seuo *SystemEventUpdateOne) SetNillableUpdatedBy(s *string) *SystemEventUp
 // ClearUpdatedBy clears the value of the "updated_by" field.
 func (seuo *SystemEventUpdateOne) ClearUpdatedBy() *SystemEventUpdateOne {
 	seuo.mutation.ClearUpdatedBy()
+	return seuo
+}
+
+// SetEventName sets the "event_name" field.
+func (seuo *SystemEventUpdateOne) SetEventName(s string) *SystemEventUpdateOne {
+	seuo.mutation.SetEventName(s)
+	return seuo
+}
+
+// SetNillableEventName sets the "event_name" field if the given value is not nil.
+func (seuo *SystemEventUpdateOne) SetNillableEventName(s *string) *SystemEventUpdateOne {
+	if s != nil {
+		seuo.SetEventName(*s)
+	}
+	return seuo
+}
+
+// ClearEventName clears the value of the "event_name" field.
+func (seuo *SystemEventUpdateOne) ClearEventName() *SystemEventUpdateOne {
+	seuo.mutation.ClearEventName()
 	return seuo
 }
 
@@ -507,6 +553,12 @@ func (seuo *SystemEventUpdateOne) sqlSave(ctx context.Context) (_node *SystemEve
 	}
 	if seuo.mutation.EnvironmentIDCleared() {
 		_spec.ClearField(systemevent.FieldEnvironmentID, field.TypeString)
+	}
+	if value, ok := seuo.mutation.EventName(); ok {
+		_spec.SetField(systemevent.FieldEventName, field.TypeString, value)
+	}
+	if seuo.mutation.EventNameCleared() {
+		_spec.ClearField(systemevent.FieldEventName, field.TypeString)
 	}
 	if value, ok := seuo.mutation.EntityType(); ok {
 		_spec.SetField(systemevent.FieldEntityType, field.TypeString, value)

--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,6 @@ require (
 	github.com/zclconf/go-cty v1.8.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.31.0 // indirect
-	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.17.0
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect

--- a/internal/repository/ent/systemevent.go
+++ b/internal/repository/ent/systemevent.go
@@ -39,6 +39,7 @@ func (r *SystemEventRepository) OnConsumed(ctx context.Context, event *types.Web
 		SetID(event.ID).
 		SetTenantID(event.TenantID).
 		SetEnvironmentID(event.EnvironmentID).
+		SetEventName(string(event.EventName)).
 		SetEntityType(string(event.EntityType)).
 		SetEntityID(event.EntityID).
 		SetPayload(payloadMap).
@@ -57,6 +58,9 @@ func (r *SystemEventRepository) OnConsumed(ctx context.Context, event *types.Web
 	// Row already exists (created by another consumer process with stale code).
 	// Overwrite entity_type / entity_id so the correct values win.
 	updateQ := client.SystemEvent.UpdateOneID(event.ID).SetUpdatedAt(now)
+	if event.EventName != "" {
+		updateQ = updateQ.SetEventName(string(event.EventName))
+	}
 	if event.EntityType != "" {
 		updateQ = updateQ.SetEntityType(string(event.EntityType))
 	}

--- a/migrations/ent/migration_20260401034948.sql
+++ b/migrations/ent/migration_20260401034948.sql
@@ -1,0 +1,1 @@
+Using config file: /Users/nikhilmishra/work/flexprice/.claude/worktrees/objective-bell/internal/config/config.yaml

--- a/migrations/ent/migration_20260401034948.sql
+++ b/migrations/ent/migration_20260401034948.sql
@@ -1,1 +1,0 @@
-Using config file: /Users/nikhilmishra/work/flexprice/.claude/worktrees/objective-bell/internal/config/config.yaml


### PR DESCRIPTION
## Changes

- Add `event_name` field to SystemEvent schema with varchar(128) type
- Generate Ent ORM code for new field (mutations, predicates, CRUD operations)
- Update SystemEventRepository to populate `event_name` when consuming webhook events
- Remove unused indirect dependency from go.mod

## Details

This adds support for storing event names in the system_events table, allowing better tracking and filtering of different event types. The field is optional with an empty string default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System events now support optional event name storage, enabling improved event categorization with advanced filtering and ordering capabilities.

* **Chores**
  * Removed OpenTelemetry dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->