### PR TITLE
fix(webhooks): write to system events immediately

### DIFF
--- a/internal/testutil/base_service_suite.go
+++ b/internal/testutil/base_service_suite.go
@@ -141,7 +141,7 @@ func (s *BaseServiceTestSuite) setupDependencies() {
 	eventStore := s.stores.EventRepo.(*InMemoryEventStore)
 	s.publisher = NewInMemoryEventPublisher(eventStore)
 	pubsub := NewInMemoryPubSub()
-	webhookPublisher, err := webhookPublisher.NewPublisher(pubsub, s.config, s.logger)
+	webhookPublisher, err := webhookPublisher.NewPublisher(pubsub, s.config, s.logger, nil)
 	if err != nil {
 		s.T().Fatalf("failed to create webhook publisher: %v", err)
 	}
@@ -242,7 +242,7 @@ func (s *BaseServiceTestSuite) setupStores() {
 	eventStore := s.stores.EventRepo.(*InMemoryEventStore)
 	s.publisher = NewInMemoryEventPublisher(eventStore)
 	pubsub := NewInMemoryPubSub()
-	webhookPublisher, err := webhookPublisher.NewPublisher(pubsub, s.config, s.logger)
+	webhookPublisher, err := webhookPublisher.NewPublisher(pubsub, s.config, s.logger, nil)
 	if err != nil {
 		s.T().Fatalf("failed to create webhook publisher: %v", err)
 	}

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -155,8 +155,8 @@ func (h *handler) processMessage(msg *message.Message) error {
 				"tenant_id", event.TenantID,
 				"event", event.EventName,
 			)
-			return nil
 		}
+		return nil
 	}
 
 	err := h.processMessageNative(ctx, &event, msg.UUID)

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -145,21 +145,30 @@ func (h *handler) processMessage(msg *message.Message) error {
 		"tenant_id", event.TenantID,
 	)
 
-	// Log inbound — create a bare system_events row (entity info populated on delivery).
-	if err := h.systemEventRepo.OnConsumed(ctx, &event); err != nil {
-		h.logger.Warnw("system_events OnConsumed failed",
-			"error", err,
-			"event_id", event.ID,
-			"event_name", event.EventName,
-		)
-	}
-
 	// After verify: deliver the webhook (Svix or native endpoint)
 	if h.config.Svix.Enabled {
-		return h.processMessageSvix(ctx, &event, msg.UUID)
+		err := h.processMessageSvix(ctx, &event, msg.UUID)
+		if err != nil {
+			h.logger.Errorw("failed to send webhook via Svix",
+				"error", err,
+				"message_uuid", msg.UUID,
+				"tenant_id", event.TenantID,
+				"event", event.EventName,
+			)
+			return nil
+		}
 	}
 
-	return h.processMessageNative(ctx, &event, msg.UUID)
+	err := h.processMessageNative(ctx, &event, msg.UUID)
+	if err != nil {
+		h.logger.Errorw("failed to send webhook via native endpoint",
+			"error", err,
+			"message_uuid", msg.UUID,
+			"tenant_id", event.TenantID,
+			"event", event.EventName,
+		)
+	}
+	return nil
 }
 
 // processMessageSvix processes a webhook message using Svix

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -6,6 +6,7 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/pubsub"
 	"github.com/flexprice/flexprice/internal/pubsub/kafka"
+	repoent "github.com/flexprice/flexprice/internal/repository/ent"
 	"github.com/flexprice/flexprice/internal/sentry"
 	"github.com/flexprice/flexprice/internal/service"
 	"github.com/flexprice/flexprice/internal/webhook/handler"
@@ -76,6 +77,7 @@ func provideWebhookPublisher(
 	cfg *config.Configuration,
 	logger *logger.Logger,
 	producer *kafkaProducerPkg.Producer,
+	systemEventRepo *repoent.SystemEventRepository,
 ) (publisher.WebhookPublisher, error) {
-	return publisher.NewPublisherFromProducer(producer, cfg, logger)
+	return publisher.NewPublisherFromProducer(producer, cfg, logger, systemEventRepo)
 }

--- a/internal/webhook/publisher/publisher.go
+++ b/internal/webhook/publisher/publisher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/pubsub"
+	repoent "github.com/flexprice/flexprice/internal/repository/ent"
 	"github.com/flexprice/flexprice/internal/types"
 )
 
@@ -27,10 +28,11 @@ type WebhookPublisher interface {
 
 // webhookPublisher publishes webhook events to a topic (memory PubSub or shared Kafka producer).
 type webhookPublisher struct {
-	pubSub   pubsub.PubSub       // used when pubsub is memory
-	producer MessagePublisher    // used when pubsub is kafka (shared producer); Close is no-op
-	config   *config.Webhook
-	logger   *logger.Logger
+	pubSub          pubsub.PubSub    // used when pubsub is memory
+	producer        MessagePublisher // used when pubsub is kafka (shared producer); Close is no-op
+	config          *config.Webhook
+	logger          *logger.Logger
+	systemEventRepo *repoent.SystemEventRepository
 }
 
 // NewPublisher creates a webhook publisher backed by a PubSub (e.g. in-memory for tests/local).
@@ -38,11 +40,13 @@ func NewPublisher(
 	pubSub pubsub.PubSub,
 	cfg *config.Configuration,
 	logger *logger.Logger,
+	systemEventRepo *repoent.SystemEventRepository,
 ) (WebhookPublisher, error) {
 	return &webhookPublisher{
-		pubSub: pubSub,
-		config: &cfg.Webhook,
-		logger: logger,
+		pubSub:          pubSub,
+		config:          &cfg.Webhook,
+		logger:          logger,
+		systemEventRepo: systemEventRepo,
 	}, nil
 }
 
@@ -52,11 +56,13 @@ func NewPublisherFromProducer(
 	producer MessagePublisher,
 	cfg *config.Configuration,
 	logger *logger.Logger,
+	systemEventRepo *repoent.SystemEventRepository,
 ) (WebhookPublisher, error) {
 	return &webhookPublisher{
-		producer: producer,
-		config:   &cfg.Webhook,
-		logger:   logger,
+		producer:        producer,
+		config:          &cfg.Webhook,
+		logger:          logger,
+		systemEventRepo: systemEventRepo,
 	}, nil
 }
 
@@ -83,6 +89,14 @@ func (p *webhookPublisher) PublishWebhook(ctx context.Context, event *types.Webh
 		"topic", p.config.Topic,
 		"payload", string(payload),
 	)
+
+	if err := p.systemEventRepo.OnConsumed(ctx, event); err != nil {
+		p.logger.ErrorwCtx(ctx, "system_events OnConsumed failed",
+			"error", err,
+			"event_id", event.ID,
+			"event_name", event.EventName,
+		)
+	}
 
 	if p.producer != nil {
 		if err := p.producer.Publish(p.config.Topic, msg); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook error logging and changed delivery failure handling so delivery errors are logged but no longer cause automatic retries or propagate as failures.
* **Refactor**
  * Webhook publishing now records message consumption state before sending; failures to record are logged but do not block delivery. Internal wiring updated to support this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->