### PR TITLE
fix(stripe): always set due_date for send_invoice

### DIFF
--- a/internal/integration/stripe/invoice_sync.go
+++ b/internal/integration/stripe/invoice_sync.go
@@ -171,14 +171,13 @@ func (s *InvoiceSyncService) createDraftInvoiceInStripe(ctx context.Context, fle
 		params.CollectionMethod = stripe.String(string(stripe.InvoiceCollectionMethodChargeAutomatically))
 	}
 
-	// Set due date only for send_invoice collection method.
-	// Stripe rejects past due dates; clamp to at least 15 minutes from now so
-	// that wallet top-up invoices (DueDate = time.Now()) don't fail on sync.
-	if flexInvoice.DueDate != nil && collectionMethod == types.CollectionMethodSendInvoice {
+	// Stripe requires due_date when collection_method is send_invoice.
+	// Use the invoice due date if it's at least 15 minutes from now; otherwise default.
+	if collectionMethod == types.CollectionMethodSendInvoice {
 		minDueDate := time.Now().UTC().Add(15 * time.Minute)
-		dueDate := *flexInvoice.DueDate
-		if dueDate.Before(minDueDate) {
-			dueDate = minDueDate
+		dueDate := time.Now().UTC().Add(time.Duration(types.InvoiceDefaultDueDays) * 24 * time.Hour)
+		if flexInvoice.DueDate != nil && flexInvoice.DueDate.After(minDueDate) {
+			dueDate = *flexInvoice.DueDate
 		}
 		params.DueDate = stripe.Int64(dueDate.Unix())
 	}


### PR DESCRIPTION
## Summary
- Stripe rejects `send_invoice` creation when neither `due_date` nor `days_until_due` is provided
- Previously only set `due_date` when `flexInvoice.DueDate` was non-nil — invoices without a due date would fail
- Now: use invoice due date if valid (≥15 min from now), otherwise fall back to `now + InvoiceDefaultDueDays`

## Test plan
- [ ] Sync an invoice with `collection_method=send_invoice` and a valid due date — uses the invoice due date
- [ ] Sync an invoice with `collection_method=send_invoice` and no due date — uses default (now + 1 day)
- [ ] Sync an invoice with `collection_method=send_invoice` and a past/stale due date — uses default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice due date handling in Stripe payment collection. Invoices now consistently have a due date assigned, with a default 15-minute grace period applied when no custom due date is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->