### PR TITLE
fix(webhook): guard against nil systemEventRepo in publisher

### DIFF
--- a/internal/webhook/publisher/publisher.go
+++ b/internal/webhook/publisher/publisher.go
@@ -90,12 +90,14 @@ func (p *webhookPublisher) PublishWebhook(ctx context.Context, event *types.Webh
 		"payload", string(payload),
 	)
 
-	if err := p.systemEventRepo.OnConsumed(ctx, event); err != nil {
-		p.logger.ErrorwCtx(ctx, "system_events OnConsumed failed",
-			"error", err,
-			"event_id", event.ID,
-			"event_name", event.EventName,
-		)
+	if p.systemEventRepo != nil {
+		if err := p.systemEventRepo.OnConsumed(ctx, event); err != nil {
+			p.logger.ErrorwCtx(ctx, "system_events OnConsumed failed",
+				"error", err,
+				"event_id", event.ID,
+				"event_name", event.EventName,
+			)
+		}
 	}
 
 	if p.producer != nil {


### PR DESCRIPTION
## Summary

- `webhookPublisher.PublishWebhook` called `p.systemEventRepo.OnConsumed` unconditionally, causing a nil pointer dereference panic when tests pass `nil` for the system event repo
- Added a nil guard so the DB write is skipped gracefully when no repo is wired (test environments)

## What changed

`internal/webhook/publisher/publisher.go` — wrapped the `systemEventRepo.OnConsumed` call in a `nil` check

## Test plan

- [ ] `make test` passes — all 18 packages green, including `internal/service` which covers `TestCreditGrantService/TestWeeklyGrantMonthlySubscription`
- [ ] No behaviour change in production (repo is always non-nil when running with real infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook processing to gracefully handle edge cases, preventing unnecessary error logging and enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->