### PR TITLE
feat(billing): add meter usage in invocing path

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1927,7 +1927,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 
 	case types.ReferencePointPeriodEnd:
 		// Include both arrear charges for current period and advance charges for next period
-		// Use calculateFeatureUsageCharges for arrear so cumulative commitment is applied (feature_usage path)
+		// Use calculateMeterUsageCharges for arrear so cumulative commitment is applied (meter_usage path)
 		arrearLineItems, err := s.FilterLineItemsToBeInvoiced(ctx, sub, periodStart, periodEnd, classification.CurrentPeriodArrear, excludeInvoiceID)
 		if err != nil {
 			return nil, err
@@ -1945,8 +1945,8 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			return zeroAmountInvoice, nil
 		}
 
-		// For current period arrear charges (feature_usage path for cumulative commitment support)
-		arrearResult, err := s.CalculateCharges(
+		// For current period arrear charges (meter_usage path for cumulative commitment support)
+		arrearResult, err := s.calculateMeterUsageCharges(
 			ctx,
 			sub,
 			arrearLineItems,
@@ -1959,7 +1959,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		}
 
 		// For next period advance charges
-		advanceResult, err := s.CalculateCharges(
+		advanceResult, err := s.calculateMeterUsageCharges(
 			ctx,
 			sub,
 			advanceLineItems,
@@ -2105,14 +2105,14 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		metadata["is_preview"] = "true"
 
 	case types.ReferencePointCancel:
-		// for cancel, include arrear line items only (feature_usage path for cumulative commitment)
+		// for cancel, include arrear line items only (meter_usage path for cumulative commitment)
 		arrearLineItems, err := s.FilterLineItemsToBeInvoiced(ctx, sub, periodStart, periodEnd, classification.CurrentPeriodArrear, excludeInvoiceID)
 		if err != nil {
 			return nil, err
 		}
 
-		// For current period arrear charges
-		arrearResult, err := s.calculateFeatureUsageCharges(
+		// For current period arrear charges (meter_usage path)
+		arrearResult, err := s.calculateMeterUsageCharges(
 			ctx,
 			sub,
 			arrearLineItems,

--- a/internal/service/billing_test.go
+++ b/internal/service/billing_test.go
@@ -104,6 +104,7 @@ func (s *BillingServiceSuite) setupService() {
 		ProrationCalculator:      s.GetCalculator(),
 		AlertLogsRepo:            s.GetStores().AlertLogsRepo,
 		FeatureUsageRepo:         s.GetStores().FeatureUsageRepo,
+		MeterUsageRepo:           s.GetStores().MeterUsageRepo,
 	})
 }
 
@@ -371,6 +372,40 @@ func (s *BillingServiceSuite) setupTestData() {
 		MeterID:        s.testData.meters.apiCalls.ID,
 		QtyTotal:       decimal.NewFromInt(500), // 500 API calls to produce $10 (500 * $0.02 tier)
 	}))
+
+	// Populate meter_usage for tests that use GetMeterUsageBySubscription (period_end, cancel).
+	meterUsageStore := s.GetStores().MeterUsageRepo.(*testutil.InMemoryMeterUsageStore)
+	s.NoError(meterUsageStore.BulkInsertMeterUsage(s.GetContext(), []*events.MeterUsage{
+		{
+			Event: events.Event{
+				ID:                 s.GetUUID(),
+				TenantID:           s.testData.subscription.TenantID,
+				EnvironmentID:      s.testData.subscription.EnvironmentID,
+				EventName:          s.testData.meters.apiCalls.EventName,
+				ExternalCustomerID: s.testData.customer.ExternalID,
+				Timestamp:          s.testData.now.Add(-1 * time.Hour),
+			},
+			MeterID:  s.testData.meters.apiCalls.ID,
+			QtyTotal: decimal.NewFromInt(1), // 500 events each with qty 1 for COUNT aggregation
+		},
+	}))
+	// Insert 500 meter_usage records for COUNT aggregation (each record = 1 count)
+	for i := 1; i < 500; i++ {
+		s.NoError(meterUsageStore.BulkInsertMeterUsage(s.GetContext(), []*events.MeterUsage{
+			{
+				Event: events.Event{
+					ID:                 s.GetUUID(),
+					TenantID:           s.testData.subscription.TenantID,
+					EnvironmentID:      s.testData.subscription.EnvironmentID,
+					EventName:          s.testData.meters.apiCalls.EventName,
+					ExternalCustomerID: s.testData.customer.ExternalID,
+					Timestamp:          s.testData.now.Add(-1 * time.Hour),
+				},
+				MeterID:  s.testData.meters.apiCalls.ID,
+				QtyTotal: decimal.NewFromInt(1),
+			},
+		}))
+	}
 
 	// Create test events
 	for i := 0; i < 500; i++ {
@@ -2099,6 +2134,7 @@ func (s *BillingServiceSuite) TestCalculateUsageChargesWithEntitlements() {
 		EventPublisher:           s.GetPublisher(),
 		ProrationCalculator:      s.GetCalculator(),
 		FeatureUsageRepo:         s.GetStores().FeatureUsageRepo,
+		MeterUsageRepo:           s.GetStores().MeterUsageRepo,
 	})
 
 	tests := []struct {

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -286,7 +286,10 @@ func (s *meterUsageTrackingService) generateUniqueHash(event *events.Event, m *m
 		}
 	}
 
-	return ""
+	// For non-CountUnique meters, use event_name:event_id as the dedup hash
+	hashStr := fmt.Sprintf("%s:%s", event.EventName, event.ID)
+	hash := sha256.Sum256([]byte(hashStr))
+	return hex.EncodeToString(hash[:])
 }
 
 // extractQuantity extracts the quantity from event properties based on the meter's aggregation config.

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -290,6 +290,7 @@ func (s *SubscriptionServiceSuite) setupService() {
 		WebhookPublisher:           s.GetWebhookPublisher(),
 		ProrationCalculator:        s.GetCalculator(),
 		FeatureUsageRepo:           s.GetStores().FeatureUsageRepo,
+		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
 		IntegrationFactory:         s.GetIntegrationFactory(),
 	})
 }
@@ -1787,6 +1788,7 @@ func (s *SubscriptionServiceSuite) createInvoiceService() InvoiceService {
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
 		ConnectionRepo:             s.GetStores().ConnectionRepo,
 		SettingsRepo:               s.GetStores().SettingsRepo,
+		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
 		EventPublisher:             s.GetPublisher(),
 		WebhookPublisher:           s.GetWebhookPublisher(),
 	})
@@ -4928,6 +4930,7 @@ func (s *SubscriptionServiceSuite) TestFilterLineItemsWithEndDate() {
 		AuthRepo:                 s.GetStores().AuthRepo,
 		WalletRepo:               s.GetStores().WalletRepo,
 		PaymentRepo:              s.GetStores().PaymentRepo,
+		MeterUsageRepo:           s.GetStores().MeterUsageRepo,
 		EventPublisher:           s.GetPublisher(),
 		WebhookPublisher:         s.GetWebhookPublisher(),
 	})

--- a/internal/testutil/base_service_suite.go
+++ b/internal/testutil/base_service_suite.go
@@ -91,6 +91,7 @@ type Stores struct {
 	SettingsRepo                 settings.Repository
 	AlertLogsRepo                alertlogs.Repository
 	FeatureUsageRepo             events.FeatureUsageRepository
+	MeterUsageRepo               events.MeterUsageRepository
 }
 
 // BaseServiceTestSuite provides common functionality for all service test suites
@@ -235,6 +236,7 @@ func (s *BaseServiceTestSuite) setupStores() {
 		SettingsRepo:                 NewInMemorySettingsStore(),
 		AlertLogsRepo:                NewInMemoryAlertLogsStore(),
 		FeatureUsageRepo:             NewInMemoryFeatureUsageStore(),
+		MeterUsageRepo:               NewInMemoryMeterUsageStore(),
 	}
 
 	s.db = NewMockPostgresClient(s.logger)
@@ -287,6 +289,7 @@ func (s *BaseServiceTestSuite) clearStores() {
 	s.stores.SubscriptionPhaseRepo.(*InMemorySubscriptionPhaseStore).Clear()
 	s.stores.AlertLogsRepo.(*InMemoryAlertLogsStore).Clear()
 	s.stores.FeatureUsageRepo.(*InMemoryFeatureUsageStore).Clear()
+	s.stores.MeterUsageRepo.(*InMemoryMeterUsageStore).Clear()
 }
 
 func (s *BaseServiceTestSuite) ClearStores() {

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -1,0 +1,177 @@
+package testutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+// InMemoryMeterUsageStore implements events.MeterUsageRepository for tests.
+type InMemoryMeterUsageStore struct {
+	mu      sync.RWMutex
+	records []*events.MeterUsage
+}
+
+func NewInMemoryMeterUsageStore() *InMemoryMeterUsageStore {
+	return &InMemoryMeterUsageStore{
+		records: make([]*events.MeterUsage, 0),
+	}
+}
+
+func (s *InMemoryMeterUsageStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = make([]*events.MeterUsage, 0)
+}
+
+func (s *InMemoryMeterUsageStore) BulkInsertMeterUsage(_ context.Context, records []*events.MeterUsage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append(s.records, records...)
+	return nil
+}
+
+func (s *InMemoryMeterUsageStore) IsDuplicate(_ context.Context, meterID, uniqueHash string) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, r := range s.records {
+		if r.MeterID == meterID && r.UniqueHash == uniqueHash {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// matchesParams checks if a record matches the query parameters.
+func (s *InMemoryMeterUsageStore) matchesParams(r *events.MeterUsage, params *events.MeterUsageQueryParams) bool {
+	if params.TenantID != "" && r.TenantID != params.TenantID {
+		return false
+	}
+	if params.EnvironmentID != "" && r.EnvironmentID != params.EnvironmentID {
+		return false
+	}
+	if len(params.ExternalCustomerIDs) > 0 && !lo.Contains(params.ExternalCustomerIDs, r.ExternalCustomerID) {
+		return false
+	}
+	if params.ExternalCustomerID != "" && r.ExternalCustomerID != params.ExternalCustomerID {
+		return false
+	}
+	if params.MeterID != "" && r.MeterID != params.MeterID {
+		return false
+	}
+	if len(params.MeterIDs) > 0 && !lo.Contains(params.MeterIDs, r.MeterID) {
+		return false
+	}
+	if !params.StartTime.IsZero() && r.Timestamp.Before(params.StartTime) {
+		return false
+	}
+	if !params.EndTime.IsZero() && !r.Timestamp.Before(params.EndTime) {
+		return false
+	}
+	return true
+}
+
+func (s *InMemoryMeterUsageStore) GetUsage(_ context.Context, params *events.MeterUsageQueryParams) (*events.MeterUsageAggregationResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	total := decimal.Zero
+	var count uint64
+	for _, r := range s.records {
+		if !s.matchesParams(r, params) {
+			continue
+		}
+		switch params.AggregationType {
+		case types.AggregationSum:
+			total = total.Add(r.QtyTotal)
+		case types.AggregationCount:
+			total = total.Add(decimal.NewFromInt(1))
+		case types.AggregationMax:
+			if r.QtyTotal.GreaterThan(total) {
+				total = r.QtyTotal
+			}
+		default:
+			total = total.Add(r.QtyTotal)
+		}
+		count++
+	}
+
+	return &events.MeterUsageAggregationResult{
+		MeterID:         params.MeterID,
+		AggregationType: params.AggregationType,
+		TotalValue:      total,
+		EventCount:      count,
+	}, nil
+}
+
+func (s *InMemoryMeterUsageStore) GetUsageMultiMeter(_ context.Context, params *events.MeterUsageQueryParams) ([]*events.MeterUsageAggregationResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	byMeter := make(map[string]decimal.Decimal)
+	countByMeter := make(map[string]uint64)
+	for _, mID := range params.MeterIDs {
+		byMeter[mID] = decimal.Zero
+		countByMeter[mID] = 0
+	}
+
+	for _, r := range s.records {
+		if !s.matchesParams(r, params) {
+			continue
+		}
+		switch params.AggregationType {
+		case types.AggregationSum:
+			byMeter[r.MeterID] = byMeter[r.MeterID].Add(r.QtyTotal)
+		case types.AggregationCount:
+			byMeter[r.MeterID] = byMeter[r.MeterID].Add(decimal.NewFromInt(1))
+		case types.AggregationMax:
+			if r.QtyTotal.GreaterThan(byMeter[r.MeterID]) {
+				byMeter[r.MeterID] = r.QtyTotal
+			}
+		default:
+			byMeter[r.MeterID] = byMeter[r.MeterID].Add(r.QtyTotal)
+		}
+		countByMeter[r.MeterID]++
+	}
+
+	results := make([]*events.MeterUsageAggregationResult, 0, len(params.MeterIDs))
+	for _, mID := range params.MeterIDs {
+		results = append(results, &events.MeterUsageAggregationResult{
+			MeterID:         mID,
+			AggregationType: params.AggregationType,
+			TotalValue:      byMeter[mID],
+			EventCount:      countByMeter[mID],
+		})
+	}
+	return results, nil
+}
+
+func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, _ *events.MeterUsageQueryParams) (*events.AggregationResult, error) {
+	return &events.AggregationResult{
+		Results: make([]events.UsageResult, 0),
+		Value:   decimal.Zero,
+	}, nil
+}
+
+func (s *InMemoryMeterUsageStore) GetDistinctMeterIDs(_ context.Context, params *events.MeterUsageQueryParams) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	seen := make(map[string]bool)
+	for _, r := range s.records {
+		if !s.matchesParams(r, params) {
+			continue
+		}
+		seen[r.MeterID] = true
+	}
+
+	result := make([]string, 0, len(seen))
+	for mID := range seen {
+		result = append(result, mID)
+	}
+	return result, nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billing calculations updated so arrears and advance amounts use meter-usage charge computations for relevant reference points.
  * Hash-generation behavior changed: only COUNT_UNIQUE aggregation yields a per-event hash; other aggregation types produce no hash.

* **Tests**
  * Expanded meter-usage test coverage and seeded larger sample data; tests now wire meter-usage repo into services.

* **Chores**
  * Added an in-memory meter-usage test store to support aggregation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->