### PR TITLE
fix(sub): add inv and wallet tx in preview response

### DIFF
--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -23,14 +23,10 @@ func (r *SubModifyInheritanceRequest) Validate() error {
 	return nil
 }
 
-// =============================================
-// Quantity change
-// =============================================
-
 // LineItemQuantityChange describes a quantity change for a single line item.
 type LineItemQuantityChange struct {
-	ID            string          `json:"id" binding:"required"`
-	Quantity      decimal.Decimal `json:"quantity" swaggertype:"string" binding:"required"`
+	ID       string          `json:"id" binding:"required"`
+	Quantity decimal.Decimal `json:"quantity" swaggertype:"string" binding:"required"`
 	// EffectiveDate is when the quantity change takes effect.
 	// If omitted, the change is effective immediately (now).
 	EffectiveDate *time.Time `json:"effective_date,omitempty"`
@@ -61,10 +57,6 @@ func (r *SubModifyQuantityChangeRequest) Validate() error {
 	}
 	return nil
 }
-
-// =============================================
-// Unified execute / preview request
-// =============================================
 
 // SubscriptionModifyType identifies the kind of modification.
 type SubscriptionModifyType string
@@ -104,28 +96,78 @@ func (r *ExecuteSubscriptionModifyRequest) Validate() error {
 	}
 }
 
+// ChangedLineItemAction describes how a subscription line item changed.
+// @Description created | updated | ended
+type ChangedLineItemAction string
+
+const (
+	ChangedLineItemActionCreated ChangedLineItemAction = "created"
+	ChangedLineItemActionUpdated ChangedLineItemAction = "updated"
+	ChangedLineItemActionEnded   ChangedLineItemAction = "ended"
+)
+
+// ChangedSubscriptionAction describes how a subscription row changed.
+// @Description created | updated
+type ChangedSubscriptionAction string
+
+const (
+	ChangedSubscriptionActionCreated ChangedSubscriptionAction = "created"
+	ChangedSubscriptionActionUpdated ChangedSubscriptionAction = "updated"
+)
+
+// ChangedInvoiceAction classifies invoice-side effects from a modification.
+// @Description created (proration invoice) | wallet_credit (downgrade credit)
+type ChangedInvoiceAction string
+
+const (
+	ChangedInvoiceActionCreated      ChangedInvoiceAction = "created"
+	ChangedInvoiceActionWalletCredit ChangedInvoiceAction = "wallet_credit"
+)
+
+// ChangedInvoiceStatus is the high-level status for ChangedInvoice.
+// Values "preview" and "issued" are used for preview payloads and completed wallet credits.
+// Proration invoice results use the same strings as types.PaymentStatus (e.g. SUCCEEDED, PENDING, FAILED).
+// @Description preview | issued | INITIATED | PENDING | PROCESSING | SUCCEEDED | OVERPAID | FAILED | REFUNDED | PARTIALLY_REFUNDED
+type ChangedInvoiceStatus string
+
+const (
+	ChangedInvoiceStatusPreview      ChangedInvoiceStatus = "preview"
+	ChangedInvoiceStatusWalletIssued ChangedInvoiceStatus = "issued"
+)
+
+// ChangedInvoiceStatusFromPaymentStatus maps a persisted invoice payment status for execute responses.
+func ChangedInvoiceStatusFromPaymentStatus(ps types.PaymentStatus) ChangedInvoiceStatus {
+	return ChangedInvoiceStatus(ps)
+}
+
 // ChangedLineItem describes a subscription line item that was created, updated, or ended.
 type ChangedLineItem struct {
-	ID           string          `json:"id"`
-	PriceID      string          `json:"price_id"`
-	Quantity     decimal.Decimal `json:"quantity" swaggertype:"string"`
-	StartDate    *time.Time      `json:"start_date,omitempty"`
-	EndDate      *time.Time      `json:"end_date,omitempty"`
-	ChangeAction string          `json:"change_action"` // "created" | "updated" | "ended"
+	ID           string                `json:"id"`
+	PriceID      string                `json:"price_id"`
+	Quantity     decimal.Decimal       `json:"quantity" swaggertype:"string"`
+	StartDate    *time.Time            `json:"start_date,omitempty"`
+	EndDate      *time.Time            `json:"end_date,omitempty"`
+	ChangeAction ChangedLineItemAction `json:"change_action" enums:"created,updated,ended"`
 }
 
 // ChangedSubscription describes a subscription that was created or updated.
 type ChangedSubscription struct {
-	ID     string                   `json:"id"`
-	Action string                   `json:"action"` // "created" | "updated"
-	Status types.SubscriptionStatus `json:"status"`
+	ID     string                    `json:"id"`
+	Action ChangedSubscriptionAction `json:"action"`
+	Status types.SubscriptionStatus  `json:"status"`
 }
 
-// ChangedInvoice describes a proration invoice that was created.
+// ChangedInvoice describes a proration invoice or wallet credit from a modification.
 type ChangedInvoice struct {
-	ID     string `json:"id"`
-	Action string `json:"action"` // "created" | "wallet_credit"
-	Status string `json:"status"`
+	ID string `json:"id"`
+	// Action is created for a proration charge invoice, wallet_credit for downgrade credit.
+	Action ChangedInvoiceAction `json:"action"`
+	// Status is preview (dry-run), issued (wallet credit applied), or a PaymentStatus string for real invoices.
+	Status ChangedInvoiceStatus `json:"status"`
+	// Invoice is set for proration charges: preview returns a synthetic invoice; execute returns the persisted invoice when created.
+	Invoice *InvoiceResponse `json:"invoice,omitempty"`
+	// WalletTransaction is set for downgrade wallet credits: preview is synthetic; execute returns the transaction from the top-up.
+	WalletTransaction *WalletTransactionResponse `json:"wallet_transaction,omitempty"`
 }
 
 // ChangedResources is the Orb-inspired envelope for all mutation side-effects.

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1741,7 +1741,6 @@ func (s *subscriptionService) UpdateSubscription(ctx context.Context, subscripti
 	return s.GetSubscription(ctx, subscriptionID)
 }
 
-
 // CancelSubscription provides enhanced cancellation with proration support
 func (s *subscriptionService) CancelSubscription(
 	ctx context.Context,
@@ -1938,7 +1937,7 @@ func (s *subscriptionService) CancelSubscription(
 		if totalCreditAmount.GreaterThan(decimal.Zero) {
 			walletService := NewWalletService(s.ServiceParams)
 			cancelKey := s.buildCancellationProrationKey(subscription, req, effectiveDate)
-			err = walletService.TopUpWalletForProratedCharge(ctx, subscription.CustomerID, totalCreditAmount.Abs(), subscription.Currency, cancelKey)
+			_, err = walletService.TopUpWalletForProratedCharge(ctx, subscription.GetInvoicingCustomerID(), totalCreditAmount.Abs(), subscription.Currency, cancelKey)
 			if err != nil {
 				return err
 			}

--- a/internal/service/subscription_modification.go
+++ b/internal/service/subscription_modification.go
@@ -909,19 +909,44 @@ func previewProrationQuantityChangeInvoiceResponse(
 	return dto.NewInvoiceResponse(inv)
 }
 
-func previewProrationWalletTransactionResponse(
+func (s *subscriptionModificationService) previewProrationWalletTransactionResponse(
 	ctx context.Context,
 	sub *subscription.Subscription,
-	creditAmount decimal.Decimal,
-) *dto.WalletTransactionResponse {
+	currencyTopUpAmount decimal.Decimal,
+) (*dto.WalletTransactionResponse, error) {
 	billingCustomer := sub.GetInvoicingCustomerID()
+	currency := sub.Currency
+
+	topupRate := decimal.NewFromInt(1)
+	walletSvc := NewWalletService(s.serviceParams)
+	if billingCustomer != "" {
+		existingWallets, err := walletSvc.GetWalletsByCustomerID(ctx, billingCustomer)
+		if err != nil {
+			return nil, err
+		}
+		var selected *dto.WalletResponse
+		for _, w := range existingWallets {
+			if w.WalletStatus == types.WalletStatusActive &&
+				types.IsMatchingCurrency(w.Currency, currency) &&
+				w.WalletType == types.WalletTypePrePaid {
+				selected = w
+				break
+			}
+		}
+		if selected != nil && !selected.TopupConversionRate.IsZero() && selected.TopupConversionRate.GreaterThan(decimal.Zero) {
+			topupRate = selected.TopupConversionRate
+		}
+	}
+
+	creditAmount := walletSvc.GetCreditsFromCurrencyAmount(currencyTopUpAmount, topupRate)
+
 	envID := types.GetEnvironmentID(ctx)
 	bm := types.GetDefaultBaseModel(ctx)
 	tx := &wallet.Transaction{
 		ID:                  "(preview-wallet-credit)",
 		CustomerID:          billingCustomer,
 		Type:                types.TransactionTypeCredit,
-		Amount:              creditAmount,
+		Amount:              currencyTopUpAmount,
 		CreditAmount:        creditAmount,
 		CreditBalanceBefore: decimal.Zero,
 		CreditBalanceAfter:  creditAmount,
@@ -933,8 +958,9 @@ func previewProrationWalletTransactionResponse(
 		Currency:            sub.Currency,
 		EnvironmentID:       envID,
 		BaseModel:           bm,
+		TopupConversionRate: lo.ToPtr(topupRate),
 	}
-	return dto.FromWalletTransaction(tx)
+	return dto.FromWalletTransaction(tx), nil
 }
 
 // previewQuantityChangeProration calculates what proration would occur without creating any
@@ -999,7 +1025,10 @@ func (s *subscriptionModificationService) previewQuantityChangeProration(
 			Invoice: invResp,
 		}, nil
 	}
-	walletTx := previewProrationWalletTransactionResponse(ctx, sub, result.NetAmount.Abs())
+	walletTx, err := s.previewProrationWalletTransactionResponse(ctx, sub, result.NetAmount.Abs())
+	if err != nil {
+		return nil, err
+	}
 	return &dto.ChangedInvoice{
 		ID:                "(preview-wallet-credit)",
 		Action:            dto.ChangedInvoiceActionWalletCredit,

--- a/internal/service/subscription_modification.go
+++ b/internal/service/subscription_modification.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/domain/wallet"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	webhookDto "github.com/flexprice/flexprice/internal/webhook/dto"
@@ -143,7 +145,7 @@ func (s *subscriptionModificationService) executeInheritance(
 			}
 			changedSubs = append(changedSubs, dto.ChangedSubscription{
 				ID:     sub.ID,
-				Action: "updated",
+				Action: dto.ChangedSubscriptionActionUpdated,
 				Status: sub.SubscriptionStatus,
 			})
 		}
@@ -156,7 +158,7 @@ func (s *subscriptionModificationService) executeInheritance(
 			}
 			changedSubs = append(changedSubs, dto.ChangedSubscription{
 				ID:     inheritedSub.ID,
-				Action: "created",
+				Action: dto.ChangedSubscriptionActionCreated,
 				Status: inheritedSub.SubscriptionStatus,
 			})
 		}
@@ -240,14 +242,14 @@ func (s *subscriptionModificationService) previewInheritance(
 	if sub.SubscriptionType == types.SubscriptionTypeStandalone {
 		changedSubs = append(changedSubs, dto.ChangedSubscription{
 			ID:     sub.ID,
-			Action: "updated",
+			Action: dto.ChangedSubscriptionActionUpdated,
 			Status: sub.SubscriptionStatus,
 		})
 	}
 	for range childCustomerIDs {
 		changedSubs = append(changedSubs, dto.ChangedSubscription{
 			ID:     "(preview-created)",
-			Action: "created",
+			Action: dto.ChangedSubscriptionActionCreated,
 			Status: types.SubscriptionStatusActive,
 		})
 	}
@@ -459,9 +461,7 @@ func (s *subscriptionModificationService) executeQuantityChange(
 				BaseModel:               types.GetDefaultBaseModel(txCtx),
 			}
 			if err := sp.SubscriptionLineItemRepo.Create(txCtx, newItem); err != nil {
-				return ierr.WithError(err).
-					WithHint("Failed to create new line item with updated quantity").
-					Mark(ierr.ErrDatabase)
+				return err
 			}
 
 			oldStart := lineItem.StartDate
@@ -479,7 +479,7 @@ func (s *subscriptionModificationService) executeQuantityChange(
 					Quantity:     lineItem.Quantity,
 					StartDate:    &oldStart,
 					EndDate:      &endDate,
-					ChangeAction: "ended",
+					ChangeAction: dto.ChangedLineItemActionEnded,
 				},
 				dto.ChangedLineItem{
 					ID:           newItem.ID,
@@ -487,7 +487,7 @@ func (s *subscriptionModificationService) executeQuantityChange(
 					Quantity:     newItem.Quantity,
 					StartDate:    &startDate,
 					EndDate:      &newEndDate,
-					ChangeAction: "created",
+					ChangeAction: dto.ChangedLineItemActionCreated,
 				},
 			)
 
@@ -636,7 +636,7 @@ func (s *subscriptionModificationService) previewQuantityChange(
 				Quantity:     lineItem.Quantity,
 				StartDate:    &oldStart,
 				EndDate:      &endDate,
-				ChangeAction: "ended",
+				ChangeAction: dto.ChangedLineItemActionEnded,
 			},
 			dto.ChangedLineItem{
 				ID:           "(preview-created)",
@@ -644,7 +644,7 @@ func (s *subscriptionModificationService) previewQuantityChange(
 				Quantity:     change.Quantity,
 				StartDate:    &startDate,
 				EndDate:      &newEndDate,
-				ChangeAction: "created",
+				ChangeAction: dto.ChangedLineItemActionCreated,
 			},
 		)
 
@@ -736,6 +736,7 @@ func (s *subscriptionModificationService) handleQuantityChangeProration(
 		invoiceSvc := NewInvoiceService(sp)
 		periodEnd := sub.CurrentPeriodEnd
 		billingPeriod := string(sub.BillingPeriod)
+		billingCustomer := sub.GetInvoicingCustomerID()
 
 		// Build a descriptive line item for the delta charge.
 		qtyDelta := newItem.Quantity.Sub(oldItem.Quantity)
@@ -768,7 +769,7 @@ func (s *subscriptionModificationService) handleQuantityChangeProration(
 		// than recomputing from the subscription's (now-updated) line items.
 		// SubscriptionID is set for reference/traceability only.
 		inv, err := invoiceSvc.CreateInvoice(ctx, dto.CreateInvoiceRequest{
-			CustomerID:     sub.CustomerID,
+			CustomerID:     billingCustomer,
 			SubscriptionID: &sub.ID,
 			InvoiceType:    types.InvoiceTypeOneOff,
 			Currency:       sub.Currency,
@@ -796,26 +797,144 @@ func (s *subscriptionModificationService) handleQuantityChangeProration(
 			latest = inv
 		}
 		return &dto.ChangedInvoice{
-			ID:     latest.ID,
-			Action: "created",
-			Status: string(latest.PaymentStatus),
+			ID:      latest.ID,
+			Action:  dto.ChangedInvoiceActionCreated,
+			Status:  dto.ChangedInvoiceStatusFromPaymentStatus(latest.PaymentStatus),
+			Invoice: latest,
 		}, nil
 	}
 
 	// Downgrade: wallet credit
 	walletSvc := NewWalletService(sp)
 	creditAmount := result.NetAmount.Abs()
+	billingCustomer := sub.GetInvoicingCustomerID()
 	// Stable idempotency key: prevents duplicate credits if this call is retried.
 	idempotencyKey := fmt.Sprintf("proration_credit_%s_%s_%s", sub.ID, oldItem.ID, effectiveDate.Format(time.RFC3339))
-	if err := walletSvc.TopUpWalletForProratedCharge(ctx, sub.CustomerID, creditAmount, sub.Currency, idempotencyKey); err != nil {
+	walletTx, err := walletSvc.TopUpWalletForProratedCharge(ctx, billingCustomer, creditAmount, sub.Currency, idempotencyKey)
+	if err != nil {
 		sp.Logger.Errorw("failed to top up wallet for downgrade proration", "error", err)
 		return nil, err
 	}
+	changedID := "(wallet_credit)"
+	if walletTx != nil && walletTx.Transaction != nil && walletTx.ID != "" {
+		changedID = walletTx.ID
+	}
 	return &dto.ChangedInvoice{
-		ID:     "(wallet_credit)",
-		Action: "wallet_credit",
-		Status: "issued",
+		ID:                changedID,
+		Action:            dto.ChangedInvoiceActionWalletCredit,
+		Status:            dto.ChangedInvoiceStatusWalletIssued,
+		WalletTransaction: walletTx,
 	}, nil
+}
+
+// previewProrationQuantityChangeInvoiceResponse builds a non-persisted invoice shaped like the execute-path delta invoice.
+func previewProrationQuantityChangeInvoiceResponse(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	oldItem *subscription.SubscriptionLineItem,
+	newItem *subscription.SubscriptionLineItem,
+	effectiveDate time.Time,
+	priceResp *dto.PriceResponse,
+	netAmount decimal.Decimal,
+) *dto.InvoiceResponse {
+	billingCustomer := sub.GetInvoicingCustomerID()
+	periodEnd := sub.CurrentPeriodEnd
+	qtyDelta := newItem.Quantity.Sub(oldItem.Quantity)
+	displayName := fmt.Sprintf("%s — Quantity Change Proration (%s – %s)",
+		oldItem.PlanDisplayName,
+		effectiveDate.Format("2 Jan 2006"),
+		periodEnd.Format("2 Jan 2006"))
+	priceID := oldItem.PriceID
+	priceType := string(priceResp.Price.Type)
+	planDisplayName := oldItem.PlanDisplayName
+	lineItemDescription := fmt.Sprintf("Proration for quantity change: %s → %s units × %s %s/unit (%s – %s)",
+		oldItem.Quantity.String(), newItem.Quantity.String(),
+		strings.ToUpper(sub.Currency), priceResp.Price.Amount.String(),
+		effectiveDate.Format("2 Jan 2006"), periodEnd.Format("2 Jan 2006"))
+
+	subscriptionID := sub.ID
+	subscriptionCustomerID := sub.CustomerID
+	envID := types.GetEnvironmentID(ctx)
+	bm := types.GetDefaultBaseModel(ctx)
+
+	invLine := &invoice.InvoiceLineItem{
+		ID:                    "(preview-line)",
+		InvoiceID:             "(preview-invoice)",
+		CustomerID:            billingCustomer,
+		SubscriptionID:        &subscriptionID,
+		PlanDisplayName:       &planDisplayName,
+		PriceID:               &priceID,
+		PriceType:             &priceType,
+		DisplayName:           &displayName,
+		Amount:                netAmount,
+		Quantity:              qtyDelta,
+		Currency:              sub.Currency,
+		PeriodStart:           &effectiveDate,
+		PeriodEnd:             &periodEnd,
+		Metadata:              types.Metadata{"description": lineItemDescription},
+		EnvironmentID:         envID,
+		PrepaidCreditsApplied: decimal.Zero,
+		LineItemDiscount:      decimal.Zero,
+		InvoiceLevelDiscount:  decimal.Zero,
+		BaseModel:             bm,
+	}
+
+	inv := &invoice.Invoice{
+		ID:                         "(preview-invoice)",
+		CustomerID:                 billingCustomer,
+		SubscriptionID:             &subscriptionID,
+		SubscriptionCustomerID:     &subscriptionCustomerID,
+		InvoiceType:                types.InvoiceTypeOneOff,
+		InvoiceStatus:              types.InvoiceStatusDraft,
+		PaymentStatus:              types.PaymentStatusPending,
+		Currency:                   sub.Currency,
+		AmountDue:                  netAmount,
+		AmountPaid:                 decimal.Zero,
+		Subtotal:                   netAmount,
+		Total:                      netAmount,
+		TotalDiscount:              decimal.Zero,
+		AmountRemaining:            netAmount,
+		PeriodStart:                &effectiveDate,
+		PeriodEnd:                  &periodEnd,
+		BillingReason:              string(types.InvoiceBillingReasonSubscriptionUpdate),
+		LineItems:                  []*invoice.InvoiceLineItem{invLine},
+		Version:                    1,
+		EnvironmentID:              envID,
+		AdjustmentAmount:           decimal.Zero,
+		RefundedAmount:             decimal.Zero,
+		TotalTax:                   decimal.Zero,
+		TotalPrepaidCreditsApplied: decimal.Zero,
+		BaseModel:                  bm,
+	}
+	return dto.NewInvoiceResponse(inv)
+}
+
+func previewProrationWalletTransactionResponse(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	creditAmount decimal.Decimal,
+) *dto.WalletTransactionResponse {
+	billingCustomer := sub.GetInvoicingCustomerID()
+	envID := types.GetEnvironmentID(ctx)
+	bm := types.GetDefaultBaseModel(ctx)
+	tx := &wallet.Transaction{
+		ID:                  "(preview-wallet-credit)",
+		CustomerID:          billingCustomer,
+		Type:                types.TransactionTypeCredit,
+		Amount:              creditAmount,
+		CreditAmount:        creditAmount,
+		CreditBalanceBefore: decimal.Zero,
+		CreditBalanceAfter:  creditAmount,
+		TxStatus:            types.TransactionStatusCompleted,
+		ReferenceType:       types.WalletTxReferenceTypeExternal,
+		ReferenceID:         "preview",
+		Description:         "Proration credit from subscription change (preview)",
+		TransactionReason:   types.TransactionReasonSubscriptionCredit,
+		Currency:            sub.Currency,
+		EnvironmentID:       envID,
+		BaseModel:           bm,
+	}
+	return dto.FromWalletTransaction(tx)
 }
 
 // previewQuantityChangeProration calculates what proration would occur without creating any
@@ -872,17 +991,20 @@ func (s *subscriptionModificationService) previewQuantityChangeProration(
 
 	// Return a preview-only ChangedInvoice — no invoice is created, no payment attempted.
 	if result.NetAmount.GreaterThan(decimal.Zero) {
+		invResp := previewProrationQuantityChangeInvoiceResponse(ctx, sub, oldItem, newItem, effectiveDate, price, result.NetAmount)
 		return &dto.ChangedInvoice{
-			ID:     "(preview-invoice)",
-			Action: "created",
-			Status: "preview",
+			ID:      "(preview-invoice)",
+			Action:  dto.ChangedInvoiceActionCreated,
+			Status:  dto.ChangedInvoiceStatusPreview,
+			Invoice: invResp,
 		}, nil
 	}
-	// Downgrade preview
+	walletTx := previewProrationWalletTransactionResponse(ctx, sub, result.NetAmount.Abs())
 	return &dto.ChangedInvoice{
-		ID:     "(preview-wallet-credit)",
-		Action: "wallet_credit",
-		Status: "preview",
+		ID:                "(preview-wallet-credit)",
+		Action:            dto.ChangedInvoiceActionWalletCredit,
+		Status:            dto.ChangedInvoiceStatusPreview,
+		WalletTransaction: walletTx,
 	}, nil
 }
 

--- a/internal/service/subscription_modification_test.go
+++ b/internal/service/subscription_modification_test.go
@@ -233,10 +233,10 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 		name               string
 		oldQty             decimal.Decimal
 		newQty             decimal.Decimal
-		effectiveDayOffset int    // days after periodStart; -1 = special sentinel (periodEnd - 1s)
-		wantLineItems      int    // expected len(ChangedResources.LineItems)
-		wantInvoiceAction  string // "created", "wallet_credit", or "" (no invoice)
-		wantNoOp           bool   // old line item EndDate must remain zero
+		effectiveDayOffset int                      // days after periodStart; -1 = special sentinel (periodEnd - 1s)
+		wantLineItems      int                      // expected len(ChangedResources.LineItems)
+		wantInvoiceAction  dto.ChangedInvoiceAction // "created", "wallet_credit", or "" (no invoice)
+		wantNoOp           bool                     // old line item EndDate must remain zero
 	}
 	cases := []tc{
 		{
@@ -245,7 +245,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			newQty:             decimal.NewFromInt(3),
 			effectiveDayOffset: 15,
 			wantLineItems:      2,
-			wantInvoiceAction:  "created",
+			wantInvoiceAction:  dto.ChangedInvoiceActionCreated,
 		},
 		{
 			name:               "downgrade_midperiod",
@@ -253,7 +253,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			newQty:             decimal.NewFromInt(1),
 			effectiveDayOffset: 15,
 			wantLineItems:      2,
-			wantInvoiceAction:  "wallet_credit",
+			wantInvoiceAction:  dto.ChangedInvoiceActionWalletCredit,
 		},
 		{
 			name:               "upgrade_at_period_start",
@@ -261,7 +261,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			newQty:             decimal.NewFromInt(3),
 			effectiveDayOffset: 0,
 			wantLineItems:      2,
-			wantInvoiceAction:  "created",
+			wantInvoiceAction:  dto.ChangedInvoiceActionCreated,
 		},
 		{
 			name:               "upgrade_near_period_end",
@@ -335,9 +335,9 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 			s.Require().Len(resp.ChangedResources.Invoices, 1)
 			inv := resp.ChangedResources.Invoices[0]
 			s.Equal(tc.wantInvoiceAction, inv.Action)
-			s.NotEqual("failed", inv.Status)
+			s.NotEqual(dto.ChangedInvoiceStatusFromPaymentStatus(types.PaymentStatusFailed), inv.Status)
 
-			if tc.wantInvoiceAction == "created" {
+			if tc.wantInvoiceAction == dto.ChangedInvoiceActionCreated {
 				// Fetch real invoice and verify amount is positive and approximately correct
 				realInv, fetchErr := s.GetStores().InvoiceRepo.Get(ctx, inv.ID)
 				s.Require().NoError(fetchErr)
@@ -359,10 +359,12 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 				s.True(diff.LessThanOrEqual(tolerance),
 					"invoice amount %s should be ≈ %s (diff=%s)",
 					realInv.AmountDue.String(), expectedAmt.String(), diff.String())
+				s.Require().NotNil(inv.Invoice, "execute upgrade should include full invoice in changed_resources")
 			}
 
-			if tc.wantInvoiceAction == "wallet_credit" {
-				s.Equal("issued", inv.Status)
+			if tc.wantInvoiceAction == dto.ChangedInvoiceActionWalletCredit {
+				s.Equal(dto.ChangedInvoiceStatusWalletIssued, inv.Status)
+				s.Require().NotNil(inv.WalletTransaction, "execute downgrade should include wallet transaction")
 				wallets, err := s.GetStores().WalletRepo.GetWalletsByCustomerID(ctx, cust.ID)
 				s.Require().NoError(err)
 				s.Require().NotEmpty(wallets, "a PRE_PAID wallet must exist after downgrade credit")
@@ -431,7 +433,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Arrear(
 				// Verify the new line item exists with updated quantity
 				var newLIID string
 				for _, cli := range resp.ChangedResources.LineItems {
-					if cli.ChangeAction == "created" {
+					if cli.ChangeAction == dto.ChangedLineItemActionCreated {
 						newLIID = cli.ID
 					}
 				}
@@ -558,10 +560,10 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteInheritance_Success() 
 
 	actions := make(map[string]int)
 	for _, cs := range resp.ChangedResources.Subscriptions {
-		actions[cs.Action]++
+		actions[string(cs.Action)]++
 	}
-	s.Equal(1, actions["updated"], "expected one 'updated' entry")
-	s.Equal(1, actions["created"], "expected one 'created' entry")
+	s.Equal(1, actions[string(dto.ChangedSubscriptionActionUpdated)], "expected one 'updated' entry")
+	s.Equal(1, actions[string(dto.ChangedSubscriptionActionCreated)], "expected one 'created' entry")
 
 	// The parent subscription type should now be "parent"
 	updatedSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
@@ -666,10 +668,10 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Version
 
 	actions := make(map[string]int)
 	for _, cli := range resp.ChangedResources.LineItems {
-		actions[cli.ChangeAction]++
+		actions[string(cli.ChangeAction)]++
 	}
-	s.Equal(1, actions["ended"], "expected one 'ended' entry")
-	s.Equal(1, actions["created"], "expected one 'created' entry")
+	s.Equal(1, actions[string(dto.ChangedLineItemActionEnded)], "expected one 'ended' entry")
+	s.Equal(1, actions[string(dto.ChangedLineItemActionCreated)], "expected one 'created' entry")
 
 	// Verify old line item has EndDate set in the store
 	oldLI, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, li.ID)
@@ -679,7 +681,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Version
 	// Verify new line item exists with updated quantity
 	var newLIID string
 	for _, cli := range resp.ChangedResources.LineItems {
-		if cli.ChangeAction == "created" {
+		if cli.ChangeAction == dto.ChangedLineItemActionCreated {
 			newLIID = cli.ID
 		}
 	}
@@ -904,8 +906,9 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_MultiLi
 	s.Len(resp.ChangedResources.LineItems, 4)
 
 	s.Require().Len(resp.ChangedResources.Invoices, 1)
-	s.Equal("created", resp.ChangedResources.Invoices[0].Action)
-	s.NotEqual("failed", resp.ChangedResources.Invoices[0].Status)
+	s.Equal(dto.ChangedInvoiceActionCreated, resp.ChangedResources.Invoices[0].Action)
+	s.NotEqual(dto.ChangedInvoiceStatusFromPaymentStatus(types.PaymentStatusFailed), resp.ChangedResources.Invoices[0].Status)
+	s.Require().NotNil(resp.ChangedResources.Invoices[0].Invoice)
 }
 
 // TestExecuteQuantityChange_MultiLineItem_AtomicRollback verifies that a batch aborts
@@ -1046,8 +1049,19 @@ func (s *SubscriptionModificationServiceSuite) TestPreviewQuantityChange() {
 					"expected no invoice entry in response (tc=%s)", tc.name)
 			} else {
 				s.Require().Len(resp.ChangedResources.Invoices, 1)
-				s.Equal(tc.wantInvoiceID, resp.ChangedResources.Invoices[0].ID)
-				s.Equal(tc.wantInvoiceStatus, resp.ChangedResources.Invoices[0].Status)
+				inv := resp.ChangedResources.Invoices[0]
+				s.Equal(tc.wantInvoiceID, inv.ID)
+				s.Equal(dto.ChangedInvoiceStatus(tc.wantInvoiceStatus), inv.Status)
+				switch tc.wantInvoiceID {
+				case "(preview-invoice)":
+					s.Require().NotNil(inv.Invoice, "preview upgrade should include synthetic invoice")
+					s.Require().NotNil(inv.Invoice.SubscriptionID)
+					s.Equal(sub.ID, *inv.Invoice.SubscriptionID)
+					s.Equal(cust.ID, inv.Invoice.CustomerID)
+				case "(preview-wallet-credit)":
+					s.Require().NotNil(inv.WalletTransaction, "preview downgrade should include synthetic wallet tx")
+					s.Equal(cust.ID, inv.WalletTransaction.CustomerID)
+				}
 			}
 		})
 	}
@@ -1134,8 +1148,9 @@ func (s *SubscriptionModificationServiceSuite) TestProrationMath_Upgrade() {
 			s.Require().Len(resp.ChangedResources.Invoices, 1)
 
 			inv := resp.ChangedResources.Invoices[0]
-			s.Equal("created", inv.Action)
-			s.NotEqual("failed", inv.Status)
+			s.Equal(dto.ChangedInvoiceActionCreated, inv.Action)
+			s.NotEqual(dto.ChangedInvoiceStatusFromPaymentStatus(types.PaymentStatusFailed), inv.Status)
+			s.Require().NotNil(inv.Invoice)
 
 			realInv, fetchErr := s.GetStores().InvoiceRepo.Get(ctx, inv.ID)
 			s.Require().NoError(fetchErr)

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -94,7 +94,7 @@ type WalletService interface {
 	// TopUpWalletForProratedCharge tops up a wallet for proration credits from subscription changes.
 	// idempotencyKey should be a stable string derived from the change (e.g. lineItemID + effectiveDate)
 	// to prevent duplicate credits on retries.
-	TopUpWalletForProratedCharge(ctx context.Context, customerID string, amount decimal.Decimal, currency string, idempotencyKey string) error
+	TopUpWalletForProratedCharge(ctx context.Context, customerID string, amount decimal.Decimal, currency string, idempotencyKey string) (*dto.WalletTransactionResponse, error)
 
 	// CompletePurchasedCreditTransaction completes a pending wallet transaction when payment succeeds
 	CompletePurchasedCreditTransactionWithRetry(ctx context.Context, walletTransactionID string) error
@@ -2221,15 +2221,15 @@ func (s *walletService) CheckBalanceThresholds(ctx context.Context, w *wallet.Wa
 	return nil
 }
 
-func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, customerID string, amount decimal.Decimal, currency string, idempotencyKey string) error {
+func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, customerID string, amount decimal.Decimal, currency string, idempotencyKey string) (*dto.WalletTransactionResponse, error) {
 	if customerID == "" {
-		return ierr.NewError("customer_id is required").
+		return nil, ierr.NewError("customer_id is required").
 			WithHint("Customer ID is required for wallet top-up").
 			Mark(ierr.ErrValidation)
 	}
 
 	if amount.LessThanOrEqual(decimal.Zero) {
-		return ierr.NewError("amount must be positive").
+		return nil, ierr.NewError("amount must be positive").
 			WithHint("Top-up amount must be greater than zero").
 			Mark(ierr.ErrValidation)
 	}
@@ -2241,7 +2241,7 @@ func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, custom
 	// Get customer to validate existence
 	_, err := s.CustomerRepo.Get(ctx, customerID)
 	if err != nil {
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to get customer").
 			WithReportableDetails(map[string]interface{}{
 				"customer_id": customerID,
@@ -2252,7 +2252,7 @@ func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, custom
 	// Get existing wallets for the customer
 	existingWallets, err := s.GetWalletsByCustomerID(ctx, customerID)
 	if err != nil {
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to get existing wallets").
 			WithReportableDetails(map[string]interface{}{
 				"customer_id": customerID,
@@ -2293,7 +2293,7 @@ func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, custom
 
 		selectedWallet, err = s.CreateWallet(ctx, walletReq)
 		if err != nil {
-			return ierr.WithError(err).
+			return nil, ierr.WithError(err).
 				WithHint("Failed to create wallet for proration credit").
 				WithReportableDetails(map[string]interface{}{
 					"customer_id": customerID,
@@ -2315,9 +2315,9 @@ func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, custom
 		IdempotencyKey: lo.ToPtr(idempotencyKey),
 	}
 
-	_, err = s.TopUpWallet(ctx, selectedWallet.ID, topUpReq)
+	topUpResp, err := s.TopUpWallet(ctx, selectedWallet.ID, topUpReq)
 	if err != nil {
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to top up wallet with proration credit").
 			WithReportableDetails(map[string]interface{}{
 				"customer_id": customerID,
@@ -2333,7 +2333,13 @@ func (s *walletService) TopUpWalletForProratedCharge(ctx context.Context, custom
 		"amount", amount.String(),
 		"currency", currency)
 
-	return nil
+	if topUpResp == nil || topUpResp.WalletTransaction == nil {
+		return nil, ierr.NewError("wallet top-up returned no transaction").
+			WithHint("Proration credit was applied but transaction details are missing").
+			Mark(ierr.ErrInternal)
+	}
+
+	return topUpResp.WalletTransaction, nil
 }
 
 func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string) (*dto.WalletBalanceResponse, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected customer identifier usage for wallet proration top-ups to ensure accurate billing adjustments.

* **Improvements**
  * Subscription change responses now include typed action/status fields and return detailed invoice or wallet-transaction payloads (including in previews) for clearer billing visibility.
  * Wallet proration operations now surface the created wallet transaction information so credit events are visible in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->