### PR TITLE
feat(subscription): add validation for BillingAnchor

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -383,8 +383,8 @@ type CreateSubscriptionRequest struct {
 	// If not set, the default value is UTC.
 	CustomerTimezone string `json:"customer_timezone" validate:"omitempty,timezone"`
 
-	//Billing Anchor
-	BillingAnchor *time.Time `json:"-"`
+	// BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.
+	BillingAnchor *time.Time `json:"billing_anchor,omitempty"`
 
 	// Workflow
 	Workflow *types.TemporalWorkflowType `json:"-"`
@@ -623,6 +623,15 @@ func (r *CreateSubscriptionRequest) Validate() error {
 
 	if err := r.BillingCycle.Validate(); err != nil {
 		return err
+	}
+	if r.BillingAnchor != nil && r.BillingCycle != types.BillingCycleAnniversary {
+		return ierr.NewError("invalid billing_anchor for billing_cycle").
+			WithHint("billing_anchor can only be passed when billing_cycle is anniversary").
+			WithReportableDetails(map[string]any{
+				"billing_cycle":  r.BillingCycle,
+				"billing_anchor": r.BillingAnchor,
+			}).
+			Mark(ierr.ErrValidation)
 	}
 
 	// Handle legacy collection method conversion and validation
@@ -1083,6 +1092,9 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 			billingAnchor = startDate
 		}
 		endDate = r.EndDate
+	}
+	if r.BillingAnchor != nil {
+		billingAnchor = *r.BillingAnchor
 	}
 
 	subscriptionType := r.SubscriptionType

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -1,0 +1,53 @@
+package dto
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+func baseCreateSubscriptionRequest() CreateSubscriptionRequest {
+	return CreateSubscriptionRequest{
+		CustomerID:     "cust_test",
+		PlanID:         "plan_test",
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		BillingCycle:   types.BillingCycleAnniversary,
+		StartDate:      nil,
+		EndDate:        nil,
+		BillingAnchor:  nil,
+		PaymentBehavior: nil,
+	}
+}
+
+func TestCreateSubscriptionRequestValidate_BillingAnchorRequiresAnniversaryBillingCycle(t *testing.T) {
+	anchor := time.Now().UTC()
+
+	t.Run("fails when billing_cycle is calendar", func(t *testing.T) {
+		req := baseCreateSubscriptionRequest()
+		req.BillingCycle = types.BillingCycleCalendar
+		req.BillingAnchor = &anchor
+
+		err := req.Validate()
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "billing_anchor") {
+			t.Fatalf("expected error to mention billing_anchor, got: %v", err)
+		}
+	})
+
+	t.Run("passes when billing_cycle is anniversary", func(t *testing.T) {
+		req := baseCreateSubscriptionRequest()
+		req.BillingCycle = types.BillingCycleAnniversary
+		req.BillingAnchor = &anchor
+
+		err := req.Validate()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+}

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -137,7 +137,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		sub.StartDate = sub.StartDate.UTC().Truncate(time.Millisecond)
 	}
 	if req.BillingAnchor != nil {
-		sub.BillingAnchor = *req.BillingAnchor
+		sub.BillingAnchor = lo.FromPtr(req.BillingAnchor)
 	} else if sub.BillingCycle == types.BillingCycleCalendar {
 		sub.BillingAnchor = types.CalculateCalendarBillingAnchor(sub.StartDate, sub.BillingPeriod)
 	} else {
@@ -1740,7 +1740,6 @@ func (s *subscriptionService) UpdateSubscription(ctx context.Context, subscripti
 	// Return the updated subscription
 	return s.GetSubscription(ctx, subscriptionID)
 }
-
 
 // CancelSubscription provides enhanced cancellation with proration support
 func (s *subscriptionService) CancelSubscription(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to specify a custom billing anchor date when creating subscriptions with anniversary billing cycles.
  * The billing anchor field is optional and validates that it only applies to anniversary billing cycle subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->