### PR TITLE
     feat(workflow): add GitHub Action to close stale pull requests after 15 days of inactivity

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,90 @@
+# Closes open pull requests with no activity for more than 15 days (non-draft).
+# Schedule: daily; manual runs via workflow_dispatch.
+
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: close-stale-prs
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close:
+    name: Close inactive PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PRs with no updates for 15+ days (excluding drafts)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          CUTOFF=$(date -u -d '15 days ago' +%s)
+
+          # List open PRs; raise --limit if the repo routinely has >500 open PRs
+          PR_JSON=$(gh pr list --state open --json number,updatedAt,title,url,isDraft --limit 500)
+
+          mapfile -t TO_CLOSE < <(echo "$PR_JSON" | jq -r --argjson cutoff "$CUTOFF" '
+            .[]
+            | select(.isDraft == false)
+            | select((.updatedAt | fromdateiso8601) < $cutoff)
+            | .number
+          ')
+
+          CLOSED=0
+          {
+            echo "## Stale PR closure"
+            echo ""
+            echo "**Cutoff:** no \`updatedAt\` since $(date -u -d '15 days ago' -Iseconds) (UTC)"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ ${#TO_CLOSE[@]} -eq 0 ] || [ -z "${TO_CLOSE[0]:-}" ]; then
+            echo "No matching PRs to close."
+            {
+              echo "### Summary"
+              echo "No pull requests matched the stale criteria (**0** closed)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          COMMENT="This pull request was closed automatically because it has had no activity for more than 15 days. Reopen or open a new PR when you are ready to continue."
+
+          {
+            echo "### Closed pull requests"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Closing ${#TO_CLOSE[@]} pull request(s); links will appear in the step summary and below."
+          echo ""
+
+          for num in "${TO_CLOSE[@]}"; do
+            echo "Closing PR #$num"
+            gh pr close "$num" --comment "$COMMENT"
+            # Step summary: one markdown line per PR (jq avoids shell quoting issues with titles)
+            echo "$PR_JSON" | jq -r --argjson n "$num" '.[] | select(.number == $n) | "- **#\(.number)** — [\(.title)](\(.url))"' >> "$GITHUB_STEP_SUMMARY"
+            URL=$(echo "$PR_JSON" | jq -r --argjson n "$num" '.[] | select(.number == $n) | .url')
+            echo "  Closed: ${URL}"
+            CLOSED=$((CLOSED + 1))
+          done
+
+          echo ""
+          echo "=== Summary: ${CLOSED} PR(s) closed (GitHub URLs) ==="
+          for num in "${TO_CLOSE[@]}"; do
+            echo "$PR_JSON" | jq -r --argjson n "$num" '.[] | select(.number == $n) | .url'
+          done
+
+          {
+            echo ""
+            echo "### Summary"
+            echo "**${CLOSED}** pull request(s) closed this run."
+            echo ""
+            echo "Each item under **Closed pull requests** is a link to the PR on GitHub."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/delete-stale-branches.yml
+++ b/.github/workflows/delete-stale-branches.yml
@@ -1,0 +1,137 @@
+# Deletes remote branches whose tip commit is older than 2 months (committer date).
+# Skips the default branch, common protected names, and any branch that is the head of an open PR.
+
+name: Delete stale branches
+
+on:
+  schedule:
+    - cron: "0 7 * * 0" # 07:00 UTC every Sunday
+  workflow_dispatch:
+
+concurrency:
+  group: delete-stale-branches
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  delete-stale:
+    name: Remove remote branches inactive 2+ months
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout full history (for per-ref commit dates)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Delete stale remote branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git fetch --prune origin
+
+          CUTOFF=$(date -u -d '2 months ago' +%s)
+
+          DEFAULT=$(gh repo view "${GITHUB_REPOSITORY}" --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+          # Branches that must never be deleted here (plus default branch above)
+          PROTECTED_NAMES=(main master develop)
+
+          # Only same-repo PR heads: fork PRs use branches on the fork, not on this repo
+          mapfile -t OPEN_PR_BRANCHES < <(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls" -f state=open --paginate \
+              --jq --arg r "${GITHUB_REPOSITORY}" '.[] | select(.head.repo.full_name == $r) | .head.ref' \
+              | sort -u
+          )
+
+          is_protected() {
+            local b="$1"
+            [ "$b" = "$DEFAULT" ] && return 0
+            local n
+            for n in "${PROTECTED_NAMES[@]}"; do
+              [ "$b" = "$n" ] && return 0
+            done
+            return 1
+          }
+
+          is_open_pr_head() {
+            local b="$1"
+            local h
+            for h in "${OPEN_PR_BRANCHES[@]}"; do
+              [ "$b" = "$h" ] && return 0
+            done
+            return 1
+          }
+
+          DELETED=0
+          {
+            echo "## Stale branch deletion"
+            echo ""
+            echo "**Rule:** delete remote \`refs/heads/*\` whose tip \`committer\` date is **before** $(date -u -d '2 months ago' -Iseconds) (UTC)."
+            echo ""
+            echo "**Skipped:** default branch (\`${DEFAULT}\`), named long-lived branches (\`main\` / \`master\` / \`develop\`), and any branch that is the **head** of an **open** PR."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          declare -a TO_DELETE=()
+
+          while IFS='|' read -r ref_short ts; do
+            [ -z "$ref_short" ] && continue
+            branch="${ref_short#origin/}"
+            [ -z "$branch" ] && continue
+            [ "$branch" = "HEAD" ] && continue
+            [[ "$ref_short" == origin/HEAD ]] && continue
+
+            is_protected "$branch" && continue
+            is_open_pr_head "$branch" && continue
+
+            if [ "$ts" -lt "$CUTOFF" ] 2>/dev/null; then
+              TO_DELETE+=("$branch")
+            fi
+          done < <(
+            git for-each-ref refs/remotes/origin/ \
+              --format='%(refname:short)|%(committerdate:unix)'
+          )
+
+          if [ ${#TO_DELETE[@]} -eq 0 ]; then
+            echo "No stale remote branches to delete."
+            {
+              echo "### Summary"
+              echo "**0** branch(es) deleted."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "Deleting ${#TO_DELETE[@]} stale remote branch(es)."
+          echo ""
+
+          {
+            echo "### Deleted branches"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          BASE_URL="https://github.com/${GITHUB_REPOSITORY}"
+
+          for branch in "${TO_DELETE[@]}"; do
+            echo "Deleting origin/${branch}"
+            git push origin --delete "$branch"
+            echo "- **\`${branch}\`**" >> "$GITHUB_STEP_SUMMARY"
+            echo "  Removed remote ref \`refs/heads/${branch}\` (previously ${BASE_URL}/tree/${branch})"
+            DELETED=$((DELETED + 1))
+          done
+
+          echo ""
+          echo "=== Summary: ${DELETED} remote branch(es) deleted ==="
+          for branch in "${TO_DELETE[@]}"; do
+            echo "${branch}"
+          done
+
+          {
+            echo ""
+            echo "### Summary"
+            echo "**${DELETED}** remote branch(es) deleted this run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/delete-stale-branches.yml
+++ b/.github/workflows/delete-stale-branches.yml
@@ -67,6 +67,18 @@ jobs:
             return 1
           }
 
+          # Derive GitHub username from a noreply email when possible (common for GitHub web commits)
+          github_handle_from_email() {
+            local e="$1"
+            if [[ "$e" =~ ^[0-9]+\+([^@]+)@users\.noreply\.github\.com$ ]]; then
+              printf '@%s' "${BASH_REMATCH[1]}"
+            elif [[ "$e" =~ ^([^@]+)@users\.noreply\.github\.com$ ]]; then
+              printf '@%s' "${BASH_REMATCH[1]}"
+            else
+              printf ''
+            fi
+          }
+
           DELETED=0
           {
             echo "## Stale branch deletion"
@@ -112,15 +124,30 @@ jobs:
           {
             echo "### Deleted branches"
             echo ""
+            echo "| Branch | Tip \`sha\` | Author (last commit) | Email | GitHub user (from noreply) |"
+            echo "| --- | --- | --- | --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           BASE_URL="https://github.com/${GITHUB_REPOSITORY}"
 
           for branch in "${TO_DELETE[@]}"; do
-            echo "Deleting origin/${branch}"
+            REF="origin/${branch}"
+            # Must read tip before deleting the remote ref (separate fields: author/email may contain |)
+            SHA=$(git rev-parse --short "$REF" 2>/dev/null || echo "???????")
+            AUTHOR=$(git log -1 --format='%an' "$REF" 2>/dev/null || echo "?")
+            EMAIL=$(git log -1 --format='%ae' "$REF" 2>/dev/null || echo "?")
+            GH_HANDLE="$(github_handle_from_email "$EMAIL")"
+
+            echo "Deleting origin/${branch} (tip ${SHA} by ${AUTHOR})"
             git push origin --delete "$branch"
-            echo "- **\`${branch}\`**" >> "$GITHUB_STEP_SUMMARY"
-            echo "  Removed remote ref \`refs/heads/${branch}\` (previously ${BASE_URL}/tree/${branch})"
+
+            # Markdown table row: escape pipes in text fields
+            AUTH_ESC="${AUTHOR//|/\\|}"
+            EMAIL_ESC="${EMAIL//|/\\|}"
+            echo "| \`${branch}\` | \`${SHA}\` | ${AUTH_ESC} | ${EMAIL_ESC} | ${GH_HANDLE:-—} |" >> "$GITHUB_STEP_SUMMARY"
+
+            echo "  Removed \`refs/heads/${branch}\` — tip ${SHA}, author: ${AUTHOR} <${EMAIL}> ${GH_HANDLE:+(GitHub ${GH_HANDLE})}"
+            echo "  (was ${BASE_URL}/tree/${branch})"
             DELETED=$((DELETED + 1))
           done
 
@@ -133,5 +160,7 @@ jobs:
           {
             echo ""
             echo "### Summary"
-            echo "**${DELETED}** remote branch(es) deleted this run."
+            echo "**${DELETED}** remote branch(es) deleted this run. The table above lists each branch with the **last commit** author and email from the tip before deletion."
+            echo ""
+            echo "When the email is a GitHub \`users.noreply.github.com\` address, the **GitHub user** column shows the inferred handle (e.g. \`@octocat\`). Other emails show — in that column."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -436,11 +436,11 @@ func (s *onboardingService) OnboardNewUserWithTenant(ctx context.Context, userID
 			return err
 		}
 
-		if envType == types.EnvironmentDevelopment {
-			if err := s.SetupSandboxEnvironment(ctx, tenantID, userID, env.ID); err != nil {
-				return err
-			}
-		}
+		// if envType == types.EnvironmentDevelopment {
+		// 	if err := s.SetupSandboxEnvironment(ctx, tenantID, userID, env.ID); err != nil {
+		// 		return err
+		// 	}
+		// }
 	}
 
 	// Send Zapier webhook for onboarding (never fails - errors are logged internally)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a daily workflow to automatically close pull requests with no activity for 15+ days (runs at 06:00 UTC; manual dispatch available). Closed PRs receive a comment explaining the reason and advising how to reopen or resubmit.
  * Added a weekly workflow to delete remote branches older than ~2 months (runs Sundays 07:00 UTC; manual dispatch available), skipping default/protected branches and branches with open PRs; detailed deletion summaries are recorded.
* **Bug Fix**
  * Disabled automatic sandbox environment setup during new user onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->