### PR TITLE
fix(invoice): prevent nil pointer dereference in IsFinalizationDue

### DIFF
--- a/internal/service/invoice.go
+++ b/internal/service/invoice.go
@@ -993,7 +993,7 @@ func (s *invoiceService) IsFinalizationDue(ctx context.Context, invoiceID string
 		return false, nil
 	}
 
-	if inv.LastComputedAt != nil && inv.LastComputedAt.Before(*inv.PeriodEnd) && inv.BillingReason == string(types.InvoiceBillingReasonSubscriptionCycle) {
+	if inv.LastComputedAt != nil && inv.PeriodEnd != nil && inv.LastComputedAt.Before(*inv.PeriodEnd) && inv.BillingReason == string(types.InvoiceBillingReasonSubscriptionCycle) {
 		return false, nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes a runtime panic in the invoice finalization workflow caused by dereferencing a nil  pointer.

## Problem

The  method in the invoice service was dereferencing  without first checking if it was nil, causing a panic in the :

```
runtime error: invalid memory address or nil pointer dereference
at github.com/flexprice/flexprice/internal/service/invoice.go:996
```

## Solution

Add a nil check for  before dereferencing it in the condition at line 996.

## Changes

- Added  check before dereferencing in 
- This prevents the panic when processing invoices that may have a nil PeriodEnd value

## Testing

This fix ensures the finalization activity can safely handle invoices with nil PeriodEnd values by skipping the comparison logic and continuing to the next check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed an issue preventing proper finalization of invoices in subscription-cycle billing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->