### PR TITLE
fix(environment): explicitly set status to published in GetEnvironments

### DIFF
--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -106,6 +106,10 @@ func (s *environmentService) GetEnvironment(ctx context.Context, id string) (*dt
 }
 
 func (s *environmentService) GetEnvironments(ctx context.Context, filter types.Filter) (*dto.ListEnvironmentsResponse, error) {
+
+	// explicitly set status to published
+	filter.Status = types.StatusPublished
+
 	environments, err := s.repo.List(ctx, filter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified environment retrieval to consistently return only published environments, regardless of filter criteria provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->