### PR TITLE
fix: disable benchmark usage

### DIFF
--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -2426,7 +2426,7 @@ func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string)
 			if err != nil {
 				return nil, err
 			}
-			s.publishBenchmarkEvent(ctx, sub.ID, periodStart, periodEnd)
+			// s.publishBenchmarkEvent(ctx, sub.ID, periodStart, periodEnd)
 
 			// Calculate usage charges for feature usage data
 			usageCharges, usageTotal, err := billingService.CalculateFeatureUsageCharges(ctx, sub, usage, periodStart, periodEnd, nil)
@@ -2595,7 +2595,7 @@ func (s *walletService) GetWalletBalanceFromCache(ctx context.Context, walletID 
 			if err != nil {
 				return nil, err
 			}
-			s.publishBenchmarkEvent(ctx, sub.ID, periodStart, periodEnd)
+			// s.publishBenchmarkEvent(ctx, sub.ID, periodStart, periodEnd)
 			// Calculate usage charges for feature usage data
 			usageCharges, usageTotal, err := billingService.CalculateFeatureUsageCharges(ctx, sub, usage, periodStart, periodEnd, nil)
 			if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled benchmark event publishing in wallet balance calculation operations during per-subscription feature-usage charge calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->