### PR TITLE
feat(user): add support for user creation via in-house auth provider

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,9 +11,6 @@ import (
 	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/config"
-	"github.com/flexprice/flexprice/internal/domain/auth"
-	"github.com/flexprice/flexprice/internal/domain/tenant"
-	"github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/dynamodb"
 	"github.com/flexprice/flexprice/internal/httpclient"
 	integrationevents "github.com/flexprice/flexprice/internal/integration/events"
@@ -219,7 +216,7 @@ func main() {
 			service.NewTenantService,
 			service.NewAuthService,
 			provideSupabaseClient,
-			provideUserService,
+			service.NewUserService,
 			service.NewEnvAccessService,
 			service.NewEnvironmentService,
 			service.NewMeterService,
@@ -430,28 +427,6 @@ func provideSupabaseClient(cfg *config.Configuration) *supabase.Client {
 		return nil
 	}
 	return supabase.CreateClient(cfg.Auth.Supabase.BaseURL, cfg.Auth.Supabase.ServiceKey)
-}
-
-func provideUserService(
-	userRepo user.Repository,
-	tenantRepo tenant.Repository,
-	authRepo auth.Repository,
-	cfg *config.Configuration,
-	rbacService *rbac.RBACService,
-	supabaseClient *supabase.Client,
-	settingsService service.SettingsService,
-	logger *logger.Logger,
-) service.UserService {
-	return service.NewUserService(
-		userRepo,
-		tenantRepo,
-		authRepo,
-		cfg,
-		rbacService,
-		supabaseClient,
-		settingsService,
-		logger,
-	)
 }
 
 func provideTemporalConfig(cfg *config.Configuration) *config.TemporalConfig {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,9 @@ import (
 	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/auth"
+	"github.com/flexprice/flexprice/internal/domain/tenant"
+	"github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/dynamodb"
 	"github.com/flexprice/flexprice/internal/httpclient"
 	integrationevents "github.com/flexprice/flexprice/internal/integration/events"
@@ -216,7 +219,7 @@ func main() {
 			service.NewTenantService,
 			service.NewAuthService,
 			provideSupabaseClient,
-			service.NewUserService,
+			provideUserService,
 			service.NewEnvAccessService,
 			service.NewEnvironmentService,
 			service.NewMeterService,
@@ -427,6 +430,28 @@ func provideSupabaseClient(cfg *config.Configuration) *supabase.Client {
 		return nil
 	}
 	return supabase.CreateClient(cfg.Auth.Supabase.BaseURL, cfg.Auth.Supabase.ServiceKey)
+}
+
+func provideUserService(
+	userRepo user.Repository,
+	tenantRepo tenant.Repository,
+	authRepo auth.Repository,
+	cfg *config.Configuration,
+	rbacService *rbac.RBACService,
+	supabaseClient *supabase.Client,
+	settingsService service.SettingsService,
+	logger *logger.Logger,
+) service.UserService {
+	return service.NewUserService(
+		userRepo,
+		tenantRepo,
+		authRepo,
+		cfg,
+		rbacService,
+		supabaseClient,
+		settingsService,
+		logger,
+	)
 }
 
 func provideTemporalConfig(cfg *config.Configuration) *config.TemporalConfig {

--- a/internal/auth/flexprice.go
+++ b/internal/auth/flexprice.go
@@ -11,6 +11,7 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/sethvargo/go-password/password"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -265,5 +266,39 @@ func (f *flexpriceAuth) ValidateSessionToken(ctx context.Context, token string) 
 		ExternalCustomerID: externalCustomerID,
 		TenantID:           tenantID,
 		EnvironmentID:      environmentID,
+	}, nil
+}
+
+// UserInvite provisions a user in the configured auth provider and returns the newly created user ID and password.
+func (f *flexpriceAuth) UserInvite(ctx context.Context, req UserInviteRequest) (*UserInviteResponse, error) {
+	tenantID := types.GetTenantID(ctx)
+	if tenantID == "" {
+		return nil, ierr.NewError("tenant id is required").
+			WithHint("Provide tenant id in request context when creating a user").
+			Mark(ierr.ErrValidation)
+	}
+
+	// Generate an initial password (no auth token issuance here).
+	password, err := password.Generate(16, 4, 2, false, false)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to generate password").
+			Mark(ierr.ErrSystem)
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to hash password").
+			Mark(ierr.ErrSystem)
+	}
+
+	// Flexprice auth provisioning here is about allocating a user ID and returning
+	// the hashed password as an auth record so the caller can persist it (no auth token issuance).
+	userID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USER)
+	return &UserInviteResponse{
+		ID:         userID,
+		Password:   password,
+		AuthRecord: auth.NewAuth(userID, types.AuthProviderFlexprice, string(hashedPassword)),
 	}, nil
 }

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -31,10 +31,27 @@ type AuthResponse struct {
 	ID string
 }
 
+// UserInviteRequest is used to create/invite a user in the configured auth provider.
+// This flow provisions a user identity and sets the initial password (no auth token issuance).
+type UserInviteRequest struct {
+	Email string
+}
+
+type UserInviteResponse struct {
+	// ID is the provider user ID (or generated user ID for Flexprice).
+	ID string
+	// Password is the generated initial password for the user (returned so it can be shown once).
+	Password string
+	// AuthRecord is optional provider-specific auth material that must be persisted server-side.
+	// For Flexprice this contains the bcrypt hash; for Supabase it will be nil.
+	AuthRecord *auth.Auth
+}
+
 type Provider interface {
 
 	// User Management
 	GetProvider() types.AuthProvider
+	UserInvite(ctx context.Context, req UserInviteRequest) (*UserInviteResponse, error)
 	SignUp(ctx context.Context, req AuthRequest) (*AuthResponse, error)
 	Login(ctx context.Context, req AuthRequest, userAuthInfo *auth.Auth) (*AuthResponse, error)
 	ValidateToken(ctx context.Context, token string) (*auth.Claims, error)

--- a/internal/auth/supabase.go
+++ b/internal/auth/supabase.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/nedpals/supabase-go"
+	"github.com/sethvargo/go-password/password"
 )
 
 type supabaseAuth struct {
@@ -184,4 +185,44 @@ func (s *supabaseAuth) GenerateSessionToken(customerID, externalCustomerID, tena
 func (s *supabaseAuth) ValidateSessionToken(ctx context.Context, token string) (*auth.SessionClaims, error) {
 	// Not Implemented yet
 	return nil, nil
+}
+
+// UserInvite provisions a user in the configured auth provider and returns the newly created user ID and password.
+func (s *supabaseAuth) UserInvite(ctx context.Context, req UserInviteRequest) (*UserInviteResponse, error) {
+	if req.Email == "" {
+		return nil, ierr.NewError("email is required").
+			WithHint("Provide a valid email to invite/create a user").
+			Mark(ierr.ErrValidation)
+	}
+	tenantID := types.GetTenantID(ctx)
+	if tenantID == "" {
+		return nil, ierr.NewError("tenant id is required").
+			WithHint("Provide tenant id in request context to associate the user in app_metadata").
+			Mark(ierr.ErrValidation)
+	}
+
+	// Generate an initial password (no auth token issuance here).
+	createdPassword, err := password.Generate(16, 4, 2, false, false)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to generate password").
+			Mark(ierr.ErrSystem)
+	}
+
+	// Create in Supabase first. We intentionally do NOT return any auth token here.
+	supabaseUser, err := s.client.Admin.CreateUser(ctx, supabase.AdminUserParams{
+		Email:        req.Email,
+		Password:     &createdPassword,
+		EmailConfirm: true,
+		AppMetadata: map[string]interface{}{
+			"tenant_id": tenantID,
+		},
+	})
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to create user in Supabase auth provider").
+			Mark(ierr.ErrSystem)
+	}
+
+	return &UserInviteResponse{ID: supabaseUser.ID, Password: createdPassword, AuthRecord: nil}, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,9 +408,7 @@ func NewConfig() (*Configuration, error) {
 	v := viper.New()
 
 	// Step 1: Load `.env` then `.env.local` if they exist.
-	// .env.local takes precedence (loaded second so it overrides .env values).
 	_ = godotenv.Load()
-	_ = godotenv.Overload(".env.local")
 
 	// Step 2: Initialize Viper
 	v.SetConfigName("config")

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -5,9 +5,13 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	authProvider "github.com/flexprice/flexprice/internal/auth"
+	"github.com/flexprice/flexprice/internal/config"
+	domainAuth "github.com/flexprice/flexprice/internal/domain/auth"
 	"github.com/flexprice/flexprice/internal/domain/tenant"
 	"github.com/flexprice/flexprice/internal/domain/user"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/nedpals/supabase-go"
@@ -24,24 +28,33 @@ type UserService interface {
 type userService struct {
 	userRepo        user.Repository
 	tenantRepo      tenant.Repository
+	authRepo        domainAuth.Repository
+	cfg             *config.Configuration
 	rbacService     *rbac.RBACService
 	supabaseAuth    *supabase.Client
 	settingsService SettingsService
+	logger          *logger.Logger
 }
 
 func NewUserService(
 	userRepo user.Repository,
 	tenantRepo tenant.Repository,
+	authRepo domainAuth.Repository,
+	cfg *config.Configuration,
 	rbacService *rbac.RBACService,
 	supabaseAuth *supabase.Client,
 	settingsService SettingsService,
+	logger *logger.Logger,
 ) UserService {
 	return &userService{
 		userRepo:        userRepo,
 		tenantRepo:      tenantRepo,
+		authRepo:        authRepo,
+		cfg:             cfg,
 		rbacService:     rbacService,
 		supabaseAuth:    supabaseAuth,
 		settingsService: settingsService,
+		logger:          logger,
 	}
 }
 
@@ -99,6 +112,7 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 
 	var newUser *user.User
 	var password string
+	var userID string
 
 	switch req.Type {
 	case types.UserTypeUser:
@@ -140,32 +154,70 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 				WithReportableDetails(map[string]interface{}{"max_users": addUserConfig.MaxUsers, "current_active_users": totalActiveUsers}).
 				Mark(ierr.ErrValidation)
 		}
-		if s.supabaseAuth == nil {
-			return nil, ierr.NewError("auth provider not configured").
-				WithHint("User accounts require Supabase auth to be configured; create user (type=user) only when Supabase is available.").
-				Mark(ierr.ErrValidation)
-		}
 		plainPassword, err := generateSecurePassword()
 		if err != nil {
 			return nil, ierr.WithError(err).WithHint("Failed to generate password").Mark(ierr.ErrSystem)
 		}
 		password = plainPassword
 
-		// Create in Supabase first; only on success create in DB. We cannot rollback either side
-		// This ordering ensures we never persist in DB without auth; if DB create fails after Supabase succeeds, caller sees the error.
-		supabaseUser, err := s.supabaseAuth.Admin.CreateUser(ctx, supabase.AdminUserParams{
-			Email:        req.Email,
-			Password:     lo.ToPtr(plainPassword),
-			EmailConfirm: true,
-			AppMetadata: map[string]interface{}{
-				"tenant_id": tenantID,
-			},
-		})
-		if err != nil {
-			return nil, ierr.WithError(err).WithHint("Failed to create user in auth provider").Mark(ierr.ErrSystem)
+		if s.cfg != nil && s.cfg.Auth.Provider == types.AuthProviderSupabase {
+			if s.supabaseAuth == nil {
+				return nil, ierr.NewError("supabase auth not configured").
+					WithHint("Supabase auth provider is selected but Supabase client is nil").
+					Mark(ierr.ErrValidation)
+			}
+			// Create in Supabase first; only on success create in DB. We cannot rollback either side
+			// This ordering ensures we never persist in DB without auth; if DB create fails after Supabase succeeds, caller sees the error.
+			supabaseUser, err := s.supabaseAuth.Admin.CreateUser(ctx, supabase.AdminUserParams{
+				Email:        req.Email,
+				Password:     lo.ToPtr(plainPassword),
+				EmailConfirm: true,
+				AppMetadata: map[string]interface{}{
+					"tenant_id": tenantID,
+				},
+			})
+			if err != nil {
+				return nil, ierr.WithError(err).WithHint("Failed to create user in auth provider").Mark(ierr.ErrSystem)
+			}
+			userID = supabaseUser.ID
 		}
+
+		// If configured for Supabase, create the auth user in Supabase
+		// Otherwise, create the auth user via Flexprice auth provider
+		if s.cfg.Auth.Provider != types.AuthProviderSupabase {
+			s.logger.InfowCtx(ctx,
+				"supabase auth not configured, using flexprice auth provider",
+				"email", req.Email,
+				"tenant_id", tenantID,
+			)
+			if s.cfg == nil || s.authRepo == nil {
+				return nil, ierr.NewError("flexprice auth provider not configured").
+					WithHint("Provide configuration and auth repository to create users without Supabase").
+					Mark(ierr.ErrValidation)
+			}
+
+			flexpriceProvider := authProvider.NewFlexpriceAuth(s.cfg)
+			authResp, err := flexpriceProvider.SignUp(ctx, authProvider.AuthRequest{
+				Email:    req.Email,
+				Password: plainPassword,
+				TenantID: tenantID,
+			})
+			if err != nil {
+				return nil, ierr.WithError(err).
+					WithHint("Failed to create user in flexprice auth provider").
+					Mark(ierr.ErrSystem)
+			}
+			userID = authResp.ID
+			if err := s.authRepo.CreateAuth(ctx, domainAuth.NewAuth(authResp.ID, types.AuthProviderFlexprice, authResp.ProviderToken)); err != nil {
+				return nil, ierr.WithError(err).
+					WithHint("Failed to create authentication record").
+					WithReportableDetails(map[string]interface{}{"user_id": userID}).
+					Mark(ierr.ErrDatabase)
+			}
+		}
+
 		newUser = &user.User{
-			ID:    supabaseUser.ID,
+			ID:    userID,
 			Email: req.Email,
 			Type:  types.UserTypeUser,
 			Roles: []string{},

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -111,131 +111,16 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 	}
 
 	var newUser *user.User
-	var password string
-	var userID string
+	var password *string
 
 	switch req.Type {
 	case types.UserTypeUser:
-		existingUser, err := s.userRepo.GetByEmail(ctx, req.Email)
-		if err != nil && !ierr.IsNotFound(err) {
-			return nil, err
-		}
-		if existingUser != nil {
-			return nil, ierr.NewError("email already in use").
-				WithHint("A user with this email already exists in this tenant").
-				WithReportableDetails(map[string]interface{}{"email": req.Email}).
-				Mark(ierr.ErrAlreadyExists)
-		}
-		// Enforce per-tenant user limit from add_user_config (GetSetting returns default when not set)
-		svc, ok := s.settingsService.(*settingsService)
-		if !ok || svc == nil {
-			return nil, ierr.NewError("settings service not configured").
-				WithHint("User creation requires settings service for add_user_config.").
-				Mark(ierr.ErrValidation)
-		}
-		addUserConfig, err := GetSetting[types.TenantConfig](svc, ctx, types.SettingKeyTenantConfig)
+		// invite user to the tenant
+		newUser, password, err = s.InviteUser(ctx, req, currentUserID)
 		if err != nil {
 			return nil, err
 		}
-		// ListByFilter uses tenant from context and repo filters by StatusPublished
-		_, totalActiveUsers, err := s.userRepo.ListByFilter(ctx, &types.UserFilter{
-			QueryFilter: &types.QueryFilter{
-				Limit:  lo.ToPtr(1),
-				Offset: lo.ToPtr(0),
-				Status: lo.ToPtr(types.StatusPublished),
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-		if totalActiveUsers >= int64(addUserConfig.MaxUsers) {
-			return nil, ierr.NewError("user limit reached: you cannot add any more users").
-				WithHintf("Maximum %d user(s) allowed for this tenant. Limit reached.", addUserConfig.MaxUsers).
-				WithReportableDetails(map[string]interface{}{"max_users": addUserConfig.MaxUsers, "current_active_users": totalActiveUsers}).
-				Mark(ierr.ErrValidation)
-		}
-		plainPassword, err := generateSecurePassword()
-		if err != nil {
-			return nil, ierr.WithError(err).WithHint("Failed to generate password").Mark(ierr.ErrSystem)
-		}
-		password = plainPassword
 
-		if s.cfg != nil && s.cfg.Auth.Provider == types.AuthProviderSupabase {
-			if s.supabaseAuth == nil {
-				return nil, ierr.NewError("supabase auth not configured").
-					WithHint("Supabase auth provider is selected but Supabase client is nil").
-					Mark(ierr.ErrValidation)
-			}
-			// Create in Supabase first; only on success create in DB. We cannot rollback either side
-			// This ordering ensures we never persist in DB without auth; if DB create fails after Supabase succeeds, caller sees the error.
-			supabaseUser, err := s.supabaseAuth.Admin.CreateUser(ctx, supabase.AdminUserParams{
-				Email:        req.Email,
-				Password:     lo.ToPtr(plainPassword),
-				EmailConfirm: true,
-				AppMetadata: map[string]interface{}{
-					"tenant_id": tenantID,
-				},
-			})
-			if err != nil {
-				return nil, ierr.WithError(err).WithHint("Failed to create user in auth provider").Mark(ierr.ErrSystem)
-			}
-			userID = supabaseUser.ID
-		}
-
-		// If configured for Supabase, create the auth user in Supabase
-		// Otherwise, create the auth user via Flexprice auth provider
-		if s.cfg.Auth.Provider != types.AuthProviderSupabase {
-			s.logger.InfowCtx(ctx,
-				"supabase auth not configured, using flexprice auth provider",
-				"email", req.Email,
-				"tenant_id", tenantID,
-			)
-			if s.cfg == nil || s.authRepo == nil {
-				return nil, ierr.NewError("flexprice auth provider not configured").
-					WithHint("Provide configuration and auth repository to create users without Supabase").
-					Mark(ierr.ErrValidation)
-			}
-
-			flexpriceProvider := authProvider.NewFlexpriceAuth(s.cfg)
-			authResp, err := flexpriceProvider.SignUp(ctx, authProvider.AuthRequest{
-				Email:    req.Email,
-				Password: plainPassword,
-				TenantID: tenantID,
-			})
-			if err != nil {
-				return nil, ierr.WithError(err).
-					WithHint("Failed to create user in flexprice auth provider").
-					Mark(ierr.ErrSystem)
-			}
-			userID = authResp.ID
-			if err := s.authRepo.CreateAuth(ctx, domainAuth.NewAuth(authResp.ID, types.AuthProviderFlexprice, authResp.ProviderToken)); err != nil {
-				return nil, ierr.WithError(err).
-					WithHint("Failed to create authentication record").
-					WithReportableDetails(map[string]interface{}{"user_id": userID}).
-					Mark(ierr.ErrDatabase)
-			}
-		}
-
-		newUser = &user.User{
-			ID:    userID,
-			Email: req.Email,
-			Type:  types.UserTypeUser,
-			Roles: []string{},
-			BaseModel: types.BaseModel{
-				TenantID:  tenantID,
-				Status:    types.StatusPublished,
-				CreatedBy: currentUserID,
-				UpdatedBy: currentUserID,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-			},
-		}
-		if err := newUser.Validate(); err != nil {
-			return nil, err
-		}
-		if err := s.userRepo.Create(ctx, newUser); err != nil {
-			return nil, err
-		}
 	case types.UserTypeServiceAccount:
 		if s.rbacService == nil {
 			return nil, ierr.NewError("RBAC not configured").
@@ -276,7 +161,7 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 
 	return &dto.CreateUserResponse{
 		UserResponse: dto.NewUserResponse(newUser, tenant),
-		Password:     password,
+		Password:     *password,
 	}, nil
 }
 
@@ -317,4 +202,138 @@ func (s *userService) ListUsersByFilter(ctx context.Context, filter *types.UserF
 		Items:      userResponses,
 		Pagination: types.NewPaginationResponse(int(total), filter.GetLimit(), filter.GetOffset()),
 	}, nil
+}
+
+// InviteUser invites a user to the tenant
+func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest, currentUserID string) (*user.User, *string, error) {
+
+	var userID string
+	tenantID := types.GetTenantID(ctx)
+
+	// Check if user by email already exists
+	existingUser, err := s.userRepo.GetByEmail(ctx, req.Email)
+	if err != nil && !ierr.IsNotFound(err) {
+		return nil, nil, err
+	}
+	if existingUser != nil {
+		return nil, nil, ierr.NewError("email already in use").
+			WithHint("A user with this email already exists in this tenant").
+			WithReportableDetails(map[string]interface{}{"email": req.Email}).
+			Mark(ierr.ErrAlreadyExists)
+	}
+	// Enforce per-tenant user limit from add_user_config (GetSetting returns default when not set)
+	svc, ok := s.settingsService.(*settingsService)
+	if !ok || svc == nil {
+		return nil, nil, ierr.NewError("settings service not configured").
+			WithHint("User creation requires settings service for add_user_config.").
+			Mark(ierr.ErrValidation)
+	}
+	addUserConfig, err := GetSetting[types.TenantConfig](svc, ctx, types.SettingKeyTenantConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	// ListByFilter uses tenant from context and repo filters by StatusPublished
+	_, totalActiveUsers, err := s.userRepo.ListByFilter(ctx, &types.UserFilter{
+		QueryFilter: &types.QueryFilter{
+			Limit:  lo.ToPtr(1),
+			Offset: lo.ToPtr(0),
+			Status: lo.ToPtr(types.StatusPublished),
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	if totalActiveUsers >= int64(addUserConfig.MaxUsers) {
+		return nil, nil, ierr.NewError("user limit reached: you cannot add any more users").
+			WithHintf("Maximum %d user(s) allowed for this tenant. Limit reached.", addUserConfig.MaxUsers).
+			WithReportableDetails(map[string]interface{}{"max_users": addUserConfig.MaxUsers, "current_active_users": totalActiveUsers}).
+			Mark(ierr.ErrValidation)
+	}
+	password, err := generateSecurePassword()
+	if err != nil {
+		return nil, nil, ierr.WithError(err).WithHint("Failed to generate password").
+			Mark(ierr.ErrSystem)
+	}
+
+	switch s.cfg.Auth.Provider {
+	case types.AuthProviderSupabase:
+		if s.supabaseAuth == nil {
+			return nil, nil, ierr.NewError("supabase auth not configured").
+				WithHint("Supabase auth provider is selected but Supabase client is nil").
+				Mark(ierr.ErrValidation)
+		}
+		// Create in Supabase first; only on success create in DB. We cannot rollback either side
+		// This ordering ensures we never persist in DB without auth; if DB create fails after Supabase succeeds, caller sees the error.
+		supabaseUser, err := s.supabaseAuth.Admin.CreateUser(ctx, supabase.AdminUserParams{
+			Email:        req.Email,
+			Password:     lo.ToPtr(password),
+			EmailConfirm: true,
+			AppMetadata: map[string]interface{}{
+				"tenant_id": tenantID,
+			},
+		})
+		if err != nil {
+			return nil, nil, ierr.WithError(err).WithHint("Failed to create user in auth provider").
+				Mark(ierr.ErrSystem)
+		}
+		userID = supabaseUser.ID
+
+	case types.AuthProviderFlexprice:
+		s.logger.InfowCtx(ctx,
+			"supabase auth not configured, using flexprice auth provider",
+			"email", req.Email,
+			"tenant_id", tenantID,
+		)
+		if s.cfg == nil || s.authRepo == nil {
+			return nil, nil, ierr.NewError("flexprice auth provider not configured").
+				WithHint("Provide configuration and auth repository to create users without Supabase").
+				Mark(ierr.ErrValidation)
+		}
+
+		flexpriceProvider := authProvider.NewFlexpriceAuth(s.cfg)
+		authResp, err := flexpriceProvider.SignUp(ctx, authProvider.AuthRequest{
+			Email:    req.Email,
+			Password: password,
+			TenantID: tenantID,
+		})
+		if err != nil {
+			return nil, nil, ierr.WithError(err).
+				WithHint("Failed to create user in flexprice auth provider").
+				Mark(ierr.ErrSystem)
+		}
+		userID = authResp.ID
+		if err := s.authRepo.CreateAuth(ctx, domainAuth.NewAuth(authResp.ID, types.AuthProviderFlexprice, authResp.ProviderToken)); err != nil {
+			return nil, nil, ierr.WithError(err).
+				WithHint("Failed to create authentication record").
+				WithReportableDetails(map[string]interface{}{"user_id": userID}).
+				Mark(ierr.ErrDatabase)
+		}
+	default:
+		return nil, nil, ierr.NewError("auth provider not configured").
+			WithHint("Auth provider not configured").
+			Mark(ierr.ErrValidation)
+	}
+
+	newUser := &user.User{
+		ID:    userID,
+		Email: req.Email,
+		Type:  types.UserTypeUser,
+		Roles: []string{},
+		BaseModel: types.BaseModel{
+			TenantID:  tenantID,
+			Status:    types.StatusPublished,
+			CreatedBy: currentUserID,
+			UpdatedBy: currentUserID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+
+	if err := newUser.Validate(); err != nil {
+		return nil, nil, err
+	}
+	if err := s.userRepo.Create(ctx, newUser); err != nil {
+		return nil, nil, err
+	}
+	return newUser, &password, nil
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -255,6 +255,12 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 			Mark(ierr.ErrSystem)
 	}
 
+	if s.cfg == nil {
+		return nil, nil, ierr.NewError("auth configuration missing").
+			WithHint("User creation requires auth provider configuration").
+			Mark(ierr.ErrValidation)
+	}
+
 	switch s.cfg.Auth.Provider {
 	case types.AuthProviderSupabase:
 		if s.supabaseAuth == nil {

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/nedpals/supabase-go"
 	"github.com/samber/lo"
-	"github.com/sethvargo/go-password/password"
 )
 
 type UserService interface {
@@ -165,12 +164,6 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 	}, nil
 }
 
-// generateSecurePassword returns a cryptographically secure random password via sethvargo/go-password (crypto/rand).
-func generateSecurePassword() (string, error) {
-	// 16 chars, 4 digits, 2 symbols, allow upper, no repeat (strong, copyable)
-	return password.Generate(16, 4, 2, false, false)
-}
-
 func (s *userService) ListUsersByFilter(ctx context.Context, filter *types.UserFilter) (*dto.ListUsersResponse, error) {
 	// Get tenant ID from context
 	tenantID := types.GetTenantID(ctx)
@@ -249,11 +242,6 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 			WithReportableDetails(map[string]interface{}{"max_users": addUserConfig.MaxUsers, "current_active_users": totalActiveUsers}).
 			Mark(ierr.ErrValidation)
 	}
-	password, err := generateSecurePassword()
-	if err != nil {
-		return nil, nil, ierr.WithError(err).WithHint("Failed to generate password").
-			Mark(ierr.ErrSystem)
-	}
 
 	if s.cfg == nil {
 		return nil, nil, ierr.NewError("auth configuration missing").
@@ -261,63 +249,29 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 			Mark(ierr.ErrValidation)
 	}
 
-	switch s.cfg.Auth.Provider {
-	case types.AuthProviderSupabase:
-		if s.supabaseAuth == nil {
-			return nil, nil, ierr.NewError("supabase auth not configured").
-				WithHint("Supabase auth provider is selected but Supabase client is nil").
+	provider := authProvider.NewProvider(s.cfg)
+	inviteResp, err := provider.UserInvite(ctx, authProvider.UserInviteRequest{
+		Email: req.Email,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	userID = inviteResp.ID
+	password := inviteResp.Password
+
+	// Persist provider-specific auth material for later login (e.g. Flexprice bcrypt hash).
+	if inviteResp.AuthRecord != nil {
+		if s.authRepo == nil {
+			return nil, nil, ierr.NewError("auth repository not configured").
+				WithHint("Auth provider returned an auth record but auth repository is nil").
 				Mark(ierr.ErrValidation)
 		}
-		// Create in Supabase first; only on success create in DB. We cannot rollback either side
-		// This ordering ensures we never persist in DB without auth; if DB create fails after Supabase succeeds, caller sees the error.
-		supabaseUser, err := s.supabaseAuth.Admin.CreateUser(ctx, supabase.AdminUserParams{
-			Email:        req.Email,
-			Password:     lo.ToPtr(password),
-			EmailConfirm: true,
-			AppMetadata: map[string]interface{}{
-				"tenant_id": tenantID,
-			},
-		})
-		if err != nil {
-			return nil, nil, ierr.WithError(err).WithHint("Failed to create user in auth provider").
-				Mark(ierr.ErrSystem)
-		}
-		userID = supabaseUser.ID
-
-	case types.AuthProviderFlexprice:
-		s.logger.InfowCtx(ctx,
-			"supabase auth not configured, using flexprice auth provider",
-			"email", req.Email,
-			"tenant_id", tenantID,
-		)
-		if s.cfg == nil || s.authRepo == nil {
-			return nil, nil, ierr.NewError("flexprice auth provider not configured").
-				WithHint("Provide configuration and auth repository to create users without Supabase").
-				Mark(ierr.ErrValidation)
-		}
-
-		flexpriceProvider := authProvider.NewFlexpriceAuth(s.cfg)
-		authResp, err := flexpriceProvider.SignUp(ctx, authProvider.AuthRequest{
-			Email:    req.Email,
-			Password: password,
-			TenantID: tenantID,
-		})
-		if err != nil {
-			return nil, nil, ierr.WithError(err).
-				WithHint("Failed to create user in flexprice auth provider").
-				Mark(ierr.ErrSystem)
-		}
-		userID = authResp.ID
-		if err := s.authRepo.CreateAuth(ctx, domainAuth.NewAuth(authResp.ID, types.AuthProviderFlexprice, authResp.ProviderToken)); err != nil {
+		if err := s.authRepo.CreateAuth(ctx, inviteResp.AuthRecord); err != nil {
 			return nil, nil, ierr.WithError(err).
 				WithHint("Failed to create authentication record").
 				WithReportableDetails(map[string]interface{}{"user_id": userID}).
 				Mark(ierr.ErrDatabase)
 		}
-	default:
-		return nil, nil, ierr.NewError("auth provider not configured").
-			WithHint("Auth provider not configured").
-			Mark(ierr.ErrValidation)
 	}
 
 	newUser := &user.User{

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -468,7 +468,7 @@ func (s *walletService) loadUsersForExpansion(ctx context.Context, expand types.
 	}
 
 	// Fetch users in bulk
-	userService := NewUserService(s.UserRepo, s.TenantRepo, nil, nil, nil)
+	userService := NewUserService(s.UserRepo, s.TenantRepo, nil, nil, nil, nil, nil, s.Logger)
 	userFilter := &types.UserFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),
 		UserIDs:     userIDs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-driven user invitation flow returning one-time/generated credentials when applicable.
* **Configuration**
  * Environment loading simplified to a single .env file; .env.local no longer overrides values.
* **Refactor**
  * User provisioning centralized into the auth provider layer and extracted from the core user creation path for clearer separation of concerns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->