### PR TITLE
fix(webhook): case-insensitive tenant lookup for native webhooks

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -478,6 +478,7 @@ func NewConfig() (*Configuration, error) {
 		return nil, fmt.Errorf("failed to unmarshal webhook tenants config: %v", err)
 	}
 	cfg.Webhook.Tenants = tenantWebhookConfig
+	cfg.Webhook.normalizeTenantKeys()
 
 	// Alternative: try to parse user_env_mapping directly
 	userEnvMappingJSON := v.GetString("user_env_mapping")

--- a/internal/config/webhook.go
+++ b/internal/config/webhook.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"time"
 )
 
@@ -31,4 +32,30 @@ type Svix struct {
 	Enabled   bool   `mapstructure:"enabled"`
 	AuthToken string `mapstructure:"auth_token"`
 	BaseURL   string `mapstructure:"base_url"`
+}
+
+// TenantConfig returns the webhook config for a tenant. Lookup is
+// case-insensitive because Viper lowercases YAML map keys while tenant
+// IDs (ULIDs) are uppercase. Always use this helper instead of indexing
+// w.Tenants directly.
+func (w *Webhook) TenantConfig(tenantID string) (TenantWebhookConfig, bool) {
+	if w == nil || w.Tenants == nil {
+		return TenantWebhookConfig{}, false
+	}
+	cfg, ok := w.Tenants[strings.ToLower(tenantID)]
+	return cfg, ok
+}
+
+// normalizeTenantKeys rewrites Tenants so every key is lowercase. Safe to
+// call multiple times. Guards against future config sources (env, remote)
+// that may not lowercase keys like Viper's YAML loader does.
+func (w *Webhook) normalizeTenantKeys() {
+	if w == nil || len(w.Tenants) == 0 {
+		return
+	}
+	normalized := make(map[string]TenantWebhookConfig, len(w.Tenants))
+	for k, v := range w.Tenants {
+		normalized[strings.ToLower(k)] = v
+	}
+	w.Tenants = normalized
 }

--- a/internal/config/webhook_test.go
+++ b/internal/config/webhook_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebhook_TenantConfig_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var w *Webhook
+	cfg, ok := w.TenantConfig("tenant_01KE93H5A5S0S3DMBJT4YP589M")
+	require.False(t, ok)
+	require.Equal(t, TenantWebhookConfig{}, cfg)
+}
+
+func TestWebhook_TenantConfig_NilMap(t *testing.T) {
+	t.Parallel()
+
+	w := &Webhook{}
+	cfg, ok := w.TenantConfig("tenant_01KE93H5A5S0S3DMBJT4YP589M")
+	require.False(t, ok)
+	require.Equal(t, TenantWebhookConfig{}, cfg)
+}
+
+func TestWebhook_TenantConfig_CaseInsensitiveLookup(t *testing.T) {
+	t.Parallel()
+
+	// Mimic Viper's post-load state: map key is lowercase. Real tenant IDs
+	// arrive uppercase (ULID / Crockford Base32), so the lookup must
+	// normalize before indexing.
+	w := &Webhook{
+		Tenants: map[string]TenantWebhookConfig{
+			"tenant_01ke93h5a5s0s3dmbjt4yp589m": {
+				Enabled:  true,
+				Endpoint: "http://localhost:8080/health",
+			},
+		},
+	}
+
+	cfg, ok := w.TenantConfig("tenant_01KE93H5A5S0S3DMBJT4YP589M")
+	require.True(t, ok)
+	require.True(t, cfg.Enabled)
+	require.Equal(t, "http://localhost:8080/health", cfg.Endpoint)
+}
+
+func TestWebhook_TenantConfig_Miss(t *testing.T) {
+	t.Parallel()
+
+	w := &Webhook{
+		Tenants: map[string]TenantWebhookConfig{
+			"tenant_known": {Enabled: true},
+		},
+	}
+
+	_, ok := w.TenantConfig("tenant_unknown")
+	require.False(t, ok)
+}
+
+func TestWebhook_normalizeTenantKeys(t *testing.T) {
+	t.Parallel()
+
+	w := &Webhook{
+		Tenants: map[string]TenantWebhookConfig{
+			"tenant_01KE93H5A5S0S3DMBJT4YP589M": {Enabled: true, Endpoint: "a"},
+			"already_lowercase":                 {Enabled: false, Endpoint: "b"},
+		},
+	}
+
+	w.normalizeTenantKeys()
+
+	require.Len(t, w.Tenants, 2)
+	upper, ok := w.Tenants["tenant_01ke93h5a5s0s3dmbjt4yp589m"]
+	require.True(t, ok)
+	require.Equal(t, "a", upper.Endpoint)
+	lower, ok := w.Tenants["already_lowercase"]
+	require.True(t, ok)
+	require.Equal(t, "b", lower.Endpoint)
+
+	// Idempotent.
+	require.NotPanics(t, func() { w.normalizeTenantKeys() })
+	require.Len(t, w.Tenants, 2)
+}
+
+func TestWebhook_normalizeTenantKeys_NilAndEmptySafe(t *testing.T) {
+	t.Parallel()
+
+	var nilWebhook *Webhook
+	require.NotPanics(t, func() { nilWebhook.normalizeTenantKeys() })
+
+	emptyWebhook := &Webhook{}
+	require.NotPanics(t, func() { emptyWebhook.normalizeTenantKeys() })
+	require.Nil(t, emptyWebhook.Tenants)
+}

--- a/internal/webhook/handler/delivery_test.go
+++ b/internal/webhook/handler/delivery_test.go
@@ -73,6 +73,45 @@ func TestDeliverNative_TenantNotConfigured(t *testing.T) {
 	require.True(t, ierr.IsNotFound(err))
 }
 
+// TestDeliverNative_TenantLookupIsCaseInsensitive guards against a regression where
+// Viper lowercases YAML map keys but event.TenantID arrives in its original
+// ULID uppercase form, causing the tenant config lookup to miss. We simulate
+// Viper's post-load state (lowercase key) and pass an uppercase tenant ID;
+// the handler must find the config and fail only on the downstream
+// "tenant disabled" check, not with ErrNotFound.
+func TestDeliverNative_TenantLookupIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	const (
+		upperTenantID = "tenant_01KE93H5A5S0S3DMBJT4YP589M"
+		lowerTenantID = "tenant_01ke93h5a5s0s3dmbjt4yp589m"
+	)
+
+	h := &handler{
+		config: &config.Webhook{
+			Enabled: true,
+			Svix:    config.Svix{Enabled: false},
+			Tenants: map[string]config.TenantWebhookConfig{
+				lowerTenantID: {Enabled: false, Endpoint: "http://localhost:8080/health"},
+			},
+		},
+		logger: testLogger(t),
+	}
+
+	err := h.deliverNative(context.Background(), &types.WebhookEvent{
+		ID:            "sev_1",
+		TenantID:      upperTenantID,
+		EnvironmentID: "env_1",
+		EventName:     types.WebhookEventCustomerCreated,
+		Timestamp:     time.Now().UTC(),
+		Payload:       []byte(`{"customer_id":"c1"}`),
+	}, "msg-uuid")
+
+	require.Error(t, err)
+	require.False(t, ierr.IsNotFound(err), "lookup must succeed case-insensitively; got ErrNotFound: %v", err)
+	require.True(t, ierr.IsInvalidOperation(err), "expected ErrInvalidOperation (tenant disabled), got: %v", err)
+}
+
 func TestAbsorbDeliveryError_NilErrNoPanic(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -250,7 +250,7 @@ func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, me
 
 // deliverNative sends a webhook to the configured HTTP endpoint.
 func (h *handler) deliverNative(ctx context.Context, event *types.WebhookEvent, messageUUID string) error {
-	tenantCfg, ok := h.config.Tenants[event.TenantID]
+	tenantCfg, ok := h.config.TenantConfig(event.TenantID)
 	if !ok {
 		return ierr.NewError("native webhook is not configured for this tenant").
 			WithHint("Add the tenant to webhook.tenants in configuration.").


### PR DESCRIPTION
Viper lowercases YAML map keys, but event.TenantID arrives as an uppercase ULID (Crockford Base32), so h.config.Tenants[event.TenantID] always missed and native webhook delivery failed with "tenant config not found".
- Add Webhook.TenantConfig helper that lowercases the lookup key.
- Normalize Webhook.Tenants keys at config load time so the invariant is explicit and does not rely on Viper's implicit lowercasing.
- Route deliverNative through the helper.
- Unit tests cover the helper and the handler regression.

Fixes #1022 


## 📝 Description
Native webhook delivery was failing for every real tenant with `tenant config not found`, even when `webhook.tenants.<tenant_id>` was correctly set in configuration.
**Root cause:** Viper lowercases YAML map keys by default. Tenant IDs are ULIDs (Crockford Base32, uppercase) prefixed with `tenant_`, so:
- YAML has `tenant_01KE93H5A5S0S3DMBJT4YP589M`
- After `v.UnmarshalKey("webhook.tenants", ...)` in `internal/config/config.go`, the map key becomes `tenant_01ke93h5a5s0s3dmbjt4yp589m`
- `event.TenantID` arriving from the DB is still uppercase
- `h.config.Tenants[event.TenantID]` in `deliverNative` always misses and returns `ErrNotFound`
**Fix:** Normalize both the stored keys and lookups to lowercase, centralized behind a helper so future call sites cannot reintroduce the bug. Lowercasing is lossless for ULIDs because Crockford Base32 has no lowercase glyphs.
### Why not force Viper to be case-sensitive?
Viper has no public API for disabling key lowercasing (long-standing upstream limitation). Forking the library would be disproportionate for this fix. Normalization on both sides is simpler, covers future config sources (env vars, remote KV), and removes the implicit dependency on Viper's quirk.

---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook tenant configuration lookups are now case-insensitive. Tenant IDs in any letter case format are correctly matched to their associated webhook settings, improving webhook delivery reliability and preventing configuration mismatches due to case differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->