### PR TITLE
perf(meter-usage): cache meter list lookups per event name

### DIFF
--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -19,9 +19,34 @@ import (
 	"github.com/flexprice/flexprice/internal/pubsub/kafka"
 	pubsubRouter "github.com/flexprice/flexprice/internal/pubsub/router"
 	"github.com/flexprice/flexprice/internal/types"
+	goCache "github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
+
+// meterCacheTTL is how long we cache meter lists per (tenant, environment, eventName).
+//
+// Why 10 minutes:
+//   - Meters are append-only in practice; existing meters never change after creation.
+//   - The TTL only matters for newly-created meters: a consumer process will start
+//     seeing a new meter within at most meterCacheTTL of it being created.
+//   - Using NoExpiration would be marginally faster but would require a process
+//     restart to pick up new meters. 10 minutes is a safe middle ground.
+//
+// Why in-process and not Redis:
+//   - The global cache.Type may be "redis", which adds a network hop on every
+//     lookup and would not improve latency over a fresh Postgres query.
+//   - Meter data per (tenant, environment, eventName) key is tiny (~KB), so a
+//     per-process copy across N consumer pods is perfectly fine.
+//
+// Memory footprint estimate (worst case):
+//   - 200 tenants × 20 event names × 10 meters × ~500 B/meter ≈ 20 MB
+//
+// Singleton guarantee:
+//   - This service is registered via fx.Provide() (main.go) and is therefore
+//     instantiated exactly once per process. The goCache.Cache inside it, and
+//     its single background cleanup goroutine, are also allocated exactly once.
+const meterCacheTTL = 10 * time.Minute
 
 // MeterUsageTrackingService handles meter-level usage tracking.
 // Unlike FeatureUsageTrackingService, this skips subscription/feature/price resolution.
@@ -39,6 +64,12 @@ type meterUsageTrackingService struct {
 	pubSub              pubsub.PubSub
 	meterUsageRepo      events.MeterUsageRepository
 	expressionEvaluator expression.Evaluator
+	// meterListCache is a dedicated in-memory cache for meter lists keyed by
+	// "tenantID:environmentID:eventName". It is intentionally separate from the
+	// global cache so it is always in-memory (fast) and unaffected by the
+	// global cache.Type config (which may be Redis). Meters are immutable after
+	// creation so no active invalidation is required.
+	meterListCache *goCache.Cache
 }
 
 // NewMeterUsageTrackingService creates a new meter usage tracking service
@@ -50,6 +81,7 @@ func NewMeterUsageTrackingService(
 		ServiceParams:       params,
 		meterUsageRepo:      meterUsageRepo,
 		expressionEvaluator: expression.NewCELEvaluator(),
+		meterListCache:      goCache.New(meterCacheTTL, 2*meterCacheTTL),
 	}
 
 	ps, err := kafka.NewPubSubFromConfig(
@@ -161,14 +193,45 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 	return nil
 }
 
+// getMetersForEvent returns meters matching the given event name.
+// Results are cached in-process for meterCacheTTL to avoid a Postgres round-trip
+// on every Kafka message. The cache is nil-safe: if the service was constructed
+// without a cache (e.g. directly in unit tests) it falls through to the repo.
+func (s *meterUsageTrackingService) getMetersForEvent(ctx context.Context, eventName string) ([]*meter.Meter, error) {
+	if s.meterListCache != nil {
+		tenantID := types.GetTenantID(ctx)
+		environmentID := types.GetEnvironmentID(ctx)
+		cacheKey := tenantID + ":" + environmentID + ":" + eventName
+
+		if cached, ok := s.meterListCache.Get(cacheKey); ok {
+			return cached.([]*meter.Meter), nil
+		}
+
+		meterFilter := types.NewNoLimitMeterFilter()
+		meterFilter.EventName = eventName
+
+		meters, err := s.MeterRepo.List(ctx, meterFilter)
+		if err != nil {
+			return nil, err
+		}
+
+		// goCache.DefaultExpiration (0) means "use the TTL set at New() time",
+		// i.e. meterCacheTTL. The stored slice is never mutated after insertion so
+		// concurrent reads do not need additional synchronisation.
+		s.meterListCache.Set(cacheKey, meters, goCache.DefaultExpiration)
+		return meters, nil
+	}
+
+	meterFilter := types.NewNoLimitMeterFilter()
+	meterFilter.EventName = eventName
+	return s.MeterRepo.List(ctx, meterFilter)
+}
+
 // processEvent matches an event to meters and writes meter_usage records.
 // No subscription/feature/price resolution needed.
 func (s *meterUsageTrackingService) processEvent(ctx context.Context, event *events.Event) error {
-	// Step 1: Lookup meters by event name
-	meterFilter := types.NewNoLimitMeterFilter()
-	meterFilter.EventName = event.EventName
-
-	meters, err := s.MeterRepo.List(ctx, meterFilter)
+	// Step 1: Lookup meters by event name (cache-first)
+	meters, err := s.getMetersForEvent(ctx, event.EventName)
 	if err != nil {
 		return fmt.Errorf("failed to list meters for event %s: %w", event.EventName, err)
 	}

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -215,10 +215,17 @@ func (s *meterUsageTrackingService) getMetersForEvent(ctx context.Context, event
 			return nil, err
 		}
 
+		// Only cache non-empty results. Caching empty slices for event names that
+		// have no matching meters would cause unbounded cache growth when the
+		// consumer receives high-cardinality event names. Unknown event names are
+		// cheap to query (indexed, returns zero rows quickly).
+		//
 		// goCache.DefaultExpiration (0) means "use the TTL set at New() time",
 		// i.e. meterCacheTTL. The stored slice is never mutated after insertion so
 		// concurrent reads do not need additional synchronisation.
-		s.meterListCache.Set(cacheKey, meters, goCache.DefaultExpiration)
+		if len(meters) > 0 {
+			s.meterListCache.Set(cacheKey, meters, goCache.DefaultExpiration)
+		}
 		return meters, nil
 	}
 
@@ -335,21 +342,26 @@ func (s *meterUsageTrackingService) checkMeterFilters(event *events.Event, filte
 	return true
 }
 
-// Generate a unique hash for deduplication
-// there are 2 cases:
-// 1. event_name + event_id // for non COUNT_UNIQUE aggregation types
-// 2. event_name + event_field_name + event_field_value // for COUNT_UNIQUE aggregation types
+// generateUniqueHash returns a SHA-256 hex string used for deduplication.
+// Two cases:
+//  1. COUNT_UNIQUE: hash(eventName + fieldName + fieldValue) — two events with
+//     the same field value produce the same hash and are deduplicated.
+//  2. All other types: hash(eventName + eventID) — every distinct event is unique.
 func (s *meterUsageTrackingService) generateUniqueHash(event *events.Event, m *meter.Meter) string {
+	var hashStr string
 
 	if m.Aggregation.Type == types.AggregationCountUnique && m.Aggregation.Field != "" {
 		if fieldValue, ok := event.Properties[m.Aggregation.Field]; ok {
-			hashStr := fmt.Sprintf("%s:%s:%v", event.EventName, m.Aggregation.Field, fieldValue)
-			hash := sha256.Sum256([]byte(hashStr))
-			return hex.EncodeToString(hash[:])
+			hashStr = fmt.Sprintf("%s:%s:%v", event.EventName, m.Aggregation.Field, fieldValue)
 		}
 	}
 
-	return ""
+	if hashStr == "" {
+		hashStr = event.EventName + ":" + event.ID
+	}
+
+	hash := sha256.Sum256([]byte(hashStr))
+	return hex.EncodeToString(hash[:])
 }
 
 // extractQuantity extracts the quantity from event properties based on the meter's aggregation config.


### PR DESCRIPTION
## Changes

- Add in-process caching layer for meter list lookups using go-cache
- Cache key: `tenantID:environmentID:eventName` with 10-minute TTL
- Introduce `getMetersForEvent()` helper method to encapsulate cache logic
- Add comprehensive documentation explaining cache design decisions

## Benefits

- Eliminates redundant Postgres queries for the same event name within the TTL window
- Improves Kafka message processing latency on high-throughput topics
- Negligible memory footprint (~20 MB worst case for 200 tenants)
- Safe middle ground: picks up new meters within 10 minutes without requiring process restart

## Implementation Details

- Uses dedicated in-process cache (not Redis) for guaranteed sub-millisecond lookup
- Meters are immutable after creation, so no active invalidation needed
- Cache is nil-safe for backward compatibility with tests
- Singleton cache instance per process via fx dependency injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added an internal in-process cache for meter lookups to reduce redundant queries during event processing and improve performance with no public API changes.

* **Bug Fix**
  * Improved deduplication hash generation so unique counts are consistently computed even when expected event fields are missing, preventing empty-hash cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->