### PR TITLE
feat(invoice): add subs customer id to invoice

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -48,7 +48,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAddonRequest"
+                            "$ref": "#/definitions/CreateAddonRequest"
                         }
                     }
                 ],
@@ -56,19 +56,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAddonResponse"
+                            "$ref": "#/definitions/CreateAddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -103,19 +103,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonResponse"
+                            "$ref": "#/definitions/AddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -147,7 +147,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonFilter"
+                            "$ref": "#/definitions/types.AddonFilter"
                         }
                     }
                 ],
@@ -161,13 +161,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -202,19 +202,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonResponse"
+                            "$ref": "#/definitions/AddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -251,7 +251,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateAddonRequest"
+                            "$ref": "#/definitions/UpdateAddonRequest"
                         }
                     }
                 ],
@@ -259,19 +259,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonResponse"
+                            "$ref": "#/definitions/AddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -304,19 +304,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -357,19 +357,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -401,7 +401,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertLogFilter"
+                            "$ref": "#/definitions/types.AlertLogFilter"
                         }
                     }
                 ],
@@ -409,19 +409,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListAlertLogsResponse"
+                            "$ref": "#/definitions/ListAlertLogsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -453,7 +453,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCostsheetRequest"
+                            "$ref": "#/definitions/CreateCostsheetRequest"
                         }
                     }
                 ],
@@ -461,25 +461,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created costsheet",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCostsheetResponse"
+                            "$ref": "#/definitions/CreateCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -505,19 +505,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Active costsheet",
                         "schema": {
-                            "$ref": "#/definitions/dto.CostsheetResponse"
+                            "$ref": "#/definitions/CostsheetResponse"
                         }
                     },
                     "404": {
                         "description": "No active costsheet",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -549,7 +549,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCostAnalyticsRequest"
+                            "$ref": "#/definitions/GetCostAnalyticsRequest"
                         }
                     }
                 ],
@@ -557,19 +557,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetDetailedCostAnalyticsResponse"
+                            "$ref": "#/definitions/GetDetailedCostAnalyticsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -601,7 +601,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCostAnalyticsRequest"
+                            "$ref": "#/definitions/GetCostAnalyticsRequest"
                         }
                     }
                 ],
@@ -609,19 +609,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetDetailedCostAnalyticsResponse"
+                            "$ref": "#/definitions/GetDetailedCostAnalyticsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -661,19 +661,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Paginated costsheets",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListCostsheetResponse"
+                            "$ref": "#/definitions/ListCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -714,25 +714,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Costsheet details",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCostsheetResponse"
+                            "$ref": "#/definitions/GetCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Costsheet not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -769,7 +769,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCostsheetRequest"
+                            "$ref": "#/definitions/UpdateCostsheetRequest"
                         }
                     }
                 ],
@@ -777,31 +777,31 @@ const docTemplate = `{
                     "200": {
                         "description": "Updated costsheet",
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCostsheetResponse"
+                            "$ref": "#/definitions/UpdateCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Costsheet not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -837,25 +837,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Costsheet deleted",
                         "schema": {
-                            "$ref": "#/definitions/dto.DeleteCostsheetResponse"
+                            "$ref": "#/definitions/DeleteCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Costsheet not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -890,7 +890,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCouponRequest"
+                            "$ref": "#/definitions/CreateCouponRequest"
                         }
                     }
                 ],
@@ -898,37 +898,37 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CouponResponse"
+                            "$ref": "#/definitions/CouponResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -960,7 +960,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponFilter"
+                            "$ref": "#/definitions/types.CouponFilter"
                         }
                     }
                 ],
@@ -974,13 +974,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1015,25 +1015,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CouponResponse"
+                            "$ref": "#/definitions/CouponResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1073,7 +1073,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCouponRequest"
+                            "$ref": "#/definitions/UpdateCouponRequest"
                         }
                     }
                 ],
@@ -1081,37 +1081,37 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CouponResponse"
+                            "$ref": "#/definitions/CouponResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1159,31 +1159,31 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1215,7 +1215,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCreditGrantRequest"
+                            "$ref": "#/definitions/CreateCreditGrantRequest"
                         }
                     }
                 ],
@@ -1223,19 +1223,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditGrantResponse"
+                            "$ref": "#/definitions/CreditGrantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1270,19 +1270,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditGrantResponse"
+                            "$ref": "#/definitions/CreditGrantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1319,7 +1319,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCreditGrantRequest"
+                            "$ref": "#/definitions/UpdateCreditGrantRequest"
                         }
                     }
                 ],
@@ -1327,19 +1327,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditGrantResponse"
+                            "$ref": "#/definitions/CreditGrantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1375,7 +1375,7 @@ const docTemplate = `{
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/dto.DeleteCreditGrantRequest"
+                            "$ref": "#/definitions/DeleteCreditGrantRequest"
                         }
                     }
                 ],
@@ -1383,19 +1383,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1430,7 +1430,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCreditNoteRequest"
+                            "$ref": "#/definitions/CreateCreditNoteRequest"
                         }
                     }
                 ],
@@ -1438,37 +1438,37 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1503,25 +1503,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error\" \"Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1562,37 +1562,37 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1633,37 +1633,37 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1707,7 +1707,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCustomerRequest"
+                            "$ref": "#/definitions/UpdateCustomerRequest"
                         }
                     }
                 ],
@@ -1715,19 +1715,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1757,7 +1757,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCustomerRequest"
+                            "$ref": "#/definitions/CreateCustomerRequest"
                         }
                     }
                 ],
@@ -1765,19 +1765,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -1813,25 +1813,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1863,7 +1863,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CustomerFilter"
+                            "$ref": "#/definitions/types.CustomerFilter"
                         }
                     }
                 ],
@@ -1877,13 +1877,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -1952,19 +1952,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerUsageSummaryResponse"
+                            "$ref": "#/definitions/CustomerUsageSummaryResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2030,26 +2030,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.WalletResponse"
+                                "$ref": "#/definitions/WalletResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2084,19 +2084,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -2136,13 +2136,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2177,19 +2177,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerEntitlementsResponse"
+                            "$ref": "#/definitions/CustomerEntitlementsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2230,19 +2230,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2280,19 +2280,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerMultiCurrencyInvoiceSummary"
+                            "$ref": "#/definitions/CustomerMultiCurrencyInvoiceSummary"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2332,20 +2332,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.WalletResponse"
+                                "$ref": "#/definitions/WalletResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2377,7 +2377,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateEntitlementRequest"
+                            "$ref": "#/definitions/CreateEntitlementRequest"
                         }
                     }
                 ],
@@ -2385,19 +2385,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.EntitlementResponse"
+                            "$ref": "#/definitions/EntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2429,7 +2429,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkEntitlementRequest"
+                            "$ref": "#/definitions/CreateBulkEntitlementRequest"
                         }
                     }
                 ],
@@ -2437,19 +2437,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkEntitlementResponse"
+                            "$ref": "#/definitions/CreateBulkEntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2481,7 +2481,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementFilter"
+                            "$ref": "#/definitions/types.EntitlementFilter"
                         }
                     }
                 ],
@@ -2495,13 +2495,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2536,19 +2536,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.EntitlementResponse"
+                            "$ref": "#/definitions/EntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2585,7 +2585,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateEntitlementRequest"
+                            "$ref": "#/definitions/UpdateEntitlementRequest"
                         }
                     }
                 ],
@@ -2593,19 +2593,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.EntitlementResponse"
+                            "$ref": "#/definitions/EntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2641,19 +2641,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2685,7 +2685,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.IngestEventRequest"
+                            "$ref": "#/definitions/IngestEventRequest"
                         }
                     }
                 ],
@@ -2702,13 +2702,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2740,7 +2740,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageAnalyticsRequest"
+                            "$ref": "#/definitions/GetUsageAnalyticsRequest"
                         }
                     }
                 ],
@@ -2748,19 +2748,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageAnalyticsResponse"
+                            "$ref": "#/definitions/GetUsageAnalyticsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2792,7 +2792,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.BulkIngestEventRequest"
+                            "$ref": "#/definitions/BulkIngestEventRequest"
                         }
                     }
                 ],
@@ -2809,13 +2809,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2841,13 +2841,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetHuggingFaceBillingDataResponse"
+                            "$ref": "#/definitions/GetHuggingFaceBillingDataResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2879,7 +2879,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetEventsRequest"
+                            "$ref": "#/definitions/GetEventsRequest"
                         }
                     }
                 ],
@@ -2887,19 +2887,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetEventsResponse"
+                            "$ref": "#/definitions/GetEventsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2931,7 +2931,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageRequest"
+                            "$ref": "#/definitions/GetUsageRequest"
                         }
                     }
                 ],
@@ -2939,19 +2939,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageResponse"
+                            "$ref": "#/definitions/GetUsageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2983,7 +2983,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageByMeterRequest"
+                            "$ref": "#/definitions/GetUsageByMeterRequest"
                         }
                     }
                 ],
@@ -2991,25 +2991,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageResponse"
+                            "$ref": "#/definitions/GetUsageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3044,19 +3044,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetEventByIDResponse"
+                            "$ref": "#/definitions/GetEventByIDResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3088,7 +3088,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateFeatureRequest"
+                            "$ref": "#/definitions/CreateFeatureRequest"
                         }
                     }
                 ],
@@ -3096,19 +3096,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.FeatureResponse"
+                            "$ref": "#/definitions/FeatureResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3140,7 +3140,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureFilter"
+                            "$ref": "#/definitions/types.FeatureFilter"
                         }
                     }
                 ],
@@ -3154,13 +3154,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3199,7 +3199,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateFeatureRequest"
+                            "$ref": "#/definitions/UpdateFeatureRequest"
                         }
                     }
                 ],
@@ -3207,25 +3207,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.FeatureResponse"
+                            "$ref": "#/definitions/FeatureResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3261,25 +3261,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3311,7 +3311,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateGroupRequest"
+                            "$ref": "#/definitions/CreateGroupRequest"
                         }
                     }
                 ],
@@ -3319,19 +3319,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.GroupResponse"
+                            "$ref": "#/definitions/GroupResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3363,7 +3363,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.GroupFilter"
+                            "$ref": "#/definitions/types.GroupFilter"
                         }
                     }
                 ],
@@ -3377,13 +3377,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3421,25 +3421,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GroupResponse"
+                            "$ref": "#/definitions/GroupResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3478,19 +3478,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3522,7 +3522,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.LinkIntegrationMappingRequest"
+                            "$ref": "#/definitions/LinkIntegrationMappingRequest"
                         }
                     }
                 ],
@@ -3530,19 +3530,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.LinkIntegrationMappingResponse"
+                            "$ref": "#/definitions/LinkIntegrationMappingResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3574,7 +3574,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateInvoiceRequest"
+                            "$ref": "#/definitions/CreateInvoiceRequest"
                         }
                     }
                 ],
@@ -3582,19 +3582,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3626,7 +3626,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetPreviewInvoiceRequest"
+                            "$ref": "#/definitions/GetPreviewInvoiceRequest"
                         }
                     }
                 ],
@@ -3634,19 +3634,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3678,7 +3678,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceFilter"
+                            "$ref": "#/definitions/types.InvoiceFilter"
                         }
                     }
                 ],
@@ -3692,13 +3692,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3752,19 +3752,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3801,7 +3801,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateInvoiceRequest"
+                            "$ref": "#/definitions/UpdateInvoiceRequest"
                         }
                     }
                 ],
@@ -3809,25 +3809,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3865,25 +3865,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3921,19 +3921,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -3973,7 +3973,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePaymentStatusRequest"
+                            "$ref": "#/definitions/UpdatePaymentStatusRequest"
                         }
                     }
                 ],
@@ -3981,25 +3981,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4037,25 +4037,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4105,19 +4105,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4158,19 +4158,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request or invoice already recalculated",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Invoice not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4214,25 +4214,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4270,19 +4270,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4420,19 +4420,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Paginated payments",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListPaymentsResponse"
+                            "$ref": "#/definitions/ListPaymentsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4462,7 +4462,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePaymentRequest"
+                            "$ref": "#/definitions/CreatePaymentRequest"
                         }
                     }
                 ],
@@ -4470,19 +4470,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created payment",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4520,25 +4520,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Payment details",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Payment not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4575,7 +4575,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePaymentRequest"
+                            "$ref": "#/definitions/UpdatePaymentRequest"
                         }
                     }
                 ],
@@ -4583,19 +4583,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Updated payment",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4631,25 +4631,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Payment deleted",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Payment not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4687,25 +4687,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Processed payment",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Payment not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4737,7 +4737,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePlanRequest"
+                            "$ref": "#/definitions/CreatePlanRequest"
                         }
                     }
                 ],
@@ -4745,19 +4745,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4789,7 +4789,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PlanFilter"
+                            "$ref": "#/definitions/types.PlanFilter"
                         }
                     }
                 ],
@@ -4803,13 +4803,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4844,25 +4844,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4899,7 +4899,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePlanRequest"
+                            "$ref": "#/definitions/UpdatePlanRequest"
                         }
                     }
                 ],
@@ -4907,25 +4907,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4961,25 +4961,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5017,7 +5017,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ClonePlanRequest"
+                            "$ref": "#/definitions/ClonePlanRequest"
                         }
                     }
                 ],
@@ -5025,31 +5025,31 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5090,19 +5090,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5143,19 +5143,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5199,25 +5199,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5249,7 +5249,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePriceRequest"
+                            "$ref": "#/definitions/CreatePriceRequest"
                         }
                     }
                 ],
@@ -5257,19 +5257,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5301,7 +5301,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkPriceRequest"
+                            "$ref": "#/definitions/CreateBulkPriceRequest"
                         }
                     }
                 ],
@@ -5309,19 +5309,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkPriceResponse"
+                            "$ref": "#/definitions/CreateBulkPriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5359,19 +5359,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5403,7 +5403,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceFilter"
+                            "$ref": "#/definitions/types.PriceFilter"
                         }
                     }
                 ],
@@ -5417,13 +5417,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5499,13 +5499,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5535,7 +5535,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePriceUnitRequest"
+                            "$ref": "#/definitions/CreatePriceUnitRequest"
                         }
                     }
                 ],
@@ -5543,19 +5543,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePriceUnitResponse"
+                            "$ref": "#/definitions/CreatePriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5593,25 +5593,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceUnitResponse"
+                            "$ref": "#/definitions/PriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5643,7 +5643,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitFilter"
+                            "$ref": "#/definitions/types.PriceUnitFilter"
                         }
                     }
                 ],
@@ -5657,13 +5657,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5701,19 +5701,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceUnitResponse"
+                            "$ref": "#/definitions/PriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5750,7 +5750,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePriceUnitRequest"
+                            "$ref": "#/definitions/UpdatePriceUnitRequest"
                         }
                     }
                 ],
@@ -5758,19 +5758,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceUnitResponse"
+                            "$ref": "#/definitions/PriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5806,19 +5806,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5856,19 +5856,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5905,7 +5905,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePriceRequest"
+                            "$ref": "#/definitions/UpdatePriceRequest"
                         }
                     }
                 ],
@@ -5913,19 +5913,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5962,7 +5962,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.DeletePriceRequest"
+                            "$ref": "#/definitions/DeletePriceRequest"
                         }
                     }
                 ],
@@ -5970,19 +5970,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6118,19 +6118,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListSecretsResponse"
+                            "$ref": "#/definitions/ListSecretsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6160,7 +6160,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAPIKeyRequest"
+                            "$ref": "#/definitions/CreateAPIKeyRequest"
                         }
                     }
                 ],
@@ -6168,19 +6168,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAPIKeyResponse"
+                            "$ref": "#/definitions/CreateAPIKeyResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6221,13 +6221,13 @@ const docTemplate = `{
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6259,7 +6259,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateSubscriptionRequest"
+                            "$ref": "#/definitions/CreateSubscriptionRequest"
                         }
                     }
                 ],
@@ -6267,19 +6267,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6311,7 +6311,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.AddAddonRequest"
+                            "$ref": "#/definitions/AddAddonRequest"
                         }
                     }
                 ],
@@ -6319,19 +6319,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonAssociationResponse"
+                            "$ref": "#/definitions/AddonAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6361,7 +6361,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.RemoveAddonRequest"
+                            "$ref": "#/definitions/RemoveAddonRequest"
                         }
                     }
                 ],
@@ -6369,19 +6369,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6420,7 +6420,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateSubscriptionLineItemRequest"
+                            "$ref": "#/definitions/UpdateSubscriptionLineItemRequest"
                         }
                     }
                 ],
@@ -6428,19 +6428,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                            "$ref": "#/definitions/SubscriptionLineItemResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6477,7 +6477,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.DeleteSubscriptionLineItemRequest"
+                            "$ref": "#/definitions/DeleteSubscriptionLineItemRequest"
                         }
                     }
                 ],
@@ -6485,19 +6485,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                            "$ref": "#/definitions/SubscriptionLineItemResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6529,7 +6529,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionFilter"
+                            "$ref": "#/definitions/types.SubscriptionFilter"
                         }
                     }
                 ],
@@ -6543,13 +6543,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6581,7 +6581,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageBySubscriptionRequest"
+                            "$ref": "#/definitions/GetUsageBySubscriptionRequest"
                         }
                     }
                 ],
@@ -6589,19 +6589,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageBySubscriptionResponse"
+                            "$ref": "#/definitions/GetUsageBySubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6636,19 +6636,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6685,7 +6685,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateSubscriptionRequest"
+                            "$ref": "#/definitions/UpdateSubscriptionRequest"
                         }
                     }
                 ],
@@ -6693,19 +6693,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6744,7 +6744,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ActivateDraftSubscriptionRequest"
+                            "$ref": "#/definitions/ActivateDraftSubscriptionRequest"
                         }
                     }
                 ],
@@ -6752,19 +6752,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6801,26 +6801,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.AddonAssociationResponse"
+                                "$ref": "#/definitions/AddonAssociationResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6859,7 +6859,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelSubscriptionRequest"
+                            "$ref": "#/definitions/CancelSubscriptionRequest"
                         }
                     }
                 ],
@@ -6867,19 +6867,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelSubscriptionResponse"
+                            "$ref": "#/definitions/CancelSubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6918,7 +6918,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangeRequest"
+                            "$ref": "#/definitions/SubscriptionChangeRequest"
                         }
                     }
                 ],
@@ -6926,25 +6926,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangeExecuteResponse"
+                            "$ref": "#/definitions/SubscriptionChangeExecuteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6983,7 +6983,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangeRequest"
+                            "$ref": "#/definitions/SubscriptionChangeRequest"
                         }
                     }
                 ],
@@ -6991,25 +6991,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangePreviewResponse"
+                            "$ref": "#/definitions/SubscriptionChangePreviewResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7057,25 +7057,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionEntitlementsResponse"
+                            "$ref": "#/definitions/SubscriptionEntitlementsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7116,19 +7116,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7167,7 +7167,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateSubscriptionLineItemRequest"
+                            "$ref": "#/definitions/CreateSubscriptionLineItemRequest"
                         }
                     }
                 ],
@@ -7175,25 +7175,25 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                            "$ref": "#/definitions/SubscriptionLineItemResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7232,7 +7232,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ExecuteSubscriptionInheritanceRequest"
+                            "$ref": "#/definitions/ExecuteSubscriptionInheritanceRequest"
                         }
                     }
                 ],
@@ -7240,25 +7240,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -7298,7 +7298,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PauseSubscriptionRequest"
+                            "$ref": "#/definitions/PauseSubscriptionRequest"
                         }
                     }
                 ],
@@ -7306,25 +7306,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionPauseResponse"
+                            "$ref": "#/definitions/SubscriptionPauseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7356,26 +7356,26 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.ListSubscriptionPausesResponse"
+                                "$ref": "#/definitions/ListSubscriptionPausesResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7414,7 +7414,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ResumeSubscriptionRequest"
+                            "$ref": "#/definitions/ResumeSubscriptionRequest"
                         }
                     }
                 ],
@@ -7422,25 +7422,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionPauseResponse"
+                            "$ref": "#/definitions/SubscriptionPauseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7481,19 +7481,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponseV2"
+                            "$ref": "#/definitions/SubscriptionResponseV2"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7638,19 +7638,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListTasksResponse"
+                            "$ref": "#/definitions/ListTasksResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7680,7 +7680,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateTaskRequest"
+                            "$ref": "#/definitions/CreateTaskRequest"
                         }
                     }
                 ],
@@ -7688,19 +7688,19 @@ const docTemplate = `{
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaskResponse"
+                            "$ref": "#/definitions/TaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7744,19 +7744,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7829,13 +7829,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7865,7 +7865,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateScheduledTaskRequest"
+                            "$ref": "#/definitions/CreateScheduledTaskRequest"
                         }
                     }
                 ],
@@ -7873,19 +7873,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                            "$ref": "#/definitions/ScheduledTaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7920,13 +7920,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7972,13 +7972,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8016,25 +8016,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                            "$ref": "#/definitions/ScheduledTaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8071,7 +8071,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateScheduledTaskRequest"
+                            "$ref": "#/definitions/UpdateScheduledTaskRequest"
                         }
                     }
                 ],
@@ -8079,25 +8079,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                            "$ref": "#/definitions/ScheduledTaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or task is archived",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Scheduled task not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to update Temporal schedule",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8136,19 +8136,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Task already archived",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Scheduled task not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to archive task",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8186,7 +8186,7 @@ const docTemplate = `{
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/dto.TriggerForceRunRequest"
+                            "$ref": "#/definitions/TriggerForceRunRequest"
                         }
                     }
                 ],
@@ -8194,25 +8194,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Returns workflow details and time range",
                         "schema": {
-                            "$ref": "#/definitions/dto.TriggerForceRunResponse"
+                            "$ref": "#/definitions/TriggerForceRunResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8250,25 +8250,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaskResponse"
+                            "$ref": "#/definitions/TaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8315,19 +8315,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8366,7 +8366,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateTaskStatusRequest"
+                            "$ref": "#/definitions/UpdateTaskStatusRequest"
                         }
                     }
                 ],
@@ -8374,25 +8374,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8453,13 +8453,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8489,7 +8489,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateTaxAssociationRequest"
+                            "$ref": "#/definitions/CreateTaxAssociationRequest"
                         }
                     }
                 ],
@@ -8497,19 +8497,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8547,19 +8547,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8596,7 +8596,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationUpdateRequest"
+                            "$ref": "#/definitions/TaxAssociationUpdateRequest"
                         }
                     }
                 ],
@@ -8604,19 +8604,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8652,19 +8652,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8782,20 +8782,20 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.TaxRateResponse"
+                                "$ref": "#/definitions/TaxRateResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8825,7 +8825,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateTaxRateRequest"
+                            "$ref": "#/definitions/CreateTaxRateRequest"
                         }
                     }
                 ],
@@ -8833,19 +8833,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxRateResponse"
+                            "$ref": "#/definitions/TaxRateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8883,19 +8883,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxRateResponse"
+                            "$ref": "#/definitions/TaxRateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8932,7 +8932,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateTaxRateRequest"
+                            "$ref": "#/definitions/UpdateTaxRateRequest"
                         }
                     }
                 ],
@@ -8940,19 +8940,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxRateResponse"
+                            "$ref": "#/definitions/TaxRateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8991,13 +8991,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9026,25 +9026,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Tenant billing usage",
                         "schema": {
-                            "$ref": "#/definitions/dto.TenantBillingUsage"
+                            "$ref": "#/definitions/TenantBillingUsage"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Tenant not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9076,7 +9076,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateTenantRequest"
+                            "$ref": "#/definitions/UpdateTenantRequest"
                         }
                     }
                 ],
@@ -9084,25 +9084,25 @@ const docTemplate = `{
                     "200": {
                         "description": "Updated tenant",
                         "schema": {
-                            "$ref": "#/definitions/dto.TenantResponse"
+                            "$ref": "#/definitions/TenantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Tenant not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9140,19 +9140,19 @@ const docTemplate = `{
                     "200": {
                         "description": "Tenant details",
                         "schema": {
-                            "$ref": "#/definitions/dto.TenantResponse"
+                            "$ref": "#/definitions/TenantResponse"
                         }
                     },
                     "404": {
                         "description": "Tenant not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9184,7 +9184,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateUserRequest"
+                            "$ref": "#/definitions/CreateUserRequest"
                         }
                     }
                 ],
@@ -9192,19 +9192,19 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateUserResponse"
+                            "$ref": "#/definitions/CreateUserResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9230,19 +9230,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.UserResponse"
+                            "$ref": "#/definitions/UserResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9274,7 +9274,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserFilter"
+                            "$ref": "#/definitions/types.UserFilter"
                         }
                     }
                 ],
@@ -9288,13 +9288,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9344,7 +9344,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetPendingSchedulesResponse"
+                            "$ref": "#/definitions/GetPendingSchedulesResponse"
                         }
                     }
                 }
@@ -9377,7 +9377,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionScheduleResponse"
+                            "$ref": "#/definitions/SubscriptionScheduleResponse"
                         }
                     }
                 }
@@ -9409,7 +9409,7 @@ const docTemplate = `{
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelScheduleRequest"
+                            "$ref": "#/definitions/CancelScheduleRequest"
                         }
                     }
                 ],
@@ -9417,7 +9417,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelScheduleResponse"
+                            "$ref": "#/definitions/CancelScheduleResponse"
                         }
                     }
                 }
@@ -9450,7 +9450,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetPendingSchedulesResponse"
+                            "$ref": "#/definitions/GetPendingSchedulesResponse"
                         }
                     }
                 }
@@ -9482,7 +9482,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateWalletRequest"
+                            "$ref": "#/definitions/CreateWalletRequest"
                         }
                     }
                 ],
@@ -9490,19 +9490,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9534,7 +9534,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletFilter"
+                            "$ref": "#/definitions/types.WalletFilter"
                         }
                     }
                 ],
@@ -9548,13 +9548,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9586,7 +9586,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletTransactionFilter"
+                            "$ref": "#/definitions/types.WalletTransactionFilter"
                         }
                     }
                 ],
@@ -9600,13 +9600,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9644,25 +9644,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9699,7 +9699,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateWalletRequest"
+                            "$ref": "#/definitions/UpdateWalletRequest"
                         }
                     }
                 ],
@@ -9707,25 +9707,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9769,25 +9769,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletBalanceResponse"
+                            "$ref": "#/definitions/WalletBalanceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9825,25 +9825,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9882,7 +9882,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.TopUpWalletRequest"
+                            "$ref": "#/definitions/TopUpWalletRequest"
                         }
                     }
                 ],
@@ -9890,25 +9890,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TopUpWalletResponse"
+                            "$ref": "#/definitions/TopUpWalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -10103,19 +10103,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -11113,7 +11113,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WorkflowExecutionFilter"
+                            "$ref": "#/definitions/types.WorkflowExecutionFilter"
                         }
                     }
                 ],
@@ -11127,13 +11127,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -11147,11 +11147,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AddonResponse"
+                        "$ref": "#/definitions/AddonResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11161,11 +11161,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponResponse"
+                        "$ref": "#/definitions/CouponResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11175,11 +11175,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantApplicationResponse"
+                        "$ref": "#/definitions/CreditGrantApplicationResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11189,11 +11189,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11204,11 +11204,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CustomerResponse"
+                        "$ref": "#/definitions/CustomerResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11218,11 +11218,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11232,11 +11232,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.FeatureResponse"
+                        "$ref": "#/definitions/FeatureResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11246,11 +11246,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.GroupResponse"
+                        "$ref": "#/definitions/GroupResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11260,11 +11260,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceResponse"
+                        "$ref": "#/definitions/InvoiceResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11274,11 +11274,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PlanResponse"
+                        "$ref": "#/definitions/PlanResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11288,11 +11288,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceUnitResponse"
+                        "$ref": "#/definitions/PriceUnitResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11302,11 +11302,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11316,11 +11316,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                        "$ref": "#/definitions/ScheduledTaskResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11330,11 +11330,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionResponse"
+                        "$ref": "#/definitions/SubscriptionResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11344,11 +11344,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxAssociationResponse"
+                        "$ref": "#/definitions/TaxAssociationResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11358,11 +11358,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UserResponse"
+                        "$ref": "#/definitions/UserResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11372,11 +11372,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.WalletTransactionResponse"
+                        "$ref": "#/definitions/WalletTransactionResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11386,11 +11386,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.WorkflowExecutionDTO"
+                        "$ref": "#/definitions/WorkflowExecutionDTO"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11412,7 +11412,7 @@ const docTemplate = `{
                     "description": "Filters contains custom filtering conditions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "lookupKey": {
@@ -11427,7 +11427,7 @@ const docTemplate = `{
                     "description": "QueryFilter contains pagination and basic query parameters",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.QueryFilter"
+                            "$ref": "#/definitions/types.QueryFilter"
                         }
                     ]
                 },
@@ -11435,14 +11435,14 @@ const docTemplate = `{
                     "description": "Sort specifies result ordering preferences",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "status": {
                     "description": "Status filters by costsheet status",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                            "$ref": "#/definitions/types.Status"
                         }
                     ]
                 },
@@ -11454,7 +11454,7 @@ const docTemplate = `{
                     "description": "TimeRangeFilter allows filtering by time periods",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TimeRangeFilter"
+                            "$ref": "#/definitions/types.TimeRangeFilter"
                         }
                     ]
                 }
@@ -11489,7 +11489,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "discount_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "discounted_amount": {
                     "type": "string"
@@ -11519,7 +11519,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -11539,7 +11539,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "coupon": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_coupon.Coupon"
+                    "$ref": "#/definitions/Coupon"
                 },
                 "coupon_id": {
                     "type": "string"
@@ -11570,7 +11570,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "Mandatory",
@@ -11629,7 +11629,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -11642,7 +11642,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ActivateDraftSubscriptionRequest": {
+        "ActivateDraftSubscriptionRequest": {
             "type": "object",
             "required": [
                 "start_date"
@@ -11654,7 +11654,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.AddAddonRequest": {
+        "AddAddonRequest": {
             "type": "object",
             "required": [
                 "addon_id",
@@ -11668,7 +11668,7 @@ const docTemplate = `{
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/dto.LineItemCommitmentConfig"
+                        "$ref": "#/definitions/LineItemCommitmentConfig"
                     }
                 },
                 "metadata": {
@@ -11683,7 +11683,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.AddAddonToSubscriptionRequest": {
+        "AddAddonToSubscriptionRequest": {
             "type": "object",
             "required": [
                 "addon_id"
@@ -11696,7 +11696,7 @@ const docTemplate = `{
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/dto.LineItemCommitmentConfig"
+                        "$ref": "#/definitions/LineItemCommitmentConfig"
                     }
                 },
                 "metadata": {
@@ -11708,17 +11708,17 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.AddonAssociationResponse": {
+        "AddonAssociationResponse": {
             "type": "object",
             "properties": {
                 "addon": {
-                    "$ref": "#/definitions/dto.AddonResponse"
+                    "$ref": "#/definitions/AddonResponse"
                 },
                 "addon_id": {
                     "type": "string"
                 },
                 "addon_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonStatus"
+                    "$ref": "#/definitions/types.AddonStatus"
                 },
                 "cancellation_reason": {
                     "type": "string"
@@ -11739,7 +11739,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonAssociationEntityType"
+                    "$ref": "#/definitions/types.AddonAssociationEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -11755,10 +11755,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription": {
-                    "$ref": "#/definitions/dto.SubscriptionResponse"
+                    "$ref": "#/definitions/SubscriptionResponse"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -11771,7 +11771,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.AddonResponse": {
+        "AddonResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -11786,7 +11786,7 @@ const docTemplate = `{
                 "entitlements": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "environment_id": {
@@ -11809,17 +11809,17 @@ const docTemplate = `{
                     "description": "Optional expanded fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -11829,7 +11829,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.Address": {
+        "Address": {
             "type": "object",
             "properties": {
                 "address_city": {
@@ -11857,7 +11857,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.AggregatedEntitlement": {
+        "AggregatedEntitlement": {
             "type": "object",
             "properties": {
                 "is_enabled": {
@@ -11877,38 +11877,38 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.AggregatedFeature": {
+        "AggregatedFeature": {
             "type": "object",
             "properties": {
                 "entitlement": {
-                    "$ref": "#/definitions/dto.AggregatedEntitlement"
+                    "$ref": "#/definitions/AggregatedEntitlement"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "sources": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementSource"
+                        "$ref": "#/definitions/EntitlementSource"
                     }
                 }
             }
         },
-        "dto.AlertLogResponse": {
+        "AlertLogResponse": {
             "type": "object",
             "properties": {
                 "alert_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertInfo"
+                    "$ref": "#/definitions/types.AlertInfo"
                 },
                 "alert_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "alert_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertType"
+                    "$ref": "#/definitions/types.AlertType"
                 },
                 "created_at": {
                     "type": "string"
@@ -11920,7 +11920,7 @@ const docTemplate = `{
                     "description": "Expanded fields",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     ]
                 },
@@ -11931,13 +11931,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertEntityType"
+                    "$ref": "#/definitions/types.AlertEntityType"
                 },
                 "environment_id": {
                     "type": "string"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "id": {
                     "type": "string"
@@ -11961,11 +11961,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         },
-        "dto.BillingCycleInfo": {
+        "BillingCycleInfo": {
             "type": "object",
             "properties": {
                 "billing_anchor": {
@@ -11976,7 +11976,7 @@ const docTemplate = `{
                     "description": "billing_cadence is the billing cadence",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                            "$ref": "#/definitions/types.BillingCadence"
                         }
                     ]
                 },
@@ -11984,7 +11984,7 @@ const docTemplate = `{
                     "description": "billing_period is the billing period",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                            "$ref": "#/definitions/types.BillingPeriod"
                         }
                     ]
                 },
@@ -12003,7 +12003,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.BillingPeriodInfo": {
+        "BillingPeriodInfo": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -12018,7 +12018,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.BulkIngestEventRequest": {
+        "BulkIngestEventRequest": {
             "type": "object",
             "required": [
                 "events"
@@ -12029,12 +12029,12 @@ const docTemplate = `{
                     "maxItems": 1000,
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.IngestEventRequest"
+                        "$ref": "#/definitions/IngestEventRequest"
                     }
                 }
             }
         },
-        "dto.CancelScheduleRequest": {
+        "CancelScheduleRequest": {
             "description": "Request to cancel a subscription schedule (supports two modes)",
             "type": "object",
             "properties": {
@@ -12046,7 +12046,7 @@ const docTemplate = `{
                     "description": "schedule_type is the type of schedule to cancel (required if schedule_id is not provided)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType"
+                            "$ref": "#/definitions/types.SubscriptionScheduleChangeType"
                         }
                     ]
                 },
@@ -12056,7 +12056,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CancelScheduleResponse": {
+        "CancelScheduleResponse": {
             "description": "Confirmation of schedule cancellation",
             "type": "object",
             "properties": {
@@ -12068,13 +12068,13 @@ const docTemplate = `{
                     "description": "status is the new status (should be \"cancelled\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleStatus"
+                            "$ref": "#/definitions/types.ScheduleStatus"
                         }
                     ]
                 }
             }
         },
-        "dto.CancelSubscriptionRequest": {
+        "CancelSubscriptionRequest": {
             "type": "object",
             "required": [
                 "cancellation_type"
@@ -12087,7 +12087,7 @@ const docTemplate = `{
                     "description": "CancelImmediatelyInvoicePolicy controls whether to generate a final invoice on immediate cancellation. Defaults to skip.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CancelImmediatelyInvoicePolicy"
+                            "$ref": "#/definitions/types.CancelImmediatelyInvoicePolicy"
                         }
                     ]
                 },
@@ -12095,7 +12095,7 @@ const docTemplate = `{
                     "description": "CancellationType determines when the cancellation takes effect",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CancellationType"
+                            "$ref": "#/definitions/types.CancellationType"
                         }
                     ]
                 },
@@ -12103,7 +12103,7 @@ const docTemplate = `{
                     "description": "ProrationBehavior controls how proration is handled.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                            "$ref": "#/definitions/types.ProrationBehavior"
                         }
                     ]
                 },
@@ -12113,11 +12113,11 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CancelSubscriptionResponse": {
+        "CancelSubscriptionResponse": {
             "type": "object",
             "properties": {
                 "cancellation_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CancellationType"
+                    "$ref": "#/definitions/types.CancellationType"
                 },
                 "effective_date": {
                     "type": "string"
@@ -12132,14 +12132,14 @@ const docTemplate = `{
                 "proration_details": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.ProrationDetail"
+                        "$ref": "#/definitions/ProrationDetail"
                     }
                 },
                 "proration_invoice": {
                     "description": "Proration details",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     ]
                 },
@@ -12147,7 +12147,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "subscription_id": {
                     "description": "Basic cancellation info",
@@ -12158,7 +12158,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ClonePlanRequest": {
+        "ClonePlanRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -12187,14 +12187,14 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CostAnalyticItem": {
+        "CostAnalyticItem": {
             "type": "object",
             "properties": {
                 "cost_by_period": {
                     "description": "Breakdown",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CostPoint"
+                        "$ref": "#/definitions/CostPoint"
                     }
                 },
                 "costsheet_id": {
@@ -12251,7 +12251,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CostPoint": {
+        "CostPoint": {
             "type": "object",
             "properties": {
                 "cost": {
@@ -12268,7 +12268,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CostsheetResponse": {
+        "CostsheetResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -12302,11 +12302,11 @@ const docTemplate = `{
                     "description": "Associated prices",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -12319,7 +12319,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CouponApplicationResponse": {
+        "CouponApplicationResponse": {
             "type": "object",
             "properties": {
                 "applied_at": {
@@ -12348,7 +12348,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "discount_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "discounted_amount": {
                     "type": "string"
@@ -12378,7 +12378,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -12394,11 +12394,11 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CouponAssociationResponse": {
+        "CouponAssociationResponse": {
             "type": "object",
             "properties": {
                 "coupon": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_coupon.Coupon"
+                    "$ref": "#/definitions/Coupon"
                 },
                 "coupon_id": {
                     "type": "string"
@@ -12429,7 +12429,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "Mandatory",
@@ -12454,14 +12454,14 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CouponResponse": {
+        "CouponResponse": {
             "type": "object",
             "properties": {
                 "amount_off": {
                     "type": "string"
                 },
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence"
+                    "$ref": "#/definitions/types.CouponCadence"
                 },
                 "created_at": {
                     "type": "string"
@@ -12507,7 +12507,7 @@ const docTemplate = `{
                     "additionalProperties": true
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -12516,7 +12516,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -12526,7 +12526,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateAPIKeyRequest": {
+        "CreateAPIKeyRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -12543,22 +12543,22 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SecretType"
+                    "$ref": "#/definitions/types.SecretType"
                 }
             }
         },
-        "dto.CreateAPIKeyResponse": {
+        "CreateAPIKeyResponse": {
             "type": "object",
             "properties": {
                 "api_key": {
                     "type": "string"
                 },
                 "secret": {
-                    "$ref": "#/definitions/dto.SecretResponse"
+                    "$ref": "#/definitions/SecretResponse"
                 }
             }
         },
-        "dto.CreateAddonRequest": {
+        "CreateAddonRequest": {
             "type": "object",
             "required": [
                 "lookup_key",
@@ -12580,11 +12580,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 }
             }
         },
-        "dto.CreateAddonResponse": {
+        "CreateAddonResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -12599,7 +12599,7 @@ const docTemplate = `{
                 "entitlements": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "environment_id": {
@@ -12622,17 +12622,17 @@ const docTemplate = `{
                     "description": "Optional expanded fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -12642,7 +12642,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateBulkEntitlementRequest": {
+        "CreateBulkEntitlementRequest": {
             "type": "object",
             "required": [
                 "items"
@@ -12653,23 +12653,23 @@ const docTemplate = `{
                     "maxItems": 100,
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.CreateEntitlementRequest"
+                        "$ref": "#/definitions/CreateEntitlementRequest"
                     }
                 }
             }
         },
-        "dto.CreateBulkEntitlementResponse": {
+        "CreateBulkEntitlementResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 }
             }
         },
-        "dto.CreateBulkPriceRequest": {
+        "CreateBulkPriceRequest": {
             "type": "object",
             "required": [
                 "items"
@@ -12680,23 +12680,23 @@ const docTemplate = `{
                     "maxItems": 100,
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceRequest"
+                        "$ref": "#/definitions/CreatePriceRequest"
                     }
                 }
             }
         },
-        "dto.CreateBulkPriceResponse": {
+        "CreateBulkPriceResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 }
             }
         },
-        "dto.CreateCostsheetRequest": {
+        "CreateCostsheetRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -12723,15 +12723,15 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateCostsheetResponse": {
+        "CreateCostsheetResponse": {
             "type": "object",
             "properties": {
                 "costsheet": {
-                    "$ref": "#/definitions/dto.CostsheetResponse"
+                    "$ref": "#/definitions/CostsheetResponse"
                 }
             }
         },
-        "dto.CreateCouponRequest": {
+        "CreateCouponRequest": {
             "type": "object",
             "required": [
                 "cadence",
@@ -12750,7 +12750,7 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence"
+                            "$ref": "#/definitions/types.CouponCadence"
                         }
                     ]
                 },
@@ -12792,13 +12792,13 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                            "$ref": "#/definitions/types.CouponType"
                         }
                     ]
                 }
             }
         },
-        "dto.CreateCreditGrantRequest": {
+        "CreateCreditGrantRequest": {
             "type": "object",
             "required": [
                 "cadence",
@@ -12808,7 +12808,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantCadence"
+                    "$ref": "#/definitions/types.CreditGrantCadence"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -12824,10 +12824,10 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "expiration_duration_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit"
+                    "$ref": "#/definitions/types.CreditGrantExpiryDurationUnit"
                 },
                 "expiration_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType"
+                    "$ref": "#/definitions/types.CreditGrantExpiryType"
                 },
                 "metadata": {
                     "$ref": "#/definitions/types.Metadata"
@@ -12836,7 +12836,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantPeriod"
+                    "$ref": "#/definitions/types.CreditGrantPeriod"
                 },
                 "period_count": {
                     "type": "integer"
@@ -12848,7 +12848,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "scope": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantScope"
+                    "$ref": "#/definitions/types.CreditGrantScope"
                 },
                 "start_date": {
                     "type": "string"
@@ -12862,7 +12862,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateCreditNoteLineItemRequest": {
+        "CreateCreditNoteLineItemRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -12891,7 +12891,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateCreditNoteRequest": {
+        "CreateCreditNoteRequest": {
             "type": "object",
             "required": [
                 "invoice_id",
@@ -12914,7 +12914,7 @@ const docTemplate = `{
                     "description": "line_items contains the individual line items that make up this credit note (minimum 1 required)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateCreditNoteLineItemRequest"
+                        "$ref": "#/definitions/CreateCreditNoteLineItemRequest"
                     }
                 },
                 "memo": {
@@ -12938,13 +12938,13 @@ const docTemplate = `{
                     "description": "reason specifies the reason for creating this credit note (duplicate, fraudulent, order_change, product_unsatisfactory)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteReason"
+                            "$ref": "#/definitions/types.CreditNoteReason"
                         }
                     ]
                 }
             }
         },
-        "dto.CreateCustomerRequest": {
+        "CreateCustomerRequest": {
             "description": "Request object for creating a new customer in the system",
             "type": "object",
             "required": [
@@ -12992,7 +12992,7 @@ const docTemplate = `{
                     "description": "integration_entity_mapping contains provider integration mappings for this customer",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateEntityIntegrationMappingRequest"
+                        "$ref": "#/definitions/CreateEntityIntegrationMappingRequest"
                     }
                 },
                 "metadata": {
@@ -13014,12 +13014,12 @@ const docTemplate = `{
                     "description": "tax_rate_overrides contains tax rate configurations to be linked to this customer",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateOverride"
+                        "$ref": "#/definitions/TaxRateOverride"
                     }
                 }
             }
         },
-        "dto.CreateEntitlementRequest": {
+        "CreateEntitlementRequest": {
             "type": "object",
             "required": [
                 "feature_id",
@@ -13033,13 +13033,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType"
+                    "$ref": "#/definitions/types.EntitlementEntityType"
                 },
                 "feature_id": {
                     "type": "string"
                 },
                 "feature_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -13063,11 +13063,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.CreateEntityIntegrationMappingRequest": {
+        "CreateEntityIntegrationMappingRequest": {
             "type": "object",
             "required": [
                 "entity_id",
@@ -13081,7 +13081,7 @@ const docTemplate = `{
                     "maxLength": 255
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType"
+                    "$ref": "#/definitions/types.IntegrationEntityType"
                 },
                 "metadata": {
                     "type": "object",
@@ -13097,7 +13097,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateFeatureRequest": {
+        "CreateFeatureRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -13105,7 +13105,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "description": {
                     "type": "string"
@@ -13121,7 +13121,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "meter": {
-                    "$ref": "#/definitions/dto.CreateMeterRequest"
+                    "$ref": "#/definitions/CreateMeterRequest"
                 },
                 "meter_id": {
                     "type": "string"
@@ -13130,10 +13130,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -13143,7 +13143,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateGroupRequest": {
+        "CreateGroupRequest": {
             "type": "object",
             "required": [
                 "entity_type",
@@ -13162,7 +13162,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateInvoiceLineItemRequest": {
+        "CreateInvoiceLineItemRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -13177,7 +13177,7 @@ const docTemplate = `{
                     "description": "commitment_info contains details about any commitment applied to this line item",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                            "$ref": "#/definitions/types.CommitmentInfo"
                         }
                     ]
                 },
@@ -13259,7 +13259,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateInvoiceRequest": {
+        "CreateInvoiceRequest": {
             "type": "object",
             "required": [
                 "amount_due",
@@ -13285,7 +13285,7 @@ const docTemplate = `{
                     "description": "billing_reason indicates why this invoice was created (subscription_cycle, manual, etc.)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceBillingReason"
+                            "$ref": "#/definitions/types.InvoiceBillingReason"
                         }
                     ]
                 },
@@ -13320,7 +13320,7 @@ const docTemplate = `{
                     "description": "Invoice Coupons",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceCoupon"
+                        "$ref": "#/definitions/InvoiceCoupon"
                     }
                 },
                 "invoice_number": {
@@ -13335,7 +13335,7 @@ const docTemplate = `{
                     "description": "invoice_status represents the current status of the invoice (draft, finalized, etc.)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus"
+                            "$ref": "#/definitions/types.InvoiceStatus"
                         }
                     ]
                 },
@@ -13343,7 +13343,7 @@ const docTemplate = `{
                     "description": "invoice_type indicates the type of invoice (subscription, one_time, etc.)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType"
+                            "$ref": "#/definitions/types.InvoiceType"
                         }
                     ]
                 },
@@ -13351,14 +13351,14 @@ const docTemplate = `{
                     "description": "Invoice Line Item Coupons",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceLineItemCoupon"
+                        "$ref": "#/definitions/InvoiceLineItemCoupon"
                     }
                 },
                 "line_items": {
                     "description": "line_items contains the individual items that make up this invoice",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateInvoiceLineItemRequest"
+                        "$ref": "#/definitions/CreateInvoiceLineItemRequest"
                     }
                 },
                 "metadata": {
@@ -13373,7 +13373,7 @@ const docTemplate = `{
                     "description": "payment_status represents the payment status of the invoice (unpaid, paid, etc.)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                            "$ref": "#/definitions/types.PaymentStatus"
                         }
                     ]
                 },
@@ -13389,8 +13389,12 @@ const docTemplate = `{
                     "description": "prepared_tax_rates contains the tax rates pre-resolved by the caller (e.g., billing service)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateResponse"
+                        "$ref": "#/definitions/TaxRateResponse"
                     }
+                },
+                "subscription_customer_id": {
+                    "description": "subscription_customer_id is the subscription owner's customer ID when it differs from customer_id (invoicing customer)",
+                    "type": "string"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the optional unique identifier of the subscription associated with this invoice",
@@ -13404,7 +13408,7 @@ const docTemplate = `{
                     "description": "tax_rate_overrides is the tax rate overrides to be applied to the invoice",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateOverride"
+                        "$ref": "#/definitions/TaxRateOverride"
                     }
                 },
                 "tax_rates": {
@@ -13424,7 +13428,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateMeterRequest": {
+        "CreateMeterRequest": {
             "type": "object",
             "required": [
                 "aggregation",
@@ -13451,11 +13455,11 @@ const docTemplate = `{
                     "example": "API Usage Meter"
                 },
                 "reset_usage": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage"
+                    "$ref": "#/definitions/types.ResetUsage"
                 }
             }
         },
-        "dto.CreatePaymentRequest": {
+        "CreatePaymentRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -13478,7 +13482,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "destination_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentDestinationType"
+                    "$ref": "#/definitions/types.PaymentDestinationType"
                 },
                 "idempotency_key": {
                     "type": "string"
@@ -13487,13 +13491,13 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "payment_gateway": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentGatewayType"
+                    "$ref": "#/definitions/types.PaymentGatewayType"
                 },
                 "payment_method_id": {
                     "type": "string"
                 },
                 "payment_method_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentMethodType"
+                    "$ref": "#/definitions/types.PaymentMethodType"
                 },
                 "process_payment": {
                     "type": "boolean",
@@ -13508,7 +13512,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreatePlanRequest": {
+        "CreatePlanRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -13531,7 +13535,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreatePriceRequest": {
+        "CreatePriceRequest": {
             "type": "object",
             "required": [
                 "billing_cadence",
@@ -13549,13 +13553,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "type": "integer",
@@ -13577,7 +13581,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
+                    "$ref": "#/definitions/types.PriceEntityType"
                 },
                 "filter_values": {
                     "type": "object",
@@ -13593,7 +13597,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "type": "string"
@@ -13612,21 +13616,21 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "price_unit_config": {
-                    "$ref": "#/definitions/dto.PriceUnitConfig"
+                    "$ref": "#/definitions/PriceUnitConfig"
                 },
                 "price_unit_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
+                    "$ref": "#/definitions/types.PriceUnitType"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -13636,11 +13640,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 }
             }
         },
-        "dto.CreatePriceTier": {
+        "CreatePriceTier": {
             "type": "object",
             "required": [
                 "unit_amount"
@@ -13660,7 +13664,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreatePriceUnitRequest": {
+        "CreatePriceUnitRequest": {
             "type": "object",
             "required": [
                 "base_currency",
@@ -13692,7 +13696,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreatePriceUnitResponse": {
+        "CreatePriceUnitResponse": {
             "type": "object",
             "properties": {
                 "base_currency": {
@@ -13723,7 +13727,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "symbol": {
                     "type": "string"
@@ -13739,7 +13743,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateScheduledTaskRequest": {
+        "CreateScheduledTaskRequest": {
             "type": "object",
             "required": [
                 "connection_id",
@@ -13755,7 +13759,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType"
+                    "$ref": "#/definitions/types.ScheduledTaskEntityType"
                 },
                 "interval": {
                     "description": "Note: \"custom\" is excluded from API (internal testing only)",
@@ -13765,16 +13769,16 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval"
+                            "$ref": "#/definitions/types.ScheduledTaskInterval"
                         }
                     ]
                 },
                 "job_config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3JobConfig"
+                    "$ref": "#/definitions/types.S3JobConfig"
                 }
             }
         },
-        "dto.CreateSubscriptionLineItemRequest": {
+        "CreateSubscriptionLineItemRequest": {
             "type": "object",
             "properties": {
                 "commitment_amount": {
@@ -13782,7 +13786,7 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "number"
@@ -13794,7 +13798,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -13815,7 +13819,7 @@ const docTemplate = `{
                     "description": "Price defines a new price inline; server creates a subscription-scoped price and adds the line item. Exactly one of price_id or price must be set. Entity/currency are set from the subscription.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.SubscriptionPriceCreateRequest"
+                            "$ref": "#/definitions/SubscriptionPriceCreateRequest"
                         }
                     ]
                 },
@@ -13834,7 +13838,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateSubscriptionRequest": {
+        "CreateSubscriptionRequest": {
             "type": "object",
             "required": [
                 "billing_cadence",
@@ -13847,22 +13851,22 @@ const docTemplate = `{
                     "description": "Addons represents addons to be added to the subscription during creation",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AddAddonToSubscriptionRequest"
+                        "$ref": "#/definitions/AddAddonToSubscriptionRequest"
                     }
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
+                            "$ref": "#/definitions/types.BillingCycle"
                         }
                     ]
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "type": "integer",
@@ -13872,7 +13876,7 @@ const docTemplate = `{
                     "description": "collection_method determines how invoices are collected\n\"default_incomplete\" - subscription waits for payment confirmation before activation\n\"send_invoice\" - subscription activates immediately, invoice is sent for payment",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CollectionMethod"
+                            "$ref": "#/definitions/types.CollectionMethod"
                         }
                     ]
                 },
@@ -13884,7 +13888,7 @@ const docTemplate = `{
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                            "$ref": "#/definitions/types.BillingPeriod"
                         }
                     ]
                 },
@@ -13898,7 +13902,7 @@ const docTemplate = `{
                     "description": "Credit grants to be applied when subscription is created",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateCreditGrantRequest"
+                        "$ref": "#/definitions/CreateCreditGrantRequest"
                     }
                 },
                 "currency": {
@@ -13930,7 +13934,7 @@ const docTemplate = `{
                     "description": "Inheritance groups all customer-hierarchy fields.\nWhen provided with at least one child ID, the subscription becomes a PARENT type.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.SubscriptionInheritanceConfig"
+                            "$ref": "#/definitions/SubscriptionInheritanceConfig"
                         }
                     ]
                 },
@@ -13938,7 +13942,7 @@ const docTemplate = `{
                     "description": "LineItemCommitments allows setting commitment configuration per line item (keyed by price_id)",
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/dto.LineItemCommitmentConfig"
+                        "$ref": "#/definitions/LineItemCommitmentConfig"
                     }
                 },
                 "line_item_coupons": {
@@ -13954,7 +13958,7 @@ const docTemplate = `{
                     "description": "LineItems are extra line items to add at creation (each with price_id or price), in addition to plan prices",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateSubscriptionLineItemRequest"
+                        "$ref": "#/definitions/CreateSubscriptionLineItemRequest"
                     }
                 },
                 "lookup_key": {
@@ -13974,21 +13978,21 @@ const docTemplate = `{
                     "description": "OverrideEntitlements allows customizing specific entitlements for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.OverrideEntitlementRequest"
+                        "$ref": "#/definitions/OverrideEntitlementRequest"
                     }
                 },
                 "override_line_items": {
                     "description": "OverrideLineItems allows customizing specific prices for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.OverrideLineItemRequest"
+                        "$ref": "#/definitions/OverrideLineItemRequest"
                     }
                 },
                 "payment_behavior": {
                     "description": "Payment behavior configuration",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentBehavior"
+                            "$ref": "#/definitions/types.PaymentBehavior"
                         }
                     ]
                 },
@@ -13996,7 +14000,7 @@ const docTemplate = `{
                     "description": "PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms"
+                            "$ref": "#/definitions/types.PaymentTerms"
                         }
                     ]
                 },
@@ -14004,7 +14008,7 @@ const docTemplate = `{
                     "description": "Phases represents subscription phases to be created with the subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPhaseCreateRequest"
+                        "$ref": "#/definitions/SubscriptionPhaseCreateRequest"
                     }
                 },
                 "plan_id": {
@@ -14014,7 +14018,7 @@ const docTemplate = `{
                     "description": "ProrationBehavior controls how proration is handled.\nIf not set, the default value is none. Possible values are create_prorations and none.\ncreate_prorations means the proration will be calculated and applied.\nnone means the proration will not be calculated.\nThis is IGNORED when the billing cycle is anniversary.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                            "$ref": "#/definitions/types.ProrationBehavior"
                         }
                     ]
                 },
@@ -14025,7 +14029,7 @@ const docTemplate = `{
                     "description": "SubscriptionStatus determines the initial status of the subscription\nIf set to \"draft\", the subscription will be created as a draft (skips invoice creation and payment processing)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                            "$ref": "#/definitions/types.SubscriptionStatus"
                         }
                     ]
                 },
@@ -14033,7 +14037,7 @@ const docTemplate = `{
                     "description": "tax_rate_overrides is the tax rate overrides\tto be applied to the subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateOverride"
+                        "$ref": "#/definitions/TaxRateOverride"
                     }
                 },
                 "trial_end": {
@@ -14044,7 +14048,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateTaskRequest": {
+        "CreateTaskRequest": {
             "type": "object",
             "required": [
                 "entity_type",
@@ -14054,13 +14058,13 @@ const docTemplate = `{
             ],
             "properties": {
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntityType"
+                    "$ref": "#/definitions/types.EntityType"
                 },
                 "file_name": {
                     "type": "string"
                 },
                 "file_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FileType"
+                    "$ref": "#/definitions/types.FileType"
                 },
                 "file_url": {
                     "type": "string"
@@ -14070,11 +14074,11 @@ const docTemplate = `{
                     "additionalProperties": true
                 },
                 "task_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskType"
+                    "$ref": "#/definitions/types.TaskType"
                 }
             }
         },
-        "dto.CreateTaxAssociationRequest": {
+        "CreateTaxAssociationRequest": {
             "type": "object",
             "required": [
                 "tax_rate_code"
@@ -14090,7 +14094,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType"
+                    "$ref": "#/definitions/types.TaxRateEntityType"
                 },
                 "external_customer_id": {
                     "type": "string"
@@ -14109,7 +14113,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreateTaxRateRequest": {
+        "CreateTaxRateRequest": {
             "type": "object",
             "required": [
                 "code",
@@ -14147,7 +14151,7 @@ const docTemplate = `{
                     "description": "scope defines where this tax rate applies",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateScope"
+                            "$ref": "#/definitions/types.TaxRateScope"
                         }
                     ]
                 },
@@ -14155,13 +14159,13 @@ const docTemplate = `{
                     "description": "tax_rate_type determines how the tax is calculated (\"percentage\" or \"fixed\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateType"
+                            "$ref": "#/definitions/types.TaxRateType"
                         }
                     ]
                 }
             }
         },
-        "dto.CreateUserRequest": {
+        "CreateUserRequest": {
             "type": "object",
             "required": [
                 "type"
@@ -14182,13 +14186,13 @@ const docTemplate = `{
                     "description": "\"user\" or \"service_account\"",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                            "$ref": "#/definitions/types.UserType"
                         }
                     ]
                 }
             }
         },
-        "dto.CreateUserResponse": {
+        "CreateUserResponse": {
             "type": "object",
             "properties": {
                 "email": {
@@ -14208,14 +14212,14 @@ const docTemplate = `{
                     }
                 },
                 "tenant": {
-                    "$ref": "#/definitions/dto.TenantResponse"
+                    "$ref": "#/definitions/TenantResponse"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                    "$ref": "#/definitions/types.UserType"
                 }
             }
         },
-        "dto.CreateWalletRequest": {
+        "CreateWalletRequest": {
             "type": "object",
             "required": [
                 "currency"
@@ -14225,7 +14229,7 @@ const docTemplate = `{
                     "description": "alert_settings is the alert settings for the wallet (optional)\nIf not provided, tenant level alert settings will be used",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                            "$ref": "#/definitions/types.AlertSettings"
                         }
                     ]
                 },
@@ -14233,7 +14237,7 @@ const docTemplate = `{
                     "description": "auto top-up object",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                            "$ref": "#/definitions/types.AutoTopup"
                         }
                     ]
                 },
@@ -14280,18 +14284,18 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "wallet_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletType"
+                    "$ref": "#/definitions/types.WalletType"
                 }
             }
         },
-        "dto.CreditGrantApplicationResponse": {
+        "CreditGrantApplicationResponse": {
             "type": "object",
             "properties": {
                 "application_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantApplicationReason"
+                    "$ref": "#/definitions/types.CreditGrantApplicationReason"
                 },
                 "application_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ApplicationStatus"
+                    "$ref": "#/definitions/types.ApplicationStatus"
                 },
                 "applied_at": {
                     "type": "string"
@@ -14336,13 +14340,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
                 },
                 "subscription_status_at_application": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -14355,11 +14359,11 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreditGrantResponse": {
+        "CreditGrantResponse": {
             "type": "object",
             "properties": {
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantCadence"
+                    "$ref": "#/definitions/types.CreditGrantCadence"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -14387,10 +14391,10 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "expiration_duration_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit"
+                    "$ref": "#/definitions/types.CreditGrantExpiryDurationUnit"
                 },
                 "expiration_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType"
+                    "$ref": "#/definitions/types.CreditGrantExpiryType"
                 },
                 "id": {
                     "type": "string"
@@ -14402,7 +14406,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantPeriod"
+                    "$ref": "#/definitions/types.CreditGrantPeriod"
                 },
                 "period_count": {
                     "type": "integer"
@@ -14414,13 +14418,13 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "scope": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantScope"
+                    "$ref": "#/definitions/types.CreditGrantScope"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -14440,7 +14444,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CreditNoteResponse": {
+        "CreditNoteResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -14457,7 +14461,7 @@ const docTemplate = `{
                     "description": "credit_note_status represents the current status of the credit note (e.g., draft, finalized, voided)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteStatus"
+                            "$ref": "#/definitions/types.CreditNoteStatus"
                         }
                     ]
                 },
@@ -14465,7 +14469,7 @@ const docTemplate = `{
                     "description": "credit_note_type indicates the type of credit note (refund, adjustment)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteType"
+                            "$ref": "#/definitions/types.CreditNoteType"
                         }
                     ]
                 },
@@ -14477,7 +14481,7 @@ const docTemplate = `{
                     "description": "customer contains the customer information associated with this credit note",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_customer.Customer"
+                            "$ref": "#/definitions/Customer"
                         }
                     ]
                 },
@@ -14505,7 +14509,7 @@ const docTemplate = `{
                     "description": "invoice contains the associated invoice information if requested",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     ]
                 },
@@ -14536,7 +14540,7 @@ const docTemplate = `{
                     "description": "reason specifies the reason for creating this credit note (duplicate, fraudulent, order_change, product_unsatisfactory)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteReason"
+                            "$ref": "#/definitions/types.CreditNoteReason"
                         }
                     ]
                 },
@@ -14544,18 +14548,18 @@ const docTemplate = `{
                     "description": "refund_status represents the status of any refund associated with this credit note",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                            "$ref": "#/definitions/types.PaymentStatus"
                         }
                     ]
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription": {
                     "description": "subscription contains the associated subscription information if applicable",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     ]
                 },
@@ -14582,7 +14586,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CustomAnalyticItem": {
+        "CustomAnalyticItem": {
             "type": "object",
             "properties": {
                 "feature_name": {
@@ -14605,7 +14609,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CustomerEntitlementsResponse": {
+        "CustomerEntitlementsResponse": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -14614,12 +14618,12 @@ const docTemplate = `{
                 "features": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AggregatedFeature"
+                        "$ref": "#/definitions/AggregatedFeature"
                     }
                 }
             }
         },
-        "dto.CustomerInvoiceSummary": {
+        "CustomerInvoiceSummary": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -14664,21 +14668,21 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CustomerLookupResult": {
+        "CustomerLookupResult": {
             "type": "object",
             "properties": {
                 "customer": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_customer.Customer"
+                    "$ref": "#/definitions/Customer"
                 },
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.CustomerMultiCurrencyInvoiceSummary": {
+        "CustomerMultiCurrencyInvoiceSummary": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -14693,12 +14697,12 @@ const docTemplate = `{
                     "description": "summaries contains the invoice summaries for each currency",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CustomerInvoiceSummary"
+                        "$ref": "#/definitions/CustomerInvoiceSummary"
                     }
                 }
             }
         },
-        "dto.CustomerResponse": {
+        "CustomerResponse": {
             "description": "Customer response object containing all customer information",
             "type": "object",
             "properties": {
@@ -14751,7 +14755,7 @@ const docTemplate = `{
                 "integrations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntityIntegrationMappingResponse"
+                        "$ref": "#/definitions/EntityIntegrationMappingResponse"
                     }
                 },
                 "metadata": {
@@ -14766,7 +14770,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -14779,7 +14783,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.CustomerUsageSummaryResponse": {
+        "CustomerUsageSummaryResponse": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -14788,38 +14792,38 @@ const docTemplate = `{
                 "features": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.FeatureUsageSummary"
+                        "$ref": "#/definitions/FeatureUsageSummary"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 },
                 "period": {
-                    "$ref": "#/definitions/dto.BillingPeriodInfo"
+                    "$ref": "#/definitions/BillingPeriodInfo"
                 }
             }
         },
-        "dto.DebugTracker": {
+        "DebugTracker": {
             "type": "object",
             "properties": {
                 "customer_lookup": {
-                    "$ref": "#/definitions/dto.CustomerLookupResult"
+                    "$ref": "#/definitions/CustomerLookupResult"
                 },
                 "failure_point": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FailurePoint"
+                    "$ref": "#/definitions/types.FailurePoint"
                 },
                 "meter_matching": {
-                    "$ref": "#/definitions/dto.MeterMatchingResult"
+                    "$ref": "#/definitions/MeterMatchingResult"
                 },
                 "price_lookup": {
-                    "$ref": "#/definitions/dto.PriceLookupResult"
+                    "$ref": "#/definitions/PriceLookupResult"
                 },
                 "subscription_line_item_lookup": {
-                    "$ref": "#/definitions/dto.SubscriptionLineItemLookupResult"
+                    "$ref": "#/definitions/SubscriptionLineItemLookupResult"
                 }
             }
         },
-        "dto.DeleteCostsheetResponse": {
+        "DeleteCostsheetResponse": {
             "type": "object",
             "properties": {
                 "id": {
@@ -14830,7 +14834,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.DeleteCreditGrantRequest": {
+        "DeleteCreditGrantRequest": {
             "type": "object",
             "properties": {
                 "effective_date": {
@@ -14839,7 +14843,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.DeletePriceRequest": {
+        "DeletePriceRequest": {
             "type": "object",
             "properties": {
                 "end_date": {
@@ -14847,7 +14851,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.DeleteSubscriptionLineItemRequest": {
+        "DeleteSubscriptionLineItemRequest": {
             "type": "object",
             "properties": {
                 "effective_from": {
@@ -14855,11 +14859,11 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.EntitlementResponse": {
+        "EntitlementResponse": {
             "type": "object",
             "properties": {
                 "addon": {
-                    "$ref": "#/definitions/dto.AddonResponse"
+                    "$ref": "#/definitions/AddonResponse"
                 },
                 "created_at": {
                     "type": "string"
@@ -14877,19 +14881,19 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType"
+                    "$ref": "#/definitions/types.EntitlementEntityType"
                 },
                 "environment_id": {
                     "type": "string"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "feature_id": {
                     "type": "string"
                 },
                 "feature_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "id": {
                     "type": "string"
@@ -14904,7 +14908,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "plan": {
-                    "$ref": "#/definitions/dto.PlanResponse"
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "plan_id": {
                     "description": "TODO: Remove this once we have a proper entitlement entity type",
@@ -14917,7 +14921,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -14932,11 +14936,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.EntitlementSource": {
+        "EntitlementSource": {
             "type": "object",
             "properties": {
                 "entitlement_id": {
@@ -14949,7 +14953,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/dto.EntitlementSourceEntityType"
+                    "$ref": "#/definitions/EntitlementSourceEntityType"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -14967,11 +14971,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 }
             }
         },
-        "dto.EntitlementSourceEntityType": {
+        "EntitlementSourceEntityType": {
             "type": "string",
             "enum": [
                 "plan",
@@ -14984,7 +14988,7 @@ const docTemplate = `{
                 "EntitlementSourceEntityTypeSubscription"
             ]
         },
-        "dto.EntityIntegrationMappingResponse": {
+        "EntityIntegrationMappingResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -14997,7 +15001,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType"
+                    "$ref": "#/definitions/types.IntegrationEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -15012,7 +15016,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -15025,7 +15029,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.Event": {
+        "Event": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -15055,7 +15059,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.EventCostInfo": {
+        "EventCostInfo": {
             "type": "object",
             "properties": {
                 "costNanoUsd": {
@@ -15066,7 +15070,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ExecuteSubscriptionInheritanceRequest": {
+        "ExecuteSubscriptionInheritanceRequest": {
             "type": "object",
             "properties": {
                 "external_customer_ids_to_inherit_subscription": {
@@ -15077,11 +15081,11 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.FeatureResponse": {
+        "FeatureResponse": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "created_at": {
                     "type": "string"
@@ -15099,7 +15103,7 @@ const docTemplate = `{
                     "description": "Group is the full group object when the feature belongs to a group (populated in response)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.GroupResponse"
+                            "$ref": "#/definitions/GroupResponse"
                         }
                     ]
                 },
@@ -15116,7 +15120,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "meter": {
-                    "$ref": "#/definitions/dto.MeterResponse"
+                    "$ref": "#/definitions/MeterResponse"
                 },
                 "meter_id": {
                     "type": "string"
@@ -15125,16 +15129,16 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -15150,7 +15154,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.FeatureUsageInfo": {
+        "FeatureUsageInfo": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -15179,14 +15183,14 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.FeatureUsageSummary": {
+        "FeatureUsageSummary": {
             "type": "object",
             "properties": {
                 "current_usage": {
                     "type": "string"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -15203,7 +15207,7 @@ const docTemplate = `{
                 "sources": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementSource"
+                        "$ref": "#/definitions/EntitlementSource"
                     }
                 },
                 "total_limit": {
@@ -15214,7 +15218,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetCostAnalyticsRequest": {
+        "GetCostAnalyticsRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -15251,22 +15255,22 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetCostsheetResponse": {
+        "GetCostsheetResponse": {
             "type": "object",
             "properties": {
                 "costsheet": {
-                    "$ref": "#/definitions/dto.CostsheetResponse"
+                    "$ref": "#/definitions/CostsheetResponse"
                 }
             }
         },
-        "dto.GetDetailedCostAnalyticsResponse": {
+        "GetDetailedCostAnalyticsResponse": {
             "type": "object",
             "properties": {
                 "cost_analytics": {
                     "description": "Cost analytics array (flattened from nested structure)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CostAnalyticItem"
+                        "$ref": "#/definitions/CostAnalyticItem"
                     }
                 },
                 "currency": {
@@ -15303,27 +15307,27 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetEventByIDResponse": {
+        "GetEventByIDResponse": {
             "type": "object",
             "properties": {
                 "debug_tracker": {
-                    "$ref": "#/definitions/dto.DebugTracker"
+                    "$ref": "#/definitions/DebugTracker"
                 },
                 "event": {
-                    "$ref": "#/definitions/dto.Event"
+                    "$ref": "#/definitions/Event"
                 },
                 "processed_events": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.FeatureUsageInfo"
+                        "$ref": "#/definitions/FeatureUsageInfo"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EventProcessingStatusType"
+                    "$ref": "#/definitions/types.EventProcessingStatusType"
                 }
             }
         },
-        "dto.GetEventsRequest": {
+        "GetEventsRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -15390,13 +15394,13 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetEventsResponse": {
+        "GetEventsResponse": {
             "type": "object",
             "properties": {
                 "events": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.Event"
+                        "$ref": "#/definitions/Event"
                     }
                 },
                 "has_more": {
@@ -15416,18 +15420,18 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetHuggingFaceBillingDataResponse": {
+        "GetHuggingFaceBillingDataResponse": {
             "type": "object",
             "properties": {
                 "requests": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EventCostInfo"
+                        "$ref": "#/definitions/EventCostInfo"
                     }
                 }
             }
         },
-        "dto.GetPendingSchedulesResponse": {
+        "GetPendingSchedulesResponse": {
             "description": "List of pending schedules for a subscription",
             "type": "object",
             "properties": {
@@ -15439,12 +15443,12 @@ const docTemplate = `{
                     "description": "schedules is the list of pending schedules",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionScheduleResponse"
+                        "$ref": "#/definitions/SubscriptionScheduleResponse"
                     }
                 }
             }
         },
-        "dto.GetPreviewInvoiceRequest": {
+        "GetPreviewInvoiceRequest": {
             "type": "object",
             "required": [
                 "subscription_id"
@@ -15469,7 +15473,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetUsageAnalyticsRequest": {
+        "GetUsageAnalyticsRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -15523,11 +15527,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "window_size": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.GetUsageAnalyticsResponse": {
+        "GetUsageAnalyticsResponse": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -15536,13 +15540,13 @@ const docTemplate = `{
                 "custom_analytics": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CustomAnalyticItem"
+                        "$ref": "#/definitions/CustomAnalyticItem"
                     }
                 },
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageAnalyticItem"
+                        "$ref": "#/definitions/UsageAnalyticItem"
                     }
                 },
                 "total_cost": {
@@ -15550,7 +15554,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetUsageByMeterRequest": {
+        "GetUsageByMeterRequest": {
             "type": "object",
             "required": [
                 "meter_id"
@@ -15565,7 +15569,7 @@ const docTemplate = `{
                     "description": "Optional, only used for MAX aggregation with windowing",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                            "$ref": "#/definitions/types.WindowSize"
                         }
                     ],
                     "example": "HOUR"
@@ -15600,11 +15604,11 @@ const docTemplate = `{
                     "example": "2024-11-09T00:00:00Z"
                 },
                 "window_size": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.GetUsageBySubscriptionRequest": {
+        "GetUsageBySubscriptionRequest": {
             "type": "object",
             "required": [
                 "subscription_id"
@@ -15628,7 +15632,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetUsageBySubscriptionResponse": {
+        "GetUsageBySubscriptionResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -15637,7 +15641,7 @@ const docTemplate = `{
                 "charges": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionUsageByMetersResponse"
+                        "$ref": "#/definitions/SubscriptionUsageByMetersResponse"
                     }
                 },
                 "commitment_amount": {
@@ -15672,7 +15676,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.GetUsageRequest": {
+        "GetUsageRequest": {
             "type": "object",
             "required": [
                 "aggregation_type",
@@ -15680,7 +15684,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "aggregation_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 },
                 "billing_anchor": {
                     "description": "BillingAnchor enables custom monthly billing periods for usage aggregation.\n\nWhen to use:\n- WindowSize = \"MONTH\" AND you need custom monthly periods (not calendar months)\n- Subscription billing that doesn't align with calendar months\n- Example: Customer signed up on 15th, so billing periods are 15th to 15th\n\nWhen NOT to use:\n- WindowSize != \"MONTH\" (ignored for DAY, HOUR, WEEK, etc.)\n- Standard calendar-based billing (1st to 1st of each month)\n\nExample values:\n- \"2024-03-05T14:30:45.123456789Z\" (5th of each month at 2:30:45 PM)\n- \"2024-01-15T00:00:00Z\" (15th of each month at midnight)\n- \"2024-02-29T12:00:00Z\" (29th of each month at noon - handles leap years)",
@@ -15691,7 +15695,7 @@ const docTemplate = `{
                     "description": "Optional, only used for MAX aggregation with windowing",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                            "$ref": "#/definitions/types.WindowSize"
                         }
                     ],
                     "example": "HOUR"
@@ -15738,11 +15742,11 @@ const docTemplate = `{
                     "example": "2024-03-13T00:00:00Z"
                 },
                 "window_size": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.GetUsageResponse": {
+        "GetUsageResponse": {
             "type": "object",
             "properties": {
                 "event_name": {
@@ -15751,18 +15755,18 @@ const docTemplate = `{
                 "results": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageResult"
+                        "$ref": "#/definitions/UsageResult"
                     }
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 },
                 "value": {
                     "type": "number"
                 }
             }
         },
-        "dto.GroupResponse": {
+        "GroupResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -15800,7 +15804,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.IngestEventRequest": {
+        "IngestEventRequest": {
             "type": "object",
             "required": [
                 "event_name",
@@ -15845,7 +15849,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.InvoiceCoupon": {
+        "InvoiceCoupon": {
             "type": "object",
             "required": [
                 "coupon_id"
@@ -15859,7 +15863,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.InvoiceLineItemCoupon": {
+        "InvoiceLineItemCoupon": {
             "type": "object",
             "required": [
                 "coupon_id",
@@ -15878,7 +15882,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.InvoiceLineItemPreview": {
+        "InvoiceLineItemPreview": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -15911,14 +15915,14 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.InvoiceLineItemResponse": {
+        "InvoiceLineItemResponse": {
             "type": "object",
             "properties": {
                 "amount": {
                     "type": "string"
                 },
                 "commitment_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "created_at": {
                     "type": "string"
@@ -15999,7 +16003,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -16017,19 +16021,19 @@ const docTemplate = `{
                     "description": "usage_analytics contains usage analytics for this line item (legacy - grouped by source)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SourceUsageItem"
+                        "$ref": "#/definitions/SourceUsageItem"
                     }
                 },
                 "usage_breakdown": {
                     "description": "usage_breakdown contains flexible usage breakdown for this line item (supports any grouping)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageBreakdownItem"
+                        "$ref": "#/definitions/UsageBreakdownItem"
                     }
                 }
             }
         },
-        "dto.InvoicePreview": {
+        "InvoicePreview": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -16044,7 +16048,7 @@ const docTemplate = `{
                     "description": "line_items contains preview of line items",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceLineItemPreview"
+                        "$ref": "#/definitions/InvoiceLineItemPreview"
                     }
                 },
                 "subtotal": {
@@ -16061,7 +16065,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.InvoiceResponse": {
+        "InvoiceResponse": {
             "type": "object",
             "properties": {
                 "adjustment_amount": {
@@ -16096,7 +16100,7 @@ const docTemplate = `{
                     "description": "coupon_applications contains the coupon applications associated with this invoice (overrides embedded field)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponApplicationResponse"
+                        "$ref": "#/definitions/CouponApplicationResponse"
                     }
                 },
                 "created_at": {
@@ -16113,7 +16117,7 @@ const docTemplate = `{
                     "description": "customer contains the customer information associated with this invoice",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     ]
                 },
@@ -16157,7 +16161,7 @@ const docTemplate = `{
                     "description": "invoice_status represents the current status of the invoice - values include draft, open, paid, void, etc.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus"
+                            "$ref": "#/definitions/types.InvoiceStatus"
                         }
                     ]
                 },
@@ -16165,7 +16169,7 @@ const docTemplate = `{
                     "description": "invoice_type indicates the type of invoice - whether this is a subscription invoice, one-time charge, or other billing type",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType"
+                            "$ref": "#/definitions/types.InvoiceType"
                         }
                     ]
                 },
@@ -16177,7 +16181,7 @@ const docTemplate = `{
                     "description": "line_items contains the individual items that make up this invoice (overrides embedded field)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceLineItemResponse"
+                        "$ref": "#/definitions/InvoiceLineItemResponse"
                     }
                 },
                 "metadata": {
@@ -16200,7 +16204,7 @@ const docTemplate = `{
                     "description": "payment_status indicates whether the invoice has been paid, is pending, or failed",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                            "$ref": "#/definitions/types.PaymentStatus"
                         }
                     ]
                 },
@@ -16221,15 +16225,19 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription": {
                     "description": "subscription contains the associated subscription information if requested",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     ]
+                },
+                "subscription_customer_id": {
+                    "description": "subscription_customer_id is the subscription owner's customer ID (Subscription.CustomerID).\nIt may differ from customer_id when the subscription uses an invoicing customer.",
+                    "type": "string"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the ID of the subscription this invoice is associated with (only present for subscription-based invoices)",
@@ -16243,7 +16251,7 @@ const docTemplate = `{
                     "description": "tax_applied_records contains the tax applied records associated with this invoice",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxAppliedResponse"
+                        "$ref": "#/definitions/TaxAppliedResponse"
                     }
                 },
                 "tenant_id": {
@@ -16281,7 +16289,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.LineItemCommitmentConfig": {
+        "LineItemCommitmentConfig": {
             "type": "object",
             "properties": {
                 "commitment_amount": {
@@ -16292,7 +16300,7 @@ const docTemplate = `{
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                            "$ref": "#/definitions/types.BillingPeriod"
                         }
                     ]
                 },
@@ -16304,7 +16312,7 @@ const docTemplate = `{
                     "description": "CommitmentType specifies whether commitment is based on amount or quantity",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                            "$ref": "#/definitions/types.CommitmentType"
                         }
                     ]
                 },
@@ -16322,7 +16330,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.LinkIntegrationMappingRequest": {
+        "LinkIntegrationMappingRequest": {
             "type": "object",
             "required": [
                 "entity_id",
@@ -16336,7 +16344,7 @@ const docTemplate = `{
                     "maxLength": 255
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType"
+                    "$ref": "#/definitions/types.IntegrationEntityType"
                 },
                 "metadata": {
                     "type": "object",
@@ -16352,71 +16360,71 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.LinkIntegrationMappingResponse": {
+        "LinkIntegrationMappingResponse": {
             "type": "object",
             "properties": {
                 "mapping": {
-                    "$ref": "#/definitions/dto.EntityIntegrationMappingResponse"
+                    "$ref": "#/definitions/EntityIntegrationMappingResponse"
                 }
             }
         },
-        "dto.ListAlertLogsResponse": {
+        "ListAlertLogsResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AlertLogResponse"
+                        "$ref": "#/definitions/AlertLogResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListCostsheetResponse": {
+        "ListCostsheetResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CostsheetResponse"
+                        "$ref": "#/definitions/CostsheetResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListPaymentsResponse": {
+        "ListPaymentsResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PaymentResponse"
+                        "$ref": "#/definitions/PaymentResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListSecretsResponse": {
+        "ListSecretsResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SecretResponse"
+                        "$ref": "#/definitions/SecretResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListSubscriptionPausesResponse": {
+        "ListSubscriptionPausesResponse": {
             "description": "Response object for listing subscription pauses with total count",
             "type": "object",
             "properties": {
@@ -16424,7 +16432,7 @@ const docTemplate = `{
                     "description": "List of subscription pause objects\n@Description Array of subscription pauses",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPauseResponse"
+                        "$ref": "#/definitions/SubscriptionPauseResponse"
                     }
                 },
                 "total": {
@@ -16433,21 +16441,21 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ListTasksResponse": {
+        "ListTasksResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaskResponse"
+                        "$ref": "#/definitions/TaskResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.MatchedMeter": {
+        "MatchedMeter": {
             "type": "object",
             "properties": {
                 "event_name": {
@@ -16461,7 +16469,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.MatchedPrice": {
+        "MatchedPrice": {
             "type": "object",
             "properties": {
                 "meter_id": {
@@ -16478,7 +16486,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.MatchedSubscriptionLineItem": {
+        "MatchedSubscriptionLineItem": {
             "type": "object",
             "properties": {
                 "end_date": {
@@ -16507,24 +16515,24 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.MeterMatchingResult": {
+        "MeterMatchingResult": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "matched_meters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.MatchedMeter"
+                        "$ref": "#/definitions/MatchedMeter"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.MeterResponse": {
+        "MeterResponse": {
             "type": "object",
             "properties": {
                 "aggregation": {
@@ -16553,7 +16561,7 @@ const docTemplate = `{
                     "example": "API Usage Meter"
                 },
                 "reset_usage": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage"
+                    "$ref": "#/definitions/types.ResetUsage"
                 },
                 "status": {
                     "type": "string",
@@ -16569,7 +16577,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.OverrideEntitlementRequest": {
+        "OverrideEntitlementRequest": {
             "type": "object",
             "required": [
                 "entitlement_id"
@@ -16593,7 +16601,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.OverrideLineItemRequest": {
+        "OverrideLineItemRequest": {
             "type": "object",
             "required": [
                 "price_id"
@@ -16604,7 +16612,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "price_id": {
                     "description": "PriceID references the plan price to override",
@@ -16618,7 +16626,7 @@ const docTemplate = `{
                     "description": "PriceUnitTiers are the tiers for the price unit (for CUSTOM type, TIERED billing model)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "quantity": {
@@ -16629,7 +16637,7 @@ const docTemplate = `{
                     "description": "TierMode determines how to calculate the price for a given quantity",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                            "$ref": "#/definitions/types.BillingTier"
                         }
                     ]
                 },
@@ -16637,7 +16645,7 @@ const docTemplate = `{
                     "description": "Tiers determines the pricing tiers for this line item",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -16650,7 +16658,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PauseSubscriptionRequest": {
+        "PauseSubscriptionRequest": {
             "description": "Request object for pausing an active subscription with various pause modes and options",
             "type": "object",
             "required": [
@@ -16680,7 +16688,7 @@ const docTemplate = `{
                     "description": "Mode for pausing the subscription\n@Description Determines when the pause takes effect. \"immediate\" pauses right away, \"scheduled\" pauses at a specified time\n@Enum immediate,scheduled",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode"
+                            "$ref": "#/definitions/types.PauseMode"
                         }
                     ]
                 },
@@ -16695,7 +16703,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PaymentAttemptResponse": {
+        "PaymentAttemptResponse": {
             "type": "object",
             "properties": {
                 "attempt_number": {
@@ -16730,7 +16738,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PaymentResponse": {
+        "PaymentResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -16739,7 +16747,7 @@ const docTemplate = `{
                 "attempts": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PaymentAttemptResponse"
+                        "$ref": "#/definitions/PaymentAttemptResponse"
                     }
                 },
                 "created_at": {
@@ -16755,7 +16763,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "destination_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentDestinationType"
+                    "$ref": "#/definitions/types.PaymentDestinationType"
                 },
                 "error_message": {
                     "type": "string"
@@ -16791,10 +16799,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "payment_method_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentMethodType"
+                    "$ref": "#/definitions/types.PaymentMethodType"
                 },
                 "payment_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                    "$ref": "#/definitions/types.PaymentStatus"
                 },
                 "payment_url": {
                     "type": "string"
@@ -16822,7 +16830,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PlanResponse": {
+        "PlanResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -16834,7 +16842,7 @@ const docTemplate = `{
                 "credit_grants": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "description": {
@@ -16846,7 +16854,7 @@ const docTemplate = `{
                 "entitlements": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "environment_id": {
@@ -16868,11 +16876,11 @@ const docTemplate = `{
                     "description": "TODO: Add inline addons",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -16885,7 +16893,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PlanSummary": {
+        "PlanSummary": {
             "type": "object",
             "properties": {
                 "description": {
@@ -16906,41 +16914,41 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PriceLookupResult": {
+        "PriceLookupResult": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "matched_prices": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.MatchedPrice"
+                        "$ref": "#/definitions/MatchedPrice"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.PriceResponse": {
+        "PriceResponse": {
             "type": "object",
             "properties": {
                 "addon": {
-                    "$ref": "#/definitions/dto.AddonResponse"
+                    "$ref": "#/definitions/AddonResponse"
                 },
                 "amount": {
                     "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50",
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
@@ -16989,7 +16997,7 @@ const docTemplate = `{
                     "description": "EntityType holds the value of the \"entity_type\" field.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
+                            "$ref": "#/definitions/types.PriceEntityType"
                         }
                     ]
                 },
@@ -16998,7 +17006,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "group": {
-                    "$ref": "#/definitions/dto.GroupResponse"
+                    "$ref": "#/definitions/GroupResponse"
                 },
                 "group_id": {
                     "description": "GroupID references the group this price belongs to",
@@ -17009,7 +17017,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "description": "LookupKey used for looking up the price in the database",
@@ -17019,7 +17027,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/price.JSONBMetadata"
                 },
                 "meter": {
-                    "$ref": "#/definitions/dto.MeterResponse"
+                    "$ref": "#/definitions/MeterResponse"
                 },
                 "meter_id": {
                     "description": "MeterID is the id of the meter for usage based pricing",
@@ -17035,7 +17043,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "plan": {
-                    "$ref": "#/definitions/dto.PlanResponse"
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "price_unit": {
                     "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')",
@@ -17060,25 +17068,25 @@ const docTemplate = `{
                     "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
+                            "$ref": "#/definitions/types.PriceUnitType"
                         }
                     ]
                 },
                 "pricing_unit": {
-                    "$ref": "#/definitions/dto.PriceUnitResponse"
+                    "$ref": "#/definitions/PriceUnitResponse"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the price",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
@@ -17094,7 +17102,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -17104,7 +17112,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PriceUnitConfig": {
+        "PriceUnitConfig": {
             "type": "object",
             "required": [
                 "price_unit"
@@ -17119,12 +17127,12 @@ const docTemplate = `{
                 "price_unit_tiers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 }
             }
         },
-        "dto.PriceUnitResponse": {
+        "PriceUnitResponse": {
             "type": "object",
             "properties": {
                 "base_currency": {
@@ -17155,7 +17163,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "symbol": {
                     "type": "string"
@@ -17171,7 +17179,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ProrationDetail": {
+        "ProrationDetail": {
             "type": "object",
             "properties": {
                 "charge_amount": {
@@ -17200,7 +17208,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ProrationDetails": {
+        "ProrationDetails": {
             "type": "object",
             "properties": {
                 "charge_amount": {
@@ -17249,7 +17257,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.RemoveAddonRequest": {
+        "RemoveAddonRequest": {
             "type": "object",
             "required": [
                 "addon_association_id"
@@ -17263,7 +17271,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ResumeSubscriptionRequest": {
+        "ResumeSubscriptionRequest": {
             "description": "Request object for resuming a paused subscription",
             "type": "object",
             "required": [
@@ -17285,13 +17293,13 @@ const docTemplate = `{
                     "description": "Mode for resuming the subscription\n@Description Determines how the subscription should be resumed\n@Enum immediate,scheduled",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode"
+                            "$ref": "#/definitions/types.ResumeMode"
                         }
                     ]
                 }
             }
         },
-        "dto.ScheduledTaskResponse": {
+        "ScheduledTaskResponse": {
             "type": "object",
             "properties": {
                 "connection_id": {
@@ -17304,7 +17312,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType"
+                    "$ref": "#/definitions/types.ScheduledTaskEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -17320,12 +17328,12 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval"
+                            "$ref": "#/definitions/types.ScheduledTaskInterval"
                         }
                     ]
                 },
                 "job_config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3JobConfig"
+                    "$ref": "#/definitions/types.S3JobConfig"
                 },
                 "status": {
                     "type": "string"
@@ -17338,7 +17346,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SecretResponse": {
+        "SecretResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -17360,7 +17368,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "provider": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SecretProvider"
+                    "$ref": "#/definitions/types.SecretProvider"
                 },
                 "roles": {
                     "description": "RBAC roles",
@@ -17370,10 +17378,10 @@ const docTemplate = `{
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SecretType"
+                    "$ref": "#/definitions/types.SecretType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -17382,13 +17390,13 @@ const docTemplate = `{
                     "description": "\"user\" or \"service_account\"",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                            "$ref": "#/definitions/types.UserType"
                         }
                     ]
                 }
             }
         },
-        "dto.SourceUsageItem": {
+        "SourceUsageItem": {
             "type": "object",
             "properties": {
                 "cost": {
@@ -17413,7 +17421,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionChangeExecuteResponse": {
+        "SubscriptionChangeExecuteResponse": {
             "description": "Response after successfully executing a subscription plan change",
             "type": "object",
             "properties": {
@@ -17421,7 +17429,7 @@ const docTemplate = `{
                     "description": "change_type indicates whether this was an upgrade, downgrade, or lateral change",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionChangeType"
+                            "$ref": "#/definitions/types.SubscriptionChangeType"
                         }
                     ]
                 },
@@ -17429,7 +17437,7 @@ const docTemplate = `{
                     "description": "credit_grants contains any credit grants created for proration credits",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "effective_date": {
@@ -17440,7 +17448,7 @@ const docTemplate = `{
                     "description": "invoice contains the immediate invoice generated for the change (if any)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     ]
                 },
@@ -17459,7 +17467,7 @@ const docTemplate = `{
                     "description": "new_subscription contains the new subscription details (only if is_scheduled=false)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.SubscriptionSummary"
+                            "$ref": "#/definitions/SubscriptionSummary"
                         }
                     ]
                 },
@@ -17467,7 +17475,7 @@ const docTemplate = `{
                     "description": "old_subscription contains the archived subscription details (only if is_scheduled=false)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.SubscriptionSummary"
+                            "$ref": "#/definitions/SubscriptionSummary"
                         }
                     ]
                 },
@@ -17475,7 +17483,7 @@ const docTemplate = `{
                     "description": "proration_applied contains details of the proration that was applied",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.ProrationDetails"
+                            "$ref": "#/definitions/ProrationDetails"
                         }
                     ]
                 },
@@ -17489,7 +17497,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionChangePreviewResponse": {
+        "SubscriptionChangePreviewResponse": {
             "description": "Response showing the financial impact of a subscription plan change",
             "type": "object",
             "properties": {
@@ -17497,7 +17505,7 @@ const docTemplate = `{
                     "description": "change_type indicates whether this is an upgrade, downgrade, or lateral change",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionChangeType"
+                            "$ref": "#/definitions/types.SubscriptionChangeType"
                         }
                     ]
                 },
@@ -17505,7 +17513,7 @@ const docTemplate = `{
                     "description": "current_plan contains information about the current plan",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.PlanSummary"
+                            "$ref": "#/definitions/PlanSummary"
                         }
                     ]
                 },
@@ -17524,7 +17532,7 @@ const docTemplate = `{
                     "description": "new_billing_cycle shows the new billing cycle details",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.BillingCycleInfo"
+                            "$ref": "#/definitions/BillingCycleInfo"
                         }
                     ]
                 },
@@ -17532,7 +17540,7 @@ const docTemplate = `{
                     "description": "next_invoice_preview shows how the next regular invoice would be affected",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.InvoicePreview"
+                            "$ref": "#/definitions/InvoicePreview"
                         }
                     ]
                 },
@@ -17540,7 +17548,7 @@ const docTemplate = `{
                     "description": "proration_details contains the calculated proration amounts",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.ProrationDetails"
+                            "$ref": "#/definitions/ProrationDetails"
                         }
                     ]
                 },
@@ -17552,7 +17560,7 @@ const docTemplate = `{
                     "description": "target_plan contains information about the target plan",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.PlanSummary"
+                            "$ref": "#/definitions/PlanSummary"
                         }
                     ]
                 },
@@ -17565,7 +17573,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionChangeRequest": {
+        "SubscriptionChangeRequest": {
             "description": "Request object for changing a subscription plan (upgrade/downgrade)",
             "type": "object",
             "required": [
@@ -17580,7 +17588,7 @@ const docTemplate = `{
                     "description": "billing_cadence is the billing cadence for the new subscription",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                            "$ref": "#/definitions/types.BillingCadence"
                         }
                     ]
                 },
@@ -17588,7 +17596,7 @@ const docTemplate = `{
                     "description": "billing_cycle is the billing cycle for the new subscription",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
+                            "$ref": "#/definitions/types.BillingCycle"
                         }
                     ]
                 },
@@ -17596,7 +17604,7 @@ const docTemplate = `{
                     "description": "billing_period is the billing period for the new subscription",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                            "$ref": "#/definitions/types.BillingPeriod"
                         }
                     ]
                 },
@@ -17609,7 +17617,7 @@ const docTemplate = `{
                     "description": "change_at determines when the change should take effect (optional)\nIf not provided or null: change executes immediately\nIf \"immediate\": change executes immediately (explicit)\nIf \"period_end\": change is scheduled for the end of the current billing period",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleType"
+                            "$ref": "#/definitions/types.ScheduleType"
                         }
                     ]
                 },
@@ -17624,7 +17632,7 @@ const docTemplate = `{
                     "description": "proration_behavior controls how proration is handled for the change\nOptions: create_prorations, none",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                            "$ref": "#/definitions/types.ProrationBehavior"
                         }
                     ]
                 },
@@ -17634,13 +17642,13 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionEntitlementsResponse": {
+        "SubscriptionEntitlementsResponse": {
             "type": "object",
             "properties": {
                 "features": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AggregatedFeature"
+                        "$ref": "#/definitions/AggregatedFeature"
                     }
                 },
                 "plan_id": {
@@ -17651,7 +17659,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionInheritanceConfig": {
+        "SubscriptionInheritanceConfig": {
             "type": "object",
             "properties": {
                 "external_customer_ids_to_inherit_subscription": {
@@ -17668,28 +17676,28 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionLineItemLookupResult": {
+        "SubscriptionLineItemLookupResult": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "matched_line_items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.MatchedSubscriptionLineItem"
+                        "$ref": "#/definitions/MatchedSubscriptionLineItem"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.SubscriptionLineItemResponse": {
+        "SubscriptionLineItemResponse": {
             "type": "object",
             "properties": {
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "from price at create; default 1",
@@ -17700,7 +17708,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "string"
@@ -17712,7 +17720,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -17739,7 +17747,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType"
+                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -17748,7 +17756,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "metadata": {
                     "type": "object",
@@ -17766,13 +17774,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "price": {
-                    "$ref": "#/definitions/dto.PriceResponse"
+                    "$ref": "#/definitions/PriceResponse"
                 },
                 "price_id": {
                     "type": "string"
                 },
                 "price_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "price_unit": {
                     "type": "string"
@@ -17787,7 +17795,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -17809,7 +17817,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionPauseResponse": {
+        "SubscriptionPauseResponse": {
             "description": "Response object containing subscription pause information",
             "type": "object",
             "properties": {
@@ -17843,28 +17851,28 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "pause_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode"
+                    "$ref": "#/definitions/types.PauseMode"
                 },
                 "pause_start": {
                     "description": "PauseStart is when the pause actually started",
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "reason": {
                     "description": "Reason is the reason for pausing",
                     "type": "string"
                 },
                 "resume_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode"
+                    "$ref": "#/definitions/types.ResumeMode"
                 },
                 "resumed_at": {
                     "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -17881,7 +17889,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionPhaseCreateRequest": {
+        "SubscriptionPhaseCreateRequest": {
             "type": "object",
             "required": [
                 "start_date"
@@ -17917,7 +17925,7 @@ const docTemplate = `{
                     "description": "OverrideLineItems allows customizing specific prices for this phase\nIf not provided, phase will use the same line items as the subscription (plan prices)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.OverrideLineItemRequest"
+                        "$ref": "#/definitions/OverrideLineItemRequest"
                     }
                 },
                 "start_date": {
@@ -17925,7 +17933,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionPhaseResponse": {
+        "SubscriptionPhaseResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -17959,7 +17967,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -17976,7 +17984,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionPriceCreateRequest": {
+        "SubscriptionPriceCreateRequest": {
             "type": "object",
             "required": [
                 "billing_cadence",
@@ -17991,13 +17999,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "type": "integer"
@@ -18021,7 +18029,7 @@ const docTemplate = `{
                     }
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "type": "string"
@@ -18039,21 +18047,21 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "price_unit_config": {
-                    "$ref": "#/definitions/dto.PriceUnitConfig"
+                    "$ref": "#/definitions/PriceUnitConfig"
                 },
                 "price_unit_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
+                    "$ref": "#/definitions/types.PriceUnitType"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -18063,11 +18071,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 }
             }
         },
-        "dto.SubscriptionResponse": {
+        "SubscriptionResponse": {
             "type": "object",
             "properties": {
                 "active_pause_id": {
@@ -18079,18 +18087,18 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
+                            "$ref": "#/definitions/types.BillingCycle"
                         }
                     ]
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the total number units of the billing period.",
@@ -18121,7 +18129,7 @@ const docTemplate = `{
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on a MONTHLY subscription)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                            "$ref": "#/definitions/types.BillingPeriod"
                         }
                     ]
                 },
@@ -18129,7 +18137,7 @@ const docTemplate = `{
                     "description": "CouponAssociations are the coupon associations for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponAssociationResponse"
+                        "$ref": "#/definitions/CouponAssociationResponse"
                     }
                 },
                 "created_at": {
@@ -18142,7 +18150,7 @@ const docTemplate = `{
                     "description": "Credit grants are the credit grants for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "currency": {
@@ -18158,7 +18166,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "description": "CustomerID is the identifier for the customer in our system",
@@ -18194,7 +18202,7 @@ const docTemplate = `{
                     "description": "Latest invoice information for incomplete subscriptions",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     ]
                 },
@@ -18220,7 +18228,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "pauses": {
                     "type": "array",
@@ -18236,7 +18244,7 @@ const docTemplate = `{
                     "description": "PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms"
+                            "$ref": "#/definitions/types.PaymentTerms"
                         }
                     ]
                 },
@@ -18244,28 +18252,28 @@ const docTemplate = `{
                     "description": "Phases are the subscription phases for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPhaseResponse"
+                        "$ref": "#/definitions/SubscriptionPhaseResponse"
                     }
                 },
                 "plan": {
-                    "$ref": "#/definitions/dto.PlanResponse"
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "plan_id": {
                     "description": "PlanID is the identifier for the plan in our system",
                     "type": "string"
                 },
                 "proration_behavior": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the subscription",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "subscription_type": {
                     "description": "SubscriptionType categorises the subscription within a customer hierarchy (standalone, parent, inherited).",
@@ -18298,7 +18306,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionResponseV2": {
+        "SubscriptionResponseV2": {
             "type": "object",
             "properties": {
                 "active_pause_id": {
@@ -18310,18 +18318,18 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
+                            "$ref": "#/definitions/types.BillingCycle"
                         }
                     ]
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the total number units of the billing period.",
@@ -18352,7 +18360,7 @@ const docTemplate = `{
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on a MONTHLY subscription)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                            "$ref": "#/definitions/types.BillingPeriod"
                         }
                     ]
                 },
@@ -18360,7 +18368,7 @@ const docTemplate = `{
                     "description": "CouponAssociations are included when \"coupon_associations\" is in expand parameter",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponAssociationResponse"
+                        "$ref": "#/definitions/CouponAssociationResponse"
                     }
                 },
                 "created_at": {
@@ -18373,7 +18381,7 @@ const docTemplate = `{
                     "description": "CreditGrants are included when \"credit_grants\" is in expand parameter",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "currency": {
@@ -18392,7 +18400,7 @@ const docTemplate = `{
                     "description": "Customer is expanded only if \"customer\" is in expand parameter",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     ]
                 },
@@ -18430,7 +18438,7 @@ const docTemplate = `{
                     "description": "LineItems is expanded only if \"subscription_line_items\" is in expand parameter\nEach line item can optionally include expanded price data",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                        "$ref": "#/definitions/SubscriptionLineItemResponse"
                     }
                 },
                 "lookup_key": {
@@ -18449,7 +18457,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "pauses": {
                     "description": "Pauses are included when subscription has pause status",
@@ -18466,7 +18474,7 @@ const docTemplate = `{
                     "description": "PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms"
+                            "$ref": "#/definitions/types.PaymentTerms"
                         }
                     ]
                 },
@@ -18474,14 +18482,14 @@ const docTemplate = `{
                     "description": "Phases are included when \"phases\" is in expand parameter",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPhaseResponse"
+                        "$ref": "#/definitions/SubscriptionPhaseResponse"
                     }
                 },
                 "plan": {
                     "description": "Plan is expanded only if \"plan\" is in expand parameter",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     ]
                 },
@@ -18490,17 +18498,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "proration_behavior": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the subscription",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "subscription_type": {
                     "description": "SubscriptionType categorises the subscription within a customer hierarchy (standalone, parent, inherited).",
@@ -18533,7 +18541,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionScheduleResponse": {
+        "SubscriptionScheduleResponse": {
             "description": "Full details of a subscription schedule",
             "type": "object",
             "properties": {
@@ -18582,7 +18590,7 @@ const docTemplate = `{
                     "description": "schedule_type is the type of schedule (plan_change, addon_change, etc.)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType"
+                            "$ref": "#/definitions/types.SubscriptionScheduleChangeType"
                         }
                     ]
                 },
@@ -18594,7 +18602,7 @@ const docTemplate = `{
                     "description": "status is the current status of the schedule",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleStatus"
+                            "$ref": "#/definitions/types.ScheduleStatus"
                         }
                     ]
                 },
@@ -18608,7 +18616,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SubscriptionSummary": {
+        "SubscriptionSummary": {
             "type": "object",
             "properties": {
                 "archived_at": {
@@ -18643,13 +18651,13 @@ const docTemplate = `{
                     "description": "status of the subscription",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                            "$ref": "#/definitions/types.SubscriptionStatus"
                         }
                     ]
                 }
             }
         },
-        "dto.SubscriptionUsageByMetersResponse": {
+        "SubscriptionUsageByMetersResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -18690,7 +18698,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.SuccessResponse": {
+        "SuccessResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -18698,7 +18706,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TaskResponse": {
+        "TaskResponse": {
             "type": "object",
             "properties": {
                 "completed_at": {
@@ -18711,7 +18719,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntityType"
+                    "$ref": "#/definitions/types.EntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -18729,7 +18737,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "file_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FileType"
+                    "$ref": "#/definitions/types.FileType"
                 },
                 "file_url": {
                     "type": "string"
@@ -18751,16 +18759,16 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "successful_records": {
                     "type": "integer"
                 },
                 "task_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskStatus"
+                    "$ref": "#/definitions/types.TaskStatus"
                 },
                 "task_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskType"
+                    "$ref": "#/definitions/types.TaskType"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -18779,7 +18787,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TaxAppliedResponse": {
+        "TaxAppliedResponse": {
             "type": "object",
             "properties": {
                 "applied_at": {
@@ -18798,7 +18806,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType"
+                    "$ref": "#/definitions/types.TaxRateEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -18816,7 +18824,7 @@ const docTemplate = `{
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tax_amount": {
                     "type": "string"
@@ -18825,7 +18833,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "tax_rate": {
-                    "$ref": "#/definitions/dto.TaxRateResponse"
+                    "$ref": "#/definitions/TaxRateResponse"
                 },
                 "tax_rate_id": {
                     "type": "string"
@@ -18844,7 +18852,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TaxAssociationResponse": {
+        "TaxAssociationResponse": {
             "type": "object",
             "properties": {
                 "auto_apply": {
@@ -18869,7 +18877,7 @@ const docTemplate = `{
                     "description": "Type of entity this tax rate applies to",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType"
+                            "$ref": "#/definitions/types.TaxRateEntityType"
                         }
                     ]
                 },
@@ -18893,10 +18901,10 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tax_rate": {
-                    "$ref": "#/definitions/dto.TaxRateResponse"
+                    "$ref": "#/definitions/TaxRateResponse"
                 },
                 "tax_rate_id": {
                     "description": "Reference to the TaxRate entity",
@@ -18913,7 +18921,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TaxAssociationUpdateRequest": {
+        "TaxAssociationUpdateRequest": {
             "type": "object",
             "properties": {
                 "auto_apply": {
@@ -18930,7 +18938,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TaxRateOverride": {
+        "TaxRateOverride": {
             "type": "object",
             "required": [
                 "currency",
@@ -18958,7 +18966,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TaxRateResponse": {
+        "TaxRateResponse": {
             "type": "object",
             "properties": {
                 "code": {
@@ -18995,16 +19003,16 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateScope"
+                    "$ref": "#/definitions/types.TaxRateScope"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tax_rate_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateStatus"
+                    "$ref": "#/definitions/types.TaxRateStatus"
                 },
                 "tax_rate_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateType"
+                    "$ref": "#/definitions/types.TaxRateType"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -19017,11 +19025,11 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TenantBillingDetails": {
+        "TenantBillingDetails": {
             "type": "object",
             "properties": {
                 "address": {
-                    "$ref": "#/definitions/dto.Address"
+                    "$ref": "#/definitions/Address"
                 },
                 "email": {
                     "type": "string"
@@ -19034,25 +19042,25 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TenantBillingUsage": {
+        "TenantBillingUsage": {
             "type": "object",
             "properties": {
                 "subscriptions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionResponse"
+                        "$ref": "#/definitions/SubscriptionResponse"
                     }
                 },
                 "usage": {
-                    "$ref": "#/definitions/dto.CustomerUsageSummaryResponse"
+                    "$ref": "#/definitions/CustomerUsageSummaryResponse"
                 }
             }
         },
-        "dto.TenantResponse": {
+        "TenantResponse": {
             "type": "object",
             "properties": {
                 "billing_details": {
-                    "$ref": "#/definitions/dto.TenantBillingDetails"
+                    "$ref": "#/definitions/TenantBillingDetails"
                 },
                 "created_at": {
                     "type": "string"
@@ -19074,7 +19082,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TopUpWalletRequest": {
+        "TopUpWalletRequest": {
             "type": "object",
             "required": [
                 "transaction_reason"
@@ -19113,11 +19121,11 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "transaction_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason"
+                    "$ref": "#/definitions/types.TransactionReason"
                 }
             }
         },
-        "dto.TopUpWalletResponse": {
+        "TopUpWalletResponse": {
             "type": "object",
             "properties": {
                 "invoice_id": {
@@ -19128,7 +19136,7 @@ const docTemplate = `{
                     "description": "Wallet details after the operation",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     ]
                 },
@@ -19136,13 +19144,13 @@ const docTemplate = `{
                     "description": "Wallet transaction created (could be PENDING or COMPLETED)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.WalletTransactionResponse"
+                            "$ref": "#/definitions/WalletTransactionResponse"
                         }
                     ]
                 }
             }
         },
-        "dto.TriggerForceRunRequest": {
+        "TriggerForceRunRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -19153,7 +19161,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TriggerForceRunResponse": {
+        "TriggerForceRunResponse": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -19174,7 +19182,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateAddonRequest": {
+        "UpdateAddonRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -19189,7 +19197,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateCostsheetRequest": {
+        "UpdateCostsheetRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -19213,15 +19221,15 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateCostsheetResponse": {
+        "UpdateCostsheetResponse": {
             "type": "object",
             "properties": {
                 "costsheet": {
-                    "$ref": "#/definitions/dto.CostsheetResponse"
+                    "$ref": "#/definitions/CostsheetResponse"
                 }
             }
         },
-        "dto.UpdateCouponRequest": {
+        "UpdateCouponRequest": {
             "type": "object",
             "properties": {
                 "metadata": {
@@ -19235,7 +19243,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateCreditGrantRequest": {
+        "UpdateCreditGrantRequest": {
             "type": "object",
             "properties": {
                 "metadata": {
@@ -19246,7 +19254,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateCustomerRequest": {
+        "UpdateCustomerRequest": {
             "description": "Request object for updating an existing customer. All fields are optional - only provided fields will be updated",
             "type": "object",
             "properties": {
@@ -19291,7 +19299,7 @@ const docTemplate = `{
                     "description": "integration_entity_mapping contains provider integration mappings for this customer",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateEntityIntegrationMappingRequest"
+                        "$ref": "#/definitions/CreateEntityIntegrationMappingRequest"
                     }
                 },
                 "metadata": {
@@ -19307,7 +19315,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateEntitlementRequest": {
+        "UpdateEntitlementRequest": {
             "type": "object",
             "properties": {
                 "is_enabled": {
@@ -19323,15 +19331,15 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.UpdateFeatureRequest": {
+        "UpdateFeatureRequest": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "description": {
                     "type": "string"
@@ -19353,7 +19361,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -19363,7 +19371,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateInvoiceRequest": {
+        "UpdateInvoiceRequest": {
             "type": "object",
             "properties": {
                 "due_date": {
@@ -19383,7 +19391,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdatePaymentRequest": {
+        "UpdatePaymentRequest": {
             "type": "object",
             "properties": {
                 "error_message": {
@@ -19412,7 +19420,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdatePaymentStatusRequest": {
+        "UpdatePaymentStatusRequest": {
             "type": "object",
             "required": [
                 "payment_status"
@@ -19426,13 +19434,13 @@ const docTemplate = `{
                     "description": "payment_status is the new payment status to set for the invoice (paid, unpaid, etc.)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                            "$ref": "#/definitions/types.PaymentStatus"
                         }
                     ]
                 }
             }
         },
-        "dto.UpdatePlanRequest": {
+        "UpdatePlanRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -19452,7 +19460,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdatePriceRequest": {
+        "UpdatePriceRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -19460,7 +19468,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "description": {
                     "type": "string"
@@ -19493,14 +19501,14 @@ const docTemplate = `{
                     "description": "PriceUnitTiers are the price unit tiers (for CUSTOM price unit type, TIERED billing model)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "tier_mode": {
                     "description": "TierMode determines how to calculate the price for a given quantity",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                            "$ref": "#/definitions/types.BillingTier"
                         }
                     ]
                 },
@@ -19508,7 +19516,7 @@ const docTemplate = `{
                     "description": "Tiers determines the pricing tiers for this line item",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -19521,7 +19529,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdatePriceUnitRequest": {
+        "UpdatePriceUnitRequest": {
             "type": "object",
             "properties": {
                 "metadata": {
@@ -19532,7 +19540,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateScheduledTaskRequest": {
+        "UpdateScheduledTaskRequest": {
             "type": "object",
             "required": [
                 "enabled"
@@ -19543,7 +19551,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateSubscriptionLineItemRequest": {
+        "UpdateSubscriptionLineItemRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -19551,14 +19559,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "commitment_amount": {
                     "description": "Commitment fields",
                     "type": "number"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "number"
@@ -19570,7 +19578,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -19590,7 +19598,7 @@ const docTemplate = `{
                     "description": "TierMode determines how to calculate the price for a given quantity",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                            "$ref": "#/definitions/types.BillingTier"
                         }
                     ]
                 },
@@ -19598,7 +19606,7 @@ const docTemplate = `{
                     "description": "Tiers determines the pricing tiers for this line item",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -19611,7 +19619,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateSubscriptionRequest": {
+        "UpdateSubscriptionRequest": {
             "type": "object",
             "properties": {
                 "cancel_at": {
@@ -19625,22 +19633,22 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 }
             }
         },
-        "dto.UpdateTaskStatusRequest": {
+        "UpdateTaskStatusRequest": {
             "type": "object",
             "required": [
                 "task_status"
             ],
             "properties": {
                 "task_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskStatus"
+                    "$ref": "#/definitions/types.TaskStatus"
                 }
             }
         },
-        "dto.UpdateTaxRateRequest": {
+        "UpdateTaxRateRequest": {
             "type": "object",
             "properties": {
                 "code": {
@@ -19666,17 +19674,17 @@ const docTemplate = `{
                     "description": "tax_rate_type determines how the tax is calculated (\"percentage\" or \"fixed\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateStatus"
+                            "$ref": "#/definitions/types.TaxRateStatus"
                         }
                     ]
                 }
             }
         },
-        "dto.UpdateTenantRequest": {
+        "UpdateTenantRequest": {
             "type": "object",
             "properties": {
                 "billing_details": {
-                    "$ref": "#/definitions/dto.TenantBillingDetails"
+                    "$ref": "#/definitions/TenantBillingDetails"
                 },
                 "metadata": {
                     "$ref": "#/definitions/types.Metadata"
@@ -19686,17 +19694,17 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UpdateWalletRequest": {
+        "UpdateWalletRequest": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "auto_topup": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig"
+                    "$ref": "#/definitions/types.WalletConfig"
                 },
                 "description": {
                     "type": "string"
@@ -19709,7 +19717,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UsageAnalyticItem": {
+        "UsageAnalyticItem": {
             "type": "object",
             "properties": {
                 "add_on_id": {
@@ -19719,15 +19727,15 @@ const docTemplate = `{
                     "description": "Full addon object (only if expand includes \"addon\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_addon.Addon"
+                            "$ref": "#/definitions/Addon"
                         }
                     ]
                 },
                 "aggregation_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 },
                 "commitment_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "currency": {
                     "type": "string"
@@ -19743,7 +19751,7 @@ const docTemplate = `{
                     "description": "Full feature object (only if expand includes \"feature\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_feature.Feature"
+                            "$ref": "#/definitions/Feature"
                         }
                     ]
                 },
@@ -19777,7 +19785,7 @@ const docTemplate = `{
                     "description": "Full plan object (only if expand includes \"plan\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_plan.Plan"
+                            "$ref": "#/definitions/Plan"
                         }
                     ]
                 },
@@ -19787,14 +19795,14 @@ const docTemplate = `{
                 "points": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageAnalyticPoint"
+                        "$ref": "#/definitions/UsageAnalyticPoint"
                     }
                 },
                 "price": {
                     "description": "Full price object (only if expand includes \"price\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     ]
                 },
@@ -19813,7 +19821,7 @@ const docTemplate = `{
                     "description": "Present when total_usage_display is set (unit_singular, unit_plural, conversion_rate)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                            "$ref": "#/definitions/types.ReportingUnit"
                         }
                     ]
                 },
@@ -19863,13 +19871,13 @@ const docTemplate = `{
                     "description": "Window size for bucketed meters (only set if meter is bucketed)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                            "$ref": "#/definitions/types.WindowSize"
                         }
                     ]
                 }
             }
         },
-        "dto.UsageAnalyticPoint": {
+        "UsageAnalyticPoint": {
             "type": "object",
             "properties": {
                 "computed_commitment_utilized_amount": {
@@ -19897,7 +19905,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UsageBreakdownItem": {
+        "UsageBreakdownItem": {
             "type": "object",
             "properties": {
                 "cost": {
@@ -19925,7 +19933,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UsageResult": {
+        "UsageResult": {
             "type": "object",
             "properties": {
                 "value": {
@@ -19936,7 +19944,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.UserResponse": {
+        "UserResponse": {
             "type": "object",
             "properties": {
                 "email": {
@@ -19953,24 +19961,24 @@ const docTemplate = `{
                     }
                 },
                 "tenant": {
-                    "$ref": "#/definitions/dto.TenantResponse"
+                    "$ref": "#/definitions/TenantResponse"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                    "$ref": "#/definitions/types.UserType"
                 }
             }
         },
-        "dto.WalletBalanceResponse": {
+        "WalletBalanceResponse": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "alert_state": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "auto_topup": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "balance": {
                     "type": "string"
@@ -19979,7 +19987,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig"
+                    "$ref": "#/definitions/types.WalletConfig"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -19995,7 +20003,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "credits_available_breakdown": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditBreakdown"
+                    "$ref": "#/definitions/types.CreditBreakdown"
                 },
                 "currency": {
                     "type": "string"
@@ -20028,7 +20036,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20047,30 +20055,30 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "wallet_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus"
+                    "$ref": "#/definitions/types.WalletStatus"
                 },
                 "wallet_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletType"
+                    "$ref": "#/definitions/types.WalletType"
                 }
             }
         },
-        "dto.WalletResponse": {
+        "WalletResponse": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "alert_state": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "auto_topup": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "balance": {
                     "type": "string"
                 },
                 "config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig"
+                    "$ref": "#/definitions/types.WalletConfig"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -20086,7 +20094,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "credits_available_breakdown": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditBreakdown"
+                    "$ref": "#/definitions/types.CreditBreakdown"
                 },
                 "currency": {
                     "type": "string"
@@ -20110,7 +20118,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20126,14 +20134,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "wallet_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus"
+                    "$ref": "#/definitions/types.WalletStatus"
                 },
                 "wallet_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletType"
+                    "$ref": "#/definitions/types.WalletType"
                 }
             }
         },
-        "dto.WalletTransactionResponse": {
+        "WalletTransactionResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -20150,7 +20158,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "created_by_user": {
-                    "$ref": "#/definitions/dto.UserResponse"
+                    "$ref": "#/definitions/UserResponse"
                 },
                 "credit_amount": {
                     "type": "string"
@@ -20168,7 +20176,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "type": "string"
@@ -20198,10 +20206,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "reference_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletTxReferenceType"
+                    "$ref": "#/definitions/types.WalletTxReferenceType"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20211,13 +20219,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "transaction_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason"
+                    "$ref": "#/definitions/types.TransactionReason"
                 },
                 "transaction_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionStatus"
+                    "$ref": "#/definitions/types.TransactionStatus"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionType"
+                    "$ref": "#/definitions/types.TransactionType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -20226,14 +20234,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 },
                 "wallet_id": {
                     "type": "string"
                 }
             }
         },
-        "dto.WorkflowExecutionDTO": {
+        "WorkflowExecutionDTO": {
             "type": "object",
             "properties": {
                 "close_time": {
@@ -20276,7 +20284,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_addon.Addon": {
+        "Addon": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -20305,13 +20313,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -20321,14 +20329,14 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_coupon.Coupon": {
+        "Coupon": {
             "type": "object",
             "properties": {
                 "amount_off": {
                     "type": "string"
                 },
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence"
+                    "$ref": "#/definitions/types.CouponCadence"
                 },
                 "created_at": {
                     "type": "string"
@@ -20374,7 +20382,7 @@ const docTemplate = `{
                     "additionalProperties": true
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20383,7 +20391,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -20393,7 +20401,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_customer.Customer": {
+        "Customer": {
             "type": "object",
             "properties": {
                 "address_city": {
@@ -20454,7 +20462,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20467,11 +20475,11 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_feature.Feature": {
+        "Feature": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "created_at": {
                     "type": "string"
@@ -20512,16 +20520,16 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -20537,7 +20545,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_plan.Plan": {
+        "Plan": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -20568,7 +20576,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20581,7 +20589,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_errors.ErrorResponse": {
+        "errors.ErrorResponse": {
             "type": "object",
             "properties": {
                 "code": {
@@ -20612,7 +20620,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AddonAssociationEntityType": {
+        "types.AddonAssociationEntityType": {
             "type": "string",
             "enum": [
                 "subscription",
@@ -20625,7 +20633,7 @@ const docTemplate = `{
                 "AddonAssociationEntityTypeAddon"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AddonFilter": {
+        "types.AddonFilter": {
             "type": "object",
             "properties": {
                 "addon_ids": {
@@ -20635,7 +20643,7 @@ const docTemplate = `{
                     }
                 },
                 "addon_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "end_time": {
                     "type": "string"
@@ -20647,7 +20655,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -20675,18 +20683,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AddonStatus": {
+        "types.AddonStatus": {
             "type": "string",
             "enum": [
                 "active",
@@ -20699,7 +20707,7 @@ const docTemplate = `{
                 "AddonStatusPaused"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AddonType": {
+        "types.AddonType": {
             "type": "string",
             "enum": [
                 "onetime",
@@ -20710,7 +20718,7 @@ const docTemplate = `{
                 "AddonTypeMultipleInstance"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AggregationType": {
+        "types.AggregationType": {
             "type": "string",
             "enum": [
                 "COUNT",
@@ -20736,7 +20744,7 @@ const docTemplate = `{
                 "AggregationWeightedSum"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertCondition": {
+        "types.AlertCondition": {
             "type": "string",
             "enum": [
                 "above",
@@ -20747,7 +20755,7 @@ const docTemplate = `{
                 "AlertConditionBelow"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertEntityType": {
+        "types.AlertEntityType": {
             "type": "string",
             "enum": [
                 "wallet",
@@ -20758,11 +20766,11 @@ const docTemplate = `{
                 "AlertEntityTypeFeature"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertInfo": {
+        "types.AlertInfo": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "timestamp": {
                     "type": "string"
@@ -20772,14 +20780,14 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertLogFilter": {
+        "types.AlertLogFilter": {
             "type": "object",
             "properties": {
                 "alert_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "alert_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertType"
+                    "$ref": "#/definitions/types.AlertType"
                 },
                 "customer_id": {
                     "type": "string"
@@ -20791,7 +20799,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertEntityType"
+                    "$ref": "#/definitions/types.AlertEntityType"
                 },
                 "expand": {
                     "type": "string"
@@ -20800,7 +20808,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -20822,35 +20830,35 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertSettings": {
+        "types.AlertSettings": {
             "type": "object",
             "properties": {
                 "alert_enabled": {
                     "type": "boolean"
                 },
                 "critical": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold"
+                    "$ref": "#/definitions/types.AlertThreshold"
                 },
                 "info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold"
+                    "$ref": "#/definitions/types.AlertThreshold"
                 },
                 "warning": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold"
+                    "$ref": "#/definitions/types.AlertThreshold"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertState": {
+        "types.AlertState": {
             "type": "string",
             "enum": [
                 "ok",
@@ -20865,18 +20873,18 @@ const docTemplate = `{
                 "AlertStateInAlarm"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertThreshold": {
+        "types.AlertThreshold": {
             "type": "object",
             "properties": {
                 "condition": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertCondition"
+                    "$ref": "#/definitions/types.AlertCondition"
                 },
                 "threshold": {
                     "type": "number"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertType": {
+        "types.AlertType": {
             "type": "string",
             "enum": [
                 "low_ongoing_balance",
@@ -20889,7 +20897,7 @@ const docTemplate = `{
                 "AlertTypeFeatureWalletBalance"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ApplicationStatus": {
+        "types.ApplicationStatus": {
             "type": "string",
             "enum": [
                 "applied",
@@ -20906,7 +20914,7 @@ const docTemplate = `{
                 "ApplicationStatusCancelled"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AutoTopup": {
+        "types.AutoTopup": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -20923,7 +20931,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.BillingCadence": {
+        "types.BillingCadence": {
             "type": "string",
             "enum": [
                 "RECURRING",
@@ -20934,7 +20942,7 @@ const docTemplate = `{
                 "BILLING_CADENCE_ONETIME"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingCycle": {
+        "types.BillingCycle": {
             "type": "string",
             "enum": [
                 "anniversary",
@@ -20945,7 +20953,7 @@ const docTemplate = `{
                 "BillingCycleCalendar"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingModel": {
+        "types.BillingModel": {
             "type": "string",
             "enum": [
                 "FLAT_FEE",
@@ -20958,7 +20966,7 @@ const docTemplate = `{
                 "BILLING_MODEL_TIERED"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingPeriod": {
+        "types.BillingPeriod": {
             "type": "string",
             "enum": [
                 "MONTHLY",
@@ -20977,7 +20985,7 @@ const docTemplate = `{
                 "BILLING_PERIOD_HALF_YEAR"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingTier": {
+        "types.BillingTier": {
             "type": "string",
             "enum": [
                 "VOLUME",
@@ -20988,7 +20996,7 @@ const docTemplate = `{
                 "BILLING_TIER_SLAB"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CancelImmediatelyInvoicePolicy": {
+        "types.CancelImmediatelyInvoicePolicy": {
             "type": "string",
             "enum": [
                 "generate_invoice",
@@ -20999,7 +21007,7 @@ const docTemplate = `{
                 "CancelImmediatelyInvoicePolicySkip"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CancellationType": {
+        "types.CancellationType": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -21012,7 +21020,7 @@ const docTemplate = `{
                 "CancellationTypeScheduledDate"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CollectionMethod": {
+        "types.CollectionMethod": {
             "type": "string",
             "enum": [
                 "charge_automatically",
@@ -21023,7 +21031,7 @@ const docTemplate = `{
                 "CollectionMethodSendInvoice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CommitmentInfo": {
+        "types.CommitmentInfo": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -21040,7 +21048,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "is_windowed": {
                     "type": "boolean"
@@ -21056,11 +21064,11 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.CommitmentType": {
+        "types.CommitmentType": {
             "type": "string",
             "enum": [
                 "amount",
@@ -21071,7 +21079,7 @@ const docTemplate = `{
                 "COMMITMENT_TYPE_QUANTITY"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CouponCadence": {
+        "types.CouponCadence": {
             "type": "string",
             "enum": [
                 "once",
@@ -21084,7 +21092,7 @@ const docTemplate = `{
                 "CouponCadenceForever"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CouponFilter": {
+        "types.CouponFilter": {
             "type": "object",
             "properties": {
                 "coupon_ids": {
@@ -21099,7 +21107,7 @@ const docTemplate = `{
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -21121,15 +21129,15 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.CouponType": {
+        "types.CouponType": {
             "type": "string",
             "enum": [
                 "fixed",
@@ -21140,7 +21148,7 @@ const docTemplate = `{
                 "CouponTypePercentage"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditBreakdown": {
+        "types.CreditBreakdown": {
             "type": "object",
             "properties": {
                 "free": {
@@ -21151,7 +21159,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantApplicationReason": {
+        "types.CreditGrantApplicationReason": {
             "type": "string",
             "enum": [
                 "first_time_recurring_credit_grant",
@@ -21164,7 +21172,7 @@ const docTemplate = `{
                 "ApplicationReasonOnetimeCreditGrant"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantCadence": {
+        "types.CreditGrantCadence": {
             "type": "string",
             "enum": [
                 "ONETIME",
@@ -21175,7 +21183,7 @@ const docTemplate = `{
                 "CreditGrantCadenceRecurring"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit": {
+        "types.CreditGrantExpiryDurationUnit": {
             "type": "string",
             "enum": [
                 "DAY",
@@ -21190,7 +21198,7 @@ const docTemplate = `{
                 "CreditGrantExpiryDurationUnitYears"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType": {
+        "types.CreditGrantExpiryType": {
             "type": "string",
             "enum": [
                 "NEVER",
@@ -21203,7 +21211,7 @@ const docTemplate = `{
                 "CreditGrantExpiryTypeBillingCycle"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantPeriod": {
+        "types.CreditGrantPeriod": {
             "type": "string",
             "enum": [
                 "DAILY",
@@ -21222,7 +21230,7 @@ const docTemplate = `{
                 "CREDIT_GRANT_PERIOD_HALF_YEARLY"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantScope": {
+        "types.CreditGrantScope": {
             "type": "string",
             "enum": [
                 "PLAN",
@@ -21233,7 +21241,7 @@ const docTemplate = `{
                 "CreditGrantScopeSubscription"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditNoteReason": {
+        "types.CreditNoteReason": {
             "type": "string",
             "enum": [
                 "DUPLICATE",
@@ -21254,7 +21262,7 @@ const docTemplate = `{
                 "CreditNoteReasonSubscriptionCancellation"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditNoteStatus": {
+        "types.CreditNoteStatus": {
             "type": "string",
             "enum": [
                 "DRAFT",
@@ -21267,7 +21275,7 @@ const docTemplate = `{
                 "CreditNoteStatusVoided"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditNoteType": {
+        "types.CreditNoteType": {
             "type": "string",
             "enum": [
                 "ADJUSTMENT",
@@ -21278,7 +21286,7 @@ const docTemplate = `{
                 "CreditNoteTypeRefund"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CustomerFilter": {
+        "types.CustomerFilter": {
             "type": "object",
             "properties": {
                 "customer_ids": {
@@ -21308,7 +21316,7 @@ const docTemplate = `{
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -21330,18 +21338,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.DataType": {
+        "types.DataType": {
             "type": "string",
             "enum": [
                 "string",
@@ -21356,7 +21364,7 @@ const docTemplate = `{
                 "DataTypeArray"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.DebugTrackerStatus": {
+        "types.DebugTrackerStatus": {
             "type": "string",
             "enum": [
                 "unprocessed",
@@ -21371,7 +21379,7 @@ const docTemplate = `{
                 "DebugTrackerStatusError"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EntitlementEntityType": {
+        "types.EntitlementEntityType": {
             "type": "string",
             "enum": [
                 "PLAN",
@@ -21384,7 +21392,7 @@ const docTemplate = `{
                 "ENTITLEMENT_ENTITY_TYPE_ADDON"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EntitlementFilter": {
+        "types.EntitlementFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -21397,7 +21405,7 @@ const docTemplate = `{
                     }
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType"
+                    "$ref": "#/definitions/types.EntitlementEntityType"
                 },
                 "expand": {
                     "type": "string"
@@ -21409,13 +21417,13 @@ const docTemplate = `{
                     }
                 },
                 "feature_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "filters": {
                     "description": "Specific filters for entitlements",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "is_enabled": {
@@ -21446,18 +21454,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod": {
+        "types.EntitlementUsageResetPeriod": {
             "type": "string",
             "enum": [
                 "MONTHLY",
@@ -21478,7 +21486,7 @@ const docTemplate = `{
                 "ENTITLEMENT_USAGE_RESET_PERIOD_NEVER"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EntityType": {
+        "types.EntityType": {
             "type": "string",
             "enum": [
                 "EVENTS",
@@ -21493,7 +21501,7 @@ const docTemplate = `{
                 "EntityTypeFeatures"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EventProcessingStatusType": {
+        "types.EventProcessingStatusType": {
             "type": "string",
             "enum": [
                 "processed",
@@ -21506,18 +21514,18 @@ const docTemplate = `{
                 "EventProcessingStatusTypeFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FailurePoint": {
+        "types.FailurePoint": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "failure_point_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FailurePointType"
+                    "$ref": "#/definitions/types.FailurePointType"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.FailurePointType": {
+        "types.FailurePointType": {
             "type": "string",
             "enum": [
                 "customer_lookup",
@@ -21532,7 +21540,7 @@ const docTemplate = `{
                 "FailurePointTypeSubscriptionLineItemLookup"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FeatureFilter": {
+        "types.FeatureFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -21552,7 +21560,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -21592,18 +21600,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.FeatureType": {
+        "types.FeatureType": {
             "type": "string",
             "enum": [
                 "metered",
@@ -21616,7 +21624,7 @@ const docTemplate = `{
                 "FeatureTypeStatic"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FileType": {
+        "types.FileType": {
             "type": "string",
             "enum": [
                 "CSV",
@@ -21627,24 +21635,24 @@ const docTemplate = `{
                 "FileTypeJSON"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FilterCondition": {
+        "types.FilterCondition": {
             "type": "object",
             "properties": {
                 "data_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DataType"
+                    "$ref": "#/definitions/types.DataType"
                 },
                 "field": {
                     "type": "string"
                 },
                 "operator": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterOperatorType"
+                    "$ref": "#/definitions/types.FilterOperatorType"
                 },
                 "value": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Value"
+                    "$ref": "#/definitions/types.Value"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.FilterOperatorType": {
+        "types.FilterOperatorType": {
             "type": "string",
             "enum": [
                 "eq",
@@ -21669,7 +21677,7 @@ const docTemplate = `{
                 "AFTER"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.GroupEntityType": {
+        "types.GroupEntityType": {
             "type": "string",
             "enum": [
                 "price",
@@ -21680,7 +21688,7 @@ const docTemplate = `{
                 "GroupEntityTypeFeature"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.GroupFilter": {
+        "types.GroupFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -21696,7 +21704,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "group_ids": {
@@ -21731,18 +21739,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.IntegrationEntityType": {
+        "types.IntegrationEntityType": {
             "type": "string",
             "enum": [
                 "customer",
@@ -21769,7 +21777,7 @@ const docTemplate = `{
                 "IntegrationEntityTypePrice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceBillingReason": {
+        "types.InvoiceBillingReason": {
             "type": "string",
             "enum": [
                 "SUBSCRIPTION_CREATE",
@@ -21786,7 +21794,7 @@ const docTemplate = `{
                 "InvoiceBillingReasonManual"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceCadence": {
+        "types.InvoiceCadence": {
             "type": "string",
             "enum": [
                 "ARREAR",
@@ -21797,7 +21805,7 @@ const docTemplate = `{
                 "InvoiceCadenceAdvance"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceFilter": {
+        "types.InvoiceFilter": {
             "type": "object",
             "properties": {
                 "amount_due_gt": {
@@ -21825,7 +21833,7 @@ const docTemplate = `{
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "invoice_ids": {
@@ -21839,14 +21847,14 @@ const docTemplate = `{
                     "description": "invoice_status filters by the current state of invoices in their lifecycle\nMultiple statuses can be specified to include invoices in any of the listed states",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus"
+                        "$ref": "#/definitions/types.InvoiceStatus"
                     }
                 },
                 "invoice_type": {
                     "description": "invoice_type filters by the nature of the invoice (SUBSCRIPTION, ONE_OFF, or CREDIT)\nUse this to separate recurring charges from one-time fees or credit adjustments",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType"
+                            "$ref": "#/definitions/types.InvoiceType"
                         }
                     ]
                 },
@@ -21870,7 +21878,7 @@ const docTemplate = `{
                     "description": "payment_status filters by the payment state of invoices\nMultiple statuses can be specified to include invoices with any of the listed payment states",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                        "$ref": "#/definitions/types.PaymentStatus"
                     }
                 },
                 "period_end_gte": {
@@ -21896,14 +21904,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_customer_id": {
+                    "description": "subscription_customer_id filters invoices by the subscription owner's customer ID",
+                    "type": "string"
                 },
                 "subscription_id": {
                     "description": "subscription_id filters invoices generated for a specific subscription\nOnly returns invoices that were created as part of the specified subscription's billing",
@@ -21911,7 +21923,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceStatus": {
+        "types.InvoiceStatus": {
             "type": "string",
             "enum": [
                 "DRAFT",
@@ -21926,7 +21938,7 @@ const docTemplate = `{
                 "InvoiceStatusSkipped"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceType": {
+        "types.InvoiceType": {
             "type": "string",
             "enum": [
                 "SUBSCRIPTION",
@@ -21939,7 +21951,7 @@ const docTemplate = `{
                 "InvoiceTypeCredit"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaginationResponse": {
+        "types.PaginationResponse": {
             "type": "object",
             "properties": {
                 "limit": {
@@ -21953,7 +21965,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PauseMode": {
+        "types.PauseMode": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -21966,7 +21978,7 @@ const docTemplate = `{
                 "PauseModePeriodEnd"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PauseStatus": {
+        "types.PauseStatus": {
             "type": "string",
             "enum": [
                 "none",
@@ -21983,7 +21995,7 @@ const docTemplate = `{
                 "PauseStatusCancelled"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentBehavior": {
+        "types.PaymentBehavior": {
             "type": "string",
             "enum": [
                 "allow_incomplete",
@@ -21998,7 +22010,7 @@ const docTemplate = `{
                 "PaymentBehaviorDefaultActive"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentDestinationType": {
+        "types.PaymentDestinationType": {
             "type": "string",
             "enum": [
                 "INVOICE"
@@ -22007,7 +22019,7 @@ const docTemplate = `{
                 "PaymentDestinationTypeInvoice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentGatewayType": {
+        "types.PaymentGatewayType": {
             "type": "string",
             "enum": [
                 "stripe",
@@ -22024,7 +22036,7 @@ const docTemplate = `{
                 "PaymentGatewayTypePaddle"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentMethodType": {
+        "types.PaymentMethodType": {
             "type": "string",
             "enum": [
                 "CARD",
@@ -22041,7 +22053,7 @@ const docTemplate = `{
                 "PaymentMethodTypePaymentLink"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentStatus": {
+        "types.PaymentStatus": {
             "type": "string",
             "enum": [
                 "INITIATED",
@@ -22064,7 +22076,7 @@ const docTemplate = `{
                 "PaymentStatusPartiallyRefunded"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentTerms": {
+        "types.PaymentTerms": {
             "type": "string",
             "enum": [
                 "15 NET",
@@ -22083,7 +22095,7 @@ const docTemplate = `{
                 "PaymentTerms90Net"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PlanFilter": {
+        "types.PlanFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22096,7 +22108,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22127,18 +22139,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PriceEntityType": {
+        "types.PriceEntityType": {
             "type": "string",
             "enum": [
                 "PLAN",
@@ -22155,7 +22167,7 @@ const docTemplate = `{
                 "PRICE_ENTITY_TYPE_COSTSHEET"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PriceFilter": {
+        "types.PriceFilter": {
             "type": "object",
             "properties": {
                 "allow_expired_prices": {
@@ -22172,7 +22184,7 @@ const docTemplate = `{
                     }
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
+                    "$ref": "#/definitions/types.PriceEntityType"
                 },
                 "expand": {
                     "type": "string"
@@ -22181,7 +22193,7 @@ const docTemplate = `{
                     "description": "DSL filters",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22232,14 +22244,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PriceType": {
+        "types.PriceType": {
             "type": "string",
             "enum": [
                 "USAGE",
@@ -22250,7 +22262,7 @@ const docTemplate = `{
                 "PRICE_TYPE_FIXED"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PriceUnitFilter": {
+        "types.PriceUnitFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22263,7 +22275,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22291,18 +22303,18 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PriceUnitType": {
+        "types.PriceUnitType": {
             "type": "string",
             "enum": [
                 "FIAT",
@@ -22313,7 +22325,7 @@ const docTemplate = `{
                 "PRICE_UNIT_TYPE_CUSTOM"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ProrationBehavior": {
+        "types.ProrationBehavior": {
             "type": "string",
             "enum": [
                 "create_prorations",
@@ -22328,7 +22340,7 @@ const docTemplate = `{
                 "ProrationBehaviorNone"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.QueryFilter": {
+        "types.QueryFilter": {
             "type": "object",
             "properties": {
                 "expand": {
@@ -22354,11 +22366,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.ReportingUnit": {
+        "types.ReportingUnit": {
             "type": "object",
             "properties": {
                 "conversion_rate": {
@@ -22375,7 +22387,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.ResetUsage": {
+        "types.ResetUsage": {
             "type": "string",
             "enum": [
                 "BILLING_PERIOD",
@@ -22386,7 +22398,7 @@ const docTemplate = `{
                 "ResetUsageNever"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ResumeMode": {
+        "types.ResumeMode": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -22399,7 +22411,7 @@ const docTemplate = `{
                 "ResumeModeAuto"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.RoundType": {
+        "types.RoundType": {
             "type": "string",
             "enum": [
                 "up",
@@ -22410,7 +22422,7 @@ const docTemplate = `{
                 "ROUND_DOWN"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.S3CompressionType": {
+        "types.S3CompressionType": {
             "type": "string",
             "enum": [
                 "none",
@@ -22421,7 +22433,7 @@ const docTemplate = `{
                 "S3CompressionTypeGzip"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.S3EncryptionType": {
+        "types.S3EncryptionType": {
             "type": "string",
             "enum": [
                 "AES256",
@@ -22434,7 +22446,7 @@ const docTemplate = `{
                 "S3EncryptionTypeAwsKmsDsse"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.S3JobConfig": {
+        "types.S3JobConfig": {
             "type": "object",
             "properties": {
                 "bucket": {
@@ -22445,7 +22457,7 @@ const docTemplate = `{
                     "description": "Compression type: \"gzip\", \"none\" (default: \"none\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3CompressionType"
+                            "$ref": "#/definitions/types.S3CompressionType"
                         }
                     ]
                 },
@@ -22453,7 +22465,7 @@ const docTemplate = `{
                     "description": "Encryption type: \"AES256\", \"aws:kms\", \"aws:kms:dsse\" (default: \"AES256\")",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3EncryptionType"
+                            "$ref": "#/definitions/types.S3EncryptionType"
                         }
                     ]
                 },
@@ -22475,7 +22487,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduleStatus": {
+        "types.ScheduleStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -22492,7 +22504,7 @@ const docTemplate = `{
                 "ScheduleStatusFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduleType": {
+        "types.ScheduleType": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -22503,7 +22515,7 @@ const docTemplate = `{
                 "ScheduleTypePeriodEnd"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType": {
+        "types.ScheduledTaskEntityType": {
             "type": "string",
             "enum": [
                 "events",
@@ -22518,7 +22530,7 @@ const docTemplate = `{
                 "ScheduledTaskEntityTypeCreditUsage"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval": {
+        "types.ScheduledTaskInterval": {
             "type": "string",
             "enum": [
                 "15MIN",
@@ -22538,7 +22550,7 @@ const docTemplate = `{
                 "ScheduledTaskIntervalDaily"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SecretProvider": {
+        "types.SecretProvider": {
             "type": "string",
             "enum": [
                 "flexprice",
@@ -22565,7 +22577,7 @@ const docTemplate = `{
                 "SecretProviderPaddle"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SecretType": {
+        "types.SecretType": {
             "type": "string",
             "enum": [
                 "private_key",
@@ -22578,18 +22590,18 @@ const docTemplate = `{
                 "SecretTypeIntegration"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SortCondition": {
+        "types.SortCondition": {
             "type": "object",
             "properties": {
                 "direction": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortDirection"
+                    "$ref": "#/definitions/types.SortDirection"
                 },
                 "field": {
                     "type": "string"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.SortDirection": {
+        "types.SortDirection": {
             "type": "string",
             "enum": [
                 "asc",
@@ -22600,7 +22612,7 @@ const docTemplate = `{
                 "SortDirectionDesc"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.Status": {
+        "types.Status": {
             "type": "string",
             "enum": [
                 "published",
@@ -22613,7 +22625,7 @@ const docTemplate = `{
                 "StatusArchived"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionChangeType": {
+        "types.SubscriptionChangeType": {
             "type": "string",
             "enum": [
                 "upgrade",
@@ -22626,7 +22638,7 @@ const docTemplate = `{
                 "SubscriptionChangeTypeLateral"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionFilter": {
+        "types.SubscriptionFilter": {
             "type": "object",
             "properties": {
                 "active_at": {
@@ -22637,14 +22649,14 @@ const docTemplate = `{
                     "description": "BillingCadence filters by billing cadence",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                        "$ref": "#/definitions/types.BillingCadence"
                     }
                 },
                 "billing_period": {
                     "description": "BillingPeriod filters by billing period",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                        "$ref": "#/definitions/types.BillingPeriod"
                     }
                 },
                 "customer_id": {
@@ -22675,7 +22687,7 @@ const docTemplate = `{
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "invoicing_customer_ids": {
@@ -22715,14 +22727,14 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_ids": {
                     "type": "array",
@@ -22734,7 +22746,7 @@ const docTemplate = `{
                     "description": "SubscriptionStatus filters by subscription status",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                        "$ref": "#/definitions/types.SubscriptionStatus"
                     }
                 },
                 "subscription_type": {
@@ -22750,7 +22762,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType": {
+        "types.SubscriptionLineItemEntityType": {
             "type": "string",
             "enum": [
                 "plan",
@@ -22763,7 +22775,7 @@ const docTemplate = `{
                 "SubscriptionLineItemEntityTypeSubscription"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType": {
+        "types.SubscriptionScheduleChangeType": {
             "type": "string",
             "enum": [
                 "plan_change",
@@ -22774,7 +22786,7 @@ const docTemplate = `{
                 "SubscriptionScheduleChangeTypeCancellation"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionStatus": {
+        "types.SubscriptionStatus": {
             "type": "string",
             "enum": [
                 "active",
@@ -22793,7 +22805,20 @@ const docTemplate = `{
                 "SubscriptionStatusDraft"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaskStatus": {
+        "types.SubscriptionType": {
+            "type": "string",
+            "enum": [
+                "standalone",
+                "parent",
+                "inherited"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionTypeStandalone",
+                "SubscriptionTypeParent",
+                "SubscriptionTypeInherited"
+            ]
+        },
+        "types.TaskStatus": {
             "type": "string",
             "enum": [
                 "PENDING",
@@ -22808,7 +22833,7 @@ const docTemplate = `{
                 "TaskStatusFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaskType": {
+        "types.TaskType": {
             "type": "string",
             "enum": [
                 "IMPORT",
@@ -22819,7 +22844,7 @@ const docTemplate = `{
                 "TaskTypeExport"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateEntityType": {
+        "types.TaxRateEntityType": {
             "type": "string",
             "enum": [
                 "customer",
@@ -22834,7 +22859,7 @@ const docTemplate = `{
                 "TaxRateEntityTypeTenant"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateScope": {
+        "types.TaxRateScope": {
             "type": "string",
             "enum": [
                 "INTERNAL",
@@ -22847,7 +22872,7 @@ const docTemplate = `{
                 "TaxRateScopeOneTime"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateStatus": {
+        "types.TaxRateStatus": {
             "type": "string",
             "enum": [
                 "ACTIVE",
@@ -22858,7 +22883,7 @@ const docTemplate = `{
                 "TaxRateStatusInactive"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateType": {
+        "types.TaxRateType": {
             "type": "string",
             "enum": [
                 "percentage",
@@ -22869,7 +22894,7 @@ const docTemplate = `{
                 "TaxRateTypeFixed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TimeRangeFilter": {
+        "types.TimeRangeFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22880,7 +22905,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.TransactionReason": {
+        "types.TransactionReason": {
             "type": "string",
             "enum": [
                 "INVOICE_PAYMENT",
@@ -22909,7 +22934,7 @@ const docTemplate = `{
                 "TransactionReasonInvoiceVoidRefund"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TransactionStatus": {
+        "types.TransactionStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -22922,7 +22947,7 @@ const docTemplate = `{
                 "TransactionStatusFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TransactionType": {
+        "types.TransactionType": {
             "type": "string",
             "enum": [
                 "credit",
@@ -22933,7 +22958,7 @@ const docTemplate = `{
                 "TransactionTypeDebit"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.UserFilter": {
+        "types.UserFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22946,7 +22971,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22974,14 +22999,14 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "type": {
                     "enum": [
@@ -22990,7 +23015,7 @@ const docTemplate = `{
                     ],
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                            "$ref": "#/definitions/types.UserType"
                         }
                     ]
                 },
@@ -23003,7 +23028,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.UserType": {
+        "types.UserType": {
             "type": "string",
             "enum": [
                 "user",
@@ -23014,7 +23039,7 @@ const docTemplate = `{
                 "UserTypeServiceAccount"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.Value": {
+        "types.Value": {
             "type": "object",
             "properties": {
                 "array": {
@@ -23037,19 +23062,19 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletConfig": {
+        "types.WalletConfig": {
             "type": "object",
             "properties": {
                 "allowed_price_types": {
                     "description": "AllowedPriceTypes is a list of price types that are allowed for the wallet\nnil means all price types are allowed",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfigPriceType"
+                        "$ref": "#/definitions/types.WalletConfigPriceType"
                     }
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletConfigPriceType": {
+        "types.WalletConfigPriceType": {
             "type": "string",
             "enum": [
                 "ALL",
@@ -23062,7 +23087,7 @@ const docTemplate = `{
                 "WalletConfigPriceTypeFixed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WalletFilter": {
+        "types.WalletFilter": {
             "type": "object",
             "properties": {
                 "alert_enabled": {
@@ -23091,7 +23116,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus"
+                    "$ref": "#/definitions/types.WalletStatus"
                 },
                 "wallet_ids": {
                     "type": "array",
@@ -23101,7 +23126,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletStatus": {
+        "types.WalletStatus": {
             "type": "string",
             "enum": [
                 "active",
@@ -23114,7 +23139,7 @@ const docTemplate = `{
                 "WalletStatusClosed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WalletTransactionFilter": {
+        "types.WalletTransactionFilter": {
             "type": "object",
             "properties": {
                 "created_by": {
@@ -23139,7 +23164,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "id": {
@@ -23173,27 +23198,27 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "transaction_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason"
+                    "$ref": "#/definitions/types.TransactionReason"
                 },
                 "transaction_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionStatus"
+                    "$ref": "#/definitions/types.TransactionStatus"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionType"
+                    "$ref": "#/definitions/types.TransactionType"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletTxReferenceType": {
+        "types.WalletTxReferenceType": {
             "type": "string",
             "enum": [
                 "PAYMENT",
@@ -23208,7 +23233,7 @@ const docTemplate = `{
                 "WalletTxReferenceTypeInvoice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WalletType": {
+        "types.WalletType": {
             "type": "string",
             "enum": [
                 "PRE_PAID",
@@ -23219,7 +23244,7 @@ const docTemplate = `{
                 "WalletTypePostPaid"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WebhookEventName": {
+        "types.WebhookEventName": {
             "type": "string",
             "enum": [
                 "subscription.created",
@@ -23310,10 +23335,9 @@ const docTemplate = `{
                 "WebhookEventCreditNoteUpdated"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WindowSize": {
+        "types.WindowSize": {
             "type": "string",
             "enum": [
-                "MONTH",
                 "MINUTE",
                 "15MIN",
                 "30MIN",
@@ -23323,10 +23347,10 @@ const docTemplate = `{
                 "12HOUR",
                 "DAY",
                 "WEEK",
+                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
-                "DefaultWindowSize",
                 "WindowSizeMinute",
                 "WindowSize15Min",
                 "WindowSize30Min",
@@ -23336,10 +23360,11 @@ const docTemplate = `{
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth"
+                "WindowSizeMonth",
+                "DefaultWindowSize"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WorkflowExecutionFilter": {
+        "types.WorkflowExecutionFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -23360,7 +23385,7 @@ const docTemplate = `{
                     "description": "filters allows complex filtering based on multiple fields (same as FeatureFilter)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -23382,14 +23407,14 @@ const docTemplate = `{
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "task_queue": {
                     "type": "string"
@@ -23417,7 +23442,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.GroupEntityType"
+                    "$ref": "#/definitions/types.GroupEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -23438,7 +23463,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -23458,7 +23483,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "commitment_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "created_at": {
                     "type": "string"
@@ -23539,7 +23564,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -23562,7 +23587,7 @@ const docTemplate = `{
                     "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                            "$ref": "#/definitions/types.WindowSize"
                         }
                     ]
                 },
@@ -23583,7 +23608,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 }
             }
         },
@@ -23647,12 +23672,12 @@ const docTemplate = `{
                     "description": "ResetUsage defines whether the usage should be reset periodically or not\nFor ex meters tracking total storage used do not get reset but meters tracking\ntotal API requests do.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage"
+                            "$ref": "#/definitions/types.ResetUsage"
                         }
                     ]
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -23705,7 +23730,7 @@ const docTemplate = `{
                     "description": "up or down",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.RoundType"
+                            "$ref": "#/definitions/types.RoundType"
                         }
                     ]
                 }
@@ -23719,13 +23744,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
@@ -23774,7 +23799,7 @@ const docTemplate = `{
                     "description": "EntityType holds the value of the \"entity_type\" field.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
+                            "$ref": "#/definitions/types.PriceEntityType"
                         }
                     ]
                 },
@@ -23791,7 +23816,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "description": "LookupKey used for looking up the price in the database",
@@ -23836,7 +23861,7 @@ const docTemplate = `{
                     "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
+                            "$ref": "#/definitions/types.PriceUnitType"
                         }
                     ]
                 },
@@ -23845,13 +23870,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
@@ -23867,7 +23892,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -23905,7 +23930,7 @@ const docTemplate = `{
                     "description": "up or down",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.RoundType"
+                            "$ref": "#/definitions/types.RoundType"
                         }
                     ]
                 }
@@ -23915,7 +23940,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "from price at create; default 1",
@@ -23926,7 +23951,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "string"
@@ -23938,7 +23963,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -23965,7 +23990,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType"
+                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -23974,7 +23999,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "metadata": {
                     "type": "object",
@@ -23998,7 +24023,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "price_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "price_unit": {
                     "type": "string"
@@ -24013,7 +24038,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -24068,28 +24093,28 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "pause_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode"
+                    "$ref": "#/definitions/types.PauseMode"
                 },
                 "pause_start": {
                     "description": "PauseStart is when the pause actually started",
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "reason": {
                     "description": "Reason is the reason for pausing",
                     "type": "string"
                 },
                 "resume_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode"
+                    "$ref": "#/definitions/types.ResumeMode"
                 },
                 "resumed_at": {
                     "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -24140,7 +24165,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -24163,11 +24188,11 @@ const docTemplate = `{
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.WalletResponse"
+                        "$ref": "#/definitions/WalletResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -24176,19 +24201,6 @@ const docTemplate = `{
             "additionalProperties": {
                 "type": "string"
             }
-        },
-        "types.SubscriptionType": {
-            "type": "string",
-            "enum": [
-                "standalone",
-                "parent",
-                "inherited"
-            ],
-            "x-enum-varnames": [
-                "SubscriptionTypeStandalone",
-                "SubscriptionTypeParent",
-                "SubscriptionTypeInherited"
-            ]
         },
         "webhookDto.AlertWebhookPayload": {
             "type": "object",
@@ -24200,16 +24212,16 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         },
@@ -24217,10 +24229,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "invoice": {
-                    "$ref": "#/definitions/dto.InvoiceResponse"
+                    "$ref": "#/definitions/InvoiceResponse"
                 }
             }
         },
@@ -24228,10 +24240,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "credit_note": {
-                    "$ref": "#/definitions/dto.CreditNoteResponse"
+                    "$ref": "#/definitions/CreditNoteResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 }
             }
         },
@@ -24239,10 +24251,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 }
             }
         },
@@ -24250,10 +24262,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "entitlement": {
-                    "$ref": "#/definitions/dto.EntitlementResponse"
+                    "$ref": "#/definitions/EntitlementResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 }
             }
         },
@@ -24261,10 +24273,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 }
             }
         },
@@ -24272,10 +24284,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "invoice": {
-                    "$ref": "#/definitions/dto.InvoiceResponse"
+                    "$ref": "#/definitions/InvoiceResponse"
                 }
             }
         },
@@ -24283,10 +24295,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "payment": {
-                    "$ref": "#/definitions/dto.PaymentResponse"
+                    "$ref": "#/definitions/PaymentResponse"
                 }
             }
         },
@@ -24294,10 +24306,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "phase": {
-                    "$ref": "#/definitions/dto.SubscriptionPhaseResponse"
+                    "$ref": "#/definitions/SubscriptionPhaseResponse"
                 }
             }
         },
@@ -24305,10 +24317,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "subscription": {
-                    "$ref": "#/definitions/dto.SubscriptionResponse"
+                    "$ref": "#/definitions/SubscriptionResponse"
                 }
             }
         },
@@ -24316,13 +24328,13 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "transaction": {
-                    "$ref": "#/definitions/dto.WalletTransactionResponse"
+                    "$ref": "#/definitions/WalletTransactionResponse"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         },
@@ -24330,7 +24342,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "alert_type": {
                     "type": "string"
@@ -24353,13 +24365,13 @@ const docTemplate = `{
                     "$ref": "#/definitions/webhookDto.WalletAlertInfo"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         }

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -15280,6 +15280,10 @@
               "$ref": "#/components/schemas/TaxRateResponse"
             }
           },
+          "subscription_customer_id": {
+            "type": "string",
+            "description": "subscription_customer_id is the subscription owner's customer ID when it differs from customer_id (invoicing customer)"
+          },
           "subscription_id": {
             "type": "string",
             "description": "subscription_id is the optional unique identifier of the subscription associated with this invoice"
@@ -18024,6 +18028,10 @@
           },
           "subscription": {
             "$ref": "#/components/schemas/SubscriptionResponse"
+          },
+          "subscription_customer_id": {
+            "type": "string",
+            "description": "subscription_customer_id is the subscription owner's customer ID (Subscription.CustomerID).\nIt may differ from customer_id when the subscription uses an invoicing customer."
           },
           "subscription_id": {
             "type": "string",
@@ -23581,6 +23589,10 @@
           "status": {
             "$ref": "#/components/schemas/types.Status"
           },
+          "subscription_customer_id": {
+            "type": "string",
+            "description": "subscription_customer_id filters invoices by the subscription owner's customer ID"
+          },
           "subscription_id": {
             "type": "string",
             "description": "subscription_id filters invoices generated for a specific subscription\nOnly returns invoices that were created as part of the specified subscription's billing"
@@ -24508,6 +24520,20 @@
           "SubscriptionStatusDraft"
         ],
         "x-speakeasy-name-override": "SubscriptionStatus"
+      },
+      "types.SubscriptionType": {
+        "type": "string",
+        "enum": [
+          "standalone",
+          "parent",
+          "inherited"
+        ],
+        "x-enum-varnames": [
+          "SubscriptionTypeStandalone",
+          "SubscriptionTypeParent",
+          "SubscriptionTypeInherited"
+        ],
+        "x-speakeasy-name-override": "SubscriptionType"
       },
       "types.TaskStatus": {
         "type": "string",
@@ -25903,20 +25929,6 @@
           "type": "string"
         },
         "x-speakeasy-name-override": "Metadata"
-      },
-      "types.SubscriptionType": {
-        "type": "string",
-        "enum": [
-          "standalone",
-          "parent",
-          "inherited"
-        ],
-        "x-enum-varnames": [
-          "SubscriptionTypeStandalone",
-          "SubscriptionTypeParent",
-          "SubscriptionTypeInherited"
-        ],
-        "x-speakeasy-name-override": "SubscriptionType"
       },
       "webhookDto.AlertWebhookPayload": {
         "type": "object",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -44,7 +44,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAddonRequest"
+                            "$ref": "#/definitions/CreateAddonRequest"
                         }
                     }
                 ],
@@ -52,19 +52,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAddonResponse"
+                            "$ref": "#/definitions/CreateAddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -99,19 +99,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonResponse"
+                            "$ref": "#/definitions/AddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -143,7 +143,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonFilter"
+                            "$ref": "#/definitions/types.AddonFilter"
                         }
                     }
                 ],
@@ -157,13 +157,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -198,19 +198,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonResponse"
+                            "$ref": "#/definitions/AddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -247,7 +247,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateAddonRequest"
+                            "$ref": "#/definitions/UpdateAddonRequest"
                         }
                     }
                 ],
@@ -255,19 +255,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonResponse"
+                            "$ref": "#/definitions/AddonResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -300,19 +300,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -353,19 +353,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -397,7 +397,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertLogFilter"
+                            "$ref": "#/definitions/types.AlertLogFilter"
                         }
                     }
                 ],
@@ -405,19 +405,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListAlertLogsResponse"
+                            "$ref": "#/definitions/ListAlertLogsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -449,7 +449,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCostsheetRequest"
+                            "$ref": "#/definitions/CreateCostsheetRequest"
                         }
                     }
                 ],
@@ -457,25 +457,25 @@
                     "201": {
                         "description": "Created costsheet",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCostsheetResponse"
+                            "$ref": "#/definitions/CreateCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -501,19 +501,19 @@
                     "200": {
                         "description": "Active costsheet",
                         "schema": {
-                            "$ref": "#/definitions/dto.CostsheetResponse"
+                            "$ref": "#/definitions/CostsheetResponse"
                         }
                     },
                     "404": {
                         "description": "No active costsheet",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -545,7 +545,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCostAnalyticsRequest"
+                            "$ref": "#/definitions/GetCostAnalyticsRequest"
                         }
                     }
                 ],
@@ -553,19 +553,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetDetailedCostAnalyticsResponse"
+                            "$ref": "#/definitions/GetDetailedCostAnalyticsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -597,7 +597,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCostAnalyticsRequest"
+                            "$ref": "#/definitions/GetCostAnalyticsRequest"
                         }
                     }
                 ],
@@ -605,19 +605,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetDetailedCostAnalyticsResponse"
+                            "$ref": "#/definitions/GetDetailedCostAnalyticsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -657,19 +657,19 @@
                     "200": {
                         "description": "Paginated costsheets",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListCostsheetResponse"
+                            "$ref": "#/definitions/ListCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -710,25 +710,25 @@
                     "200": {
                         "description": "Costsheet details",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetCostsheetResponse"
+                            "$ref": "#/definitions/GetCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Costsheet not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -765,7 +765,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCostsheetRequest"
+                            "$ref": "#/definitions/UpdateCostsheetRequest"
                         }
                     }
                 ],
@@ -773,31 +773,31 @@
                     "200": {
                         "description": "Updated costsheet",
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCostsheetResponse"
+                            "$ref": "#/definitions/UpdateCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Costsheet not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -833,25 +833,25 @@
                     "200": {
                         "description": "Costsheet deleted",
                         "schema": {
-                            "$ref": "#/definitions/dto.DeleteCostsheetResponse"
+                            "$ref": "#/definitions/DeleteCostsheetResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Costsheet not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -886,7 +886,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCouponRequest"
+                            "$ref": "#/definitions/CreateCouponRequest"
                         }
                     }
                 ],
@@ -894,37 +894,37 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CouponResponse"
+                            "$ref": "#/definitions/CouponResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -956,7 +956,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponFilter"
+                            "$ref": "#/definitions/types.CouponFilter"
                         }
                     }
                 ],
@@ -970,13 +970,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1011,25 +1011,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CouponResponse"
+                            "$ref": "#/definitions/CouponResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1069,7 +1069,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCouponRequest"
+                            "$ref": "#/definitions/UpdateCouponRequest"
                         }
                     }
                 ],
@@ -1077,37 +1077,37 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CouponResponse"
+                            "$ref": "#/definitions/CouponResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1155,31 +1155,31 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1211,7 +1211,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCreditGrantRequest"
+                            "$ref": "#/definitions/CreateCreditGrantRequest"
                         }
                     }
                 ],
@@ -1219,19 +1219,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditGrantResponse"
+                            "$ref": "#/definitions/CreditGrantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1266,19 +1266,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditGrantResponse"
+                            "$ref": "#/definitions/CreditGrantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1315,7 +1315,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCreditGrantRequest"
+                            "$ref": "#/definitions/UpdateCreditGrantRequest"
                         }
                     }
                 ],
@@ -1323,19 +1323,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditGrantResponse"
+                            "$ref": "#/definitions/CreditGrantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1371,7 +1371,7 @@
                         "name": "body",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/dto.DeleteCreditGrantRequest"
+                            "$ref": "#/definitions/DeleteCreditGrantRequest"
                         }
                     }
                 ],
@@ -1379,19 +1379,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1426,7 +1426,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCreditNoteRequest"
+                            "$ref": "#/definitions/CreateCreditNoteRequest"
                         }
                     }
                 ],
@@ -1434,37 +1434,37 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1499,25 +1499,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error\" \"Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1558,37 +1558,37 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1629,37 +1629,37 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreditNoteResponse"
+                            "$ref": "#/definitions/CreditNoteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1703,7 +1703,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateCustomerRequest"
+                            "$ref": "#/definitions/UpdateCustomerRequest"
                         }
                     }
                 ],
@@ -1711,19 +1711,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1753,7 +1753,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateCustomerRequest"
+                            "$ref": "#/definitions/CreateCustomerRequest"
                         }
                     }
                 ],
@@ -1761,19 +1761,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -1809,25 +1809,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -1859,7 +1859,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CustomerFilter"
+                            "$ref": "#/definitions/types.CustomerFilter"
                         }
                     }
                 ],
@@ -1873,13 +1873,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -1948,19 +1948,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerUsageSummaryResponse"
+                            "$ref": "#/definitions/CustomerUsageSummaryResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2026,26 +2026,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.WalletResponse"
+                                "$ref": "#/definitions/WalletResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2080,19 +2080,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerResponse"
+                            "$ref": "#/definitions/CustomerResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -2132,13 +2132,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2173,19 +2173,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerEntitlementsResponse"
+                            "$ref": "#/definitions/CustomerEntitlementsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2226,19 +2226,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2276,19 +2276,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CustomerMultiCurrencyInvoiceSummary"
+                            "$ref": "#/definitions/CustomerMultiCurrencyInvoiceSummary"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2328,20 +2328,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.WalletResponse"
+                                "$ref": "#/definitions/WalletResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2373,7 +2373,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateEntitlementRequest"
+                            "$ref": "#/definitions/CreateEntitlementRequest"
                         }
                     }
                 ],
@@ -2381,19 +2381,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.EntitlementResponse"
+                            "$ref": "#/definitions/EntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2425,7 +2425,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkEntitlementRequest"
+                            "$ref": "#/definitions/CreateBulkEntitlementRequest"
                         }
                     }
                 ],
@@ -2433,19 +2433,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkEntitlementResponse"
+                            "$ref": "#/definitions/CreateBulkEntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2477,7 +2477,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementFilter"
+                            "$ref": "#/definitions/types.EntitlementFilter"
                         }
                     }
                 ],
@@ -2491,13 +2491,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2532,19 +2532,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.EntitlementResponse"
+                            "$ref": "#/definitions/EntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2581,7 +2581,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateEntitlementRequest"
+                            "$ref": "#/definitions/UpdateEntitlementRequest"
                         }
                     }
                 ],
@@ -2589,19 +2589,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.EntitlementResponse"
+                            "$ref": "#/definitions/EntitlementResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2637,19 +2637,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2681,7 +2681,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.IngestEventRequest"
+                            "$ref": "#/definitions/IngestEventRequest"
                         }
                     }
                 ],
@@ -2698,13 +2698,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2736,7 +2736,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageAnalyticsRequest"
+                            "$ref": "#/definitions/GetUsageAnalyticsRequest"
                         }
                     }
                 ],
@@ -2744,19 +2744,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageAnalyticsResponse"
+                            "$ref": "#/definitions/GetUsageAnalyticsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2788,7 +2788,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.BulkIngestEventRequest"
+                            "$ref": "#/definitions/BulkIngestEventRequest"
                         }
                     }
                 ],
@@ -2805,13 +2805,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2837,13 +2837,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetHuggingFaceBillingDataResponse"
+                            "$ref": "#/definitions/GetHuggingFaceBillingDataResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2875,7 +2875,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetEventsRequest"
+                            "$ref": "#/definitions/GetEventsRequest"
                         }
                     }
                 ],
@@ -2883,19 +2883,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetEventsResponse"
+                            "$ref": "#/definitions/GetEventsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2927,7 +2927,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageRequest"
+                            "$ref": "#/definitions/GetUsageRequest"
                         }
                     }
                 ],
@@ -2935,19 +2935,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageResponse"
+                            "$ref": "#/definitions/GetUsageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -2979,7 +2979,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageByMeterRequest"
+                            "$ref": "#/definitions/GetUsageByMeterRequest"
                         }
                     }
                 ],
@@ -2987,25 +2987,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageResponse"
+                            "$ref": "#/definitions/GetUsageResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3040,19 +3040,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetEventByIDResponse"
+                            "$ref": "#/definitions/GetEventByIDResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3084,7 +3084,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateFeatureRequest"
+                            "$ref": "#/definitions/CreateFeatureRequest"
                         }
                     }
                 ],
@@ -3092,19 +3092,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.FeatureResponse"
+                            "$ref": "#/definitions/FeatureResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3136,7 +3136,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureFilter"
+                            "$ref": "#/definitions/types.FeatureFilter"
                         }
                     }
                 ],
@@ -3150,13 +3150,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3195,7 +3195,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateFeatureRequest"
+                            "$ref": "#/definitions/UpdateFeatureRequest"
                         }
                     }
                 ],
@@ -3203,25 +3203,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.FeatureResponse"
+                            "$ref": "#/definitions/FeatureResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3257,25 +3257,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3307,7 +3307,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateGroupRequest"
+                            "$ref": "#/definitions/CreateGroupRequest"
                         }
                     }
                 ],
@@ -3315,19 +3315,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.GroupResponse"
+                            "$ref": "#/definitions/GroupResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3359,7 +3359,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.GroupFilter"
+                            "$ref": "#/definitions/types.GroupFilter"
                         }
                     }
                 ],
@@ -3373,13 +3373,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3417,25 +3417,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GroupResponse"
+                            "$ref": "#/definitions/GroupResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3474,19 +3474,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3518,7 +3518,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.LinkIntegrationMappingRequest"
+                            "$ref": "#/definitions/LinkIntegrationMappingRequest"
                         }
                     }
                 ],
@@ -3526,19 +3526,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.LinkIntegrationMappingResponse"
+                            "$ref": "#/definitions/LinkIntegrationMappingResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3570,7 +3570,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateInvoiceRequest"
+                            "$ref": "#/definitions/CreateInvoiceRequest"
                         }
                     }
                 ],
@@ -3578,19 +3578,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3622,7 +3622,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetPreviewInvoiceRequest"
+                            "$ref": "#/definitions/GetPreviewInvoiceRequest"
                         }
                     }
                 ],
@@ -3630,19 +3630,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3674,7 +3674,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceFilter"
+                            "$ref": "#/definitions/types.InvoiceFilter"
                         }
                     }
                 ],
@@ -3688,13 +3688,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3748,19 +3748,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3797,7 +3797,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateInvoiceRequest"
+                            "$ref": "#/definitions/UpdateInvoiceRequest"
                         }
                     }
                 ],
@@ -3805,25 +3805,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3861,25 +3861,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -3917,19 +3917,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -3969,7 +3969,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePaymentStatusRequest"
+                            "$ref": "#/definitions/UpdatePaymentStatusRequest"
                         }
                     }
                 ],
@@ -3977,25 +3977,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4033,25 +4033,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4101,19 +4101,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4154,19 +4154,19 @@
                     "400": {
                         "description": "Invalid request or invoice already recalculated",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Invoice not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4210,25 +4210,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
+                            "$ref": "#/definitions/InvoiceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4266,19 +4266,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4416,19 +4416,19 @@
                     "200": {
                         "description": "Paginated payments",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListPaymentsResponse"
+                            "$ref": "#/definitions/ListPaymentsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4458,7 +4458,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePaymentRequest"
+                            "$ref": "#/definitions/CreatePaymentRequest"
                         }
                     }
                 ],
@@ -4466,19 +4466,19 @@
                     "201": {
                         "description": "Created payment",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4516,25 +4516,25 @@
                     "200": {
                         "description": "Payment details",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Payment not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4571,7 +4571,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePaymentRequest"
+                            "$ref": "#/definitions/UpdatePaymentRequest"
                         }
                     }
                 ],
@@ -4579,19 +4579,19 @@
                     "200": {
                         "description": "Updated payment",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4627,25 +4627,25 @@
                     "200": {
                         "description": "Payment deleted",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Payment not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4683,25 +4683,25 @@
                     "200": {
                         "description": "Processed payment",
                         "schema": {
-                            "$ref": "#/definitions/dto.PaymentResponse"
+                            "$ref": "#/definitions/PaymentResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Payment not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4733,7 +4733,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePlanRequest"
+                            "$ref": "#/definitions/CreatePlanRequest"
                         }
                     }
                 ],
@@ -4741,19 +4741,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4785,7 +4785,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PlanFilter"
+                            "$ref": "#/definitions/types.PlanFilter"
                         }
                     }
                 ],
@@ -4799,13 +4799,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4840,25 +4840,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4895,7 +4895,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePlanRequest"
+                            "$ref": "#/definitions/UpdatePlanRequest"
                         }
                     }
                 ],
@@ -4903,25 +4903,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -4957,25 +4957,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5013,7 +5013,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ClonePlanRequest"
+                            "$ref": "#/definitions/ClonePlanRequest"
                         }
                     }
                 ],
@@ -5021,31 +5021,31 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PlanResponse"
+                            "$ref": "#/definitions/PlanResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5086,19 +5086,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5139,19 +5139,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5195,25 +5195,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5245,7 +5245,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePriceRequest"
+                            "$ref": "#/definitions/CreatePriceRequest"
                         }
                     }
                 ],
@@ -5253,19 +5253,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5297,7 +5297,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkPriceRequest"
+                            "$ref": "#/definitions/CreateBulkPriceRequest"
                         }
                     }
                 ],
@@ -5305,19 +5305,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateBulkPriceResponse"
+                            "$ref": "#/definitions/CreateBulkPriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5355,19 +5355,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5399,7 +5399,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceFilter"
+                            "$ref": "#/definitions/types.PriceFilter"
                         }
                     }
                 ],
@@ -5413,13 +5413,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5495,13 +5495,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5531,7 +5531,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePriceUnitRequest"
+                            "$ref": "#/definitions/CreatePriceUnitRequest"
                         }
                     }
                 ],
@@ -5539,19 +5539,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreatePriceUnitResponse"
+                            "$ref": "#/definitions/CreatePriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5589,25 +5589,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceUnitResponse"
+                            "$ref": "#/definitions/PriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5639,7 +5639,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitFilter"
+                            "$ref": "#/definitions/types.PriceUnitFilter"
                         }
                     }
                 ],
@@ -5653,13 +5653,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5697,19 +5697,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceUnitResponse"
+                            "$ref": "#/definitions/PriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5746,7 +5746,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePriceUnitRequest"
+                            "$ref": "#/definitions/UpdatePriceUnitRequest"
                         }
                     }
                 ],
@@ -5754,19 +5754,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceUnitResponse"
+                            "$ref": "#/definitions/PriceUnitResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5802,19 +5802,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5852,19 +5852,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5901,7 +5901,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdatePriceRequest"
+                            "$ref": "#/definitions/UpdatePriceRequest"
                         }
                     }
                 ],
@@ -5909,19 +5909,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.PriceResponse"
+                            "$ref": "#/definitions/PriceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -5958,7 +5958,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.DeletePriceRequest"
+                            "$ref": "#/definitions/DeletePriceRequest"
                         }
                     }
                 ],
@@ -5966,19 +5966,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6114,19 +6114,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListSecretsResponse"
+                            "$ref": "#/definitions/ListSecretsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6156,7 +6156,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAPIKeyRequest"
+                            "$ref": "#/definitions/CreateAPIKeyRequest"
                         }
                     }
                 ],
@@ -6164,19 +6164,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateAPIKeyResponse"
+                            "$ref": "#/definitions/CreateAPIKeyResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6217,13 +6217,13 @@
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6255,7 +6255,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateSubscriptionRequest"
+                            "$ref": "#/definitions/CreateSubscriptionRequest"
                         }
                     }
                 ],
@@ -6263,19 +6263,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6307,7 +6307,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.AddAddonRequest"
+                            "$ref": "#/definitions/AddAddonRequest"
                         }
                     }
                 ],
@@ -6315,19 +6315,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.AddonAssociationResponse"
+                            "$ref": "#/definitions/AddonAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6357,7 +6357,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.RemoveAddonRequest"
+                            "$ref": "#/definitions/RemoveAddonRequest"
                         }
                     }
                 ],
@@ -6365,19 +6365,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6416,7 +6416,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateSubscriptionLineItemRequest"
+                            "$ref": "#/definitions/UpdateSubscriptionLineItemRequest"
                         }
                     }
                 ],
@@ -6424,19 +6424,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                            "$ref": "#/definitions/SubscriptionLineItemResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6473,7 +6473,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.DeleteSubscriptionLineItemRequest"
+                            "$ref": "#/definitions/DeleteSubscriptionLineItemRequest"
                         }
                     }
                 ],
@@ -6481,19 +6481,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                            "$ref": "#/definitions/SubscriptionLineItemResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6525,7 +6525,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionFilter"
+                            "$ref": "#/definitions/types.SubscriptionFilter"
                         }
                     }
                 ],
@@ -6539,13 +6539,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6577,7 +6577,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageBySubscriptionRequest"
+                            "$ref": "#/definitions/GetUsageBySubscriptionRequest"
                         }
                     }
                 ],
@@ -6585,19 +6585,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetUsageBySubscriptionResponse"
+                            "$ref": "#/definitions/GetUsageBySubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6632,19 +6632,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6681,7 +6681,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateSubscriptionRequest"
+                            "$ref": "#/definitions/UpdateSubscriptionRequest"
                         }
                     }
                 ],
@@ -6689,19 +6689,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6740,7 +6740,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ActivateDraftSubscriptionRequest"
+                            "$ref": "#/definitions/ActivateDraftSubscriptionRequest"
                         }
                     }
                 ],
@@ -6748,19 +6748,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6797,26 +6797,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.AddonAssociationResponse"
+                                "$ref": "#/definitions/AddonAssociationResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6855,7 +6855,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelSubscriptionRequest"
+                            "$ref": "#/definitions/CancelSubscriptionRequest"
                         }
                     }
                 ],
@@ -6863,19 +6863,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelSubscriptionResponse"
+                            "$ref": "#/definitions/CancelSubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6914,7 +6914,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangeRequest"
+                            "$ref": "#/definitions/SubscriptionChangeRequest"
                         }
                     }
                 ],
@@ -6922,25 +6922,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangeExecuteResponse"
+                            "$ref": "#/definitions/SubscriptionChangeExecuteResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -6979,7 +6979,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangeRequest"
+                            "$ref": "#/definitions/SubscriptionChangeRequest"
                         }
                     }
                 ],
@@ -6987,25 +6987,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionChangePreviewResponse"
+                            "$ref": "#/definitions/SubscriptionChangePreviewResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7053,25 +7053,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionEntitlementsResponse"
+                            "$ref": "#/definitions/SubscriptionEntitlementsResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7112,19 +7112,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7163,7 +7163,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateSubscriptionLineItemRequest"
+                            "$ref": "#/definitions/CreateSubscriptionLineItemRequest"
                         }
                     }
                 ],
@@ -7171,25 +7171,25 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                            "$ref": "#/definitions/SubscriptionLineItemResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7228,7 +7228,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ExecuteSubscriptionInheritanceRequest"
+                            "$ref": "#/definitions/ExecuteSubscriptionInheritanceRequest"
                         }
                     }
                 ],
@@ -7236,25 +7236,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
+                            "$ref": "#/definitions/SubscriptionResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 },
@@ -7294,7 +7294,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PauseSubscriptionRequest"
+                            "$ref": "#/definitions/PauseSubscriptionRequest"
                         }
                     }
                 ],
@@ -7302,25 +7302,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionPauseResponse"
+                            "$ref": "#/definitions/SubscriptionPauseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7352,26 +7352,26 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.ListSubscriptionPausesResponse"
+                                "$ref": "#/definitions/ListSubscriptionPausesResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7410,7 +7410,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ResumeSubscriptionRequest"
+                            "$ref": "#/definitions/ResumeSubscriptionRequest"
                         }
                     }
                 ],
@@ -7418,25 +7418,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionPauseResponse"
+                            "$ref": "#/definitions/SubscriptionPauseResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7477,19 +7477,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionResponseV2"
+                            "$ref": "#/definitions/SubscriptionResponseV2"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7634,19 +7634,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ListTasksResponse"
+                            "$ref": "#/definitions/ListTasksResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7676,7 +7676,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateTaskRequest"
+                            "$ref": "#/definitions/CreateTaskRequest"
                         }
                     }
                 ],
@@ -7684,19 +7684,19 @@
                     "202": {
                         "description": "Accepted",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaskResponse"
+                            "$ref": "#/definitions/TaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7740,19 +7740,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7825,13 +7825,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7861,7 +7861,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateScheduledTaskRequest"
+                            "$ref": "#/definitions/CreateScheduledTaskRequest"
                         }
                     }
                 ],
@@ -7869,19 +7869,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                            "$ref": "#/definitions/ScheduledTaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7916,13 +7916,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -7968,13 +7968,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8012,25 +8012,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                            "$ref": "#/definitions/ScheduledTaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8067,7 +8067,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateScheduledTaskRequest"
+                            "$ref": "#/definitions/UpdateScheduledTaskRequest"
                         }
                     }
                 ],
@@ -8075,25 +8075,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                            "$ref": "#/definitions/ScheduledTaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request or task is archived",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Scheduled task not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to update Temporal schedule",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8132,19 +8132,19 @@
                     "400": {
                         "description": "Task already archived",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Scheduled task not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Failed to archive task",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8182,7 +8182,7 @@
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/dto.TriggerForceRunRequest"
+                            "$ref": "#/definitions/TriggerForceRunRequest"
                         }
                     }
                 ],
@@ -8190,25 +8190,25 @@
                     "200": {
                         "description": "Returns workflow details and time range",
                         "schema": {
-                            "$ref": "#/definitions/dto.TriggerForceRunResponse"
+                            "$ref": "#/definitions/TriggerForceRunResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8246,25 +8246,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaskResponse"
+                            "$ref": "#/definitions/TaskResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8311,19 +8311,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8362,7 +8362,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateTaskStatusRequest"
+                            "$ref": "#/definitions/UpdateTaskStatusRequest"
                         }
                     }
                 ],
@@ -8370,25 +8370,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SuccessResponse"
+                            "$ref": "#/definitions/SuccessResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8449,13 +8449,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8485,7 +8485,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateTaxAssociationRequest"
+                            "$ref": "#/definitions/CreateTaxAssociationRequest"
                         }
                     }
                 ],
@@ -8493,19 +8493,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8543,19 +8543,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8592,7 +8592,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationUpdateRequest"
+                            "$ref": "#/definitions/TaxAssociationUpdateRequest"
                         }
                     }
                 ],
@@ -8600,19 +8600,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8648,19 +8648,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxAssociationResponse"
+                            "$ref": "#/definitions/TaxAssociationResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8778,20 +8778,20 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/dto.TaxRateResponse"
+                                "$ref": "#/definitions/TaxRateResponse"
                             }
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8821,7 +8821,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateTaxRateRequest"
+                            "$ref": "#/definitions/CreateTaxRateRequest"
                         }
                     }
                 ],
@@ -8829,19 +8829,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxRateResponse"
+                            "$ref": "#/definitions/TaxRateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8879,19 +8879,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxRateResponse"
+                            "$ref": "#/definitions/TaxRateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8928,7 +8928,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateTaxRateRequest"
+                            "$ref": "#/definitions/UpdateTaxRateRequest"
                         }
                     }
                 ],
@@ -8936,19 +8936,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TaxRateResponse"
+                            "$ref": "#/definitions/TaxRateResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -8987,13 +8987,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9022,25 +9022,25 @@
                     "200": {
                         "description": "Tenant billing usage",
                         "schema": {
-                            "$ref": "#/definitions/dto.TenantBillingUsage"
+                            "$ref": "#/definitions/TenantBillingUsage"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Tenant not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9072,7 +9072,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateTenantRequest"
+                            "$ref": "#/definitions/UpdateTenantRequest"
                         }
                     }
                 ],
@@ -9080,25 +9080,25 @@
                     "200": {
                         "description": "Updated tenant",
                         "schema": {
-                            "$ref": "#/definitions/dto.TenantResponse"
+                            "$ref": "#/definitions/TenantResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Tenant not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9136,19 +9136,19 @@
                     "200": {
                         "description": "Tenant details",
                         "schema": {
-                            "$ref": "#/definitions/dto.TenantResponse"
+                            "$ref": "#/definitions/TenantResponse"
                         }
                     },
                     "404": {
                         "description": "Tenant not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9180,7 +9180,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateUserRequest"
+                            "$ref": "#/definitions/CreateUserRequest"
                         }
                     }
                 ],
@@ -9188,19 +9188,19 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateUserResponse"
+                            "$ref": "#/definitions/CreateUserResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9226,19 +9226,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.UserResponse"
+                            "$ref": "#/definitions/UserResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9270,7 +9270,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserFilter"
+                            "$ref": "#/definitions/types.UserFilter"
                         }
                     }
                 ],
@@ -9284,13 +9284,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9340,7 +9340,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetPendingSchedulesResponse"
+                            "$ref": "#/definitions/GetPendingSchedulesResponse"
                         }
                     }
                 }
@@ -9373,7 +9373,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.SubscriptionScheduleResponse"
+                            "$ref": "#/definitions/SubscriptionScheduleResponse"
                         }
                     }
                 }
@@ -9405,7 +9405,7 @@
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelScheduleRequest"
+                            "$ref": "#/definitions/CancelScheduleRequest"
                         }
                     }
                 ],
@@ -9413,7 +9413,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.CancelScheduleResponse"
+                            "$ref": "#/definitions/CancelScheduleResponse"
                         }
                     }
                 }
@@ -9446,7 +9446,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.GetPendingSchedulesResponse"
+                            "$ref": "#/definitions/GetPendingSchedulesResponse"
                         }
                     }
                 }
@@ -9478,7 +9478,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.CreateWalletRequest"
+                            "$ref": "#/definitions/CreateWalletRequest"
                         }
                     }
                 ],
@@ -9486,19 +9486,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9530,7 +9530,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletFilter"
+                            "$ref": "#/definitions/types.WalletFilter"
                         }
                     }
                 ],
@@ -9544,13 +9544,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9582,7 +9582,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletTransactionFilter"
+                            "$ref": "#/definitions/types.WalletTransactionFilter"
                         }
                     }
                 ],
@@ -9596,13 +9596,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9640,25 +9640,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9695,7 +9695,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.UpdateWalletRequest"
+                            "$ref": "#/definitions/UpdateWalletRequest"
                         }
                     }
                 ],
@@ -9703,25 +9703,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9765,25 +9765,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletBalanceResponse"
+                            "$ref": "#/definitions/WalletBalanceResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9821,25 +9821,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.WalletResponse"
+                            "$ref": "#/definitions/WalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -9878,7 +9878,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.TopUpWalletRequest"
+                            "$ref": "#/definitions/TopUpWalletRequest"
                         }
                     }
                 ],
@@ -9886,25 +9886,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TopUpWalletResponse"
+                            "$ref": "#/definitions/TopUpWalletResponse"
                         }
                     },
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -10099,19 +10099,19 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "404": {
                         "description": "Resource not found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -11109,7 +11109,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WorkflowExecutionFilter"
+                            "$ref": "#/definitions/types.WorkflowExecutionFilter"
                         }
                     }
                 ],
@@ -11123,13 +11123,13 @@
                     "400": {
                         "description": "Invalid request",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
                         "description": "Server error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
                 }
@@ -11143,11 +11143,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AddonResponse"
+                        "$ref": "#/definitions/AddonResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11157,11 +11157,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponResponse"
+                        "$ref": "#/definitions/CouponResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11171,11 +11171,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantApplicationResponse"
+                        "$ref": "#/definitions/CreditGrantApplicationResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11185,11 +11185,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11200,11 +11200,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CustomerResponse"
+                        "$ref": "#/definitions/CustomerResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11214,11 +11214,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11228,11 +11228,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.FeatureResponse"
+                        "$ref": "#/definitions/FeatureResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11242,11 +11242,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.GroupResponse"
+                        "$ref": "#/definitions/GroupResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11256,11 +11256,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceResponse"
+                        "$ref": "#/definitions/InvoiceResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11270,11 +11270,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PlanResponse"
+                        "$ref": "#/definitions/PlanResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11284,11 +11284,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceUnitResponse"
+                        "$ref": "#/definitions/PriceUnitResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11298,11 +11298,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11312,11 +11312,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.ScheduledTaskResponse"
+                        "$ref": "#/definitions/ScheduledTaskResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11326,11 +11326,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionResponse"
+                        "$ref": "#/definitions/SubscriptionResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11340,11 +11340,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxAssociationResponse"
+                        "$ref": "#/definitions/TaxAssociationResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11354,11 +11354,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UserResponse"
+                        "$ref": "#/definitions/UserResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11368,11 +11368,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.WalletTransactionResponse"
+                        "$ref": "#/definitions/WalletTransactionResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11382,11 +11382,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.WorkflowExecutionDTO"
+                        "$ref": "#/definitions/WorkflowExecutionDTO"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -11408,7 +11408,7 @@
                     "description": "Filters contains custom filtering conditions",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "lookupKey": {
@@ -11421,26 +11421,18 @@
                 },
                 "queryFilter": {
                     "description": "QueryFilter contains pagination and basic query parameters",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.QueryFilter"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.QueryFilter"
                 },
                 "sort": {
                     "description": "Sort specifies result ordering preferences",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "status": {
                     "description": "Status filters by costsheet status",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenantID": {
                     "description": "TenantID filters by specific tenant ID",
@@ -11448,11 +11440,7 @@
                 },
                 "timeRangeFilter": {
                     "description": "TimeRangeFilter allows filtering by time periods",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TimeRangeFilter"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.TimeRangeFilter"
                 }
             }
         },
@@ -11485,7 +11473,7 @@
                     "type": "string"
                 },
                 "discount_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "discounted_amount": {
                     "type": "string"
@@ -11515,7 +11503,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -11535,7 +11523,7 @@
             "type": "object",
             "properties": {
                 "coupon": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_coupon.Coupon"
+                    "$ref": "#/definitions/Coupon"
                 },
                 "coupon_id": {
                     "type": "string"
@@ -11566,7 +11554,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "Mandatory",
@@ -11625,7 +11613,7 @@
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -11638,7 +11626,7 @@
                 }
             }
         },
-        "dto.ActivateDraftSubscriptionRequest": {
+        "ActivateDraftSubscriptionRequest": {
             "type": "object",
             "required": [
                 "start_date"
@@ -11650,7 +11638,7 @@
                 }
             }
         },
-        "dto.AddAddonRequest": {
+        "AddAddonRequest": {
             "type": "object",
             "required": [
                 "addon_id",
@@ -11664,7 +11652,7 @@
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/dto.LineItemCommitmentConfig"
+                        "$ref": "#/definitions/LineItemCommitmentConfig"
                     }
                 },
                 "metadata": {
@@ -11679,7 +11667,7 @@
                 }
             }
         },
-        "dto.AddAddonToSubscriptionRequest": {
+        "AddAddonToSubscriptionRequest": {
             "type": "object",
             "required": [
                 "addon_id"
@@ -11692,7 +11680,7 @@
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/dto.LineItemCommitmentConfig"
+                        "$ref": "#/definitions/LineItemCommitmentConfig"
                     }
                 },
                 "metadata": {
@@ -11704,17 +11692,17 @@
                 }
             }
         },
-        "dto.AddonAssociationResponse": {
+        "AddonAssociationResponse": {
             "type": "object",
             "properties": {
                 "addon": {
-                    "$ref": "#/definitions/dto.AddonResponse"
+                    "$ref": "#/definitions/AddonResponse"
                 },
                 "addon_id": {
                     "type": "string"
                 },
                 "addon_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonStatus"
+                    "$ref": "#/definitions/types.AddonStatus"
                 },
                 "cancellation_reason": {
                     "type": "string"
@@ -11735,7 +11723,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonAssociationEntityType"
+                    "$ref": "#/definitions/types.AddonAssociationEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -11751,10 +11739,10 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription": {
-                    "$ref": "#/definitions/dto.SubscriptionResponse"
+                    "$ref": "#/definitions/SubscriptionResponse"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -11767,7 +11755,7 @@
                 }
             }
         },
-        "dto.AddonResponse": {
+        "AddonResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -11782,7 +11770,7 @@
                 "entitlements": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "environment_id": {
@@ -11805,17 +11793,17 @@
                     "description": "Optional expanded fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -11825,7 +11813,7 @@
                 }
             }
         },
-        "dto.Address": {
+        "Address": {
             "type": "object",
             "properties": {
                 "address_city": {
@@ -11853,7 +11841,7 @@
                 }
             }
         },
-        "dto.AggregatedEntitlement": {
+        "AggregatedEntitlement": {
             "type": "object",
             "properties": {
                 "is_enabled": {
@@ -11873,38 +11861,38 @@
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.AggregatedFeature": {
+        "AggregatedFeature": {
             "type": "object",
             "properties": {
                 "entitlement": {
-                    "$ref": "#/definitions/dto.AggregatedEntitlement"
+                    "$ref": "#/definitions/AggregatedEntitlement"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "sources": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementSource"
+                        "$ref": "#/definitions/EntitlementSource"
                     }
                 }
             }
         },
-        "dto.AlertLogResponse": {
+        "AlertLogResponse": {
             "type": "object",
             "properties": {
                 "alert_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertInfo"
+                    "$ref": "#/definitions/types.AlertInfo"
                 },
                 "alert_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "alert_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertType"
+                    "$ref": "#/definitions/types.AlertType"
                 },
                 "created_at": {
                     "type": "string"
@@ -11914,11 +11902,7 @@
                 },
                 "customer": {
                     "description": "Expanded fields",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.CustomerResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "type": "string"
@@ -11927,13 +11911,13 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertEntityType"
+                    "$ref": "#/definitions/types.AlertEntityType"
                 },
                 "environment_id": {
                     "type": "string"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "id": {
                     "type": "string"
@@ -11957,11 +11941,11 @@
                     "type": "string"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         },
-        "dto.BillingCycleInfo": {
+        "BillingCycleInfo": {
             "type": "object",
             "properties": {
                 "billing_anchor": {
@@ -11970,19 +11954,11 @@
                 },
                 "billing_cadence": {
                     "description": "billing_cadence is the billing cadence",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_period": {
                     "description": "billing_period is the billing period",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "billing_period_count is the billing period count",
@@ -11999,7 +11975,7 @@
                 }
             }
         },
-        "dto.BillingPeriodInfo": {
+        "BillingPeriodInfo": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -12014,7 +11990,7 @@
                 }
             }
         },
-        "dto.BulkIngestEventRequest": {
+        "BulkIngestEventRequest": {
             "type": "object",
             "required": [
                 "events"
@@ -12025,12 +12001,12 @@
                     "maxItems": 1000,
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.IngestEventRequest"
+                        "$ref": "#/definitions/IngestEventRequest"
                     }
                 }
             }
         },
-        "dto.CancelScheduleRequest": {
+        "CancelScheduleRequest": {
             "description": "Request to cancel a subscription schedule (supports two modes)",
             "type": "object",
             "properties": {
@@ -12040,11 +12016,7 @@
                 },
                 "schedule_type": {
                     "description": "schedule_type is the type of schedule to cancel (required if schedule_id is not provided)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionScheduleChangeType"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the ID of the subscription (required if schedule_id is not provided)",
@@ -12052,7 +12024,7 @@
                 }
             }
         },
-        "dto.CancelScheduleResponse": {
+        "CancelScheduleResponse": {
             "description": "Confirmation of schedule cancellation",
             "type": "object",
             "properties": {
@@ -12062,15 +12034,11 @@
                 },
                 "status": {
                     "description": "status is the new status (should be \"cancelled\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ScheduleStatus"
                 }
             }
         },
-        "dto.CancelSubscriptionRequest": {
+        "CancelSubscriptionRequest": {
             "type": "object",
             "required": [
                 "cancellation_type"
@@ -12081,27 +12049,15 @@
                 },
                 "cancel_immediately_inovice_policy": {
                     "description": "CancelImmediatelyInvoicePolicy controls whether to generate a final invoice on immediate cancellation. Defaults to skip.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CancelImmediatelyInvoicePolicy"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CancelImmediatelyInvoicePolicy"
                 },
                 "cancellation_type": {
                     "description": "CancellationType determines when the cancellation takes effect",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CancellationType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CancellationType"
                 },
                 "proration_behavior": {
                     "description": "ProrationBehavior controls how proration is handled.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "reason": {
                     "description": "Reason for cancellation (for audit and business intelligence)",
@@ -12109,11 +12065,11 @@
                 }
             }
         },
-        "dto.CancelSubscriptionResponse": {
+        "CancelSubscriptionResponse": {
             "type": "object",
             "properties": {
                 "cancellation_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CancellationType"
+                    "$ref": "#/definitions/types.CancellationType"
                 },
                 "effective_date": {
                     "type": "string"
@@ -12128,22 +12084,18 @@
                 "proration_details": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.ProrationDetail"
+                        "$ref": "#/definitions/ProrationDetail"
                     }
                 },
                 "proration_invoice": {
                     "description": "Proration details",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/InvoiceResponse"
                 },
                 "reason": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "subscription_id": {
                     "description": "Basic cancellation info",
@@ -12154,7 +12106,7 @@
                 }
             }
         },
-        "dto.ClonePlanRequest": {
+        "ClonePlanRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -12171,11 +12123,7 @@
                 },
                 "metadata": {
                     "description": "Metadata overrides the source plan's metadata when provided",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "name": {
                     "description": "Name is required and must be different from the source plan's name",
@@ -12183,14 +12131,14 @@
                 }
             }
         },
-        "dto.CostAnalyticItem": {
+        "CostAnalyticItem": {
             "type": "object",
             "properties": {
                 "cost_by_period": {
                     "description": "Breakdown",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CostPoint"
+                        "$ref": "#/definitions/CostPoint"
                     }
                 },
                 "costsheet_id": {
@@ -12208,11 +12156,7 @@
                 },
                 "meter": {
                     "description": "Expanded data (populated when expand options are specified)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/meter.Meter"
-                        }
-                    ]
+                    "$ref": "#/definitions/meter.Meter"
                 },
                 "meter_id": {
                     "type": "string"
@@ -12247,7 +12191,7 @@
                 }
             }
         },
-        "dto.CostPoint": {
+        "CostPoint": {
             "type": "object",
             "properties": {
                 "cost": {
@@ -12264,7 +12208,7 @@
                 }
             }
         },
-        "dto.CostsheetResponse": {
+        "CostsheetResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -12298,11 +12242,11 @@
                     "description": "Associated prices",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -12315,7 +12259,7 @@
                 }
             }
         },
-        "dto.CouponApplicationResponse": {
+        "CouponApplicationResponse": {
             "type": "object",
             "properties": {
                 "applied_at": {
@@ -12344,7 +12288,7 @@
                     "type": "string"
                 },
                 "discount_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "discounted_amount": {
                     "type": "string"
@@ -12374,7 +12318,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -12390,11 +12334,11 @@
                 }
             }
         },
-        "dto.CouponAssociationResponse": {
+        "CouponAssociationResponse": {
             "type": "object",
             "properties": {
                 "coupon": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_coupon.Coupon"
+                    "$ref": "#/definitions/Coupon"
                 },
                 "coupon_id": {
                     "type": "string"
@@ -12425,7 +12369,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "Mandatory",
@@ -12450,14 +12394,14 @@
                 }
             }
         },
-        "dto.CouponResponse": {
+        "CouponResponse": {
             "type": "object",
             "properties": {
                 "amount_off": {
                     "type": "string"
                 },
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence"
+                    "$ref": "#/definitions/types.CouponCadence"
                 },
                 "created_at": {
                     "type": "string"
@@ -12503,7 +12447,7 @@
                     "additionalProperties": true
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -12512,7 +12456,7 @@
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -12522,7 +12466,7 @@
                 }
             }
         },
-        "dto.CreateAPIKeyRequest": {
+        "CreateAPIKeyRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -12539,22 +12483,22 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SecretType"
+                    "$ref": "#/definitions/types.SecretType"
                 }
             }
         },
-        "dto.CreateAPIKeyResponse": {
+        "CreateAPIKeyResponse": {
             "type": "object",
             "properties": {
                 "api_key": {
                     "type": "string"
                 },
                 "secret": {
-                    "$ref": "#/definitions/dto.SecretResponse"
+                    "$ref": "#/definitions/SecretResponse"
                 }
             }
         },
-        "dto.CreateAddonRequest": {
+        "CreateAddonRequest": {
             "type": "object",
             "required": [
                 "lookup_key",
@@ -12576,11 +12520,11 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 }
             }
         },
-        "dto.CreateAddonResponse": {
+        "CreateAddonResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -12595,7 +12539,7 @@
                 "entitlements": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "environment_id": {
@@ -12618,17 +12562,17 @@
                     "description": "Optional expanded fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -12638,7 +12582,7 @@
                 }
             }
         },
-        "dto.CreateBulkEntitlementRequest": {
+        "CreateBulkEntitlementRequest": {
             "type": "object",
             "required": [
                 "items"
@@ -12649,23 +12593,23 @@
                     "maxItems": 100,
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.CreateEntitlementRequest"
+                        "$ref": "#/definitions/CreateEntitlementRequest"
                     }
                 }
             }
         },
-        "dto.CreateBulkEntitlementResponse": {
+        "CreateBulkEntitlementResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 }
             }
         },
-        "dto.CreateBulkPriceRequest": {
+        "CreateBulkPriceRequest": {
             "type": "object",
             "required": [
                 "items"
@@ -12676,23 +12620,23 @@
                     "maxItems": 100,
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceRequest"
+                        "$ref": "#/definitions/CreatePriceRequest"
                     }
                 }
             }
         },
-        "dto.CreateBulkPriceResponse": {
+        "CreateBulkPriceResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 }
             }
         },
-        "dto.CreateCostsheetRequest": {
+        "CreateCostsheetRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -12719,15 +12663,15 @@
                 }
             }
         },
-        "dto.CreateCostsheetResponse": {
+        "CreateCostsheetResponse": {
             "type": "object",
             "properties": {
                 "costsheet": {
-                    "$ref": "#/definitions/dto.CostsheetResponse"
+                    "$ref": "#/definitions/CostsheetResponse"
                 }
             }
         },
-        "dto.CreateCouponRequest": {
+        "CreateCouponRequest": {
             "type": "object",
             "required": [
                 "cadence",
@@ -12744,11 +12688,7 @@
                         "repeated",
                         "forever"
                     ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CouponCadence"
                 },
                 "currency": {
                     "type": "string"
@@ -12786,15 +12726,11 @@
                         "fixed",
                         "percentage"
                     ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CouponType"
                 }
             }
         },
-        "dto.CreateCreditGrantRequest": {
+        "CreateCreditGrantRequest": {
             "type": "object",
             "required": [
                 "cadence",
@@ -12804,7 +12740,7 @@
             ],
             "properties": {
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantCadence"
+                    "$ref": "#/definitions/types.CreditGrantCadence"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -12820,10 +12756,10 @@
                     "type": "integer"
                 },
                 "expiration_duration_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit"
+                    "$ref": "#/definitions/types.CreditGrantExpiryDurationUnit"
                 },
                 "expiration_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType"
+                    "$ref": "#/definitions/types.CreditGrantExpiryType"
                 },
                 "metadata": {
                     "$ref": "#/definitions/types.Metadata"
@@ -12832,7 +12768,7 @@
                     "type": "string"
                 },
                 "period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantPeriod"
+                    "$ref": "#/definitions/types.CreditGrantPeriod"
                 },
                 "period_count": {
                     "type": "integer"
@@ -12844,7 +12780,7 @@
                     "type": "integer"
                 },
                 "scope": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantScope"
+                    "$ref": "#/definitions/types.CreditGrantScope"
                 },
                 "start_date": {
                     "type": "string"
@@ -12858,7 +12794,7 @@
                 }
             }
         },
-        "dto.CreateCreditNoteLineItemRequest": {
+        "CreateCreditNoteLineItemRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -12879,15 +12815,11 @@
                 },
                 "metadata": {
                     "description": "metadata contains additional custom key-value pairs for storing extra information about this line item",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 }
             }
         },
-        "dto.CreateCreditNoteRequest": {
+        "CreateCreditNoteRequest": {
             "type": "object",
             "required": [
                 "invoice_id",
@@ -12910,7 +12842,7 @@
                     "description": "line_items contains the individual line items that make up this credit note (minimum 1 required)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateCreditNoteLineItemRequest"
+                        "$ref": "#/definitions/CreateCreditNoteLineItemRequest"
                     }
                 },
                 "memo": {
@@ -12919,11 +12851,7 @@
                 },
                 "metadata": {
                     "description": "metadata contains additional custom key-value pairs for storing extra information",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "process_credit_note": {
                     "description": "process_credit_note is a flag to process the credit note after creation",
@@ -12932,15 +12860,11 @@
                 },
                 "reason": {
                     "description": "reason specifies the reason for creating this credit note (duplicate, fraudulent, order_change, product_unsatisfactory)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteReason"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CreditNoteReason"
                 }
             }
         },
-        "dto.CreateCustomerRequest": {
+        "CreateCustomerRequest": {
             "description": "Request object for creating a new customer in the system",
             "type": "object",
             "required": [
@@ -12988,7 +12912,7 @@
                     "description": "integration_entity_mapping contains provider integration mappings for this customer",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateEntityIntegrationMappingRequest"
+                        "$ref": "#/definitions/CreateEntityIntegrationMappingRequest"
                     }
                 },
                 "metadata": {
@@ -13010,12 +12934,12 @@
                     "description": "tax_rate_overrides contains tax rate configurations to be linked to this customer",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateOverride"
+                        "$ref": "#/definitions/TaxRateOverride"
                     }
                 }
             }
         },
-        "dto.CreateEntitlementRequest": {
+        "CreateEntitlementRequest": {
             "type": "object",
             "required": [
                 "feature_id",
@@ -13029,13 +12953,13 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType"
+                    "$ref": "#/definitions/types.EntitlementEntityType"
                 },
                 "feature_id": {
                     "type": "string"
                 },
                 "feature_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -13059,11 +12983,11 @@
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.CreateEntityIntegrationMappingRequest": {
+        "CreateEntityIntegrationMappingRequest": {
             "type": "object",
             "required": [
                 "entity_id",
@@ -13077,7 +13001,7 @@
                     "maxLength": 255
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType"
+                    "$ref": "#/definitions/types.IntegrationEntityType"
                 },
                 "metadata": {
                     "type": "object",
@@ -13093,7 +13017,7 @@
                 }
             }
         },
-        "dto.CreateFeatureRequest": {
+        "CreateFeatureRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -13101,7 +13025,7 @@
             ],
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "description": {
                     "type": "string"
@@ -13117,7 +13041,7 @@
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "meter": {
-                    "$ref": "#/definitions/dto.CreateMeterRequest"
+                    "$ref": "#/definitions/CreateMeterRequest"
                 },
                 "meter_id": {
                     "type": "string"
@@ -13126,10 +13050,10 @@
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -13139,7 +13063,7 @@
                 }
             }
         },
-        "dto.CreateGroupRequest": {
+        "CreateGroupRequest": {
             "type": "object",
             "required": [
                 "entity_type",
@@ -13158,7 +13082,7 @@
                 }
             }
         },
-        "dto.CreateInvoiceLineItemRequest": {
+        "CreateInvoiceLineItemRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -13171,11 +13095,7 @@
                 },
                 "commitment_info": {
                     "description": "commitment_info contains details about any commitment applied to this line item",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "display_name": {
                     "description": "display_name is the optional human-readable name for this line item",
@@ -13199,11 +13119,7 @@
                 },
                 "metadata": {
                     "description": "metadata contains additional custom key-value pairs for storing extra information about this line item",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "meter_display_name": {
                     "description": "meter_display_name is the optional human-readable name of the meter",
@@ -13255,7 +13171,7 @@
                 }
             }
         },
-        "dto.CreateInvoiceRequest": {
+        "CreateInvoiceRequest": {
             "type": "object",
             "required": [
                 "amount_due",
@@ -13279,11 +13195,7 @@
                 },
                 "billing_reason": {
                     "description": "billing_reason indicates why this invoice was created (subscription_cycle, manual, etc.)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceBillingReason"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.InvoiceBillingReason"
                 },
                 "coupons": {
                     "description": "coupons",
@@ -13316,7 +13228,7 @@
                     "description": "Invoice Coupons",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceCoupon"
+                        "$ref": "#/definitions/InvoiceCoupon"
                     }
                 },
                 "invoice_number": {
@@ -13329,49 +13241,33 @@
                 },
                 "invoice_status": {
                     "description": "invoice_status represents the current status of the invoice (draft, finalized, etc.)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.InvoiceStatus"
                 },
                 "invoice_type": {
                     "description": "invoice_type indicates the type of invoice (subscription, one_time, etc.)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.InvoiceType"
                 },
                 "line_item_coupons": {
                     "description": "Invoice Line Item Coupons",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceLineItemCoupon"
+                        "$ref": "#/definitions/InvoiceLineItemCoupon"
                     }
                 },
                 "line_items": {
                     "description": "line_items contains the individual items that make up this invoice",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateInvoiceLineItemRequest"
+                        "$ref": "#/definitions/CreateInvoiceLineItemRequest"
                     }
                 },
                 "metadata": {
                     "description": "metadata contains additional custom key-value pairs for storing extra information",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "payment_status": {
                     "description": "payment_status represents the payment status of the invoice (unpaid, paid, etc.)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentStatus"
                 },
                 "period_end": {
                     "description": "period_end is the end date of the billing period",
@@ -13385,8 +13281,12 @@
                     "description": "prepared_tax_rates contains the tax rates pre-resolved by the caller (e.g., billing service)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateResponse"
+                        "$ref": "#/definitions/TaxRateResponse"
                     }
+                },
+                "subscription_customer_id": {
+                    "description": "subscription_customer_id is the subscription owner's customer ID when it differs from customer_id (invoicing customer)",
+                    "type": "string"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the optional unique identifier of the subscription associated with this invoice",
@@ -13400,7 +13300,7 @@
                     "description": "tax_rate_overrides is the tax rate overrides to be applied to the invoice",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateOverride"
+                        "$ref": "#/definitions/TaxRateOverride"
                     }
                 },
                 "tax_rates": {
@@ -13420,7 +13320,7 @@
                 }
             }
         },
-        "dto.CreateMeterRequest": {
+        "CreateMeterRequest": {
             "type": "object",
             "required": [
                 "aggregation",
@@ -13447,11 +13347,11 @@
                     "example": "API Usage Meter"
                 },
                 "reset_usage": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage"
+                    "$ref": "#/definitions/types.ResetUsage"
                 }
             }
         },
-        "dto.CreatePaymentRequest": {
+        "CreatePaymentRequest": {
             "type": "object",
             "required": [
                 "amount",
@@ -13474,7 +13374,7 @@
                     "type": "string"
                 },
                 "destination_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentDestinationType"
+                    "$ref": "#/definitions/types.PaymentDestinationType"
                 },
                 "idempotency_key": {
                     "type": "string"
@@ -13483,13 +13383,13 @@
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "payment_gateway": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentGatewayType"
+                    "$ref": "#/definitions/types.PaymentGatewayType"
                 },
                 "payment_method_id": {
                     "type": "string"
                 },
                 "payment_method_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentMethodType"
+                    "$ref": "#/definitions/types.PaymentMethodType"
                 },
                 "process_payment": {
                     "type": "boolean",
@@ -13504,7 +13404,7 @@
                 }
             }
         },
-        "dto.CreatePlanRequest": {
+        "CreatePlanRequest": {
             "type": "object",
             "required": [
                 "name"
@@ -13527,7 +13427,7 @@
                 }
             }
         },
-        "dto.CreatePriceRequest": {
+        "CreatePriceRequest": {
             "type": "object",
             "required": [
                 "billing_cadence",
@@ -13545,13 +13445,13 @@
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "type": "integer",
@@ -13573,7 +13473,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
+                    "$ref": "#/definitions/types.PriceEntityType"
                 },
                 "filter_values": {
                     "type": "object",
@@ -13589,7 +13489,7 @@
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "type": "string"
@@ -13608,21 +13508,21 @@
                     "type": "integer"
                 },
                 "price_unit_config": {
-                    "$ref": "#/definitions/dto.PriceUnitConfig"
+                    "$ref": "#/definitions/PriceUnitConfig"
                 },
                 "price_unit_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
+                    "$ref": "#/definitions/types.PriceUnitType"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -13632,11 +13532,11 @@
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 }
             }
         },
-        "dto.CreatePriceTier": {
+        "CreatePriceTier": {
             "type": "object",
             "required": [
                 "unit_amount"
@@ -13656,7 +13556,7 @@
                 }
             }
         },
-        "dto.CreatePriceUnitRequest": {
+        "CreatePriceUnitRequest": {
             "type": "object",
             "required": [
                 "base_currency",
@@ -13688,7 +13588,7 @@
                 }
             }
         },
-        "dto.CreatePriceUnitResponse": {
+        "CreatePriceUnitResponse": {
             "type": "object",
             "properties": {
                 "base_currency": {
@@ -13719,7 +13619,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "symbol": {
                     "type": "string"
@@ -13735,7 +13635,7 @@
                 }
             }
         },
-        "dto.CreateScheduledTaskRequest": {
+        "CreateScheduledTaskRequest": {
             "type": "object",
             "required": [
                 "connection_id",
@@ -13751,7 +13651,7 @@
                     "type": "boolean"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType"
+                    "$ref": "#/definitions/types.ScheduledTaskEntityType"
                 },
                 "interval": {
                     "description": "Note: \"custom\" is excluded from API (internal testing only)",
@@ -13759,18 +13659,14 @@
                         "hourly",
                         "daily"
                     ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ScheduledTaskInterval"
                 },
                 "job_config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3JobConfig"
+                    "$ref": "#/definitions/types.S3JobConfig"
                 }
             }
         },
-        "dto.CreateSubscriptionLineItemRequest": {
+        "CreateSubscriptionLineItemRequest": {
             "type": "object",
             "properties": {
                 "commitment_amount": {
@@ -13778,7 +13674,7 @@
                     "type": "number"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "number"
@@ -13790,7 +13686,7 @@
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -13809,11 +13705,7 @@
                 },
                 "price": {
                     "description": "Price defines a new price inline; server creates a subscription-scoped price and adds the line item. Exactly one of price_id or price must be set. Entity/currency are set from the subscription.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.SubscriptionPriceCreateRequest"
-                        }
-                    ]
+                    "$ref": "#/definitions/SubscriptionPriceCreateRequest"
                 },
                 "price_id": {
                     "description": "PriceID references an existing price (plan, addon, or subscription-scoped). Exactly one of price_id or price must be set.",
@@ -13830,7 +13722,7 @@
                 }
             }
         },
-        "dto.CreateSubscriptionRequest": {
+        "CreateSubscriptionRequest": {
             "type": "object",
             "required": [
                 "billing_cadence",
@@ -13843,22 +13735,18 @@
                     "description": "Addons represents addons to be added to the subscription during creation",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AddAddonToSubscriptionRequest"
+                        "$ref": "#/definitions/AddAddonToSubscriptionRequest"
                     }
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingCycle"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "type": "integer",
@@ -13866,11 +13754,7 @@
                 },
                 "collection_method": {
                     "description": "collection_method determines how invoices are collected\n\"default_incomplete\" - subscription waits for payment confirmation before activation\n\"send_invoice\" - subscription activates immediately, invoice is sent for payment",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CollectionMethod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CollectionMethod"
                 },
                 "commitment_amount": {
                     "description": "CommitmentAmount is the minimum amount a customer commits to paying for a billing period",
@@ -13878,11 +13762,7 @@
                 },
                 "commitment_duration": {
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "coupons": {
                     "type": "array",
@@ -13894,7 +13774,7 @@
                     "description": "Credit grants to be applied when subscription is created",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateCreditGrantRequest"
+                        "$ref": "#/definitions/CreateCreditGrantRequest"
                     }
                 },
                 "currency": {
@@ -13924,17 +13804,13 @@
                 },
                 "inheritance": {
                     "description": "Inheritance groups all customer-hierarchy fields.\nWhen provided with at least one child ID, the subscription becomes a PARENT type.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.SubscriptionInheritanceConfig"
-                        }
-                    ]
+                    "$ref": "#/definitions/SubscriptionInheritanceConfig"
                 },
                 "line_item_commitments": {
                     "description": "LineItemCommitments allows setting commitment configuration per line item (keyed by price_id)",
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/dto.LineItemCommitmentConfig"
+                        "$ref": "#/definitions/LineItemCommitmentConfig"
                     }
                 },
                 "line_item_coupons": {
@@ -13950,7 +13826,7 @@
                     "description": "LineItems are extra line items to add at creation (each with price_id or price), in addition to plan prices",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateSubscriptionLineItemRequest"
+                        "$ref": "#/definitions/CreateSubscriptionLineItemRequest"
                     }
                 },
                 "lookup_key": {
@@ -13970,37 +13846,29 @@
                     "description": "OverrideEntitlements allows customizing specific entitlements for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.OverrideEntitlementRequest"
+                        "$ref": "#/definitions/OverrideEntitlementRequest"
                     }
                 },
                 "override_line_items": {
                     "description": "OverrideLineItems allows customizing specific prices for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.OverrideLineItemRequest"
+                        "$ref": "#/definitions/OverrideLineItemRequest"
                     }
                 },
                 "payment_behavior": {
                     "description": "Payment behavior configuration",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentBehavior"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentBehavior"
                 },
                 "payment_terms": {
                     "description": "PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentTerms"
                 },
                 "phases": {
                     "description": "Phases represents subscription phases to be created with the subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPhaseCreateRequest"
+                        "$ref": "#/definitions/SubscriptionPhaseCreateRequest"
                     }
                 },
                 "plan_id": {
@@ -14008,28 +13876,20 @@
                 },
                 "proration_behavior": {
                     "description": "ProrationBehavior controls how proration is handled.\nIf not set, the default value is none. Possible values are create_prorations and none.\ncreate_prorations means the proration will be calculated and applied.\nnone means the proration will not be calculated.\nThis is IGNORED when the billing cycle is anniversary.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "subscription_status": {
                     "description": "SubscriptionStatus determines the initial status of the subscription\nIf set to \"draft\", the subscription will be created as a draft (skips invoice creation and payment processing)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "tax_rate_overrides": {
                     "description": "tax_rate_overrides is the tax rate overrides\tto be applied to the subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxRateOverride"
+                        "$ref": "#/definitions/TaxRateOverride"
                     }
                 },
                 "trial_end": {
@@ -14040,7 +13900,7 @@
                 }
             }
         },
-        "dto.CreateTaskRequest": {
+        "CreateTaskRequest": {
             "type": "object",
             "required": [
                 "entity_type",
@@ -14050,13 +13910,13 @@
             ],
             "properties": {
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntityType"
+                    "$ref": "#/definitions/types.EntityType"
                 },
                 "file_name": {
                     "type": "string"
                 },
                 "file_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FileType"
+                    "$ref": "#/definitions/types.FileType"
                 },
                 "file_url": {
                     "type": "string"
@@ -14066,11 +13926,11 @@
                     "additionalProperties": true
                 },
                 "task_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskType"
+                    "$ref": "#/definitions/types.TaskType"
                 }
             }
         },
-        "dto.CreateTaxAssociationRequest": {
+        "CreateTaxAssociationRequest": {
             "type": "object",
             "required": [
                 "tax_rate_code"
@@ -14086,7 +13946,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType"
+                    "$ref": "#/definitions/types.TaxRateEntityType"
                 },
                 "external_customer_id": {
                     "type": "string"
@@ -14105,7 +13965,7 @@
                 }
             }
         },
-        "dto.CreateTaxRateRequest": {
+        "CreateTaxRateRequest": {
             "type": "object",
             "required": [
                 "code",
@@ -14141,23 +14001,15 @@
                 },
                 "scope": {
                     "description": "scope defines where this tax rate applies",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateScope"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.TaxRateScope"
                 },
                 "tax_rate_type": {
                     "description": "tax_rate_type determines how the tax is calculated (\"percentage\" or \"fixed\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.TaxRateType"
                 }
             }
         },
-        "dto.CreateUserRequest": {
+        "CreateUserRequest": {
             "type": "object",
             "required": [
                 "type"
@@ -14176,15 +14028,11 @@
                 },
                 "type": {
                     "description": "\"user\" or \"service_account\"",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.UserType"
                 }
             }
         },
-        "dto.CreateUserResponse": {
+        "CreateUserResponse": {
             "type": "object",
             "properties": {
                 "email": {
@@ -14204,14 +14052,14 @@
                     }
                 },
                 "tenant": {
-                    "$ref": "#/definitions/dto.TenantResponse"
+                    "$ref": "#/definitions/TenantResponse"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                    "$ref": "#/definitions/types.UserType"
                 }
             }
         },
-        "dto.CreateWalletRequest": {
+        "CreateWalletRequest": {
             "type": "object",
             "required": [
                 "currency"
@@ -14219,19 +14067,11 @@
             "properties": {
                 "alert_settings": {
                     "description": "alert_settings is the alert settings for the wallet (optional)\nIf not provided, tenant level alert settings will be used",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "auto_topup": {
                     "description": "auto top-up object",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -14276,18 +14116,18 @@
                     "type": "string"
                 },
                 "wallet_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletType"
+                    "$ref": "#/definitions/types.WalletType"
                 }
             }
         },
-        "dto.CreditGrantApplicationResponse": {
+        "CreditGrantApplicationResponse": {
             "type": "object",
             "properties": {
                 "application_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantApplicationReason"
+                    "$ref": "#/definitions/types.CreditGrantApplicationReason"
                 },
                 "application_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ApplicationStatus"
+                    "$ref": "#/definitions/types.ApplicationStatus"
                 },
                 "applied_at": {
                     "type": "string"
@@ -14332,13 +14172,13 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
                 },
                 "subscription_status_at_application": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -14351,11 +14191,11 @@
                 }
             }
         },
-        "dto.CreditGrantResponse": {
+        "CreditGrantResponse": {
             "type": "object",
             "properties": {
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantCadence"
+                    "$ref": "#/definitions/types.CreditGrantCadence"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -14383,10 +14223,10 @@
                     "type": "integer"
                 },
                 "expiration_duration_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit"
+                    "$ref": "#/definitions/types.CreditGrantExpiryDurationUnit"
                 },
                 "expiration_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType"
+                    "$ref": "#/definitions/types.CreditGrantExpiryType"
                 },
                 "id": {
                     "type": "string"
@@ -14398,7 +14238,7 @@
                     "type": "string"
                 },
                 "period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantPeriod"
+                    "$ref": "#/definitions/types.CreditGrantPeriod"
                 },
                 "period_count": {
                     "type": "integer"
@@ -14410,13 +14250,13 @@
                     "type": "integer"
                 },
                 "scope": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantScope"
+                    "$ref": "#/definitions/types.CreditGrantScope"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -14436,7 +14276,7 @@
                 }
             }
         },
-        "dto.CreditNoteResponse": {
+        "CreditNoteResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -14451,19 +14291,11 @@
                 },
                 "credit_note_status": {
                     "description": "credit_note_status represents the current status of the credit note (e.g., draft, finalized, voided)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CreditNoteStatus"
                 },
                 "credit_note_type": {
                     "description": "credit_note_type indicates the type of credit note (refund, adjustment)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CreditNoteType"
                 },
                 "currency": {
                     "description": "currency is the three-letter ISO currency code (e.g., USD, EUR) for the credit note",
@@ -14471,11 +14303,7 @@
                 },
                 "customer": {
                     "description": "customer contains the customer information associated with this credit note",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_customer.Customer"
-                        }
-                    ]
+                    "$ref": "#/definitions/Customer"
                 },
                 "customer_id": {
                     "description": "customer_id is the unique identifier of the customer who owns this credit note",
@@ -14499,11 +14327,7 @@
                 },
                 "invoice": {
                     "description": "invoice contains the associated invoice information if requested",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/InvoiceResponse"
                 },
                 "invoice_id": {
                     "description": "invoice_id is the id of the invoice resource that this credit note is applied to",
@@ -14522,38 +14346,22 @@
                 },
                 "metadata": {
                     "description": "metadata contains additional custom key-value pairs for storing extra information",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "reason": {
                     "description": "reason specifies the reason for creating this credit note (duplicate, fraudulent, order_change, product_unsatisfactory)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteReason"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CreditNoteReason"
                 },
                 "refund_status": {
                     "description": "refund_status represents the status of any refund associated with this credit note",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentStatus"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription": {
                     "description": "subscription contains the associated subscription information if applicable",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/SubscriptionResponse"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the optional unique identifier of the subscription related to this credit note",
@@ -14578,7 +14386,7 @@
                 }
             }
         },
-        "dto.CustomAnalyticItem": {
+        "CustomAnalyticItem": {
             "type": "object",
             "properties": {
                 "feature_name": {
@@ -14601,7 +14409,7 @@
                 }
             }
         },
-        "dto.CustomerEntitlementsResponse": {
+        "CustomerEntitlementsResponse": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -14610,12 +14418,12 @@
                 "features": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AggregatedFeature"
+                        "$ref": "#/definitions/AggregatedFeature"
                     }
                 }
             }
         },
-        "dto.CustomerInvoiceSummary": {
+        "CustomerInvoiceSummary": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -14660,21 +14468,21 @@
                 }
             }
         },
-        "dto.CustomerLookupResult": {
+        "CustomerLookupResult": {
             "type": "object",
             "properties": {
                 "customer": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_customer.Customer"
+                    "$ref": "#/definitions/Customer"
                 },
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.CustomerMultiCurrencyInvoiceSummary": {
+        "CustomerMultiCurrencyInvoiceSummary": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -14689,12 +14497,12 @@
                     "description": "summaries contains the invoice summaries for each currency",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CustomerInvoiceSummary"
+                        "$ref": "#/definitions/CustomerInvoiceSummary"
                     }
                 }
             }
         },
-        "dto.CustomerResponse": {
+        "CustomerResponse": {
             "description": "Customer response object containing all customer information",
             "type": "object",
             "properties": {
@@ -14747,7 +14555,7 @@
                 "integrations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntityIntegrationMappingResponse"
+                        "$ref": "#/definitions/EntityIntegrationMappingResponse"
                     }
                 },
                 "metadata": {
@@ -14762,7 +14570,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -14775,7 +14583,7 @@
                 }
             }
         },
-        "dto.CustomerUsageSummaryResponse": {
+        "CustomerUsageSummaryResponse": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -14784,38 +14592,38 @@
                 "features": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.FeatureUsageSummary"
+                        "$ref": "#/definitions/FeatureUsageSummary"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 },
                 "period": {
-                    "$ref": "#/definitions/dto.BillingPeriodInfo"
+                    "$ref": "#/definitions/BillingPeriodInfo"
                 }
             }
         },
-        "dto.DebugTracker": {
+        "DebugTracker": {
             "type": "object",
             "properties": {
                 "customer_lookup": {
-                    "$ref": "#/definitions/dto.CustomerLookupResult"
+                    "$ref": "#/definitions/CustomerLookupResult"
                 },
                 "failure_point": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FailurePoint"
+                    "$ref": "#/definitions/types.FailurePoint"
                 },
                 "meter_matching": {
-                    "$ref": "#/definitions/dto.MeterMatchingResult"
+                    "$ref": "#/definitions/MeterMatchingResult"
                 },
                 "price_lookup": {
-                    "$ref": "#/definitions/dto.PriceLookupResult"
+                    "$ref": "#/definitions/PriceLookupResult"
                 },
                 "subscription_line_item_lookup": {
-                    "$ref": "#/definitions/dto.SubscriptionLineItemLookupResult"
+                    "$ref": "#/definitions/SubscriptionLineItemLookupResult"
                 }
             }
         },
-        "dto.DeleteCostsheetResponse": {
+        "DeleteCostsheetResponse": {
             "type": "object",
             "properties": {
                 "id": {
@@ -14826,7 +14634,7 @@
                 }
             }
         },
-        "dto.DeleteCreditGrantRequest": {
+        "DeleteCreditGrantRequest": {
             "type": "object",
             "properties": {
                 "effective_date": {
@@ -14835,7 +14643,7 @@
                 }
             }
         },
-        "dto.DeletePriceRequest": {
+        "DeletePriceRequest": {
             "type": "object",
             "properties": {
                 "end_date": {
@@ -14843,7 +14651,7 @@
                 }
             }
         },
-        "dto.DeleteSubscriptionLineItemRequest": {
+        "DeleteSubscriptionLineItemRequest": {
             "type": "object",
             "properties": {
                 "effective_from": {
@@ -14851,11 +14659,11 @@
                 }
             }
         },
-        "dto.EntitlementResponse": {
+        "EntitlementResponse": {
             "type": "object",
             "properties": {
                 "addon": {
-                    "$ref": "#/definitions/dto.AddonResponse"
+                    "$ref": "#/definitions/AddonResponse"
                 },
                 "created_at": {
                     "type": "string"
@@ -14873,19 +14681,19 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType"
+                    "$ref": "#/definitions/types.EntitlementEntityType"
                 },
                 "environment_id": {
                     "type": "string"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "feature_id": {
                     "type": "string"
                 },
                 "feature_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "id": {
                     "type": "string"
@@ -14900,7 +14708,7 @@
                     "type": "string"
                 },
                 "plan": {
-                    "$ref": "#/definitions/dto.PlanResponse"
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "plan_id": {
                     "description": "TODO: Remove this once we have a proper entitlement entity type",
@@ -14913,7 +14721,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -14928,11 +14736,11 @@
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.EntitlementSource": {
+        "EntitlementSource": {
             "type": "object",
             "properties": {
                 "entitlement_id": {
@@ -14945,7 +14753,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/dto.EntitlementSourceEntityType"
+                    "$ref": "#/definitions/EntitlementSourceEntityType"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -14963,11 +14771,11 @@
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 }
             }
         },
-        "dto.EntitlementSourceEntityType": {
+        "EntitlementSourceEntityType": {
             "type": "string",
             "enum": [
                 "plan",
@@ -14980,7 +14788,7 @@
                 "EntitlementSourceEntityTypeSubscription"
             ]
         },
-        "dto.EntityIntegrationMappingResponse": {
+        "EntityIntegrationMappingResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -14993,7 +14801,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType"
+                    "$ref": "#/definitions/types.IntegrationEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -15008,7 +14816,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -15021,7 +14829,7 @@
                 }
             }
         },
-        "dto.Event": {
+        "Event": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -15051,7 +14859,7 @@
                 }
             }
         },
-        "dto.EventCostInfo": {
+        "EventCostInfo": {
             "type": "object",
             "properties": {
                 "costNanoUsd": {
@@ -15062,7 +14870,7 @@
                 }
             }
         },
-        "dto.ExecuteSubscriptionInheritanceRequest": {
+        "ExecuteSubscriptionInheritanceRequest": {
             "type": "object",
             "properties": {
                 "external_customer_ids_to_inherit_subscription": {
@@ -15073,11 +14881,11 @@
                 }
             }
         },
-        "dto.FeatureResponse": {
+        "FeatureResponse": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "created_at": {
                     "type": "string"
@@ -15093,11 +14901,7 @@
                 },
                 "group": {
                     "description": "Group is the full group object when the feature belongs to a group (populated in response)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.GroupResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/GroupResponse"
                 },
                 "group_id": {
                     "type": "string"
@@ -15112,7 +14916,7 @@
                     "$ref": "#/definitions/types.Metadata"
                 },
                 "meter": {
-                    "$ref": "#/definitions/dto.MeterResponse"
+                    "$ref": "#/definitions/MeterResponse"
                 },
                 "meter_id": {
                     "type": "string"
@@ -15121,16 +14925,16 @@
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -15146,7 +14950,7 @@
                 }
             }
         },
-        "dto.FeatureUsageInfo": {
+        "FeatureUsageInfo": {
             "type": "object",
             "properties": {
                 "customer_id": {
@@ -15175,14 +14979,14 @@
                 }
             }
         },
-        "dto.FeatureUsageSummary": {
+        "FeatureUsageSummary": {
             "type": "object",
             "properties": {
                 "current_usage": {
                     "type": "string"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -15199,7 +15003,7 @@
                 "sources": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementSource"
+                        "$ref": "#/definitions/EntitlementSource"
                     }
                 },
                 "total_limit": {
@@ -15210,7 +15014,7 @@
                 }
             }
         },
-        "dto.GetCostAnalyticsRequest": {
+        "GetCostAnalyticsRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -15247,22 +15051,22 @@
                 }
             }
         },
-        "dto.GetCostsheetResponse": {
+        "GetCostsheetResponse": {
             "type": "object",
             "properties": {
                 "costsheet": {
-                    "$ref": "#/definitions/dto.CostsheetResponse"
+                    "$ref": "#/definitions/CostsheetResponse"
                 }
             }
         },
-        "dto.GetDetailedCostAnalyticsResponse": {
+        "GetDetailedCostAnalyticsResponse": {
             "type": "object",
             "properties": {
                 "cost_analytics": {
                     "description": "Cost analytics array (flattened from nested structure)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CostAnalyticItem"
+                        "$ref": "#/definitions/CostAnalyticItem"
                     }
                 },
                 "currency": {
@@ -15299,27 +15103,27 @@
                 }
             }
         },
-        "dto.GetEventByIDResponse": {
+        "GetEventByIDResponse": {
             "type": "object",
             "properties": {
                 "debug_tracker": {
-                    "$ref": "#/definitions/dto.DebugTracker"
+                    "$ref": "#/definitions/DebugTracker"
                 },
                 "event": {
-                    "$ref": "#/definitions/dto.Event"
+                    "$ref": "#/definitions/Event"
                 },
                 "processed_events": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.FeatureUsageInfo"
+                        "$ref": "#/definitions/FeatureUsageInfo"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EventProcessingStatusType"
+                    "$ref": "#/definitions/types.EventProcessingStatusType"
                 }
             }
         },
-        "dto.GetEventsRequest": {
+        "GetEventsRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -15386,13 +15190,13 @@
                 }
             }
         },
-        "dto.GetEventsResponse": {
+        "GetEventsResponse": {
             "type": "object",
             "properties": {
                 "events": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.Event"
+                        "$ref": "#/definitions/Event"
                     }
                 },
                 "has_more": {
@@ -15412,18 +15216,18 @@
                 }
             }
         },
-        "dto.GetHuggingFaceBillingDataResponse": {
+        "GetHuggingFaceBillingDataResponse": {
             "type": "object",
             "properties": {
                 "requests": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EventCostInfo"
+                        "$ref": "#/definitions/EventCostInfo"
                     }
                 }
             }
         },
-        "dto.GetPendingSchedulesResponse": {
+        "GetPendingSchedulesResponse": {
             "description": "List of pending schedules for a subscription",
             "type": "object",
             "properties": {
@@ -15435,12 +15239,12 @@
                     "description": "schedules is the list of pending schedules",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionScheduleResponse"
+                        "$ref": "#/definitions/SubscriptionScheduleResponse"
                     }
                 }
             }
         },
-        "dto.GetPreviewInvoiceRequest": {
+        "GetPreviewInvoiceRequest": {
             "type": "object",
             "required": [
                 "subscription_id"
@@ -15465,7 +15269,7 @@
                 }
             }
         },
-        "dto.GetUsageAnalyticsRequest": {
+        "GetUsageAnalyticsRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -15519,11 +15323,11 @@
                     "type": "string"
                 },
                 "window_size": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.GetUsageAnalyticsResponse": {
+        "GetUsageAnalyticsResponse": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -15532,13 +15336,13 @@
                 "custom_analytics": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CustomAnalyticItem"
+                        "$ref": "#/definitions/CustomAnalyticItem"
                     }
                 },
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageAnalyticItem"
+                        "$ref": "#/definitions/UsageAnalyticItem"
                     }
                 },
                 "total_cost": {
@@ -15546,7 +15350,7 @@
                 }
             }
         },
-        "dto.GetUsageByMeterRequest": {
+        "GetUsageByMeterRequest": {
             "type": "object",
             "required": [
                 "meter_id"
@@ -15559,11 +15363,7 @@
                 },
                 "bucket_size": {
                     "description": "Optional, only used for MAX aggregation with windowing",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
-                        }
-                    ],
+                    "$ref": "#/definitions/types.WindowSize",
                     "example": "HOUR"
                 },
                 "customer_id": {
@@ -15596,11 +15396,11 @@
                     "example": "2024-11-09T00:00:00Z"
                 },
                 "window_size": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.GetUsageBySubscriptionRequest": {
+        "GetUsageBySubscriptionRequest": {
             "type": "object",
             "required": [
                 "subscription_id"
@@ -15624,7 +15424,7 @@
                 }
             }
         },
-        "dto.GetUsageBySubscriptionResponse": {
+        "GetUsageBySubscriptionResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -15633,7 +15433,7 @@
                 "charges": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionUsageByMetersResponse"
+                        "$ref": "#/definitions/SubscriptionUsageByMetersResponse"
                     }
                 },
                 "commitment_amount": {
@@ -15668,7 +15468,7 @@
                 }
             }
         },
-        "dto.GetUsageRequest": {
+        "GetUsageRequest": {
             "type": "object",
             "required": [
                 "aggregation_type",
@@ -15676,7 +15476,7 @@
             ],
             "properties": {
                 "aggregation_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 },
                 "billing_anchor": {
                     "description": "BillingAnchor enables custom monthly billing periods for usage aggregation.\n\nWhen to use:\n- WindowSize = \"MONTH\" AND you need custom monthly periods (not calendar months)\n- Subscription billing that doesn't align with calendar months\n- Example: Customer signed up on 15th, so billing periods are 15th to 15th\n\nWhen NOT to use:\n- WindowSize != \"MONTH\" (ignored for DAY, HOUR, WEEK, etc.)\n- Standard calendar-based billing (1st to 1st of each month)\n\nExample values:\n- \"2024-03-05T14:30:45.123456789Z\" (5th of each month at 2:30:45 PM)\n- \"2024-01-15T00:00:00Z\" (15th of each month at midnight)\n- \"2024-02-29T12:00:00Z\" (29th of each month at noon - handles leap years)",
@@ -15685,11 +15485,7 @@
                 },
                 "bucket_size": {
                     "description": "Optional, only used for MAX aggregation with windowing",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
-                        }
-                    ],
+                    "$ref": "#/definitions/types.WindowSize",
                     "example": "HOUR"
                 },
                 "customer_id": {
@@ -15734,11 +15530,11 @@
                     "example": "2024-03-13T00:00:00Z"
                 },
                 "window_size": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.GetUsageResponse": {
+        "GetUsageResponse": {
             "type": "object",
             "properties": {
                 "event_name": {
@@ -15747,18 +15543,18 @@
                 "results": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageResult"
+                        "$ref": "#/definitions/UsageResult"
                     }
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 },
                 "value": {
                     "type": "number"
                 }
             }
         },
-        "dto.GroupResponse": {
+        "GroupResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -15796,7 +15592,7 @@
                 }
             }
         },
-        "dto.IngestEventRequest": {
+        "IngestEventRequest": {
             "type": "object",
             "required": [
                 "event_name",
@@ -15841,7 +15637,7 @@
                 }
             }
         },
-        "dto.InvoiceCoupon": {
+        "InvoiceCoupon": {
             "type": "object",
             "required": [
                 "coupon_id"
@@ -15855,7 +15651,7 @@
                 }
             }
         },
-        "dto.InvoiceLineItemCoupon": {
+        "InvoiceLineItemCoupon": {
             "type": "object",
             "required": [
                 "coupon_id",
@@ -15874,7 +15670,7 @@
                 }
             }
         },
-        "dto.InvoiceLineItemPreview": {
+        "InvoiceLineItemPreview": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -15907,14 +15703,14 @@
                 }
             }
         },
-        "dto.InvoiceLineItemResponse": {
+        "InvoiceLineItemResponse": {
             "type": "object",
             "properties": {
                 "amount": {
                     "type": "string"
                 },
                 "commitment_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "created_at": {
                     "type": "string"
@@ -15995,7 +15791,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -16013,19 +15809,19 @@
                     "description": "usage_analytics contains usage analytics for this line item (legacy - grouped by source)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SourceUsageItem"
+                        "$ref": "#/definitions/SourceUsageItem"
                     }
                 },
                 "usage_breakdown": {
                     "description": "usage_breakdown contains flexible usage breakdown for this line item (supports any grouping)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageBreakdownItem"
+                        "$ref": "#/definitions/UsageBreakdownItem"
                     }
                 }
             }
         },
-        "dto.InvoicePreview": {
+        "InvoicePreview": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -16040,7 +15836,7 @@
                     "description": "line_items contains preview of line items",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceLineItemPreview"
+                        "$ref": "#/definitions/InvoiceLineItemPreview"
                     }
                 },
                 "subtotal": {
@@ -16057,7 +15853,7 @@
                 }
             }
         },
-        "dto.InvoiceResponse": {
+        "InvoiceResponse": {
             "type": "object",
             "properties": {
                 "adjustment_amount": {
@@ -16092,7 +15888,7 @@
                     "description": "coupon_applications contains the coupon applications associated with this invoice (overrides embedded field)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponApplicationResponse"
+                        "$ref": "#/definitions/CouponApplicationResponse"
                     }
                 },
                 "created_at": {
@@ -16107,11 +15903,7 @@
                 },
                 "customer": {
                     "description": "customer contains the customer information associated with this invoice",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.CustomerResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "description": "customer_id is the ID of the customer who will receive this invoice",
@@ -16151,19 +15943,11 @@
                 },
                 "invoice_status": {
                     "description": "invoice_status represents the current status of the invoice - values include draft, open, paid, void, etc.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.InvoiceStatus"
                 },
                 "invoice_type": {
                     "description": "invoice_type indicates the type of invoice - whether this is a subscription invoice, one-time charge, or other billing type",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.InvoiceType"
                 },
                 "last_computed_at": {
                     "description": "last_computed_at is the timestamp when this invoice was last computed by ComputeInvoice",
@@ -16173,16 +15957,12 @@
                     "description": "line_items contains the individual items that make up this invoice (overrides embedded field)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.InvoiceLineItemResponse"
+                        "$ref": "#/definitions/InvoiceLineItemResponse"
                     }
                 },
                 "metadata": {
                     "description": "metadata contains custom key-value pairs for storing additional information about this invoice",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "overpaid_amount": {
                     "description": "overpaid_amount is the amount overpaid if payment_status is OVERPAID (amount_paid - total)",
@@ -16194,11 +15974,7 @@
                 },
                 "payment_status": {
                     "description": "payment_status indicates whether the invoice has been paid, is pending, or failed",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentStatus"
                 },
                 "period_end": {
                     "description": "period_end is the end date of the billing period covered by this invoice",
@@ -16217,15 +15993,15 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription": {
                     "description": "subscription contains the associated subscription information if requested",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.SubscriptionResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/SubscriptionResponse"
+                },
+                "subscription_customer_id": {
+                    "description": "subscription_customer_id is the subscription owner's customer ID (Subscription.CustomerID).\nIt may differ from customer_id when the subscription uses an invoicing customer.",
+                    "type": "string"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the ID of the subscription this invoice is associated with (only present for subscription-based invoices)",
@@ -16239,7 +16015,7 @@
                     "description": "tax_applied_records contains the tax applied records associated with this invoice",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaxAppliedResponse"
+                        "$ref": "#/definitions/TaxAppliedResponse"
                     }
                 },
                 "tenant_id": {
@@ -16277,7 +16053,7 @@
                 }
             }
         },
-        "dto.LineItemCommitmentConfig": {
+        "LineItemCommitmentConfig": {
             "type": "object",
             "properties": {
                 "commitment_amount": {
@@ -16286,11 +16062,7 @@
                 },
                 "commitment_duration": {
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_quantity": {
                     "description": "CommitmentQuantity is the minimum quantity committed for this line item",
@@ -16298,11 +16070,7 @@
                 },
                 "commitment_type": {
                     "description": "CommitmentType specifies whether commitment is based on amount or quantity",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "enable_true_up": {
                     "description": "EnableTrueUp determines if true-up fee should be applied when usage is below commitment",
@@ -16318,7 +16086,7 @@
                 }
             }
         },
-        "dto.LinkIntegrationMappingRequest": {
+        "LinkIntegrationMappingRequest": {
             "type": "object",
             "required": [
                 "entity_id",
@@ -16332,7 +16100,7 @@
                     "maxLength": 255
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType"
+                    "$ref": "#/definitions/types.IntegrationEntityType"
                 },
                 "metadata": {
                     "type": "object",
@@ -16348,71 +16116,71 @@
                 }
             }
         },
-        "dto.LinkIntegrationMappingResponse": {
+        "LinkIntegrationMappingResponse": {
             "type": "object",
             "properties": {
                 "mapping": {
-                    "$ref": "#/definitions/dto.EntityIntegrationMappingResponse"
+                    "$ref": "#/definitions/EntityIntegrationMappingResponse"
                 }
             }
         },
-        "dto.ListAlertLogsResponse": {
+        "ListAlertLogsResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AlertLogResponse"
+                        "$ref": "#/definitions/AlertLogResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListCostsheetResponse": {
+        "ListCostsheetResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CostsheetResponse"
+                        "$ref": "#/definitions/CostsheetResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListPaymentsResponse": {
+        "ListPaymentsResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PaymentResponse"
+                        "$ref": "#/definitions/PaymentResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListSecretsResponse": {
+        "ListSecretsResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SecretResponse"
+                        "$ref": "#/definitions/SecretResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.ListSubscriptionPausesResponse": {
+        "ListSubscriptionPausesResponse": {
             "description": "Response object for listing subscription pauses with total count",
             "type": "object",
             "properties": {
@@ -16420,7 +16188,7 @@
                     "description": "List of subscription pause objects\n@Description Array of subscription pauses",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPauseResponse"
+                        "$ref": "#/definitions/SubscriptionPauseResponse"
                     }
                 },
                 "total": {
@@ -16429,21 +16197,21 @@
                 }
             }
         },
-        "dto.ListTasksResponse": {
+        "ListTasksResponse": {
             "type": "object",
             "properties": {
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TaskResponse"
+                        "$ref": "#/definitions/TaskResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
-        "dto.MatchedMeter": {
+        "MatchedMeter": {
             "type": "object",
             "properties": {
                 "event_name": {
@@ -16457,7 +16225,7 @@
                 }
             }
         },
-        "dto.MatchedPrice": {
+        "MatchedPrice": {
             "type": "object",
             "properties": {
                 "meter_id": {
@@ -16474,7 +16242,7 @@
                 }
             }
         },
-        "dto.MatchedSubscriptionLineItem": {
+        "MatchedSubscriptionLineItem": {
             "type": "object",
             "properties": {
                 "end_date": {
@@ -16503,24 +16271,24 @@
                 }
             }
         },
-        "dto.MeterMatchingResult": {
+        "MeterMatchingResult": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "matched_meters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.MatchedMeter"
+                        "$ref": "#/definitions/MatchedMeter"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.MeterResponse": {
+        "MeterResponse": {
             "type": "object",
             "properties": {
                 "aggregation": {
@@ -16549,7 +16317,7 @@
                     "example": "API Usage Meter"
                 },
                 "reset_usage": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage"
+                    "$ref": "#/definitions/types.ResetUsage"
                 },
                 "status": {
                     "type": "string",
@@ -16565,7 +16333,7 @@
                 }
             }
         },
-        "dto.OverrideEntitlementRequest": {
+        "OverrideEntitlementRequest": {
             "type": "object",
             "required": [
                 "entitlement_id"
@@ -16589,7 +16357,7 @@
                 }
             }
         },
-        "dto.OverrideLineItemRequest": {
+        "OverrideLineItemRequest": {
             "type": "object",
             "required": [
                 "price_id"
@@ -16600,7 +16368,7 @@
                     "type": "string"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "price_id": {
                     "description": "PriceID references the plan price to override",
@@ -16614,7 +16382,7 @@
                     "description": "PriceUnitTiers are the tiers for the price unit (for CUSTOM type, TIERED billing model)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "quantity": {
@@ -16623,30 +16391,22 @@
                 },
                 "tier_mode": {
                     "description": "TierMode determines how to calculate the price for a given quantity",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "description": "Tiers determines the pricing tiers for this line item",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
                     "description": "TransformQuantity determines how to transform the quantity for this line item",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/price.TransformQuantity"
-                        }
-                    ]
+                    "$ref": "#/definitions/price.TransformQuantity"
                 }
             }
         },
-        "dto.PauseSubscriptionRequest": {
+        "PauseSubscriptionRequest": {
             "description": "Request object for pausing an active subscription with various pause modes and options",
             "type": "object",
             "required": [
@@ -16674,11 +16434,7 @@
                 },
                 "pause_mode": {
                     "description": "Mode for pausing the subscription\n@Description Determines when the pause takes effect. \"immediate\" pauses right away, \"scheduled\" pauses at a specified time\n@Enum immediate,scheduled",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PauseMode"
                 },
                 "pause_start": {
                     "description": "Start date for the subscription pause\n@Description ISO 8601 timestamp when the pause should begin. Required when pause_mode is \"scheduled\"\n@Example \"2024-01-15T00:00:00Z\"",
@@ -16691,7 +16447,7 @@
                 }
             }
         },
-        "dto.PaymentAttemptResponse": {
+        "PaymentAttemptResponse": {
             "type": "object",
             "properties": {
                 "attempt_number": {
@@ -16726,7 +16482,7 @@
                 }
             }
         },
-        "dto.PaymentResponse": {
+        "PaymentResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -16735,7 +16491,7 @@
                 "attempts": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PaymentAttemptResponse"
+                        "$ref": "#/definitions/PaymentAttemptResponse"
                     }
                 },
                 "created_at": {
@@ -16751,7 +16507,7 @@
                     "type": "string"
                 },
                 "destination_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentDestinationType"
+                    "$ref": "#/definitions/types.PaymentDestinationType"
                 },
                 "error_message": {
                     "type": "string"
@@ -16787,10 +16543,10 @@
                     "type": "string"
                 },
                 "payment_method_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentMethodType"
+                    "$ref": "#/definitions/types.PaymentMethodType"
                 },
                 "payment_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                    "$ref": "#/definitions/types.PaymentStatus"
                 },
                 "payment_url": {
                     "type": "string"
@@ -16818,7 +16574,7 @@
                 }
             }
         },
-        "dto.PlanResponse": {
+        "PlanResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -16830,7 +16586,7 @@
                 "credit_grants": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "description": {
@@ -16842,7 +16598,7 @@
                 "entitlements": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.EntitlementResponse"
+                        "$ref": "#/definitions/EntitlementResponse"
                     }
                 },
                 "environment_id": {
@@ -16864,11 +16620,11 @@
                     "description": "TODO: Add inline addons",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.PriceResponse"
+                        "$ref": "#/definitions/PriceResponse"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -16881,7 +16637,7 @@
                 }
             }
         },
-        "dto.PlanSummary": {
+        "PlanSummary": {
             "type": "object",
             "properties": {
                 "description": {
@@ -16902,41 +16658,41 @@
                 }
             }
         },
-        "dto.PriceLookupResult": {
+        "PriceLookupResult": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "matched_prices": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.MatchedPrice"
+                        "$ref": "#/definitions/MatchedPrice"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.PriceResponse": {
+        "PriceResponse": {
             "type": "object",
             "properties": {
                 "addon": {
-                    "$ref": "#/definitions/dto.AddonResponse"
+                    "$ref": "#/definitions/AddonResponse"
                 },
                 "amount": {
                     "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50",
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
@@ -16983,18 +16739,14 @@
                 },
                 "entity_type": {
                     "description": "EntityType holds the value of the \"entity_type\" field.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PriceEntityType"
                 },
                 "environment_id": {
                     "description": "EnvironmentID is the environment identifier for the price",
                     "type": "string"
                 },
                 "group": {
-                    "$ref": "#/definitions/dto.GroupResponse"
+                    "$ref": "#/definitions/GroupResponse"
                 },
                 "group_id": {
                     "description": "GroupID references the group this price belongs to",
@@ -17005,7 +16757,7 @@
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "description": "LookupKey used for looking up the price in the database",
@@ -17015,7 +16767,7 @@
                     "$ref": "#/definitions/price.JSONBMetadata"
                 },
                 "meter": {
-                    "$ref": "#/definitions/dto.MeterResponse"
+                    "$ref": "#/definitions/MeterResponse"
                 },
                 "meter_id": {
                     "description": "MeterID is the id of the meter for usage based pricing",
@@ -17031,7 +16783,7 @@
                     "type": "string"
                 },
                 "plan": {
-                    "$ref": "#/definitions/dto.PlanResponse"
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "price_unit": {
                     "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')",
@@ -17054,27 +16806,23 @@
                 },
                 "price_unit_type": {
                     "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PriceUnitType"
                 },
                 "pricing_unit": {
-                    "$ref": "#/definitions/dto.PriceUnitResponse"
+                    "$ref": "#/definitions/PriceUnitResponse"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the price",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
@@ -17090,7 +16838,7 @@
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -17100,7 +16848,7 @@
                 }
             }
         },
-        "dto.PriceUnitConfig": {
+        "PriceUnitConfig": {
             "type": "object",
             "required": [
                 "price_unit"
@@ -17115,12 +16863,12 @@
                 "price_unit_tiers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 }
             }
         },
-        "dto.PriceUnitResponse": {
+        "PriceUnitResponse": {
             "type": "object",
             "properties": {
                 "base_currency": {
@@ -17151,7 +16899,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "symbol": {
                     "type": "string"
@@ -17167,7 +16915,7 @@
                 }
             }
         },
-        "dto.ProrationDetail": {
+        "ProrationDetail": {
             "type": "object",
             "properties": {
                 "charge_amount": {
@@ -17196,7 +16944,7 @@
                 }
             }
         },
-        "dto.ProrationDetails": {
+        "ProrationDetails": {
             "type": "object",
             "properties": {
                 "charge_amount": {
@@ -17245,7 +16993,7 @@
                 }
             }
         },
-        "dto.RemoveAddonRequest": {
+        "RemoveAddonRequest": {
             "type": "object",
             "required": [
                 "addon_association_id"
@@ -17259,7 +17007,7 @@
                 }
             }
         },
-        "dto.ResumeSubscriptionRequest": {
+        "ResumeSubscriptionRequest": {
             "description": "Request object for resuming a paused subscription",
             "type": "object",
             "required": [
@@ -17279,15 +17027,11 @@
                 },
                 "resume_mode": {
                     "description": "Mode for resuming the subscription\n@Description Determines how the subscription should be resumed\n@Enum immediate,scheduled",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ResumeMode"
                 }
             }
         },
-        "dto.ScheduledTaskResponse": {
+        "ScheduledTaskResponse": {
             "type": "object",
             "properties": {
                 "connection_id": {
@@ -17300,7 +17044,7 @@
                     "type": "boolean"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType"
+                    "$ref": "#/definitions/types.ScheduledTaskEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -17314,14 +17058,10 @@
                         "hourly",
                         "daily"
                     ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ScheduledTaskInterval"
                 },
                 "job_config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3JobConfig"
+                    "$ref": "#/definitions/types.S3JobConfig"
                 },
                 "status": {
                     "type": "string"
@@ -17334,7 +17074,7 @@
                 }
             }
         },
-        "dto.SecretResponse": {
+        "SecretResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -17356,7 +17096,7 @@
                     "type": "string"
                 },
                 "provider": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SecretProvider"
+                    "$ref": "#/definitions/types.SecretProvider"
                 },
                 "roles": {
                     "description": "RBAC roles",
@@ -17366,25 +17106,21 @@
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SecretType"
+                    "$ref": "#/definitions/types.SecretType"
                 },
                 "updated_at": {
                     "type": "string"
                 },
                 "user_type": {
                     "description": "\"user\" or \"service_account\"",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.UserType"
                 }
             }
         },
-        "dto.SourceUsageItem": {
+        "SourceUsageItem": {
             "type": "object",
             "properties": {
                 "cost": {
@@ -17409,23 +17145,19 @@
                 }
             }
         },
-        "dto.SubscriptionChangeExecuteResponse": {
+        "SubscriptionChangeExecuteResponse": {
             "description": "Response after successfully executing a subscription plan change",
             "type": "object",
             "properties": {
                 "change_type": {
                     "description": "change_type indicates whether this was an upgrade, downgrade, or lateral change",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionChangeType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionChangeType"
                 },
                 "credit_grants": {
                     "description": "credit_grants contains any credit grants created for proration credits",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "effective_date": {
@@ -17434,11 +17166,7 @@
                 },
                 "invoice": {
                     "description": "invoice contains the immediate invoice generated for the change (if any)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/InvoiceResponse"
                 },
                 "is_scheduled": {
                     "description": "is_scheduled indicates if the change was scheduled or executed immediately",
@@ -17453,27 +17181,15 @@
                 },
                 "new_subscription": {
                     "description": "new_subscription contains the new subscription details (only if is_scheduled=false)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.SubscriptionSummary"
-                        }
-                    ]
+                    "$ref": "#/definitions/SubscriptionSummary"
                 },
                 "old_subscription": {
                     "description": "old_subscription contains the archived subscription details (only if is_scheduled=false)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.SubscriptionSummary"
-                        }
-                    ]
+                    "$ref": "#/definitions/SubscriptionSummary"
                 },
                 "proration_applied": {
                     "description": "proration_applied contains details of the proration that was applied",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.ProrationDetails"
-                        }
-                    ]
+                    "$ref": "#/definitions/ProrationDetails"
                 },
                 "schedule_id": {
                     "description": "schedule_id is the ID of the created schedule (only if is_scheduled=true)",
@@ -17485,25 +17201,17 @@
                 }
             }
         },
-        "dto.SubscriptionChangePreviewResponse": {
+        "SubscriptionChangePreviewResponse": {
             "description": "Response showing the financial impact of a subscription plan change",
             "type": "object",
             "properties": {
                 "change_type": {
                     "description": "change_type indicates whether this is an upgrade, downgrade, or lateral change",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionChangeType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionChangeType"
                 },
                 "current_plan": {
                     "description": "current_plan contains information about the current plan",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.PlanSummary"
-                        }
-                    ]
+                    "$ref": "#/definitions/PlanSummary"
                 },
                 "effective_date": {
                     "description": "effective_date is when the change would take effect",
@@ -17518,27 +17226,15 @@
                 },
                 "new_billing_cycle": {
                     "description": "new_billing_cycle shows the new billing cycle details",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.BillingCycleInfo"
-                        }
-                    ]
+                    "$ref": "#/definitions/BillingCycleInfo"
                 },
                 "next_invoice_preview": {
                     "description": "next_invoice_preview shows how the next regular invoice would be affected",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.InvoicePreview"
-                        }
-                    ]
+                    "$ref": "#/definitions/InvoicePreview"
                 },
                 "proration_details": {
                     "description": "proration_details contains the calculated proration amounts",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.ProrationDetails"
-                        }
-                    ]
+                    "$ref": "#/definitions/ProrationDetails"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the ID of the subscription being changed",
@@ -17546,11 +17242,7 @@
                 },
                 "target_plan": {
                     "description": "target_plan contains information about the target plan",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.PlanSummary"
-                        }
-                    ]
+                    "$ref": "#/definitions/PlanSummary"
                 },
                 "warnings": {
                     "description": "warnings contains any warnings about the change",
@@ -17561,7 +17253,7 @@
                 }
             }
         },
-        "dto.SubscriptionChangeRequest": {
+        "SubscriptionChangeRequest": {
             "description": "Request object for changing a subscription plan (upgrade/downgrade)",
             "type": "object",
             "required": [
@@ -17574,27 +17266,15 @@
             "properties": {
                 "billing_cadence": {
                     "description": "billing_cadence is the billing cadence for the new subscription",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "billing_cycle is the billing cycle for the new subscription",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingCycle"
                 },
                 "billing_period": {
                     "description": "billing_period is the billing period for the new subscription",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "billing_period_count is the billing period count for the new subscription",
@@ -17603,11 +17283,7 @@
                 },
                 "change_at": {
                     "description": "change_at determines when the change should take effect (optional)\nIf not provided or null: change executes immediately\nIf \"immediate\": change executes immediately (explicit)\nIf \"period_end\": change is scheduled for the end of the current billing period",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ScheduleType"
                 },
                 "metadata": {
                     "description": "metadata contains additional key-value pairs for storing extra information",
@@ -17618,11 +17294,7 @@
                 },
                 "proration_behavior": {
                     "description": "proration_behavior controls how proration is handled for the change\nOptions: create_prorations, none",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "target_plan_id": {
                     "description": "target_plan_id is the ID of the new plan to change to (required)",
@@ -17630,13 +17302,13 @@
                 }
             }
         },
-        "dto.SubscriptionEntitlementsResponse": {
+        "SubscriptionEntitlementsResponse": {
             "type": "object",
             "properties": {
                 "features": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.AggregatedFeature"
+                        "$ref": "#/definitions/AggregatedFeature"
                     }
                 },
                 "plan_id": {
@@ -17647,7 +17319,7 @@
                 }
             }
         },
-        "dto.SubscriptionInheritanceConfig": {
+        "SubscriptionInheritanceConfig": {
             "type": "object",
             "properties": {
                 "external_customer_ids_to_inherit_subscription": {
@@ -17664,28 +17336,28 @@
                 }
             }
         },
-        "dto.SubscriptionLineItemLookupResult": {
+        "SubscriptionLineItemLookupResult": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "matched_line_items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.MatchedSubscriptionLineItem"
+                        "$ref": "#/definitions/MatchedSubscriptionLineItem"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus"
+                    "$ref": "#/definitions/types.DebugTrackerStatus"
                 }
             }
         },
-        "dto.SubscriptionLineItemResponse": {
+        "SubscriptionLineItemResponse": {
             "type": "object",
             "properties": {
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "from price at create; default 1",
@@ -17696,7 +17368,7 @@
                     "type": "string"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "string"
@@ -17708,7 +17380,7 @@
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -17735,7 +17407,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType"
+                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -17744,7 +17416,7 @@
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "metadata": {
                     "type": "object",
@@ -17762,13 +17434,13 @@
                     "type": "string"
                 },
                 "price": {
-                    "$ref": "#/definitions/dto.PriceResponse"
+                    "$ref": "#/definitions/PriceResponse"
                 },
                 "price_id": {
                     "type": "string"
                 },
                 "price_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "price_unit": {
                     "type": "string"
@@ -17783,7 +17455,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -17805,7 +17477,7 @@
                 }
             }
         },
-        "dto.SubscriptionPauseResponse": {
+        "SubscriptionPauseResponse": {
             "description": "Response object containing subscription pause information",
             "type": "object",
             "properties": {
@@ -17839,28 +17511,28 @@
                     "type": "string"
                 },
                 "pause_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode"
+                    "$ref": "#/definitions/types.PauseMode"
                 },
                 "pause_start": {
                     "description": "PauseStart is when the pause actually started",
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "reason": {
                     "description": "Reason is the reason for pausing",
                     "type": "string"
                 },
                 "resume_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode"
+                    "$ref": "#/definitions/types.ResumeMode"
                 },
                 "resumed_at": {
                     "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -17877,7 +17549,7 @@
                 }
             }
         },
-        "dto.SubscriptionPhaseCreateRequest": {
+        "SubscriptionPhaseCreateRequest": {
             "type": "object",
             "required": [
                 "start_date"
@@ -17913,7 +17585,7 @@
                     "description": "OverrideLineItems allows customizing specific prices for this phase\nIf not provided, phase will use the same line items as the subscription (plan prices)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.OverrideLineItemRequest"
+                        "$ref": "#/definitions/OverrideLineItemRequest"
                     }
                 },
                 "start_date": {
@@ -17921,7 +17593,7 @@
                 }
             }
         },
-        "dto.SubscriptionPhaseResponse": {
+        "SubscriptionPhaseResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -17944,18 +17616,14 @@
                 },
                 "metadata": {
                     "description": "Metadata contains additional key-value pairs",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "start_date": {
                     "description": "StartDate is when the phase starts",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -17972,7 +17640,7 @@
                 }
             }
         },
-        "dto.SubscriptionPriceCreateRequest": {
+        "SubscriptionPriceCreateRequest": {
             "type": "object",
             "required": [
                 "billing_cadence",
@@ -17987,13 +17655,13 @@
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "type": "integer"
@@ -18017,7 +17685,7 @@
                     }
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "type": "string"
@@ -18035,21 +17703,21 @@
                     "type": "integer"
                 },
                 "price_unit_config": {
-                    "$ref": "#/definitions/dto.PriceUnitConfig"
+                    "$ref": "#/definitions/PriceUnitConfig"
                 },
                 "price_unit_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
+                    "$ref": "#/definitions/types.PriceUnitType"
                 },
                 "start_date": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
@@ -18059,11 +17727,11 @@
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 }
             }
         },
-        "dto.SubscriptionResponse": {
+        "SubscriptionResponse": {
             "type": "object",
             "properties": {
                 "active_pause_id": {
@@ -18075,18 +17743,14 @@
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingCycle"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the total number units of the billing period.",
@@ -18115,17 +17779,13 @@
                 },
                 "commitment_duration": {
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on a MONTHLY subscription)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "coupon_associations": {
                     "description": "CouponAssociations are the coupon associations for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponAssociationResponse"
+                        "$ref": "#/definitions/CouponAssociationResponse"
                     }
                 },
                 "created_at": {
@@ -18138,7 +17798,7 @@
                     "description": "Credit grants are the credit grants for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "currency": {
@@ -18154,7 +17814,7 @@
                     "type": "string"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "description": "CustomerID is the identifier for the customer in our system",
@@ -18188,11 +17848,7 @@
                 },
                 "latest_invoice": {
                     "description": "Latest invoice information for incomplete subscriptions",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.InvoiceResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/InvoiceResponse"
                 },
                 "line_items": {
                     "type": "array",
@@ -18216,7 +17872,7 @@
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "pauses": {
                     "type": "array",
@@ -18230,46 +17886,38 @@
                 },
                 "payment_terms": {
                     "description": "PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentTerms"
                 },
                 "phases": {
                     "description": "Phases are the subscription phases for this subscription",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPhaseResponse"
+                        "$ref": "#/definitions/SubscriptionPhaseResponse"
                     }
                 },
                 "plan": {
-                    "$ref": "#/definitions/dto.PlanResponse"
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "plan_id": {
                     "description": "PlanID is the identifier for the plan in our system",
                     "type": "string"
                 },
                 "proration_behavior": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the subscription",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "subscription_type": {
                     "description": "SubscriptionType categorises the subscription within a customer hierarchy (standalone, parent, inherited).",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.SubscriptionType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionType"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -18294,7 +17942,7 @@
                 }
             }
         },
-        "dto.SubscriptionResponseV2": {
+        "SubscriptionResponseV2": {
             "type": "object",
             "properties": {
                 "active_pause_id": {
@@ -18306,18 +17954,14 @@
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingCycle"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the total number units of the billing period.",
@@ -18346,17 +17990,13 @@
                 },
                 "commitment_duration": {
                     "description": "CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on a MONTHLY subscription)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "coupon_associations": {
                     "description": "CouponAssociations are included when \"coupon_associations\" is in expand parameter",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CouponAssociationResponse"
+                        "$ref": "#/definitions/CouponAssociationResponse"
                     }
                 },
                 "created_at": {
@@ -18369,7 +18009,7 @@
                     "description": "CreditGrants are included when \"credit_grants\" is in expand parameter",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreditGrantResponse"
+                        "$ref": "#/definitions/CreditGrantResponse"
                     }
                 },
                 "currency": {
@@ -18386,11 +18026,7 @@
                 },
                 "customer": {
                     "description": "Customer is expanded only if \"customer\" is in expand parameter",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.CustomerResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "description": "CustomerID is the identifier for the customer in our system",
@@ -18426,7 +18062,7 @@
                     "description": "LineItems is expanded only if \"subscription_line_items\" is in expand parameter\nEach line item can optionally include expanded price data",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionLineItemResponse"
+                        "$ref": "#/definitions/SubscriptionLineItemResponse"
                     }
                 },
                 "lookup_key": {
@@ -18445,7 +18081,7 @@
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "pauses": {
                     "description": "Pauses are included when subscription has pause status",
@@ -18460,51 +18096,39 @@
                 },
                 "payment_terms": {
                     "description": "PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentTerms"
                 },
                 "phases": {
                     "description": "Phases are included when \"phases\" is in expand parameter",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionPhaseResponse"
+                        "$ref": "#/definitions/SubscriptionPhaseResponse"
                     }
                 },
                 "plan": {
                     "description": "Plan is expanded only if \"plan\" is in expand parameter",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.PlanResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/PlanResponse"
                 },
                 "plan_id": {
                     "description": "PlanID is the identifier for the plan in our system",
                     "type": "string"
                 },
                 "proration_behavior": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior"
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the subscription",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 },
                 "subscription_type": {
                     "description": "SubscriptionType categorises the subscription within a customer hierarchy (standalone, parent, inherited).",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.SubscriptionType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionType"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -18529,7 +18153,7 @@
                 }
             }
         },
-        "dto.SubscriptionScheduleResponse": {
+        "SubscriptionScheduleResponse": {
             "description": "Full details of a subscription schedule",
             "type": "object",
             "properties": {
@@ -18576,11 +18200,7 @@
                 },
                 "schedule_type": {
                     "description": "schedule_type is the type of schedule (plan_change, addon_change, etc.)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionScheduleChangeType"
                 },
                 "scheduled_at": {
                     "description": "scheduled_at is when the schedule will execute",
@@ -18588,11 +18208,7 @@
                 },
                 "status": {
                     "description": "status is the current status of the schedule",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ScheduleStatus"
                 },
                 "subscription_id": {
                     "description": "subscription_id is the ID of the subscription",
@@ -18604,7 +18220,7 @@
                 }
             }
         },
-        "dto.SubscriptionSummary": {
+        "SubscriptionSummary": {
             "type": "object",
             "properties": {
                 "archived_at": {
@@ -18637,15 +18253,11 @@
                 },
                 "status": {
                     "description": "status of the subscription",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 }
             }
         },
-        "dto.SubscriptionUsageByMetersResponse": {
+        "SubscriptionUsageByMetersResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -18686,7 +18298,7 @@
                 }
             }
         },
-        "dto.SuccessResponse": {
+        "SuccessResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -18694,7 +18306,7 @@
                 }
             }
         },
-        "dto.TaskResponse": {
+        "TaskResponse": {
             "type": "object",
             "properties": {
                 "completed_at": {
@@ -18707,7 +18319,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntityType"
+                    "$ref": "#/definitions/types.EntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -18725,7 +18337,7 @@
                     "type": "string"
                 },
                 "file_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FileType"
+                    "$ref": "#/definitions/types.FileType"
                 },
                 "file_url": {
                     "type": "string"
@@ -18747,16 +18359,16 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "successful_records": {
                     "type": "integer"
                 },
                 "task_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskStatus"
+                    "$ref": "#/definitions/types.TaskStatus"
                 },
                 "task_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskType"
+                    "$ref": "#/definitions/types.TaskType"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -18775,7 +18387,7 @@
                 }
             }
         },
-        "dto.TaxAppliedResponse": {
+        "TaxAppliedResponse": {
             "type": "object",
             "properties": {
                 "applied_at": {
@@ -18794,7 +18406,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType"
+                    "$ref": "#/definitions/types.TaxRateEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -18812,7 +18424,7 @@
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tax_amount": {
                     "type": "string"
@@ -18821,7 +18433,7 @@
                     "type": "string"
                 },
                 "tax_rate": {
-                    "$ref": "#/definitions/dto.TaxRateResponse"
+                    "$ref": "#/definitions/TaxRateResponse"
                 },
                 "tax_rate_id": {
                     "type": "string"
@@ -18840,7 +18452,7 @@
                 }
             }
         },
-        "dto.TaxAssociationResponse": {
+        "TaxAssociationResponse": {
             "type": "object",
             "properties": {
                 "auto_apply": {
@@ -18863,11 +18475,7 @@
                 },
                 "entity_type": {
                     "description": "Type of entity this tax rate applies to",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.TaxRateEntityType"
                 },
                 "environment_id": {
                     "description": "EnvironmentID is the ID of the environment this tax rate config belongs to",
@@ -18889,10 +18497,10 @@
                     "type": "integer"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tax_rate": {
-                    "$ref": "#/definitions/dto.TaxRateResponse"
+                    "$ref": "#/definitions/TaxRateResponse"
                 },
                 "tax_rate_id": {
                     "description": "Reference to the TaxRate entity",
@@ -18909,7 +18517,7 @@
                 }
             }
         },
-        "dto.TaxAssociationUpdateRequest": {
+        "TaxAssociationUpdateRequest": {
             "type": "object",
             "properties": {
                 "auto_apply": {
@@ -18926,7 +18534,7 @@
                 }
             }
         },
-        "dto.TaxRateOverride": {
+        "TaxRateOverride": {
             "type": "object",
             "required": [
                 "currency",
@@ -18954,7 +18562,7 @@
                 }
             }
         },
-        "dto.TaxRateResponse": {
+        "TaxRateResponse": {
             "type": "object",
             "properties": {
                 "code": {
@@ -18991,16 +18599,16 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateScope"
+                    "$ref": "#/definitions/types.TaxRateScope"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tax_rate_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateStatus"
+                    "$ref": "#/definitions/types.TaxRateStatus"
                 },
                 "tax_rate_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateType"
+                    "$ref": "#/definitions/types.TaxRateType"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -19013,11 +18621,11 @@
                 }
             }
         },
-        "dto.TenantBillingDetails": {
+        "TenantBillingDetails": {
             "type": "object",
             "properties": {
                 "address": {
-                    "$ref": "#/definitions/dto.Address"
+                    "$ref": "#/definitions/Address"
                 },
                 "email": {
                     "type": "string"
@@ -19030,25 +18638,25 @@
                 }
             }
         },
-        "dto.TenantBillingUsage": {
+        "TenantBillingUsage": {
             "type": "object",
             "properties": {
                 "subscriptions": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.SubscriptionResponse"
+                        "$ref": "#/definitions/SubscriptionResponse"
                     }
                 },
                 "usage": {
-                    "$ref": "#/definitions/dto.CustomerUsageSummaryResponse"
+                    "$ref": "#/definitions/CustomerUsageSummaryResponse"
                 }
             }
         },
-        "dto.TenantResponse": {
+        "TenantResponse": {
             "type": "object",
             "properties": {
                 "billing_details": {
-                    "$ref": "#/definitions/dto.TenantBillingDetails"
+                    "$ref": "#/definitions/TenantBillingDetails"
                 },
                 "created_at": {
                     "type": "string"
@@ -19070,7 +18678,7 @@
                 }
             }
         },
-        "dto.TopUpWalletRequest": {
+        "TopUpWalletRequest": {
             "type": "object",
             "required": [
                 "transaction_reason"
@@ -19098,22 +18706,18 @@
                 },
                 "metadata": {
                     "description": "metadata is a map of key-value pairs to store any additional information about the transaction",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "priority": {
                     "description": "priority is the priority of the transaction\nlower number means higher priority\ndefault is nil which means no priority at all",
                     "type": "integer"
                 },
                 "transaction_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason"
+                    "$ref": "#/definitions/types.TransactionReason"
                 }
             }
         },
-        "dto.TopUpWalletResponse": {
+        "TopUpWalletResponse": {
             "type": "object",
             "properties": {
                 "invoice_id": {
@@ -19122,23 +18726,15 @@
                 },
                 "wallet": {
                     "description": "Wallet details after the operation",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.WalletResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/WalletResponse"
                 },
                 "wallet_transaction": {
                     "description": "Wallet transaction created (could be PENDING or COMPLETED)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.WalletTransactionResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/WalletTransactionResponse"
                 }
             }
         },
-        "dto.TriggerForceRunRequest": {
+        "TriggerForceRunRequest": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -19149,7 +18745,7 @@
                 }
             }
         },
-        "dto.TriggerForceRunResponse": {
+        "TriggerForceRunResponse": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -19170,7 +18766,7 @@
                 }
             }
         },
-        "dto.UpdateAddonRequest": {
+        "UpdateAddonRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -19185,7 +18781,7 @@
                 }
             }
         },
-        "dto.UpdateCostsheetRequest": {
+        "UpdateCostsheetRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -19209,15 +18805,15 @@
                 }
             }
         },
-        "dto.UpdateCostsheetResponse": {
+        "UpdateCostsheetResponse": {
             "type": "object",
             "properties": {
                 "costsheet": {
-                    "$ref": "#/definitions/dto.CostsheetResponse"
+                    "$ref": "#/definitions/CostsheetResponse"
                 }
             }
         },
-        "dto.UpdateCouponRequest": {
+        "UpdateCouponRequest": {
             "type": "object",
             "properties": {
                 "metadata": {
@@ -19231,7 +18827,7 @@
                 }
             }
         },
-        "dto.UpdateCreditGrantRequest": {
+        "UpdateCreditGrantRequest": {
             "type": "object",
             "properties": {
                 "metadata": {
@@ -19242,7 +18838,7 @@
                 }
             }
         },
-        "dto.UpdateCustomerRequest": {
+        "UpdateCustomerRequest": {
             "description": "Request object for updating an existing customer. All fields are optional - only provided fields will be updated",
             "type": "object",
             "properties": {
@@ -19287,7 +18883,7 @@
                     "description": "integration_entity_mapping contains provider integration mappings for this customer",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreateEntityIntegrationMappingRequest"
+                        "$ref": "#/definitions/CreateEntityIntegrationMappingRequest"
                     }
                 },
                 "metadata": {
@@ -19303,7 +18899,7 @@
                 }
             }
         },
-        "dto.UpdateEntitlementRequest": {
+        "UpdateEntitlementRequest": {
             "type": "object",
             "properties": {
                 "is_enabled": {
@@ -19319,15 +18915,15 @@
                     "type": "integer"
                 },
                 "usage_reset_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod"
+                    "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
                 }
             }
         },
-        "dto.UpdateFeatureRequest": {
+        "UpdateFeatureRequest": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "description": {
                     "type": "string"
@@ -19349,7 +18945,7 @@
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -19359,7 +18955,7 @@
                 }
             }
         },
-        "dto.UpdateInvoiceRequest": {
+        "UpdateInvoiceRequest": {
             "type": "object",
             "properties": {
                 "due_date": {
@@ -19371,15 +18967,11 @@
                 },
                 "metadata": {
                     "description": "Invoice metadata will be overridden with the request metadata",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 }
             }
         },
-        "dto.UpdatePaymentRequest": {
+        "UpdatePaymentRequest": {
             "type": "object",
             "properties": {
                 "error_message": {
@@ -19408,7 +19000,7 @@
                 }
             }
         },
-        "dto.UpdatePaymentStatusRequest": {
+        "UpdatePaymentStatusRequest": {
             "type": "object",
             "required": [
                 "payment_status"
@@ -19420,15 +19012,11 @@
                 },
                 "payment_status": {
                     "description": "payment_status is the new payment status to set for the invoice (paid, unpaid, etc.)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PaymentStatus"
                 }
             }
         },
-        "dto.UpdatePlanRequest": {
+        "UpdatePlanRequest": {
             "type": "object",
             "properties": {
                 "description": {
@@ -19448,7 +19036,7 @@
                 }
             }
         },
-        "dto.UpdatePriceRequest": {
+        "UpdatePriceRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -19456,7 +19044,7 @@
                     "type": "string"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "description": {
                     "type": "string"
@@ -19489,35 +19077,27 @@
                     "description": "PriceUnitTiers are the price unit tiers (for CUSTOM price unit type, TIERED billing model)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "tier_mode": {
                     "description": "TierMode determines how to calculate the price for a given quantity",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "description": "Tiers determines the pricing tiers for this line item",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
                     "description": "TransformQuantity determines how to transform the quantity for this line item",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/price.TransformQuantity"
-                        }
-                    ]
+                    "$ref": "#/definitions/price.TransformQuantity"
                 }
             }
         },
-        "dto.UpdatePriceUnitRequest": {
+        "UpdatePriceUnitRequest": {
             "type": "object",
             "properties": {
                 "metadata": {
@@ -19528,7 +19108,7 @@
                 }
             }
         },
-        "dto.UpdateScheduledTaskRequest": {
+        "UpdateScheduledTaskRequest": {
             "type": "object",
             "required": [
                 "enabled"
@@ -19539,7 +19119,7 @@
                 }
             }
         },
-        "dto.UpdateSubscriptionLineItemRequest": {
+        "UpdateSubscriptionLineItemRequest": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -19547,14 +19127,14 @@
                     "type": "string"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "commitment_amount": {
                     "description": "Commitment fields",
                     "type": "number"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "number"
@@ -19566,7 +19146,7 @@
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -19584,30 +19164,22 @@
                 },
                 "tier_mode": {
                     "description": "TierMode determines how to calculate the price for a given quantity",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "description": "Tiers determines the pricing tiers for this line item",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.CreatePriceTier"
+                        "$ref": "#/definitions/CreatePriceTier"
                     }
                 },
                 "transform_quantity": {
                     "description": "TransformQuantity determines how to transform the quantity for this line item",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/price.TransformQuantity"
-                        }
-                    ]
+                    "$ref": "#/definitions/price.TransformQuantity"
                 }
             }
         },
-        "dto.UpdateSubscriptionRequest": {
+        "UpdateSubscriptionRequest": {
             "type": "object",
             "properties": {
                 "cancel_at": {
@@ -19621,22 +19193,22 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                    "$ref": "#/definitions/types.SubscriptionStatus"
                 }
             }
         },
-        "dto.UpdateTaskStatusRequest": {
+        "UpdateTaskStatusRequest": {
             "type": "object",
             "required": [
                 "task_status"
             ],
             "properties": {
                 "task_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaskStatus"
+                    "$ref": "#/definitions/types.TaskStatus"
                 }
             }
         },
-        "dto.UpdateTaxRateRequest": {
+        "UpdateTaxRateRequest": {
             "type": "object",
             "properties": {
                 "code": {
@@ -19660,19 +19232,15 @@
                 },
                 "tax_rate_status": {
                     "description": "tax_rate_type determines how the tax is calculated (\"percentage\" or \"fixed\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateStatus"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.TaxRateStatus"
                 }
             }
         },
-        "dto.UpdateTenantRequest": {
+        "UpdateTenantRequest": {
             "type": "object",
             "properties": {
                 "billing_details": {
-                    "$ref": "#/definitions/dto.TenantBillingDetails"
+                    "$ref": "#/definitions/TenantBillingDetails"
                 },
                 "metadata": {
                     "$ref": "#/definitions/types.Metadata"
@@ -19682,17 +19250,17 @@
                 }
             }
         },
-        "dto.UpdateWalletRequest": {
+        "UpdateWalletRequest": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "auto_topup": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig"
+                    "$ref": "#/definitions/types.WalletConfig"
                 },
                 "description": {
                     "type": "string"
@@ -19705,7 +19273,7 @@
                 }
             }
         },
-        "dto.UsageAnalyticItem": {
+        "UsageAnalyticItem": {
             "type": "object",
             "properties": {
                 "add_on_id": {
@@ -19713,17 +19281,13 @@
                 },
                 "addon": {
                     "description": "Full addon object (only if expand includes \"addon\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_addon.Addon"
-                        }
-                    ]
+                    "$ref": "#/definitions/Addon"
                 },
                 "aggregation_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 },
                 "commitment_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "currency": {
                     "type": "string"
@@ -19737,30 +19301,18 @@
                 },
                 "feature": {
                     "description": "Full feature object (only if expand includes \"feature\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_feature.Feature"
-                        }
-                    ]
+                    "$ref": "#/definitions/Feature"
                 },
                 "feature_id": {
                     "type": "string"
                 },
                 "group": {
                     "description": "Group when the feature belongs to a group (object includes id)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/group.Group"
-                        }
-                    ]
+                    "$ref": "#/definitions/group.Group"
                 },
                 "meter": {
                     "description": "Full meter object (only if expand includes \"meter\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/meter.Meter"
-                        }
-                    ]
+                    "$ref": "#/definitions/meter.Meter"
                 },
                 "meter_id": {
                     "description": "Meter ID",
@@ -19771,11 +19323,7 @@
                 },
                 "plan": {
                     "description": "Full plan object (only if expand includes \"plan\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_domain_plan.Plan"
-                        }
-                    ]
+                    "$ref": "#/definitions/Plan"
                 },
                 "plan_id": {
                     "type": "string"
@@ -19783,16 +19331,12 @@
                 "points": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.UsageAnalyticPoint"
+                        "$ref": "#/definitions/UsageAnalyticPoint"
                     }
                 },
                 "price": {
                     "description": "Full price object (only if expand includes \"price\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/dto.PriceResponse"
-                        }
-                    ]
+                    "$ref": "#/definitions/PriceResponse"
                 },
                 "price_id": {
                     "description": "Price ID used for this usage",
@@ -19807,11 +19351,7 @@
                 },
                 "reporting_unit": {
                     "description": "Present when total_usage_display is set (unit_singular, unit_plural, conversion_rate)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "source": {
                     "type": "string"
@@ -19833,11 +19373,7 @@
                 },
                 "subscription_line_item": {
                     "description": "Full line item (only if expand includes \"subscription_line_item\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/subscription.SubscriptionLineItem"
-                        }
-                    ]
+                    "$ref": "#/definitions/subscription.SubscriptionLineItem"
                 },
                 "total_cost": {
                     "type": "string"
@@ -19857,15 +19393,11 @@
                 },
                 "window_size": {
                     "description": "Window size for bucketed meters (only set if meter is bucketed)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.WindowSize"
                 }
             }
         },
-        "dto.UsageAnalyticPoint": {
+        "UsageAnalyticPoint": {
             "type": "object",
             "properties": {
                 "computed_commitment_utilized_amount": {
@@ -19893,7 +19425,7 @@
                 }
             }
         },
-        "dto.UsageBreakdownItem": {
+        "UsageBreakdownItem": {
             "type": "object",
             "properties": {
                 "cost": {
@@ -19921,7 +19453,7 @@
                 }
             }
         },
-        "dto.UsageResult": {
+        "UsageResult": {
             "type": "object",
             "properties": {
                 "value": {
@@ -19932,7 +19464,7 @@
                 }
             }
         },
-        "dto.UserResponse": {
+        "UserResponse": {
             "type": "object",
             "properties": {
                 "email": {
@@ -19949,24 +19481,24 @@
                     }
                 },
                 "tenant": {
-                    "$ref": "#/definitions/dto.TenantResponse"
+                    "$ref": "#/definitions/TenantResponse"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
+                    "$ref": "#/definitions/types.UserType"
                 }
             }
         },
-        "dto.WalletBalanceResponse": {
+        "WalletBalanceResponse": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "alert_state": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "auto_topup": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "balance": {
                     "type": "string"
@@ -19975,7 +19507,7 @@
                     "type": "string"
                 },
                 "config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig"
+                    "$ref": "#/definitions/types.WalletConfig"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -19991,7 +19523,7 @@
                     "type": "string"
                 },
                 "credits_available_breakdown": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditBreakdown"
+                    "$ref": "#/definitions/types.CreditBreakdown"
                 },
                 "currency": {
                     "type": "string"
@@ -20024,7 +19556,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20043,30 +19575,30 @@
                     "type": "string"
                 },
                 "wallet_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus"
+                    "$ref": "#/definitions/types.WalletStatus"
                 },
                 "wallet_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletType"
+                    "$ref": "#/definitions/types.WalletType"
                 }
             }
         },
-        "dto.WalletResponse": {
+        "WalletResponse": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "alert_state": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "auto_topup": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup"
+                    "$ref": "#/definitions/types.AutoTopup"
                 },
                 "balance": {
                     "type": "string"
                 },
                 "config": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig"
+                    "$ref": "#/definitions/types.WalletConfig"
                 },
                 "conversion_rate": {
                     "description": "amount in the currency =  number of credits * conversion_rate\nex if conversion_rate is 1, then 1 USD = 1 credit\nex if conversion_rate is 2, then 1 USD = 0.5 credits\nex if conversion_rate is 0.5, then 1 USD = 2 credits",
@@ -20082,7 +19614,7 @@
                     "type": "string"
                 },
                 "credits_available_breakdown": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CreditBreakdown"
+                    "$ref": "#/definitions/types.CreditBreakdown"
                 },
                 "currency": {
                     "type": "string"
@@ -20106,7 +19638,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20122,14 +19654,14 @@
                     "type": "string"
                 },
                 "wallet_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus"
+                    "$ref": "#/definitions/types.WalletStatus"
                 },
                 "wallet_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletType"
+                    "$ref": "#/definitions/types.WalletType"
                 }
             }
         },
-        "dto.WalletTransactionResponse": {
+        "WalletTransactionResponse": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -20146,7 +19678,7 @@
                     "type": "string"
                 },
                 "created_by_user": {
-                    "$ref": "#/definitions/dto.UserResponse"
+                    "$ref": "#/definitions/UserResponse"
                 },
                 "credit_amount": {
                     "type": "string"
@@ -20164,7 +19696,7 @@
                     "type": "string"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "customer_id": {
                     "type": "string"
@@ -20194,10 +19726,10 @@
                     "type": "string"
                 },
                 "reference_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletTxReferenceType"
+                    "$ref": "#/definitions/types.WalletTxReferenceType"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20207,13 +19739,13 @@
                     "type": "string"
                 },
                 "transaction_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason"
+                    "$ref": "#/definitions/types.TransactionReason"
                 },
                 "transaction_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionStatus"
+                    "$ref": "#/definitions/types.TransactionStatus"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionType"
+                    "$ref": "#/definitions/types.TransactionType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -20222,14 +19754,14 @@
                     "type": "string"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 },
                 "wallet_id": {
                     "type": "string"
                 }
             }
         },
-        "dto.WorkflowExecutionDTO": {
+        "WorkflowExecutionDTO": {
             "type": "object",
             "properties": {
                 "close_time": {
@@ -20272,7 +19804,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_addon.Addon": {
+        "Addon": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -20301,13 +19833,13 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -20317,14 +19849,14 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_coupon.Coupon": {
+        "Coupon": {
             "type": "object",
             "properties": {
                 "amount_off": {
                     "type": "string"
                 },
                 "cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence"
+                    "$ref": "#/definitions/types.CouponCadence"
                 },
                 "created_at": {
                     "type": "string"
@@ -20370,7 +19902,7 @@
                     "additionalProperties": true
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20379,7 +19911,7 @@
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CouponType"
+                    "$ref": "#/definitions/types.CouponType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -20389,7 +19921,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_customer.Customer": {
+        "Customer": {
             "type": "object",
             "properties": {
                 "address_city": {
@@ -20450,7 +19982,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20463,11 +19995,11 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_feature.Feature": {
+        "Feature": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "created_at": {
                     "type": "string"
@@ -20483,11 +20015,7 @@
                 },
                 "group": {
                     "description": "Group is populated by the service layer when building responses; repository/FromEnt do not set it.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/group.Group"
-                        }
-                    ]
+                    "$ref": "#/definitions/group.Group"
                 },
                 "group_id": {
                     "type": "string"
@@ -20508,16 +20036,16 @@
                     "type": "string"
                 },
                 "reporting_unit": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit"
+                    "$ref": "#/definitions/types.ReportingUnit"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "unit_plural": {
                     "type": "string"
@@ -20533,7 +20061,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_domain_plan.Plan": {
+        "Plan": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -20564,7 +20092,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -20577,7 +20105,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_errors.ErrorResponse": {
+        "errors.ErrorResponse": {
             "type": "object",
             "properties": {
                 "code": {
@@ -20608,7 +20136,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AddonAssociationEntityType": {
+        "types.AddonAssociationEntityType": {
             "type": "string",
             "enum": [
                 "subscription",
@@ -20621,7 +20149,7 @@
                 "AddonAssociationEntityTypeAddon"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AddonFilter": {
+        "types.AddonFilter": {
             "type": "object",
             "properties": {
                 "addon_ids": {
@@ -20631,7 +20159,7 @@
                     }
                 },
                 "addon_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AddonType"
+                    "$ref": "#/definitions/types.AddonType"
                 },
                 "end_time": {
                     "type": "string"
@@ -20643,7 +20171,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -20671,18 +20199,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AddonStatus": {
+        "types.AddonStatus": {
             "type": "string",
             "enum": [
                 "active",
@@ -20695,7 +20223,7 @@
                 "AddonStatusPaused"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AddonType": {
+        "types.AddonType": {
             "type": "string",
             "enum": [
                 "onetime",
@@ -20706,7 +20234,7 @@
                 "AddonTypeMultipleInstance"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AggregationType": {
+        "types.AggregationType": {
             "type": "string",
             "enum": [
                 "COUNT",
@@ -20732,7 +20260,7 @@
                 "AggregationWeightedSum"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertCondition": {
+        "types.AlertCondition": {
             "type": "string",
             "enum": [
                 "above",
@@ -20743,7 +20271,7 @@
                 "AlertConditionBelow"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertEntityType": {
+        "types.AlertEntityType": {
             "type": "string",
             "enum": [
                 "wallet",
@@ -20754,11 +20282,11 @@
                 "AlertEntityTypeFeature"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertInfo": {
+        "types.AlertInfo": {
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "timestamp": {
                     "type": "string"
@@ -20768,14 +20296,14 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertLogFilter": {
+        "types.AlertLogFilter": {
             "type": "object",
             "properties": {
                 "alert_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertState"
+                    "$ref": "#/definitions/types.AlertState"
                 },
                 "alert_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertType"
+                    "$ref": "#/definitions/types.AlertType"
                 },
                 "customer_id": {
                     "type": "string"
@@ -20787,7 +20315,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertEntityType"
+                    "$ref": "#/definitions/types.AlertEntityType"
                 },
                 "expand": {
                     "type": "string"
@@ -20796,7 +20324,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -20818,35 +20346,35 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertSettings": {
+        "types.AlertSettings": {
             "type": "object",
             "properties": {
                 "alert_enabled": {
                     "type": "boolean"
                 },
                 "critical": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold"
+                    "$ref": "#/definitions/types.AlertThreshold"
                 },
                 "info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold"
+                    "$ref": "#/definitions/types.AlertThreshold"
                 },
                 "warning": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold"
+                    "$ref": "#/definitions/types.AlertThreshold"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertState": {
+        "types.AlertState": {
             "type": "string",
             "enum": [
                 "ok",
@@ -20861,18 +20389,18 @@
                 "AlertStateInAlarm"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AlertThreshold": {
+        "types.AlertThreshold": {
             "type": "object",
             "properties": {
                 "condition": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertCondition"
+                    "$ref": "#/definitions/types.AlertCondition"
                 },
                 "threshold": {
                     "type": "number"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.AlertType": {
+        "types.AlertType": {
             "type": "string",
             "enum": [
                 "low_ongoing_balance",
@@ -20885,7 +20413,7 @@
                 "AlertTypeFeatureWalletBalance"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ApplicationStatus": {
+        "types.ApplicationStatus": {
             "type": "string",
             "enum": [
                 "applied",
@@ -20902,7 +20430,7 @@
                 "ApplicationStatusCancelled"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.AutoTopup": {
+        "types.AutoTopup": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -20919,7 +20447,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.BillingCadence": {
+        "types.BillingCadence": {
             "type": "string",
             "enum": [
                 "RECURRING",
@@ -20930,7 +20458,7 @@
                 "BILLING_CADENCE_ONETIME"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingCycle": {
+        "types.BillingCycle": {
             "type": "string",
             "enum": [
                 "anniversary",
@@ -20941,7 +20469,7 @@
                 "BillingCycleCalendar"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingModel": {
+        "types.BillingModel": {
             "type": "string",
             "enum": [
                 "FLAT_FEE",
@@ -20954,7 +20482,7 @@
                 "BILLING_MODEL_TIERED"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingPeriod": {
+        "types.BillingPeriod": {
             "type": "string",
             "enum": [
                 "MONTHLY",
@@ -20973,7 +20501,7 @@
                 "BILLING_PERIOD_HALF_YEAR"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.BillingTier": {
+        "types.BillingTier": {
             "type": "string",
             "enum": [
                 "VOLUME",
@@ -20984,7 +20512,7 @@
                 "BILLING_TIER_SLAB"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CancelImmediatelyInvoicePolicy": {
+        "types.CancelImmediatelyInvoicePolicy": {
             "type": "string",
             "enum": [
                 "generate_invoice",
@@ -20995,7 +20523,7 @@
                 "CancelImmediatelyInvoicePolicySkip"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CancellationType": {
+        "types.CancellationType": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -21008,7 +20536,7 @@
                 "CancellationTypeScheduledDate"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CollectionMethod": {
+        "types.CollectionMethod": {
             "type": "string",
             "enum": [
                 "charge_automatically",
@@ -21019,7 +20547,7 @@
                 "CollectionMethodSendInvoice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CommitmentInfo": {
+        "types.CommitmentInfo": {
             "type": "object",
             "properties": {
                 "amount": {
@@ -21036,7 +20564,7 @@
                     "type": "string"
                 },
                 "duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "is_windowed": {
                     "type": "boolean"
@@ -21052,11 +20580,11 @@
                     "type": "boolean"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.CommitmentType": {
+        "types.CommitmentType": {
             "type": "string",
             "enum": [
                 "amount",
@@ -21067,7 +20595,7 @@
                 "COMMITMENT_TYPE_QUANTITY"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CouponCadence": {
+        "types.CouponCadence": {
             "type": "string",
             "enum": [
                 "once",
@@ -21080,7 +20608,7 @@
                 "CouponCadenceForever"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CouponFilter": {
+        "types.CouponFilter": {
             "type": "object",
             "properties": {
                 "coupon_ids": {
@@ -21095,7 +20623,7 @@
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -21117,15 +20645,15 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.CouponType": {
+        "types.CouponType": {
             "type": "string",
             "enum": [
                 "fixed",
@@ -21136,7 +20664,7 @@
                 "CouponTypePercentage"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditBreakdown": {
+        "types.CreditBreakdown": {
             "type": "object",
             "properties": {
                 "free": {
@@ -21147,7 +20675,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantApplicationReason": {
+        "types.CreditGrantApplicationReason": {
             "type": "string",
             "enum": [
                 "first_time_recurring_credit_grant",
@@ -21160,7 +20688,7 @@
                 "ApplicationReasonOnetimeCreditGrant"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantCadence": {
+        "types.CreditGrantCadence": {
             "type": "string",
             "enum": [
                 "ONETIME",
@@ -21171,7 +20699,7 @@
                 "CreditGrantCadenceRecurring"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit": {
+        "types.CreditGrantExpiryDurationUnit": {
             "type": "string",
             "enum": [
                 "DAY",
@@ -21186,7 +20714,7 @@
                 "CreditGrantExpiryDurationUnitYears"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType": {
+        "types.CreditGrantExpiryType": {
             "type": "string",
             "enum": [
                 "NEVER",
@@ -21199,7 +20727,7 @@
                 "CreditGrantExpiryTypeBillingCycle"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantPeriod": {
+        "types.CreditGrantPeriod": {
             "type": "string",
             "enum": [
                 "DAILY",
@@ -21218,7 +20746,7 @@
                 "CREDIT_GRANT_PERIOD_HALF_YEARLY"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditGrantScope": {
+        "types.CreditGrantScope": {
             "type": "string",
             "enum": [
                 "PLAN",
@@ -21229,7 +20757,7 @@
                 "CreditGrantScopeSubscription"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditNoteReason": {
+        "types.CreditNoteReason": {
             "type": "string",
             "enum": [
                 "DUPLICATE",
@@ -21250,7 +20778,7 @@
                 "CreditNoteReasonSubscriptionCancellation"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditNoteStatus": {
+        "types.CreditNoteStatus": {
             "type": "string",
             "enum": [
                 "DRAFT",
@@ -21263,7 +20791,7 @@
                 "CreditNoteStatusVoided"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CreditNoteType": {
+        "types.CreditNoteType": {
             "type": "string",
             "enum": [
                 "ADJUSTMENT",
@@ -21274,7 +20802,7 @@
                 "CreditNoteTypeRefund"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.CustomerFilter": {
+        "types.CustomerFilter": {
             "type": "object",
             "properties": {
                 "customer_ids": {
@@ -21304,7 +20832,7 @@
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -21326,18 +20854,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.DataType": {
+        "types.DataType": {
             "type": "string",
             "enum": [
                 "string",
@@ -21352,7 +20880,7 @@
                 "DataTypeArray"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.DebugTrackerStatus": {
+        "types.DebugTrackerStatus": {
             "type": "string",
             "enum": [
                 "unprocessed",
@@ -21367,7 +20895,7 @@
                 "DebugTrackerStatusError"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EntitlementEntityType": {
+        "types.EntitlementEntityType": {
             "type": "string",
             "enum": [
                 "PLAN",
@@ -21380,7 +20908,7 @@
                 "ENTITLEMENT_ENTITY_TYPE_ADDON"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EntitlementFilter": {
+        "types.EntitlementFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -21393,7 +20921,7 @@
                     }
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType"
+                    "$ref": "#/definitions/types.EntitlementEntityType"
                 },
                 "expand": {
                     "type": "string"
@@ -21405,13 +20933,13 @@
                     }
                 },
                 "feature_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType"
+                    "$ref": "#/definitions/types.FeatureType"
                 },
                 "filters": {
                     "description": "Specific filters for entitlements",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "is_enabled": {
@@ -21442,18 +20970,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod": {
+        "types.EntitlementUsageResetPeriod": {
             "type": "string",
             "enum": [
                 "MONTHLY",
@@ -21474,7 +21002,7 @@
                 "ENTITLEMENT_USAGE_RESET_PERIOD_NEVER"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EntityType": {
+        "types.EntityType": {
             "type": "string",
             "enum": [
                 "EVENTS",
@@ -21489,7 +21017,7 @@
                 "EntityTypeFeatures"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.EventProcessingStatusType": {
+        "types.EventProcessingStatusType": {
             "type": "string",
             "enum": [
                 "processed",
@@ -21502,18 +21030,18 @@
                 "EventProcessingStatusTypeFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FailurePoint": {
+        "types.FailurePoint": {
             "type": "object",
             "properties": {
                 "error": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse"
+                    "$ref": "#/definitions/errors.ErrorResponse"
                 },
                 "failure_point_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FailurePointType"
+                    "$ref": "#/definitions/types.FailurePointType"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.FailurePointType": {
+        "types.FailurePointType": {
             "type": "string",
             "enum": [
                 "customer_lookup",
@@ -21528,7 +21056,7 @@
                 "FailurePointTypeSubscriptionLineItemLookup"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FeatureFilter": {
+        "types.FeatureFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -21548,7 +21076,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -21588,18 +21116,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.FeatureType": {
+        "types.FeatureType": {
             "type": "string",
             "enum": [
                 "metered",
@@ -21612,7 +21140,7 @@
                 "FeatureTypeStatic"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FileType": {
+        "types.FileType": {
             "type": "string",
             "enum": [
                 "CSV",
@@ -21623,24 +21151,24 @@
                 "FileTypeJSON"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.FilterCondition": {
+        "types.FilterCondition": {
             "type": "object",
             "properties": {
                 "data_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.DataType"
+                    "$ref": "#/definitions/types.DataType"
                 },
                 "field": {
                     "type": "string"
                 },
                 "operator": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterOperatorType"
+                    "$ref": "#/definitions/types.FilterOperatorType"
                 },
                 "value": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Value"
+                    "$ref": "#/definitions/types.Value"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.FilterOperatorType": {
+        "types.FilterOperatorType": {
             "type": "string",
             "enum": [
                 "eq",
@@ -21665,7 +21193,7 @@
                 "AFTER"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.GroupEntityType": {
+        "types.GroupEntityType": {
             "type": "string",
             "enum": [
                 "price",
@@ -21676,7 +21204,7 @@
                 "GroupEntityTypeFeature"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.GroupFilter": {
+        "types.GroupFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -21692,7 +21220,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "group_ids": {
@@ -21727,18 +21255,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.IntegrationEntityType": {
+        "types.IntegrationEntityType": {
             "type": "string",
             "enum": [
                 "customer",
@@ -21765,7 +21293,7 @@
                 "IntegrationEntityTypePrice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceBillingReason": {
+        "types.InvoiceBillingReason": {
             "type": "string",
             "enum": [
                 "SUBSCRIPTION_CREATE",
@@ -21782,7 +21310,7 @@
                 "InvoiceBillingReasonManual"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceCadence": {
+        "types.InvoiceCadence": {
             "type": "string",
             "enum": [
                 "ARREAR",
@@ -21793,7 +21321,7 @@
                 "InvoiceCadenceAdvance"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceFilter": {
+        "types.InvoiceFilter": {
             "type": "object",
             "properties": {
                 "amount_due_gt": {
@@ -21821,7 +21349,7 @@
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "invoice_ids": {
@@ -21835,16 +21363,12 @@
                     "description": "invoice_status filters by the current state of invoices in their lifecycle\nMultiple statuses can be specified to include invoices in any of the listed states",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus"
+                        "$ref": "#/definitions/types.InvoiceStatus"
                     }
                 },
                 "invoice_type": {
                     "description": "invoice_type filters by the nature of the invoice (SUBSCRIPTION, ONE_OFF, or CREDIT)\nUse this to separate recurring charges from one-time fees or credit adjustments",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.InvoiceType"
                 },
                 "limit": {
                     "type": "integer",
@@ -21866,7 +21390,7 @@
                     "description": "payment_status filters by the payment state of invoices\nMultiple statuses can be specified to include invoices with any of the listed payment states",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus"
+                        "$ref": "#/definitions/types.PaymentStatus"
                     }
                 },
                 "period_end_gte": {
@@ -21892,14 +21416,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_customer_id": {
+                    "description": "subscription_customer_id filters invoices by the subscription owner's customer ID",
+                    "type": "string"
                 },
                 "subscription_id": {
                     "description": "subscription_id filters invoices generated for a specific subscription\nOnly returns invoices that were created as part of the specified subscription's billing",
@@ -21907,7 +21435,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceStatus": {
+        "types.InvoiceStatus": {
             "type": "string",
             "enum": [
                 "DRAFT",
@@ -21922,7 +21450,7 @@
                 "InvoiceStatusSkipped"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.InvoiceType": {
+        "types.InvoiceType": {
             "type": "string",
             "enum": [
                 "SUBSCRIPTION",
@@ -21935,7 +21463,7 @@
                 "InvoiceTypeCredit"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaginationResponse": {
+        "types.PaginationResponse": {
             "type": "object",
             "properties": {
                 "limit": {
@@ -21949,7 +21477,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PauseMode": {
+        "types.PauseMode": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -21962,7 +21490,7 @@
                 "PauseModePeriodEnd"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PauseStatus": {
+        "types.PauseStatus": {
             "type": "string",
             "enum": [
                 "none",
@@ -21979,7 +21507,7 @@
                 "PauseStatusCancelled"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentBehavior": {
+        "types.PaymentBehavior": {
             "type": "string",
             "enum": [
                 "allow_incomplete",
@@ -21994,7 +21522,7 @@
                 "PaymentBehaviorDefaultActive"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentDestinationType": {
+        "types.PaymentDestinationType": {
             "type": "string",
             "enum": [
                 "INVOICE"
@@ -22003,7 +21531,7 @@
                 "PaymentDestinationTypeInvoice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentGatewayType": {
+        "types.PaymentGatewayType": {
             "type": "string",
             "enum": [
                 "stripe",
@@ -22020,7 +21548,7 @@
                 "PaymentGatewayTypePaddle"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentMethodType": {
+        "types.PaymentMethodType": {
             "type": "string",
             "enum": [
                 "CARD",
@@ -22037,7 +21565,7 @@
                 "PaymentMethodTypePaymentLink"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentStatus": {
+        "types.PaymentStatus": {
             "type": "string",
             "enum": [
                 "INITIATED",
@@ -22060,7 +21588,7 @@
                 "PaymentStatusPartiallyRefunded"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PaymentTerms": {
+        "types.PaymentTerms": {
             "type": "string",
             "enum": [
                 "15 NET",
@@ -22079,7 +21607,7 @@
                 "PaymentTerms90Net"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PlanFilter": {
+        "types.PlanFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22092,7 +21620,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22123,18 +21651,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PriceEntityType": {
+        "types.PriceEntityType": {
             "type": "string",
             "enum": [
                 "PLAN",
@@ -22151,7 +21679,7 @@
                 "PRICE_ENTITY_TYPE_COSTSHEET"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PriceFilter": {
+        "types.PriceFilter": {
             "type": "object",
             "properties": {
                 "allow_expired_prices": {
@@ -22168,7 +21696,7 @@
                     }
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
+                    "$ref": "#/definitions/types.PriceEntityType"
                 },
                 "expand": {
                     "type": "string"
@@ -22177,7 +21705,7 @@
                     "description": "DSL filters",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22228,14 +21756,14 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PriceType": {
+        "types.PriceType": {
             "type": "string",
             "enum": [
                 "USAGE",
@@ -22246,7 +21774,7 @@
                 "PRICE_TYPE_FIXED"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.PriceUnitFilter": {
+        "types.PriceUnitFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22259,7 +21787,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22287,18 +21815,18 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.PriceUnitType": {
+        "types.PriceUnitType": {
             "type": "string",
             "enum": [
                 "FIAT",
@@ -22309,7 +21837,7 @@
                 "PRICE_UNIT_TYPE_CUSTOM"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ProrationBehavior": {
+        "types.ProrationBehavior": {
             "type": "string",
             "enum": [
                 "create_prorations",
@@ -22324,7 +21852,7 @@
                 "ProrationBehaviorNone"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.QueryFilter": {
+        "types.QueryFilter": {
             "type": "object",
             "properties": {
                 "expand": {
@@ -22350,11 +21878,11 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.ReportingUnit": {
+        "types.ReportingUnit": {
             "type": "object",
             "properties": {
                 "conversion_rate": {
@@ -22371,7 +21899,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.ResetUsage": {
+        "types.ResetUsage": {
             "type": "string",
             "enum": [
                 "BILLING_PERIOD",
@@ -22382,7 +21910,7 @@
                 "ResetUsageNever"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ResumeMode": {
+        "types.ResumeMode": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -22395,7 +21923,7 @@
                 "ResumeModeAuto"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.RoundType": {
+        "types.RoundType": {
             "type": "string",
             "enum": [
                 "up",
@@ -22406,7 +21934,7 @@
                 "ROUND_DOWN"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.S3CompressionType": {
+        "types.S3CompressionType": {
             "type": "string",
             "enum": [
                 "none",
@@ -22417,7 +21945,7 @@
                 "S3CompressionTypeGzip"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.S3EncryptionType": {
+        "types.S3EncryptionType": {
             "type": "string",
             "enum": [
                 "AES256",
@@ -22430,7 +21958,7 @@
                 "S3EncryptionTypeAwsKmsDsse"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.S3JobConfig": {
+        "types.S3JobConfig": {
             "type": "object",
             "properties": {
                 "bucket": {
@@ -22439,19 +21967,11 @@
                 },
                 "compression": {
                     "description": "Compression type: \"gzip\", \"none\" (default: \"none\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3CompressionType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.S3CompressionType"
                 },
                 "encryption": {
                     "description": "Encryption type: \"AES256\", \"aws:kms\", \"aws:kms:dsse\" (default: \"AES256\")",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.S3EncryptionType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.S3EncryptionType"
                 },
                 "endpoint_url": {
                     "description": "Custom S3 endpoint URL (e.g., \"http://minio:9000\" for MinIO)",
@@ -22471,7 +21991,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduleStatus": {
+        "types.ScheduleStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -22488,7 +22008,7 @@
                 "ScheduleStatusFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduleType": {
+        "types.ScheduleType": {
             "type": "string",
             "enum": [
                 "immediate",
@@ -22499,7 +22019,7 @@
                 "ScheduleTypePeriodEnd"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType": {
+        "types.ScheduledTaskEntityType": {
             "type": "string",
             "enum": [
                 "events",
@@ -22514,7 +22034,7 @@
                 "ScheduledTaskEntityTypeCreditUsage"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval": {
+        "types.ScheduledTaskInterval": {
             "type": "string",
             "enum": [
                 "15MIN",
@@ -22534,7 +22054,7 @@
                 "ScheduledTaskIntervalDaily"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SecretProvider": {
+        "types.SecretProvider": {
             "type": "string",
             "enum": [
                 "flexprice",
@@ -22561,7 +22081,7 @@
                 "SecretProviderPaddle"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SecretType": {
+        "types.SecretType": {
             "type": "string",
             "enum": [
                 "private_key",
@@ -22574,18 +22094,18 @@
                 "SecretTypeIntegration"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SortCondition": {
+        "types.SortCondition": {
             "type": "object",
             "properties": {
                 "direction": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortDirection"
+                    "$ref": "#/definitions/types.SortDirection"
                 },
                 "field": {
                     "type": "string"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.SortDirection": {
+        "types.SortDirection": {
             "type": "string",
             "enum": [
                 "asc",
@@ -22596,7 +22116,7 @@
                 "SortDirectionDesc"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.Status": {
+        "types.Status": {
             "type": "string",
             "enum": [
                 "published",
@@ -22609,7 +22129,7 @@
                 "StatusArchived"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionChangeType": {
+        "types.SubscriptionChangeType": {
             "type": "string",
             "enum": [
                 "upgrade",
@@ -22622,7 +22142,7 @@
                 "SubscriptionChangeTypeLateral"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionFilter": {
+        "types.SubscriptionFilter": {
             "type": "object",
             "properties": {
                 "active_at": {
@@ -22633,14 +22153,14 @@
                     "description": "BillingCadence filters by billing cadence",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                        "$ref": "#/definitions/types.BillingCadence"
                     }
                 },
                 "billing_period": {
                     "description": "BillingPeriod filters by billing period",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                        "$ref": "#/definitions/types.BillingPeriod"
                     }
                 },
                 "customer_id": {
@@ -22671,7 +22191,7 @@
                 "filters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "invoicing_customer_ids": {
@@ -22711,14 +22231,14 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_ids": {
                     "type": "array",
@@ -22730,7 +22250,7 @@
                     "description": "SubscriptionStatus filters by subscription status",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus"
+                        "$ref": "#/definitions/types.SubscriptionStatus"
                     }
                 },
                 "subscription_type": {
@@ -22746,7 +22266,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType": {
+        "types.SubscriptionLineItemEntityType": {
             "type": "string",
             "enum": [
                 "plan",
@@ -22759,7 +22279,7 @@
                 "SubscriptionLineItemEntityTypeSubscription"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType": {
+        "types.SubscriptionScheduleChangeType": {
             "type": "string",
             "enum": [
                 "plan_change",
@@ -22770,7 +22290,7 @@
                 "SubscriptionScheduleChangeTypeCancellation"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.SubscriptionStatus": {
+        "types.SubscriptionStatus": {
             "type": "string",
             "enum": [
                 "active",
@@ -22789,7 +22309,20 @@
                 "SubscriptionStatusDraft"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaskStatus": {
+        "types.SubscriptionType": {
+            "type": "string",
+            "enum": [
+                "standalone",
+                "parent",
+                "inherited"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionTypeStandalone",
+                "SubscriptionTypeParent",
+                "SubscriptionTypeInherited"
+            ]
+        },
+        "types.TaskStatus": {
             "type": "string",
             "enum": [
                 "PENDING",
@@ -22804,7 +22337,7 @@
                 "TaskStatusFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaskType": {
+        "types.TaskType": {
             "type": "string",
             "enum": [
                 "IMPORT",
@@ -22815,7 +22348,7 @@
                 "TaskTypeExport"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateEntityType": {
+        "types.TaxRateEntityType": {
             "type": "string",
             "enum": [
                 "customer",
@@ -22830,7 +22363,7 @@
                 "TaxRateEntityTypeTenant"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateScope": {
+        "types.TaxRateScope": {
             "type": "string",
             "enum": [
                 "INTERNAL",
@@ -22843,7 +22376,7 @@
                 "TaxRateScopeOneTime"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateStatus": {
+        "types.TaxRateStatus": {
             "type": "string",
             "enum": [
                 "ACTIVE",
@@ -22854,7 +22387,7 @@
                 "TaxRateStatusInactive"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TaxRateType": {
+        "types.TaxRateType": {
             "type": "string",
             "enum": [
                 "percentage",
@@ -22865,7 +22398,7 @@
                 "TaxRateTypeFixed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TimeRangeFilter": {
+        "types.TimeRangeFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22876,7 +22409,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.TransactionReason": {
+        "types.TransactionReason": {
             "type": "string",
             "enum": [
                 "INVOICE_PAYMENT",
@@ -22905,7 +22438,7 @@
                 "TransactionReasonInvoiceVoidRefund"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TransactionStatus": {
+        "types.TransactionStatus": {
             "type": "string",
             "enum": [
                 "pending",
@@ -22918,7 +22451,7 @@
                 "TransactionStatusFailed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.TransactionType": {
+        "types.TransactionType": {
             "type": "string",
             "enum": [
                 "credit",
@@ -22929,7 +22462,7 @@
                 "TransactionTypeDebit"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.UserFilter": {
+        "types.UserFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -22942,7 +22475,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -22970,25 +22503,21 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "type": {
                     "enum": [
                         "user",
                         "service_account"
                     ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.UserType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.UserType"
                 },
                 "user_ids": {
                     "description": "Specific filters for users",
@@ -22999,7 +22528,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.UserType": {
+        "types.UserType": {
             "type": "string",
             "enum": [
                 "user",
@@ -23010,7 +22539,7 @@
                 "UserTypeServiceAccount"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.Value": {
+        "types.Value": {
             "type": "object",
             "properties": {
                 "array": {
@@ -23033,19 +22562,19 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletConfig": {
+        "types.WalletConfig": {
             "type": "object",
             "properties": {
                 "allowed_price_types": {
                     "description": "AllowedPriceTypes is a list of price types that are allowed for the wallet\nnil means all price types are allowed",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfigPriceType"
+                        "$ref": "#/definitions/types.WalletConfigPriceType"
                     }
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletConfigPriceType": {
+        "types.WalletConfigPriceType": {
             "type": "string",
             "enum": [
                 "ALL",
@@ -23058,7 +22587,7 @@
                 "WalletConfigPriceTypeFixed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WalletFilter": {
+        "types.WalletFilter": {
             "type": "object",
             "properties": {
                 "alert_enabled": {
@@ -23087,7 +22616,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus"
+                    "$ref": "#/definitions/types.WalletStatus"
                 },
                 "wallet_ids": {
                     "type": "array",
@@ -23097,7 +22626,7 @@
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletStatus": {
+        "types.WalletStatus": {
             "type": "string",
             "enum": [
                 "active",
@@ -23110,7 +22639,7 @@
                 "WalletStatusClosed"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WalletTransactionFilter": {
+        "types.WalletTransactionFilter": {
             "type": "object",
             "properties": {
                 "created_by": {
@@ -23135,7 +22664,7 @@
                     "description": "filters allows complex filtering based on multiple fields",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "id": {
@@ -23169,27 +22698,27 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "transaction_reason": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason"
+                    "$ref": "#/definitions/types.TransactionReason"
                 },
                 "transaction_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionStatus"
+                    "$ref": "#/definitions/types.TransactionStatus"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.TransactionType"
+                    "$ref": "#/definitions/types.TransactionType"
                 }
             }
         },
-        "github_com_flexprice_flexprice_internal_types.WalletTxReferenceType": {
+        "types.WalletTxReferenceType": {
             "type": "string",
             "enum": [
                 "PAYMENT",
@@ -23204,7 +22733,7 @@
                 "WalletTxReferenceTypeInvoice"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WalletType": {
+        "types.WalletType": {
             "type": "string",
             "enum": [
                 "PRE_PAID",
@@ -23215,7 +22744,7 @@
                 "WalletTypePostPaid"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WebhookEventName": {
+        "types.WebhookEventName": {
             "type": "string",
             "enum": [
                 "subscription.created",
@@ -23306,10 +22835,9 @@
                 "WebhookEventCreditNoteUpdated"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WindowSize": {
+        "types.WindowSize": {
             "type": "string",
             "enum": [
-                "MONTH",
                 "MINUTE",
                 "15MIN",
                 "30MIN",
@@ -23319,10 +22847,10 @@
                 "12HOUR",
                 "DAY",
                 "WEEK",
+                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
-                "DefaultWindowSize",
                 "WindowSizeMinute",
                 "WindowSize15Min",
                 "WindowSize30Min",
@@ -23332,10 +22860,11 @@
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth"
+                "WindowSizeMonth",
+                "DefaultWindowSize"
             ]
         },
-        "github_com_flexprice_flexprice_internal_types.WorkflowExecutionFilter": {
+        "types.WorkflowExecutionFilter": {
             "type": "object",
             "properties": {
                 "end_time": {
@@ -23356,7 +22885,7 @@
                     "description": "filters allows complex filtering based on multiple fields (same as FeatureFilter)",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition"
+                        "$ref": "#/definitions/types.FilterCondition"
                     }
                 },
                 "limit": {
@@ -23378,14 +22907,14 @@
                 "sort": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition"
+                        "$ref": "#/definitions/types.SortCondition"
                     }
                 },
                 "start_time": {
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "task_queue": {
                     "type": "string"
@@ -23413,7 +22942,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.GroupEntityType"
+                    "$ref": "#/definitions/types.GroupEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -23434,7 +22963,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -23454,7 +22983,7 @@
                     "type": "string"
                 },
                 "commitment_info": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo"
+                    "$ref": "#/definitions/types.CommitmentInfo"
                 },
                 "created_at": {
                     "type": "string"
@@ -23535,7 +23064,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -23556,11 +23085,7 @@
             "properties": {
                 "bucket_size": {
                     "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.WindowSize"
                 },
                 "expression": {
                     "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).",
@@ -23579,7 +23104,7 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType"
+                    "$ref": "#/definitions/types.AggregationType"
                 }
             }
         },
@@ -23604,11 +23129,7 @@
             "properties": {
                 "aggregation": {
                     "description": "Aggregation defines the aggregation type and field for the meter\nIt is used to aggregate the events into a single value for calculating the usage",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/meter.Aggregation"
-                        }
-                    ]
+                    "$ref": "#/definitions/meter.Aggregation"
                 },
                 "created_at": {
                     "type": "string"
@@ -23641,14 +23162,10 @@
                 },
                 "reset_usage": {
                     "description": "ResetUsage defines whether the usage should be reset periodically or not\nFor ex meters tracking total storage used do not get reset but meters tracking\ntotal API requests do.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.ResetUsage"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -23699,11 +23216,7 @@
                 },
                 "round": {
                     "description": "up or down",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.RoundType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.RoundType"
                 }
             }
         },
@@ -23715,13 +23228,13 @@
                     "type": "string"
                 },
                 "billing_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence"
+                    "$ref": "#/definitions/types.BillingCadence"
                 },
                 "billing_model": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel"
+                    "$ref": "#/definitions/types.BillingModel"
                 },
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
@@ -23768,11 +23281,7 @@
                 },
                 "entity_type": {
                     "description": "EntityType holds the value of the \"entity_type\" field.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PriceEntityType"
                 },
                 "environment_id": {
                     "description": "EnvironmentID is the environment identifier for the price",
@@ -23787,7 +23296,7 @@
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "lookup_key": {
                     "description": "LookupKey used for looking up the price in the database",
@@ -23830,24 +23339,20 @@
                 },
                 "price_unit_type": {
                     "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.PriceUnitType"
                 },
                 "start_date": {
                     "description": "StartDate is the start date of the price",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "tenant_id": {
                     "type": "string"
                 },
                 "tier_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier"
+                    "$ref": "#/definitions/types.BillingTier"
                 },
                 "tiers": {
                     "type": "array",
@@ -23863,7 +23368,7 @@
                     "type": "integer"
                 },
                 "type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -23899,11 +23404,7 @@
                 },
                 "round": {
                     "description": "up or down",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.RoundType"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.RoundType"
                 }
             }
         },
@@ -23911,7 +23412,7 @@
             "type": "object",
             "properties": {
                 "billing_period": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "billing_period_count": {
                     "description": "from price at create; default 1",
@@ -23922,7 +23423,7 @@
                     "type": "string"
                 },
                 "commitment_duration": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod"
+                    "$ref": "#/definitions/types.BillingPeriod"
                 },
                 "commitment_overage_factor": {
                     "type": "string"
@@ -23934,7 +23435,7 @@
                     "type": "boolean"
                 },
                 "commitment_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType"
+                    "$ref": "#/definitions/types.CommitmentType"
                 },
                 "commitment_windowed": {
                     "type": "boolean"
@@ -23961,7 +23462,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType"
+                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
                 },
                 "environment_id": {
                     "type": "string"
@@ -23970,7 +23471,7 @@
                     "type": "string"
                 },
                 "invoice_cadence": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence"
+                    "$ref": "#/definitions/types.InvoiceCadence"
                 },
                 "metadata": {
                     "type": "object",
@@ -23994,7 +23495,7 @@
                     "type": "string"
                 },
                 "price_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PriceType"
+                    "$ref": "#/definitions/types.PriceType"
                 },
                 "price_unit": {
                     "type": "string"
@@ -24009,7 +23510,7 @@
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -24064,28 +23565,28 @@
                     "type": "string"
                 },
                 "pause_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode"
+                    "$ref": "#/definitions/types.PauseMode"
                 },
                 "pause_start": {
                     "description": "PauseStart is when the pause actually started",
                     "type": "string"
                 },
                 "pause_status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus"
+                    "$ref": "#/definitions/types.PauseStatus"
                 },
                 "reason": {
                     "description": "Reason is the reason for pausing",
                     "type": "string"
                 },
                 "resume_mode": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode"
+                    "$ref": "#/definitions/types.ResumeMode"
                 },
                 "resumed_at": {
                     "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -24125,18 +23626,14 @@
                 },
                 "metadata": {
                     "description": "Metadata contains additional key-value pairs",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
+                    "$ref": "#/definitions/types.Metadata"
                 },
                 "start_date": {
                     "description": "StartDate is when the phase starts",
                     "type": "string"
                 },
                 "status": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.Status"
+                    "$ref": "#/definitions/types.Status"
                 },
                 "subscription_id": {
                     "description": "SubscriptionID is the identifier for the subscription",
@@ -24159,11 +23656,11 @@
                 "items": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.WalletResponse"
+                        "$ref": "#/definitions/WalletResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse"
+                    "$ref": "#/definitions/types.PaginationResponse"
                 }
             }
         },
@@ -24172,19 +23669,6 @@
             "additionalProperties": {
                 "type": "string"
             }
-        },
-        "types.SubscriptionType": {
-            "type": "string",
-            "enum": [
-                "standalone",
-                "parent",
-                "inherited"
-            ],
-            "x-enum-varnames": [
-                "SubscriptionTypeStandalone",
-                "SubscriptionTypeParent",
-                "SubscriptionTypeInherited"
-            ]
         },
         "webhookDto.AlertWebhookPayload": {
             "type": "object",
@@ -24196,16 +23680,16 @@
                     "type": "string"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         },
@@ -24213,10 +23697,10 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "invoice": {
-                    "$ref": "#/definitions/dto.InvoiceResponse"
+                    "$ref": "#/definitions/InvoiceResponse"
                 }
             }
         },
@@ -24224,10 +23708,10 @@
             "type": "object",
             "properties": {
                 "credit_note": {
-                    "$ref": "#/definitions/dto.CreditNoteResponse"
+                    "$ref": "#/definitions/CreditNoteResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 }
             }
         },
@@ -24235,10 +23719,10 @@
             "type": "object",
             "properties": {
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 }
             }
         },
@@ -24246,10 +23730,10 @@
             "type": "object",
             "properties": {
                 "entitlement": {
-                    "$ref": "#/definitions/dto.EntitlementResponse"
+                    "$ref": "#/definitions/EntitlementResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 }
             }
         },
@@ -24257,10 +23741,10 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "feature": {
-                    "$ref": "#/definitions/dto.FeatureResponse"
+                    "$ref": "#/definitions/FeatureResponse"
                 }
             }
         },
@@ -24268,10 +23752,10 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "invoice": {
-                    "$ref": "#/definitions/dto.InvoiceResponse"
+                    "$ref": "#/definitions/InvoiceResponse"
                 }
             }
         },
@@ -24279,10 +23763,10 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "payment": {
-                    "$ref": "#/definitions/dto.PaymentResponse"
+                    "$ref": "#/definitions/PaymentResponse"
                 }
             }
         },
@@ -24290,10 +23774,10 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "phase": {
-                    "$ref": "#/definitions/dto.SubscriptionPhaseResponse"
+                    "$ref": "#/definitions/SubscriptionPhaseResponse"
                 }
             }
         },
@@ -24301,10 +23785,10 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "subscription": {
-                    "$ref": "#/definitions/dto.SubscriptionResponse"
+                    "$ref": "#/definitions/SubscriptionResponse"
                 }
             }
         },
@@ -24312,13 +23796,13 @@
             "type": "object",
             "properties": {
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "transaction": {
-                    "$ref": "#/definitions/dto.WalletTransactionResponse"
+                    "$ref": "#/definitions/WalletTransactionResponse"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         },
@@ -24326,7 +23810,7 @@
             "type": "object",
             "properties": {
                 "alert_settings": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings"
+                    "$ref": "#/definitions/types.AlertSettings"
                 },
                 "alert_type": {
                     "type": "string"
@@ -24349,13 +23833,13 @@
                     "$ref": "#/definitions/webhookDto.WalletAlertInfo"
                 },
                 "customer": {
-                    "$ref": "#/definitions/dto.CustomerResponse"
+                    "$ref": "#/definitions/CustomerResponse"
                 },
                 "event_type": {
-                    "$ref": "#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName"
+                    "$ref": "#/definitions/types.WebhookEventName"
                 },
                 "wallet": {
-                    "$ref": "#/definitions/dto.WalletResponse"
+                    "$ref": "#/definitions/WalletResponse"
                 }
             }
         }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -4,164 +4,164 @@ definitions:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.AddonResponse'
+          $ref: '#/definitions/AddonResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListCouponsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CouponResponse'
+          $ref: '#/definitions/CouponResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListCreditGrantApplicationsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CreditGrantApplicationResponse'
+          $ref: '#/definitions/CreditGrantApplicationResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListCreditGrantsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CreditGrantResponse'
+          $ref: '#/definitions/CreditGrantResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListCustomersResponse:
     description: Response object for listing customers with pagination
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CustomerResponse'
+          $ref: '#/definitions/CustomerResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListEntitlementsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.EntitlementResponse'
+          $ref: '#/definitions/EntitlementResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListFeaturesResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.FeatureResponse'
+          $ref: '#/definitions/FeatureResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListGroupsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.GroupResponse'
+          $ref: '#/definitions/GroupResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListInvoicesResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.InvoiceResponse'
+          $ref: '#/definitions/InvoiceResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListPlansResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.PlanResponse'
+          $ref: '#/definitions/PlanResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListPriceUnitsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.PriceUnitResponse'
+          $ref: '#/definitions/PriceUnitResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListPricesResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.PriceResponse'
+          $ref: '#/definitions/PriceResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListScheduledTasksResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.ScheduledTaskResponse'
+          $ref: '#/definitions/ScheduledTaskResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListSubscriptionsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.SubscriptionResponse'
+          $ref: '#/definitions/SubscriptionResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListTaxAssociationsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.TaxAssociationResponse'
+          $ref: '#/definitions/TaxAssociationResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListUsersResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.UserResponse'
+          $ref: '#/definitions/UserResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListWalletTransactionsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.WalletTransactionResponse'
+          $ref: '#/definitions/WalletTransactionResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   ListWorkflowsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.WorkflowExecutionDTO'
+          $ref: '#/definitions/WorkflowExecutionDTO'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   costsheet.Filter:
     properties:
@@ -176,7 +176,7 @@ definitions:
       filters:
         description: Filters contains custom filtering conditions
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       lookupKey:
         description: LookupKey filters by lookup key
@@ -186,23 +186,23 @@ definitions:
         type: string
       queryFilter:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.QueryFilter'
+        - $ref: '#/definitions/types.QueryFilter'
         description: QueryFilter contains pagination and basic query parameters
       sort:
         description: Sort specifies result ordering preferences
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        - $ref: '#/definitions/types.Status'
         description: Status filters by costsheet status
       tenantID:
         description: TenantID filters by specific tenant ID
         type: string
       timeRangeFilter:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TimeRangeFilter'
+        - $ref: '#/definitions/types.TimeRangeFilter'
         description: TimeRangeFilter allows filtering by time periods
     type: object
   coupon_application.CouponApplication:
@@ -225,7 +225,7 @@ definitions:
       discount_percentage:
         type: string
       discount_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponType'
+        $ref: '#/definitions/types.CouponType'
       discounted_amount:
         type: string
       environment_id:
@@ -245,7 +245,7 @@ definitions:
       original_price:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       tenant_id:
@@ -258,7 +258,7 @@ definitions:
   coupon_association.CouponAssociation:
     properties:
       coupon:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_coupon.Coupon'
+        $ref: '#/definitions/Coupon'
       coupon_id:
         type: string
       created_at:
@@ -279,7 +279,7 @@ definitions:
       start_date:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         description: Mandatory
         type: string
@@ -319,7 +319,7 @@ definitions:
       metadata:
         $ref: '#/definitions/types.Metadata'
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -327,7 +327,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.ActivateDraftSubscriptionRequest:
+  ActivateDraftSubscriptionRequest:
     properties:
       start_date:
         description: start_date is the new start date for the subscription when activating
@@ -335,13 +335,13 @@ definitions:
     required:
     - start_date
     type: object
-  dto.AddAddonRequest:
+  AddAddonRequest:
     properties:
       addon_id:
         type: string
       line_item_commitments:
         additionalProperties:
-          $ref: '#/definitions/dto.LineItemCommitmentConfig'
+          $ref: '#/definitions/LineItemCommitmentConfig'
         description: LineItemCommitments allows setting commitment configuration per
           addon line item (keyed by price_id)
         type: object
@@ -356,13 +356,13 @@ definitions:
     - addon_id
     - subscription_id
     type: object
-  dto.AddAddonToSubscriptionRequest:
+  AddAddonToSubscriptionRequest:
     properties:
       addon_id:
         type: string
       line_item_commitments:
         additionalProperties:
-          $ref: '#/definitions/dto.LineItemCommitmentConfig'
+          $ref: '#/definitions/LineItemCommitmentConfig'
         description: LineItemCommitments allows setting commitment configuration per
           addon line item (keyed by price_id)
         type: object
@@ -374,14 +374,14 @@ definitions:
     required:
     - addon_id
     type: object
-  dto.AddonAssociationResponse:
+  AddonAssociationResponse:
     properties:
       addon:
-        $ref: '#/definitions/dto.AddonResponse'
+        $ref: '#/definitions/AddonResponse'
       addon_id:
         type: string
       addon_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonStatus'
+        $ref: '#/definitions/types.AddonStatus'
       cancellation_reason:
         type: string
       cancelled_at:
@@ -395,7 +395,7 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonAssociationEntityType'
+        $ref: '#/definitions/types.AddonAssociationEntityType'
       environment_id:
         type: string
       id:
@@ -406,9 +406,9 @@ definitions:
       start_date:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription:
-        $ref: '#/definitions/dto.SubscriptionResponse'
+        $ref: '#/definitions/SubscriptionResponse'
       tenant_id:
         type: string
       updated_at:
@@ -416,7 +416,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.AddonResponse:
+  AddonResponse:
     properties:
       created_at:
         type: string
@@ -426,7 +426,7 @@ definitions:
         type: string
       entitlements:
         items:
-          $ref: '#/definitions/dto.EntitlementResponse'
+          $ref: '#/definitions/EntitlementResponse'
         type: array
       environment_id:
         type: string
@@ -442,20 +442,20 @@ definitions:
       prices:
         description: Optional expanded fields
         items:
-          $ref: '#/definitions/dto.PriceResponse'
+          $ref: '#/definitions/PriceResponse'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonType'
+        $ref: '#/definitions/types.AddonType'
       updated_at:
         type: string
       updated_by:
         type: string
     type: object
-  dto.Address:
+  Address:
     properties:
       address_city:
         maxLength: 100
@@ -475,7 +475,7 @@ definitions:
         maxLength: 100
         type: string
     type: object
-  dto.AggregatedEntitlement:
+  AggregatedEntitlement:
     properties:
       is_enabled:
         type: boolean
@@ -489,45 +489,45 @@ definitions:
       usage_limit:
         type: integer
       usage_reset_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod'
+        $ref: '#/definitions/types.EntitlementUsageResetPeriod'
     type: object
-  dto.AggregatedFeature:
+  AggregatedFeature:
     properties:
       entitlement:
-        $ref: '#/definitions/dto.AggregatedEntitlement'
+        $ref: '#/definitions/AggregatedEntitlement'
       feature:
-        $ref: '#/definitions/dto.FeatureResponse'
+        $ref: '#/definitions/FeatureResponse'
       sources:
         items:
-          $ref: '#/definitions/dto.EntitlementSource'
+          $ref: '#/definitions/EntitlementSource'
         type: array
     type: object
-  dto.AlertLogResponse:
+  AlertLogResponse:
     properties:
       alert_info:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertInfo'
+        $ref: '#/definitions/types.AlertInfo'
       alert_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertState'
+        $ref: '#/definitions/types.AlertState'
       alert_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertType'
+        $ref: '#/definitions/types.AlertType'
       created_at:
         type: string
       created_by:
         type: string
       customer:
         allOf:
-        - $ref: '#/definitions/dto.CustomerResponse'
+        - $ref: '#/definitions/CustomerResponse'
         description: Expanded fields
       customer_id:
         type: string
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertEntityType'
+        $ref: '#/definitions/types.AlertEntityType'
       environment_id:
         type: string
       feature:
-        $ref: '#/definitions/dto.FeatureResponse'
+        $ref: '#/definitions/FeatureResponse'
       id:
         type: string
       parent_entity_id:
@@ -543,20 +543,20 @@ definitions:
       updated_by:
         type: string
       wallet:
-        $ref: '#/definitions/dto.WalletResponse'
+        $ref: '#/definitions/WalletResponse'
     type: object
-  dto.BillingCycleInfo:
+  BillingCycleInfo:
     properties:
       billing_anchor:
         description: billing_anchor is the new billing anchor
         type: string
       billing_cadence:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        - $ref: '#/definitions/types.BillingCadence'
         description: billing_cadence is the billing cadence
       billing_period:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        - $ref: '#/definitions/types.BillingPeriod'
         description: billing_period is the billing period
       billing_period_count:
         default: 1
@@ -569,7 +569,7 @@ definitions:
         description: period_start is the start of the new billing period
         type: string
     type: object
-  dto.BillingPeriodInfo:
+  BillingPeriodInfo:
     properties:
       end_time:
         type: string
@@ -579,18 +579,18 @@ definitions:
       start_time:
         type: string
     type: object
-  dto.BulkIngestEventRequest:
+  BulkIngestEventRequest:
     properties:
       events:
         items:
-          $ref: '#/definitions/dto.IngestEventRequest'
+          $ref: '#/definitions/IngestEventRequest'
         maxItems: 1000
         minItems: 1
         type: array
     required:
     - events
     type: object
-  dto.CancelScheduleRequest:
+  CancelScheduleRequest:
     description: Request to cancel a subscription schedule (supports two modes)
     properties:
       schedule_id:
@@ -599,7 +599,7 @@ definitions:
         type: string
       schedule_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType'
+        - $ref: '#/definitions/types.SubscriptionScheduleChangeType'
         description: schedule_type is the type of schedule to cancel (required if
           schedule_id is not provided)
       subscription_id:
@@ -607,7 +607,7 @@ definitions:
           is not provided)
         type: string
     type: object
-  dto.CancelScheduleResponse:
+  CancelScheduleResponse:
     description: Confirmation of schedule cancellation
     properties:
       message:
@@ -615,25 +615,25 @@ definitions:
         type: string
       status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleStatus'
+        - $ref: '#/definitions/types.ScheduleStatus'
         description: status is the new status (should be "cancelled")
     type: object
-  dto.CancelSubscriptionRequest:
+  CancelSubscriptionRequest:
     properties:
       cancel_at:
         type: string
       cancel_immediately_inovice_policy:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CancelImmediatelyInvoicePolicy'
+        - $ref: '#/definitions/types.CancelImmediatelyInvoicePolicy'
         description: CancelImmediatelyInvoicePolicy controls whether to generate a
           final invoice on immediate cancellation. Defaults to skip.
       cancellation_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CancellationType'
+        - $ref: '#/definitions/types.CancellationType'
         description: CancellationType determines when the cancellation takes effect
       proration_behavior:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior'
+        - $ref: '#/definitions/types.ProrationBehavior'
         description: ProrationBehavior controls how proration is handled.
       reason:
         description: Reason for cancellation (for audit and business intelligence)
@@ -641,10 +641,10 @@ definitions:
     required:
     - cancellation_type
     type: object
-  dto.CancelSubscriptionResponse:
+  CancelSubscriptionResponse:
     properties:
       cancellation_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CancellationType'
+        $ref: '#/definitions/types.CancellationType'
       effective_date:
         type: string
       message:
@@ -654,23 +654,23 @@ definitions:
         type: string
       proration_details:
         items:
-          $ref: '#/definitions/dto.ProrationDetail'
+          $ref: '#/definitions/ProrationDetail'
         type: array
       proration_invoice:
         allOf:
-        - $ref: '#/definitions/dto.InvoiceResponse'
+        - $ref: '#/definitions/InvoiceResponse'
         description: Proration details
       reason:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        $ref: '#/definitions/types.SubscriptionStatus'
       subscription_id:
         description: Basic cancellation info
         type: string
       total_credit_amount:
         type: string
     type: object
-  dto.ClonePlanRequest:
+  ClonePlanRequest:
     properties:
       description:
         description: Description overrides the source plan's description when provided
@@ -690,12 +690,12 @@ definitions:
           name
         type: string
     type: object
-  dto.CostAnalyticItem:
+  CostAnalyticItem:
     properties:
       cost_by_period:
         description: Breakdown
         items:
-          $ref: '#/definitions/dto.CostPoint'
+          $ref: '#/definitions/CostPoint'
         type: array
       costsheet_id:
         type: string
@@ -732,7 +732,7 @@ definitions:
       total_quantity:
         type: string
     type: object
-  dto.CostPoint:
+  CostPoint:
     properties:
       cost:
         type: string
@@ -743,7 +743,7 @@ definitions:
       timestamp:
         type: string
     type: object
-  dto.CostsheetResponse:
+  CostsheetResponse:
     properties:
       created_at:
         type: string
@@ -766,10 +766,10 @@ definitions:
       prices:
         description: Associated prices
         items:
-          $ref: '#/definitions/dto.PriceResponse'
+          $ref: '#/definitions/PriceResponse'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -777,7 +777,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CouponApplicationResponse:
+  CouponApplicationResponse:
     properties:
       applied_at:
         type: string
@@ -797,7 +797,7 @@ definitions:
       discount_percentage:
         type: string
       discount_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponType'
+        $ref: '#/definitions/types.CouponType'
       discounted_amount:
         type: string
       environment_id:
@@ -817,7 +817,7 @@ definitions:
       original_price:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       tenant_id:
@@ -827,10 +827,10 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CouponAssociationResponse:
+  CouponAssociationResponse:
     properties:
       coupon:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_coupon.Coupon'
+        $ref: '#/definitions/Coupon'
       coupon_id:
         type: string
       created_at:
@@ -851,7 +851,7 @@ definitions:
       start_date:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         description: Mandatory
         type: string
@@ -868,12 +868,12 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CouponResponse:
+  CouponResponse:
     properties:
       amount_off:
         type: string
       cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence'
+        $ref: '#/definitions/types.CouponCadence'
       created_at:
         type: string
       created_by:
@@ -904,19 +904,19 @@ definitions:
         additionalProperties: true
         type: object
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       total_redemptions:
         type: integer
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponType'
+        $ref: '#/definitions/types.CouponType'
       updated_at:
         type: string
       updated_by:
         type: string
     type: object
-  dto.CreateAPIKeyRequest:
+  CreateAPIKeyRequest:
     properties:
       expires_at:
         type: string
@@ -925,19 +925,19 @@ definitions:
       service_account_id:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SecretType'
+        $ref: '#/definitions/types.SecretType'
     required:
     - name
     - type
     type: object
-  dto.CreateAPIKeyResponse:
+  CreateAPIKeyResponse:
     properties:
       api_key:
         type: string
       secret:
-        $ref: '#/definitions/dto.SecretResponse'
+        $ref: '#/definitions/SecretResponse'
     type: object
-  dto.CreateAddonRequest:
+  CreateAddonRequest:
     properties:
       description:
         type: string
@@ -949,13 +949,13 @@ definitions:
       name:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonType'
+        $ref: '#/definitions/types.AddonType'
     required:
     - lookup_key
     - name
     - type
     type: object
-  dto.CreateAddonResponse:
+  CreateAddonResponse:
     properties:
       created_at:
         type: string
@@ -965,7 +965,7 @@ definitions:
         type: string
       entitlements:
         items:
-          $ref: '#/definitions/dto.EntitlementResponse'
+          $ref: '#/definitions/EntitlementResponse'
         type: array
       environment_id:
         type: string
@@ -981,56 +981,56 @@ definitions:
       prices:
         description: Optional expanded fields
         items:
-          $ref: '#/definitions/dto.PriceResponse'
+          $ref: '#/definitions/PriceResponse'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonType'
+        $ref: '#/definitions/types.AddonType'
       updated_at:
         type: string
       updated_by:
         type: string
     type: object
-  dto.CreateBulkEntitlementRequest:
+  CreateBulkEntitlementRequest:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CreateEntitlementRequest'
+          $ref: '#/definitions/CreateEntitlementRequest'
         maxItems: 100
         minItems: 1
         type: array
     required:
     - items
     type: object
-  dto.CreateBulkEntitlementResponse:
+  CreateBulkEntitlementResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.EntitlementResponse'
+          $ref: '#/definitions/EntitlementResponse'
         type: array
     type: object
-  dto.CreateBulkPriceRequest:
+  CreateBulkPriceRequest:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CreatePriceRequest'
+          $ref: '#/definitions/CreatePriceRequest'
         maxItems: 100
         minItems: 1
         type: array
     required:
     - items
     type: object
-  dto.CreateBulkPriceResponse:
+  CreateBulkPriceResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.PriceResponse'
+          $ref: '#/definitions/PriceResponse'
         type: array
     type: object
-  dto.CreateCostsheetRequest:
+  CreateCostsheetRequest:
     properties:
       description:
         type: string
@@ -1049,18 +1049,18 @@ definitions:
     required:
     - name
     type: object
-  dto.CreateCostsheetResponse:
+  CreateCostsheetResponse:
     properties:
       costsheet:
-        $ref: '#/definitions/dto.CostsheetResponse'
+        $ref: '#/definitions/CostsheetResponse'
     type: object
-  dto.CreateCouponRequest:
+  CreateCouponRequest:
     properties:
       amount_off:
         type: string
       cadence:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence'
+        - $ref: '#/definitions/types.CouponCadence'
         enum:
         - once
         - repeated
@@ -1088,7 +1088,7 @@ definitions:
         type: object
       type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponType'
+        - $ref: '#/definitions/types.CouponType'
         enum:
         - fixed
         - percentage
@@ -1097,10 +1097,10 @@ definitions:
     - name
     - type
     type: object
-  dto.CreateCreditGrantRequest:
+  CreateCreditGrantRequest:
     properties:
       cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantCadence'
+        $ref: '#/definitions/types.CreditGrantCadence'
       conversion_rate:
         description: |-
           amount in the currency =  number of credits * conversion_rate
@@ -1115,15 +1115,15 @@ definitions:
       expiration_duration:
         type: integer
       expiration_duration_unit:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit'
+        $ref: '#/definitions/types.CreditGrantExpiryDurationUnit'
       expiration_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType'
+        $ref: '#/definitions/types.CreditGrantExpiryType'
       metadata:
         $ref: '#/definitions/types.Metadata'
       name:
         type: string
       period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantPeriod'
+        $ref: '#/definitions/types.CreditGrantPeriod'
       period_count:
         type: integer
       plan_id:
@@ -1131,7 +1131,7 @@ definitions:
       priority:
         type: integer
       scope:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantScope'
+        $ref: '#/definitions/types.CreditGrantScope'
       start_date:
         type: string
       subscription_id:
@@ -1149,7 +1149,7 @@ definitions:
     - name
     - scope
     type: object
-  dto.CreateCreditNoteLineItemRequest:
+  CreateCreditNoteLineItemRequest:
     properties:
       amount:
         description: amount is the monetary amount to be credited for this line item
@@ -1171,7 +1171,7 @@ definitions:
     - amount
     - invoice_line_item_id
     type: object
-  dto.CreateCreditNoteRequest:
+  CreateCreditNoteRequest:
     properties:
       credit_note_number:
         description: credit_note_number is an optional human-readable identifier for
@@ -1189,7 +1189,7 @@ definitions:
         description: line_items contains the individual line items that make up this
           credit note (minimum 1 required)
         items:
-          $ref: '#/definitions/dto.CreateCreditNoteLineItemRequest'
+          $ref: '#/definitions/CreateCreditNoteLineItemRequest'
         type: array
       memo:
         description: memo is an optional free-text field for additional notes about
@@ -1207,14 +1207,14 @@ definitions:
         type: boolean
       reason:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteReason'
+        - $ref: '#/definitions/types.CreditNoteReason'
         description: reason specifies the reason for creating this credit note (duplicate,
           fraudulent, order_change, product_unsatisfactory)
     required:
     - invoice_id
     - reason
     type: object
-  dto.CreateCustomerRequest:
+  CreateCustomerRequest:
     description: Request object for creating a new customer in the system
     properties:
       address_city:
@@ -1256,7 +1256,7 @@ definitions:
         description: integration_entity_mapping contains provider integration mappings
           for this customer
         items:
-          $ref: '#/definitions/dto.CreateEntityIntegrationMappingRequest'
+          $ref: '#/definitions/CreateEntityIntegrationMappingRequest'
         type: array
       metadata:
         additionalProperties:
@@ -1277,23 +1277,23 @@ definitions:
         description: tax_rate_overrides contains tax rate configurations to be linked
           to this customer
         items:
-          $ref: '#/definitions/dto.TaxRateOverride'
+          $ref: '#/definitions/TaxRateOverride'
         type: array
     required:
     - external_id
     type: object
-  dto.CreateEntitlementRequest:
+  CreateEntitlementRequest:
     properties:
       end_date:
         type: string
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType'
+        $ref: '#/definitions/types.EntitlementEntityType'
       feature_id:
         type: string
       feature_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType'
+        $ref: '#/definitions/types.FeatureType'
       is_enabled:
         type: boolean
       is_soft_limit:
@@ -1309,18 +1309,18 @@ definitions:
       usage_limit:
         type: integer
       usage_reset_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod'
+        $ref: '#/definitions/types.EntitlementUsageResetPeriod'
     required:
     - feature_id
     - feature_type
     type: object
-  dto.CreateEntityIntegrationMappingRequest:
+  CreateEntityIntegrationMappingRequest:
     properties:
       entity_id:
         maxLength: 255
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType'
+        $ref: '#/definitions/types.IntegrationEntityType'
       metadata:
         additionalProperties: true
         type: object
@@ -1336,10 +1336,10 @@ definitions:
     - provider_entity_id
     - provider_type
     type: object
-  dto.CreateFeatureRequest:
+  CreateFeatureRequest:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       description:
         type: string
       group_id:
@@ -1350,15 +1350,15 @@ definitions:
       metadata:
         $ref: '#/definitions/types.Metadata'
       meter:
-        $ref: '#/definitions/dto.CreateMeterRequest'
+        $ref: '#/definitions/CreateMeterRequest'
       meter_id:
         type: string
       name:
         type: string
       reporting_unit:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit'
+        $ref: '#/definitions/types.ReportingUnit'
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType'
+        $ref: '#/definitions/types.FeatureType'
       unit_plural:
         type: string
       unit_singular:
@@ -1367,7 +1367,7 @@ definitions:
     - name
     - type
     type: object
-  dto.CreateGroupRequest:
+  CreateGroupRequest:
     properties:
       entity_type:
         type: string
@@ -1380,14 +1380,14 @@ definitions:
     - lookup_key
     - name
     type: object
-  dto.CreateInvoiceLineItemRequest:
+  CreateInvoiceLineItemRequest:
     properties:
       amount:
         description: amount is the monetary amount for this line item
         type: string
       commitment_info:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo'
+        - $ref: '#/definitions/types.CommitmentInfo'
         description: commitment_info contains details about any commitment applied
           to this line item
       display_name:
@@ -1467,7 +1467,7 @@ definitions:
     - amount
     - quantity
     type: object
-  dto.CreateInvoiceRequest:
+  CreateInvoiceRequest:
     properties:
       amount_due:
         description: amount_due is the total amount that needs to be paid for this
@@ -1482,7 +1482,7 @@ definitions:
         type: string
       billing_reason:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceBillingReason'
+        - $ref: '#/definitions/types.InvoiceBillingReason'
         description: billing_reason indicates why this invoice was created (subscription_cycle,
           manual, etc.)
       coupons:
@@ -1511,7 +1511,7 @@ definitions:
       invoice_coupons:
         description: Invoice Coupons
         items:
-          $ref: '#/definitions/dto.InvoiceCoupon'
+          $ref: '#/definitions/InvoiceCoupon'
         type: array
       invoice_number:
         description: invoice_number is an optional human-readable identifier for the
@@ -1523,23 +1523,23 @@ definitions:
         type: string
       invoice_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus'
+        - $ref: '#/definitions/types.InvoiceStatus'
         description: invoice_status represents the current status of the invoice (draft,
           finalized, etc.)
       invoice_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType'
+        - $ref: '#/definitions/types.InvoiceType'
         description: invoice_type indicates the type of invoice (subscription, one_time,
           etc.)
       line_item_coupons:
         description: Invoice Line Item Coupons
         items:
-          $ref: '#/definitions/dto.InvoiceLineItemCoupon'
+          $ref: '#/definitions/InvoiceLineItemCoupon'
         type: array
       line_items:
         description: line_items contains the individual items that make up this invoice
         items:
-          $ref: '#/definitions/dto.CreateInvoiceLineItemRequest'
+          $ref: '#/definitions/CreateInvoiceLineItemRequest'
         type: array
       metadata:
         allOf:
@@ -1548,7 +1548,7 @@ definitions:
           extra information
       payment_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus'
+        - $ref: '#/definitions/types.PaymentStatus'
         description: payment_status represents the payment status of the invoice (unpaid,
           paid, etc.)
       period_end:
@@ -1561,8 +1561,12 @@ definitions:
         description: prepared_tax_rates contains the tax rates pre-resolved by the
           caller (e.g., billing service)
         items:
-          $ref: '#/definitions/dto.TaxRateResponse'
+          $ref: '#/definitions/TaxRateResponse'
         type: array
+      subscription_customer_id:
+        description: subscription_customer_id is the subscription owner's customer
+          ID when it differs from customer_id (invoicing customer)
+        type: string
       subscription_id:
         description: subscription_id is the optional unique identifier of the subscription
           associated with this invoice
@@ -1574,7 +1578,7 @@ definitions:
         description: tax_rate_overrides is the tax rate overrides to be applied to
           the invoice
         items:
-          $ref: '#/definitions/dto.TaxRateOverride'
+          $ref: '#/definitions/TaxRateOverride'
         type: array
       tax_rates:
         description: tax_rates
@@ -1596,7 +1600,7 @@ definitions:
     - subtotal
     - total
     type: object
-  dto.CreateMeterRequest:
+  CreateMeterRequest:
     properties:
       aggregation:
         $ref: '#/definitions/meter.Aggregation'
@@ -1611,14 +1615,14 @@ definitions:
         example: API Usage Meter
         type: string
       reset_usage:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage'
+        $ref: '#/definitions/types.ResetUsage'
     required:
     - aggregation
     - event_name
     - name
     - reset_usage
     type: object
-  dto.CreatePaymentRequest:
+  CreatePaymentRequest:
     properties:
       amount:
         type: string
@@ -1629,17 +1633,17 @@ definitions:
       destination_id:
         type: string
       destination_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentDestinationType'
+        $ref: '#/definitions/types.PaymentDestinationType'
       idempotency_key:
         type: string
       metadata:
         $ref: '#/definitions/types.Metadata'
       payment_gateway:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentGatewayType'
+        $ref: '#/definitions/types.PaymentGatewayType'
       payment_method_id:
         type: string
       payment_method_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentMethodType'
+        $ref: '#/definitions/types.PaymentMethodType'
       process_payment:
         default: true
         type: boolean
@@ -1655,7 +1659,7 @@ definitions:
     - destination_type
     - payment_method_type
     type: object
-  dto.CreatePlanRequest:
+  CreatePlanRequest:
     properties:
       description:
         type: string
@@ -1670,16 +1674,16 @@ definitions:
     required:
     - name
     type: object
-  dto.CreatePriceRequest:
+  CreatePriceRequest:
     properties:
       amount:
         type: string
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         default: 1
         type: integer
@@ -1694,7 +1698,7 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType'
+        $ref: '#/definitions/types.PriceEntityType'
       filter_values:
         additionalProperties:
           items:
@@ -1705,7 +1709,7 @@ definitions:
         description: GroupID is the id of the group to add the price to
         type: string
       invoice_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence'
+        $ref: '#/definitions/types.InvoiceCadence'
       lookup_key:
         type: string
       metadata:
@@ -1718,23 +1722,23 @@ definitions:
         description: MinQuantity is the minimum quantity of the price
         type: integer
       price_unit_config:
-        $ref: '#/definitions/dto.PriceUnitConfig'
+        $ref: '#/definitions/PriceUnitConfig'
       price_unit_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType'
+        $ref: '#/definitions/types.PriceUnitType'
       start_date:
         type: string
       tier_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        $ref: '#/definitions/types.BillingTier'
       tiers:
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       transform_quantity:
         $ref: '#/definitions/price.TransformQuantity'
       trial_period:
         type: integer
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceType'
+        $ref: '#/definitions/types.PriceType'
     required:
     - billing_cadence
     - billing_model
@@ -1746,7 +1750,7 @@ definitions:
     - price_unit_type
     - type
     type: object
-  dto.CreatePriceTier:
+  CreatePriceTier:
     properties:
       flat_amount:
         description: |-
@@ -1766,7 +1770,7 @@ definitions:
     required:
     - unit_amount
     type: object
-  dto.CreatePriceUnitRequest:
+  CreatePriceUnitRequest:
     properties:
       base_currency:
         description: base_currency  is the currency that the price unit is based on
@@ -1800,7 +1804,7 @@ definitions:
     - name
     - symbol
     type: object
-  dto.CreatePriceUnitResponse:
+  CreatePriceUnitResponse:
     properties:
       base_currency:
         type: string
@@ -1821,7 +1825,7 @@ definitions:
       name:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       symbol:
         type: string
       tenant_id:
@@ -1831,36 +1835,36 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CreateScheduledTaskRequest:
+  CreateScheduledTaskRequest:
     properties:
       connection_id:
         type: string
       enabled:
         type: boolean
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType'
+        $ref: '#/definitions/types.ScheduledTaskEntityType'
       interval:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval'
+        - $ref: '#/definitions/types.ScheduledTaskInterval'
         description: 'Note: "custom" is excluded from API (internal testing only)'
         enum:
         - hourly
         - daily
       job_config:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.S3JobConfig'
+        $ref: '#/definitions/types.S3JobConfig'
     required:
     - connection_id
     - entity_type
     - interval
     - job_config
     type: object
-  dto.CreateSubscriptionLineItemRequest:
+  CreateSubscriptionLineItemRequest:
     properties:
       commitment_amount:
         description: Commitment fields
         type: number
       commitment_duration:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       commitment_overage_factor:
         type: number
       commitment_quantity:
@@ -1868,7 +1872,7 @@ definitions:
       commitment_true_up_enabled:
         type: boolean
       commitment_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType'
+        $ref: '#/definitions/types.CommitmentType'
       commitment_windowed:
         type: boolean
       display_name:
@@ -1881,7 +1885,7 @@ definitions:
         type: object
       price:
         allOf:
-        - $ref: '#/definitions/dto.SubscriptionPriceCreateRequest'
+        - $ref: '#/definitions/SubscriptionPriceCreateRequest'
         description: Price defines a new price inline; server creates a subscription-scoped
           price and adds the line item. Exactly one of price_id or price must be set.
           Entity/currency are set from the subscription.
@@ -1896,19 +1900,19 @@ definitions:
       subscription_phase_id:
         type: string
     type: object
-  dto.CreateSubscriptionRequest:
+  CreateSubscriptionRequest:
     properties:
       addons:
         description: Addons represents addons to be added to the subscription during
           creation
         items:
-          $ref: '#/definitions/dto.AddAddonToSubscriptionRequest'
+          $ref: '#/definitions/AddAddonToSubscriptionRequest'
         type: array
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_cycle:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle'
+        - $ref: '#/definitions/types.BillingCycle'
         description: |-
           BillingCycle is the cycle of the billing anchor.
           This is used to determine the billing date for the subscription (i.e set the billing anchor)
@@ -1918,13 +1922,13 @@ definitions:
           For example, if the billing period is month and the start date is 2025-04-15 then in case of
           calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         default: 1
         type: integer
       collection_method:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CollectionMethod'
+        - $ref: '#/definitions/types.CollectionMethod'
         description: |-
           collection_method determines how invoices are collected
           "default_incomplete" - subscription waits for payment confirmation before activation
@@ -1935,7 +1939,7 @@ definitions:
         type: string
       commitment_duration:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        - $ref: '#/definitions/types.BillingPeriod'
         description: CommitmentDuration is the time frame of the commitment (e.g.,
           ANNUAL commitment on MONTHLY billing)
       coupons:
@@ -1945,7 +1949,7 @@ definitions:
       credit_grants:
         description: Credit grants to be applied when subscription is created
         items:
-          $ref: '#/definitions/dto.CreateCreditGrantRequest'
+          $ref: '#/definitions/CreateCreditGrantRequest'
         type: array
       currency:
         type: string
@@ -1973,13 +1977,13 @@ definitions:
         type: string
       inheritance:
         allOf:
-        - $ref: '#/definitions/dto.SubscriptionInheritanceConfig'
+        - $ref: '#/definitions/SubscriptionInheritanceConfig'
         description: |-
           Inheritance groups all customer-hierarchy fields.
           When provided with at least one child ID, the subscription becomes a PARENT type.
       line_item_commitments:
         additionalProperties:
-          $ref: '#/definitions/dto.LineItemCommitmentConfig'
+          $ref: '#/definitions/LineItemCommitmentConfig'
         description: LineItemCommitments allows setting commitment configuration per
           line item (keyed by price_id)
         type: object
@@ -1993,7 +1997,7 @@ definitions:
         description: LineItems are extra line items to add at creation (each with
           price_id or price), in addition to plan prices
         items:
-          $ref: '#/definitions/dto.CreateSubscriptionLineItemRequest'
+          $ref: '#/definitions/CreateSubscriptionLineItemRequest'
         type: array
       lookup_key:
         type: string
@@ -2009,34 +2013,34 @@ definitions:
         description: OverrideEntitlements allows customizing specific entitlements
           for this subscription
         items:
-          $ref: '#/definitions/dto.OverrideEntitlementRequest'
+          $ref: '#/definitions/OverrideEntitlementRequest'
         type: array
       override_line_items:
         description: OverrideLineItems allows customizing specific prices for this
           subscription
         items:
-          $ref: '#/definitions/dto.OverrideLineItemRequest'
+          $ref: '#/definitions/OverrideLineItemRequest'
         type: array
       payment_behavior:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentBehavior'
+        - $ref: '#/definitions/types.PaymentBehavior'
         description: Payment behavior configuration
       payment_terms:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms'
+        - $ref: '#/definitions/types.PaymentTerms'
         description: PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due
           date from period end
       phases:
         description: Phases represents subscription phases to be created with the
           subscription
         items:
-          $ref: '#/definitions/dto.SubscriptionPhaseCreateRequest'
+          $ref: '#/definitions/SubscriptionPhaseCreateRequest'
         type: array
       plan_id:
         type: string
       proration_behavior:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior'
+        - $ref: '#/definitions/types.ProrationBehavior'
         description: |-
           ProrationBehavior controls how proration is handled.
           If not set, the default value is none. Possible values are create_prorations and none.
@@ -2047,7 +2051,7 @@ definitions:
         type: string
       subscription_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        - $ref: '#/definitions/types.SubscriptionStatus'
         description: |-
           SubscriptionStatus determines the initial status of the subscription
           If set to "draft", the subscription will be created as a draft (skips invoice creation and payment processing)
@@ -2055,7 +2059,7 @@ definitions:
         description: "tax_rate_overrides is the tax rate overrides\tto be applied
           to the subscription"
         items:
-          $ref: '#/definitions/dto.TaxRateOverride'
+          $ref: '#/definitions/TaxRateOverride'
         type: array
       trial_end:
         type: string
@@ -2067,28 +2071,28 @@ definitions:
     - currency
     - plan_id
     type: object
-  dto.CreateTaskRequest:
+  CreateTaskRequest:
     properties:
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntityType'
+        $ref: '#/definitions/types.EntityType'
       file_name:
         type: string
       file_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FileType'
+        $ref: '#/definitions/types.FileType'
       file_url:
         type: string
       metadata:
         additionalProperties: true
         type: object
       task_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaskType'
+        $ref: '#/definitions/types.TaskType'
     required:
     - entity_type
     - file_type
     - file_url
     - task_type
     type: object
-  dto.CreateTaxAssociationRequest:
+  CreateTaxAssociationRequest:
     properties:
       auto_apply:
         type: boolean
@@ -2097,7 +2101,7 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType'
+        $ref: '#/definitions/types.TaxRateEntityType'
       external_customer_id:
         type: string
       metadata:
@@ -2111,7 +2115,7 @@ definitions:
     required:
     - tax_rate_code
     type: object
-  dto.CreateTaxRateRequest:
+  CreateTaxRateRequest:
     properties:
       code:
         description: code is the unique alphanumeric case sensitive identifier for
@@ -2140,18 +2144,18 @@ definitions:
         type: string
       scope:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateScope'
+        - $ref: '#/definitions/types.TaxRateScope'
         description: scope defines where this tax rate applies
       tax_rate_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateType'
+        - $ref: '#/definitions/types.TaxRateType'
         description: tax_rate_type determines how the tax is calculated ("percentage"
           or "fixed")
     required:
     - code
     - name
     type: object
-  dto.CreateUserRequest:
+  CreateUserRequest:
     properties:
       email:
         description: Required when type is "user"
@@ -2163,12 +2167,12 @@ definitions:
         type: array
       type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.UserType'
+        - $ref: '#/definitions/types.UserType'
         description: '"user" or "service_account"'
     required:
     - type
     type: object
-  dto.CreateUserResponse:
+  CreateUserResponse:
     properties:
       email:
         description: Empty for service accounts
@@ -2182,21 +2186,21 @@ definitions:
           type: string
         type: array
       tenant:
-        $ref: '#/definitions/dto.TenantResponse'
+        $ref: '#/definitions/TenantResponse'
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.UserType'
+        $ref: '#/definitions/types.UserType'
     type: object
-  dto.CreateWalletRequest:
+  CreateWalletRequest:
     properties:
       alert_settings:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        - $ref: '#/definitions/types.AlertSettings'
         description: |-
           alert_settings is the alert settings for the wallet (optional)
           If not provided, tenant level alert settings will be used
       auto_topup:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup'
+        - $ref: '#/definitions/types.AutoTopup'
         description: auto top-up object
       conversion_rate:
         default: "1"
@@ -2250,16 +2254,16 @@ definitions:
           ex if topup_conversion_rate is 0.5, then 1 USD = 2 credits
         type: string
       wallet_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletType'
+        $ref: '#/definitions/types.WalletType'
     required:
     - currency
     type: object
-  dto.CreditGrantApplicationResponse:
+  CreditGrantApplicationResponse:
     properties:
       application_reason:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantApplicationReason'
+        $ref: '#/definitions/types.CreditGrantApplicationReason'
       application_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ApplicationStatus'
+        $ref: '#/definitions/types.ApplicationStatus'
       applied_at:
         type: string
       created_at:
@@ -2289,11 +2293,11 @@ definitions:
       scheduled_for:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       subscription_status_at_application:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        $ref: '#/definitions/types.SubscriptionStatus'
       tenant_id:
         type: string
       updated_at:
@@ -2301,10 +2305,10 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CreditGrantResponse:
+  CreditGrantResponse:
     properties:
       cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantCadence'
+        $ref: '#/definitions/types.CreditGrantCadence'
       conversion_rate:
         description: |-
           amount in the currency =  number of credits * conversion_rate
@@ -2327,9 +2331,9 @@ definitions:
       expiration_duration:
         type: integer
       expiration_duration_unit:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit'
+        $ref: '#/definitions/types.CreditGrantExpiryDurationUnit'
       expiration_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType'
+        $ref: '#/definitions/types.CreditGrantExpiryType'
       id:
         type: string
       metadata:
@@ -2337,7 +2341,7 @@ definitions:
       name:
         type: string
       period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantPeriod'
+        $ref: '#/definitions/types.CreditGrantPeriod'
       period_count:
         type: integer
       plan_id:
@@ -2345,11 +2349,11 @@ definitions:
       priority:
         type: integer
       scope:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditGrantScope'
+        $ref: '#/definitions/types.CreditGrantScope'
       start_date:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       tenant_id:
@@ -2366,7 +2370,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CreditNoteResponse:
+  CreditNoteResponse:
     properties:
       created_at:
         type: string
@@ -2377,12 +2381,12 @@ definitions:
         type: string
       credit_note_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteStatus'
+        - $ref: '#/definitions/types.CreditNoteStatus'
         description: credit_note_status represents the current status of the credit
           note (e.g., draft, finalized, voided)
       credit_note_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteType'
+        - $ref: '#/definitions/types.CreditNoteType'
         description: credit_note_type indicates the type of credit note (refund, adjustment)
       currency:
         description: currency is the three-letter ISO currency code (e.g., USD, EUR)
@@ -2390,7 +2394,7 @@ definitions:
         type: string
       customer:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_customer.Customer'
+        - $ref: '#/definitions/Customer'
         description: customer contains the customer information associated with this
           credit note
       customer_id:
@@ -2413,7 +2417,7 @@ definitions:
         type: string
       invoice:
         allOf:
-        - $ref: '#/definitions/dto.InvoiceResponse'
+        - $ref: '#/definitions/InvoiceResponse'
         description: invoice contains the associated invoice information if requested
       invoice_id:
         description: invoice_id is the id of the invoice resource that this credit
@@ -2435,19 +2439,19 @@ definitions:
           extra information
       reason:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditNoteReason'
+        - $ref: '#/definitions/types.CreditNoteReason'
         description: reason specifies the reason for creating this credit note (duplicate,
           fraudulent, order_change, product_unsatisfactory)
       refund_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus'
+        - $ref: '#/definitions/types.PaymentStatus'
         description: refund_status represents the status of any refund associated
           with this credit note
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription:
         allOf:
-        - $ref: '#/definitions/dto.SubscriptionResponse'
+        - $ref: '#/definitions/SubscriptionResponse'
         description: subscription contains the associated subscription information
           if applicable
       subscription_id:
@@ -2468,7 +2472,7 @@ definitions:
         description: voided_at is the timestamp when the credit note was voided
         type: string
     type: object
-  dto.CustomAnalyticItem:
+  CustomAnalyticItem:
     properties:
       feature_name:
         description: Name of the feature this applies to
@@ -2484,16 +2488,16 @@ definitions:
       value:
         type: string
     type: object
-  dto.CustomerEntitlementsResponse:
+  CustomerEntitlementsResponse:
     properties:
       customer_id:
         type: string
       features:
         items:
-          $ref: '#/definitions/dto.AggregatedFeature'
+          $ref: '#/definitions/AggregatedFeature'
         type: array
     type: object
-  dto.CustomerInvoiceSummary:
+  CustomerInvoiceSummary:
     properties:
       currency:
         description: currency is the three-letter ISO currency code for this summary
@@ -2534,16 +2538,16 @@ definitions:
           charges in this currency
         type: string
     type: object
-  dto.CustomerLookupResult:
+  CustomerLookupResult:
     properties:
       customer:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_customer.Customer'
+        $ref: '#/definitions/Customer'
       error:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+        $ref: '#/definitions/errors.ErrorResponse'
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus'
+        $ref: '#/definitions/types.DebugTrackerStatus'
     type: object
-  dto.CustomerMultiCurrencyInvoiceSummary:
+  CustomerMultiCurrencyInvoiceSummary:
     properties:
       customer_id:
         description: customer_id is the unique identifier of the customer
@@ -2554,10 +2558,10 @@ definitions:
       summaries:
         description: summaries contains the invoice summaries for each currency
         items:
-          $ref: '#/definitions/dto.CustomerInvoiceSummary'
+          $ref: '#/definitions/CustomerInvoiceSummary'
         type: array
     type: object
-  dto.CustomerResponse:
+  CustomerResponse:
     description: Customer response object containing all customer information
     properties:
       address_city:
@@ -2597,7 +2601,7 @@ definitions:
         type: string
       integrations:
         items:
-          $ref: '#/definitions/dto.EntityIntegrationMappingResponse'
+          $ref: '#/definitions/EntityIntegrationMappingResponse'
         type: array
       metadata:
         additionalProperties:
@@ -2608,7 +2612,7 @@ definitions:
         description: Name is the name of the customer
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -2616,60 +2620,60 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.CustomerUsageSummaryResponse:
+  CustomerUsageSummaryResponse:
     properties:
       customer_id:
         type: string
       features:
         items:
-          $ref: '#/definitions/dto.FeatureUsageSummary'
+          $ref: '#/definitions/FeatureUsageSummary'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
       period:
-        $ref: '#/definitions/dto.BillingPeriodInfo'
+        $ref: '#/definitions/BillingPeriodInfo'
     type: object
-  dto.DebugTracker:
+  DebugTracker:
     properties:
       customer_lookup:
-        $ref: '#/definitions/dto.CustomerLookupResult'
+        $ref: '#/definitions/CustomerLookupResult'
       failure_point:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FailurePoint'
+        $ref: '#/definitions/types.FailurePoint'
       meter_matching:
-        $ref: '#/definitions/dto.MeterMatchingResult'
+        $ref: '#/definitions/MeterMatchingResult'
       price_lookup:
-        $ref: '#/definitions/dto.PriceLookupResult'
+        $ref: '#/definitions/PriceLookupResult'
       subscription_line_item_lookup:
-        $ref: '#/definitions/dto.SubscriptionLineItemLookupResult'
+        $ref: '#/definitions/SubscriptionLineItemLookupResult'
     type: object
-  dto.DeleteCostsheetResponse:
+  DeleteCostsheetResponse:
     properties:
       id:
         type: string
       message:
         type: string
     type: object
-  dto.DeleteCreditGrantRequest:
+  DeleteCreditGrantRequest:
     properties:
       effective_date:
         description: EffectiveDate is optional; when set (subscription scope) the
           grant end date is set to this time.
         type: string
     type: object
-  dto.DeletePriceRequest:
+  DeletePriceRequest:
     properties:
       end_date:
         type: string
     type: object
-  dto.DeleteSubscriptionLineItemRequest:
+  DeleteSubscriptionLineItemRequest:
     properties:
       effective_from:
         type: string
     type: object
-  dto.EntitlementResponse:
+  EntitlementResponse:
     properties:
       addon:
-        $ref: '#/definitions/dto.AddonResponse'
+        $ref: '#/definitions/AddonResponse'
       created_at:
         type: string
       created_by:
@@ -2681,15 +2685,15 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType'
+        $ref: '#/definitions/types.EntitlementEntityType'
       environment_id:
         type: string
       feature:
-        $ref: '#/definitions/dto.FeatureResponse'
+        $ref: '#/definitions/FeatureResponse'
       feature_id:
         type: string
       feature_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType'
+        $ref: '#/definitions/types.FeatureType'
       id:
         type: string
       is_enabled:
@@ -2699,7 +2703,7 @@ definitions:
       parent_entitlement_id:
         type: string
       plan:
-        $ref: '#/definitions/dto.PlanResponse'
+        $ref: '#/definitions/PlanResponse'
       plan_id:
         description: 'TODO: Remove this once we have a proper entitlement entity type'
         type: string
@@ -2708,7 +2712,7 @@ definitions:
       static_value:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -2718,9 +2722,9 @@ definitions:
       usage_limit:
         type: integer
       usage_reset_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod'
+        $ref: '#/definitions/types.EntitlementUsageResetPeriod'
     type: object
-  dto.EntitlementSource:
+  EntitlementSource:
     properties:
       entitlement_id:
         type: string
@@ -2729,7 +2733,7 @@ definitions:
       entity_name:
         type: string
       entity_type:
-        $ref: '#/definitions/dto.EntitlementSourceEntityType'
+        $ref: '#/definitions/EntitlementSourceEntityType'
       is_enabled:
         type: boolean
       quantity:
@@ -2741,9 +2745,9 @@ definitions:
       usage_limit:
         type: integer
       usage_reset_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
     type: object
-  dto.EntitlementSourceEntityType:
+  EntitlementSourceEntityType:
     enum:
     - plan
     - addon
@@ -2753,7 +2757,7 @@ definitions:
     - EntitlementSourceEntityTypePlan
     - EntitlementSourceEntityTypeAddon
     - EntitlementSourceEntityTypeSubscription
-  dto.EntityIntegrationMappingResponse:
+  EntityIntegrationMappingResponse:
     properties:
       created_at:
         type: string
@@ -2762,7 +2766,7 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType'
+        $ref: '#/definitions/types.IntegrationEntityType'
       environment_id:
         type: string
       id:
@@ -2772,7 +2776,7 @@ definitions:
       provider_type:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -2780,7 +2784,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.Event:
+  Event:
     properties:
       customer_id:
         type: string
@@ -2800,24 +2804,24 @@ definitions:
       timestamp:
         type: string
     type: object
-  dto.EventCostInfo:
+  EventCostInfo:
     properties:
       costNanoUsd:
         type: string
       requestId:
         type: string
     type: object
-  dto.ExecuteSubscriptionInheritanceRequest:
+  ExecuteSubscriptionInheritanceRequest:
     properties:
       external_customer_ids_to_inherit_subscription:
         items:
           type: string
         type: array
     type: object
-  dto.FeatureResponse:
+  FeatureResponse:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       created_at:
         type: string
       created_by:
@@ -2828,7 +2832,7 @@ definitions:
         type: string
       group:
         allOf:
-        - $ref: '#/definitions/dto.GroupResponse'
+        - $ref: '#/definitions/GroupResponse'
         description: Group is the full group object when the feature belongs to a
           group (populated in response)
       group_id:
@@ -2840,19 +2844,19 @@ definitions:
       metadata:
         $ref: '#/definitions/types.Metadata'
       meter:
-        $ref: '#/definitions/dto.MeterResponse'
+        $ref: '#/definitions/MeterResponse'
       meter_id:
         type: string
       name:
         type: string
       reporting_unit:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit'
+        $ref: '#/definitions/types.ReportingUnit'
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType'
+        $ref: '#/definitions/types.FeatureType'
       unit_plural:
         type: string
       unit_singular:
@@ -2862,7 +2866,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.FeatureUsageInfo:
+  FeatureUsageInfo:
     properties:
       customer_id:
         type: string
@@ -2881,12 +2885,12 @@ definitions:
       subscription_id:
         type: string
     type: object
-  dto.FeatureUsageSummary:
+  FeatureUsageSummary:
     properties:
       current_usage:
         type: string
       feature:
-        $ref: '#/definitions/dto.FeatureResponse'
+        $ref: '#/definitions/FeatureResponse'
       is_enabled:
         type: boolean
       is_soft_limit:
@@ -2897,14 +2901,14 @@ definitions:
         type: string
       sources:
         items:
-          $ref: '#/definitions/dto.EntitlementSource'
+          $ref: '#/definitions/EntitlementSource'
         type: array
       total_limit:
         type: integer
       usage_percent:
         type: string
     type: object
-  dto.GetCostAnalyticsRequest:
+  GetCostAnalyticsRequest:
     properties:
       end_time:
         type: string
@@ -2931,17 +2935,17 @@ definitions:
           provided)
         type: string
     type: object
-  dto.GetCostsheetResponse:
+  GetCostsheetResponse:
     properties:
       costsheet:
-        $ref: '#/definitions/dto.CostsheetResponse'
+        $ref: '#/definitions/CostsheetResponse'
     type: object
-  dto.GetDetailedCostAnalyticsResponse:
+  GetDetailedCostAnalyticsResponse:
     properties:
       cost_analytics:
         description: Cost analytics array (flattened from nested structure)
         items:
-          $ref: '#/definitions/dto.CostAnalyticItem'
+          $ref: '#/definitions/CostAnalyticItem'
         type: array
       currency:
         type: string
@@ -2967,20 +2971,20 @@ definitions:
         description: Derived metrics
         type: string
     type: object
-  dto.GetEventByIDResponse:
+  GetEventByIDResponse:
     properties:
       debug_tracker:
-        $ref: '#/definitions/dto.DebugTracker'
+        $ref: '#/definitions/DebugTracker'
       event:
-        $ref: '#/definitions/dto.Event'
+        $ref: '#/definitions/Event'
       processed_events:
         items:
-          $ref: '#/definitions/dto.FeatureUsageInfo'
+          $ref: '#/definitions/FeatureUsageInfo'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EventProcessingStatusType'
+        $ref: '#/definitions/types.EventProcessingStatusType'
     type: object
-  dto.GetEventsRequest:
+  GetEventsRequest:
     properties:
       end_time:
         description: |-
@@ -3037,11 +3041,11 @@ definitions:
         example: "2024-11-09T00:00:00Z"
         type: string
     type: object
-  dto.GetEventsResponse:
+  GetEventsResponse:
     properties:
       events:
         items:
-          $ref: '#/definitions/dto.Event'
+          $ref: '#/definitions/Event'
         type: array
       has_more:
         type: boolean
@@ -3054,14 +3058,14 @@ definitions:
       total_count:
         type: integer
     type: object
-  dto.GetHuggingFaceBillingDataResponse:
+  GetHuggingFaceBillingDataResponse:
     properties:
       requests:
         items:
-          $ref: '#/definitions/dto.EventCostInfo'
+          $ref: '#/definitions/EventCostInfo'
         type: array
     type: object
-  dto.GetPendingSchedulesResponse:
+  GetPendingSchedulesResponse:
     description: List of pending schedules for a subscription
     properties:
       count:
@@ -3070,10 +3074,10 @@ definitions:
       schedules:
         description: schedules is the list of pending schedules
         items:
-          $ref: '#/definitions/dto.SubscriptionScheduleResponse'
+          $ref: '#/definitions/SubscriptionScheduleResponse'
         type: array
     type: object
-  dto.GetPreviewInvoiceRequest:
+  GetPreviewInvoiceRequest:
     properties:
       hide_zero_charges_line_items:
         default: false
@@ -3093,7 +3097,7 @@ definitions:
     required:
     - subscription_id
     type: object
-  dto.GetUsageAnalyticsRequest:
+  GetUsageAnalyticsRequest:
     properties:
       end_time:
         type: string
@@ -3136,24 +3140,24 @@ definitions:
       start_time:
         type: string
       window_size:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        $ref: '#/definitions/types.WindowSize'
     type: object
-  dto.GetUsageAnalyticsResponse:
+  GetUsageAnalyticsResponse:
     properties:
       currency:
         type: string
       custom_analytics:
         items:
-          $ref: '#/definitions/dto.CustomAnalyticItem'
+          $ref: '#/definitions/CustomAnalyticItem'
         type: array
       items:
         items:
-          $ref: '#/definitions/dto.UsageAnalyticItem'
+          $ref: '#/definitions/UsageAnalyticItem'
         type: array
       total_cost:
         type: string
     type: object
-  dto.GetUsageByMeterRequest:
+  GetUsageByMeterRequest:
     properties:
       billing_anchor:
         description: |-
@@ -3177,7 +3181,7 @@ definitions:
         type: string
       bucket_size:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        - $ref: '#/definitions/types.WindowSize'
         description: Optional, only used for MAX aggregation with windowing
         example: HOUR
       customer_id:
@@ -3202,11 +3206,11 @@ definitions:
         example: "2024-11-09T00:00:00Z"
         type: string
       window_size:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        $ref: '#/definitions/types.WindowSize'
     required:
     - meter_id
     type: object
-  dto.GetUsageBySubscriptionRequest:
+  GetUsageBySubscriptionRequest:
     properties:
       end_time:
         example: "2024-03-20T00:00:00Z"
@@ -3223,13 +3227,13 @@ definitions:
     required:
     - subscription_id
     type: object
-  dto.GetUsageBySubscriptionResponse:
+  GetUsageBySubscriptionResponse:
     properties:
       amount:
         type: number
       charges:
         items:
-          $ref: '#/definitions/dto.SubscriptionUsageByMetersResponse'
+          $ref: '#/definitions/SubscriptionUsageByMetersResponse'
         type: array
       commitment_amount:
         type: number
@@ -3253,10 +3257,10 @@ definitions:
       start_time:
         type: string
     type: object
-  dto.GetUsageRequest:
+  GetUsageRequest:
     properties:
       aggregation_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType'
+        $ref: '#/definitions/types.AggregationType'
       billing_anchor:
         description: |-
           BillingAnchor enables custom monthly billing periods for usage aggregation.
@@ -3278,7 +3282,7 @@ definitions:
         type: string
       bucket_size:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        - $ref: '#/definitions/types.WindowSize'
         description: Optional, only used for MAX aggregation with windowing
         example: HOUR
       customer_id:
@@ -3315,25 +3319,25 @@ definitions:
         example: "2024-03-13T00:00:00Z"
         type: string
       window_size:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        $ref: '#/definitions/types.WindowSize'
     required:
     - aggregation_type
     - event_name
     type: object
-  dto.GetUsageResponse:
+  GetUsageResponse:
     properties:
       event_name:
         type: string
       results:
         items:
-          $ref: '#/definitions/dto.UsageResult'
+          $ref: '#/definitions/UsageResult'
         type: array
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType'
+        $ref: '#/definitions/types.AggregationType'
       value:
         type: number
     type: object
-  dto.GroupResponse:
+  GroupResponse:
     properties:
       created_at:
         type: string
@@ -3358,7 +3362,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  dto.IngestEventRequest:
+  IngestEventRequest:
     properties:
       customer_id:
         example: customer456
@@ -3391,7 +3395,7 @@ definitions:
     - event_name
     - external_customer_id
     type: object
-  dto.InvoiceCoupon:
+  InvoiceCoupon:
     properties:
       coupon_association_id:
         type: string
@@ -3400,7 +3404,7 @@ definitions:
     required:
     - coupon_id
     type: object
-  dto.InvoiceLineItemCoupon:
+  InvoiceLineItemCoupon:
     properties:
       coupon_association_id:
         type: string
@@ -3413,7 +3417,7 @@ definitions:
     - coupon_id
     - line_item_id
     type: object
-  dto.InvoiceLineItemPreview:
+  InvoiceLineItemPreview:
     properties:
       amount:
         description: amount for this line item
@@ -3437,12 +3441,12 @@ definitions:
         description: unit_price for this line item
         type: string
     type: object
-  dto.InvoiceLineItemResponse:
+  InvoiceLineItemResponse:
     properties:
       amount:
         type: string
       commitment_info:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo'
+        $ref: '#/definitions/types.CommitmentInfo'
       created_at:
         type: string
       created_by:
@@ -3500,7 +3504,7 @@ definitions:
       quantity:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       tenant_id:
@@ -3513,16 +3517,16 @@ definitions:
         description: usage_analytics contains usage analytics for this line item (legacy
           - grouped by source)
         items:
-          $ref: '#/definitions/dto.SourceUsageItem'
+          $ref: '#/definitions/SourceUsageItem'
         type: array
       usage_breakdown:
         description: usage_breakdown contains flexible usage breakdown for this line
           item (supports any grouping)
         items:
-          $ref: '#/definitions/dto.UsageBreakdownItem'
+          $ref: '#/definitions/UsageBreakdownItem'
         type: array
     type: object
-  dto.InvoicePreview:
+  InvoicePreview:
     properties:
       currency:
         description: currency is the currency for all amounts
@@ -3533,7 +3537,7 @@ definitions:
       line_items:
         description: line_items contains preview of line items
         items:
-          $ref: '#/definitions/dto.InvoiceLineItemPreview'
+          $ref: '#/definitions/InvoiceLineItemPreview'
         type: array
       subtotal:
         description: subtotal is the subtotal amount before taxes
@@ -3545,7 +3549,7 @@ definitions:
         description: total is the total amount including taxes
         type: string
     type: object
-  dto.InvoiceResponse:
+  InvoiceResponse:
     properties:
       adjustment_amount:
         description: |-
@@ -3580,7 +3584,7 @@ definitions:
         description: coupon_applications contains the coupon applications associated
           with this invoice (overrides embedded field)
         items:
-          $ref: '#/definitions/dto.CouponApplicationResponse'
+          $ref: '#/definitions/CouponApplicationResponse'
         type: array
       created_at:
         type: string
@@ -3592,7 +3596,7 @@ definitions:
         type: string
       customer:
         allOf:
-        - $ref: '#/definitions/dto.CustomerResponse'
+        - $ref: '#/definitions/CustomerResponse'
         description: customer contains the customer information associated with this
           invoice
       customer_id:
@@ -3629,12 +3633,12 @@ definitions:
         type: string
       invoice_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus'
+        - $ref: '#/definitions/types.InvoiceStatus'
         description: invoice_status represents the current status of the invoice -
           values include draft, open, paid, void, etc.
       invoice_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType'
+        - $ref: '#/definitions/types.InvoiceType'
         description: invoice_type indicates the type of invoice - whether this is
           a subscription invoice, one-time charge, or other billing type
       last_computed_at:
@@ -3645,7 +3649,7 @@ definitions:
         description: line_items contains the individual items that make up this invoice
           (overrides embedded field)
         items:
-          $ref: '#/definitions/dto.InvoiceLineItemResponse'
+          $ref: '#/definitions/InvoiceLineItemResponse'
         type: array
       metadata:
         allOf:
@@ -3661,7 +3665,7 @@ definitions:
         type: string
       payment_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus'
+        - $ref: '#/definitions/types.PaymentStatus'
         description: payment_status indicates whether the invoice has been paid, is
           pending, or failed
       period_end:
@@ -3683,12 +3687,17 @@ definitions:
           These are actual refunds issued to the customer.
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription:
         allOf:
-        - $ref: '#/definitions/dto.SubscriptionResponse'
+        - $ref: '#/definitions/SubscriptionResponse'
         description: subscription contains the associated subscription information
           if requested
+      subscription_customer_id:
+        description: |-
+          subscription_customer_id is the subscription owner's customer ID (Subscription.CustomerID).
+          It may differ from customer_id when the subscription uses an invoicing customer.
+        type: string
       subscription_id:
         description: subscription_id is the ID of the subscription this invoice is
           associated with (only present for subscription-based invoices)
@@ -3701,7 +3710,7 @@ definitions:
         description: tax_applied_records contains the tax applied records associated
           with this invoice
         items:
-          $ref: '#/definitions/dto.TaxAppliedResponse'
+          $ref: '#/definitions/TaxAppliedResponse'
         type: array
       tenant_id:
         type: string
@@ -3730,7 +3739,7 @@ definitions:
         description: voided_at is the timestamp when this invoice was voided or cancelled
         type: string
     type: object
-  dto.LineItemCommitmentConfig:
+  LineItemCommitmentConfig:
     properties:
       commitment_amount:
         description: CommitmentAmount is the minimum amount committed for this line
@@ -3738,7 +3747,7 @@ definitions:
         type: number
       commitment_duration:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        - $ref: '#/definitions/types.BillingPeriod'
         description: CommitmentDuration is the time frame of the commitment (e.g.,
           ANNUAL commitment on MONTHLY billing)
       commitment_quantity:
@@ -3747,7 +3756,7 @@ definitions:
         type: number
       commitment_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType'
+        - $ref: '#/definitions/types.CommitmentType'
         description: CommitmentType specifies whether commitment is based on amount
           or quantity
       enable_true_up:
@@ -3762,13 +3771,13 @@ definitions:
         description: OverageFactor is a multiplier applied to usage beyond the commitment
         type: number
     type: object
-  dto.LinkIntegrationMappingRequest:
+  LinkIntegrationMappingRequest:
     properties:
       entity_id:
         maxLength: 255
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.IntegrationEntityType'
+        $ref: '#/definitions/types.IntegrationEntityType'
       metadata:
         additionalProperties: true
         type: object
@@ -3784,48 +3793,48 @@ definitions:
     - provider_entity_id
     - provider_type
     type: object
-  dto.LinkIntegrationMappingResponse:
+  LinkIntegrationMappingResponse:
     properties:
       mapping:
-        $ref: '#/definitions/dto.EntityIntegrationMappingResponse'
+        $ref: '#/definitions/EntityIntegrationMappingResponse'
     type: object
-  dto.ListAlertLogsResponse:
+  ListAlertLogsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.AlertLogResponse'
+          $ref: '#/definitions/AlertLogResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
-  dto.ListCostsheetResponse:
+  ListCostsheetResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.CostsheetResponse'
+          $ref: '#/definitions/CostsheetResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
-  dto.ListPaymentsResponse:
+  ListPaymentsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.PaymentResponse'
+          $ref: '#/definitions/PaymentResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
-  dto.ListSecretsResponse:
+  ListSecretsResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.SecretResponse'
+          $ref: '#/definitions/SecretResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
-  dto.ListSubscriptionPausesResponse:
+  ListSubscriptionPausesResponse:
     description: Response object for listing subscription pauses with total count
     properties:
       items:
@@ -3833,7 +3842,7 @@ definitions:
           List of subscription pause objects
           @Description Array of subscription pauses
         items:
-          $ref: '#/definitions/dto.SubscriptionPauseResponse'
+          $ref: '#/definitions/SubscriptionPauseResponse'
         type: array
       total:
         description: |-
@@ -3841,16 +3850,16 @@ definitions:
           @Description Total count of subscription pauses in the response
         type: integer
     type: object
-  dto.ListTasksResponse:
+  ListTasksResponse:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.TaskResponse'
+          $ref: '#/definitions/TaskResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
-  dto.MatchedMeter:
+  MatchedMeter:
     properties:
       event_name:
         type: string
@@ -3859,7 +3868,7 @@ definitions:
       meter_id:
         type: string
     type: object
-  dto.MatchedPrice:
+  MatchedPrice:
     properties:
       meter_id:
         type: string
@@ -3870,7 +3879,7 @@ definitions:
       status:
         type: string
     type: object
-  dto.MatchedSubscriptionLineItem:
+  MatchedSubscriptionLineItem:
     properties:
       end_date:
         type: string
@@ -3889,18 +3898,18 @@ definitions:
       timestamp_within_range:
         type: boolean
     type: object
-  dto.MeterMatchingResult:
+  MeterMatchingResult:
     properties:
       error:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+        $ref: '#/definitions/errors.ErrorResponse'
       matched_meters:
         items:
-          $ref: '#/definitions/dto.MatchedMeter'
+          $ref: '#/definitions/MatchedMeter'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus'
+        $ref: '#/definitions/types.DebugTrackerStatus'
     type: object
-  dto.MeterResponse:
+  MeterResponse:
     properties:
       aggregation:
         $ref: '#/definitions/meter.Aggregation'
@@ -3921,7 +3930,7 @@ definitions:
         example: API Usage Meter
         type: string
       reset_usage:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage'
+        $ref: '#/definitions/types.ResetUsage'
       status:
         example: published
         type: string
@@ -3932,7 +3941,7 @@ definitions:
         example: "2024-03-20T15:04:05Z"
         type: string
     type: object
-  dto.OverrideEntitlementRequest:
+  OverrideEntitlementRequest:
     properties:
       entitlement_id:
         description: EntitlementID references the plan/addon entitlement to override
@@ -3951,14 +3960,14 @@ definitions:
     required:
     - entitlement_id
     type: object
-  dto.OverrideLineItemRequest:
+  OverrideLineItemRequest:
     properties:
       amount:
         description: Amount is the new price amount that overrides the original price
           (optional)
         type: string
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       price_id:
         description: PriceID references the plan price to override
         type: string
@@ -3970,19 +3979,19 @@ definitions:
         description: PriceUnitTiers are the tiers for the price unit (for CUSTOM type,
           TIERED billing model)
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       quantity:
         description: Quantity for this line item (optional)
         type: string
       tier_mode:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        - $ref: '#/definitions/types.BillingTier'
         description: TierMode determines how to calculate the price for a given quantity
       tiers:
         description: Tiers determines the pricing tiers for this line item
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       transform_quantity:
         allOf:
@@ -3992,7 +4001,7 @@ definitions:
     required:
     - price_id
     type: object
-  dto.PauseSubscriptionRequest:
+  PauseSubscriptionRequest:
     description: Request object for pausing an active subscription with various pause
       modes and options
     properties:
@@ -4024,7 +4033,7 @@ definitions:
         type: string
       pause_mode:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode'
+        - $ref: '#/definitions/types.PauseMode'
         description: |-
           Mode for pausing the subscription
           @Description Determines when the pause takes effect. "immediate" pauses right away, "scheduled" pauses at a specified time
@@ -4045,7 +4054,7 @@ definitions:
     required:
     - pause_mode
     type: object
-  dto.PaymentAttemptResponse:
+  PaymentAttemptResponse:
     properties:
       attempt_number:
         type: integer
@@ -4068,13 +4077,13 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.PaymentResponse:
+  PaymentResponse:
     properties:
       amount:
         type: string
       attempts:
         items:
-          $ref: '#/definitions/dto.PaymentAttemptResponse'
+          $ref: '#/definitions/PaymentAttemptResponse'
         type: array
       created_at:
         type: string
@@ -4085,7 +4094,7 @@ definitions:
       destination_id:
         type: string
       destination_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentDestinationType'
+        $ref: '#/definitions/types.PaymentDestinationType'
       error_message:
         type: string
       failed_at:
@@ -4109,9 +4118,9 @@ definitions:
       payment_method_id:
         type: string
       payment_method_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentMethodType'
+        $ref: '#/definitions/types.PaymentMethodType'
       payment_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus'
+        $ref: '#/definitions/types.PaymentStatus'
       payment_url:
         type: string
       refunded_at:
@@ -4129,7 +4138,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.PlanResponse:
+  PlanResponse:
     properties:
       created_at:
         type: string
@@ -4137,7 +4146,7 @@ definitions:
         type: string
       credit_grants:
         items:
-          $ref: '#/definitions/dto.CreditGrantResponse'
+          $ref: '#/definitions/CreditGrantResponse'
         type: array
       description:
         type: string
@@ -4145,7 +4154,7 @@ definitions:
         type: integer
       entitlements:
         items:
-          $ref: '#/definitions/dto.EntitlementResponse'
+          $ref: '#/definitions/EntitlementResponse'
         type: array
       environment_id:
         type: string
@@ -4160,10 +4169,10 @@ definitions:
       prices:
         description: 'TODO: Add inline addons'
         items:
-          $ref: '#/definitions/dto.PriceResponse'
+          $ref: '#/definitions/PriceResponse'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -4171,7 +4180,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.PlanSummary:
+  PlanSummary:
     properties:
       description:
         description: description of the plan
@@ -4186,32 +4195,32 @@ definitions:
         description: name of the plan
         type: string
     type: object
-  dto.PriceLookupResult:
+  PriceLookupResult:
     properties:
       error:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+        $ref: '#/definitions/errors.ErrorResponse'
       matched_prices:
         items:
-          $ref: '#/definitions/dto.MatchedPrice'
+          $ref: '#/definitions/MatchedPrice'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus'
+        $ref: '#/definitions/types.DebugTrackerStatus'
     type: object
-  dto.PriceResponse:
+  PriceResponse:
     properties:
       addon:
-        $ref: '#/definitions/dto.AddonResponse'
+        $ref: '#/definitions/AddonResponse'
       amount:
         description: |-
           Amount stored in main currency units (e.g., dollars, not cents)
           For USD: 12.50 means $12.50
         type: string
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         default: 1
         description: BillingPeriodCount is the count of the billing period ex 1, 3,
@@ -4251,13 +4260,13 @@ definitions:
         type: string
       entity_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType'
+        - $ref: '#/definitions/types.PriceEntityType'
         description: EntityType holds the value of the "entity_type" field.
       environment_id:
         description: EnvironmentID is the environment identifier for the price
         type: string
       group:
-        $ref: '#/definitions/dto.GroupResponse'
+        $ref: '#/definitions/GroupResponse'
       group_id:
         description: GroupID references the group this price belongs to
         type: string
@@ -4265,14 +4274,14 @@ definitions:
         description: ID uuid identifier for the price
         type: string
       invoice_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence'
+        $ref: '#/definitions/types.InvoiceCadence'
       lookup_key:
         description: LookupKey used for looking up the price in the database
         type: string
       metadata:
         $ref: '#/definitions/price.JSONBMetadata'
       meter:
-        $ref: '#/definitions/dto.MeterResponse'
+        $ref: '#/definitions/MeterResponse'
       meter_id:
         description: MeterID is the id of the meter for usage based pricing
         type: string
@@ -4285,7 +4294,7 @@ definitions:
           lineage tracking)
         type: string
       plan:
-        $ref: '#/definitions/dto.PlanResponse'
+        $ref: '#/definitions/PlanResponse'
       price_unit:
         description: PriceUnit is the code of the price unit (e.g., 'btc', 'eth')
         type: string
@@ -4303,19 +4312,19 @@ definitions:
         type: array
       price_unit_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType'
+        - $ref: '#/definitions/types.PriceUnitType'
         description: PriceUnitType is the type of the price unit (FIAT, CUSTOM)
       pricing_unit:
-        $ref: '#/definitions/dto.PriceUnitResponse'
+        $ref: '#/definitions/PriceUnitResponse'
       start_date:
         description: StartDate is the start date of the price
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       tier_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        $ref: '#/definitions/types.BillingTier'
       tiers:
         items:
           $ref: '#/definitions/price.PriceTier'
@@ -4328,13 +4337,13 @@ definitions:
           Note: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)
         type: integer
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceType'
+        $ref: '#/definitions/types.PriceType'
       updated_at:
         type: string
       updated_by:
         type: string
     type: object
-  dto.PriceUnitConfig:
+  PriceUnitConfig:
     properties:
       amount:
         type: string
@@ -4342,12 +4351,12 @@ definitions:
         type: string
       price_unit_tiers:
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
     required:
     - price_unit
     type: object
-  dto.PriceUnitResponse:
+  PriceUnitResponse:
     properties:
       base_currency:
         type: string
@@ -4368,7 +4377,7 @@ definitions:
       name:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       symbol:
         type: string
       tenant_id:
@@ -4378,7 +4387,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.ProrationDetail:
+  ProrationDetail:
     properties:
       charge_amount:
         type: string
@@ -4397,7 +4406,7 @@ definitions:
       proration_days:
         type: integer
     type: object
-  dto.ProrationDetails:
+  ProrationDetails:
     properties:
       charge_amount:
         description: charge_amount is the charge amount for the new subscription
@@ -4434,7 +4443,7 @@ definitions:
         description: proration_date is the date used for proration calculations
         type: string
     type: object
-  dto.RemoveAddonRequest:
+  RemoveAddonRequest:
     properties:
       addon_association_id:
         type: string
@@ -4443,7 +4452,7 @@ definitions:
     required:
     - addon_association_id
     type: object
-  dto.ResumeSubscriptionRequest:
+  ResumeSubscriptionRequest:
     description: Request object for resuming a paused subscription
     properties:
       dry_run:
@@ -4462,7 +4471,7 @@ definitions:
         type: object
       resume_mode:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode'
+        - $ref: '#/definitions/types.ResumeMode'
         description: |-
           Mode for resuming the subscription
           @Description Determines how the subscription should be resumed
@@ -4470,7 +4479,7 @@ definitions:
     required:
     - resume_mode
     type: object
-  dto.ScheduledTaskResponse:
+  ScheduledTaskResponse:
     properties:
       connection_id:
         type: string
@@ -4479,20 +4488,20 @@ definitions:
       enabled:
         type: boolean
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType'
+        $ref: '#/definitions/types.ScheduledTaskEntityType'
       environment_id:
         type: string
       id:
         type: string
       interval:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval'
+        - $ref: '#/definitions/types.ScheduledTaskInterval'
         description: 'Note: "custom" is excluded from API docs'
         enum:
         - hourly
         - daily
       job_config:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.S3JobConfig'
+        $ref: '#/definitions/types.S3JobConfig'
       status:
         type: string
       tenant_id:
@@ -4500,7 +4509,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  dto.SecretResponse:
+  SecretResponse:
     properties:
       created_at:
         type: string
@@ -4515,24 +4524,24 @@ definitions:
       name:
         type: string
       provider:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SecretProvider'
+        $ref: '#/definitions/types.SecretProvider'
       roles:
         description: RBAC roles
         items:
           type: string
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SecretType'
+        $ref: '#/definitions/types.SecretType'
       updated_at:
         type: string
       user_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.UserType'
+        - $ref: '#/definitions/types.UserType'
         description: '"user" or "service_account"'
     type: object
-  dto.SourceUsageItem:
+  SourceUsageItem:
     properties:
       cost:
         description: cost is the cost attributed to this source for the line item
@@ -4552,26 +4561,26 @@ definitions:
           additional context)
         type: string
     type: object
-  dto.SubscriptionChangeExecuteResponse:
+  SubscriptionChangeExecuteResponse:
     description: Response after successfully executing a subscription plan change
     properties:
       change_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionChangeType'
+        - $ref: '#/definitions/types.SubscriptionChangeType'
         description: change_type indicates whether this was an upgrade, downgrade,
           or lateral change
       credit_grants:
         description: credit_grants contains any credit grants created for proration
           credits
         items:
-          $ref: '#/definitions/dto.CreditGrantResponse'
+          $ref: '#/definitions/CreditGrantResponse'
         type: array
       effective_date:
         description: effective_date is when the change took effect
         type: string
       invoice:
         allOf:
-        - $ref: '#/definitions/dto.InvoiceResponse'
+        - $ref: '#/definitions/InvoiceResponse'
         description: invoice contains the immediate invoice generated for the change
           (if any)
       is_scheduled:
@@ -4585,17 +4594,17 @@ definitions:
         type: object
       new_subscription:
         allOf:
-        - $ref: '#/definitions/dto.SubscriptionSummary'
+        - $ref: '#/definitions/SubscriptionSummary'
         description: new_subscription contains the new subscription details (only
           if is_scheduled=false)
       old_subscription:
         allOf:
-        - $ref: '#/definitions/dto.SubscriptionSummary'
+        - $ref: '#/definitions/SubscriptionSummary'
         description: old_subscription contains the archived subscription details (only
           if is_scheduled=false)
       proration_applied:
         allOf:
-        - $ref: '#/definitions/dto.ProrationDetails'
+        - $ref: '#/definitions/ProrationDetails'
         description: proration_applied contains details of the proration that was
           applied
       schedule_id:
@@ -4605,17 +4614,17 @@ definitions:
         description: scheduled_at is when the change will execute (only if is_scheduled=true)
         type: string
     type: object
-  dto.SubscriptionChangePreviewResponse:
+  SubscriptionChangePreviewResponse:
     description: Response showing the financial impact of a subscription plan change
     properties:
       change_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionChangeType'
+        - $ref: '#/definitions/types.SubscriptionChangeType'
         description: change_type indicates whether this is an upgrade, downgrade,
           or lateral change
       current_plan:
         allOf:
-        - $ref: '#/definitions/dto.PlanSummary'
+        - $ref: '#/definitions/PlanSummary'
         description: current_plan contains information about the current plan
       effective_date:
         description: effective_date is when the change would take effect
@@ -4627,23 +4636,23 @@ definitions:
         type: object
       new_billing_cycle:
         allOf:
-        - $ref: '#/definitions/dto.BillingCycleInfo'
+        - $ref: '#/definitions/BillingCycleInfo'
         description: new_billing_cycle shows the new billing cycle details
       next_invoice_preview:
         allOf:
-        - $ref: '#/definitions/dto.InvoicePreview'
+        - $ref: '#/definitions/InvoicePreview'
         description: next_invoice_preview shows how the next regular invoice would
           be affected
       proration_details:
         allOf:
-        - $ref: '#/definitions/dto.ProrationDetails'
+        - $ref: '#/definitions/ProrationDetails'
         description: proration_details contains the calculated proration amounts
       subscription_id:
         description: subscription_id is the ID of the subscription being changed
         type: string
       target_plan:
         allOf:
-        - $ref: '#/definitions/dto.PlanSummary'
+        - $ref: '#/definitions/PlanSummary'
         description: target_plan contains information about the target plan
       warnings:
         description: warnings contains any warnings about the change
@@ -4651,20 +4660,20 @@ definitions:
           type: string
         type: array
     type: object
-  dto.SubscriptionChangeRequest:
+  SubscriptionChangeRequest:
     description: Request object for changing a subscription plan (upgrade/downgrade)
     properties:
       billing_cadence:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        - $ref: '#/definitions/types.BillingCadence'
         description: billing_cadence is the billing cadence for the new subscription
       billing_cycle:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle'
+        - $ref: '#/definitions/types.BillingCycle'
         description: billing_cycle is the billing cycle for the new subscription
       billing_period:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        - $ref: '#/definitions/types.BillingPeriod'
         description: billing_period is the billing period for the new subscription
       billing_period_count:
         default: 1
@@ -4673,7 +4682,7 @@ definitions:
         type: integer
       change_at:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleType'
+        - $ref: '#/definitions/types.ScheduleType'
         description: |-
           change_at determines when the change should take effect (optional)
           If not provided or null: change executes immediately
@@ -4687,7 +4696,7 @@ definitions:
         type: object
       proration_behavior:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior'
+        - $ref: '#/definitions/types.ProrationBehavior'
         description: |-
           proration_behavior controls how proration is handled for the change
           Options: create_prorations, none
@@ -4701,18 +4710,18 @@ definitions:
     - proration_behavior
     - target_plan_id
     type: object
-  dto.SubscriptionEntitlementsResponse:
+  SubscriptionEntitlementsResponse:
     properties:
       features:
         items:
-          $ref: '#/definitions/dto.AggregatedFeature'
+          $ref: '#/definitions/AggregatedFeature'
         type: array
       plan_id:
         type: string
       subscription_id:
         type: string
     type: object
-  dto.SubscriptionInheritanceConfig:
+  SubscriptionInheritanceConfig:
     properties:
       external_customer_ids_to_inherit_subscription:
         items:
@@ -4723,21 +4732,21 @@ definitions:
       parent_subscription_id:
         type: string
     type: object
-  dto.SubscriptionLineItemLookupResult:
+  SubscriptionLineItemLookupResult:
     properties:
       error:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+        $ref: '#/definitions/errors.ErrorResponse'
       matched_line_items:
         items:
-          $ref: '#/definitions/dto.MatchedSubscriptionLineItem'
+          $ref: '#/definitions/MatchedSubscriptionLineItem'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.DebugTrackerStatus'
+        $ref: '#/definitions/types.DebugTrackerStatus'
     type: object
-  dto.SubscriptionLineItemResponse:
+  SubscriptionLineItemResponse:
     properties:
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         description: from price at create; default 1
         type: integer
@@ -4745,7 +4754,7 @@ definitions:
         description: Commitment fields
         type: string
       commitment_duration:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       commitment_overage_factor:
         type: string
       commitment_quantity:
@@ -4753,7 +4762,7 @@ definitions:
       commitment_true_up_enabled:
         type: boolean
       commitment_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType'
+        $ref: '#/definitions/types.CommitmentType'
       commitment_windowed:
         type: boolean
       created_at:
@@ -4771,13 +4780,13 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType'
+        $ref: '#/definitions/types.SubscriptionLineItemEntityType'
       environment_id:
         type: string
       id:
         type: string
       invoice_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence'
+        $ref: '#/definitions/types.InvoiceCadence'
       metadata:
         additionalProperties:
           type: string
@@ -4789,11 +4798,11 @@ definitions:
       plan_display_name:
         type: string
       price:
-        $ref: '#/definitions/dto.PriceResponse'
+        $ref: '#/definitions/PriceResponse'
       price_id:
         type: string
       price_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceType'
+        $ref: '#/definitions/types.PriceType'
       price_unit:
         type: string
       price_unit_id:
@@ -4803,7 +4812,7 @@ definitions:
       start_date:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       subscription_phase_id:
@@ -4817,7 +4826,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.SubscriptionPauseResponse:
+  SubscriptionPauseResponse:
     description: Response object containing subscription pause information
     properties:
       created_at:
@@ -4844,22 +4853,22 @@ definitions:
         description: PauseEnd is when the pause will end (null for indefinite)
         type: string
       pause_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode'
+        $ref: '#/definitions/types.PauseMode'
       pause_start:
         description: PauseStart is when the pause actually started
         type: string
       pause_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus'
+        $ref: '#/definitions/types.PauseStatus'
       reason:
         description: Reason is the reason for pausing
         type: string
       resume_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode'
+        $ref: '#/definitions/types.ResumeMode'
       resumed_at:
         description: ResumedAt is when the pause was actually ended (if manually resumed)
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         description: SubscriptionID is the identifier for the subscription
         type: string
@@ -4870,7 +4879,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.SubscriptionPhaseCreateRequest:
+  SubscriptionPhaseCreateRequest:
     properties:
       coupons:
         description: Coupons represents subscription-level coupons to be applied to
@@ -4897,14 +4906,14 @@ definitions:
           OverrideLineItems allows customizing specific prices for this phase
           If not provided, phase will use the same line items as the subscription (plan prices)
         items:
-          $ref: '#/definitions/dto.OverrideLineItemRequest'
+          $ref: '#/definitions/OverrideLineItemRequest'
         type: array
       start_date:
         type: string
     required:
     - start_date
     type: object
-  dto.SubscriptionPhaseResponse:
+  SubscriptionPhaseResponse:
     properties:
       created_at:
         type: string
@@ -4928,7 +4937,7 @@ definitions:
         description: StartDate is when the phase starts
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         description: SubscriptionID is the identifier for the subscription
         type: string
@@ -4939,16 +4948,16 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.SubscriptionPriceCreateRequest:
+  SubscriptionPriceCreateRequest:
     properties:
       amount:
         type: string
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         type: integer
       description:
@@ -4964,7 +4973,7 @@ definitions:
           type: array
         type: object
       invoice_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence'
+        $ref: '#/definitions/types.InvoiceCadence'
       lookup_key:
         type: string
       metadata:
@@ -4976,23 +4985,23 @@ definitions:
       min_quantity:
         type: integer
       price_unit_config:
-        $ref: '#/definitions/dto.PriceUnitConfig'
+        $ref: '#/definitions/PriceUnitConfig'
       price_unit_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType'
+        $ref: '#/definitions/types.PriceUnitType'
       start_date:
         type: string
       tier_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        $ref: '#/definitions/types.BillingTier'
       tiers:
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       transform_quantity:
         $ref: '#/definitions/price.TransformQuantity'
       trial_period:
         type: integer
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceType'
+        $ref: '#/definitions/types.PriceType'
     required:
     - billing_cadence
     - billing_model
@@ -5001,7 +5010,7 @@ definitions:
     - price_unit_type
     - type
     type: object
-  dto.SubscriptionResponse:
+  SubscriptionResponse:
     properties:
       active_pause_id:
         description: |-
@@ -5015,10 +5024,10 @@ definitions:
           and the month of year for year intervals. The timestamp is in UTC format.
         type: string
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_cycle:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle'
+        - $ref: '#/definitions/types.BillingCycle'
         description: |-
           BillingCycle is the cycle of the billing anchor.
           This is used to determine the billing date for the subscription (i.e set the billing anchor)
@@ -5028,7 +5037,7 @@ definitions:
           For example, if the billing period is month and the start date is 2025-04-15 then in case of
           calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         default: 1
         description: BillingPeriodCount is the total number units of the billing period.
@@ -5052,13 +5061,13 @@ definitions:
         type: string
       commitment_duration:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        - $ref: '#/definitions/types.BillingPeriod'
         description: CommitmentDuration is the time frame of the commitment (e.g.,
           ANNUAL commitment on a MONTHLY subscription)
       coupon_associations:
         description: CouponAssociations are the coupon associations for this subscription
         items:
-          $ref: '#/definitions/dto.CouponAssociationResponse'
+          $ref: '#/definitions/CouponAssociationResponse'
         type: array
       created_at:
         type: string
@@ -5067,7 +5076,7 @@ definitions:
       credit_grants:
         description: Credit grants are the credit grants for this subscription
         items:
-          $ref: '#/definitions/dto.CreditGrantResponse'
+          $ref: '#/definitions/CreditGrantResponse'
         type: array
       currency:
         description: Currency is the currency of the subscription in lowercase 3 digit
@@ -5084,7 +5093,7 @@ definitions:
           At the end of this period, a new invoice will be created.
         type: string
       customer:
-        $ref: '#/definitions/dto.CustomerResponse'
+        $ref: '#/definitions/CustomerResponse'
       customer_id:
         description: CustomerID is the identifier for the customer in our system
         type: string
@@ -5112,7 +5121,7 @@ definitions:
         type: string
       latest_invoice:
         allOf:
-        - $ref: '#/definitions/dto.InvoiceResponse'
+        - $ref: '#/definitions/InvoiceResponse'
         description: Latest invoice information for incomplete subscriptions
       line_items:
         items:
@@ -5132,7 +5141,7 @@ definitions:
           (e.g. child subscription under a parent)
         type: string
       pause_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus'
+        $ref: '#/definitions/types.PauseStatus'
       pauses:
         items:
           $ref: '#/definitions/subscription.SubscriptionPause'
@@ -5142,28 +5151,28 @@ definitions:
         type: string
       payment_terms:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms'
+        - $ref: '#/definitions/types.PaymentTerms'
         description: PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due
           date from period end
       phases:
         description: Phases are the subscription phases for this subscription
         items:
-          $ref: '#/definitions/dto.SubscriptionPhaseResponse'
+          $ref: '#/definitions/SubscriptionPhaseResponse'
         type: array
       plan:
-        $ref: '#/definitions/dto.PlanResponse'
+        $ref: '#/definitions/PlanResponse'
       plan_id:
         description: PlanID is the identifier for the plan in our system
         type: string
       proration_behavior:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior'
+        $ref: '#/definitions/types.ProrationBehavior'
       start_date:
         description: StartDate is the start date of the subscription
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        $ref: '#/definitions/types.SubscriptionStatus'
       subscription_type:
         allOf:
         - $ref: '#/definitions/types.SubscriptionType'
@@ -5185,7 +5194,7 @@ definitions:
         description: Version is used for optimistic locking
         type: integer
     type: object
-  dto.SubscriptionResponseV2:
+  SubscriptionResponseV2:
     properties:
       active_pause_id:
         description: |-
@@ -5199,10 +5208,10 @@ definitions:
           and the month of year for year intervals. The timestamp is in UTC format.
         type: string
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_cycle:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCycle'
+        - $ref: '#/definitions/types.BillingCycle'
         description: |-
           BillingCycle is the cycle of the billing anchor.
           This is used to determine the billing date for the subscription (i.e set the billing anchor)
@@ -5212,7 +5221,7 @@ definitions:
           For example, if the billing period is month and the start date is 2025-04-15 then in case of
           calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         default: 1
         description: BillingPeriodCount is the total number units of the billing period.
@@ -5236,14 +5245,14 @@ definitions:
         type: string
       commitment_duration:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        - $ref: '#/definitions/types.BillingPeriod'
         description: CommitmentDuration is the time frame of the commitment (e.g.,
           ANNUAL commitment on a MONTHLY subscription)
       coupon_associations:
         description: CouponAssociations are included when "coupon_associations" is
           in expand parameter
         items:
-          $ref: '#/definitions/dto.CouponAssociationResponse'
+          $ref: '#/definitions/CouponAssociationResponse'
         type: array
       created_at:
         type: string
@@ -5252,7 +5261,7 @@ definitions:
       credit_grants:
         description: CreditGrants are included when "credit_grants" is in expand parameter
         items:
-          $ref: '#/definitions/dto.CreditGrantResponse'
+          $ref: '#/definitions/CreditGrantResponse'
         type: array
       currency:
         description: Currency is the currency of the subscription in lowercase 3 digit
@@ -5270,7 +5279,7 @@ definitions:
         type: string
       customer:
         allOf:
-        - $ref: '#/definitions/dto.CustomerResponse'
+        - $ref: '#/definitions/CustomerResponse'
         description: Customer is expanded only if "customer" is in expand parameter
       customer_id:
         description: CustomerID is the identifier for the customer in our system
@@ -5302,7 +5311,7 @@ definitions:
           LineItems is expanded only if "subscription_line_items" is in expand parameter
           Each line item can optionally include expanded price data
         items:
-          $ref: '#/definitions/dto.SubscriptionLineItemResponse'
+          $ref: '#/definitions/SubscriptionLineItemResponse'
         type: array
       lookup_key:
         description: LookupKey is the key used to lookup the subscription in our system
@@ -5318,7 +5327,7 @@ definitions:
           (e.g. child subscription under a parent)
         type: string
       pause_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus'
+        $ref: '#/definitions/types.PauseStatus'
       pauses:
         description: Pauses are included when subscription has pause status
         items:
@@ -5329,30 +5338,30 @@ definitions:
         type: string
       payment_terms:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentTerms'
+        - $ref: '#/definitions/types.PaymentTerms'
         description: PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due
           date from period end
       phases:
         description: Phases are included when "phases" is in expand parameter
         items:
-          $ref: '#/definitions/dto.SubscriptionPhaseResponse'
+          $ref: '#/definitions/SubscriptionPhaseResponse'
         type: array
       plan:
         allOf:
-        - $ref: '#/definitions/dto.PlanResponse'
+        - $ref: '#/definitions/PlanResponse'
         description: Plan is expanded only if "plan" is in expand parameter
       plan_id:
         description: PlanID is the identifier for the plan in our system
         type: string
       proration_behavior:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ProrationBehavior'
+        $ref: '#/definitions/types.ProrationBehavior'
       start_date:
         description: StartDate is the start date of the subscription
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        $ref: '#/definitions/types.SubscriptionStatus'
       subscription_type:
         allOf:
         - $ref: '#/definitions/types.SubscriptionType'
@@ -5374,7 +5383,7 @@ definitions:
         description: Version is used for optimistic locking
         type: integer
     type: object
-  dto.SubscriptionScheduleResponse:
+  SubscriptionScheduleResponse:
     description: Full details of a subscription schedule
     properties:
       can_be_cancelled:
@@ -5410,7 +5419,7 @@ definitions:
         type: object
       schedule_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType'
+        - $ref: '#/definitions/types.SubscriptionScheduleChangeType'
         description: schedule_type is the type of schedule (plan_change, addon_change,
           etc.)
       scheduled_at:
@@ -5418,7 +5427,7 @@ definitions:
         type: string
       status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ScheduleStatus'
+        - $ref: '#/definitions/types.ScheduleStatus'
         description: status is the current status of the schedule
       subscription_id:
         description: subscription_id is the ID of the subscription
@@ -5427,7 +5436,7 @@ definitions:
         description: updated_at timestamp
         type: string
     type: object
-  dto.SubscriptionSummary:
+  SubscriptionSummary:
     properties:
       archived_at:
         description: archived_at timestamp (for old subscriptions)
@@ -5452,10 +5461,10 @@ definitions:
         type: string
       status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        - $ref: '#/definitions/types.SubscriptionStatus'
         description: status of the subscription
     type: object
-  dto.SubscriptionUsageByMetersResponse:
+  SubscriptionUsageByMetersResponse:
     properties:
       amount:
         type: number
@@ -5483,12 +5492,12 @@ definitions:
         description: 'For feature_usage: direct match by sub_line_item_id'
         type: string
     type: object
-  dto.SuccessResponse:
+  SuccessResponse:
     properties:
       message:
         type: string
     type: object
-  dto.TaskResponse:
+  TaskResponse:
     properties:
       completed_at:
         type: string
@@ -5497,7 +5506,7 @@ definitions:
       created_by:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntityType'
+        $ref: '#/definitions/types.EntityType'
       environment_id:
         type: string
       error_summary:
@@ -5509,7 +5518,7 @@ definitions:
       file_name:
         type: string
       file_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FileType'
+        $ref: '#/definitions/types.FileType'
       file_url:
         type: string
       id:
@@ -5524,13 +5533,13 @@ definitions:
       started_at:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       successful_records:
         type: integer
       task_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaskStatus'
+        $ref: '#/definitions/types.TaskStatus'
       task_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaskType'
+        $ref: '#/definitions/types.TaskType'
       tenant_id:
         type: string
       total_records:
@@ -5542,7 +5551,7 @@ definitions:
       workflow_id:
         type: string
     type: object
-  dto.TaxAppliedResponse:
+  TaxAppliedResponse:
     properties:
       applied_at:
         type: string
@@ -5555,7 +5564,7 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType'
+        $ref: '#/definitions/types.TaxRateEntityType'
       environment_id:
         type: string
       id:
@@ -5567,13 +5576,13 @@ definitions:
           type: string
         type: object
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tax_amount:
         type: string
       tax_association_id:
         type: string
       tax_rate:
-        $ref: '#/definitions/dto.TaxRateResponse'
+        $ref: '#/definitions/TaxRateResponse'
       tax_rate_id:
         type: string
       taxable_amount:
@@ -5585,7 +5594,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.TaxAssociationResponse:
+  TaxAssociationResponse:
     properties:
       auto_apply:
         description: Whether this tax should be automatically applied
@@ -5602,7 +5611,7 @@ definitions:
         type: string
       entity_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateEntityType'
+        - $ref: '#/definitions/types.TaxRateEntityType'
         description: Type of entity this tax rate applies to
       environment_id:
         description: EnvironmentID is the ID of the environment this tax rate config
@@ -5620,9 +5629,9 @@ definitions:
         description: Priority for tax resolution (lower number = higher priority)
         type: integer
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tax_rate:
-        $ref: '#/definitions/dto.TaxRateResponse'
+        $ref: '#/definitions/TaxRateResponse'
       tax_rate_id:
         description: Reference to the TaxRate entity
         type: string
@@ -5633,7 +5642,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.TaxAssociationUpdateRequest:
+  TaxAssociationUpdateRequest:
     properties:
       auto_apply:
         type: boolean
@@ -5644,7 +5653,7 @@ definitions:
       priority:
         type: integer
     type: object
-  dto.TaxRateOverride:
+  TaxRateOverride:
     properties:
       auto_apply:
         default: true
@@ -5663,7 +5672,7 @@ definitions:
     - currency
     - tax_rate_code
     type: object
-  dto.TaxRateResponse:
+  TaxRateResponse:
     properties:
       code:
         type: string
@@ -5688,13 +5697,13 @@ definitions:
       percentage_value:
         type: string
       scope:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateScope'
+        $ref: '#/definitions/types.TaxRateScope'
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tax_rate_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateStatus'
+        $ref: '#/definitions/types.TaxRateStatus'
       tax_rate_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateType'
+        $ref: '#/definitions/types.TaxRateType'
       tenant_id:
         type: string
       updated_at:
@@ -5702,10 +5711,10 @@ definitions:
       updated_by:
         type: string
     type: object
-  dto.TenantBillingDetails:
+  TenantBillingDetails:
     properties:
       address:
-        $ref: '#/definitions/dto.Address'
+        $ref: '#/definitions/Address'
       email:
         type: string
       help_email:
@@ -5713,19 +5722,19 @@ definitions:
       phone:
         type: string
     type: object
-  dto.TenantBillingUsage:
+  TenantBillingUsage:
     properties:
       subscriptions:
         items:
-          $ref: '#/definitions/dto.SubscriptionResponse'
+          $ref: '#/definitions/SubscriptionResponse'
         type: array
       usage:
-        $ref: '#/definitions/dto.CustomerUsageSummaryResponse'
+        $ref: '#/definitions/CustomerUsageSummaryResponse'
     type: object
-  dto.TenantResponse:
+  TenantResponse:
     properties:
       billing_details:
-        $ref: '#/definitions/dto.TenantBillingDetails'
+        $ref: '#/definitions/TenantBillingDetails'
       created_at:
         type: string
       id:
@@ -5739,7 +5748,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  dto.TopUpWalletRequest:
+  TopUpWalletRequest:
     properties:
       amount:
         description: |-
@@ -5776,32 +5785,32 @@ definitions:
           default is nil which means no priority at all
         type: integer
       transaction_reason:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason'
+        $ref: '#/definitions/types.TransactionReason'
     required:
     - transaction_reason
     type: object
-  dto.TopUpWalletResponse:
+  TopUpWalletResponse:
     properties:
       invoice_id:
         description: Invoice ID if an invoice was created (only for PURCHASED_CREDIT_INVOICED)
         type: string
       wallet:
         allOf:
-        - $ref: '#/definitions/dto.WalletResponse'
+        - $ref: '#/definitions/WalletResponse'
         description: Wallet details after the operation
       wallet_transaction:
         allOf:
-        - $ref: '#/definitions/dto.WalletTransactionResponse'
+        - $ref: '#/definitions/WalletTransactionResponse'
         description: Wallet transaction created (could be PENDING or COMPLETED)
     type: object
-  dto.TriggerForceRunRequest:
+  TriggerForceRunRequest:
     properties:
       end_time:
         type: string
       start_time:
         type: string
     type: object
-  dto.TriggerForceRunResponse:
+  TriggerForceRunResponse:
     properties:
       end_time:
         type: string
@@ -5815,7 +5824,7 @@ definitions:
       workflow_id:
         type: string
     type: object
-  dto.UpdateAddonRequest:
+  UpdateAddonRequest:
     properties:
       description:
         type: string
@@ -5825,7 +5834,7 @@ definitions:
       name:
         type: string
     type: object
-  dto.UpdateCostsheetRequest:
+  UpdateCostsheetRequest:
     properties:
       description:
         type: string
@@ -5842,12 +5851,12 @@ definitions:
         minLength: 1
         type: string
     type: object
-  dto.UpdateCostsheetResponse:
+  UpdateCostsheetResponse:
     properties:
       costsheet:
-        $ref: '#/definitions/dto.CostsheetResponse'
+        $ref: '#/definitions/CostsheetResponse'
     type: object
-  dto.UpdateCouponRequest:
+  UpdateCouponRequest:
     properties:
       metadata:
         additionalProperties:
@@ -5856,14 +5865,14 @@ definitions:
       name:
         type: string
     type: object
-  dto.UpdateCreditGrantRequest:
+  UpdateCreditGrantRequest:
     properties:
       metadata:
         $ref: '#/definitions/types.Metadata'
       name:
         type: string
     type: object
-  dto.UpdateCustomerRequest:
+  UpdateCustomerRequest:
     description: Request object for updating an existing customer. All fields are
       optional - only provided fields will be updated
     properties:
@@ -5906,7 +5915,7 @@ definitions:
         description: integration_entity_mapping contains provider integration mappings
           for this customer
         items:
-          $ref: '#/definitions/dto.CreateEntityIntegrationMappingRequest'
+          $ref: '#/definitions/CreateEntityIntegrationMappingRequest'
         type: array
       metadata:
         additionalProperties:
@@ -5918,7 +5927,7 @@ definitions:
         description: name is the updated name or company name for the customer
         type: string
     type: object
-  dto.UpdateEntitlementRequest:
+  UpdateEntitlementRequest:
     properties:
       is_enabled:
         type: boolean
@@ -5929,12 +5938,12 @@ definitions:
       usage_limit:
         type: integer
       usage_reset_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod'
+        $ref: '#/definitions/types.EntitlementUsageResetPeriod'
     type: object
-  dto.UpdateFeatureRequest:
+  UpdateFeatureRequest:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       description:
         type: string
       filters:
@@ -5950,13 +5959,13 @@ definitions:
       name:
         type: string
       reporting_unit:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit'
+        $ref: '#/definitions/types.ReportingUnit'
       unit_plural:
         type: string
       unit_singular:
         type: string
     type: object
-  dto.UpdateInvoiceRequest:
+  UpdateInvoiceRequest:
     properties:
       due_date:
         type: string
@@ -5969,7 +5978,7 @@ definitions:
         - $ref: '#/definitions/types.Metadata'
         description: Invoice metadata will be overridden with the request metadata
     type: object
-  dto.UpdatePaymentRequest:
+  UpdatePaymentRequest:
     properties:
       error_message:
         type: string
@@ -5988,20 +5997,20 @@ definitions:
       succeeded_at:
         type: string
     type: object
-  dto.UpdatePaymentStatusRequest:
+  UpdatePaymentStatusRequest:
     properties:
       amount:
         description: amount is the optional payment amount to record
         type: string
       payment_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus'
+        - $ref: '#/definitions/types.PaymentStatus'
         description: payment_status is the new payment status to set for the invoice
           (paid, unpaid, etc.)
     required:
     - payment_status
     type: object
-  dto.UpdatePlanRequest:
+  UpdatePlanRequest:
     properties:
       description:
         type: string
@@ -6014,14 +6023,14 @@ definitions:
       name:
         type: string
     type: object
-  dto.UpdatePriceRequest:
+  UpdatePriceRequest:
     properties:
       amount:
         description: Amount is the new price amount that overrides the original price
           (optional)
         type: string
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       description:
         type: string
       display_name:
@@ -6052,16 +6061,16 @@ definitions:
         description: PriceUnitTiers are the price unit tiers (for CUSTOM price unit
           type, TIERED billing model)
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       tier_mode:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        - $ref: '#/definitions/types.BillingTier'
         description: TierMode determines how to calculate the price for a given quantity
       tiers:
         description: Tiers determines the pricing tiers for this line item
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       transform_quantity:
         allOf:
@@ -6069,32 +6078,32 @@ definitions:
         description: TransformQuantity determines how to transform the quantity for
           this line item
     type: object
-  dto.UpdatePriceUnitRequest:
+  UpdatePriceUnitRequest:
     properties:
       metadata:
         $ref: '#/definitions/types.Metadata'
       name:
         type: string
     type: object
-  dto.UpdateScheduledTaskRequest:
+  UpdateScheduledTaskRequest:
     properties:
       enabled:
         type: boolean
     required:
     - enabled
     type: object
-  dto.UpdateSubscriptionLineItemRequest:
+  UpdateSubscriptionLineItemRequest:
     properties:
       amount:
         description: Amount is the new price amount that overrides the original price
         type: string
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       commitment_amount:
         description: Commitment fields
         type: number
       commitment_duration:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       commitment_overage_factor:
         type: number
       commitment_quantity:
@@ -6102,7 +6111,7 @@ definitions:
       commitment_true_up_enabled:
         type: boolean
       commitment_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType'
+        $ref: '#/definitions/types.CommitmentType'
       commitment_windowed:
         type: boolean
       effective_from:
@@ -6116,12 +6125,12 @@ definitions:
         type: object
       tier_mode:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        - $ref: '#/definitions/types.BillingTier'
         description: TierMode determines how to calculate the price for a given quantity
       tiers:
         description: Tiers determines the pricing tiers for this line item
         items:
-          $ref: '#/definitions/dto.CreatePriceTier'
+          $ref: '#/definitions/CreatePriceTier'
         type: array
       transform_quantity:
         allOf:
@@ -6129,7 +6138,7 @@ definitions:
         description: TransformQuantity determines how to transform the quantity for
           this line item
     type: object
-  dto.UpdateSubscriptionRequest:
+  UpdateSubscriptionRequest:
     properties:
       cancel_at:
         type: string
@@ -6140,16 +6149,16 @@ definitions:
           Omit to leave unchanged; send "" to clear.
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+        $ref: '#/definitions/types.SubscriptionStatus'
     type: object
-  dto.UpdateTaskStatusRequest:
+  UpdateTaskStatusRequest:
     properties:
       task_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaskStatus'
+        $ref: '#/definitions/types.TaskStatus'
     required:
     - task_status
     type: object
-  dto.UpdateTaxRateRequest:
+  UpdateTaxRateRequest:
     properties:
       code:
         description: code is the updated unique alphanumeric identifier for the tax
@@ -6169,27 +6178,27 @@ definitions:
         type: string
       tax_rate_status:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TaxRateStatus'
+        - $ref: '#/definitions/types.TaxRateStatus'
         description: tax_rate_type determines how the tax is calculated ("percentage"
           or "fixed")
     type: object
-  dto.UpdateTenantRequest:
+  UpdateTenantRequest:
     properties:
       billing_details:
-        $ref: '#/definitions/dto.TenantBillingDetails'
+        $ref: '#/definitions/TenantBillingDetails'
       metadata:
         $ref: '#/definitions/types.Metadata'
       name:
         type: string
     type: object
-  dto.UpdateWalletRequest:
+  UpdateWalletRequest:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       auto_topup:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup'
+        $ref: '#/definitions/types.AutoTopup'
       config:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig'
+        $ref: '#/definitions/types.WalletConfig'
       description:
         type: string
       metadata:
@@ -6197,18 +6206,18 @@ definitions:
       name:
         type: string
     type: object
-  dto.UsageAnalyticItem:
+  UsageAnalyticItem:
     properties:
       add_on_id:
         type: string
       addon:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_addon.Addon'
+        - $ref: '#/definitions/Addon'
         description: Full addon object (only if expand includes "addon")
       aggregation_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType'
+        $ref: '#/definitions/types.AggregationType'
       commitment_info:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo'
+        $ref: '#/definitions/types.CommitmentInfo'
       currency:
         type: string
       event_count:
@@ -6218,7 +6227,7 @@ definitions:
         type: string
       feature:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_feature.Feature'
+        - $ref: '#/definitions/Feature'
         description: Full feature object (only if expand includes "feature")
       feature_id:
         type: string
@@ -6237,17 +6246,17 @@ definitions:
         type: string
       plan:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_domain_plan.Plan'
+        - $ref: '#/definitions/Plan'
         description: Full plan object (only if expand includes "plan")
       plan_id:
         type: string
       points:
         items:
-          $ref: '#/definitions/dto.UsageAnalyticPoint'
+          $ref: '#/definitions/UsageAnalyticPoint'
         type: array
       price:
         allOf:
-        - $ref: '#/definitions/dto.PriceResponse'
+        - $ref: '#/definitions/PriceResponse'
         description: Full price object (only if expand includes "price")
       price_id:
         description: Price ID used for this usage
@@ -6260,7 +6269,7 @@ definitions:
         type: object
       reporting_unit:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit'
+        - $ref: '#/definitions/types.ReportingUnit'
         description: Present when total_usage_display is set (unit_singular, unit_plural,
           conversion_rate)
       source:
@@ -6294,10 +6303,10 @@ definitions:
         type: string
       window_size:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        - $ref: '#/definitions/types.WindowSize'
         description: Window size for bucketed meters (only set if meter is bucketed)
     type: object
-  dto.UsageAnalyticPoint:
+  UsageAnalyticPoint:
     properties:
       computed_commitment_utilized_amount:
         description: Commitment breakdown (only populated for windowed commitments)
@@ -6316,7 +6325,7 @@ definitions:
       usage:
         type: string
     type: object
-  dto.UsageBreakdownItem:
+  UsageBreakdownItem:
     properties:
       cost:
         description: cost is the cost attributed to this group for the line item
@@ -6339,14 +6348,14 @@ definitions:
           additional context)
         type: string
     type: object
-  dto.UsageResult:
+  UsageResult:
     properties:
       value:
         type: number
       window_size:
         type: string
     type: object
-  dto.UserResponse:
+  UserResponse:
     properties:
       email:
         description: Empty for service accounts
@@ -6358,24 +6367,24 @@ definitions:
           type: string
         type: array
       tenant:
-        $ref: '#/definitions/dto.TenantResponse'
+        $ref: '#/definitions/TenantResponse'
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.UserType'
+        $ref: '#/definitions/types.UserType'
     type: object
-  dto.WalletBalanceResponse:
+  WalletBalanceResponse:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       alert_state:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertState'
+        $ref: '#/definitions/types.AlertState'
       auto_topup:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup'
+        $ref: '#/definitions/types.AutoTopup'
       balance:
         type: string
       balance_updated_at:
         type: string
       config:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig'
+        $ref: '#/definitions/types.WalletConfig'
       conversion_rate:
         description: |-
           amount in the currency =  number of credits * conversion_rate
@@ -6390,7 +6399,7 @@ definitions:
       credit_balance:
         type: string
       credits_available_breakdown:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditBreakdown'
+        $ref: '#/definitions/types.CreditBreakdown'
       currency:
         type: string
       current_period_usage:
@@ -6412,7 +6421,7 @@ definitions:
       real_time_credit_balance:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       topup_conversion_rate:
@@ -6429,22 +6438,22 @@ definitions:
       updated_by:
         type: string
       wallet_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus'
+        $ref: '#/definitions/types.WalletStatus'
       wallet_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletType'
+        $ref: '#/definitions/types.WalletType'
     type: object
-  dto.WalletResponse:
+  WalletResponse:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       alert_state:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertState'
+        $ref: '#/definitions/types.AlertState'
       auto_topup:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AutoTopup'
+        $ref: '#/definitions/types.AutoTopup'
       balance:
         type: string
       config:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfig'
+        $ref: '#/definitions/types.WalletConfig'
       conversion_rate:
         description: |-
           amount in the currency =  number of credits * conversion_rate
@@ -6459,7 +6468,7 @@ definitions:
       credit_balance:
         type: string
       credits_available_breakdown:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CreditBreakdown'
+        $ref: '#/definitions/types.CreditBreakdown'
       currency:
         type: string
       customer_id:
@@ -6475,7 +6484,7 @@ definitions:
       name:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       topup_conversion_rate:
@@ -6490,11 +6499,11 @@ definitions:
       updated_by:
         type: string
       wallet_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus'
+        $ref: '#/definitions/types.WalletStatus'
       wallet_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletType'
+        $ref: '#/definitions/types.WalletType'
     type: object
-  dto.WalletTransactionResponse:
+  WalletTransactionResponse:
     properties:
       amount:
         type: string
@@ -6507,7 +6516,7 @@ definitions:
       created_by:
         type: string
       created_by_user:
-        $ref: '#/definitions/dto.UserResponse'
+        $ref: '#/definitions/UserResponse'
       credit_amount:
         type: string
       credit_balance_after:
@@ -6519,7 +6528,7 @@ definitions:
       currency:
         type: string
       customer:
-        $ref: '#/definitions/dto.CustomerResponse'
+        $ref: '#/definitions/CustomerResponse'
       customer_id:
         type: string
       description:
@@ -6539,9 +6548,9 @@ definitions:
       reference_id:
         type: string
       reference_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletTxReferenceType'
+        $ref: '#/definitions/types.WalletTxReferenceType'
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       topup_conversion_rate:
@@ -6549,21 +6558,21 @@ definitions:
           the currency
         type: string
       transaction_reason:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason'
+        $ref: '#/definitions/types.TransactionReason'
       transaction_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionStatus'
+        $ref: '#/definitions/types.TransactionStatus'
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionType'
+        $ref: '#/definitions/types.TransactionType'
       updated_at:
         type: string
       updated_by:
         type: string
       wallet:
-        $ref: '#/definitions/dto.WalletResponse'
+        $ref: '#/definitions/WalletResponse'
       wallet_id:
         type: string
     type: object
-  dto.WorkflowExecutionDTO:
+  WorkflowExecutionDTO:
     properties:
       close_time:
         type: string
@@ -6592,7 +6601,7 @@ definitions:
       workflow_type:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_domain_addon.Addon:
+  Addon:
     properties:
       created_at:
         type: string
@@ -6612,22 +6621,22 @@ definitions:
       name:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonType'
+        $ref: '#/definitions/types.AddonType'
       updated_at:
         type: string
       updated_by:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_domain_coupon.Coupon:
+  Coupon:
     properties:
       amount_off:
         type: string
       cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponCadence'
+        $ref: '#/definitions/types.CouponCadence'
       created_at:
         type: string
       created_by:
@@ -6658,19 +6667,19 @@ definitions:
         additionalProperties: true
         type: object
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       total_redemptions:
         type: integer
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponType'
+        $ref: '#/definitions/types.CouponType'
       updated_at:
         type: string
       updated_by:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_domain_customer.Customer:
+  Customer:
     properties:
       address_city:
         description: AddressCity is the city of the customer's address
@@ -6716,7 +6725,7 @@ definitions:
         description: Name is the name of the customer
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -6724,10 +6733,10 @@ definitions:
       updated_by:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_domain_feature.Feature:
+  Feature:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       created_at:
         type: string
       created_by:
@@ -6754,13 +6763,13 @@ definitions:
       name:
         type: string
       reporting_unit:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ReportingUnit'
+        $ref: '#/definitions/types.ReportingUnit'
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType'
+        $ref: '#/definitions/types.FeatureType'
       unit_plural:
         type: string
       unit_singular:
@@ -6770,7 +6779,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_domain_plan.Plan:
+  Plan:
     properties:
       created_at:
         type: string
@@ -6791,7 +6800,7 @@ definitions:
       name:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -6799,7 +6808,7 @@ definitions:
       updated_by:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_errors.ErrorResponse:
+  errors.ErrorResponse:
     properties:
       code:
         enum:
@@ -6823,7 +6832,7 @@ definitions:
       message:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.AddonAssociationEntityType:
+  types.AddonAssociationEntityType:
     enum:
     - subscription
     - plan
@@ -6833,14 +6842,14 @@ definitions:
     - AddonAssociationEntityTypeSubscription
     - AddonAssociationEntityTypePlan
     - AddonAssociationEntityTypeAddon
-  github_com_flexprice_flexprice_internal_types.AddonFilter:
+  types.AddonFilter:
     properties:
       addon_ids:
         items:
           type: string
         type: array
       addon_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonType'
+        $ref: '#/definitions/types.AddonType'
       end_time:
         type: string
       expand:
@@ -6848,7 +6857,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -6868,14 +6877,14 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.AddonStatus:
+  types.AddonStatus:
     enum:
     - active
     - cancelled
@@ -6885,7 +6894,7 @@ definitions:
     - AddonStatusActive
     - AddonStatusCancelled
     - AddonStatusPaused
-  github_com_flexprice_flexprice_internal_types.AddonType:
+  types.AddonType:
     enum:
     - onetime
     - multiple_instance
@@ -6893,7 +6902,7 @@ definitions:
     x-enum-varnames:
     - AddonTypeOnetime
     - AddonTypeMultipleInstance
-  github_com_flexprice_flexprice_internal_types.AggregationType:
+  types.AggregationType:
     enum:
     - COUNT
     - SUM
@@ -6915,7 +6924,7 @@ definitions:
     - AggregationSumWithMultiplier
     - AggregationMax
     - AggregationWeightedSum
-  github_com_flexprice_flexprice_internal_types.AlertCondition:
+  types.AlertCondition:
     enum:
     - above
     - below
@@ -6923,7 +6932,7 @@ definitions:
     x-enum-varnames:
     - AlertConditionAbove
     - AlertConditionBelow
-  github_com_flexprice_flexprice_internal_types.AlertEntityType:
+  types.AlertEntityType:
     enum:
     - wallet
     - feature
@@ -6931,21 +6940,21 @@ definitions:
     x-enum-varnames:
     - AlertEntityTypeWallet
     - AlertEntityTypeFeature
-  github_com_flexprice_flexprice_internal_types.AlertInfo:
+  types.AlertInfo:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       timestamp:
         type: string
       value_at_time:
         type: number
     type: object
-  github_com_flexprice_flexprice_internal_types.AlertLogFilter:
+  types.AlertLogFilter:
     properties:
       alert_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertState'
+        $ref: '#/definitions/types.AlertState'
       alert_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertType'
+        $ref: '#/definitions/types.AlertType'
       customer_id:
         type: string
       end_time:
@@ -6953,13 +6962,13 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertEntityType'
+        $ref: '#/definitions/types.AlertEntityType'
       expand:
         type: string
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -6975,25 +6984,25 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.AlertSettings:
+  types.AlertSettings:
     properties:
       alert_enabled:
         type: boolean
       critical:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold'
+        $ref: '#/definitions/types.AlertThreshold'
       info:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold'
+        $ref: '#/definitions/types.AlertThreshold'
       warning:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertThreshold'
+        $ref: '#/definitions/types.AlertThreshold'
     type: object
-  github_com_flexprice_flexprice_internal_types.AlertState:
+  types.AlertState:
     enum:
     - ok
     - info
@@ -7005,14 +7014,14 @@ definitions:
     - AlertStateInfo
     - AlertStateWarning
     - AlertStateInAlarm
-  github_com_flexprice_flexprice_internal_types.AlertThreshold:
+  types.AlertThreshold:
     properties:
       condition:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertCondition'
+        $ref: '#/definitions/types.AlertCondition'
       threshold:
         type: number
     type: object
-  github_com_flexprice_flexprice_internal_types.AlertType:
+  types.AlertType:
     enum:
     - low_ongoing_balance
     - low_credit_balance
@@ -7022,7 +7031,7 @@ definitions:
     - AlertTypeLowOngoingBalance
     - AlertTypeLowCreditBalance
     - AlertTypeFeatureWalletBalance
-  github_com_flexprice_flexprice_internal_types.ApplicationStatus:
+  types.ApplicationStatus:
     enum:
     - applied
     - failed
@@ -7036,7 +7045,7 @@ definitions:
     - ApplicationStatusPending
     - ApplicationStatusSkipped
     - ApplicationStatusCancelled
-  github_com_flexprice_flexprice_internal_types.AutoTopup:
+  types.AutoTopup:
     properties:
       amount:
         type: number
@@ -7047,7 +7056,7 @@ definitions:
       threshold:
         type: number
     type: object
-  github_com_flexprice_flexprice_internal_types.BillingCadence:
+  types.BillingCadence:
     enum:
     - RECURRING
     - ONETIME
@@ -7055,7 +7064,7 @@ definitions:
     x-enum-varnames:
     - BILLING_CADENCE_RECURRING
     - BILLING_CADENCE_ONETIME
-  github_com_flexprice_flexprice_internal_types.BillingCycle:
+  types.BillingCycle:
     enum:
     - anniversary
     - calendar
@@ -7063,7 +7072,7 @@ definitions:
     x-enum-varnames:
     - BillingCycleAnniversary
     - BillingCycleCalendar
-  github_com_flexprice_flexprice_internal_types.BillingModel:
+  types.BillingModel:
     enum:
     - FLAT_FEE
     - PACKAGE
@@ -7073,7 +7082,7 @@ definitions:
     - BILLING_MODEL_FLAT_FEE
     - BILLING_MODEL_PACKAGE
     - BILLING_MODEL_TIERED
-  github_com_flexprice_flexprice_internal_types.BillingPeriod:
+  types.BillingPeriod:
     enum:
     - MONTHLY
     - ANNUAL
@@ -7089,7 +7098,7 @@ definitions:
     - BILLING_PERIOD_DAILY
     - BILLING_PERIOD_QUARTER
     - BILLING_PERIOD_HALF_YEAR
-  github_com_flexprice_flexprice_internal_types.BillingTier:
+  types.BillingTier:
     enum:
     - VOLUME
     - SLAB
@@ -7097,7 +7106,7 @@ definitions:
     x-enum-varnames:
     - BILLING_TIER_VOLUME
     - BILLING_TIER_SLAB
-  github_com_flexprice_flexprice_internal_types.CancelImmediatelyInvoicePolicy:
+  types.CancelImmediatelyInvoicePolicy:
     enum:
     - generate_invoice
     - skip
@@ -7105,7 +7114,7 @@ definitions:
     x-enum-varnames:
     - CancelImmediatelyInvoicePolicyGenerateInvoice
     - CancelImmediatelyInvoicePolicySkip
-  github_com_flexprice_flexprice_internal_types.CancellationType:
+  types.CancellationType:
     enum:
     - immediate
     - end_of_period
@@ -7115,7 +7124,7 @@ definitions:
     - CancellationTypeImmediate
     - CancellationTypeEndOfPeriod
     - CancellationTypeScheduledDate
-  github_com_flexprice_flexprice_internal_types.CollectionMethod:
+  types.CollectionMethod:
     enum:
     - charge_automatically
     - send_invoice
@@ -7123,7 +7132,7 @@ definitions:
     x-enum-varnames:
     - CollectionMethodChargeAutomatically
     - CollectionMethodSendInvoice
-  github_com_flexprice_flexprice_internal_types.CommitmentInfo:
+  types.CommitmentInfo:
     properties:
       amount:
         type: string
@@ -7136,7 +7145,7 @@ definitions:
           + computed_true_up_amount
         type: string
       duration:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       is_windowed:
         type: boolean
       overage_factor:
@@ -7147,9 +7156,9 @@ definitions:
       true_up_enabled:
         type: boolean
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType'
+        $ref: '#/definitions/types.CommitmentType'
     type: object
-  github_com_flexprice_flexprice_internal_types.CommitmentType:
+  types.CommitmentType:
     enum:
     - amount
     - quantity
@@ -7157,7 +7166,7 @@ definitions:
     x-enum-varnames:
     - COMMITMENT_TYPE_AMOUNT
     - COMMITMENT_TYPE_QUANTITY
-  github_com_flexprice_flexprice_internal_types.CouponCadence:
+  types.CouponCadence:
     enum:
     - once
     - repeated
@@ -7167,7 +7176,7 @@ definitions:
     - CouponCadenceOnce
     - CouponCadenceRepeated
     - CouponCadenceForever
-  github_com_flexprice_flexprice_internal_types.CouponFilter:
+  types.CouponFilter:
     properties:
       coupon_ids:
         items:
@@ -7177,7 +7186,7 @@ definitions:
         type: string
       filters:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -7193,12 +7202,12 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.CouponType:
+  types.CouponType:
     enum:
     - fixed
     - percentage
@@ -7206,14 +7215,14 @@ definitions:
     x-enum-varnames:
     - CouponTypeFixed
     - CouponTypePercentage
-  github_com_flexprice_flexprice_internal_types.CreditBreakdown:
+  types.CreditBreakdown:
     properties:
       free:
         type: string
       purchased:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.CreditGrantApplicationReason:
+  types.CreditGrantApplicationReason:
     enum:
     - first_time_recurring_credit_grant
     - recurring_credit_grant
@@ -7223,7 +7232,7 @@ definitions:
     - ApplicationReasonFirstTimeRecurringCreditGrant
     - ApplicationReasonRecurringCreditGrant
     - ApplicationReasonOnetimeCreditGrant
-  github_com_flexprice_flexprice_internal_types.CreditGrantCadence:
+  types.CreditGrantCadence:
     enum:
     - ONETIME
     - RECURRING
@@ -7231,7 +7240,7 @@ definitions:
     x-enum-varnames:
     - CreditGrantCadenceOneTime
     - CreditGrantCadenceRecurring
-  github_com_flexprice_flexprice_internal_types.CreditGrantExpiryDurationUnit:
+  types.CreditGrantExpiryDurationUnit:
     enum:
     - DAY
     - WEEK
@@ -7243,7 +7252,7 @@ definitions:
     - CreditGrantExpiryDurationUnitWeeks
     - CreditGrantExpiryDurationUnitMonths
     - CreditGrantExpiryDurationUnitYears
-  github_com_flexprice_flexprice_internal_types.CreditGrantExpiryType:
+  types.CreditGrantExpiryType:
     enum:
     - NEVER
     - DURATION
@@ -7253,7 +7262,7 @@ definitions:
     - CreditGrantExpiryTypeNever
     - CreditGrantExpiryTypeDuration
     - CreditGrantExpiryTypeBillingCycle
-  github_com_flexprice_flexprice_internal_types.CreditGrantPeriod:
+  types.CreditGrantPeriod:
     enum:
     - DAILY
     - WEEKLY
@@ -7269,7 +7278,7 @@ definitions:
     - CREDIT_GRANT_PERIOD_ANNUAL
     - CREDIT_GRANT_PERIOD_QUARTER
     - CREDIT_GRANT_PERIOD_HALF_YEARLY
-  github_com_flexprice_flexprice_internal_types.CreditGrantScope:
+  types.CreditGrantScope:
     enum:
     - PLAN
     - SUBSCRIPTION
@@ -7277,7 +7286,7 @@ definitions:
     x-enum-varnames:
     - CreditGrantScopePlan
     - CreditGrantScopeSubscription
-  github_com_flexprice_flexprice_internal_types.CreditNoteReason:
+  types.CreditNoteReason:
     enum:
     - DUPLICATE
     - FRAUDULENT
@@ -7295,7 +7304,7 @@ definitions:
     - CreditNoteReasonService
     - CreditNoteReasonBillingError
     - CreditNoteReasonSubscriptionCancellation
-  github_com_flexprice_flexprice_internal_types.CreditNoteStatus:
+  types.CreditNoteStatus:
     enum:
     - DRAFT
     - FINALIZED
@@ -7305,7 +7314,7 @@ definitions:
     - CreditNoteStatusDraft
     - CreditNoteStatusFinalized
     - CreditNoteStatusVoided
-  github_com_flexprice_flexprice_internal_types.CreditNoteType:
+  types.CreditNoteType:
     enum:
     - ADJUSTMENT
     - REFUND
@@ -7313,7 +7322,7 @@ definitions:
     x-enum-varnames:
     - CreditNoteTypeAdjustment
     - CreditNoteTypeRefund
-  github_com_flexprice_flexprice_internal_types.CustomerFilter:
+  types.CustomerFilter:
     properties:
       customer_ids:
         items:
@@ -7333,7 +7342,7 @@ definitions:
         type: array
       filters:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -7349,14 +7358,14 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.DataType:
+  types.DataType:
     enum:
     - string
     - number
@@ -7368,7 +7377,7 @@ definitions:
     - DataTypeNumber
     - DataTypeDate
     - DataTypeArray
-  github_com_flexprice_flexprice_internal_types.DebugTrackerStatus:
+  types.DebugTrackerStatus:
     enum:
     - unprocessed
     - not_found
@@ -7380,7 +7389,7 @@ definitions:
     - DebugTrackerStatusNotFound
     - DebugTrackerStatusFound
     - DebugTrackerStatusError
-  github_com_flexprice_flexprice_internal_types.EntitlementEntityType:
+  types.EntitlementEntityType:
     enum:
     - PLAN
     - SUBSCRIPTION
@@ -7390,7 +7399,7 @@ definitions:
     - ENTITLEMENT_ENTITY_TYPE_PLAN
     - ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION
     - ENTITLEMENT_ENTITY_TYPE_ADDON
-  github_com_flexprice_flexprice_internal_types.EntitlementFilter:
+  types.EntitlementFilter:
     properties:
       end_time:
         type: string
@@ -7399,7 +7408,7 @@ definitions:
           type: string
         type: array
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementEntityType'
+        $ref: '#/definitions/types.EntitlementEntityType'
       expand:
         type: string
       feature_ids:
@@ -7407,11 +7416,11 @@ definitions:
           type: string
         type: array
       feature_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureType'
+        $ref: '#/definitions/types.FeatureType'
       filters:
         description: Specific filters for entitlements
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       is_enabled:
         type: boolean
@@ -7433,14 +7442,14 @@ definitions:
         type: array
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.EntitlementUsageResetPeriod:
+  types.EntitlementUsageResetPeriod:
     enum:
     - MONTHLY
     - ANNUAL
@@ -7458,7 +7467,7 @@ definitions:
     - ENTITLEMENT_USAGE_RESET_PERIOD_QUARTER
     - ENTITLEMENT_USAGE_RESET_PERIOD_HALF_YEAR
     - ENTITLEMENT_USAGE_RESET_PERIOD_NEVER
-  github_com_flexprice_flexprice_internal_types.EntityType:
+  types.EntityType:
     enum:
     - EVENTS
     - PRICES
@@ -7470,7 +7479,7 @@ definitions:
     - EntityTypePrices
     - EntityTypeCustomers
     - EntityTypeFeatures
-  github_com_flexprice_flexprice_internal_types.EventProcessingStatusType:
+  types.EventProcessingStatusType:
     enum:
     - processed
     - processing
@@ -7480,14 +7489,14 @@ definitions:
     - EventProcessingStatusTypeProcessed
     - EventProcessingStatusTypeProcessing
     - EventProcessingStatusTypeFailed
-  github_com_flexprice_flexprice_internal_types.FailurePoint:
+  types.FailurePoint:
     properties:
       error:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+        $ref: '#/definitions/errors.ErrorResponse'
       failure_point_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FailurePointType'
+        $ref: '#/definitions/types.FailurePointType'
     type: object
-  github_com_flexprice_flexprice_internal_types.FailurePointType:
+  types.FailurePointType:
     enum:
     - customer_lookup
     - meter_lookup
@@ -7499,7 +7508,7 @@ definitions:
     - FailurePointTypeMeterLookup
     - FailurePointTypePriceLookup
     - FailurePointTypeSubscriptionLineItemLookup
-  github_com_flexprice_flexprice_internal_types.FeatureFilter:
+  types.FeatureFilter:
     properties:
       end_time:
         type: string
@@ -7513,7 +7522,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -7541,14 +7550,14 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.FeatureType:
+  types.FeatureType:
     enum:
     - metered
     - boolean
@@ -7558,7 +7567,7 @@ definitions:
     - FeatureTypeMetered
     - FeatureTypeBoolean
     - FeatureTypeStatic
-  github_com_flexprice_flexprice_internal_types.FileType:
+  types.FileType:
     enum:
     - CSV
     - JSON
@@ -7566,18 +7575,18 @@ definitions:
     x-enum-varnames:
     - FileTypeCSV
     - FileTypeJSON
-  github_com_flexprice_flexprice_internal_types.FilterCondition:
+  types.FilterCondition:
     properties:
       data_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.DataType'
+        $ref: '#/definitions/types.DataType'
       field:
         type: string
       operator:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterOperatorType'
+        $ref: '#/definitions/types.FilterOperatorType'
       value:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Value'
+        $ref: '#/definitions/types.Value'
     type: object
-  github_com_flexprice_flexprice_internal_types.FilterOperatorType:
+  types.FilterOperatorType:
     enum:
     - eq
     - contains
@@ -7599,7 +7608,7 @@ definitions:
     - NOT_IN
     - BEFORE
     - AFTER
-  github_com_flexprice_flexprice_internal_types.GroupEntityType:
+  types.GroupEntityType:
     enum:
     - price
     - feature
@@ -7607,7 +7616,7 @@ definitions:
     x-enum-varnames:
     - GroupEntityTypePrice
     - GroupEntityTypeFeature
-  github_com_flexprice_flexprice_internal_types.GroupFilter:
+  types.GroupFilter:
     properties:
       end_time:
         type: string
@@ -7618,7 +7627,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       group_ids:
         description: Group specific filters
@@ -7643,14 +7652,14 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.IntegrationEntityType:
+  types.IntegrationEntityType:
     enum:
     - customer
     - plan
@@ -7674,7 +7683,7 @@ definitions:
     - IntegrationEntityTypeItem
     - IntegrationEntityTypeItemPrice
     - IntegrationEntityTypePrice
-  github_com_flexprice_flexprice_internal_types.InvoiceBillingReason:
+  types.InvoiceBillingReason:
     enum:
     - SUBSCRIPTION_CREATE
     - SUBSCRIPTION_CYCLE
@@ -7688,7 +7697,7 @@ definitions:
     - InvoiceBillingReasonSubscriptionUpdate
     - InvoiceBillingReasonProration
     - InvoiceBillingReasonManual
-  github_com_flexprice_flexprice_internal_types.InvoiceCadence:
+  types.InvoiceCadence:
     enum:
     - ARREAR
     - ADVANCE
@@ -7696,7 +7705,7 @@ definitions:
     x-enum-varnames:
     - InvoiceCadenceArrear
     - InvoiceCadenceAdvance
-  github_com_flexprice_flexprice_internal_types.InvoiceFilter:
+  types.InvoiceFilter:
     properties:
       amount_due_gt:
         description: |-
@@ -7724,7 +7733,7 @@ definitions:
         type: string
       filters:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       invoice_ids:
         description: |-
@@ -7738,11 +7747,11 @@ definitions:
           invoice_status filters by the current state of invoices in their lifecycle
           Multiple statuses can be specified to include invoices in any of the listed states
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceStatus'
+          $ref: '#/definitions/types.InvoiceStatus'
         type: array
       invoice_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceType'
+        - $ref: '#/definitions/types.InvoiceType'
         description: |-
           invoice_type filters by the nature of the invoice (SUBSCRIPTION, ONE_OFF, or CREDIT)
           Use this to separate recurring charges from one-time fees or credit adjustments
@@ -7763,7 +7772,7 @@ definitions:
           payment_status filters by the payment state of invoices
           Multiple statuses can be specified to include invoices with any of the listed payment states
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaymentStatus'
+          $ref: '#/definitions/types.PaymentStatus'
         type: array
       period_end_gte:
         description: period_end_gte filters invoices with period_end >= value
@@ -7782,19 +7791,23 @@ definitions:
         type: boolean
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
+      subscription_customer_id:
+        description: subscription_customer_id filters invoices by the subscription
+          owner's customer ID
+        type: string
       subscription_id:
         description: |-
           subscription_id filters invoices generated for a specific subscription
           Only returns invoices that were created as part of the specified subscription's billing
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.InvoiceStatus:
+  types.InvoiceStatus:
     enum:
     - DRAFT
     - FINALIZED
@@ -7806,7 +7819,7 @@ definitions:
     - InvoiceStatusFinalized
     - InvoiceStatusVoided
     - InvoiceStatusSkipped
-  github_com_flexprice_flexprice_internal_types.InvoiceType:
+  types.InvoiceType:
     enum:
     - SUBSCRIPTION
     - ONE_OFF
@@ -7816,7 +7829,7 @@ definitions:
     - InvoiceTypeSubscription
     - InvoiceTypeOneOff
     - InvoiceTypeCredit
-  github_com_flexprice_flexprice_internal_types.PaginationResponse:
+  types.PaginationResponse:
     properties:
       limit:
         type: integer
@@ -7825,7 +7838,7 @@ definitions:
       total:
         type: integer
     type: object
-  github_com_flexprice_flexprice_internal_types.PauseMode:
+  types.PauseMode:
     enum:
     - immediate
     - scheduled
@@ -7835,7 +7848,7 @@ definitions:
     - PauseModeImmediate
     - PauseModeScheduled
     - PauseModePeriodEnd
-  github_com_flexprice_flexprice_internal_types.PauseStatus:
+  types.PauseStatus:
     enum:
     - none
     - active
@@ -7849,7 +7862,7 @@ definitions:
     - PauseStatusScheduled
     - PauseStatusCompleted
     - PauseStatusCancelled
-  github_com_flexprice_flexprice_internal_types.PaymentBehavior:
+  types.PaymentBehavior:
     enum:
     - allow_incomplete
     - default_incomplete
@@ -7861,13 +7874,13 @@ definitions:
     - PaymentBehaviorDefaultIncomplete
     - PaymentBehaviorErrorIfIncomplete
     - PaymentBehaviorDefaultActive
-  github_com_flexprice_flexprice_internal_types.PaymentDestinationType:
+  types.PaymentDestinationType:
     enum:
     - INVOICE
     type: string
     x-enum-varnames:
     - PaymentDestinationTypeInvoice
-  github_com_flexprice_flexprice_internal_types.PaymentGatewayType:
+  types.PaymentGatewayType:
     enum:
     - stripe
     - razorpay
@@ -7881,7 +7894,7 @@ definitions:
     - PaymentGatewayTypeNomod
     - PaymentGatewayTypeMoyasar
     - PaymentGatewayTypePaddle
-  github_com_flexprice_flexprice_internal_types.PaymentMethodType:
+  types.PaymentMethodType:
     enum:
     - CARD
     - ACH
@@ -7895,7 +7908,7 @@ definitions:
     - PaymentMethodTypeOffline
     - PaymentMethodTypeCredits
     - PaymentMethodTypePaymentLink
-  github_com_flexprice_flexprice_internal_types.PaymentStatus:
+  types.PaymentStatus:
     enum:
     - INITIATED
     - PENDING
@@ -7915,7 +7928,7 @@ definitions:
     - PaymentStatusFailed
     - PaymentStatusRefunded
     - PaymentStatusPartiallyRefunded
-  github_com_flexprice_flexprice_internal_types.PaymentTerms:
+  types.PaymentTerms:
     enum:
     - 15 NET
     - 30 NET
@@ -7931,7 +7944,7 @@ definitions:
     - PaymentTerms60Net
     - PaymentTerms75Net
     - PaymentTerms90Net
-  github_com_flexprice_flexprice_internal_types.PlanFilter:
+  types.PlanFilter:
     properties:
       end_time:
         type: string
@@ -7940,7 +7953,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -7962,14 +7975,14 @@ definitions:
         type: array
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.PriceEntityType:
+  types.PriceEntityType:
     enum:
     - PLAN
     - SUBSCRIPTION
@@ -7983,7 +7996,7 @@ definitions:
     - PRICE_ENTITY_TYPE_ADDON
     - PRICE_ENTITY_TYPE_PRICE
     - PRICE_ENTITY_TYPE_COSTSHEET
-  github_com_flexprice_flexprice_internal_types.PriceFilter:
+  types.PriceFilter:
     properties:
       allow_expired_prices:
         default: false
@@ -7995,13 +8008,13 @@ definitions:
           type: string
         type: array
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType'
+        $ref: '#/definitions/types.PriceEntityType'
       expand:
         type: string
       filters:
         description: DSL filters
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -8037,11 +8050,11 @@ definitions:
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.PriceType:
+  types.PriceType:
     enum:
     - USAGE
     - FIXED
@@ -8049,7 +8062,7 @@ definitions:
     x-enum-varnames:
     - PRICE_TYPE_USAGE
     - PRICE_TYPE_FIXED
-  github_com_flexprice_flexprice_internal_types.PriceUnitFilter:
+  types.PriceUnitFilter:
     properties:
       end_time:
         type: string
@@ -8058,7 +8071,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -8078,14 +8091,14 @@ definitions:
         type: array
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.PriceUnitType:
+  types.PriceUnitType:
     enum:
     - FIAT
     - CUSTOM
@@ -8093,7 +8106,7 @@ definitions:
     x-enum-varnames:
     - PRICE_UNIT_TYPE_FIAT
     - PRICE_UNIT_TYPE_CUSTOM
-  github_com_flexprice_flexprice_internal_types.ProrationBehavior:
+  types.ProrationBehavior:
     enum:
     - create_prorations
     - none
@@ -8104,7 +8117,7 @@ definitions:
     x-enum-varnames:
     - ProrationBehaviorCreateProrations
     - ProrationBehaviorNone
-  github_com_flexprice_flexprice_internal_types.QueryFilter:
+  types.QueryFilter:
     properties:
       expand:
         type: string
@@ -8123,9 +8136,9 @@ definitions:
       sort:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
     type: object
-  github_com_flexprice_flexprice_internal_types.ReportingUnit:
+  types.ReportingUnit:
     properties:
       conversion_rate:
         description: 'Multiplier: reporting_unit_value = unit_value * conversion_rate;
@@ -8138,7 +8151,7 @@ definitions:
         description: Display unit label, singular (e.g. "second")
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.ResetUsage:
+  types.ResetUsage:
     enum:
     - BILLING_PERIOD
     - NEVER
@@ -8146,7 +8159,7 @@ definitions:
     x-enum-varnames:
     - ResetUsageBillingPeriod
     - ResetUsageNever
-  github_com_flexprice_flexprice_internal_types.ResumeMode:
+  types.ResumeMode:
     enum:
     - immediate
     - scheduled
@@ -8156,7 +8169,7 @@ definitions:
     - ResumeModeImmediate
     - ResumeModeScheduled
     - ResumeModeAuto
-  github_com_flexprice_flexprice_internal_types.RoundType:
+  types.RoundType:
     enum:
     - up
     - down
@@ -8164,7 +8177,7 @@ definitions:
     x-enum-varnames:
     - ROUND_UP
     - ROUND_DOWN
-  github_com_flexprice_flexprice_internal_types.S3CompressionType:
+  types.S3CompressionType:
     enum:
     - none
     - gzip
@@ -8172,7 +8185,7 @@ definitions:
     x-enum-varnames:
     - S3CompressionTypeNone
     - S3CompressionTypeGzip
-  github_com_flexprice_flexprice_internal_types.S3EncryptionType:
+  types.S3EncryptionType:
     enum:
     - AES256
     - aws:kms
@@ -8182,18 +8195,18 @@ definitions:
     - S3EncryptionTypeAES256
     - S3EncryptionTypeAwsKms
     - S3EncryptionTypeAwsKmsDsse
-  github_com_flexprice_flexprice_internal_types.S3JobConfig:
+  types.S3JobConfig:
     properties:
       bucket:
         description: S3 bucket name
         type: string
       compression:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.S3CompressionType'
+        - $ref: '#/definitions/types.S3CompressionType'
         description: 'Compression type: "gzip", "none" (default: "none")'
       encryption:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.S3EncryptionType'
+        - $ref: '#/definitions/types.S3EncryptionType'
         description: 'Encryption type: "AES256", "aws:kms", "aws:kms:dsse" (default:
           "AES256")'
       endpoint_url:
@@ -8210,7 +8223,7 @@ definitions:
           for MinIO)
         type: boolean
     type: object
-  github_com_flexprice_flexprice_internal_types.ScheduleStatus:
+  types.ScheduleStatus:
     enum:
     - pending
     - executing
@@ -8224,7 +8237,7 @@ definitions:
     - ScheduleStatusExecuted
     - ScheduleStatusCancelled
     - ScheduleStatusFailed
-  github_com_flexprice_flexprice_internal_types.ScheduleType:
+  types.ScheduleType:
     enum:
     - immediate
     - end_of_period
@@ -8232,7 +8245,7 @@ definitions:
     x-enum-varnames:
     - ScheduleTypeImmediate
     - ScheduleTypePeriodEnd
-  github_com_flexprice_flexprice_internal_types.ScheduledTaskEntityType:
+  types.ScheduledTaskEntityType:
     enum:
     - events
     - invoice
@@ -8244,7 +8257,7 @@ definitions:
     - ScheduledTaskEntityTypeInvoice
     - ScheduledTaskEntityTypeCreditTopups
     - ScheduledTaskEntityTypeCreditUsage
-  github_com_flexprice_flexprice_internal_types.ScheduledTaskInterval:
+  types.ScheduledTaskInterval:
     enum:
     - 15MIN
     - 30MIN
@@ -8260,7 +8273,7 @@ definitions:
     - ScheduledTaskIntervalCustom
     - ScheduledTaskIntervalHourly
     - ScheduledTaskIntervalDaily
-  github_com_flexprice_flexprice_internal_types.SecretProvider:
+  types.SecretProvider:
     enum:
     - flexprice
     - stripe
@@ -8284,7 +8297,7 @@ definitions:
     - SecretProviderNomod
     - SecretProviderMoyasar
     - SecretProviderPaddle
-  github_com_flexprice_flexprice_internal_types.SecretType:
+  types.SecretType:
     enum:
     - private_key
     - publishable_key
@@ -8294,14 +8307,14 @@ definitions:
     - SecretTypePrivateKey
     - SecretTypePublishableKey
     - SecretTypeIntegration
-  github_com_flexprice_flexprice_internal_types.SortCondition:
+  types.SortCondition:
     properties:
       direction:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortDirection'
+        $ref: '#/definitions/types.SortDirection'
       field:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.SortDirection:
+  types.SortDirection:
     enum:
     - asc
     - desc
@@ -8309,7 +8322,7 @@ definitions:
     x-enum-varnames:
     - SortDirectionAsc
     - SortDirectionDesc
-  github_com_flexprice_flexprice_internal_types.Status:
+  types.Status:
     enum:
     - published
     - deleted
@@ -8319,7 +8332,7 @@ definitions:
     - StatusPublished
     - StatusDeleted
     - StatusArchived
-  github_com_flexprice_flexprice_internal_types.SubscriptionChangeType:
+  types.SubscriptionChangeType:
     enum:
     - upgrade
     - downgrade
@@ -8329,7 +8342,7 @@ definitions:
     - SubscriptionChangeTypeUpgrade
     - SubscriptionChangeTypeDowngrade
     - SubscriptionChangeTypeLateral
-  github_com_flexprice_flexprice_internal_types.SubscriptionFilter:
+  types.SubscriptionFilter:
     properties:
       active_at:
         description: ActiveAt filters subscriptions that are active at the given time
@@ -8337,12 +8350,12 @@ definitions:
       billing_cadence:
         description: BillingCadence filters by billing cadence
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+          $ref: '#/definitions/types.BillingCadence'
         type: array
       billing_period:
         description: BillingPeriod filters by billing period
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+          $ref: '#/definitions/types.BillingPeriod'
         type: array
       customer_id:
         description: CustomerID filters by customer ID
@@ -8367,7 +8380,7 @@ definitions:
         type: string
       filters:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       invoicing_customer_ids:
         description: InvoicingCustomerIDs filters by invoicing customer ID
@@ -8396,12 +8409,12 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_ids:
         items:
           type: string
@@ -8409,7 +8422,7 @@ definitions:
       subscription_status:
         description: SubscriptionStatus filters by subscription status
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionStatus'
+          $ref: '#/definitions/types.SubscriptionStatus'
         type: array
       subscription_type:
         description: SubscriptionType filters by subscription type
@@ -8420,7 +8433,7 @@ definitions:
         description: WithLineItems includes line items in the response
         type: boolean
     type: object
-  github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType:
+  types.SubscriptionLineItemEntityType:
     enum:
     - plan
     - addon
@@ -8430,7 +8443,7 @@ definitions:
     - SubscriptionLineItemEntityTypePlan
     - SubscriptionLineItemEntityTypeAddon
     - SubscriptionLineItemEntityTypeSubscription
-  github_com_flexprice_flexprice_internal_types.SubscriptionScheduleChangeType:
+  types.SubscriptionScheduleChangeType:
     enum:
     - plan_change
     - cancellation
@@ -8438,7 +8451,7 @@ definitions:
     x-enum-varnames:
     - SubscriptionScheduleChangeTypePlanChange
     - SubscriptionScheduleChangeTypeCancellation
-  github_com_flexprice_flexprice_internal_types.SubscriptionStatus:
+  types.SubscriptionStatus:
     enum:
     - active
     - paused
@@ -8454,7 +8467,17 @@ definitions:
     - SubscriptionStatusIncomplete
     - SubscriptionStatusTrialing
     - SubscriptionStatusDraft
-  github_com_flexprice_flexprice_internal_types.TaskStatus:
+  types.SubscriptionType:
+    enum:
+    - standalone
+    - parent
+    - inherited
+    type: string
+    x-enum-varnames:
+    - SubscriptionTypeStandalone
+    - SubscriptionTypeParent
+    - SubscriptionTypeInherited
+  types.TaskStatus:
     enum:
     - PENDING
     - PROCESSING
@@ -8466,7 +8489,7 @@ definitions:
     - TaskStatusProcessing
     - TaskStatusCompleted
     - TaskStatusFailed
-  github_com_flexprice_flexprice_internal_types.TaskType:
+  types.TaskType:
     enum:
     - IMPORT
     - EXPORT
@@ -8474,7 +8497,7 @@ definitions:
     x-enum-varnames:
     - TaskTypeImport
     - TaskTypeExport
-  github_com_flexprice_flexprice_internal_types.TaxRateEntityType:
+  types.TaxRateEntityType:
     enum:
     - customer
     - subscription
@@ -8486,7 +8509,7 @@ definitions:
     - TaxRateEntityTypeSubscription
     - TaxRateEntityTypeInvoice
     - TaxRateEntityTypeTenant
-  github_com_flexprice_flexprice_internal_types.TaxRateScope:
+  types.TaxRateScope:
     enum:
     - INTERNAL
     - EXTERNAL
@@ -8496,7 +8519,7 @@ definitions:
     - TaxRateScopeInternal
     - TaxRateScopeExternal
     - TaxRateScopeOneTime
-  github_com_flexprice_flexprice_internal_types.TaxRateStatus:
+  types.TaxRateStatus:
     enum:
     - ACTIVE
     - INACTIVE
@@ -8504,7 +8527,7 @@ definitions:
     x-enum-varnames:
     - TaxRateStatusActive
     - TaxRateStatusInactive
-  github_com_flexprice_flexprice_internal_types.TaxRateType:
+  types.TaxRateType:
     enum:
     - percentage
     - fixed
@@ -8512,14 +8535,14 @@ definitions:
     x-enum-varnames:
     - TaxRateTypePercentage
     - TaxRateTypeFixed
-  github_com_flexprice_flexprice_internal_types.TimeRangeFilter:
+  types.TimeRangeFilter:
     properties:
       end_time:
         type: string
       start_time:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.TransactionReason:
+  types.TransactionReason:
     enum:
     - INVOICE_PAYMENT
     - FREE_CREDIT_GRANT
@@ -8545,7 +8568,7 @@ definitions:
     - TransactionReasonManualBalanceDebit
     - TransactionReasonCreditAdjustment
     - TransactionReasonInvoiceVoidRefund
-  github_com_flexprice_flexprice_internal_types.TransactionStatus:
+  types.TransactionStatus:
     enum:
     - pending
     - completed
@@ -8555,7 +8578,7 @@ definitions:
     - TransactionStatusPending
     - TransactionStatusCompleted
     - TransactionStatusFailed
-  github_com_flexprice_flexprice_internal_types.TransactionType:
+  types.TransactionType:
     enum:
     - credit
     - debit
@@ -8563,7 +8586,7 @@ definitions:
     x-enum-varnames:
     - TransactionTypeCredit
     - TransactionTypeDebit
-  github_com_flexprice_flexprice_internal_types.UserFilter:
+  types.UserFilter:
     properties:
       end_time:
         type: string
@@ -8572,7 +8595,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -8592,15 +8615,15 @@ definitions:
         type: array
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.UserType'
+        - $ref: '#/definitions/types.UserType'
         enum:
         - user
         - service_account
@@ -8610,7 +8633,7 @@ definitions:
           type: string
         type: array
     type: object
-  github_com_flexprice_flexprice_internal_types.UserType:
+  types.UserType:
     enum:
     - user
     - service_account
@@ -8618,7 +8641,7 @@ definitions:
     x-enum-varnames:
     - UserTypeUser
     - UserTypeServiceAccount
-  github_com_flexprice_flexprice_internal_types.Value:
+  types.Value:
     properties:
       array:
         items:
@@ -8633,17 +8656,17 @@ definitions:
       string:
         type: string
     type: object
-  github_com_flexprice_flexprice_internal_types.WalletConfig:
+  types.WalletConfig:
     properties:
       allowed_price_types:
         description: |-
           AllowedPriceTypes is a list of price types that are allowed for the wallet
           nil means all price types are allowed
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletConfigPriceType'
+          $ref: '#/definitions/types.WalletConfigPriceType'
         type: array
     type: object
-  github_com_flexprice_flexprice_internal_types.WalletConfigPriceType:
+  types.WalletConfigPriceType:
     enum:
     - ALL
     - USAGE
@@ -8653,7 +8676,7 @@ definitions:
     - WalletConfigPriceTypeAll
     - WalletConfigPriceTypeUsage
     - WalletConfigPriceTypeFixed
-  github_com_flexprice_flexprice_internal_types.WalletFilter:
+  types.WalletFilter:
     properties:
       alert_enabled:
         type: boolean
@@ -8674,13 +8697,13 @@ definitions:
       sort:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletStatus'
+        $ref: '#/definitions/types.WalletStatus'
       wallet_ids:
         items:
           type: string
         type: array
     type: object
-  github_com_flexprice_flexprice_internal_types.WalletStatus:
+  types.WalletStatus:
     enum:
     - active
     - frozen
@@ -8690,7 +8713,7 @@ definitions:
     - WalletStatusActive
     - WalletStatusFrozen
     - WalletStatusClosed
-  github_com_flexprice_flexprice_internal_types.WalletTransactionFilter:
+  types.WalletTransactionFilter:
     properties:
       created_by:
         type: string
@@ -8707,7 +8730,7 @@ definitions:
       filters:
         description: filters allows complex filtering based on multiple fields
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       id:
         type: string
@@ -8731,20 +8754,20 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       transaction_reason:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionReason'
+        $ref: '#/definitions/types.TransactionReason'
       transaction_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionStatus'
+        $ref: '#/definitions/types.TransactionStatus'
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.TransactionType'
+        $ref: '#/definitions/types.TransactionType'
     type: object
-  github_com_flexprice_flexprice_internal_types.WalletTxReferenceType:
+  types.WalletTxReferenceType:
     enum:
     - PAYMENT
     - EXTERNAL
@@ -8756,7 +8779,7 @@ definitions:
     - WalletTxReferenceTypeExternal
     - WalletTxReferenceTypeRequest
     - WalletTxReferenceTypeInvoice
-  github_com_flexprice_flexprice_internal_types.WalletType:
+  types.WalletType:
     enum:
     - PRE_PAID
     - POST_PAID
@@ -8764,7 +8787,7 @@ definitions:
     x-enum-varnames:
     - WalletTypePrePaid
     - WalletTypePostPaid
-  github_com_flexprice_flexprice_internal_types.WebhookEventName:
+  types.WebhookEventName:
     enum:
     - subscription.created
     - subscription.draft.created
@@ -8852,9 +8875,8 @@ definitions:
     - WebhookEventInvoiceCommunicationTriggered
     - WebhookEventCreditNoteCreated
     - WebhookEventCreditNoteUpdated
-  github_com_flexprice_flexprice_internal_types.WindowSize:
+  types.WindowSize:
     enum:
-    - MONTH
     - MINUTE
     - 15MIN
     - 30MIN
@@ -8865,9 +8887,9 @@ definitions:
     - DAY
     - WEEK
     - MONTH
+    - MONTH
     type: string
     x-enum-varnames:
-    - DefaultWindowSize
     - WindowSizeMinute
     - WindowSize15Min
     - WindowSize30Min
@@ -8878,7 +8900,8 @@ definitions:
     - WindowSizeDay
     - WindowSizeWeek
     - WindowSizeMonth
-  github_com_flexprice_flexprice_internal_types.WorkflowExecutionFilter:
+    - DefaultWindowSize
+  types.WorkflowExecutionFilter:
     properties:
       end_time:
         type: string
@@ -8894,7 +8917,7 @@ definitions:
         description: filters allows complex filtering based on multiple fields (same
           as FeatureFilter)
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FilterCondition'
+          $ref: '#/definitions/types.FilterCondition'
         type: array
       limit:
         maximum: 1000
@@ -8910,12 +8933,12 @@ definitions:
         type: string
       sort:
         items:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SortCondition'
+          $ref: '#/definitions/types.SortCondition'
         type: array
       start_time:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       task_queue:
         type: string
       workflow_id:
@@ -8934,7 +8957,7 @@ definitions:
       created_by:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.GroupEntityType'
+        $ref: '#/definitions/types.GroupEntityType'
       environment_id:
         type: string
       id:
@@ -8948,7 +8971,7 @@ definitions:
       name:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -8961,7 +8984,7 @@ definitions:
       amount:
         type: string
       commitment_info:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentInfo'
+        $ref: '#/definitions/types.CommitmentInfo'
       created_at:
         type: string
       created_by:
@@ -9019,7 +9042,7 @@ definitions:
       quantity:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       tenant_id:
@@ -9033,7 +9056,7 @@ definitions:
     properties:
       bucket_size:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WindowSize'
+        - $ref: '#/definitions/types.WindowSize'
         description: |-
           BucketSize is used only for MAX aggregation when windowed aggregation is needed
           It defines the size of time windows to calculate max values within
@@ -9062,7 +9085,7 @@ definitions:
           to scale up by a factor of 1000. If not provided, it will be null.
         type: string
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AggregationType'
+        $ref: '#/definitions/types.AggregationType'
     type: object
   meter.Filter:
     properties:
@@ -9115,13 +9138,13 @@ definitions:
         type: string
       reset_usage:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ResetUsage'
+        - $ref: '#/definitions/types.ResetUsage'
         description: |-
           ResetUsage defines whether the usage should be reset periodically or not
           For ex meters tracking total storage used do not get reset but meters tracking
           total API requests do.
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       updated_at:
@@ -9155,7 +9178,7 @@ definitions:
         type: integer
       round:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.RoundType'
+        - $ref: '#/definitions/types.RoundType'
         description: up or down
     type: object
   price.Price:
@@ -9166,11 +9189,11 @@ definitions:
           For USD: 12.50 means $12.50
         type: string
       billing_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingCadence'
+        $ref: '#/definitions/types.BillingCadence'
       billing_model:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingModel'
+        $ref: '#/definitions/types.BillingModel'
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         default: 1
         description: BillingPeriodCount is the count of the billing period ex 1, 3,
@@ -9210,7 +9233,7 @@ definitions:
         type: string
       entity_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceEntityType'
+        - $ref: '#/definitions/types.PriceEntityType'
         description: EntityType holds the value of the "entity_type" field.
       environment_id:
         description: EnvironmentID is the environment identifier for the price
@@ -9222,7 +9245,7 @@ definitions:
         description: ID uuid identifier for the price
         type: string
       invoice_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence'
+        $ref: '#/definitions/types.InvoiceCadence'
       lookup_key:
         description: LookupKey used for looking up the price in the database
         type: string
@@ -9256,17 +9279,17 @@ definitions:
         type: array
       price_unit_type:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitType'
+        - $ref: '#/definitions/types.PriceUnitType'
         description: PriceUnitType is the type of the price unit (FIAT, CUSTOM)
       start_date:
         description: StartDate is the start date of the price
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
       tier_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingTier'
+        $ref: '#/definitions/types.BillingTier'
       tiers:
         items:
           $ref: '#/definitions/price.PriceTier'
@@ -9279,7 +9302,7 @@ definitions:
           Note: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)
         type: integer
       type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceType'
+        $ref: '#/definitions/types.PriceType'
       updated_at:
         type: string
       updated_by:
@@ -9310,13 +9333,13 @@ definitions:
         type: integer
       round:
         allOf:
-        - $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.RoundType'
+        - $ref: '#/definitions/types.RoundType'
         description: up or down
     type: object
   subscription.SubscriptionLineItem:
     properties:
       billing_period:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         description: from price at create; default 1
         type: integer
@@ -9324,7 +9347,7 @@ definitions:
         description: Commitment fields
         type: string
       commitment_duration:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.BillingPeriod'
+        $ref: '#/definitions/types.BillingPeriod'
       commitment_overage_factor:
         type: string
       commitment_quantity:
@@ -9332,7 +9355,7 @@ definitions:
       commitment_true_up_enabled:
         type: boolean
       commitment_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CommitmentType'
+        $ref: '#/definitions/types.CommitmentType'
       commitment_windowed:
         type: boolean
       created_at:
@@ -9350,13 +9373,13 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionLineItemEntityType'
+        $ref: '#/definitions/types.SubscriptionLineItemEntityType'
       environment_id:
         type: string
       id:
         type: string
       invoice_cadence:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceCadence'
+        $ref: '#/definitions/types.InvoiceCadence'
       metadata:
         additionalProperties:
           type: string
@@ -9372,7 +9395,7 @@ definitions:
       price_id:
         type: string
       price_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceType'
+        $ref: '#/definitions/types.PriceType'
       price_unit:
         type: string
       price_unit_id:
@@ -9382,7 +9405,7 @@ definitions:
       start_date:
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         type: string
       subscription_phase_id:
@@ -9422,22 +9445,22 @@ definitions:
         description: PauseEnd is when the pause will end (null for indefinite)
         type: string
       pause_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseMode'
+        $ref: '#/definitions/types.PauseMode'
       pause_start:
         description: PauseStart is when the pause actually started
         type: string
       pause_status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PauseStatus'
+        $ref: '#/definitions/types.PauseStatus'
       reason:
         description: Reason is the reason for pausing
         type: string
       resume_mode:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.ResumeMode'
+        $ref: '#/definitions/types.ResumeMode'
       resumed_at:
         description: ResumedAt is when the pause was actually ended (if manually resumed)
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         description: SubscriptionID is the identifier for the subscription
         type: string
@@ -9472,7 +9495,7 @@ definitions:
         description: StartDate is when the phase starts
         type: string
       status:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.Status'
+        $ref: '#/definitions/types.Status'
       subscription_id:
         description: SubscriptionID is the identifier for the subscription
         type: string
@@ -9487,25 +9510,15 @@ definitions:
     properties:
       items:
         items:
-          $ref: '#/definitions/dto.WalletResponse'
+          $ref: '#/definitions/WalletResponse'
         type: array
       pagination:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PaginationResponse'
+        $ref: '#/definitions/types.PaginationResponse'
     type: object
   types.Metadata:
     additionalProperties:
       type: string
     type: object
-  types.SubscriptionType:
-    enum:
-    - standalone
-    - parent
-    - inherited
-    type: string
-    x-enum-varnames:
-    - SubscriptionTypeStandalone
-    - SubscriptionTypeParent
-    - SubscriptionTypeInherited
   webhookDto.AlertWebhookPayload:
     properties:
       alert_status:
@@ -9513,90 +9526,90 @@ definitions:
       alert_type:
         type: string
       customer:
-        $ref: '#/definitions/dto.CustomerResponse'
+        $ref: '#/definitions/CustomerResponse'
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       feature:
-        $ref: '#/definitions/dto.FeatureResponse'
+        $ref: '#/definitions/FeatureResponse'
       wallet:
-        $ref: '#/definitions/dto.WalletResponse'
+        $ref: '#/definitions/WalletResponse'
     type: object
   webhookDto.CommunicationWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       invoice:
-        $ref: '#/definitions/dto.InvoiceResponse'
+        $ref: '#/definitions/InvoiceResponse'
     type: object
   webhookDto.CreditNoteWebhookPayload:
     properties:
       credit_note:
-        $ref: '#/definitions/dto.CreditNoteResponse'
+        $ref: '#/definitions/CreditNoteResponse'
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
     type: object
   webhookDto.CustomerWebhookPayload:
     properties:
       customer:
-        $ref: '#/definitions/dto.CustomerResponse'
+        $ref: '#/definitions/CustomerResponse'
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
     type: object
   webhookDto.EntitlementWebhookPayload:
     properties:
       entitlement:
-        $ref: '#/definitions/dto.EntitlementResponse'
+        $ref: '#/definitions/EntitlementResponse'
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
     type: object
   webhookDto.FeatureWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       feature:
-        $ref: '#/definitions/dto.FeatureResponse'
+        $ref: '#/definitions/FeatureResponse'
     type: object
   webhookDto.InvoiceWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       invoice:
-        $ref: '#/definitions/dto.InvoiceResponse'
+        $ref: '#/definitions/InvoiceResponse'
     type: object
   webhookDto.PaymentWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       payment:
-        $ref: '#/definitions/dto.PaymentResponse'
+        $ref: '#/definitions/PaymentResponse'
     type: object
   webhookDto.SubscriptionPhaseWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       phase:
-        $ref: '#/definitions/dto.SubscriptionPhaseResponse'
+        $ref: '#/definitions/SubscriptionPhaseResponse'
     type: object
   webhookDto.SubscriptionWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       subscription:
-        $ref: '#/definitions/dto.SubscriptionResponse'
+        $ref: '#/definitions/SubscriptionResponse'
     type: object
   webhookDto.TransactionWebhookPayload:
     properties:
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       transaction:
-        $ref: '#/definitions/dto.WalletTransactionResponse'
+        $ref: '#/definitions/WalletTransactionResponse'
       wallet:
-        $ref: '#/definitions/dto.WalletResponse'
+        $ref: '#/definitions/WalletResponse'
     type: object
   webhookDto.WalletAlertInfo:
     properties:
       alert_settings:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertSettings'
+        $ref: '#/definitions/types.AlertSettings'
       alert_type:
         type: string
       credit_balance:
@@ -9611,11 +9624,11 @@ definitions:
       alert:
         $ref: '#/definitions/webhookDto.WalletAlertInfo'
       customer:
-        $ref: '#/definitions/dto.CustomerResponse'
+        $ref: '#/definitions/CustomerResponse'
       event_type:
-        $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WebhookEventName'
+        $ref: '#/definitions/types.WebhookEventName'
       wallet:
-        $ref: '#/definitions/dto.WalletResponse'
+        $ref: '#/definitions/WalletResponse'
     type: object
 info:
   contact:
@@ -9640,22 +9653,22 @@ paths:
         name: addon
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateAddonRequest'
+          $ref: '#/definitions/CreateAddonRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreateAddonResponse'
+            $ref: '#/definitions/CreateAddonResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create addon
@@ -9678,15 +9691,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete addon
@@ -9708,15 +9721,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.AddonResponse'
+            $ref: '#/definitions/AddonResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get addon
@@ -9738,22 +9751,22 @@ paths:
         name: addon
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateAddonRequest'
+          $ref: '#/definitions/UpdateAddonRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.AddonResponse'
+            $ref: '#/definitions/AddonResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update addon
@@ -9780,15 +9793,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get addon entitlements
@@ -9811,15 +9824,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.AddonResponse'
+            $ref: '#/definitions/AddonResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get addon by lookup key
@@ -9838,7 +9851,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AddonFilter'
+          $ref: '#/definitions/types.AddonFilter'
       produces:
       - application/json
       responses:
@@ -9849,11 +9862,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query addons
@@ -9873,22 +9886,22 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.AlertLogFilter'
+          $ref: '#/definitions/types.AlertLogFilter'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.ListAlertLogsResponse'
+            $ref: '#/definitions/ListAlertLogsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query alert logs
@@ -9907,26 +9920,26 @@ paths:
         name: costsheet
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateCostsheetRequest'
+          $ref: '#/definitions/CreateCostsheetRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created costsheet
           schema:
-            $ref: '#/definitions/dto.CreateCostsheetResponse'
+            $ref: '#/definitions/CreateCostsheetResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create costsheet
@@ -9951,19 +9964,19 @@ paths:
         "200":
           description: Costsheet deleted
           schema:
-            $ref: '#/definitions/dto.DeleteCostsheetResponse'
+            $ref: '#/definitions/DeleteCostsheetResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Costsheet not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete costsheet
@@ -9989,19 +10002,19 @@ paths:
         "200":
           description: Costsheet details
           schema:
-            $ref: '#/definitions/dto.GetCostsheetResponse'
+            $ref: '#/definitions/GetCostsheetResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Costsheet not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get costsheet
@@ -10023,30 +10036,30 @@ paths:
         name: costsheet
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateCostsheetRequest'
+          $ref: '#/definitions/UpdateCostsheetRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Updated costsheet
           schema:
-            $ref: '#/definitions/dto.UpdateCostsheetResponse'
+            $ref: '#/definitions/UpdateCostsheetResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Costsheet not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update costsheet
@@ -10063,15 +10076,15 @@ paths:
         "200":
           description: Active costsheet
           schema:
-            $ref: '#/definitions/dto.CostsheetResponse'
+            $ref: '#/definitions/CostsheetResponse'
         "404":
           description: No active costsheet
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get active costsheet
@@ -10091,22 +10104,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetCostAnalyticsRequest'
+          $ref: '#/definitions/GetCostAnalyticsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetDetailedCostAnalyticsResponse'
+            $ref: '#/definitions/GetDetailedCostAnalyticsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get combined revenue and cost analytics
@@ -10127,22 +10140,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetCostAnalyticsRequest'
+          $ref: '#/definitions/GetCostAnalyticsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetDetailedCostAnalyticsResponse'
+            $ref: '#/definitions/GetDetailedCostAnalyticsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get combined revenue and cost analytics (V2)
@@ -10168,15 +10181,15 @@ paths:
         "200":
           description: Paginated costsheets
           schema:
-            $ref: '#/definitions/dto.ListCostsheetResponse'
+            $ref: '#/definitions/ListCostsheetResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query costsheets
@@ -10195,34 +10208,34 @@ paths:
         name: coupon
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateCouponRequest'
+          $ref: '#/definitions/CreateCouponRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CouponResponse'
+            $ref: '#/definitions/CouponResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       - ApiKeyAuth: []
@@ -10254,23 +10267,23 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       - ApiKeyAuth: []
@@ -10293,19 +10306,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CouponResponse'
+            $ref: '#/definitions/CouponResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get coupon
@@ -10328,34 +10341,34 @@ paths:
         name: coupon
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateCouponRequest'
+          $ref: '#/definitions/UpdateCouponRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CouponResponse'
+            $ref: '#/definitions/CouponResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       - ApiKeyAuth: []
@@ -10375,7 +10388,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CouponFilter'
+          $ref: '#/definitions/types.CouponFilter'
       produces:
       - application/json
       responses:
@@ -10386,11 +10399,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query coupons
@@ -10410,22 +10423,22 @@ paths:
         name: credit_grant
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateCreditGrantRequest'
+          $ref: '#/definitions/CreateCreditGrantRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreditGrantResponse'
+            $ref: '#/definitions/CreditGrantResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create credit grant
@@ -10449,22 +10462,22 @@ paths:
         in: body
         name: body
         schema:
-          $ref: '#/definitions/dto.DeleteCreditGrantRequest'
+          $ref: '#/definitions/DeleteCreditGrantRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete credit grant
@@ -10486,15 +10499,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CreditGrantResponse'
+            $ref: '#/definitions/CreditGrantResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get credit grant
@@ -10517,22 +10530,22 @@ paths:
         name: credit_grant
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateCreditGrantRequest'
+          $ref: '#/definitions/UpdateCreditGrantRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CreditGrantResponse'
+            $ref: '#/definitions/CreditGrantResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update credit grant
@@ -10551,34 +10564,34 @@ paths:
         name: credit_note
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateCreditNoteRequest'
+          $ref: '#/definitions/CreateCreditNoteRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreditNoteResponse'
+            $ref: '#/definitions/CreditNoteResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       - ApiKeyAuth: []
@@ -10602,19 +10615,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CreditNoteResponse'
+            $ref: '#/definitions/CreditNoteResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error" "Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get credit note
@@ -10639,27 +10652,27 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CreditNoteResponse'
+            $ref: '#/definitions/CreditNoteResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       - ApiKeyAuth: []
@@ -10685,27 +10698,27 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CreditNoteResponse'
+            $ref: '#/definitions/CreditNoteResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       - ApiKeyAuth: []
@@ -10725,22 +10738,22 @@ paths:
         name: customer
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateCustomerRequest'
+          $ref: '#/definitions/CreateCustomerRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CustomerResponse'
+            $ref: '#/definitions/CustomerResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create customer
@@ -10767,22 +10780,22 @@ paths:
         name: customer
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateCustomerRequest'
+          $ref: '#/definitions/UpdateCustomerRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CustomerResponse'
+            $ref: '#/definitions/CustomerResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update customer
@@ -10809,11 +10822,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete customer
@@ -10835,15 +10848,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CustomerResponse'
+            $ref: '#/definitions/CustomerResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get customer
@@ -10867,15 +10880,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CustomerEntitlementsResponse'
+            $ref: '#/definitions/CustomerEntitlementsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get customer entitlements
@@ -10902,15 +10915,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get upcoming credit grant applications
@@ -10935,15 +10948,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CustomerMultiCurrencyInvoiceSummary'
+            $ref: '#/definitions/CustomerMultiCurrencyInvoiceSummary'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get customer invoice summary
@@ -10969,16 +10982,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/dto.WalletResponse'
+              $ref: '#/definitions/WalletResponse'
             type: array
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get wallets by customer ID
@@ -11001,19 +11014,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CustomerResponse'
+            $ref: '#/definitions/CustomerResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get customer by external ID
@@ -11032,7 +11045,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.CustomerFilter'
+          $ref: '#/definitions/types.CustomerFilter'
       produces:
       - application/json
       responses:
@@ -11043,11 +11056,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query customers
@@ -11092,15 +11105,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CustomerUsageSummaryResponse'
+            $ref: '#/definitions/CustomerUsageSummaryResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get customer usage summary
@@ -11142,20 +11155,20 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/dto.WalletResponse'
+              $ref: '#/definitions/WalletResponse'
             type: array
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get Customer Wallets
@@ -11174,22 +11187,22 @@ paths:
         name: entitlement
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateEntitlementRequest'
+          $ref: '#/definitions/CreateEntitlementRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.EntitlementResponse'
+            $ref: '#/definitions/EntitlementResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create entitlement
@@ -11214,15 +11227,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete entitlement
@@ -11244,15 +11257,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.EntitlementResponse'
+            $ref: '#/definitions/EntitlementResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get entitlement
@@ -11275,22 +11288,22 @@ paths:
         name: entitlement
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateEntitlementRequest'
+          $ref: '#/definitions/UpdateEntitlementRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.EntitlementResponse'
+            $ref: '#/definitions/EntitlementResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update entitlement
@@ -11309,22 +11322,22 @@ paths:
         name: entitlements
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateBulkEntitlementRequest'
+          $ref: '#/definitions/CreateBulkEntitlementRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreateBulkEntitlementResponse'
+            $ref: '#/definitions/CreateBulkEntitlementResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create entitlements in bulk
@@ -11343,7 +11356,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.EntitlementFilter'
+          $ref: '#/definitions/types.EntitlementFilter'
       produces:
       - application/json
       responses:
@@ -11354,11 +11367,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query entitlements
@@ -11378,7 +11391,7 @@ paths:
         name: event
         required: true
         schema:
-          $ref: '#/definitions/dto.IngestEventRequest'
+          $ref: '#/definitions/IngestEventRequest'
       produces:
       - application/json
       responses:
@@ -11391,11 +11404,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Ingest event
@@ -11418,15 +11431,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetEventByIDResponse'
+            $ref: '#/definitions/GetEventByIDResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get event
@@ -11445,22 +11458,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetUsageAnalyticsRequest'
+          $ref: '#/definitions/GetUsageAnalyticsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetUsageAnalyticsResponse'
+            $ref: '#/definitions/GetUsageAnalyticsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get usage analytics
@@ -11479,7 +11492,7 @@ paths:
         name: event
         required: true
         schema:
-          $ref: '#/definitions/dto.BulkIngestEventRequest'
+          $ref: '#/definitions/BulkIngestEventRequest'
       produces:
       - application/json
       responses:
@@ -11492,11 +11505,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Bulk ingest events
@@ -11513,11 +11526,11 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetHuggingFaceBillingDataResponse'
+            $ref: '#/definitions/GetHuggingFaceBillingDataResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get Hugging Face inference data
@@ -11536,22 +11549,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetEventsRequest'
+          $ref: '#/definitions/GetEventsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetEventsResponse'
+            $ref: '#/definitions/GetEventsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List raw events
@@ -11570,22 +11583,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetUsageRequest'
+          $ref: '#/definitions/GetUsageRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetUsageResponse'
+            $ref: '#/definitions/GetUsageResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get usage statistics
@@ -11605,26 +11618,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetUsageByMeterRequest'
+          $ref: '#/definitions/GetUsageByMeterRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetUsageResponse'
+            $ref: '#/definitions/GetUsageResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get usage by meter
@@ -11643,22 +11656,22 @@ paths:
         name: feature
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateFeatureRequest'
+          $ref: '#/definitions/CreateFeatureRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.FeatureResponse'
+            $ref: '#/definitions/FeatureResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create feature
@@ -11683,19 +11696,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete feature
@@ -11718,26 +11731,26 @@ paths:
         name: feature
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateFeatureRequest'
+          $ref: '#/definitions/UpdateFeatureRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.FeatureResponse'
+            $ref: '#/definitions/FeatureResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update feature
@@ -11756,7 +11769,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.FeatureFilter'
+          $ref: '#/definitions/types.FeatureFilter'
       produces:
       - application/json
       responses:
@@ -11767,11 +11780,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query features
@@ -11790,22 +11803,22 @@ paths:
         name: group
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateGroupRequest'
+          $ref: '#/definitions/CreateGroupRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.GroupResponse'
+            $ref: '#/definitions/GroupResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create group
@@ -11832,15 +11845,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete group
@@ -11864,19 +11877,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GroupResponse'
+            $ref: '#/definitions/GroupResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get group
@@ -11895,7 +11908,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.GroupFilter'
+          $ref: '#/definitions/types.GroupFilter'
       produces:
       - application/json
       responses:
@@ -11906,11 +11919,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query groups
@@ -11929,22 +11942,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.LinkIntegrationMappingRequest'
+          $ref: '#/definitions/LinkIntegrationMappingRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.LinkIntegrationMappingResponse'
+            $ref: '#/definitions/LinkIntegrationMappingResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Link integration mapping
@@ -11963,22 +11976,22 @@ paths:
         name: invoice
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateInvoiceRequest'
+          $ref: '#/definitions/CreateInvoiceRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.InvoiceResponse'
+            $ref: '#/definitions/InvoiceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create one-off invoice
@@ -12015,15 +12028,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.InvoiceResponse'
+            $ref: '#/definitions/InvoiceResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get invoice
@@ -12046,26 +12059,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateInvoiceRequest'
+          $ref: '#/definitions/UpdateInvoiceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.InvoiceResponse'
+            $ref: '#/definitions/InvoiceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update invoice
@@ -12090,19 +12103,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Trigger invoice communication webhook
@@ -12127,15 +12140,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Finalize invoice
@@ -12160,26 +12173,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdatePaymentStatusRequest'
+          $ref: '#/definitions/UpdatePaymentStatusRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.InvoiceResponse'
+            $ref: '#/definitions/InvoiceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update invoice payment status
@@ -12204,19 +12217,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Attempt invoice payment
@@ -12253,15 +12266,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get invoice PDF
@@ -12290,15 +12303,15 @@ paths:
         "400":
           description: Invalid request or invoice already recalculated
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Invoice not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Recalculate invoice (voided invoice)
@@ -12329,19 +12342,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.InvoiceResponse'
+            $ref: '#/definitions/InvoiceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Recalculate draft invoice (v2)
@@ -12366,15 +12379,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Void invoice
@@ -12393,22 +12406,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetPreviewInvoiceRequest'
+          $ref: '#/definitions/GetPreviewInvoiceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.InvoiceResponse'
+            $ref: '#/definitions/InvoiceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get invoice preview
@@ -12428,7 +12441,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.InvoiceFilter'
+          $ref: '#/definitions/types.InvoiceFilter'
       produces:
       - application/json
       responses:
@@ -12439,11 +12452,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query invoices
@@ -12533,15 +12546,15 @@ paths:
         "200":
           description: Paginated payments
           schema:
-            $ref: '#/definitions/dto.ListPaymentsResponse'
+            $ref: '#/definitions/ListPaymentsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List payments
@@ -12559,22 +12572,22 @@ paths:
         name: payment
         required: true
         schema:
-          $ref: '#/definitions/dto.CreatePaymentRequest'
+          $ref: '#/definitions/CreatePaymentRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created payment
           schema:
-            $ref: '#/definitions/dto.PaymentResponse'
+            $ref: '#/definitions/PaymentResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create payment
@@ -12599,19 +12612,19 @@ paths:
         "200":
           description: Payment deleted
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Payment not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete payment
@@ -12635,19 +12648,19 @@ paths:
         "200":
           description: Payment details
           schema:
-            $ref: '#/definitions/dto.PaymentResponse'
+            $ref: '#/definitions/PaymentResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Payment not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get payment
@@ -12670,22 +12683,22 @@ paths:
         name: payment
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdatePaymentRequest'
+          $ref: '#/definitions/UpdatePaymentRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Updated payment
           schema:
-            $ref: '#/definitions/dto.PaymentResponse'
+            $ref: '#/definitions/PaymentResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update payment
@@ -12710,19 +12723,19 @@ paths:
         "200":
           description: Processed payment
           schema:
-            $ref: '#/definitions/dto.PaymentResponse'
+            $ref: '#/definitions/PaymentResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Payment not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Process payment
@@ -12741,22 +12754,22 @@ paths:
         name: plan
         required: true
         schema:
-          $ref: '#/definitions/dto.CreatePlanRequest'
+          $ref: '#/definitions/CreatePlanRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.PlanResponse'
+            $ref: '#/definitions/PlanResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create plan
@@ -12781,19 +12794,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete plan
@@ -12815,19 +12828,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PlanResponse'
+            $ref: '#/definitions/PlanResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get plan
@@ -12850,26 +12863,26 @@ paths:
         name: plan
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdatePlanRequest'
+          $ref: '#/definitions/UpdatePlanRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PlanResponse'
+            $ref: '#/definitions/PlanResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update plan
@@ -12892,30 +12905,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.ClonePlanRequest'
+          $ref: '#/definitions/ClonePlanRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.PlanResponse'
+            $ref: '#/definitions/PlanResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "409":
           description: Conflict
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Clone a plan
@@ -12942,15 +12955,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get plan credit grants
@@ -12977,15 +12990,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get plan entitlements
@@ -13014,19 +13027,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "422":
           description: Unprocessable Entity
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Synchronize plan prices
@@ -13045,7 +13058,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PlanFilter'
+          $ref: '#/definitions/types.PlanFilter'
       produces:
       - application/json
       responses:
@@ -13056,11 +13069,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query plans
@@ -13079,22 +13092,22 @@ paths:
         name: price
         required: true
         schema:
-          $ref: '#/definitions/dto.CreatePriceRequest'
+          $ref: '#/definitions/CreatePriceRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.PriceResponse'
+            $ref: '#/definitions/PriceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create price
@@ -13118,22 +13131,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.DeletePriceRequest'
+          $ref: '#/definitions/DeletePriceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete price
@@ -13157,15 +13170,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PriceResponse'
+            $ref: '#/definitions/PriceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get price
@@ -13188,22 +13201,22 @@ paths:
         name: price
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdatePriceRequest'
+          $ref: '#/definitions/UpdatePriceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PriceResponse'
+            $ref: '#/definitions/PriceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update price
@@ -13222,22 +13235,22 @@ paths:
         name: prices
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateBulkPriceRequest'
+          $ref: '#/definitions/CreateBulkPriceRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreateBulkPriceResponse'
+            $ref: '#/definitions/CreateBulkPriceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create prices in bulk
@@ -13262,15 +13275,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PriceResponse'
+            $ref: '#/definitions/PriceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get price by lookup key
@@ -13289,7 +13302,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceFilter'
+          $ref: '#/definitions/types.PriceFilter'
       produces:
       - application/json
       responses:
@@ -13300,11 +13313,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query prices
@@ -13356,11 +13369,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List price units
@@ -13378,22 +13391,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/dto.CreatePriceUnitRequest'
+          $ref: '#/definitions/CreatePriceUnitRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreatePriceUnitResponse'
+            $ref: '#/definitions/CreatePriceUnitResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create price unit
@@ -13418,15 +13431,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete price unit
@@ -13450,15 +13463,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PriceUnitResponse'
+            $ref: '#/definitions/PriceUnitResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get price unit
@@ -13481,22 +13494,22 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdatePriceUnitRequest'
+          $ref: '#/definitions/UpdatePriceUnitRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PriceUnitResponse'
+            $ref: '#/definitions/PriceUnitResponse'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update price unit
@@ -13521,19 +13534,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.PriceUnitResponse'
+            $ref: '#/definitions/PriceUnitResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get price unit by code
@@ -13552,7 +13565,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.PriceUnitFilter'
+          $ref: '#/definitions/types.PriceUnitFilter'
       produces:
       - application/json
       responses:
@@ -13563,11 +13576,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query price units
@@ -13657,15 +13670,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.ListSecretsResponse'
+            $ref: '#/definitions/ListSecretsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List API keys
@@ -13683,22 +13696,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateAPIKeyRequest'
+          $ref: '#/definitions/CreateAPIKeyRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreateAPIKeyResponse'
+            $ref: '#/definitions/CreateAPIKeyResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create a new API key
@@ -13725,11 +13738,11 @@ paths:
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete an API key
@@ -13748,22 +13761,22 @@ paths:
         name: subscription
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateSubscriptionRequest'
+          $ref: '#/definitions/CreateSubscriptionRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.SubscriptionResponse'
+            $ref: '#/definitions/SubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create subscription
@@ -13786,15 +13799,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionResponse'
+            $ref: '#/definitions/SubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get subscription
@@ -13817,22 +13830,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateSubscriptionRequest'
+          $ref: '#/definitions/UpdateSubscriptionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionResponse'
+            $ref: '#/definitions/SubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update subscription
@@ -13856,22 +13869,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.ActivateDraftSubscriptionRequest'
+          $ref: '#/definitions/ActivateDraftSubscriptionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionResponse'
+            $ref: '#/definitions/SubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Activate draft subscription
@@ -13895,20 +13908,20 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/dto.AddonAssociationResponse'
+              $ref: '#/definitions/AddonAssociationResponse'
             type: array
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get active addon associations
@@ -13933,22 +13946,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.CancelSubscriptionRequest'
+          $ref: '#/definitions/CancelSubscriptionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CancelSubscriptionResponse'
+            $ref: '#/definitions/CancelSubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Cancel subscription
@@ -13972,26 +13985,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.SubscriptionChangeRequest'
+          $ref: '#/definitions/SubscriptionChangeRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionChangeExecuteResponse'
+            $ref: '#/definitions/SubscriptionChangeExecuteResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Execute subscription plan change
@@ -14015,26 +14028,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.SubscriptionChangeRequest'
+          $ref: '#/definitions/SubscriptionChangeRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionChangePreviewResponse'
+            $ref: '#/definitions/SubscriptionChangePreviewResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Preview subscription plan change
@@ -14066,19 +14079,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionEntitlementsResponse'
+            $ref: '#/definitions/SubscriptionEntitlementsResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get subscription entitlements
@@ -14105,15 +14118,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get upcoming credit grant applications
@@ -14137,26 +14150,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateSubscriptionLineItemRequest'
+          $ref: '#/definitions/CreateSubscriptionLineItemRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.SubscriptionLineItemResponse'
+            $ref: '#/definitions/SubscriptionLineItemResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create subscription line item
@@ -14181,26 +14194,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.ExecuteSubscriptionInheritanceRequest'
+          $ref: '#/definitions/ExecuteSubscriptionInheritanceRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionResponse'
+            $ref: '#/definitions/SubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Add customers to subscription inheritance
@@ -14225,26 +14238,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.PauseSubscriptionRequest'
+          $ref: '#/definitions/PauseSubscriptionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionPauseResponse'
+            $ref: '#/definitions/SubscriptionPauseResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Pause a subscription
@@ -14268,20 +14281,20 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/dto.ListSubscriptionPausesResponse'
+              $ref: '#/definitions/ListSubscriptionPausesResponse'
             type: array
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       summary: List all pauses for a subscription
       tags:
       - Subscriptions
@@ -14303,26 +14316,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.ResumeSubscriptionRequest'
+          $ref: '#/definitions/ResumeSubscriptionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionPauseResponse'
+            $ref: '#/definitions/SubscriptionPauseResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Resume a paused subscription
@@ -14349,15 +14362,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionResponseV2'
+            $ref: '#/definitions/SubscriptionResponseV2'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get subscription (V2)
@@ -14376,22 +14389,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.RemoveAddonRequest'
+          $ref: '#/definitions/RemoveAddonRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Remove addon from subscription
@@ -14409,22 +14422,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.AddAddonRequest'
+          $ref: '#/definitions/AddAddonRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.AddonAssociationResponse'
+            $ref: '#/definitions/AddonAssociationResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Add addon to subscription
@@ -14448,22 +14461,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.DeleteSubscriptionLineItemRequest'
+          $ref: '#/definitions/DeleteSubscriptionLineItemRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionLineItemResponse'
+            $ref: '#/definitions/SubscriptionLineItemResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete subscription line item
@@ -14486,22 +14499,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateSubscriptionLineItemRequest'
+          $ref: '#/definitions/UpdateSubscriptionLineItemRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionLineItemResponse'
+            $ref: '#/definitions/SubscriptionLineItemResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update subscription line item
@@ -14521,7 +14534,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.SubscriptionFilter'
+          $ref: '#/definitions/types.SubscriptionFilter'
       produces:
       - application/json
       responses:
@@ -14532,11 +14545,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query subscriptions
@@ -14555,22 +14568,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.GetUsageBySubscriptionRequest'
+          $ref: '#/definitions/GetUsageBySubscriptionRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetUsageBySubscriptionResponse'
+            $ref: '#/definitions/GetUsageBySubscriptionResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get usage by subscription
@@ -14669,15 +14682,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.ListTasksResponse'
+            $ref: '#/definitions/ListTasksResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List tasks
@@ -14695,22 +14708,22 @@ paths:
         name: task
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateTaskRequest'
+          $ref: '#/definitions/CreateTaskRequest'
       produces:
       - application/json
       responses:
         "202":
           description: Accepted
           schema:
-            $ref: '#/definitions/dto.TaskResponse'
+            $ref: '#/definitions/TaskResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create a new task
@@ -14735,19 +14748,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaskResponse'
+            $ref: '#/definitions/TaskResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get a task
@@ -14779,15 +14792,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Download task export file
@@ -14811,26 +14824,26 @@ paths:
         name: status
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateTaskStatusRequest'
+          $ref: '#/definitions/UpdateTaskStatusRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SuccessResponse'
+            $ref: '#/definitions/SuccessResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update task status
@@ -14859,15 +14872,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get task processing result
@@ -14915,11 +14928,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List scheduled tasks
@@ -14937,22 +14950,22 @@ paths:
         name: scheduled_task
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateScheduledTaskRequest'
+          $ref: '#/definitions/CreateScheduledTaskRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.ScheduledTaskResponse'
+            $ref: '#/definitions/ScheduledTaskResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create scheduled task
@@ -14979,15 +14992,15 @@ paths:
         "400":
           description: Task already archived
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Scheduled task not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Failed to archive task
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete a scheduled task
@@ -15011,19 +15024,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.ScheduledTaskResponse'
+            $ref: '#/definitions/ScheduledTaskResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get scheduled task
@@ -15046,26 +15059,26 @@ paths:
         name: scheduled_task
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateScheduledTaskRequest'
+          $ref: '#/definitions/UpdateScheduledTaskRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.ScheduledTaskResponse'
+            $ref: '#/definitions/ScheduledTaskResponse'
         "400":
           description: Invalid request or task is archived
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Scheduled task not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Failed to update Temporal schedule
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update a scheduled task
@@ -15088,26 +15101,26 @@ paths:
         in: body
         name: request
         schema:
-          $ref: '#/definitions/dto.TriggerForceRunRequest'
+          $ref: '#/definitions/TriggerForceRunRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Returns workflow details and time range
           schema:
-            $ref: '#/definitions/dto.TriggerForceRunResponse'
+            $ref: '#/definitions/TriggerForceRunResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Trigger force run
@@ -15131,11 +15144,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Schedule draft finalization
@@ -15165,11 +15178,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Schedule update billing period
@@ -15209,11 +15222,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: List tax associations
@@ -15231,22 +15244,22 @@ paths:
         name: tax_config
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateTaxAssociationRequest'
+          $ref: '#/definitions/CreateTaxAssociationRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaxAssociationResponse'
+            $ref: '#/definitions/TaxAssociationResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create Tax Association
@@ -15271,15 +15284,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaxAssociationResponse'
+            $ref: '#/definitions/TaxAssociationResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete tax association
@@ -15303,15 +15316,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaxAssociationResponse'
+            $ref: '#/definitions/TaxAssociationResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get Tax Association
@@ -15334,22 +15347,22 @@ paths:
         name: tax_config
         required: true
         schema:
-          $ref: '#/definitions/dto.TaxAssociationUpdateRequest'
+          $ref: '#/definitions/TaxAssociationUpdateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaxAssociationResponse'
+            $ref: '#/definitions/TaxAssociationResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update tax association
@@ -15428,16 +15441,16 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/dto.TaxRateResponse'
+              $ref: '#/definitions/TaxRateResponse'
             type: array
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get tax rates
@@ -15455,22 +15468,22 @@ paths:
         name: tax_rate
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateTaxRateRequest'
+          $ref: '#/definitions/CreateTaxRateRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.TaxRateResponse'
+            $ref: '#/definitions/TaxRateResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create a tax rate
@@ -15497,11 +15510,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Delete a tax rate
@@ -15525,15 +15538,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaxRateResponse'
+            $ref: '#/definitions/TaxRateResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get a tax rate
@@ -15556,22 +15569,22 @@ paths:
         name: tax_rate
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateTaxRateRequest'
+          $ref: '#/definitions/UpdateTaxRateRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TaxRateResponse'
+            $ref: '#/definitions/TaxRateResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update a tax rate
@@ -15590,19 +15603,19 @@ paths:
         "200":
           description: Tenant billing usage
           schema:
-            $ref: '#/definitions/dto.TenantBillingUsage'
+            $ref: '#/definitions/TenantBillingUsage'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Tenant not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get billing usage for the current tenant
@@ -15626,15 +15639,15 @@ paths:
         "200":
           description: Tenant details
           schema:
-            $ref: '#/definitions/dto.TenantResponse'
+            $ref: '#/definitions/TenantResponse'
         "404":
           description: Tenant not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get tenant by ID
@@ -15653,26 +15666,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateTenantRequest'
+          $ref: '#/definitions/UpdateTenantRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Updated tenant
           schema:
-            $ref: '#/definitions/dto.TenantResponse'
+            $ref: '#/definitions/TenantResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Tenant not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update a tenant
@@ -15693,22 +15706,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateUserRequest'
+          $ref: '#/definitions/CreateUserRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/dto.CreateUserResponse'
+            $ref: '#/definitions/CreateUserResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create user or service account
@@ -15725,15 +15738,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.UserResponse'
+            $ref: '#/definitions/UserResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get current user
@@ -15752,7 +15765,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.UserFilter'
+          $ref: '#/definitions/types.UserFilter'
       produces:
       - application/json
       responses:
@@ -15763,11 +15776,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query users
@@ -15803,7 +15816,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetPendingSchedulesResponse'
+            $ref: '#/definitions/GetPendingSchedulesResponse'
       summary: List all subscription schedules
       tags:
       - Subscriptions
@@ -15826,7 +15839,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.SubscriptionScheduleResponse'
+            $ref: '#/definitions/SubscriptionScheduleResponse'
       summary: Get subscription schedule
       tags:
       - Subscriptions
@@ -15849,7 +15862,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.GetPendingSchedulesResponse'
+            $ref: '#/definitions/GetPendingSchedulesResponse'
       summary: List subscription schedules
       tags:
       - Subscriptions
@@ -15869,14 +15882,14 @@ paths:
         in: body
         name: request
         schema:
-          $ref: '#/definitions/dto.CancelScheduleRequest'
+          $ref: '#/definitions/CancelScheduleRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.CancelScheduleResponse'
+            $ref: '#/definitions/CancelScheduleResponse'
       summary: Cancel subscription schedule
       tags:
       - Subscriptions
@@ -15893,22 +15906,22 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.CreateWalletRequest'
+          $ref: '#/definitions/CreateWalletRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.WalletResponse'
+            $ref: '#/definitions/WalletResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Create a new wallet
@@ -15933,19 +15946,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.WalletResponse'
+            $ref: '#/definitions/WalletResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get wallet
@@ -15968,26 +15981,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.UpdateWalletRequest'
+          $ref: '#/definitions/UpdateWalletRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.WalletResponse'
+            $ref: '#/definitions/WalletResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Update a wallet
@@ -16017,19 +16030,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.WalletBalanceResponse'
+            $ref: '#/definitions/WalletBalanceResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get wallet balance
@@ -16054,19 +16067,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.WalletResponse'
+            $ref: '#/definitions/WalletResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Terminate a wallet
@@ -16090,26 +16103,26 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.TopUpWalletRequest'
+          $ref: '#/definitions/TopUpWalletRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TopUpWalletResponse'
+            $ref: '#/definitions/TopUpWalletResponse'
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Top up wallet
@@ -16244,15 +16257,15 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "404":
           description: Resource not found
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Get wallet transactions
@@ -16271,7 +16284,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletFilter'
+          $ref: '#/definitions/types.WalletFilter'
       produces:
       - application/json
       responses:
@@ -16282,11 +16295,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query wallets
@@ -16306,7 +16319,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WalletTransactionFilter'
+          $ref: '#/definitions/types.WalletTransactionFilter'
       produces:
       - application/json
       responses:
@@ -16317,11 +16330,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query wallet transactions
@@ -16985,7 +16998,7 @@ paths:
         name: filter
         required: true
         schema:
-          $ref: '#/definitions/github_com_flexprice_flexprice_internal_types.WorkflowExecutionFilter'
+          $ref: '#/definitions/types.WorkflowExecutionFilter'
       produces:
       - application/json
       responses:
@@ -16996,11 +17009,11 @@ paths:
         "400":
           description: Invalid request
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
         "500":
           description: Server error
           schema:
-            $ref: '#/definitions/github_com_flexprice_flexprice_internal_errors.ErrorResponse'
+            $ref: '#/definitions/errors.ErrorResponse'
       security:
       - ApiKeyAuth: []
       summary: Query workflows

--- a/ent/invoice.go
+++ b/ent/invoice.go
@@ -38,6 +38,8 @@ type Invoice struct {
 	CustomerID string `json:"customer_id,omitempty"`
 	// SubscriptionID holds the value of the "subscription_id" field.
 	SubscriptionID *string `json:"subscription_id,omitempty"`
+	// Subscription owner customer ID; set internally for subscription invoices
+	SubscriptionCustomerID *string `json:"subscription_customer_id,omitempty"`
 	// InvoiceType holds the value of the "invoice_type" field.
 	InvoiceType types.InvoiceType `json:"invoice_type,omitempty"`
 	// InvoiceStatus holds the value of the "invoice_status" field.
@@ -148,7 +150,7 @@ func (*Invoice) scanValues(columns []string) ([]any, error) {
 			values[i] = new(decimal.Decimal)
 		case invoice.FieldVersion, invoice.FieldBillingSequence:
 			values[i] = new(sql.NullInt64)
-		case invoice.FieldID, invoice.FieldTenantID, invoice.FieldStatus, invoice.FieldCreatedBy, invoice.FieldUpdatedBy, invoice.FieldEnvironmentID, invoice.FieldCustomerID, invoice.FieldSubscriptionID, invoice.FieldInvoiceType, invoice.FieldInvoiceStatus, invoice.FieldPaymentStatus, invoice.FieldCurrency, invoice.FieldDescription, invoice.FieldBillingPeriod, invoice.FieldInvoicePdfURL, invoice.FieldBillingReason, invoice.FieldInvoiceNumber, invoice.FieldIdempotencyKey, invoice.FieldRecalculatedInvoiceID:
+		case invoice.FieldID, invoice.FieldTenantID, invoice.FieldStatus, invoice.FieldCreatedBy, invoice.FieldUpdatedBy, invoice.FieldEnvironmentID, invoice.FieldCustomerID, invoice.FieldSubscriptionID, invoice.FieldSubscriptionCustomerID, invoice.FieldInvoiceType, invoice.FieldInvoiceStatus, invoice.FieldPaymentStatus, invoice.FieldCurrency, invoice.FieldDescription, invoice.FieldBillingPeriod, invoice.FieldInvoicePdfURL, invoice.FieldBillingReason, invoice.FieldInvoiceNumber, invoice.FieldIdempotencyKey, invoice.FieldRecalculatedInvoiceID:
 			values[i] = new(sql.NullString)
 		case invoice.FieldCreatedAt, invoice.FieldUpdatedAt, invoice.FieldDueDate, invoice.FieldPaidAt, invoice.FieldVoidedAt, invoice.FieldFinalizedAt, invoice.FieldLastComputedAt, invoice.FieldPeriodStart, invoice.FieldPeriodEnd:
 			values[i] = new(sql.NullTime)
@@ -227,6 +229,13 @@ func (i *Invoice) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				i.SubscriptionID = new(string)
 				*i.SubscriptionID = value.String
+			}
+		case invoice.FieldSubscriptionCustomerID:
+			if value, ok := values[j].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field subscription_customer_id", values[j])
+			} else if value.Valid {
+				i.SubscriptionCustomerID = new(string)
+				*i.SubscriptionCustomerID = value.String
 			}
 		case invoice.FieldInvoiceType:
 			if value, ok := values[j].(*sql.NullString); !ok {
@@ -504,6 +513,11 @@ func (i *Invoice) String() string {
 	builder.WriteString(", ")
 	if v := i.SubscriptionID; v != nil {
 		builder.WriteString("subscription_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := i.SubscriptionCustomerID; v != nil {
+		builder.WriteString("subscription_customer_id=")
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")

--- a/ent/invoice/invoice.go
+++ b/ent/invoice/invoice.go
@@ -34,6 +34,8 @@ const (
 	FieldCustomerID = "customer_id"
 	// FieldSubscriptionID holds the string denoting the subscription_id field in the database.
 	FieldSubscriptionID = "subscription_id"
+	// FieldSubscriptionCustomerID holds the string denoting the subscription_customer_id field in the database.
+	FieldSubscriptionCustomerID = "subscription_customer_id"
 	// FieldInvoiceType holds the string denoting the invoice_type field in the database.
 	FieldInvoiceType = "invoice_type"
 	// FieldInvoiceStatus holds the string denoting the invoice_status field in the database.
@@ -130,6 +132,7 @@ var Columns = []string{
 	FieldEnvironmentID,
 	FieldCustomerID,
 	FieldSubscriptionID,
+	FieldSubscriptionCustomerID,
 	FieldInvoiceType,
 	FieldInvoiceStatus,
 	FieldPaymentStatus,
@@ -271,6 +274,11 @@ func ByCustomerID(opts ...sql.OrderTermOption) OrderOption {
 // BySubscriptionID orders the results by the subscription_id field.
 func BySubscriptionID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSubscriptionID, opts...).ToFunc()
+}
+
+// BySubscriptionCustomerID orders the results by the subscription_customer_id field.
+func BySubscriptionCustomerID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSubscriptionCustomerID, opts...).ToFunc()
 }
 
 // ByInvoiceType orders the results by the invoice_type field.

--- a/ent/invoice/where.go
+++ b/ent/invoice/where.go
@@ -112,6 +112,11 @@ func SubscriptionID(v string) predicate.Invoice {
 	return predicate.Invoice(sql.FieldEQ(FieldSubscriptionID, v))
 }
 
+// SubscriptionCustomerID applies equality check predicate on the "subscription_customer_id" field. It's identical to SubscriptionCustomerIDEQ.
+func SubscriptionCustomerID(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldEQ(FieldSubscriptionCustomerID, v))
+}
+
 // InvoiceType applies equality check predicate on the "invoice_type" field. It's identical to InvoiceTypeEQ.
 func InvoiceType(v types.InvoiceType) predicate.Invoice {
 	vc := string(v)
@@ -839,6 +844,81 @@ func SubscriptionIDEqualFold(v string) predicate.Invoice {
 // SubscriptionIDContainsFold applies the ContainsFold predicate on the "subscription_id" field.
 func SubscriptionIDContainsFold(v string) predicate.Invoice {
 	return predicate.Invoice(sql.FieldContainsFold(FieldSubscriptionID, v))
+}
+
+// SubscriptionCustomerIDEQ applies the EQ predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDEQ(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldEQ(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDNEQ applies the NEQ predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDNEQ(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldNEQ(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDIn applies the In predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDIn(vs ...string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldIn(FieldSubscriptionCustomerID, vs...))
+}
+
+// SubscriptionCustomerIDNotIn applies the NotIn predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDNotIn(vs ...string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldNotIn(FieldSubscriptionCustomerID, vs...))
+}
+
+// SubscriptionCustomerIDGT applies the GT predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDGT(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldGT(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDGTE applies the GTE predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDGTE(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldGTE(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDLT applies the LT predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDLT(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldLT(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDLTE applies the LTE predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDLTE(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldLTE(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDContains applies the Contains predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDContains(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldContains(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDHasPrefix applies the HasPrefix predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDHasPrefix(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldHasPrefix(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDHasSuffix applies the HasSuffix predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDHasSuffix(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldHasSuffix(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDIsNil applies the IsNil predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDIsNil() predicate.Invoice {
+	return predicate.Invoice(sql.FieldIsNull(FieldSubscriptionCustomerID))
+}
+
+// SubscriptionCustomerIDNotNil applies the NotNil predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDNotNil() predicate.Invoice {
+	return predicate.Invoice(sql.FieldNotNull(FieldSubscriptionCustomerID))
+}
+
+// SubscriptionCustomerIDEqualFold applies the EqualFold predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDEqualFold(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldEqualFold(FieldSubscriptionCustomerID, v))
+}
+
+// SubscriptionCustomerIDContainsFold applies the ContainsFold predicate on the "subscription_customer_id" field.
+func SubscriptionCustomerIDContainsFold(v string) predicate.Invoice {
+	return predicate.Invoice(sql.FieldContainsFold(FieldSubscriptionCustomerID, v))
 }
 
 // InvoiceTypeEQ applies the EQ predicate on the "invoice_type" field.

--- a/ent/invoice_create.go
+++ b/ent/invoice_create.go
@@ -134,6 +134,20 @@ func (ic *InvoiceCreate) SetNillableSubscriptionID(s *string) *InvoiceCreate {
 	return ic
 }
 
+// SetSubscriptionCustomerID sets the "subscription_customer_id" field.
+func (ic *InvoiceCreate) SetSubscriptionCustomerID(s string) *InvoiceCreate {
+	ic.mutation.SetSubscriptionCustomerID(s)
+	return ic
+}
+
+// SetNillableSubscriptionCustomerID sets the "subscription_customer_id" field if the given value is not nil.
+func (ic *InvoiceCreate) SetNillableSubscriptionCustomerID(s *string) *InvoiceCreate {
+	if s != nil {
+		ic.SetSubscriptionCustomerID(*s)
+	}
+	return ic
+}
+
 // SetInvoiceType sets the "invoice_type" field.
 func (ic *InvoiceCreate) SetInvoiceType(tt types.InvoiceType) *InvoiceCreate {
 	ic.mutation.SetInvoiceType(tt)
@@ -831,6 +845,10 @@ func (ic *InvoiceCreate) createSpec() (*Invoice, *sqlgraph.CreateSpec) {
 	if value, ok := ic.mutation.SubscriptionID(); ok {
 		_spec.SetField(invoice.FieldSubscriptionID, field.TypeString, value)
 		_node.SubscriptionID = &value
+	}
+	if value, ok := ic.mutation.SubscriptionCustomerID(); ok {
+		_spec.SetField(invoice.FieldSubscriptionCustomerID, field.TypeString, value)
+		_node.SubscriptionCustomerID = &value
 	}
 	if value, ok := ic.mutation.InvoiceType(); ok {
 		_spec.SetField(invoice.FieldInvoiceType, field.TypeString, value)

--- a/ent/invoice_update.go
+++ b/ent/invoice_update.go
@@ -728,6 +728,9 @@ func (iu *InvoiceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if iu.mutation.SubscriptionIDCleared() {
 		_spec.ClearField(invoice.FieldSubscriptionID, field.TypeString)
 	}
+	if iu.mutation.SubscriptionCustomerIDCleared() {
+		_spec.ClearField(invoice.FieldSubscriptionCustomerID, field.TypeString)
+	}
 	if value, ok := iu.mutation.InvoiceStatus(); ok {
 		_spec.SetField(invoice.FieldInvoiceStatus, field.TypeString, value)
 	}
@@ -1716,6 +1719,9 @@ func (iuo *InvoiceUpdateOne) sqlSave(ctx context.Context) (_node *Invoice, err e
 	}
 	if iuo.mutation.SubscriptionIDCleared() {
 		_spec.ClearField(invoice.FieldSubscriptionID, field.TypeString)
+	}
+	if iuo.mutation.SubscriptionCustomerIDCleared() {
+		_spec.ClearField(invoice.FieldSubscriptionCustomerID, field.TypeString)
 	}
 	if value, ok := iuo.mutation.InvoiceStatus(); ok {
 		_spec.SetField(invoice.FieldInvoiceStatus, field.TypeString, value)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -974,6 +974,7 @@ var (
 		{Name: "environment_id", Type: field.TypeString, Nullable: true, Default: "", SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "subscription_customer_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "invoice_type", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "invoice_status", Type: field.TypeString, Default: "DRAFT", SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "payment_status", Type: field.TypeString, Default: "PENDING", SchemaType: map[string]string{"postgres": "varchar(50)"}},
@@ -1015,7 +1016,7 @@ var (
 			{
 				Name:    "idx_tenant_customer_status",
 				Unique:  false,
-				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[8], InvoicesColumns[11], InvoicesColumns[12], InvoicesColumns[2]},
+				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[8], InvoicesColumns[12], InvoicesColumns[13], InvoicesColumns[2]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "status = 'published'",
 				},
@@ -1023,22 +1024,22 @@ var (
 			{
 				Name:    "idx_tenant_subscription_status",
 				Unique:  false,
-				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[9], InvoicesColumns[11], InvoicesColumns[12], InvoicesColumns[2]},
+				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[9], InvoicesColumns[12], InvoicesColumns[13], InvoicesColumns[2]},
 			},
 			{
 				Name:    "idx_tenant_type_status",
 				Unique:  false,
-				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[10], InvoicesColumns[11], InvoicesColumns[12], InvoicesColumns[2]},
+				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[11], InvoicesColumns[12], InvoicesColumns[13], InvoicesColumns[2]},
 			},
 			{
 				Name:    "idx_tenant_due_date_status",
 				Unique:  false,
-				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[24], InvoicesColumns[11], InvoicesColumns[12], InvoicesColumns[2]},
+				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[25], InvoicesColumns[12], InvoicesColumns[13], InvoicesColumns[2]},
 			},
 			{
 				Name:    "idx_tenant_environment_invoice_number_unique",
 				Unique:  true,
-				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[36]},
+				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[37]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "invoice_number IS NOT NULL AND invoice_number != '' AND status = 'published'",
 				},
@@ -1046,7 +1047,7 @@ var (
 			{
 				Name:    "idx_tenant_environment_idempotency_key_unique",
 				Unique:  true,
-				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[39]},
+				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[40]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "idempotency_key IS NOT NULL",
 				},
@@ -1054,7 +1055,7 @@ var (
 			{
 				Name:    "idx_subscription_period_unique",
 				Unique:  false,
-				Columns: []*schema.Column{InvoicesColumns[9], InvoicesColumns[30], InvoicesColumns[31]},
+				Columns: []*schema.Column{InvoicesColumns[9], InvoicesColumns[31], InvoicesColumns[32]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "invoice_status != 'VOIDED' AND subscription_id IS NOT NULL",
 				},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -26066,6 +26066,7 @@ type InvoiceMutation struct {
 	environment_id                *string
 	customer_id                   *string
 	subscription_id               *string
+	subscription_customer_id      *string
 	invoice_type                  *types.InvoiceType
 	invoice_status                *types.InvoiceStatus
 	payment_status                *types.PaymentStatus
@@ -26589,6 +26590,55 @@ func (m *InvoiceMutation) SubscriptionIDCleared() bool {
 func (m *InvoiceMutation) ResetSubscriptionID() {
 	m.subscription_id = nil
 	delete(m.clearedFields, invoice.FieldSubscriptionID)
+}
+
+// SetSubscriptionCustomerID sets the "subscription_customer_id" field.
+func (m *InvoiceMutation) SetSubscriptionCustomerID(s string) {
+	m.subscription_customer_id = &s
+}
+
+// SubscriptionCustomerID returns the value of the "subscription_customer_id" field in the mutation.
+func (m *InvoiceMutation) SubscriptionCustomerID() (r string, exists bool) {
+	v := m.subscription_customer_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSubscriptionCustomerID returns the old "subscription_customer_id" field's value of the Invoice entity.
+// If the Invoice object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *InvoiceMutation) OldSubscriptionCustomerID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSubscriptionCustomerID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSubscriptionCustomerID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSubscriptionCustomerID: %w", err)
+	}
+	return oldValue.SubscriptionCustomerID, nil
+}
+
+// ClearSubscriptionCustomerID clears the value of the "subscription_customer_id" field.
+func (m *InvoiceMutation) ClearSubscriptionCustomerID() {
+	m.subscription_customer_id = nil
+	m.clearedFields[invoice.FieldSubscriptionCustomerID] = struct{}{}
+}
+
+// SubscriptionCustomerIDCleared returns if the "subscription_customer_id" field was cleared in this mutation.
+func (m *InvoiceMutation) SubscriptionCustomerIDCleared() bool {
+	_, ok := m.clearedFields[invoice.FieldSubscriptionCustomerID]
+	return ok
+}
+
+// ResetSubscriptionCustomerID resets all changes to the "subscription_customer_id" field.
+func (m *InvoiceMutation) ResetSubscriptionCustomerID() {
+	m.subscription_customer_id = nil
+	delete(m.clearedFields, invoice.FieldSubscriptionCustomerID)
 }
 
 // SetInvoiceType sets the "invoice_type" field.
@@ -28189,7 +28239,7 @@ func (m *InvoiceMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *InvoiceMutation) Fields() []string {
-	fields := make([]string, 0, 40)
+	fields := make([]string, 0, 41)
 	if m.tenant_id != nil {
 		fields = append(fields, invoice.FieldTenantID)
 	}
@@ -28216,6 +28266,9 @@ func (m *InvoiceMutation) Fields() []string {
 	}
 	if m.subscription_id != nil {
 		fields = append(fields, invoice.FieldSubscriptionID)
+	}
+	if m.subscription_customer_id != nil {
+		fields = append(fields, invoice.FieldSubscriptionCustomerID)
 	}
 	if m.invoice_type != nil {
 		fields = append(fields, invoice.FieldInvoiceType)
@@ -28336,6 +28389,8 @@ func (m *InvoiceMutation) Field(name string) (ent.Value, bool) {
 		return m.CustomerID()
 	case invoice.FieldSubscriptionID:
 		return m.SubscriptionID()
+	case invoice.FieldSubscriptionCustomerID:
+		return m.SubscriptionCustomerID()
 	case invoice.FieldInvoiceType:
 		return m.InvoiceType()
 	case invoice.FieldInvoiceStatus:
@@ -28425,6 +28480,8 @@ func (m *InvoiceMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldCustomerID(ctx)
 	case invoice.FieldSubscriptionID:
 		return m.OldSubscriptionID(ctx)
+	case invoice.FieldSubscriptionCustomerID:
+		return m.OldSubscriptionCustomerID(ctx)
 	case invoice.FieldInvoiceType:
 		return m.OldInvoiceType(ctx)
 	case invoice.FieldInvoiceStatus:
@@ -28558,6 +28615,13 @@ func (m *InvoiceMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetSubscriptionID(v)
+		return nil
+	case invoice.FieldSubscriptionCustomerID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSubscriptionCustomerID(v)
 		return nil
 	case invoice.FieldInvoiceType:
 		v, ok := value.(types.InvoiceType)
@@ -28845,6 +28909,9 @@ func (m *InvoiceMutation) ClearedFields() []string {
 	if m.FieldCleared(invoice.FieldSubscriptionID) {
 		fields = append(fields, invoice.FieldSubscriptionID)
 	}
+	if m.FieldCleared(invoice.FieldSubscriptionCustomerID) {
+		fields = append(fields, invoice.FieldSubscriptionCustomerID)
+	}
 	if m.FieldCleared(invoice.FieldSubtotal) {
 		fields = append(fields, invoice.FieldSubtotal)
 	}
@@ -28939,6 +29006,9 @@ func (m *InvoiceMutation) ClearField(name string) error {
 		return nil
 	case invoice.FieldSubscriptionID:
 		m.ClearSubscriptionID()
+		return nil
+	case invoice.FieldSubscriptionCustomerID:
+		m.ClearSubscriptionCustomerID()
 		return nil
 	case invoice.FieldSubtotal:
 		m.ClearSubtotal()
@@ -29043,6 +29113,9 @@ func (m *InvoiceMutation) ResetField(name string) error {
 		return nil
 	case invoice.FieldSubscriptionID:
 		m.ResetSubscriptionID()
+		return nil
+	case invoice.FieldSubscriptionCustomerID:
+		m.ResetSubscriptionCustomerID()
 		return nil
 	case invoice.FieldInvoiceType:
 		m.ResetInvoiceType()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -949,63 +949,63 @@ func init() {
 	// invoice.CustomerIDValidator is a validator for the "customer_id" field. It is called by the builders before save.
 	invoice.CustomerIDValidator = invoiceDescCustomerID.Validators[0].(func(string) error)
 	// invoiceDescInvoiceType is the schema descriptor for invoice_type field.
-	invoiceDescInvoiceType := invoiceFields[3].Descriptor()
+	invoiceDescInvoiceType := invoiceFields[4].Descriptor()
 	// invoice.InvoiceTypeValidator is a validator for the "invoice_type" field. It is called by the builders before save.
 	invoice.InvoiceTypeValidator = invoiceDescInvoiceType.Validators[0].(func(string) error)
 	// invoiceDescInvoiceStatus is the schema descriptor for invoice_status field.
-	invoiceDescInvoiceStatus := invoiceFields[4].Descriptor()
+	invoiceDescInvoiceStatus := invoiceFields[5].Descriptor()
 	// invoice.DefaultInvoiceStatus holds the default value on creation for the invoice_status field.
 	invoice.DefaultInvoiceStatus = types.InvoiceStatus(invoiceDescInvoiceStatus.Default.(string))
 	// invoiceDescPaymentStatus is the schema descriptor for payment_status field.
-	invoiceDescPaymentStatus := invoiceFields[5].Descriptor()
+	invoiceDescPaymentStatus := invoiceFields[6].Descriptor()
 	// invoice.DefaultPaymentStatus holds the default value on creation for the payment_status field.
 	invoice.DefaultPaymentStatus = types.PaymentStatus(invoiceDescPaymentStatus.Default.(string))
 	// invoiceDescCurrency is the schema descriptor for currency field.
-	invoiceDescCurrency := invoiceFields[6].Descriptor()
+	invoiceDescCurrency := invoiceFields[7].Descriptor()
 	// invoice.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	invoice.CurrencyValidator = invoiceDescCurrency.Validators[0].(func(string) error)
 	// invoiceDescAmountDue is the schema descriptor for amount_due field.
-	invoiceDescAmountDue := invoiceFields[7].Descriptor()
+	invoiceDescAmountDue := invoiceFields[8].Descriptor()
 	// invoice.DefaultAmountDue holds the default value on creation for the amount_due field.
 	invoice.DefaultAmountDue = invoiceDescAmountDue.Default.(decimal.Decimal)
 	// invoiceDescAmountPaid is the schema descriptor for amount_paid field.
-	invoiceDescAmountPaid := invoiceFields[8].Descriptor()
+	invoiceDescAmountPaid := invoiceFields[9].Descriptor()
 	// invoice.DefaultAmountPaid holds the default value on creation for the amount_paid field.
 	invoice.DefaultAmountPaid = invoiceDescAmountPaid.Default.(decimal.Decimal)
 	// invoiceDescAmountRemaining is the schema descriptor for amount_remaining field.
-	invoiceDescAmountRemaining := invoiceFields[9].Descriptor()
+	invoiceDescAmountRemaining := invoiceFields[10].Descriptor()
 	// invoice.DefaultAmountRemaining holds the default value on creation for the amount_remaining field.
 	invoice.DefaultAmountRemaining = invoiceDescAmountRemaining.Default.(decimal.Decimal)
 	// invoiceDescSubtotal is the schema descriptor for subtotal field.
-	invoiceDescSubtotal := invoiceFields[10].Descriptor()
+	invoiceDescSubtotal := invoiceFields[11].Descriptor()
 	// invoice.DefaultSubtotal holds the default value on creation for the subtotal field.
 	invoice.DefaultSubtotal = invoiceDescSubtotal.Default.(decimal.Decimal)
 	// invoiceDescAdjustmentAmount is the schema descriptor for adjustment_amount field.
-	invoiceDescAdjustmentAmount := invoiceFields[11].Descriptor()
+	invoiceDescAdjustmentAmount := invoiceFields[12].Descriptor()
 	// invoice.DefaultAdjustmentAmount holds the default value on creation for the adjustment_amount field.
 	invoice.DefaultAdjustmentAmount = invoiceDescAdjustmentAmount.Default.(decimal.Decimal)
 	// invoiceDescRefundedAmount is the schema descriptor for refunded_amount field.
-	invoiceDescRefundedAmount := invoiceFields[12].Descriptor()
+	invoiceDescRefundedAmount := invoiceFields[13].Descriptor()
 	// invoice.DefaultRefundedAmount holds the default value on creation for the refunded_amount field.
 	invoice.DefaultRefundedAmount = invoiceDescRefundedAmount.Default.(decimal.Decimal)
 	// invoiceDescTotalTax is the schema descriptor for total_tax field.
-	invoiceDescTotalTax := invoiceFields[13].Descriptor()
+	invoiceDescTotalTax := invoiceFields[14].Descriptor()
 	// invoice.DefaultTotalTax holds the default value on creation for the total_tax field.
 	invoice.DefaultTotalTax = invoiceDescTotalTax.Default.(decimal.Decimal)
 	// invoiceDescTotalDiscount is the schema descriptor for total_discount field.
-	invoiceDescTotalDiscount := invoiceFields[14].Descriptor()
+	invoiceDescTotalDiscount := invoiceFields[15].Descriptor()
 	// invoice.DefaultTotalDiscount holds the default value on creation for the total_discount field.
 	invoice.DefaultTotalDiscount = invoiceDescTotalDiscount.Default.(decimal.Decimal)
 	// invoiceDescTotal is the schema descriptor for total field.
-	invoiceDescTotal := invoiceFields[15].Descriptor()
+	invoiceDescTotal := invoiceFields[16].Descriptor()
 	// invoice.DefaultTotal holds the default value on creation for the total field.
 	invoice.DefaultTotal = invoiceDescTotal.Default.(decimal.Decimal)
 	// invoiceDescVersion is the schema descriptor for version field.
-	invoiceDescVersion := invoiceFields[28].Descriptor()
+	invoiceDescVersion := invoiceFields[29].Descriptor()
 	// invoice.DefaultVersion holds the default value on creation for the version field.
 	invoice.DefaultVersion = invoiceDescVersion.Default.(int)
 	// invoiceDescTotalPrepaidCreditsApplied is the schema descriptor for total_prepaid_credits_applied field.
-	invoiceDescTotalPrepaidCreditsApplied := invoiceFields[31].Descriptor()
+	invoiceDescTotalPrepaidCreditsApplied := invoiceFields[32].Descriptor()
 	// invoice.DefaultTotalPrepaidCreditsApplied holds the default value on creation for the total_prepaid_credits_applied field.
 	invoice.DefaultTotalPrepaidCreditsApplied = invoiceDescTotalPrepaidCreditsApplied.Default.(decimal.Decimal)
 	invoicelineitemMixin := schema.InvoiceLineItem{}.Mixin()

--- a/ent/schema/invoice.go
+++ b/ent/schema/invoice.go
@@ -49,6 +49,16 @@ func (Invoice) Fields() []ent.Field {
 			}).
 			Optional().
 			Nillable(),
+
+		field.String("subscription_customer_id").
+			SchemaType(map[string]string{
+				"postgres": "varchar(50)",
+			}).
+			Optional().
+			Nillable().
+			Immutable().
+			Comment("Subscription owner customer ID; set internally for subscription invoices"),
+
 		field.String("invoice_type").
 			SchemaType(map[string]string{
 				"postgres": "varchar(50)",

--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -158,19 +158,21 @@ func (r *CreateInvoiceRequest) ToComputeRequest() InvoiceComputeRequest {
 // draft invoice. No amounts, no line items, no coupons, no taxes — those are populated
 // later by ComputeInvoice. Used by CreateEmptyDraftInvoice and CreateDraftInvoiceForSubscription.
 type CreateDraftInvoiceRequest struct {
-	CustomerID     string                       `json:"customer_id" validate:"required"`
-	SubscriptionID *string                      `json:"subscription_id,omitempty"`
-	InvoiceType    types.InvoiceType            `json:"invoice_type" validate:"required"`
-	Currency       string                       `json:"currency" validate:"required"`
-	PeriodStart    *time.Time                   `json:"period_start,omitempty"`
-	PeriodEnd      *time.Time                   `json:"period_end,omitempty"`
-	BillingPeriod  *string                      `json:"billing_period,omitempty"`
-	BillingReason  types.InvoiceBillingReason   `json:"billing_reason,omitempty"`
-	Description    string                       `json:"description,omitempty"`
-	DueDate        *time.Time                   `json:"due_date,omitempty"`
-	Metadata       types.Metadata               `json:"metadata,omitempty"`
-	IdempotencyKey *string                      `json:"idempotency_key,omitempty"`
-	InvoicePDFURL  *string                      `json:"invoice_pdf_url,omitempty"`
+	CustomerID     string  `json:"customer_id" validate:"required"`
+	SubscriptionID *string `json:"subscription_id,omitempty"`
+	// SubscriptionCustomerID is the subscription owner's customer ID; set by service only (not in JSON).
+	SubscriptionCustomerID *string                    `json:"-"`
+	InvoiceType            types.InvoiceType          `json:"invoice_type" validate:"required"`
+	Currency               string                     `json:"currency" validate:"required"`
+	PeriodStart            *time.Time                 `json:"period_start,omitempty"`
+	PeriodEnd              *time.Time                 `json:"period_end,omitempty"`
+	BillingPeriod          *string                    `json:"billing_period,omitempty"`
+	BillingReason          types.InvoiceBillingReason `json:"billing_reason,omitempty"`
+	Description            string                     `json:"description,omitempty"`
+	DueDate                *time.Time                 `json:"due_date,omitempty"`
+	Metadata               types.Metadata             `json:"metadata,omitempty"`
+	IdempotencyKey         *string                    `json:"idempotency_key,omitempty"`
+	InvoicePDFURL          *string                    `json:"invoice_pdf_url,omitempty"`
 }
 
 // Validate validates the draft invoice creation request.
@@ -219,29 +221,30 @@ func (r *CreateDraftInvoiceRequest) ToDraftInvoice(ctx context.Context) (*invoic
 	}
 
 	return &invoice.Invoice{
-		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE),
-		CustomerID:      r.CustomerID,
-		SubscriptionID:  r.SubscriptionID,
-		InvoiceType:     r.InvoiceType,
-		Currency:        strings.ToLower(r.Currency),
-		AmountDue:       decimal.Zero,
-		Total:           decimal.Zero,
-		Subtotal:        decimal.Zero,
-		AmountPaid:      decimal.Zero,
-		AmountRemaining: decimal.Zero,
-		TotalDiscount:   decimal.Zero,
-		TotalTax:        decimal.Zero,
-		Description:     r.Description,
-		DueDate:         r.DueDate,
-		PeriodStart:     r.PeriodStart,
-		BillingPeriod:   r.BillingPeriod,
-		PeriodEnd:       r.PeriodEnd,
-		BillingReason:   string(r.BillingReason),
-		Metadata:        r.Metadata,
-		InvoicePDFURL:   r.InvoicePDFURL,
-		InvoiceStatus:   types.InvoiceStatusDraft,
-		PaymentStatus:   types.PaymentStatusPending,
-		BaseModel:       types.GetDefaultBaseModel(ctx),
+		ID:                     types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE),
+		CustomerID:             r.CustomerID,
+		SubscriptionID:         r.SubscriptionID,
+		SubscriptionCustomerID: r.SubscriptionCustomerID,
+		InvoiceType:            r.InvoiceType,
+		Currency:               strings.ToLower(r.Currency),
+		AmountDue:              decimal.Zero,
+		Total:                  decimal.Zero,
+		Subtotal:               decimal.Zero,
+		AmountPaid:             decimal.Zero,
+		AmountRemaining:        decimal.Zero,
+		TotalDiscount:          decimal.Zero,
+		TotalTax:               decimal.Zero,
+		Description:            r.Description,
+		DueDate:                r.DueDate,
+		PeriodStart:            r.PeriodStart,
+		BillingPeriod:          r.BillingPeriod,
+		PeriodEnd:              r.PeriodEnd,
+		BillingReason:          string(r.BillingReason),
+		Metadata:               r.Metadata,
+		InvoicePDFURL:          r.InvoicePDFURL,
+		InvoiceStatus:          types.InvoiceStatusDraft,
+		PaymentStatus:          types.PaymentStatusPending,
+		BaseModel:              types.GetDefaultBaseModel(ctx),
 	}, nil
 }
 

--- a/internal/domain/invoice/model.go
+++ b/internal/domain/invoice/model.go
@@ -22,6 +22,10 @@ type Invoice struct {
 	// subscription_id is the ID of the subscription this invoice is associated with (only present for subscription-based invoices)
 	SubscriptionID *string `json:"subscription_id,omitempty"`
 
+	// subscription_customer_id is the subscription owner's customer ID (Subscription.CustomerID).
+	// It may differ from customer_id when the subscription uses an invoicing customer. Set internally; nullable in DB.
+	SubscriptionCustomerID *string `json:"subscription_customer_id,omitempty"`
+
 	// invoice_type indicates the type of invoice - whether this is a subscription invoice, one-time charge, or other billing type
 	InvoiceType types.InvoiceType `json:"invoice_type"`
 
@@ -151,22 +155,23 @@ func FromEnt(e *ent.Invoice) *Invoice {
 		couponApplications = coupon_application.FromEntList(e.Edges.CouponApplications)
 	}
 	return &Invoice{
-		ID:               e.ID,
-		CustomerID:       e.CustomerID,
-		SubscriptionID:   e.SubscriptionID,
-		InvoiceType:      types.InvoiceType(e.InvoiceType),
-		InvoiceStatus:    types.InvoiceStatus(e.InvoiceStatus),
-		PaymentStatus:    types.PaymentStatus(e.PaymentStatus),
-		Currency:         e.Currency,
-		AmountDue:        e.AmountDue,
-		AmountPaid:       e.AmountPaid,
-		Subtotal:         e.Subtotal,
-		Total:            e.Total,
-		TotalDiscount:    lo.FromPtrOr(e.TotalDiscount, decimal.Zero),
-		TotalTax:         lo.FromPtrOr(e.TotalTax, decimal.Zero),
-		AmountRemaining:  e.AmountRemaining,
-		AdjustmentAmount: e.AdjustmentAmount,
-		RefundedAmount:   e.RefundedAmount,
+		ID:                     e.ID,
+		CustomerID:             e.CustomerID,
+		SubscriptionID:         e.SubscriptionID,
+		SubscriptionCustomerID: e.SubscriptionCustomerID,
+		InvoiceType:            types.InvoiceType(e.InvoiceType),
+		InvoiceStatus:          types.InvoiceStatus(e.InvoiceStatus),
+		PaymentStatus:          types.PaymentStatus(e.PaymentStatus),
+		Currency:               e.Currency,
+		AmountDue:              e.AmountDue,
+		AmountPaid:             e.AmountPaid,
+		Subtotal:               e.Subtotal,
+		Total:                  e.Total,
+		TotalDiscount:          lo.FromPtrOr(e.TotalDiscount, decimal.Zero),
+		TotalTax:               lo.FromPtrOr(e.TotalTax, decimal.Zero),
+		AmountRemaining:        e.AmountRemaining,
+		AdjustmentAmount:       e.AdjustmentAmount,
+		RefundedAmount:         e.RefundedAmount,
 		// TODO: remove optional and nillable after migration
 		TotalPrepaidCreditsApplied: lo.FromPtrOr(e.TotalPrepaidCreditsApplied, decimal.Zero),
 		InvoiceNumber:              e.InvoiceNumber,

--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -61,6 +61,7 @@ func (r *invoiceRepository) Create(ctx context.Context, inv *domainInvoice.Invoi
 		SetTenantID(inv.TenantID).
 		SetCustomerID(inv.CustomerID).
 		SetNillableSubscriptionID(inv.SubscriptionID).
+		SetNillableSubscriptionCustomerID(inv.SubscriptionCustomerID).
 		SetInvoiceType(inv.InvoiceType).
 		SetInvoiceStatus(inv.InvoiceStatus).
 		SetPaymentStatus(inv.PaymentStatus).
@@ -165,6 +166,7 @@ func (r *invoiceRepository) CreateWithLineItems(ctx context.Context, inv *domain
 			SetTenantID(inv.TenantID).
 			SetCustomerID(inv.CustomerID).
 			SetNillableSubscriptionID(inv.SubscriptionID).
+			SetNillableSubscriptionCustomerID(inv.SubscriptionCustomerID).
 			SetInvoiceType(inv.InvoiceType).
 			SetInvoiceStatus(inv.InvoiceStatus).
 			SetPaymentStatus(inv.PaymentStatus).
@@ -1057,6 +1059,11 @@ func (o InvoiceQueryOptions) applyEntityQueryOptions(_ context.Context, f *types
 	if f.SubscriptionID != "" {
 		query = query.Where(invoice.SubscriptionID(f.SubscriptionID))
 	}
+
+	if len(f.SubscriptionCustomerIDs) > 0 {
+		query = query.Where(invoice.SubscriptionCustomerIDIn(f.SubscriptionCustomerIDs...))
+	}
+
 	if f.InvoiceType != "" {
 		query = query.Where(invoice.InvoiceType(f.InvoiceType))
 	}

--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -343,6 +343,7 @@ func (s *invoiceService) CreateDraftInvoiceForSubscription(ctx context.Context, 
 	if referencePoint == types.ReferencePointCancel {
 		req.BillingReason = types.InvoiceBillingReasonProration
 	}
+	req.SubscriptionCustomerID = &sub.CustomerID
 	return s.CreateEmptyDraftInvoice(ctx, req)
 }
 
@@ -1761,6 +1762,7 @@ func (s *invoiceService) CreateSubscriptionInvoice(ctx context.Context, req *dto
 	if flowType == types.InvoiceFlowSubscriptionCreation {
 		draftReq.BillingReason = types.InvoiceBillingReasonSubscriptionCreate
 	}
+	draftReq.SubscriptionCustomerID = &subscription.CustomerID
 	draft, err := s.CreateEmptyDraftInvoice(ctx, draftReq)
 	if err != nil {
 		return nil, nil, err

--- a/internal/testutil/inmemory_invoice_store.go
+++ b/internal/testutil/inmemory_invoice_store.go
@@ -77,6 +77,7 @@ func copyInvoice(inv *invoice.Invoice) *invoice.Invoice {
 		ID:                         inv.ID,
 		CustomerID:                 inv.CustomerID,
 		SubscriptionID:             inv.SubscriptionID,
+		SubscriptionCustomerID:     inv.SubscriptionCustomerID,
 		InvoiceType:                inv.InvoiceType,
 		InvoiceStatus:              inv.InvoiceStatus,
 		PaymentStatus:              inv.PaymentStatus,

--- a/internal/types/invoice.go
+++ b/internal/types/invoice.go
@@ -332,6 +332,9 @@ type InvoiceFilter struct {
 	// Only returns invoices that were created as part of the specified subscription's billing
 	SubscriptionID string `json:"subscription_id,omitempty" form:"subscription_id"`
 
+	// subscription_customer_id filters invoices by the subscription owner's customer ID
+	SubscriptionCustomerIDs []string `json:"subscription_customer_id,omitempty" form:"subscription_customer_id"`
+
 	// invoice_type filters by the nature of the invoice (SUBSCRIPTION, ONE_OFF, or CREDIT)
 	// Use this to separate recurring charges from one-time fees or credit adjustments
 	InvoiceType InvoiceType `json:"invoice_type,omitempty" form:"invoice_type"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoices now include a nullable `subscription_customer_id` to record the subscription owner’s customer ID; automatically set for subscription invoices.
  * API requests/responses and invoice creation flows support the new field (service-only where applicable).
  * Listing invoices can be filtered by `subscription_customer_id`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->