### PR TITLE
feat(billing): optimize usage-based charge calculation by conditionally querying ClickHouse

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -2090,6 +2090,16 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			return nil, err
 		}
 
+		// Only fetch usage from ClickHouse if the subscription has usage-based (metered) arrear
+		// line items. FIXED-price-only subscriptions don't need a ClickHouse query.
+		hasUsageArrearItems := false
+		for _, li := range arrearLineItems {
+			if li.MeterID != "" {
+				hasUsageArrearItems = true
+				break
+			}
+		}
+
 		// For current period arrear charges
 		arrearResult, err := s.calculateFeatureUsageCharges(
 			ctx,
@@ -2097,7 +2107,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			arrearLineItems,
 			periodStart,
 			periodEnd,
-			true, // Include usage for arrear
+			hasUsageArrearItems,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -2090,16 +2090,6 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			return nil, err
 		}
 
-		// Only fetch usage from ClickHouse if the subscription has usage-based (metered) arrear
-		// line items. FIXED-price-only subscriptions don't need a ClickHouse query.
-		hasUsageArrearItems := false
-		for _, li := range arrearLineItems {
-			if li.MeterID != "" {
-				hasUsageArrearItems = true
-				break
-			}
-		}
-
 		// For current period arrear charges
 		arrearResult, err := s.calculateFeatureUsageCharges(
 			ctx,
@@ -2107,7 +2097,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			arrearLineItems,
 			periodStart,
 			periodEnd,
-			hasUsageArrearItems,
+			true, // Include usage for arrear
 		)
 		if err != nil {
 			return nil, err

--- a/internal/service/subscription_modification.go
+++ b/internal/service/subscription_modification.go
@@ -415,6 +415,9 @@ func (s *subscriptionModificationService) executeQuantityChange(
 				continue
 			}
 
+			// Capture original end date before mutation (used later for changed_resources).
+			originalEndDate := lineItem.EndDate
+
 			// End the old line item at effective date
 			lineItem.EndDate = effectiveDate
 			if err := sp.SubscriptionLineItemRepo.Update(txCtx, lineItem); err != nil {
@@ -461,13 +464,20 @@ func (s *subscriptionModificationService) executeQuantityChange(
 					Mark(ierr.ErrDatabase)
 			}
 
+			oldStart := lineItem.StartDate
 			endDate := effectiveDate
 			startDate := effectiveDate
+			// New item runs from effectiveDate until the original item's end (or period end if open-ended).
+			newEndDate := sub.CurrentPeriodEnd
+			if !originalEndDate.IsZero() {
+				newEndDate = originalEndDate
+			}
 			changedLineItems = append(changedLineItems,
 				dto.ChangedLineItem{
 					ID:           lineItem.ID,
 					PriceID:      lineItem.PriceID,
 					Quantity:     lineItem.Quantity,
+					StartDate:    &oldStart,
 					EndDate:      &endDate,
 					ChangeAction: "ended",
 				},
@@ -476,15 +486,14 @@ func (s *subscriptionModificationService) executeQuantityChange(
 					PriceID:      newItem.PriceID,
 					Quantity:     newItem.Quantity,
 					StartDate:    &startDate,
+					EndDate:      &newEndDate,
 					ChangeAction: "created",
 				},
 			)
 
 			// Collect pairs that need proration (handled after the transaction commits).
-			// Only ADVANCE items are prorated immediately; ARREAR items settle at period end.
-			// Respect the subscription's proration_behavior setting.
-			if lineItem.InvoiceCadence == types.InvoiceCadenceAdvance &&
-				sub.ProrationBehavior != types.ProrationBehaviorNone {
+			// ADVANCE items are billed upfront, so any mid-cycle quantity change requires a proration.
+			if lineItem.InvoiceCadence == types.InvoiceCadenceAdvance {
 				itemsForProration = append(itemsForProration, prorationPair{old: lineItem, new_: newItem, effectiveDate: effectiveDate})
 			}
 		}
@@ -612,13 +621,20 @@ func (s *subscriptionModificationService) previewQuantityChange(
 			continue
 		}
 
+		oldStart := lineItem.StartDate
 		endDate := effectiveDate
 		startDate := effectiveDate
+		// New item runs from effectiveDate until the old item's end (or period end if open-ended).
+		newEndDate := sub.CurrentPeriodEnd
+		if !lineItem.EndDate.IsZero() {
+			newEndDate = lineItem.EndDate
+		}
 		changedLineItems = append(changedLineItems,
 			dto.ChangedLineItem{
 				ID:           "(preview-ended)",
 				PriceID:      lineItem.PriceID,
 				Quantity:     lineItem.Quantity,
+				StartDate:    &oldStart,
 				EndDate:      &endDate,
 				ChangeAction: "ended",
 			},
@@ -627,13 +643,14 @@ func (s *subscriptionModificationService) previewQuantityChange(
 				PriceID:      lineItem.PriceID,
 				Quantity:     change.Quantity,
 				StartDate:    &startDate,
+				EndDate:      &newEndDate,
 				ChangeAction: "created",
 			},
 		)
 
 		// Preview proration for ADVANCE items — calculate only, do NOT create invoices or wallet credits.
-		if lineItem.InvoiceCadence == types.InvoiceCadenceAdvance &&
-			sub.ProrationBehavior != types.ProrationBehaviorNone {
+		// Always preview for ADVANCE items regardless of proration_behavior (same reasoning as execute).
+		if lineItem.InvoiceCadence == types.InvoiceCadenceAdvance {
 			previewNewItem := &subscription.SubscriptionLineItem{
 				PriceID:  lineItem.PriceID,
 				Quantity: change.Quantity,

--- a/internal/service/subscription_modification_test.go
+++ b/internal/service/subscription_modification_test.go
@@ -227,15 +227,13 @@ func (s *SubscriptionModificationServiceSuite) setSubPeriod(subID string, start,
 // ─────────────────────────────────────────────
 
 // TestExecuteQuantityChange_Advance verifies invoice creation for upgrades,
-// wallet credit for downgrades, proration-behavior=none, and same-quantity no-ops
-// on ADVANCE (in-advance) line items.
+// wallet credit for downgrades, and same-quantity no-ops on ADVANCE (in-advance) line items.
 func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance() {
 	type tc struct {
 		name               string
 		oldQty             decimal.Decimal
 		newQty             decimal.Decimal
-		effectiveDayOffset int // days after periodStart; -1 = special sentinel (periodEnd - 1s)
-		prorationBehavior  types.ProrationBehavior
+		effectiveDayOffset int    // days after periodStart; -1 = special sentinel (periodEnd - 1s)
 		wantLineItems      int    // expected len(ChangedResources.LineItems)
 		wantInvoiceAction  string // "created", "wallet_credit", or "" (no invoice)
 		wantNoOp           bool   // old line item EndDate must remain zero
@@ -246,7 +244,6 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			oldQty:             decimal.NewFromInt(1),
 			newQty:             decimal.NewFromInt(3),
 			effectiveDayOffset: 15,
-			prorationBehavior:  types.ProrationBehaviorCreateProrations,
 			wantLineItems:      2,
 			wantInvoiceAction:  "created",
 		},
@@ -255,7 +252,6 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			oldQty:             decimal.NewFromInt(3),
 			newQty:             decimal.NewFromInt(1),
 			effectiveDayOffset: 15,
-			prorationBehavior:  types.ProrationBehaviorCreateProrations,
 			wantLineItems:      2,
 			wantInvoiceAction:  "wallet_credit",
 		},
@@ -264,7 +260,6 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			oldQty:             decimal.NewFromInt(1),
 			newQty:             decimal.NewFromInt(3),
 			effectiveDayOffset: 0,
-			prorationBehavior:  types.ProrationBehaviorCreateProrations,
 			wantLineItems:      2,
 			wantInvoiceAction:  "created",
 		},
@@ -273,25 +268,14 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			oldQty:             decimal.NewFromInt(1),
 			newQty:             decimal.NewFromInt(3),
 			effectiveDayOffset: -1, // sentinel: periodEnd - 1 second
-			prorationBehavior:  types.ProrationBehaviorCreateProrations,
 			wantLineItems:      2,
 			wantInvoiceAction:  "", // proration amount rounds to 0 at 1s before period end
-		},
-		{
-			name:               "proration_behavior_none",
-			oldQty:             decimal.NewFromInt(1),
-			newQty:             decimal.NewFromInt(3),
-			effectiveDayOffset: 15,
-			prorationBehavior:  types.ProrationBehaviorNone,
-			wantLineItems:      2,
-			wantInvoiceAction:  "",
 		},
 		{
 			name:               "same_quantity_noop",
 			oldQty:             decimal.NewFromInt(5),
 			newQty:             decimal.NewFromInt(5),
 			effectiveDayOffset: 5,
-			prorationBehavior:  types.ProrationBehaviorCreateProrations,
 			wantLineItems:      0,
 			wantInvoiceAction:  "",
 			wantNoOp:           true,
@@ -314,14 +298,6 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 
 			cust := s.createCustomer("adv-" + tc.name)
 			sub := s.createActiveSub(cust.ID)
-
-			// Patch proration behavior when test requires "none"
-			if tc.prorationBehavior == types.ProrationBehaviorNone {
-				storedSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
-				s.Require().NoError(err)
-				storedSub.ProrationBehavior = types.ProrationBehaviorNone
-				s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, storedSub))
-			}
 
 			priceAmount := decimal.NewFromInt(50)
 			p := s.createFixedPrice(priceAmount, types.InvoiceCadenceAdvance)
@@ -351,7 +327,8 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			}
 
 			if tc.wantInvoiceAction == "" {
-				s.Empty(resp.ChangedResources.Invoices, "expected no invoices for proration_behavior=none")
+				s.Empty(resp.ChangedResources.Invoices,
+					"expected no proration invoice or wallet credit (tc=%s)", tc.name)
 				return
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription quantity modifications now accurately track and preserve start and end dates for all created and ended line items, ensuring proper billing periods
  * Proration calculations now apply consistently across all advance invoice billing scenarios, eliminating previous behavior variations that depended on configuration settings
  * Original line item end dates are properly preserved during mid-subscription quantity updates, ensuring accurate billing period calculations and more reliable invoice generation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->