### PR TITLE
fix(meter): reject duplicate filter keys in Meter.Validate

### DIFF
--- a/internal/domain/meter/model.go
+++ b/internal/domain/meter/model.go
@@ -242,6 +242,7 @@ func (m *Meter) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	seenKeys := make(map[string]struct{}, len(m.Filters))
 	for _, filter := range m.Filters {
 		if filter.Key == "" {
 			return ierr.NewError("filter key cannot be empty").
@@ -256,6 +257,15 @@ func (m *Meter) Validate() error {
 				}).
 				Mark(ierr.ErrValidation)
 		}
+		if _, exists := seenKeys[filter.Key]; exists {
+			return ierr.NewError("duplicate filter key").
+				WithHint("Each filter key must be unique within a meter").
+				WithReportableDetails(map[string]interface{}{
+					"filter_key": filter.Key,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		seenKeys[filter.Key] = struct{}{}
 	}
 	return nil
 }


### PR DESCRIPTION
Two Filter entries sharing the same Key would silently overwrite each other in ToFilterMap(), causing part of the filter set to be lost and potentially querying the wrong usage data. Meter.Validate() now returns a validation error when duplicate filter keys are detected.

Fixes #1530


## 📝 Description
`Meter.ToFilterMap()` in `internal/domain/meter/model.go` converts `Meter.Filters` (a `[]Filter`) into a `map[string][]string`. When two `Filter` entries share the same `Key`, the later entry silently overwrites the earlier one in the resulting map, so part of the configured filter set is dropped. Downstream usage queries then run against an incomplete filter definition and can return the wrong usage data.
`Meter.Validate()` did not guard against this — it only checked that each filter had a non-empty key and at least one value. This PR extends the existing per-filter validation loop with a duplicate-key guard that returns an `ierr.ErrValidation` error (`"duplicate filter key"`) with the offending key in `WithReportableDetails`, so such meters are rejected before they can reach `ToFilterMap()`.

---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

**File changed:** `internal/domain/meter/model.go`
- Added a `seenKeys := make(map[string]struct{}, len(m.Filters))` set inside `Meter.Validate()`.
- Inside the existing filter loop, after the empty-key and empty-values checks, added a lookup against `seenKeys`; on a hit it returns `ierr.NewError("duplicate filter key").WithHint("Each filter key must be unique within a meter").WithReportableDetails(...).Mark(ierr.ErrValidation)`.
- Non-duplicate keys are recorded in `seenKeys` and iteration continues.
- Single-pass, no extra allocation for valid meters beyond a small set.

### Behavior
| Input | Before | After |
|---|---|---|
| Unique filter keys | Valid | Valid (unchanged) |
| Empty key | `"filter key cannot be empty"` | `"filter key cannot be empty"` (unchanged, checked first) |
| Empty values | `"filter values cannot be empty"` | `"filter values cannot be empty"` (unchanged) |
| Two filters with the same non-empty key | Passed validation, one value set silently lost in `ToFilterMap()` | Rejected with `"duplicate filter key"` and the offending key in reportable details |
---

## ✅ Checklist
- [x] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [x] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meter validation to prevent duplicate filter keys, ensuring each filter key appears only once per meter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->