### PR TITLE
feat(addon): add proration in addons

### DIFF
--- a/api/tests/go/test_sdk.go
+++ b/api/tests/go/test_sdk.go
@@ -790,7 +790,6 @@ func testCreateAddon(ctx context.Context, client *flexprice.Flexprice) {
 		Name:        testAddonName,
 		LookupKey:   testAddonLookupKey,
 		Description: strPtr("This is a test addon created by SDK tests"),
-		Type:        types.AddonTypeOnetime,
 		Metadata: map[string]any{
 			"source":      "sdk_test",
 			"test_run":    time.Now().Format(time.RFC3339),

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -12020,7 +12020,6 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "addon_id",
-                "cadence",
                 "subscription_id"
             ],
             "properties": {
@@ -12055,8 +12054,7 @@ const docTemplate = `{
         "AddAddonToSubscriptionRequest": {
             "type": "object",
             "required": [
-                "addon_id",
-                "cadence"
+                "addon_id"
             ],
             "properties": {
                 "addon_id": {
@@ -14390,6 +14388,14 @@ const docTemplate = `{
                     "description": "PriceID references an existing price (plan, addon, or subscription-scoped). Exactly one of price_id or price must be set.",
                     "type": "string"
                 },
+                "proration_behavior": {
+                    "description": "ProrationBehavior controls mid-period charge creation. Defaults to none.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ProrationBehavior"
+                        }
+                    ]
+                },
                 "quantity": {
                     "type": "number"
                 },
@@ -15419,6 +15425,14 @@ const docTemplate = `{
             "properties": {
                 "effective_from": {
                     "type": "string"
+                },
+                "proration_behavior": {
+                    "description": "ProrationBehavior controls mid-period credit issuance. Defaults to none.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ProrationBehavior"
+                        }
+                    ]
                 }
             }
         },
@@ -18015,6 +18029,10 @@ const docTemplate = `{
                 "addon_association_id": {
                     "type": "string"
                 },
+                "effective_date": {
+                    "description": "EffectiveDate is the date the cancellation takes effect.\nWhen nil the addon is cancelled at the end of the current period.\nWhen provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period\nvalues combined with create_prorations will issue a wallet credit for unused time.",
+                    "type": "string"
+                },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
                 },
@@ -18474,6 +18492,9 @@ const docTemplate = `{
         "SubscriptionLineItemResponse": {
             "type": "object",
             "properties": {
+                "addon_association_id": {
+                    "type": "string"
+                },
                 "billing_period": {
                     "$ref": "#/definitions/types.BillingPeriod"
                 },
@@ -21506,12 +21527,12 @@ const docTemplate = `{
             "enum": [
                 "active",
                 "cancelled",
-                "paused"
+                "pending"
             ],
             "x-enum-varnames": [
                 "AddonStatusActive",
                 "AddonStatusCancelled",
-                "AddonStatusPaused"
+                "AddonStatusPending"
             ]
         },
         "types.AggregationType": {
@@ -24139,6 +24160,7 @@ const docTemplate = `{
         "types.WindowSize": {
             "type": "string",
             "enum": [
+                "MONTH",
                 "MINUTE",
                 "15MIN",
                 "30MIN",
@@ -24148,10 +24170,10 @@ const docTemplate = `{
                 "12HOUR",
                 "DAY",
                 "WEEK",
-                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
+                "DefaultWindowSize",
                 "WindowSizeMinute",
                 "WindowSize15Min",
                 "WindowSize30Min",
@@ -24161,8 +24183,7 @@ const docTemplate = `{
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth",
-                "DefaultWindowSize"
+                "WindowSizeMonth"
             ]
         },
         "types.WorkflowExecutionFilter": {
@@ -24740,6 +24761,9 @@ const docTemplate = `{
         "subscription.SubscriptionLineItem": {
             "type": "object",
             "properties": {
+                "addon_association_id": {
+                    "type": "string"
+                },
                 "billing_period": {
                     "$ref": "#/definitions/types.BillingPeriod"
                 },

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2659,6 +2659,72 @@ const docTemplate = `{
                 }
             }
         },
+        "/environments/{id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Clone all published features and plans from the source environment into a target environment. If target_environment_id is provided, entities are cloned into that existing environment. Otherwise a new environment is created from name and type first.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Clone an environment",
+                "operationId": "cloneEnvironment",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source Environment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Clone configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CloneEnvironmentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/models.TemporalWorkflowResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "write"
+            }
+        },
         "/events": {
             "post": {
                 "security": [
@@ -3283,6 +3349,78 @@ const docTemplate = `{
                         }
                     }
                 }
+            }
+        },
+        "/features/{id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Clone an existing feature",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Clone a feature",
+                "operationId": "cloneFeature",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source Feature ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Clone configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CloneFeatureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/FeatureResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "write"
             }
         },
         "/groups": {
@@ -5159,6 +5297,7 @@ const docTemplate = `{
                     "Plans"
                 ],
                 "summary": "Clone a plan",
+                "operationId": "clonePlan",
                 "parameters": [
                     {
                         "type": "string",
@@ -5208,7 +5347,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
-                }
+                },
+                "x-scope": "write"
             }
         },
         "/plans/{id}/creditgrants": {
@@ -11880,11 +12020,15 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "addon_id",
+                "cadence",
                 "subscription_id"
             ],
             "properties": {
                 "addon_id": {
                     "type": "string"
+                },
+                "cadence": {
+                    "$ref": "#/definitions/types.AddonCadence"
                 },
                 "line_item_commitments": {
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
@@ -11896,6 +12040,9 @@ const docTemplate = `{
                 "metadata": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proration_behavior": {
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "type": "string"
@@ -11908,11 +12055,15 @@ const docTemplate = `{
         "AddAddonToSubscriptionRequest": {
             "type": "object",
             "required": [
-                "addon_id"
+                "addon_id",
+                "cadence"
             ],
             "properties": {
                 "addon_id": {
                     "type": "string"
+                },
+                "cadence": {
+                    "$ref": "#/definitions/types.AddonCadence"
                 },
                 "line_item_commitments": {
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
@@ -11924,6 +12075,9 @@ const docTemplate = `{
                 "metadata": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proration_behavior": {
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "type": "string"
@@ -12039,9 +12193,6 @@ const docTemplate = `{
                 },
                 "tenant_id": {
                     "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -12384,23 +12535,80 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "action": {
-                    "description": "\"created\" | \"wallet_credit\"",
-                    "type": "string"
+                    "description": "Action is created for a proration charge invoice, wallet_credit for downgrade credit.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ChangedInvoiceAction"
+                        }
+                    ]
                 },
                 "id": {
                     "type": "string"
                 },
+                "invoice": {
+                    "description": "Invoice is set for proration charges: preview returns a synthetic invoice; execute returns the persisted invoice when created.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/InvoiceResponse"
+                        }
+                    ]
+                },
                 "status": {
-                    "type": "string"
+                    "description": "Status is preview (dry-run), issued (wallet credit applied), or a PaymentStatus string for real invoices.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ChangedInvoiceStatus"
+                        }
+                    ]
+                },
+                "wallet_transaction": {
+                    "description": "WalletTransaction is set for downgrade wallet credits: preview is synthetic; execute returns the transaction from the top-up.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/WalletTransactionResponse"
+                        }
+                    ]
                 }
             }
+        },
+        "ChangedInvoiceAction": {
+            "description": "created (proration invoice) | wallet_credit (downgrade credit)",
+            "type": "string",
+            "enum": [
+                "created",
+                "wallet_credit"
+            ],
+            "x-enum-varnames": [
+                "ChangedInvoiceActionCreated",
+                "ChangedInvoiceActionWalletCredit"
+            ]
+        },
+        "ChangedInvoiceStatus": {
+            "description": "preview | issued | INITIATED | PENDING | PROCESSING | SUCCEEDED | OVERPAID | FAILED | REFUNDED | PARTIALLY_REFUNDED",
+            "type": "string",
+            "enum": [
+                "preview",
+                "issued"
+            ],
+            "x-enum-varnames": [
+                "ChangedInvoiceStatusPreview",
+                "ChangedInvoiceStatusWalletIssued"
+            ]
         },
         "ChangedLineItem": {
             "type": "object",
             "properties": {
                 "change_action": {
-                    "description": "\"created\" | \"updated\" | \"ended\"",
-                    "type": "string"
+                    "enum": [
+                        "created",
+                        "updated",
+                        "ended"
+                    ],
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/ChangedLineItemAction"
+                        }
+                    ]
                 },
                 "end_date": {
                     "type": "string"
@@ -12418,6 +12626,20 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "ChangedLineItemAction": {
+            "description": "created | updated | ended",
+            "type": "string",
+            "enum": [
+                "created",
+                "updated",
+                "ended"
+            ],
+            "x-enum-varnames": [
+                "ChangedLineItemActionCreated",
+                "ChangedLineItemActionUpdated",
+                "ChangedLineItemActionEnded"
+            ]
         },
         "ChangedResources": {
             "type": "object",
@@ -12446,14 +12668,71 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "action": {
-                    "description": "\"created\" | \"updated\"",
-                    "type": "string"
+                    "$ref": "#/definitions/ChangedSubscriptionAction"
                 },
                 "id": {
                     "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/types.SubscriptionStatus"
+                }
+            }
+        },
+        "ChangedSubscriptionAction": {
+            "description": "created | updated",
+            "type": "string",
+            "enum": [
+                "created",
+                "updated"
+            ],
+            "x-enum-varnames": [
+                "ChangedSubscriptionActionCreated",
+                "ChangedSubscriptionActionUpdated"
+            ]
+        },
+        "CloneEnvironmentRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Name of the new environment (required when target_environment_id is not provided)",
+                    "type": "string"
+                },
+                "target_environment_id": {
+                    "description": "TargetEnvironmentID is the ID of an existing environment to clone into (optional).\nWhen provided, Name and Type are ignored. When omitted, Name and Type are required.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type of the new environment, e.g. \"production\" or \"development\" (required when target_environment_id is not provided)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.EnvironmentType"
+                        }
+                    ]
+                }
+            }
+        },
+        "CloneFeatureRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Description overrides the source feature's description when provided",
+                    "type": "string"
+                },
+                "lookup_key": {
+                    "description": "LookupKey is required and must be unique across published features",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Metadata overrides the source feature's metadata when provided",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.Metadata"
+                        }
+                    ]
+                },
+                "name": {
+                    "description": "Name is required and must be different from the source feature's name",
+                    "type": "string"
                 }
             }
         },
@@ -12861,8 +13140,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "lookup_key",
-                "name",
-                "type"
+                "name"
             ],
             "properties": {
                 "description": {
@@ -12877,9 +13155,6 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
                 }
             }
         },
@@ -12929,9 +13204,6 @@ const docTemplate = `{
                 },
                 "tenant_id": {
                     "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -14143,6 +14415,10 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/AddAddonToSubscriptionRequest"
                     }
+                },
+                "billing_anchor": {
+                    "description": "BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.\nFor monthly billing, the day-of-month (and time-of-day) define cycle boundaries: if start_date\nis before that day in the month, the first billing period ends on the next occurrence of that\nday in the same month (a shorter first period); subsequent periods follow the usual interval.",
+                    "type": "string"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
@@ -17739,6 +18015,9 @@ const docTemplate = `{
                 "addon_association_id": {
                     "type": "string"
                 },
+                "proration_behavior": {
+                    "$ref": "#/definitions/types.ProrationBehavior"
+                },
                 "reason": {
                     "type": "string"
                 }
@@ -20852,9 +21131,6 @@ const docTemplate = `{
                 "tenant_id": {
                     "type": "string"
                 },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
-                },
                 "updated_at": {
                     "type": "string"
                 },
@@ -21176,9 +21452,6 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
-                "addon_type": {
-                    "$ref": "#/definitions/types.AddonType"
-                },
                 "end_time": {
                     "type": "string"
                 },
@@ -21239,17 +21512,6 @@ const docTemplate = `{
                 "AddonStatusActive",
                 "AddonStatusCancelled",
                 "AddonStatusPaused"
-            ]
-        },
-        "types.AddonType": {
-            "type": "string",
-            "enum": [
-                "onetime",
-                "multiple_instance"
-            ],
-            "x-enum-varnames": [
-                "AddonTypeOnetime",
-                "AddonTypeMultipleInstance"
             ]
         },
         "types.AggregationType": {
@@ -24720,6 +24982,28 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "types.AddonCadence": {
+            "type": "string",
+            "enum": [
+                "onetime",
+                "recurring"
+            ],
+            "x-enum-varnames": [
+                "AddonCadenceOnetime",
+                "AddonCadenceRecurring"
+            ]
+        },
+        "types.EnvironmentType": {
+            "type": "string",
+            "enum": [
+                "development",
+                "production"
+            ],
+            "x-enum-varnames": [
+                "EnvironmentDevelopment",
+                "EnvironmentProduction"
+            ]
         },
         "types.ListResponse-dto_WalletResponse": {
             "type": "object",

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -14058,7 +14058,6 @@
       "AddAddonRequest": {
         "required": [
           "addon_id",
-          "cadence",
           "subscription_id"
         ],
         "type": "object",
@@ -14094,8 +14093,7 @@
       },
       "AddAddonToSubscriptionRequest": {
         "required": [
-          "addon_id",
-          "cadence"
+          "addon_id"
         ],
         "type": "object",
         "properties": {
@@ -16301,6 +16299,9 @@
             "type": "string",
             "description": "PriceID references an existing price (plan, addon, or subscription-scoped). Exactly one of price_id or price must be set."
           },
+          "proration_behavior": {
+            "$ref": "#/components/schemas/types.ProrationBehavior"
+          },
           "quantity": {
             "type": "number"
           },
@@ -17248,6 +17249,9 @@
         "properties": {
           "effective_from": {
             "type": "string"
+          },
+          "proration_behavior": {
+            "$ref": "#/components/schemas/types.ProrationBehavior"
           }
         }
       },
@@ -19815,6 +19819,11 @@
           "addon_association_id": {
             "type": "string"
           },
+          "effective_date": {
+            "type": "string",
+            "description": "EffectiveDate is the date the cancellation takes effect.\nWhen nil the addon is cancelled at the end of the current period.\nWhen provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period\nvalues combined with create_prorations will issue a wallet credit for unused time.",
+            "format": "date-time"
+          },
           "proration_behavior": {
             "$ref": "#/components/schemas/types.ProrationBehavior"
           },
@@ -20183,6 +20192,9 @@
       "SubscriptionLineItemResponse": {
         "type": "object",
         "properties": {
+          "addon_association_id": {
+            "type": "string"
+          },
           "billing_period": {
             "$ref": "#/components/schemas/types.BillingPeriod"
           },
@@ -23125,12 +23137,12 @@
         "enum": [
           "active",
           "cancelled",
-          "paused"
+          "pending"
         ],
         "x-enum-varnames": [
           "AddonStatusActive",
           "AddonStatusCancelled",
-          "AddonStatusPaused"
+          "AddonStatusPending"
         ],
         "x-speakeasy-name-override": "AddonStatus"
       },
@@ -25880,6 +25892,7 @@
       "types.WindowSize": {
         "type": "string",
         "enum": [
+          "MONTH",
           "MINUTE",
           "15MIN",
           "30MIN",
@@ -25889,10 +25902,10 @@
           "12HOUR",
           "DAY",
           "WEEK",
-          "MONTH",
           "MONTH"
         ],
         "x-enum-varnames": [
+          "DefaultWindowSize",
           "WindowSizeMinute",
           "WindowSize15Min",
           "WindowSize30Min",
@@ -25902,8 +25915,7 @@
           "WindowSize12Hour",
           "WindowSizeDay",
           "WindowSizeWeek",
-          "WindowSizeMonth",
-          "DefaultWindowSize"
+          "WindowSizeMonth"
         ],
         "x-speakeasy-name-override": "WindowSize"
       },
@@ -26461,6 +26473,9 @@
       "subscription.SubscriptionLineItem": {
         "type": "object",
         "properties": {
+          "addon_association_id": {
+            "type": "string"
+          },
           "billing_period": {
             "$ref": "#/components/schemas/types.BillingPeriod"
           },

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -3220,6 +3220,87 @@
         ]
       }
     },
+    "/environments/{id}/clone": {
+      "post": {
+        "tags": [
+          "Environments"
+        ],
+        "summary": "Clone an environment",
+        "description": "Clone all published features and plans from the source environment into a target environment. If target_environment_id is provided, entities are cloned into that existing environment. Otherwise a new environment is created from name and type first.",
+        "operationId": "cloneEnvironment",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Source Environment ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Clone configuration",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CloneEnvironmentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/models.TemporalWorkflowResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "x-scope": "write",
+        "x-codegen-request-body-name": "request"
+      }
+    },
     "/events": {
       "post": {
         "tags": [
@@ -3947,6 +4028,97 @@
             "ApiKeyAuth": []
           }
         ]
+      }
+    },
+    "/features/{id}/clone": {
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "summary": "Clone a feature",
+        "description": "Clone an existing feature",
+        "operationId": "cloneFeature",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Source Feature ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Clone configuration",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CloneFeatureRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "x-scope": "write",
+        "x-codegen-request-body-name": "request"
       }
     },
     "/groups": {
@@ -6187,6 +6359,7 @@
         ],
         "summary": "Clone a plan",
         "description": "Clone an existing plan, copying its active prices, published entitlements, and published credit grants",
+        "operationId": "clonePlan",
         "parameters": [
           {
             "name": "id",
@@ -6266,6 +6439,7 @@
             "ApiKeyAuth": []
           }
         ],
+        "x-scope": "write",
         "x-codegen-request-body-name": "request"
       }
     },
@@ -13884,12 +14058,16 @@
       "AddAddonRequest": {
         "required": [
           "addon_id",
+          "cadence",
           "subscription_id"
         ],
         "type": "object",
         "properties": {
           "addon_id": {
             "type": "string"
+          },
+          "cadence": {
+            "$ref": "#/components/schemas/types.AddonCadence"
           },
           "line_item_commitments": {
             "type": "object",
@@ -13901,6 +14079,9 @@
           "metadata": {
             "type": "object",
             "additionalProperties": true
+          },
+          "proration_behavior": {
+            "$ref": "#/components/schemas/types.ProrationBehavior"
           },
           "start_date": {
             "type": "string",
@@ -13913,12 +14094,16 @@
       },
       "AddAddonToSubscriptionRequest": {
         "required": [
-          "addon_id"
+          "addon_id",
+          "cadence"
         ],
         "type": "object",
         "properties": {
           "addon_id": {
             "type": "string"
+          },
+          "cadence": {
+            "$ref": "#/components/schemas/types.AddonCadence"
           },
           "line_item_commitments": {
             "type": "object",
@@ -13930,6 +14115,9 @@
           "metadata": {
             "type": "object",
             "additionalProperties": true
+          },
+          "proration_behavior": {
+            "$ref": "#/components/schemas/types.ProrationBehavior"
           },
           "start_date": {
             "type": "string",
@@ -14052,9 +14240,6 @@
           },
           "tenant_id": {
             "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/types.AddonType"
           },
           "updated_at": {
             "type": "string",
@@ -14362,23 +14547,51 @@
         "type": "object",
         "properties": {
           "action": {
-            "type": "string",
-            "description": "\"created\" | \"wallet_credit\""
+            "$ref": "#/components/schemas/ChangedInvoiceAction"
           },
           "id": {
             "type": "string"
           },
+          "invoice": {
+            "$ref": "#/components/schemas/InvoiceResponse"
+          },
           "status": {
-            "type": "string"
+            "$ref": "#/components/schemas/ChangedInvoiceStatus"
+          },
+          "wallet_transaction": {
+            "$ref": "#/components/schemas/WalletTransactionResponse"
           }
         }
+      },
+      "ChangedInvoiceAction": {
+        "type": "string",
+        "description": "created (proration invoice) | wallet_credit (downgrade credit)",
+        "enum": [
+          "created",
+          "wallet_credit"
+        ],
+        "x-enum-varnames": [
+          "ChangedInvoiceActionCreated",
+          "ChangedInvoiceActionWalletCredit"
+        ]
+      },
+      "ChangedInvoiceStatus": {
+        "type": "string",
+        "description": "preview | issued | INITIATED | PENDING | PROCESSING | SUCCEEDED | OVERPAID | FAILED | REFUNDED | PARTIALLY_REFUNDED",
+        "enum": [
+          "preview",
+          "issued"
+        ],
+        "x-enum-varnames": [
+          "ChangedInvoiceStatusPreview",
+          "ChangedInvoiceStatusWalletIssued"
+        ]
       },
       "ChangedLineItem": {
         "type": "object",
         "properties": {
           "change_action": {
-            "type": "string",
-            "description": "\"created\" | \"updated\" | \"ended\""
+            "$ref": "#/components/schemas/ChangedLineItemAction"
           },
           "end_date": {
             "type": "string",
@@ -14398,6 +14611,20 @@
             "format": "date-time"
           }
         }
+      },
+      "ChangedLineItemAction": {
+        "type": "string",
+        "description": "created | updated | ended",
+        "enum": [
+          "created",
+          "updated",
+          "ended"
+        ],
+        "x-enum-varnames": [
+          "ChangedLineItemActionCreated",
+          "ChangedLineItemActionUpdated",
+          "ChangedLineItemActionEnded"
+        ]
       },
       "ChangedResources": {
         "type": "object",
@@ -14426,14 +14653,61 @@
         "type": "object",
         "properties": {
           "action": {
-            "type": "string",
-            "description": "\"created\" | \"updated\""
+            "$ref": "#/components/schemas/ChangedSubscriptionAction"
           },
           "id": {
             "type": "string"
           },
           "status": {
             "$ref": "#/components/schemas/types.SubscriptionStatus"
+          }
+        }
+      },
+      "ChangedSubscriptionAction": {
+        "type": "string",
+        "description": "created | updated",
+        "enum": [
+          "created",
+          "updated"
+        ],
+        "x-enum-varnames": [
+          "ChangedSubscriptionActionCreated",
+          "ChangedSubscriptionActionUpdated"
+        ]
+      },
+      "CloneEnvironmentRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the new environment (required when target_environment_id is not provided)"
+          },
+          "target_environment_id": {
+            "type": "string",
+            "description": "TargetEnvironmentID is the ID of an existing environment to clone into (optional).\nWhen provided, Name and Type are ignored. When omitted, Name and Type are required."
+          },
+          "type": {
+            "$ref": "#/components/schemas/types.EnvironmentType"
+          }
+        }
+      },
+      "CloneFeatureRequest": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Description overrides the source feature's description when provided"
+          },
+          "lookup_key": {
+            "type": "string",
+            "description": "LookupKey is required and must be unique across published features"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/types.Metadata"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is required and must be different from the source feature's name"
           }
         }
       },
@@ -14842,8 +15116,7 @@
       "CreateAddonRequest": {
         "required": [
           "lookup_key",
-          "name",
-          "type"
+          "name"
         ],
         "type": "object",
         "properties": {
@@ -14859,9 +15132,6 @@
           },
           "name": {
             "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/types.AddonType"
           }
         }
       },
@@ -14912,9 +15182,6 @@
           },
           "tenant_id": {
             "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/types.AddonType"
           },
           "updated_at": {
             "type": "string",
@@ -16060,6 +16327,11 @@
             "items": {
               "$ref": "#/components/schemas/AddAddonToSubscriptionRequest"
             }
+          },
+          "billing_anchor": {
+            "type": "string",
+            "description": "BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.\nFor monthly billing, the day-of-month (and time-of-day) define cycle boundaries: if start_date\nis before that day in the month, the first billing period ends on the next occurrence of that\nday in the same month (a shorter first period); subsequent periods follow the usual interval.",
+            "format": "date-time"
           },
           "billing_cycle": {
             "$ref": "#/components/schemas/types.BillingCycle"
@@ -19543,6 +19815,9 @@
           "addon_association_id": {
             "type": "string"
           },
+          "proration_behavior": {
+            "$ref": "#/components/schemas/types.ProrationBehavior"
+          },
           "reason": {
             "type": "string"
           }
@@ -22464,9 +22739,6 @@
           "tenant_id": {
             "type": "string"
           },
-          "type": {
-            "$ref": "#/components/schemas/types.AddonType"
-          },
           "updated_at": {
             "type": "string",
             "format": "date-time"
@@ -22796,9 +23068,6 @@
               "type": "string"
             }
           },
-          "addon_type": {
-            "$ref": "#/components/schemas/types.AddonType"
-          },
           "end_time": {
             "type": "string",
             "format": "date-time"
@@ -22864,18 +23133,6 @@
           "AddonStatusPaused"
         ],
         "x-speakeasy-name-override": "AddonStatus"
-      },
-      "types.AddonType": {
-        "type": "string",
-        "enum": [
-          "onetime",
-          "multiple_instance"
-        ],
-        "x-enum-varnames": [
-          "AddonTypeOnetime",
-          "AddonTypeMultipleInstance"
-        ],
-        "x-speakeasy-name-override": "AddonType"
       },
       "types.AggregationType": {
         "type": "string",
@@ -26456,6 +26713,30 @@
             "type": "string"
           }
         }
+      },
+      "types.AddonCadence": {
+        "type": "string",
+        "enum": [
+          "onetime",
+          "recurring"
+        ],
+        "x-enum-varnames": [
+          "AddonCadenceOnetime",
+          "AddonCadenceRecurring"
+        ],
+        "x-speakeasy-name-override": "AddonCadence"
+      },
+      "types.EnvironmentType": {
+        "type": "string",
+        "enum": [
+          "development",
+          "production"
+        ],
+        "x-enum-varnames": [
+          "EnvironmentDevelopment",
+          "EnvironmentProduction"
+        ],
+        "x-speakeasy-name-override": "EnvironmentType"
       },
       "types.ListResponse-dto_WalletResponse": {
         "type": "object",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -12004,7 +12004,6 @@
             "type": "object",
             "required": [
                 "addon_id",
-                "cadence",
                 "subscription_id"
             ],
             "properties": {
@@ -12039,8 +12038,7 @@
         "AddAddonToSubscriptionRequest": {
             "type": "object",
             "required": [
-                "addon_id",
-                "cadence"
+                "addon_id"
             ],
             "properties": {
                 "addon_id": {
@@ -14246,6 +14244,10 @@
                     "description": "PriceID references an existing price (plan, addon, or subscription-scoped). Exactly one of price_id or price must be set.",
                     "type": "string"
                 },
+                "proration_behavior": {
+                    "description": "ProrationBehavior controls mid-period charge creation. Defaults to none.",
+                    "$ref": "#/definitions/types.ProrationBehavior"
+                },
                 "quantity": {
                     "type": "number"
                 },
@@ -15191,6 +15193,10 @@
             "properties": {
                 "effective_from": {
                     "type": "string"
+                },
+                "proration_behavior": {
+                    "description": "ProrationBehavior controls mid-period credit issuance. Defaults to none.",
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 }
             }
         },
@@ -17703,6 +17709,10 @@
                 "addon_association_id": {
                     "type": "string"
                 },
+                "effective_date": {
+                    "description": "EffectiveDate is the date the cancellation takes effect.\nWhen nil the addon is cancelled at the end of the current period.\nWhen provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period\nvalues combined with create_prorations will issue a wallet credit for unused time.",
+                    "type": "string"
+                },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
                 },
@@ -18086,6 +18096,9 @@
         "SubscriptionLineItemResponse": {
             "type": "object",
             "properties": {
+                "addon_association_id": {
+                    "type": "string"
+                },
                 "billing_period": {
                     "$ref": "#/definitions/types.BillingPeriod"
                 },
@@ -20966,12 +20979,12 @@
             "enum": [
                 "active",
                 "cancelled",
-                "paused"
+                "pending"
             ],
             "x-enum-varnames": [
                 "AddonStatusActive",
                 "AddonStatusCancelled",
-                "AddonStatusPaused"
+                "AddonStatusPending"
             ]
         },
         "types.AggregationType": {
@@ -23583,6 +23596,7 @@
         "types.WindowSize": {
             "type": "string",
             "enum": [
+                "MONTH",
                 "MINUTE",
                 "15MIN",
                 "30MIN",
@@ -23592,10 +23606,10 @@
                 "12HOUR",
                 "DAY",
                 "WEEK",
-                "MONTH",
                 "MONTH"
             ],
             "x-enum-varnames": [
+                "DefaultWindowSize",
                 "WindowSizeMinute",
                 "WindowSize15Min",
                 "WindowSize30Min",
@@ -23605,8 +23619,7 @@
                 "WindowSize12Hour",
                 "WindowSizeDay",
                 "WindowSizeWeek",
-                "WindowSizeMonth",
-                "DefaultWindowSize"
+                "WindowSizeMonth"
             ]
         },
         "types.WorkflowExecutionFilter": {
@@ -24156,6 +24169,9 @@
         "subscription.SubscriptionLineItem": {
             "type": "object",
             "properties": {
+                "addon_association_id": {
+                    "type": "string"
+                },
                 "billing_period": {
                     "$ref": "#/definitions/types.BillingPeriod"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2655,6 +2655,72 @@
                 }
             }
         },
+        "/environments/{id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Clone all published features and plans from the source environment into a target environment. If target_environment_id is provided, entities are cloned into that existing environment. Otherwise a new environment is created from name and type first.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Environments"
+                ],
+                "summary": "Clone an environment",
+                "operationId": "cloneEnvironment",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source Environment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Clone configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CloneEnvironmentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/models.TemporalWorkflowResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "write"
+            }
+        },
         "/events": {
             "post": {
                 "security": [
@@ -3279,6 +3345,78 @@
                         }
                     }
                 }
+            }
+        },
+        "/features/{id}/clone": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Clone an existing feature",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Clone a feature",
+                "operationId": "cloneFeature",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Source Feature ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Clone configuration",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CloneFeatureRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/FeatureResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "write"
             }
         },
         "/groups": {
@@ -5155,6 +5293,7 @@
                     "Plans"
                 ],
                 "summary": "Clone a plan",
+                "operationId": "clonePlan",
                 "parameters": [
                     {
                         "type": "string",
@@ -5204,7 +5343,8 @@
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     }
-                }
+                },
+                "x-scope": "write"
             }
         },
         "/plans/{id}/creditgrants": {
@@ -11864,11 +12004,15 @@
             "type": "object",
             "required": [
                 "addon_id",
+                "cadence",
                 "subscription_id"
             ],
             "properties": {
                 "addon_id": {
                     "type": "string"
+                },
+                "cadence": {
+                    "$ref": "#/definitions/types.AddonCadence"
                 },
                 "line_item_commitments": {
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
@@ -11880,6 +12024,9 @@
                 "metadata": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proration_behavior": {
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "type": "string"
@@ -11892,11 +12039,15 @@
         "AddAddonToSubscriptionRequest": {
             "type": "object",
             "required": [
-                "addon_id"
+                "addon_id",
+                "cadence"
             ],
             "properties": {
                 "addon_id": {
                     "type": "string"
+                },
+                "cadence": {
+                    "$ref": "#/definitions/types.AddonCadence"
                 },
                 "line_item_commitments": {
                     "description": "LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)",
@@ -11908,6 +12059,9 @@
                 "metadata": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "proration_behavior": {
+                    "$ref": "#/definitions/types.ProrationBehavior"
                 },
                 "start_date": {
                     "type": "string"
@@ -12023,9 +12177,6 @@
                 },
                 "tenant_id": {
                     "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -12332,23 +12483,60 @@
             "type": "object",
             "properties": {
                 "action": {
-                    "description": "\"created\" | \"wallet_credit\"",
-                    "type": "string"
+                    "description": "Action is created for a proration charge invoice, wallet_credit for downgrade credit.",
+                    "$ref": "#/definitions/ChangedInvoiceAction"
                 },
                 "id": {
                     "type": "string"
                 },
+                "invoice": {
+                    "description": "Invoice is set for proration charges: preview returns a synthetic invoice; execute returns the persisted invoice when created.",
+                    "$ref": "#/definitions/InvoiceResponse"
+                },
                 "status": {
-                    "type": "string"
+                    "description": "Status is preview (dry-run), issued (wallet credit applied), or a PaymentStatus string for real invoices.",
+                    "$ref": "#/definitions/ChangedInvoiceStatus"
+                },
+                "wallet_transaction": {
+                    "description": "WalletTransaction is set for downgrade wallet credits: preview is synthetic; execute returns the transaction from the top-up.",
+                    "$ref": "#/definitions/WalletTransactionResponse"
                 }
             }
+        },
+        "ChangedInvoiceAction": {
+            "description": "created (proration invoice) | wallet_credit (downgrade credit)",
+            "type": "string",
+            "enum": [
+                "created",
+                "wallet_credit"
+            ],
+            "x-enum-varnames": [
+                "ChangedInvoiceActionCreated",
+                "ChangedInvoiceActionWalletCredit"
+            ]
+        },
+        "ChangedInvoiceStatus": {
+            "description": "preview | issued | INITIATED | PENDING | PROCESSING | SUCCEEDED | OVERPAID | FAILED | REFUNDED | PARTIALLY_REFUNDED",
+            "type": "string",
+            "enum": [
+                "preview",
+                "issued"
+            ],
+            "x-enum-varnames": [
+                "ChangedInvoiceStatusPreview",
+                "ChangedInvoiceStatusWalletIssued"
+            ]
         },
         "ChangedLineItem": {
             "type": "object",
             "properties": {
                 "change_action": {
-                    "description": "\"created\" | \"updated\" | \"ended\"",
-                    "type": "string"
+                    "enum": [
+                        "created",
+                        "updated",
+                        "ended"
+                    ],
+                    "$ref": "#/definitions/ChangedLineItemAction"
                 },
                 "end_date": {
                     "type": "string"
@@ -12366,6 +12554,20 @@
                     "type": "string"
                 }
             }
+        },
+        "ChangedLineItemAction": {
+            "description": "created | updated | ended",
+            "type": "string",
+            "enum": [
+                "created",
+                "updated",
+                "ended"
+            ],
+            "x-enum-varnames": [
+                "ChangedLineItemActionCreated",
+                "ChangedLineItemActionUpdated",
+                "ChangedLineItemActionEnded"
+            ]
         },
         "ChangedResources": {
             "type": "object",
@@ -12394,14 +12596,63 @@
             "type": "object",
             "properties": {
                 "action": {
-                    "description": "\"created\" | \"updated\"",
-                    "type": "string"
+                    "$ref": "#/definitions/ChangedSubscriptionAction"
                 },
                 "id": {
                     "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/types.SubscriptionStatus"
+                }
+            }
+        },
+        "ChangedSubscriptionAction": {
+            "description": "created | updated",
+            "type": "string",
+            "enum": [
+                "created",
+                "updated"
+            ],
+            "x-enum-varnames": [
+                "ChangedSubscriptionActionCreated",
+                "ChangedSubscriptionActionUpdated"
+            ]
+        },
+        "CloneEnvironmentRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Name of the new environment (required when target_environment_id is not provided)",
+                    "type": "string"
+                },
+                "target_environment_id": {
+                    "description": "TargetEnvironmentID is the ID of an existing environment to clone into (optional).\nWhen provided, Name and Type are ignored. When omitted, Name and Type are required.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type of the new environment, e.g. \"production\" or \"development\" (required when target_environment_id is not provided)",
+                    "$ref": "#/definitions/types.EnvironmentType"
+                }
+            }
+        },
+        "CloneFeatureRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Description overrides the source feature's description when provided",
+                    "type": "string"
+                },
+                "lookup_key": {
+                    "description": "LookupKey is required and must be unique across published features",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Metadata overrides the source feature's metadata when provided",
+                    "$ref": "#/definitions/types.Metadata"
+                },
+                "name": {
+                    "description": "Name is required and must be different from the source feature's name",
+                    "type": "string"
                 }
             }
         },
@@ -12801,8 +13052,7 @@
             "type": "object",
             "required": [
                 "lookup_key",
-                "name",
-                "type"
+                "name"
             ],
             "properties": {
                 "description": {
@@ -12817,9 +13067,6 @@
                 },
                 "name": {
                     "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
                 }
             }
         },
@@ -12869,9 +13116,6 @@
                 },
                 "tenant_id": {
                     "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
                 },
                 "updated_at": {
                     "type": "string"
@@ -14027,6 +14271,10 @@
                     "items": {
                         "$ref": "#/definitions/AddAddonToSubscriptionRequest"
                     }
+                },
+                "billing_anchor": {
+                    "description": "BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.\nFor monthly billing, the day-of-month (and time-of-day) define cycle boundaries: if start_date\nis before that day in the month, the first billing period ends on the next occurrence of that\nday in the same month (a shorter first period); subsequent periods follow the usual interval.",
+                    "type": "string"
                 },
                 "billing_cycle": {
                     "description": "BillingCycle is the cycle of the billing anchor.\nThis is used to determine the billing date for the subscription (i.e set the billing anchor)\nIf not set, the default value is anniversary. Possible values are anniversary and calendar.\nAnniversary billing means the billing anchor will be the start date of the subscription.\nCalendar billing means the billing anchor will be the appropriate date based on the billing period.\nFor example, if the billing period is month and the start date is 2025-04-15 then in case of\ncalendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.",
@@ -17455,6 +17703,9 @@
                 "addon_association_id": {
                     "type": "string"
                 },
+                "proration_behavior": {
+                    "$ref": "#/definitions/types.ProrationBehavior"
+                },
                 "reason": {
                     "type": "string"
                 }
@@ -20344,9 +20595,6 @@
                 "tenant_id": {
                     "type": "string"
                 },
-                "type": {
-                    "$ref": "#/definitions/types.AddonType"
-                },
                 "updated_at": {
                     "type": "string"
                 },
@@ -20664,9 +20912,6 @@
                         "type": "string"
                     }
                 },
-                "addon_type": {
-                    "$ref": "#/definitions/types.AddonType"
-                },
                 "end_time": {
                     "type": "string"
                 },
@@ -20727,17 +20972,6 @@
                 "AddonStatusActive",
                 "AddonStatusCancelled",
                 "AddonStatusPaused"
-            ]
-        },
-        "types.AddonType": {
-            "type": "string",
-            "enum": [
-                "onetime",
-                "multiple_instance"
-            ],
-            "x-enum-varnames": [
-                "AddonTypeOnetime",
-                "AddonTypeMultipleInstance"
             ]
         },
         "types.AggregationType": {
@@ -24160,6 +24394,28 @@
                     "type": "string"
                 }
             }
+        },
+        "types.AddonCadence": {
+            "type": "string",
+            "enum": [
+                "onetime",
+                "recurring"
+            ],
+            "x-enum-varnames": [
+                "AddonCadenceOnetime",
+                "AddonCadenceRecurring"
+            ]
+        },
+        "types.EnvironmentType": {
+            "type": "string",
+            "enum": [
+                "development",
+                "production"
+            ],
+            "x-enum-varnames": [
+                "EnvironmentDevelopment",
+                "EnvironmentProduction"
+            ]
         },
         "types.ListResponse-dto_WalletResponse": {
             "type": "object",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -358,7 +358,6 @@ definitions:
         type: string
     required:
     - addon_id
-    - cadence
     - subscription_id
     type: object
   AddAddonToSubscriptionRequest:
@@ -382,7 +381,6 @@ definitions:
         type: string
     required:
     - addon_id
-    - cadence
     type: object
   AddonAssociationResponse:
     properties:
@@ -2031,6 +2029,11 @@ definitions:
         description: PriceID references an existing price (plan, addon, or subscription-scoped).
           Exactly one of price_id or price must be set.
         type: string
+      proration_behavior:
+        allOf:
+        - $ref: '#/definitions/types.ProrationBehavior'
+        description: ProrationBehavior controls mid-period charge creation. Defaults
+          to none.
       quantity:
         type: number
       start_date:
@@ -2811,6 +2814,11 @@ definitions:
     properties:
       effective_from:
         type: string
+      proration_behavior:
+        allOf:
+        - $ref: '#/definitions/types.ProrationBehavior'
+        description: ProrationBehavior controls mid-period credit issuance. Defaults
+          to none.
     type: object
   EntitlementResponse:
     properties:
@@ -4715,6 +4723,13 @@ definitions:
     properties:
       addon_association_id:
         type: string
+      effective_date:
+        description: |-
+          EffectiveDate is the date the cancellation takes effect.
+          When nil the addon is cancelled at the end of the current period.
+          When provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period
+          values combined with create_prorations will issue a wallet credit for unused time.
+        type: string
       proration_behavior:
         $ref: '#/definitions/types.ProrationBehavior'
       reason:
@@ -5032,6 +5047,8 @@ definitions:
     type: object
   SubscriptionLineItemResponse:
     properties:
+      addon_association_id:
+        type: string
       billing_period:
         $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
@@ -7194,12 +7211,12 @@ definitions:
     enum:
     - active
     - cancelled
-    - paused
+    - pending
     type: string
     x-enum-varnames:
     - AddonStatusActive
     - AddonStatusCancelled
-    - AddonStatusPaused
+    - AddonStatusPending
   types.AggregationType:
     enum:
     - COUNT
@@ -9179,6 +9196,7 @@ definitions:
     - WebhookEventCreditNoteUpdated
   types.WindowSize:
     enum:
+    - MONTH
     - MINUTE
     - 15MIN
     - 30MIN
@@ -9189,9 +9207,9 @@ definitions:
     - DAY
     - WEEK
     - MONTH
-    - MONTH
     type: string
     x-enum-varnames:
+    - DefaultWindowSize
     - WindowSizeMinute
     - WindowSize15Min
     - WindowSize30Min
@@ -9202,7 +9220,6 @@ definitions:
     - WindowSizeDay
     - WindowSizeWeek
     - WindowSizeMonth
-    - DefaultWindowSize
   types.WorkflowExecutionFilter:
     properties:
       end_time:
@@ -9640,6 +9657,8 @@ definitions:
     type: object
   subscription.SubscriptionLineItem:
     properties:
+      addon_association_id:
+        type: string
       billing_period:
         $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -339,6 +339,8 @@ definitions:
     properties:
       addon_id:
         type: string
+      cadence:
+        $ref: '#/definitions/types.AddonCadence'
       line_item_commitments:
         additionalProperties:
           $ref: '#/definitions/LineItemCommitmentConfig'
@@ -348,18 +350,23 @@ definitions:
       metadata:
         additionalProperties: true
         type: object
+      proration_behavior:
+        $ref: '#/definitions/types.ProrationBehavior'
       start_date:
         type: string
       subscription_id:
         type: string
     required:
     - addon_id
+    - cadence
     - subscription_id
     type: object
   AddAddonToSubscriptionRequest:
     properties:
       addon_id:
         type: string
+      cadence:
+        $ref: '#/definitions/types.AddonCadence'
       line_item_commitments:
         additionalProperties:
           $ref: '#/definitions/LineItemCommitmentConfig'
@@ -369,10 +376,13 @@ definitions:
       metadata:
         additionalProperties: true
         type: object
+      proration_behavior:
+        $ref: '#/definitions/types.ProrationBehavior'
       start_date:
         type: string
     required:
     - addon_id
+    - cadence
     type: object
   AddonAssociationResponse:
     properties:
@@ -448,8 +458,6 @@ definitions:
         $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
-      type:
-        $ref: '#/definitions/types.AddonType'
       updated_at:
         type: string
       updated_by:
@@ -673,18 +681,56 @@ definitions:
   ChangedInvoice:
     properties:
       action:
-        description: '"created" | "wallet_credit"'
-        type: string
+        allOf:
+        - $ref: '#/definitions/ChangedInvoiceAction'
+        description: Action is created for a proration charge invoice, wallet_credit
+          for downgrade credit.
       id:
         type: string
+      invoice:
+        allOf:
+        - $ref: '#/definitions/InvoiceResponse'
+        description: 'Invoice is set for proration charges: preview returns a synthetic
+          invoice; execute returns the persisted invoice when created.'
       status:
-        type: string
+        allOf:
+        - $ref: '#/definitions/ChangedInvoiceStatus'
+        description: Status is preview (dry-run), issued (wallet credit applied),
+          or a PaymentStatus string for real invoices.
+      wallet_transaction:
+        allOf:
+        - $ref: '#/definitions/WalletTransactionResponse'
+        description: 'WalletTransaction is set for downgrade wallet credits: preview
+          is synthetic; execute returns the transaction from the top-up.'
     type: object
+  ChangedInvoiceAction:
+    description: created (proration invoice) | wallet_credit (downgrade credit)
+    enum:
+    - created
+    - wallet_credit
+    type: string
+    x-enum-varnames:
+    - ChangedInvoiceActionCreated
+    - ChangedInvoiceActionWalletCredit
+  ChangedInvoiceStatus:
+    description: preview | issued | INITIATED | PENDING | PROCESSING | SUCCEEDED |
+      OVERPAID | FAILED | REFUNDED | PARTIALLY_REFUNDED
+    enum:
+    - preview
+    - issued
+    type: string
+    x-enum-varnames:
+    - ChangedInvoiceStatusPreview
+    - ChangedInvoiceStatusWalletIssued
   ChangedLineItem:
     properties:
       change_action:
-        description: '"created" | "updated" | "ended"'
-        type: string
+        allOf:
+        - $ref: '#/definitions/ChangedLineItemAction'
+        enum:
+        - created
+        - updated
+        - ended
       end_date:
         type: string
       id:
@@ -696,6 +742,17 @@ definitions:
       start_date:
         type: string
     type: object
+  ChangedLineItemAction:
+    description: created | updated | ended
+    enum:
+    - created
+    - updated
+    - ended
+    type: string
+    x-enum-varnames:
+    - ChangedLineItemActionCreated
+    - ChangedLineItemActionUpdated
+    - ChangedLineItemActionEnded
   ChangedResources:
     properties:
       invoices:
@@ -714,12 +771,54 @@ definitions:
   ChangedSubscription:
     properties:
       action:
-        description: '"created" | "updated"'
-        type: string
+        $ref: '#/definitions/ChangedSubscriptionAction'
       id:
         type: string
       status:
         $ref: '#/definitions/types.SubscriptionStatus'
+    type: object
+  ChangedSubscriptionAction:
+    description: created | updated
+    enum:
+    - created
+    - updated
+    type: string
+    x-enum-varnames:
+    - ChangedSubscriptionActionCreated
+    - ChangedSubscriptionActionUpdated
+  CloneEnvironmentRequest:
+    properties:
+      name:
+        description: Name of the new environment (required when target_environment_id
+          is not provided)
+        type: string
+      target_environment_id:
+        description: |-
+          TargetEnvironmentID is the ID of an existing environment to clone into (optional).
+          When provided, Name and Type are ignored. When omitted, Name and Type are required.
+        type: string
+      type:
+        allOf:
+        - $ref: '#/definitions/types.EnvironmentType'
+        description: Type of the new environment, e.g. "production" or "development"
+          (required when target_environment_id is not provided)
+    type: object
+  CloneFeatureRequest:
+    properties:
+      description:
+        description: Description overrides the source feature's description when provided
+        type: string
+      lookup_key:
+        description: LookupKey is required and must be unique across published features
+        type: string
+      metadata:
+        allOf:
+        - $ref: '#/definitions/types.Metadata'
+        description: Metadata overrides the source feature's metadata when provided
+      name:
+        description: Name is required and must be different from the source feature's
+          name
+        type: string
     type: object
   ClonePlanRequest:
     properties:
@@ -999,12 +1098,9 @@ definitions:
         type: object
       name:
         type: string
-      type:
-        $ref: '#/definitions/types.AddonType'
     required:
     - lookup_key
     - name
-    - type
     type: object
   CreateAddonResponse:
     properties:
@@ -1038,8 +1134,6 @@ definitions:
         $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
-      type:
-        $ref: '#/definitions/types.AddonType'
       updated_at:
         type: string
       updated_by:
@@ -1952,6 +2046,13 @@ definitions:
         items:
           $ref: '#/definitions/AddAddonToSubscriptionRequest'
         type: array
+      billing_anchor:
+        description: |-
+          BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.
+          For monthly billing, the day-of-month (and time-of-day) define cycle boundaries: if start_date
+          is before that day in the month, the first billing period ends on the next occurrence of that
+          day in the same month (a shorter first period); subsequent periods follow the usual interval.
+        type: string
       billing_cycle:
         allOf:
         - $ref: '#/definitions/types.BillingCycle'
@@ -4614,6 +4715,8 @@ definitions:
     properties:
       addon_association_id:
         type: string
+      proration_behavior:
+        $ref: '#/definitions/types.ProrationBehavior'
       reason:
         type: string
     required:
@@ -6831,8 +6934,6 @@ definitions:
         $ref: '#/definitions/types.Status'
       tenant_id:
         type: string
-      type:
-        $ref: '#/definitions/types.AddonType'
       updated_at:
         type: string
       updated_by:
@@ -7055,8 +7156,6 @@ definitions:
         items:
           type: string
         type: array
-      addon_type:
-        $ref: '#/definitions/types.AddonType'
       end_time:
         type: string
       expand:
@@ -7101,14 +7200,6 @@ definitions:
     - AddonStatusActive
     - AddonStatusCancelled
     - AddonStatusPaused
-  types.AddonType:
-    enum:
-    - onetime
-    - multiple_instance
-    type: string
-    x-enum-varnames:
-    - AddonTypeOnetime
-    - AddonTypeMultipleInstance
   types.AggregationType:
     enum:
     - COUNT
@@ -9717,6 +9808,22 @@ definitions:
       updated_by:
         type: string
     type: object
+  types.AddonCadence:
+    enum:
+    - onetime
+    - recurring
+    type: string
+    x-enum-varnames:
+    - AddonCadenceOnetime
+    - AddonCadenceRecurring
+  types.EnvironmentType:
+    enum:
+    - development
+    - production
+    type: string
+    x-enum-varnames:
+    - EnvironmentDevelopment
+    - EnvironmentProduction
   types.ListResponse-dto_WalletResponse:
     properties:
       items:
@@ -11588,6 +11695,52 @@ paths:
       summary: Query entitlements
       tags:
       - Entitlements
+  /environments/{id}/clone:
+    post:
+      consumes:
+      - application/json
+      description: Clone all published features and plans from the source environment
+        into a target environment. If target_environment_id is provided, entities
+        are cloned into that existing environment. Otherwise a new environment is
+        created from name and type first.
+      operationId: cloneEnvironment
+      parameters:
+      - description: Source Environment ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Clone configuration
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/CloneEnvironmentRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/models.TemporalWorkflowResult'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Clone an environment
+      tags:
+      - Environments
+      x-scope: write
   /events:
     post:
       consumes:
@@ -11967,6 +12120,53 @@ paths:
       summary: Update feature
       tags:
       - Features
+  /features/{id}/clone:
+    post:
+      consumes:
+      - application/json
+      description: Clone an existing feature
+      operationId: cloneFeature
+      parameters:
+      - description: Source Feature ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Clone configuration
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/CloneFeatureRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/FeatureResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Clone a feature
+      tags:
+      - Features
+      x-scope: write
   /features/search:
     post:
       consumes:
@@ -13206,6 +13406,7 @@ paths:
       - application/json
       description: Clone an existing plan, copying its active prices, published entitlements,
         and published credit grants
+      operationId: clonePlan
       parameters:
       - description: Source Plan ID
         in: path
@@ -13246,6 +13447,7 @@ paths:
       summary: Clone a plan
       tags:
       - Plans
+      x-scope: write
   /plans/{id}/creditgrants:
     get:
       description: Use when listing credits attached to a plan (e.g. included prepaid

--- a/ent/addon.go
+++ b/ent/addon.go
@@ -38,8 +38,6 @@ type Addon struct {
 	Name string `json:"name,omitempty"`
 	// Description holds the value of the "description" field.
 	Description string `json:"description,omitempty"`
-	// single_instance or multi_instance
-	Type string `json:"type,omitempty"`
 	// Metadata holds the value of the "metadata" field.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -73,7 +71,7 @@ func (*Addon) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case addon.FieldMetadata:
 			values[i] = new([]byte)
-		case addon.FieldID, addon.FieldTenantID, addon.FieldStatus, addon.FieldCreatedBy, addon.FieldUpdatedBy, addon.FieldEnvironmentID, addon.FieldLookupKey, addon.FieldName, addon.FieldDescription, addon.FieldType:
+		case addon.FieldID, addon.FieldTenantID, addon.FieldStatus, addon.FieldCreatedBy, addon.FieldUpdatedBy, addon.FieldEnvironmentID, addon.FieldLookupKey, addon.FieldName, addon.FieldDescription:
 			values[i] = new(sql.NullString)
 		case addon.FieldCreatedAt, addon.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -158,12 +156,6 @@ func (a *Addon) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				a.Description = value.String
 			}
-		case addon.FieldType:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field type", values[i])
-			} else if value.Valid {
-				a.Type = value.String
-			}
 		case addon.FieldMetadata:
 			if value, ok := values[i].(*[]byte); !ok {
 				return fmt.Errorf("unexpected type %T for field metadata", values[i])
@@ -242,9 +234,6 @@ func (a *Addon) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("description=")
 	builder.WriteString(a.Description)
-	builder.WriteString(", ")
-	builder.WriteString("type=")
-	builder.WriteString(a.Type)
 	builder.WriteString(", ")
 	builder.WriteString("metadata=")
 	builder.WriteString(fmt.Sprintf("%v", a.Metadata))

--- a/ent/addon/addon.go
+++ b/ent/addon/addon.go
@@ -34,8 +34,6 @@ const (
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
-	// FieldType holds the string denoting the type field in the database.
-	FieldType = "type"
 	// FieldMetadata holds the string denoting the metadata field in the database.
 	FieldMetadata = "metadata"
 	// EdgeEntitlements holds the string denoting the entitlements edge name in mutations.
@@ -64,7 +62,6 @@ var Columns = []string{
 	FieldLookupKey,
 	FieldName,
 	FieldDescription,
-	FieldType,
 	FieldMetadata,
 }
 
@@ -95,8 +92,6 @@ var (
 	LookupKeyValidator func(string) error
 	// NameValidator is a validator for the "name" field. It is called by the builders before save.
 	NameValidator func(string) error
-	// TypeValidator is a validator for the "type" field. It is called by the builders before save.
-	TypeValidator func(string) error
 )
 
 // OrderOption defines the ordering options for the Addon queries.
@@ -155,11 +150,6 @@ func ByName(opts ...sql.OrderTermOption) OrderOption {
 // ByDescription orders the results by the description field.
 func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDescription, opts...).ToFunc()
-}
-
-// ByType orders the results by the type field.
-func ByType(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldType, opts...).ToFunc()
 }
 
 // ByEntitlementsCount orders the results by entitlements count.

--- a/ent/addon/where.go
+++ b/ent/addon/where.go
@@ -115,11 +115,6 @@ func Description(v string) predicate.Addon {
 	return predicate.Addon(sql.FieldEQ(FieldDescription, v))
 }
 
-// Type applies equality check predicate on the "type" field. It's identical to TypeEQ.
-func Type(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldEQ(FieldType, v))
-}
-
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
 func TenantIDEQ(v string) predicate.Addon {
 	return predicate.Addon(sql.FieldEQ(FieldTenantID, v))
@@ -758,71 +753,6 @@ func DescriptionEqualFold(v string) predicate.Addon {
 // DescriptionContainsFold applies the ContainsFold predicate on the "description" field.
 func DescriptionContainsFold(v string) predicate.Addon {
 	return predicate.Addon(sql.FieldContainsFold(FieldDescription, v))
-}
-
-// TypeEQ applies the EQ predicate on the "type" field.
-func TypeEQ(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldEQ(FieldType, v))
-}
-
-// TypeNEQ applies the NEQ predicate on the "type" field.
-func TypeNEQ(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldNEQ(FieldType, v))
-}
-
-// TypeIn applies the In predicate on the "type" field.
-func TypeIn(vs ...string) predicate.Addon {
-	return predicate.Addon(sql.FieldIn(FieldType, vs...))
-}
-
-// TypeNotIn applies the NotIn predicate on the "type" field.
-func TypeNotIn(vs ...string) predicate.Addon {
-	return predicate.Addon(sql.FieldNotIn(FieldType, vs...))
-}
-
-// TypeGT applies the GT predicate on the "type" field.
-func TypeGT(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldGT(FieldType, v))
-}
-
-// TypeGTE applies the GTE predicate on the "type" field.
-func TypeGTE(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldGTE(FieldType, v))
-}
-
-// TypeLT applies the LT predicate on the "type" field.
-func TypeLT(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldLT(FieldType, v))
-}
-
-// TypeLTE applies the LTE predicate on the "type" field.
-func TypeLTE(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldLTE(FieldType, v))
-}
-
-// TypeContains applies the Contains predicate on the "type" field.
-func TypeContains(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldContains(FieldType, v))
-}
-
-// TypeHasPrefix applies the HasPrefix predicate on the "type" field.
-func TypeHasPrefix(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldHasPrefix(FieldType, v))
-}
-
-// TypeHasSuffix applies the HasSuffix predicate on the "type" field.
-func TypeHasSuffix(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldHasSuffix(FieldType, v))
-}
-
-// TypeEqualFold applies the EqualFold predicate on the "type" field.
-func TypeEqualFold(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldEqualFold(FieldType, v))
-}
-
-// TypeContainsFold applies the ContainsFold predicate on the "type" field.
-func TypeContainsFold(v string) predicate.Addon {
-	return predicate.Addon(sql.FieldContainsFold(FieldType, v))
 }
 
 // MetadataIsNil applies the IsNil predicate on the "metadata" field.

--- a/ent/addon_create.go
+++ b/ent/addon_create.go
@@ -137,12 +137,6 @@ func (ac *AddonCreate) SetNillableDescription(s *string) *AddonCreate {
 	return ac
 }
 
-// SetType sets the "type" field.
-func (ac *AddonCreate) SetType(s string) *AddonCreate {
-	ac.mutation.SetType(s)
-	return ac
-}
-
 // SetMetadata sets the "metadata" field.
 func (ac *AddonCreate) SetMetadata(m map[string]interface{}) *AddonCreate {
 	ac.mutation.SetMetadata(m)
@@ -258,14 +252,6 @@ func (ac *AddonCreate) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Addon.name": %w`, err)}
 		}
 	}
-	if _, ok := ac.mutation.GetType(); !ok {
-		return &ValidationError{Name: "type", err: errors.New(`ent: missing required field "Addon.type"`)}
-	}
-	if v, ok := ac.mutation.GetType(); ok {
-		if err := addon.TypeValidator(v); err != nil {
-			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "Addon.type": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -340,10 +326,6 @@ func (ac *AddonCreate) createSpec() (*Addon, *sqlgraph.CreateSpec) {
 	if value, ok := ac.mutation.Description(); ok {
 		_spec.SetField(addon.FieldDescription, field.TypeString, value)
 		_node.Description = value
-	}
-	if value, ok := ac.mutation.GetType(); ok {
-		_spec.SetField(addon.FieldType, field.TypeString, value)
-		_node.Type = value
 	}
 	if value, ok := ac.mutation.Metadata(); ok {
 		_spec.SetField(addon.FieldMetadata, field.TypeJSON, value)

--- a/ent/addon_update.go
+++ b/ent/addon_update.go
@@ -103,20 +103,6 @@ func (au *AddonUpdate) ClearDescription() *AddonUpdate {
 	return au
 }
 
-// SetType sets the "type" field.
-func (au *AddonUpdate) SetType(s string) *AddonUpdate {
-	au.mutation.SetType(s)
-	return au
-}
-
-// SetNillableType sets the "type" field if the given value is not nil.
-func (au *AddonUpdate) SetNillableType(s *string) *AddonUpdate {
-	if s != nil {
-		au.SetType(*s)
-	}
-	return au
-}
-
 // SetMetadata sets the "metadata" field.
 func (au *AddonUpdate) SetMetadata(m map[string]interface{}) *AddonUpdate {
 	au.mutation.SetMetadata(m)
@@ -213,11 +199,6 @@ func (au *AddonUpdate) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Addon.name": %w`, err)}
 		}
 	}
-	if v, ok := au.mutation.GetType(); ok {
-		if err := addon.TypeValidator(v); err != nil {
-			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "Addon.type": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -259,9 +240,6 @@ func (au *AddonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if au.mutation.DescriptionCleared() {
 		_spec.ClearField(addon.FieldDescription, field.TypeString)
-	}
-	if value, ok := au.mutation.GetType(); ok {
-		_spec.SetField(addon.FieldType, field.TypeString, value)
 	}
 	if value, ok := au.mutation.Metadata(); ok {
 		_spec.SetField(addon.FieldMetadata, field.TypeJSON, value)
@@ -408,20 +386,6 @@ func (auo *AddonUpdateOne) ClearDescription() *AddonUpdateOne {
 	return auo
 }
 
-// SetType sets the "type" field.
-func (auo *AddonUpdateOne) SetType(s string) *AddonUpdateOne {
-	auo.mutation.SetType(s)
-	return auo
-}
-
-// SetNillableType sets the "type" field if the given value is not nil.
-func (auo *AddonUpdateOne) SetNillableType(s *string) *AddonUpdateOne {
-	if s != nil {
-		auo.SetType(*s)
-	}
-	return auo
-}
-
 // SetMetadata sets the "metadata" field.
 func (auo *AddonUpdateOne) SetMetadata(m map[string]interface{}) *AddonUpdateOne {
 	auo.mutation.SetMetadata(m)
@@ -531,11 +495,6 @@ func (auo *AddonUpdateOne) check() error {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`ent: validator failed for field "Addon.name": %w`, err)}
 		}
 	}
-	if v, ok := auo.mutation.GetType(); ok {
-		if err := addon.TypeValidator(v); err != nil {
-			return &ValidationError{Name: "type", err: fmt.Errorf(`ent: validator failed for field "Addon.type": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -594,9 +553,6 @@ func (auo *AddonUpdateOne) sqlSave(ctx context.Context) (_node *Addon, err error
 	}
 	if auo.mutation.DescriptionCleared() {
 		_spec.ClearField(addon.FieldDescription, field.TypeString)
-	}
-	if value, ok := auo.mutation.GetType(); ok {
-		_spec.SetField(addon.FieldType, field.TypeString, value)
 	}
 	if value, ok := auo.mutation.Metadata(); ok {
 		_spec.SetField(addon.FieldMetadata, field.TypeJSON, value)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -22,7 +22,6 @@ var (
 		{Name: "lookup_key", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "name", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(255)"}},
 		{Name: "description", Type: field.TypeString, Nullable: true, Size: 2147483647},
-		{Name: "type", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(20)"}},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 	}
 	// AddonsTable holds the schema information for the "addons" table.

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1690,6 +1690,7 @@ var (
 		{Name: "start_date", Type: field.TypeTime, Nullable: true},
 		{Name: "end_date", Type: field.TypeTime, Nullable: true},
 		{Name: "subscription_phase_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "addon_association_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "commitment_amount", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric(20,8)"}},
 		{Name: "commitment_quantity", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric(20,8)"}},
@@ -1708,7 +1709,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "subscription_line_items_subscriptions_line_items",
-				Columns:    []*schema.Column{SubscriptionLineItemsColumns[36]},
+				Columns:    []*schema.Column{SubscriptionLineItemsColumns[37]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -1717,7 +1718,7 @@ var (
 			{
 				Name:    "subscriptionlineitem_tenant_id_environment_id_subscription_id_status",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionLineItemsColumns[1], SubscriptionLineItemsColumns[7], SubscriptionLineItemsColumns[36], SubscriptionLineItemsColumns[2]},
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[1], SubscriptionLineItemsColumns[7], SubscriptionLineItemsColumns[37], SubscriptionLineItemsColumns[2]},
 			},
 			{
 				Name:    "subscriptionlineitem_tenant_id_environment_id_customer_id_status",
@@ -1747,7 +1748,12 @@ var (
 			{
 				Name:    "subscriptionlineitem_subscription_id_status",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionLineItemsColumns[36], SubscriptionLineItemsColumns[2]},
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[37], SubscriptionLineItemsColumns[2]},
+			},
+			{
+				Name:    "subscriptionlineitem_tenant_id_environment_id_addon_association_id_status",
+				Unique:  false,
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[1], SubscriptionLineItemsColumns[7], SubscriptionLineItemsColumns[28], SubscriptionLineItemsColumns[2]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -49177,6 +49177,7 @@ type SubscriptionLineItemMutation struct {
 	start_date                 *time.Time
 	end_date                   *time.Time
 	subscription_phase_id      *string
+	addon_association_id       *string
 	metadata                   *map[string]string
 	commitment_amount          *decimal.Decimal
 	commitment_quantity        *decimal.Decimal
@@ -50543,6 +50544,55 @@ func (m *SubscriptionLineItemMutation) ResetSubscriptionPhaseID() {
 	delete(m.clearedFields, subscriptionlineitem.FieldSubscriptionPhaseID)
 }
 
+// SetAddonAssociationID sets the "addon_association_id" field.
+func (m *SubscriptionLineItemMutation) SetAddonAssociationID(s string) {
+	m.addon_association_id = &s
+}
+
+// AddonAssociationID returns the value of the "addon_association_id" field in the mutation.
+func (m *SubscriptionLineItemMutation) AddonAssociationID() (r string, exists bool) {
+	v := m.addon_association_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAddonAssociationID returns the old "addon_association_id" field's value of the SubscriptionLineItem entity.
+// If the SubscriptionLineItem object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SubscriptionLineItemMutation) OldAddonAssociationID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAddonAssociationID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAddonAssociationID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAddonAssociationID: %w", err)
+	}
+	return oldValue.AddonAssociationID, nil
+}
+
+// ClearAddonAssociationID clears the value of the "addon_association_id" field.
+func (m *SubscriptionLineItemMutation) ClearAddonAssociationID() {
+	m.addon_association_id = nil
+	m.clearedFields[subscriptionlineitem.FieldAddonAssociationID] = struct{}{}
+}
+
+// AddonAssociationIDCleared returns if the "addon_association_id" field was cleared in this mutation.
+func (m *SubscriptionLineItemMutation) AddonAssociationIDCleared() bool {
+	_, ok := m.clearedFields[subscriptionlineitem.FieldAddonAssociationID]
+	return ok
+}
+
+// ResetAddonAssociationID resets all changes to the "addon_association_id" field.
+func (m *SubscriptionLineItemMutation) ResetAddonAssociationID() {
+	m.addon_association_id = nil
+	delete(m.clearedFields, subscriptionlineitem.FieldAddonAssociationID)
+}
+
 // SetMetadata sets the "metadata" field.
 func (m *SubscriptionLineItemMutation) SetMetadata(value map[string]string) {
 	m.metadata = &value
@@ -51024,7 +51074,7 @@ func (m *SubscriptionLineItemMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SubscriptionLineItemMutation) Fields() []string {
-	fields := make([]string, 0, 36)
+	fields := make([]string, 0, 37)
 	if m.tenant_id != nil {
 		fields = append(fields, subscriptionlineitem.FieldTenantID)
 	}
@@ -51108,6 +51158,9 @@ func (m *SubscriptionLineItemMutation) Fields() []string {
 	}
 	if m.subscription_phase_id != nil {
 		fields = append(fields, subscriptionlineitem.FieldSubscriptionPhaseID)
+	}
+	if m.addon_association_id != nil {
+		fields = append(fields, subscriptionlineitem.FieldAddonAssociationID)
 	}
 	if m.metadata != nil {
 		fields = append(fields, subscriptionlineitem.FieldMetadata)
@@ -51197,6 +51250,8 @@ func (m *SubscriptionLineItemMutation) Field(name string) (ent.Value, bool) {
 		return m.EndDate()
 	case subscriptionlineitem.FieldSubscriptionPhaseID:
 		return m.SubscriptionPhaseID()
+	case subscriptionlineitem.FieldAddonAssociationID:
+		return m.AddonAssociationID()
 	case subscriptionlineitem.FieldMetadata:
 		return m.Metadata()
 	case subscriptionlineitem.FieldCommitmentAmount:
@@ -51278,6 +51333,8 @@ func (m *SubscriptionLineItemMutation) OldField(ctx context.Context, name string
 		return m.OldEndDate(ctx)
 	case subscriptionlineitem.FieldSubscriptionPhaseID:
 		return m.OldSubscriptionPhaseID(ctx)
+	case subscriptionlineitem.FieldAddonAssociationID:
+		return m.OldAddonAssociationID(ctx)
 	case subscriptionlineitem.FieldMetadata:
 		return m.OldMetadata(ctx)
 	case subscriptionlineitem.FieldCommitmentAmount:
@@ -51499,6 +51556,13 @@ func (m *SubscriptionLineItemMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetSubscriptionPhaseID(v)
 		return nil
+	case subscriptionlineitem.FieldAddonAssociationID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAddonAssociationID(v)
+		return nil
 	case subscriptionlineitem.FieldMetadata:
 		v, ok := value.(map[string]string)
 		if !ok {
@@ -51657,6 +51721,9 @@ func (m *SubscriptionLineItemMutation) ClearedFields() []string {
 	if m.FieldCleared(subscriptionlineitem.FieldSubscriptionPhaseID) {
 		fields = append(fields, subscriptionlineitem.FieldSubscriptionPhaseID)
 	}
+	if m.FieldCleared(subscriptionlineitem.FieldAddonAssociationID) {
+		fields = append(fields, subscriptionlineitem.FieldAddonAssociationID)
+	}
 	if m.FieldCleared(subscriptionlineitem.FieldMetadata) {
 		fields = append(fields, subscriptionlineitem.FieldMetadata)
 	}
@@ -51733,6 +51800,9 @@ func (m *SubscriptionLineItemMutation) ClearField(name string) error {
 		return nil
 	case subscriptionlineitem.FieldSubscriptionPhaseID:
 		m.ClearSubscriptionPhaseID()
+		return nil
+	case subscriptionlineitem.FieldAddonAssociationID:
+		m.ClearAddonAssociationID()
 		return nil
 	case subscriptionlineitem.FieldMetadata:
 		m.ClearMetadata()
@@ -51843,6 +51913,9 @@ func (m *SubscriptionLineItemMutation) ResetField(name string) error {
 		return nil
 	case subscriptionlineitem.FieldSubscriptionPhaseID:
 		m.ResetSubscriptionPhaseID()
+		return nil
+	case subscriptionlineitem.FieldAddonAssociationID:
+		m.ResetAddonAssociationID()
 		return nil
 	case subscriptionlineitem.FieldMetadata:
 		m.ResetMetadata()

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -138,7 +138,6 @@ type AddonMutation struct {
 	lookup_key          *string
 	name                *string
 	description         *string
-	_type               *string
 	metadata            *map[string]interface{}
 	clearedFields       map[string]struct{}
 	entitlements        map[string]struct{}
@@ -665,42 +664,6 @@ func (m *AddonMutation) ResetDescription() {
 	delete(m.clearedFields, addon.FieldDescription)
 }
 
-// SetType sets the "type" field.
-func (m *AddonMutation) SetType(s string) {
-	m._type = &s
-}
-
-// GetType returns the value of the "type" field in the mutation.
-func (m *AddonMutation) GetType() (r string, exists bool) {
-	v := m._type
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldType returns the old "type" field's value of the Addon entity.
-// If the Addon object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *AddonMutation) OldType(ctx context.Context) (v string, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldType is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldType requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldType: %w", err)
-	}
-	return oldValue.Type, nil
-}
-
-// ResetType resets all changes to the "type" field.
-func (m *AddonMutation) ResetType() {
-	m._type = nil
-}
-
 // SetMetadata sets the "metadata" field.
 func (m *AddonMutation) SetMetadata(value map[string]interface{}) {
 	m.metadata = &value
@@ -838,7 +801,7 @@ func (m *AddonMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AddonMutation) Fields() []string {
-	fields := make([]string, 0, 12)
+	fields := make([]string, 0, 11)
 	if m.tenant_id != nil {
 		fields = append(fields, addon.FieldTenantID)
 	}
@@ -868,9 +831,6 @@ func (m *AddonMutation) Fields() []string {
 	}
 	if m.description != nil {
 		fields = append(fields, addon.FieldDescription)
-	}
-	if m._type != nil {
-		fields = append(fields, addon.FieldType)
 	}
 	if m.metadata != nil {
 		fields = append(fields, addon.FieldMetadata)
@@ -903,8 +863,6 @@ func (m *AddonMutation) Field(name string) (ent.Value, bool) {
 		return m.Name()
 	case addon.FieldDescription:
 		return m.Description()
-	case addon.FieldType:
-		return m.GetType()
 	case addon.FieldMetadata:
 		return m.Metadata()
 	}
@@ -936,8 +894,6 @@ func (m *AddonMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldName(ctx)
 	case addon.FieldDescription:
 		return m.OldDescription(ctx)
-	case addon.FieldType:
-		return m.OldType(ctx)
 	case addon.FieldMetadata:
 		return m.OldMetadata(ctx)
 	}
@@ -1018,13 +974,6 @@ func (m *AddonMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetDescription(v)
-		return nil
-	case addon.FieldType:
-		v, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetType(v)
 		return nil
 	case addon.FieldMetadata:
 		v, ok := value.(map[string]interface{})
@@ -1144,9 +1093,6 @@ func (m *AddonMutation) ResetField(name string) error {
 		return nil
 	case addon.FieldDescription:
 		m.ResetDescription()
-		return nil
-	case addon.FieldType:
-		m.ResetType()
 		return nil
 	case addon.FieldMetadata:
 		m.ResetMetadata()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -1737,11 +1737,11 @@ func init() {
 	// subscriptionlineitem.DefaultTrialPeriod holds the default value on creation for the trial_period field.
 	subscriptionlineitem.DefaultTrialPeriod = subscriptionlineitemDescTrialPeriod.Default.(int)
 	// subscriptionlineitemDescCommitmentTrueUpEnabled is the schema descriptor for commitment_true_up_enabled field.
-	subscriptionlineitemDescCommitmentTrueUpEnabled := subscriptionlineitemFields[27].Descriptor()
+	subscriptionlineitemDescCommitmentTrueUpEnabled := subscriptionlineitemFields[28].Descriptor()
 	// subscriptionlineitem.DefaultCommitmentTrueUpEnabled holds the default value on creation for the commitment_true_up_enabled field.
 	subscriptionlineitem.DefaultCommitmentTrueUpEnabled = subscriptionlineitemDescCommitmentTrueUpEnabled.Default.(bool)
 	// subscriptionlineitemDescCommitmentWindowed is the schema descriptor for commitment_windowed field.
-	subscriptionlineitemDescCommitmentWindowed := subscriptionlineitemFields[28].Descriptor()
+	subscriptionlineitemDescCommitmentWindowed := subscriptionlineitemFields[29].Descriptor()
 	// subscriptionlineitem.DefaultCommitmentWindowed holds the default value on creation for the commitment_windowed field.
 	subscriptionlineitem.DefaultCommitmentWindowed = subscriptionlineitemDescCommitmentWindowed.Default.(bool)
 	subscriptionpauseMixin := schema.SubscriptionPause{}.Mixin()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -98,10 +98,6 @@ func init() {
 	addonDescName := addonFields[2].Descriptor()
 	// addon.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	addon.NameValidator = addonDescName.Validators[0].(func(string) error)
-	// addonDescType is the schema descriptor for type field.
-	addonDescType := addonFields[4].Descriptor()
-	// addon.TypeValidator is a validator for the "type" field. It is called by the builders before save.
-	addon.TypeValidator = addonDescType.Validators[0].(func(string) error)
 	addonassociationMixin := schema.AddonAssociation{}.Mixin()
 	addonassociationMixinFields0 := addonassociationMixin[0].Fields()
 	_ = addonassociationMixinFields0

--- a/ent/schema/addon.go
+++ b/ent/schema/addon.go
@@ -52,13 +52,6 @@ func (Addon) Fields() []ent.Field {
 		field.Text("description").
 			Optional(),
 
-		field.String("type").
-			SchemaType(map[string]string{
-				"postgres": "varchar(20)",
-			}).
-			NotEmpty().
-			Comment("single_instance or multi_instance"),
-
 		field.JSON("metadata", map[string]interface{}{}).
 			Optional().
 			SchemaType(map[string]string{

--- a/ent/schema/subscription_line_item.go
+++ b/ent/schema/subscription_line_item.go
@@ -137,6 +137,15 @@ func (SubscriptionLineItem) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			Immutable(),
+		// addon_association_id links this line item to the AddonAssociation that created it.
+		// Set once on creation (immutable); nil for line items not originating from an addon add.
+		field.String("addon_association_id").
+			SchemaType(map[string]string{
+				"postgres": "varchar(50)",
+			}).
+			Optional().
+			Nillable().
+			Immutable(),
 		field.JSON("metadata", map[string]string{}).
 			Optional().
 			SchemaType(map[string]string{
@@ -205,5 +214,6 @@ func (SubscriptionLineItem) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "meter_id", "status"),
 		index.Fields("start_date", "end_date"),
 		index.Fields("subscription_id", "status"),
+		index.Fields("tenant_id", "environment_id", "addon_association_id", "status"),
 	}
 }

--- a/ent/subscriptionlineitem.go
+++ b/ent/subscriptionlineitem.go
@@ -77,6 +77,8 @@ type SubscriptionLineItem struct {
 	EndDate *time.Time `json:"end_date,omitempty"`
 	// SubscriptionPhaseID holds the value of the "subscription_phase_id" field.
 	SubscriptionPhaseID *string `json:"subscription_phase_id,omitempty"`
+	// AddonAssociationID holds the value of the "addon_association_id" field.
+	AddonAssociationID *string `json:"addon_association_id,omitempty"`
 	// Metadata holds the value of the "metadata" field.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// CommitmentAmount holds the value of the "commitment_amount" field.
@@ -145,7 +147,7 @@ func (*SubscriptionLineItem) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case subscriptionlineitem.FieldBillingPeriodCount, subscriptionlineitem.FieldTrialPeriod:
 			values[i] = new(sql.NullInt64)
-		case subscriptionlineitem.FieldID, subscriptionlineitem.FieldTenantID, subscriptionlineitem.FieldStatus, subscriptionlineitem.FieldCreatedBy, subscriptionlineitem.FieldUpdatedBy, subscriptionlineitem.FieldEnvironmentID, subscriptionlineitem.FieldSubscriptionID, subscriptionlineitem.FieldCustomerID, subscriptionlineitem.FieldEntityID, subscriptionlineitem.FieldEntityType, subscriptionlineitem.FieldPlanDisplayName, subscriptionlineitem.FieldPriceID, subscriptionlineitem.FieldPriceType, subscriptionlineitem.FieldMeterID, subscriptionlineitem.FieldMeterDisplayName, subscriptionlineitem.FieldPriceUnitID, subscriptionlineitem.FieldPriceUnit, subscriptionlineitem.FieldDisplayName, subscriptionlineitem.FieldCurrency, subscriptionlineitem.FieldBillingPeriod, subscriptionlineitem.FieldInvoiceCadence, subscriptionlineitem.FieldSubscriptionPhaseID, subscriptionlineitem.FieldCommitmentType, subscriptionlineitem.FieldCommitmentDuration:
+		case subscriptionlineitem.FieldID, subscriptionlineitem.FieldTenantID, subscriptionlineitem.FieldStatus, subscriptionlineitem.FieldCreatedBy, subscriptionlineitem.FieldUpdatedBy, subscriptionlineitem.FieldEnvironmentID, subscriptionlineitem.FieldSubscriptionID, subscriptionlineitem.FieldCustomerID, subscriptionlineitem.FieldEntityID, subscriptionlineitem.FieldEntityType, subscriptionlineitem.FieldPlanDisplayName, subscriptionlineitem.FieldPriceID, subscriptionlineitem.FieldPriceType, subscriptionlineitem.FieldMeterID, subscriptionlineitem.FieldMeterDisplayName, subscriptionlineitem.FieldPriceUnitID, subscriptionlineitem.FieldPriceUnit, subscriptionlineitem.FieldDisplayName, subscriptionlineitem.FieldCurrency, subscriptionlineitem.FieldBillingPeriod, subscriptionlineitem.FieldInvoiceCadence, subscriptionlineitem.FieldSubscriptionPhaseID, subscriptionlineitem.FieldAddonAssociationID, subscriptionlineitem.FieldCommitmentType, subscriptionlineitem.FieldCommitmentDuration:
 			values[i] = new(sql.NullString)
 		case subscriptionlineitem.FieldCreatedAt, subscriptionlineitem.FieldUpdatedAt, subscriptionlineitem.FieldStartDate, subscriptionlineitem.FieldEndDate:
 			values[i] = new(sql.NullTime)
@@ -348,6 +350,13 @@ func (sli *SubscriptionLineItem) assignValues(columns []string, values []any) er
 			} else if value.Valid {
 				sli.SubscriptionPhaseID = new(string)
 				*sli.SubscriptionPhaseID = value.String
+			}
+		case subscriptionlineitem.FieldAddonAssociationID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field addon_association_id", values[i])
+			} else if value.Valid {
+				sli.AddonAssociationID = new(string)
+				*sli.AddonAssociationID = value.String
 			}
 		case subscriptionlineitem.FieldMetadata:
 			if value, ok := values[i].(*[]byte); !ok {
@@ -553,6 +562,11 @@ func (sli *SubscriptionLineItem) String() string {
 	builder.WriteString(", ")
 	if v := sli.SubscriptionPhaseID; v != nil {
 		builder.WriteString("subscription_phase_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := sli.AddonAssociationID; v != nil {
+		builder.WriteString("addon_association_id=")
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")

--- a/ent/subscriptionlineitem/subscriptionlineitem.go
+++ b/ent/subscriptionlineitem/subscriptionlineitem.go
@@ -72,6 +72,8 @@ const (
 	FieldEndDate = "end_date"
 	// FieldSubscriptionPhaseID holds the string denoting the subscription_phase_id field in the database.
 	FieldSubscriptionPhaseID = "subscription_phase_id"
+	// FieldAddonAssociationID holds the string denoting the addon_association_id field in the database.
+	FieldAddonAssociationID = "addon_association_id"
 	// FieldMetadata holds the string denoting the metadata field in the database.
 	FieldMetadata = "metadata"
 	// FieldCommitmentAmount holds the string denoting the commitment_amount field in the database.
@@ -141,6 +143,7 @@ var Columns = []string{
 	FieldStartDate,
 	FieldEndDate,
 	FieldSubscriptionPhaseID,
+	FieldAddonAssociationID,
 	FieldMetadata,
 	FieldCommitmentAmount,
 	FieldCommitmentQuantity,
@@ -344,6 +347,11 @@ func ByEndDate(opts ...sql.OrderTermOption) OrderOption {
 // BySubscriptionPhaseID orders the results by the subscription_phase_id field.
 func BySubscriptionPhaseID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSubscriptionPhaseID, opts...).ToFunc()
+}
+
+// ByAddonAssociationID orders the results by the addon_association_id field.
+func ByAddonAssociationID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAddonAssociationID, opts...).ToFunc()
 }
 
 // ByCommitmentAmount orders the results by the commitment_amount field.

--- a/ent/subscriptionlineitem/where.go
+++ b/ent/subscriptionlineitem/where.go
@@ -211,6 +211,11 @@ func SubscriptionPhaseID(v string) predicate.SubscriptionLineItem {
 	return predicate.SubscriptionLineItem(sql.FieldEQ(FieldSubscriptionPhaseID, v))
 }
 
+// AddonAssociationID applies equality check predicate on the "addon_association_id" field. It's identical to AddonAssociationIDEQ.
+func AddonAssociationID(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldEQ(FieldAddonAssociationID, v))
+}
+
 // CommitmentAmount applies equality check predicate on the "commitment_amount" field. It's identical to CommitmentAmountEQ.
 func CommitmentAmount(v decimal.Decimal) predicate.SubscriptionLineItem {
 	return predicate.SubscriptionLineItem(sql.FieldEQ(FieldCommitmentAmount, v))
@@ -2116,6 +2121,81 @@ func SubscriptionPhaseIDEqualFold(v string) predicate.SubscriptionLineItem {
 // SubscriptionPhaseIDContainsFold applies the ContainsFold predicate on the "subscription_phase_id" field.
 func SubscriptionPhaseIDContainsFold(v string) predicate.SubscriptionLineItem {
 	return predicate.SubscriptionLineItem(sql.FieldContainsFold(FieldSubscriptionPhaseID, v))
+}
+
+// AddonAssociationIDEQ applies the EQ predicate on the "addon_association_id" field.
+func AddonAssociationIDEQ(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldEQ(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDNEQ applies the NEQ predicate on the "addon_association_id" field.
+func AddonAssociationIDNEQ(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldNEQ(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDIn applies the In predicate on the "addon_association_id" field.
+func AddonAssociationIDIn(vs ...string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldIn(FieldAddonAssociationID, vs...))
+}
+
+// AddonAssociationIDNotIn applies the NotIn predicate on the "addon_association_id" field.
+func AddonAssociationIDNotIn(vs ...string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldNotIn(FieldAddonAssociationID, vs...))
+}
+
+// AddonAssociationIDGT applies the GT predicate on the "addon_association_id" field.
+func AddonAssociationIDGT(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldGT(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDGTE applies the GTE predicate on the "addon_association_id" field.
+func AddonAssociationIDGTE(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldGTE(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDLT applies the LT predicate on the "addon_association_id" field.
+func AddonAssociationIDLT(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldLT(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDLTE applies the LTE predicate on the "addon_association_id" field.
+func AddonAssociationIDLTE(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldLTE(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDContains applies the Contains predicate on the "addon_association_id" field.
+func AddonAssociationIDContains(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldContains(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDHasPrefix applies the HasPrefix predicate on the "addon_association_id" field.
+func AddonAssociationIDHasPrefix(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldHasPrefix(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDHasSuffix applies the HasSuffix predicate on the "addon_association_id" field.
+func AddonAssociationIDHasSuffix(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldHasSuffix(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDIsNil applies the IsNil predicate on the "addon_association_id" field.
+func AddonAssociationIDIsNil() predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldIsNull(FieldAddonAssociationID))
+}
+
+// AddonAssociationIDNotNil applies the NotNil predicate on the "addon_association_id" field.
+func AddonAssociationIDNotNil() predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldNotNull(FieldAddonAssociationID))
+}
+
+// AddonAssociationIDEqualFold applies the EqualFold predicate on the "addon_association_id" field.
+func AddonAssociationIDEqualFold(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldEqualFold(FieldAddonAssociationID, v))
+}
+
+// AddonAssociationIDContainsFold applies the ContainsFold predicate on the "addon_association_id" field.
+func AddonAssociationIDContainsFold(v string) predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldContainsFold(FieldAddonAssociationID, v))
 }
 
 // MetadataIsNil applies the IsNil predicate on the "metadata" field.

--- a/ent/subscriptionlineitem_create.go
+++ b/ent/subscriptionlineitem_create.go
@@ -368,6 +368,20 @@ func (slic *SubscriptionLineItemCreate) SetNillableSubscriptionPhaseID(s *string
 	return slic
 }
 
+// SetAddonAssociationID sets the "addon_association_id" field.
+func (slic *SubscriptionLineItemCreate) SetAddonAssociationID(s string) *SubscriptionLineItemCreate {
+	slic.mutation.SetAddonAssociationID(s)
+	return slic
+}
+
+// SetNillableAddonAssociationID sets the "addon_association_id" field if the given value is not nil.
+func (slic *SubscriptionLineItemCreate) SetNillableAddonAssociationID(s *string) *SubscriptionLineItemCreate {
+	if s != nil {
+		slic.SetAddonAssociationID(*s)
+	}
+	return slic
+}
+
 // SetMetadata sets the "metadata" field.
 func (slic *SubscriptionLineItemCreate) SetMetadata(m map[string]string) *SubscriptionLineItemCreate {
 	slic.mutation.SetMetadata(m)
@@ -812,6 +826,10 @@ func (slic *SubscriptionLineItemCreate) createSpec() (*SubscriptionLineItem, *sq
 	if value, ok := slic.mutation.SubscriptionPhaseID(); ok {
 		_spec.SetField(subscriptionlineitem.FieldSubscriptionPhaseID, field.TypeString, value)
 		_node.SubscriptionPhaseID = &value
+	}
+	if value, ok := slic.mutation.AddonAssociationID(); ok {
+		_spec.SetField(subscriptionlineitem.FieldAddonAssociationID, field.TypeString, value)
+		_node.AddonAssociationID = &value
 	}
 	if value, ok := slic.mutation.Metadata(); ok {
 		_spec.SetField(subscriptionlineitem.FieldMetadata, field.TypeJSON, value)

--- a/ent/subscriptionlineitem_update.go
+++ b/ent/subscriptionlineitem_update.go
@@ -739,6 +739,9 @@ func (sliu *SubscriptionLineItemUpdate) sqlSave(ctx context.Context) (n int, err
 	if sliu.mutation.SubscriptionPhaseIDCleared() {
 		_spec.ClearField(subscriptionlineitem.FieldSubscriptionPhaseID, field.TypeString)
 	}
+	if sliu.mutation.AddonAssociationIDCleared() {
+		_spec.ClearField(subscriptionlineitem.FieldAddonAssociationID, field.TypeString)
+	}
 	if value, ok := sliu.mutation.Metadata(); ok {
 		_spec.SetField(subscriptionlineitem.FieldMetadata, field.TypeJSON, value)
 	}
@@ -1583,6 +1586,9 @@ func (sliuo *SubscriptionLineItemUpdateOne) sqlSave(ctx context.Context) (_node 
 	}
 	if sliuo.mutation.SubscriptionPhaseIDCleared() {
 		_spec.ClearField(subscriptionlineitem.FieldSubscriptionPhaseID, field.TypeString)
+	}
+	if sliuo.mutation.AddonAssociationIDCleared() {
+		_spec.ClearField(subscriptionlineitem.FieldAddonAssociationID, field.TypeString)
 	}
 	if value, ok := sliuo.mutation.Metadata(); ok {
 		_spec.SetField(subscriptionlineitem.FieldMetadata, field.TypeJSON, value)

--- a/internal/api/dto/addon.go
+++ b/internal/api/dto/addon.go
@@ -16,7 +16,6 @@ type CreateAddonRequest struct {
 	Name        string                 `json:"name" validate:"required"`
 	LookupKey   string                 `json:"lookup_key" validate:"required"`
 	Description string                 `json:"description"`
-	Type        types.AddonType        `json:"type" validate:"required"`
 	Metadata    map[string]interface{} `json:"metadata"`
 }
 
@@ -25,11 +24,6 @@ func (r *CreateAddonRequest) Validate() error {
 	if err != nil {
 		return err
 	}
-
-	if err := r.Type.Validate(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -39,7 +33,6 @@ func (r *CreateAddonRequest) ToAddon(ctx context.Context) *addon.Addon {
 		Name:          r.Name,
 		LookupKey:     r.LookupKey,
 		Description:   r.Description,
-		Type:          r.Type,
 		Metadata:      r.Metadata,
 		EnvironmentID: types.GetEnvironmentID(ctx),
 		BaseModel:     types.GetDefaultBaseModel(ctx),
@@ -81,9 +74,11 @@ type ListAddonsResponse = types.ListResponse[*AddonResponse] // @name ListAddons
 
 // AddAddonToSubscriptionRequest represents the request to add an addon to a subscription
 type AddAddonToSubscriptionRequest struct {
-	AddonID   string                 `json:"addon_id" validate:"required"`
-	StartDate *time.Time             `json:"start_date,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata"`
+	AddonID           string                  `json:"addon_id" validate:"required"`
+	Cadence           types.AddonCadence      `json:"cadence" validate:"required"`
+	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
+	StartDate         *time.Time              `json:"start_date,omitempty"`
+	Metadata          map[string]interface{}  `json:"metadata"`
 
 	// LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)
 	LineItemCommitments map[string]*LineItemCommitmentConfig `json:"line_item_commitments,omitempty" validate:"omitempty,dive"`
@@ -116,9 +111,18 @@ func (a *AddAddonToSubscriptionRequest) ToAddonAssociation(ctx context.Context, 
 }
 
 func (r *AddAddonToSubscriptionRequest) Validate() error {
-	err := validator.ValidateRequest(r)
-	if err != nil {
+	if err := validator.ValidateRequest(r); err != nil {
 		return err
+	}
+
+	if err := r.Cadence.Validate(); err != nil {
+		return err
+	}
+
+	if r.ProrationBehavior != "" {
+		if err := r.ProrationBehavior.Validate(); err != nil {
+			return err
+		}
 	}
 
 	if err := validateLineItemCommitments(r.LineItemCommitments); err != nil {

--- a/internal/api/dto/addon.go
+++ b/internal/api/dto/addon.go
@@ -75,7 +75,7 @@ type ListAddonsResponse = types.ListResponse[*AddonResponse] // @name ListAddons
 // AddAddonToSubscriptionRequest represents the request to add an addon to a subscription
 type AddAddonToSubscriptionRequest struct {
 	AddonID           string                  `json:"addon_id" validate:"required"`
-	Cadence           types.AddonCadence      `json:"cadence" validate:"required"`
+	Cadence           types.AddonCadence      `json:"cadence"`
 	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
 	StartDate         *time.Time              `json:"start_date,omitempty"`
 	Metadata          map[string]interface{}  `json:"metadata"`
@@ -113,6 +113,11 @@ func (a *AddAddonToSubscriptionRequest) ToAddonAssociation(ctx context.Context, 
 func (r *AddAddonToSubscriptionRequest) Validate() error {
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
+	}
+
+	// Default to recurring when not provided for backward compatibility.
+	if r.Cadence == "" {
+		r.Cadence = types.AddonCadenceRecurring
 	}
 
 	if err := r.Cadence.Validate(); err != nil {

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -418,13 +418,24 @@ type AddAddonRequest struct {
 
 // RemoveAddonRequest is used by body-based endpoint /subscriptions/addon (DELETE)
 type RemoveAddonRequest struct {
-	AddonAssociationID string `json:"addon_association_id" validate:"required"`
-	Reason             string `json:"reason,omitempty"`
+	AddonAssociationID string                  `json:"addon_association_id" validate:"required"`
+	Reason             string                  `json:"reason,omitempty"`
+	ProrationBehavior  types.ProrationBehavior `json:"proration_behavior,omitempty"`
+	// EffectiveDate is the date the cancellation takes effect.
+	// When nil the addon is cancelled at the end of the current period.
+	// When provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period
+	// values combined with create_prorations will issue a wallet credit for unused time.
+	EffectiveDate *time.Time `json:"effective_date,omitempty"`
 }
 
 func (r *RemoveAddonRequest) Validate() error {
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
+	}
+	if r.ProrationBehavior != "" {
+		if err := r.ProrationBehavior.Validate(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -93,6 +93,9 @@ type CreateSubscriptionLineItemRequest struct {
 	SubscriptionPhaseID  *string                         `json:"subscription_phase_id,omitempty"`
 	SkipEntitlementCheck bool                            `json:"-"` // This is used to skip entitlement check when creating a subscription line item
 
+	// ProrationBehavior controls mid-period charge creation. Defaults to none.
+	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
+
 	// Commitment fields
 	CommitmentAmount        *decimal.Decimal     `json:"commitment_amount,omitempty"`
 	CommitmentQuantity      *decimal.Decimal     `json:"commitment_quantity,omitempty"`
@@ -106,6 +109,9 @@ type CreateSubscriptionLineItemRequest struct {
 // DeleteSubscriptionLineItemRequest represents the request to delete a subscription line item
 type DeleteSubscriptionLineItemRequest struct {
 	EffectiveFrom *time.Time `json:"effective_from,omitempty"`
+
+	// ProrationBehavior controls mid-period credit issuance. Defaults to none.
+	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
 }
 
 type UpdateSubscriptionLineItemRequest struct {

--- a/internal/api/v1/wallet.go
+++ b/internal/api/v1/wallet.go
@@ -577,6 +577,9 @@ func (h *WalletHandler) ListWallets(c *gin.Context) {
 		return
 	}
 
+	if filter.QueryFilter == nil {
+		filter.QueryFilter = types.NewDefaultQueryFilter()
+	}
 	if filter.GetLimit() == 0 {
 		filter.Limit = lo.ToPtr(types.GetDefaultFilter().Limit)
 	}

--- a/internal/domain/addon/model.go
+++ b/internal/domain/addon/model.go
@@ -12,7 +12,6 @@ type Addon struct {
 	LookupKey     string                 `json:"lookup_key,omitempty"`
 	Name          string                 `json:"name,omitempty"`
 	Description   string                 `json:"description,omitempty"`
-	Type          types.AddonType        `json:"type,omitempty"`
 	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 
 	types.BaseModel
@@ -25,7 +24,6 @@ func FromEnt(ent *ent.Addon) *Addon {
 		LookupKey:     ent.LookupKey,
 		Name:          ent.Name,
 		Description:   ent.Description,
-		Type:          types.AddonType(ent.Type),
 		Metadata:      ent.Metadata,
 		BaseModel: types.BaseModel{
 			TenantID:  ent.TenantID,

--- a/internal/domain/subscription/line_item.go
+++ b/internal/domain/subscription/line_item.go
@@ -34,6 +34,7 @@ type SubscriptionLineItem struct {
 	StartDate           time.Time                            `db:"start_date" json:"start_date,omitempty"`
 	EndDate             time.Time                            `db:"end_date" json:"end_date,omitempty"`
 	SubscriptionPhaseID *string                              `db:"subscription_phase_id" json:"subscription_phase_id,omitempty"`
+	AddonAssociationID  *string                              `db:"addon_association_id" json:"addon_association_id,omitempty"`
 	Metadata            map[string]string                    `db:"metadata" json:"metadata,omitempty"`
 	EnvironmentID       string                               `db:"environment_id" json:"environment_id"`
 
@@ -115,6 +116,7 @@ func SubscriptionLineItemFromEnt(e *ent.SubscriptionLineItem) *SubscriptionLineI
 	var meterID, meterDisplayName, displayName string
 	var startDate, endDate time.Time
 	var subscriptionPhaseID *string
+	var addonAssociationID *string
 
 	priceType := lo.FromPtr(e.PriceType)
 	if e.MeterID != nil {
@@ -135,6 +137,9 @@ func SubscriptionLineItemFromEnt(e *ent.SubscriptionLineItem) *SubscriptionLineI
 	}
 	if e.SubscriptionPhaseID != nil {
 		subscriptionPhaseID = e.SubscriptionPhaseID
+	}
+	if e.AddonAssociationID != nil {
+		addonAssociationID = e.AddonAssociationID
 	}
 
 	// Handle commitment fields
@@ -176,6 +181,7 @@ func SubscriptionLineItemFromEnt(e *ent.SubscriptionLineItem) *SubscriptionLineI
 		StartDate:               startDate,
 		EndDate:                 endDate,
 		SubscriptionPhaseID:     subscriptionPhaseID,
+		AddonAssociationID:      addonAssociationID,
 		Metadata:                e.Metadata,
 		EnvironmentID:           e.EnvironmentID,
 		CommitmentAmount:        e.CommitmentAmount,

--- a/internal/repository/ent/addon.go
+++ b/internal/repository/ent/addon.go
@@ -65,7 +65,6 @@ func (r *addonRepository) Create(ctx context.Context, a *domainAddon.Addon) erro
 		SetStatus(string(a.Status)).
 		SetName(a.Name).
 		SetDescription(a.Description).
-		SetType(string(a.Type)).
 		SetLookupKey(a.LookupKey).
 		SetMetadata(a.Metadata).
 		SetCreatedBy(types.GetUserID(ctx)).
@@ -318,7 +317,6 @@ func (r *addonRepository) Update(ctx context.Context, a *domainAddon.Addon) erro
 		SetName(a.Name).
 		SetDescription(a.Description).
 		SetStatus(string(a.Status)).
-		SetType(string(a.Type)).
 		SetMetadata(a.Metadata).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
@@ -472,11 +470,6 @@ func (o AddonQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.A
 	// Apply addon IDs filter if specified
 	if len(f.AddonIDs) > 0 {
 		query = query.Where(addon.IDIn(f.AddonIDs...))
-	}
-
-	// Apply addon type filter if specified
-	if f.AddonType != "" {
-		query = query.Where(addon.Type(string(f.AddonType)))
 	}
 
 	// Apply lookup keys filter if specified

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -108,6 +108,7 @@ func (r *subscriptionLineItemRepository) Create(ctx context.Context, item *subsc
 		SetNillableStartDate(types.ToNillableTime(item.StartDate)).
 		SetNillableEndDate(types.ToNillableTime(item.EndDate)).
 		SetNillableSubscriptionPhaseID(item.SubscriptionPhaseID).
+		SetNillableAddonAssociationID(item.AddonAssociationID).
 		SetInvoiceCadence(item.InvoiceCadence).
 		SetTrialPeriod(item.TrialPeriod).
 		SetMetadata(item.Metadata).
@@ -373,6 +374,7 @@ func (r *subscriptionLineItemRepository) CreateBulk(ctx context.Context, items [
 			SetNillableStartDate(types.ToNillableTime(item.StartDate)).
 			SetNillableEndDate(types.ToNillableTime(item.EndDate)).
 			SetNillableSubscriptionPhaseID(item.SubscriptionPhaseID).
+			SetNillableAddonAssociationID(item.AddonAssociationID).
 			SetQuantity(item.Quantity).
 			SetCurrency(item.Currency).
 			SetBillingPeriod(item.BillingPeriod).
@@ -634,6 +636,11 @@ func (o *SubscriptionLineItemQueryOptions) applyEntityQueryOptions(_ context.Con
 	}
 	if f.EntityType != nil {
 		query = query.Where(subscriptionlineitem.EntityType(types.InvoiceLineItemEntityType(*f.EntityType)))
+	}
+
+	// Apply addon association IDs filter if specified
+	if len(f.AddonAssociationIDs) > 0 {
+		query = query.Where(subscriptionlineitem.AddonAssociationIDIn(f.AddonAssociationIDs...))
 	}
 
 	// Apply price IDs filter if specified

--- a/internal/service/line_item_proration.go
+++ b/internal/service/line_item_proration.go
@@ -1,0 +1,299 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/proration"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+)
+
+// LineItemProrationEntry pairs a line item with its loaded price and the requested action.
+type LineItemProrationEntry struct {
+	LineItem    *subscription.SubscriptionLineItem
+	Price       *price.Price
+	Action      types.ProrationAction
+	OldQuantity decimal.Decimal // non-zero only for quantity changes
+	NewQuantity decimal.Decimal // zero for remove; equals line item qty for add
+}
+
+// LineItemProrationRequest is the unified input for Compute and Apply.
+type LineItemProrationRequest struct {
+	Subscription   *subscription.Subscription
+	Entries        []LineItemProrationEntry
+	EffectiveDate  time.Time
+	Behavior       types.ProrationBehavior
+	Reason         string // shown in wallet credit description
+	IdempotencyKey string // required when Behavior == create_prorations and credits may be issued
+}
+
+// LineItemProrationSummary is returned by Compute and used internally by Apply.
+type LineItemProrationSummary struct {
+	// Per-item results in the same order as Entries (skipped entries are omitted).
+	Results []proration.ProrationResult
+
+	// Positive-net items aggregated into a single one-off invoice.
+	ChargeLineItems   []dto.CreateInvoiceLineItemRequest
+	TotalChargeAmount decimal.Decimal
+
+	// Absolute value of negative-net items; used for a single wallet credit.
+	TotalCreditAmount decimal.Decimal
+
+	Currency  string
+	IsPreview bool
+}
+
+// LineItemProrationService centralises compute + settlement for mid-period
+// add/remove of individual subscription line items.
+type LineItemProrationService interface {
+	// Compute calculates proration for all entries and returns a summary.
+	// No invoices or wallet credits are created.
+	Compute(ctx context.Context, req LineItemProrationRequest) (*LineItemProrationSummary, error)
+
+	// Apply calls Compute and then settles:
+	//   net > 0  → creates a single InvoiceTypeOneOff and attempts payment
+	//   net < 0  → issues a single wallet credit using req.IdempotencyKey
+	//   net == 0 → no-op
+	// If req.Behavior != ProrationBehaviorCreateProrations, Apply is a no-op.
+	Apply(ctx context.Context, req LineItemProrationRequest) error
+}
+
+type lineItemProrationService struct {
+	params ServiceParams
+}
+
+// NewLineItemProrationService creates a new LineItemProrationService.
+func NewLineItemProrationService(params ServiceParams) LineItemProrationService {
+	return &lineItemProrationService{params: params}
+}
+
+func (s *lineItemProrationService) Compute(ctx context.Context, req LineItemProrationRequest) (*LineItemProrationSummary, error) {
+	sub := req.Subscription
+	prorationSvc := NewProrationService(s.params)
+
+	customerTimezone := sub.CustomerTimezone
+	if customerTimezone == "" {
+		customerTimezone = "UTC"
+	}
+
+	summary := &LineItemProrationSummary{
+		Currency:          sub.Currency,
+		IsPreview:         req.Behavior == types.ProrationBehaviorNone,
+		TotalChargeAmount: decimal.Zero,
+		TotalCreditAmount: decimal.Zero,
+	}
+
+	for _, entry := range req.Entries {
+		item := entry.LineItem
+		p := entry.Price
+
+		// Skip usage prices — future consumption is unknown at change time.
+		if item.PriceType == types.PRICE_TYPE_USAGE {
+			continue
+		}
+
+		// Skip remove of onetime addons — non-refundable (EndDate non-zero means onetime cadence).
+		if entry.Action == types.ProrationActionRemoveItem && !item.EndDate.IsZero() {
+			continue
+		}
+
+		params, skip := s.buildProrationParams(sub, entry, req, customerTimezone)
+		if skip {
+			continue
+		}
+
+		result, err := prorationSvc.CalculateProration(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			// ProrationBehavior == none returns nil
+			continue
+		}
+
+		summary.Results = append(summary.Results, *result)
+
+		if result.NetAmount.GreaterThan(decimal.Zero) {
+			lineItem := s.buildChargeLineItem(sub, entry, result.NetAmount, req.EffectiveDate, p)
+			summary.ChargeLineItems = append(summary.ChargeLineItems, lineItem)
+			summary.TotalChargeAmount = summary.TotalChargeAmount.Add(result.NetAmount)
+		} else if result.NetAmount.LessThan(decimal.Zero) {
+			summary.TotalCreditAmount = summary.TotalCreditAmount.Add(result.NetAmount.Abs())
+		}
+	}
+
+	return summary, nil
+}
+
+func (s *lineItemProrationService) Apply(ctx context.Context, req LineItemProrationRequest) error {
+	if req.Behavior != types.ProrationBehaviorCreateProrations {
+		return nil
+	}
+
+	summary, err := s.Compute(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	sub := req.Subscription
+
+	if summary.TotalChargeAmount.GreaterThan(decimal.Zero) && len(summary.ChargeLineItems) > 0 {
+		invoiceSvc := NewInvoiceService(s.params)
+		if err := s.settleCharge(ctx, sub, summary, req.EffectiveDate, invoiceSvc); err != nil {
+			return err
+		}
+	}
+
+	if summary.TotalCreditAmount.GreaterThan(decimal.Zero) {
+		walletSvc := NewWalletService(s.params)
+		billingCustomer := sub.GetInvoicingCustomerID()
+		if _, err := walletSvc.TopUpWalletForProratedCharge(
+			ctx, billingCustomer, summary.TotalCreditAmount, sub.Currency, req.IdempotencyKey,
+		); err != nil {
+			s.params.Logger.ErrorwCtx(ctx, "failed to issue wallet credit for proration", "error", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// buildProrationParams constructs the ProrationParams for a single entry.
+// Returns (params, skip=true) when the entry should be skipped entirely.
+func (s *lineItemProrationService) buildProrationParams(
+	sub *subscription.Subscription,
+	entry LineItemProrationEntry,
+	req LineItemProrationRequest,
+	customerTimezone string,
+) (proration.ProrationParams, bool) {
+	item := entry.LineItem
+	p := entry.Price
+	periodEnd := sub.CurrentPeriodEnd.Add(-time.Second)
+
+	base := proration.ProrationParams{
+		SubscriptionID:     sub.ID,
+		LineItemID:         item.ID,
+		PlanPayInAdvance:   p.InvoiceCadence == types.InvoiceCadenceAdvance,
+		CurrentPeriodStart: sub.CurrentPeriodStart,
+		CurrentPeriodEnd:   periodEnd,
+		ProrationDate:      req.EffectiveDate,
+		ProrationBehavior:  req.Behavior,
+		ProrationStrategy:  types.StrategySecondBased,
+		Currency:           sub.Currency,
+		PlanDisplayName:    item.DisplayName,
+		CustomerTimezone:   customerTimezone,
+	}
+
+	switch entry.Action {
+	case types.ProrationActionAddItem:
+		base.Action = types.ProrationActionAddItem
+		base.NewPriceID = item.PriceID
+		base.NewQuantity = item.Quantity
+		base.NewPricePerUnit = p.Amount
+
+	case types.ProrationActionRemoveItem:
+		base.Action = types.ProrationActionRemoveItem
+		base.OldPriceID = item.PriceID
+		base.OldQuantity = item.Quantity
+		base.OldPricePerUnit = p.Amount
+		base.CancellationType = types.CancellationTypeImmediate
+		base.CancellationReason = req.Reason
+		base.RefundEligible = true
+		base.OriginalAmountPaid = p.Amount.Mul(item.Quantity)
+		base.PreviousCreditsIssued = decimal.Zero
+
+	default:
+		return proration.ProrationParams{}, true
+	}
+
+	return base, false
+}
+
+// buildChargeLineItem constructs the invoice line item for a positive proration result.
+func (s *lineItemProrationService) buildChargeLineItem(
+	sub *subscription.Subscription,
+	entry LineItemProrationEntry,
+	amount decimal.Decimal,
+	effectiveDate time.Time,
+	p *price.Price,
+) dto.CreateInvoiceLineItemRequest {
+	item := entry.LineItem
+	periodEnd := sub.CurrentPeriodEnd
+	priceID := item.PriceID
+	priceType := string(p.Type)
+	displayName := item.DisplayName
+
+	qty := item.Quantity
+	if entry.Action == types.ProrationActionAddItem && !entry.NewQuantity.IsZero() {
+		qty = entry.NewQuantity
+	}
+
+	var description string
+	if entry.Action == types.ProrationActionAddItem {
+		description = fmt.Sprintf("Proration charge: %s × %s %s %s/unit (%s – %s)",
+			qty.String(), displayName,
+			strings.ToUpper(sub.Currency), p.Amount.String(),
+			effectiveDate.Format("2 Jan 2006"), periodEnd.Format("2 Jan 2006"))
+	} else {
+		description = fmt.Sprintf("Proration credit: %s × %s %s %s/unit (%s – %s)",
+			qty.String(), displayName,
+			strings.ToUpper(sub.Currency), p.Amount.String(),
+			effectiveDate.Format("2 Jan 2006"), periodEnd.Format("2 Jan 2006"))
+	}
+
+	return dto.CreateInvoiceLineItemRequest{
+		PriceID:     &priceID,
+		PriceType:   &priceType,
+		DisplayName: &displayName,
+		Amount:      amount,
+		Quantity:    qty,
+		PeriodStart: &effectiveDate,
+		PeriodEnd:   &periodEnd,
+		Metadata:    types.Metadata{"description": description},
+	}
+}
+
+// settleCharge creates a one-off invoice for the aggregated charge amount.
+func (s *lineItemProrationService) settleCharge(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	summary *LineItemProrationSummary,
+	effectiveDate time.Time,
+	invoiceSvc InvoiceService,
+) error {
+	billingCustomer := sub.GetInvoicingCustomerID()
+	billingPeriod := string(sub.BillingPeriod)
+	periodEnd := sub.CurrentPeriodEnd
+
+	inv, err := invoiceSvc.CreateInvoice(ctx, dto.CreateInvoiceRequest{
+		CustomerID:     billingCustomer,
+		SubscriptionID: &sub.ID,
+		InvoiceType:    types.InvoiceTypeOneOff,
+		Currency:       sub.Currency,
+		BillingReason:  types.InvoiceBillingReasonSubscriptionUpdate,
+		AmountDue:      summary.TotalChargeAmount,
+		Total:          summary.TotalChargeAmount,
+		Subtotal:       summary.TotalChargeAmount,
+		PeriodStart:    &effectiveDate,
+		PeriodEnd:      &periodEnd,
+		BillingPeriod:  &billingPeriod,
+		LineItems:      summary.ChargeLineItems,
+	})
+	if err != nil {
+		s.params.Logger.ErrorwCtx(ctx, "failed to create proration charge invoice", "error", err)
+		return err
+	}
+
+	if err := invoiceSvc.AttemptPayment(ctx, inv.ID); err != nil {
+		s.params.Logger.WarnwCtx(ctx, "failed to attempt payment for proration charge invoice",
+			"error", err, "invoice_id", inv.ID)
+	}
+
+	return nil
+}

--- a/internal/service/line_item_proration_test.go
+++ b/internal/service/line_item_proration_test.go
@@ -1,0 +1,663 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// ─── Suite ───────────────────────────────────────────────────────────────────
+
+// LineItemProrationServiceSuite tests the LineItemProrationService in isolation
+// using in-memory repositories. It focuses on:
+//   1. Compute – pure math correctness (no side effects)
+//   2. Apply   – Compute + settle (invoice creation / wallet credit)
+type LineItemProrationServiceSuite struct {
+	testutil.BaseServiceTestSuite
+	svc LineItemProrationService
+	td  lineItemProrationTestData
+}
+
+type lineItemProrationTestData struct {
+	sub         *subscription.Subscription
+	fixedPrice  *price.Price
+	usagePrice  *price.Price
+	lineItem    *subscription.SubscriptionLineItem
+	periodStart time.Time // Apr 1 00:00:00 UTC
+	periodEnd   time.Time // May 1 00:00:00 UTC (exclusive)
+}
+
+func TestLineItemProrationService(t *testing.T) {
+	suite.Run(t, new(LineItemProrationServiceSuite))
+}
+
+func (s *LineItemProrationServiceSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.setupService()
+	s.setupTestData()
+}
+
+func (s *LineItemProrationServiceSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+}
+
+func (s *LineItemProrationServiceSuite) setupService() {
+	s.svc = NewLineItemProrationService(ServiceParams{
+		Logger:                     s.GetLogger(),
+		Config:                     s.GetConfig(),
+		DB:                         s.GetDB(),
+		SubRepo:                    s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo:   s.GetStores().SubscriptionLineItemRepo,
+		SubscriptionPhaseRepo:      s.GetStores().SubscriptionPhaseRepo,
+		SubScheduleRepo:            s.GetStores().SubscriptionScheduleRepo,
+		PlanRepo:                   s.GetStores().PlanRepo,
+		PriceRepo:                  s.GetStores().PriceRepo,
+		PriceUnitRepo:              s.GetStores().PriceUnitRepo,
+		EventRepo:                  s.GetStores().EventRepo,
+		MeterRepo:                  s.GetStores().MeterRepo,
+		CustomerRepo:               s.GetStores().CustomerRepo,
+		InvoiceRepo:                s.GetStores().InvoiceRepo,
+		EntitlementRepo:            s.GetStores().EntitlementRepo,
+		EnvironmentRepo:            s.GetStores().EnvironmentRepo,
+		FeatureRepo:                s.GetStores().FeatureRepo,
+		TenantRepo:                 s.GetStores().TenantRepo,
+		UserRepo:                   s.GetStores().UserRepo,
+		AuthRepo:                   s.GetStores().AuthRepo,
+		WalletRepo:                 s.GetStores().WalletRepo,
+		PaymentRepo:                s.GetStores().PaymentRepo,
+		CreditGrantRepo:            s.GetStores().CreditGrantRepo,
+		CreditGrantApplicationRepo: s.GetStores().CreditGrantApplicationRepo,
+		CouponRepo:                 s.GetStores().CouponRepo,
+		CouponAssociationRepo:      s.GetStores().CouponAssociationRepo,
+		CouponApplicationRepo:      s.GetStores().CouponApplicationRepo,
+		AddonRepo:                  testutil.NewInMemoryAddonStore(),
+		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
+		ConnectionRepo:             s.GetStores().ConnectionRepo,
+		SettingsRepo:               s.GetStores().SettingsRepo,
+		TaxAssociationRepo:         s.GetStores().TaxAssociationRepo,
+		TaxRateRepo:                s.GetStores().TaxRateRepo,
+		EventPublisher:             s.GetPublisher(),
+		WebhookPublisher:           s.GetWebhookPublisher(),
+		ProrationCalculator:        s.GetCalculator(),
+		FeatureUsageRepo:           s.GetStores().FeatureUsageRepo,
+		IntegrationFactory:         s.GetIntegrationFactory(),
+	})
+}
+
+func (s *LineItemProrationServiceSuite) setupTestData() {
+	ctx := s.GetContext()
+
+	// Billing period: Apr 1 → May 1 (30-day month, UTC)
+	s.td.periodStart = time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	s.td.periodEnd = time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	// Fixed $20/month price
+	s.td.fixedPrice = &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(20),
+		Currency:           "usd",
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.td.fixedPrice))
+
+	// Usage price (should be skipped by proration)
+	s.td.usagePrice = &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.td.usagePrice))
+
+	// Subscription anchored to Apr 1, current period Apr 1–May 1
+	s.td.sub = &subscription.Subscription{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		CustomerID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		StartDate:          s.td.periodStart,
+		CurrentPeriodStart: s.td.periodStart,
+		CurrentPeriodEnd:   s.td.periodEnd,
+		BillingAnchor:      s.td.periodStart,
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		CustomerTimezone:   "UTC",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, s.td.sub))
+
+	// Active fixed-price line item (EndDate zero = active recurring)
+	s.td.lineItem = &subscription.SubscriptionLineItem{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID: s.td.sub.ID,
+		CustomerID:     s.td.sub.CustomerID,
+		PriceID:        s.td.fixedPrice.ID,
+		PriceType:      types.PRICE_TYPE_FIXED,
+		Quantity:       decimal.NewFromInt(1),
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceAdvance,
+		StartDate:      s.td.periodStart,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, s.td.lineItem))
+}
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+// subCopyWithPeriod returns a shallow copy of the subscription with the billing
+// period overridden.  Matches the pattern used in production code.
+func (s *LineItemProrationServiceSuite) subCopyWithPeriod(start, end time.Time) *subscription.Subscription {
+	cp := *s.td.sub
+	cp.CurrentPeriodStart = start
+	cp.CurrentPeriodEnd = end
+	return &cp
+}
+
+// ─── Compute – AddItem ───────────────────────────────────────────────────────
+
+// TestCompute_AddItem_FullPeriod verifies that adding a line item at period start
+// results in a charge equal to the full price (coefficient == 1.0).
+func (s *LineItemProrationServiceSuite) TestCompute_AddItem_FullPeriod() {
+	ctx := s.GetContext()
+	effectiveDate := s.td.periodStart // Apr 1 – entire period remaining
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_add_full",
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+
+	// Coefficient = (May1-1s - Apr1) / (May1-1s - Apr1) = 1.0 → $20.00
+	s.True(summary.TotalChargeAmount.Equal(decimal.NewFromInt(20)),
+		"full-period add should charge the full price; got %s", summary.TotalChargeAmount)
+	s.True(summary.TotalCreditAmount.IsZero(), "no credit expected for AddItem")
+	s.Len(summary.ChargeLineItems, 1)
+	s.False(summary.IsPreview)
+}
+
+// TestCompute_AddItem_MidPeriod verifies the proportional charge when a line item
+// is added partway through the billing period.
+//
+// Period: Apr 1–May 1 (30 days).  Effective: Apr 11 (10 days elapsed, 20 remaining).
+// SecondBased: remaining=(Apr30 23:59:59 - Apr11 00:00:00)=1,727,999s
+//
+//	total=(Apr30 23:59:59 - Apr1 00:00:00)=2,591,999s
+//	charge = $20 × (1,727,999/2,591,999) ≈ $13.33
+func (s *LineItemProrationServiceSuite) TestCompute_AddItem_MidPeriod() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC) // Apr 11
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_add_mid",
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+
+	// Expected: $20 × (1,727,999 / 2,591,999) = $13.33
+	expected, _ := decimal.NewFromString("13.33")
+	s.True(summary.TotalChargeAmount.Equal(expected),
+		"mid-period add charge mismatch: want %s, got %s", expected, summary.TotalChargeAmount)
+	s.True(summary.TotalCreditAmount.IsZero())
+	s.Len(summary.ChargeLineItems, 1)
+}
+
+// TestCompute_AddItem_LastSecond adds at the very last second of the period —
+// proration coefficient ≈ 0, so charge rounds to $0.
+func (s *LineItemProrationServiceSuite) TestCompute_AddItem_LastSecond() {
+	ctx := s.GetContext()
+	// periodEnd - 1s is the last valid second
+	effectiveDate := s.td.periodEnd.Add(-time.Second)
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_add_last",
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+	// 1 second remaining out of 2,591,999 → $0.00 after rounding
+	s.True(summary.TotalChargeAmount.IsZero(),
+		"last-second add should round to $0, got %s", summary.TotalChargeAmount)
+}
+
+// ─── Compute – RemoveItem ────────────────────────────────────────────────────
+
+// TestCompute_RemoveItem_MidPeriod mirrors the AddItem mid-period test but for
+// removal — the credit amount should equal the unused portion of the period.
+func (s *LineItemProrationServiceSuite) TestCompute_RemoveItem_MidPeriod() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_rem_mid",
+		Entries: []LineItemProrationEntry{{
+			LineItem: s.td.lineItem,
+			Price:    s.td.fixedPrice,
+			Action:   types.ProrationActionRemoveItem,
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+
+	expected, _ := decimal.NewFromString("13.33")
+	s.True(summary.TotalCreditAmount.Equal(expected),
+		"mid-period remove credit mismatch: want %s, got %s", expected, summary.TotalCreditAmount)
+	s.True(summary.TotalChargeAmount.IsZero())
+}
+
+// TestCompute_RemoveItem_OnetimeAddon verifies that removing an item whose EndDate
+// is non-zero (onetime addon) is silently skipped — onetime charges are non-refundable.
+func (s *LineItemProrationServiceSuite) TestCompute_RemoveItem_OnetimeAddon() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	// Clone the line item but give it a non-zero EndDate to simulate a onetime addon.
+	onetimeItem := *s.td.lineItem
+	onetimeItem.EndDate = s.td.periodEnd
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_rem_onetime",
+		Entries: []LineItemProrationEntry{{
+			LineItem: &onetimeItem,
+			Price:    s.td.fixedPrice,
+			Action:   types.ProrationActionRemoveItem,
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+
+	s.True(summary.TotalCreditAmount.IsZero(), "onetime addon remove must not produce a credit")
+	s.True(summary.TotalChargeAmount.IsZero())
+	s.Empty(summary.Results, "no proration result expected for onetime remove")
+}
+
+// ─── Compute – Usage price skip ──────────────────────────────────────────────
+
+// TestCompute_SkipsUsagePrice asserts that usage-type line items are excluded
+// from proration because future consumption is unknown at change time.
+func (s *LineItemProrationServiceSuite) TestCompute_SkipsUsagePrice() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	usageItem := *s.td.lineItem
+	usageItem.PriceType = types.PRICE_TYPE_USAGE
+	usageItem.PriceID = s.td.usagePrice.ID
+
+	req := LineItemProrationRequest{
+		Subscription:  s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate: effectiveDate,
+		Behavior:      types.ProrationBehaviorCreateProrations,
+		Entries: []LineItemProrationEntry{{
+			LineItem:    &usageItem,
+			Price:       s.td.usagePrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: decimal.NewFromInt(1),
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+	s.True(summary.TotalChargeAmount.IsZero(), "usage price must be skipped")
+	s.Empty(summary.Results)
+}
+
+// ─── Compute – ProrationBehavior = none ──────────────────────────────────────
+
+// TestCompute_NoneProrationBehavior confirms that when behavior == none the
+// summary is returned with IsPreview=true and zero amounts (the underlying
+// calculator returns nil for none-behavior params).
+func (s *LineItemProrationServiceSuite) TestCompute_NoneProrationBehavior() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:  s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate: effectiveDate,
+		Behavior:      types.ProrationBehaviorNone,
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.NotNil(summary)
+	s.True(summary.IsPreview, "behavior=none should produce a preview summary")
+	s.True(summary.TotalChargeAmount.IsZero())
+	s.True(summary.TotalCreditAmount.IsZero())
+}
+
+// ─── Compute – Multiple entries ───────────────────────────────────────────────
+
+// TestCompute_MultipleEntries_AddAndRemove covers a batch where one entry triggers
+// a charge (AddItem) and another triggers a credit (RemoveItem). Both amounts
+// should be accumulated independently.
+func (s *LineItemProrationServiceSuite) TestCompute_MultipleEntries_AddAndRemove() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	// Second line item to add (same price for simplicity)
+	addItem := *s.td.lineItem
+	addItem.ID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM)
+
+	req := LineItemProrationRequest{
+		Subscription:  s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate: effectiveDate,
+		Behavior:      types.ProrationBehaviorCreateProrations,
+		Entries: []LineItemProrationEntry{
+			{
+				LineItem:    s.td.lineItem,
+				Price:       s.td.fixedPrice,
+				Action:      types.ProrationActionRemoveItem,
+			},
+			{
+				LineItem:    &addItem,
+				Price:       s.td.fixedPrice,
+				Action:      types.ProrationActionAddItem,
+				NewQuantity: addItem.Quantity,
+			},
+		},
+	}
+
+	summary, err := s.svc.Compute(ctx, req)
+	s.NoError(err)
+	s.Len(summary.Results, 2)
+
+	expected, _ := decimal.NewFromString("13.33")
+	s.True(summary.TotalCreditAmount.Equal(expected), "remove credit mismatch: %s", summary.TotalCreditAmount)
+	s.True(summary.TotalChargeAmount.Equal(expected), "add charge mismatch: %s", summary.TotalChargeAmount)
+}
+
+// ─── Apply – charge (invoice creation) ───────────────────────────────────────
+
+// TestApply_AddItem_CreatesOneOffInvoice verifies that Apply with CreateProrations
+// and a positive net amount creates exactly one ONE_OFF invoice in the invoice repo.
+func (s *LineItemProrationServiceSuite) TestApply_AddItem_CreatesOneOffInvoice() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_apply_add",
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	err := s.svc.Apply(ctx, req)
+	s.NoError(err)
+
+	// Invoice should have been created in the in-memory repo.
+	invoices, listErr := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	s.Require().NotEmpty(invoices, "expected one proration invoice to be created")
+
+	inv := invoices[0]
+	s.Equal(types.InvoiceTypeOneOff, inv.InvoiceType)
+	s.True(inv.AmountDue.GreaterThan(decimal.Zero),
+		"invoice amount must be positive, got %s", inv.AmountDue)
+}
+
+// ─── Apply – credit (wallet top-up) ──────────────────────────────────────────
+
+// TestApply_RemoveItem_CreatesWalletCredit verifies that Apply with CreateProrations
+// and a negative net amount creates a wallet top-up for the customer.
+func (s *LineItemProrationServiceSuite) TestApply_RemoveItem_CreatesWalletCredit() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_apply_remove",
+		Entries: []LineItemProrationEntry{{
+			LineItem: s.td.lineItem,
+			Price:    s.td.fixedPrice,
+			Action:   types.ProrationActionRemoveItem,
+		}},
+	}
+
+	err := s.svc.Apply(ctx, req)
+	s.NoError(err)
+
+	// A wallet should have been created/topped-up for the customer.
+	wallets, listErr := s.GetStores().WalletRepo.GetWalletsByFilter(ctx, &types.WalletFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	s.Require().NotEmpty(wallets, "expected a wallet to be created for the proration credit")
+
+	w := wallets[0]
+	expectedCredit, _ := decimal.NewFromString("13.33")
+	s.True(w.Balance.GreaterThanOrEqual(expectedCredit),
+		"wallet balance %s should be >= expected credit %s", w.Balance, expectedCredit)
+}
+
+// ─── Apply – ProrationBehavior = none (no-op) ────────────────────────────────
+
+// TestApply_NoneProrationBehavior_IsNoOp verifies that Apply returns immediately
+// without creating any invoices or wallets when behavior == none.
+func (s *LineItemProrationServiceSuite) TestApply_NoneProrationBehavior_IsNoOp() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:  s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate: effectiveDate,
+		Behavior:      types.ProrationBehaviorNone,
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	err := s.svc.Apply(ctx, req)
+	s.NoError(err)
+
+	// No invoice and no wallet should exist.
+	invoices, _ := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.Empty(invoices, "no invoice expected for behavior=none")
+
+	wallets, _ := s.GetStores().WalletRepo.GetWalletsByFilter(ctx, &types.WalletFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.Empty(wallets, "no wallet expected for behavior=none")
+}
+
+// TestApply_OnetimeRemove_IsNoOp confirms that removing a onetime addon
+// (EndDate != zero) produces no credit even when behavior == create_prorations.
+func (s *LineItemProrationServiceSuite) TestApply_OnetimeRemove_IsNoOp() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	onetimeItem := *s.td.lineItem
+	onetimeItem.EndDate = s.td.periodEnd
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "test_apply_onetime",
+		Entries: []LineItemProrationEntry{{
+			LineItem: &onetimeItem,
+			Price:    s.td.fixedPrice,
+			Action:   types.ProrationActionRemoveItem,
+		}},
+	}
+
+	err := s.svc.Apply(ctx, req)
+	s.NoError(err)
+
+	wallets, _ := s.GetStores().WalletRepo.GetWalletsByFilter(ctx, &types.WalletFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.Empty(wallets, "onetime remove must not create a wallet credit")
+}
+
+// ─── Apply – idempotency key propagated to wallet ────────────────────────────
+
+// TestApply_RemoveItem_IdempotencyKeyUsed verifies that calling Apply twice with
+// the same IdempotencyKey does not double-credit the customer.
+func (s *LineItemProrationServiceSuite) TestApply_RemoveItem_IdempotencyKeyUsed() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "idempotency_test_key",
+		Entries: []LineItemProrationEntry{{
+			LineItem: s.td.lineItem,
+			Price:    s.td.fixedPrice,
+			Action:   types.ProrationActionRemoveItem,
+		}},
+	}
+
+	// First call
+	err := s.svc.Apply(ctx, req)
+	s.NoError(err)
+
+	// Second call with same key
+	err = s.svc.Apply(ctx, req)
+	s.NoError(err, "duplicate Apply call with same idempotency key must not error")
+}
+
+// ─── Table-driven: various effective dates ────────────────────────────────────
+
+// TestCompute_AddItem_TableDriven covers a range of effective dates for an
+// AddItem in the Apr 1–May 1 period, verifying the proportional charge.
+func (s *LineItemProrationServiceSuite) TestCompute_AddItem_TableDriven() {
+	ctx := s.GetContext()
+
+	// All expected amounts are pre-calculated for Apr 1–May 1 (30-day month)
+	// using SecondBased strategy: charge = $20 × (remainingSeconds / totalSeconds)
+	// totalSeconds = 2,591,999  (Apr 1 00:00:00 → Apr 30 23:59:59)
+	tests := []struct {
+		name          string
+		effectiveDate time.Time
+		wantCharge    string // decimal string, rounded to 2dp
+	}{
+		{
+			name:          "period_start_full_charge",
+			effectiveDate: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			wantCharge:    "20.00",
+		},
+		{
+			name: "ten_days_in",
+			// Apr 11: remaining 1,727,999 / 2,591,999 → $13.33
+			effectiveDate: time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC),
+			wantCharge:    "13.33",
+		},
+		{
+			name: "twenty_days_in",
+			// Apr 21: remaining 863,999 / 2,591,999 → $6.67
+			effectiveDate: time.Date(2026, 4, 21, 0, 0, 0, 0, time.UTC),
+			wantCharge:    "6.67",
+		},
+		{
+			name: "last_day",
+			// Apr 30: remaining 86,399 / 2,591,999 → $0.67
+			effectiveDate: time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+			wantCharge:    "0.67",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			req := LineItemProrationRequest{
+				Subscription:  s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+				EffectiveDate: tt.effectiveDate,
+				Behavior:      types.ProrationBehaviorCreateProrations,
+				Entries: []LineItemProrationEntry{{
+					LineItem:    s.td.lineItem,
+					Price:       s.td.fixedPrice,
+					Action:      types.ProrationActionAddItem,
+					NewQuantity: s.td.lineItem.Quantity,
+				}},
+			}
+
+			summary, err := s.svc.Compute(ctx, req)
+			s.NoError(err)
+			s.NotNil(summary)
+
+			want, _ := decimal.NewFromString(tt.wantCharge)
+			s.True(summary.TotalChargeAmount.Equal(want),
+				"[%s] charge: want %s, got %s", tt.name, want, summary.TotalChargeAmount)
+		})
+	}
+}

--- a/internal/service/line_item_proration_test.go
+++ b/internal/service/line_item_proration_test.go
@@ -83,6 +83,7 @@ func (s *LineItemProrationServiceSuite) setupService() {
 		SettingsRepo:               s.GetStores().SettingsRepo,
 		TaxAssociationRepo:         s.GetStores().TaxAssociationRepo,
 		TaxRateRepo:                s.GetStores().TaxRateRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
 		EventPublisher:             s.GetPublisher(),
 		WebhookPublisher:           s.GetWebhookPublisher(),
 		ProrationCalculator:        s.GetCalculator(),

--- a/internal/service/line_item_proration_test.go
+++ b/internal/service/line_item_proration_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/testutil"
@@ -125,10 +126,20 @@ func (s *LineItemProrationServiceSuite) setupTestData() {
 	}
 	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.td.usagePrice))
 
+	// Customer (needed by wallet service's TopUpWalletForProratedCharge)
+	customerID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER)
+	cust := &customer.Customer{
+		ID:        customerID,
+		Name:      "Test Customer",
+		Email:     "test@example.com",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, cust))
+
 	// Subscription anchored to Apr 1, current period Apr 1–May 1
 	s.td.sub = &subscription.Subscription{
 		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
-		CustomerID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		CustomerID:         customerID,
 		StartDate:          s.td.periodStart,
 		CurrentPeriodStart: s.td.periodStart,
 		CurrentPeriodEnd:   s.td.periodEnd,

--- a/internal/service/proration.go
+++ b/internal/service/proration.go
@@ -52,6 +52,10 @@ func (s *prorationService) CalculateProration(ctx context.Context, params prorat
 			Mark(ierr.ErrSystem)
 	}
 
+	if result == nil {
+		return nil, nil
+	}
+
 	s.serviceParams.Logger.Debug("proration calculation completed",
 		zap.String("subscription_id", params.SubscriptionID),
 		zap.String("line_item_id", params.LineItemID),

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4143,31 +4143,6 @@ func (s *subscriptionService) addAddonToSubscription(
 			Mark(ierr.ErrValidation)
 	}
 
-	// Check if addon is already active on this subscription (only for onetime addons)
-	// For multiple_instance addons, allow multiple instances of the same addon
-	if a.Addon.Type == types.AddonTypeOnetime {
-		activeAddons, err := addonService.GetActiveAddonAssociation(ctx, dto.GetActiveAddonAssociationRequest{
-			EntityID:   sub.ID,
-			EntityType: types.AddonAssociationEntityTypeSubscription,
-			StartDate:  req.StartDate,
-			AddonIds:   []string{req.AddonID},
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		if activeAddons != nil && len(activeAddons.Items) > 0 {
-			return nil, ierr.NewError("addon is already added to subscription").
-				WithHint("Cannot add onetime addon to subscription that already has an active instance").
-				WithReportableDetails(map[string]interface{}{
-					"subscription_id": sub.ID,
-					"addon_id":        req.AddonID,
-					"active_addons":   activeAddons,
-				}).
-				Mark(ierr.ErrValidation)
-		}
-	}
-
 	// Validate entitlement compatibility if check is not skipped
 	if !req.SkipEntityValidation {
 		if err := s.validateEntitlementCompatibility(ctx, sub.ID, req.AddonID); err != nil {
@@ -4188,10 +4163,32 @@ func (s *subscriptionService) addAddonToSubscription(
 		types.AddonAssociationEntityTypeSubscription,
 	)
 
+	// For onetime cadence, determine which period's end to use as the line item end date.
+	// If StartDate falls in a future period we walk forward to find the right boundary.
+	var onetimePeriodEnd time.Time
+	if req.Cadence == types.AddonCadenceOnetime {
+		effectiveStart := time.Now()
+		if req.StartDate != nil {
+			effectiveStart = *req.StartDate
+		}
+		var periodErr error
+		onetimePeriodEnd, periodErr = addonPeriodEndForStartDate(sub, effectiveStart)
+		if periodErr != nil {
+			return nil, periodErr
+		}
+	}
+
 	// Create line items for addon prices
 	lineItems := make([]*subscription.SubscriptionLineItem, 0, len(validPrices))
 	for _, priceResponse := range validPrices {
 		lineItem := s.createLineItemFromPrice(ctx, priceResponse, sub, req.AddonID, a.Addon.Name)
+
+		// Onetime: end at the period boundary containing the start date.
+		// Recurring: no end date (renews each period).
+		if req.Cadence == types.AddonCadenceOnetime {
+			lineItem.EndDate = onetimePeriodEnd
+		}
+
 		if err := s.applyLineItemCommitmentFromMap(ctx, lineItem, req.LineItemCommitments); err != nil {
 			return nil, err
 		}
@@ -4226,6 +4223,15 @@ func (s *subscriptionService) addAddonToSubscription(
 	})
 
 	if err != nil {
+		return nil, err
+	}
+
+	effectiveDate := time.Now()
+	if req.StartDate != nil {
+		effectiveDate = *req.StartDate
+	}
+
+	if err := s.applyAddonAddProration(ctx, sub, lineItems, effectiveDate, req.ProrationBehavior); err != nil {
 		return nil, err
 	}
 
@@ -4437,16 +4443,79 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 			Mark(ierr.ErrValidation)
 	}
 
+	// Fetch line items early — needed both for the onetime-cadence guard and for proration.
+	lineItemFilter := types.NewSubscriptionLineItemFilter()
+	lineItemFilter.SubscriptionIDs = []string{association.EntityID}
+	lineItemFilter.EntityIDs = []string{association.AddonID}
+	lineItemFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+
+	lineItems, err := s.SubscriptionLineItemRepo.List(ctx, lineItemFilter)
+	if err != nil {
+		return err
+	}
+
+	// Onetime addons have EndDate set on ALL their line items — they are already scheduled to end.
+	// We check ALL items: if any item has no EndDate (recurring), the addon is cancellable.
+	// This handles the case where a previous association was cancelled at period-end (EndDate set)
+	// while a new recurring association was added on top (EndDate zero).
+	var onetimeEndDate time.Time
+	allOnetime := len(lineItems) > 0
+	for _, li := range lineItems {
+		if li.EndDate.IsZero() {
+			allOnetime = false
+			break
+		}
+		onetimeEndDate = li.EndDate
+	}
+	if allOnetime {
+		return ierr.NewError("addon is already scheduled to end").
+			WithHintf("This addon is already scheduled to end at %s", onetimeEndDate.Format("2 Jan 2006")).
+			WithReportableDetails(map[string]interface{}{
+				"addon_association_id": association.ID,
+				"expires_at":           onetimeEndDate,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	// Keep only line items that are NOT already scheduled to end.
+	// Line items from a previous association cancelled at period-end have EndDate set
+	// and must be excluded — they are already handled and must not be re-processed.
+	var activeLineItems []*subscription.SubscriptionLineItem
+	for _, li := range lineItems {
+		if li.EndDate.IsZero() {
+			activeLineItems = append(activeLineItems, li)
+		}
+	}
+	lineItems = activeLineItems
+
 	// get cancel at date from subscription
 	var effectiveEndDate *time.Time
+	var sub *subscription.Subscription
 
 	if association.EntityType == types.AddonAssociationEntityTypeSubscription {
-		sub, err := s.SubRepo.Get(ctx, association.EntityID)
+		var err error
+		sub, err = s.SubRepo.Get(ctx, association.EntityID)
 		if err != nil {
 			return err
 		}
 
-		effectiveEndDate = lo.ToPtr(sub.CurrentPeriodEnd)
+		if req.EffectiveDate != nil {
+			// Validate that the provided date falls within [CurrentPeriodStart, CurrentPeriodEnd].
+			ed := *req.EffectiveDate
+			if ed.Before(sub.CurrentPeriodStart) || ed.After(sub.CurrentPeriodEnd) {
+				return ierr.NewError("effective_date is outside the current billing period").
+					WithHint("effective_date must be between the subscription's current period start and end").
+					WithReportableDetails(map[string]any{
+						"effective_date":       ed,
+						"current_period_start": sub.CurrentPeriodStart,
+						"current_period_end":   sub.CurrentPeriodEnd,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+			effectiveEndDate = lo.ToPtr(ed)
+		} else {
+			effectiveEndDate = lo.ToPtr(sub.CurrentPeriodEnd)
+		}
 	}
 
 	endReason := "Cancelled by API"
@@ -4459,18 +4528,7 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 	association.CancelledAt = effectiveEndDate
 	association.EndDate = effectiveEndDate
 
-	// Get line items to terminate
-	lineItemFilter := types.NewSubscriptionLineItemFilter()
-	lineItemFilter.SubscriptionIDs = []string{association.EntityID}
-	lineItemFilter.EntityIDs = []string{association.AddonID}
-	lineItemFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
-
-	lineItems, err := s.SubscriptionLineItemRepo.List(ctx, lineItemFilter)
-	if err != nil {
-		return err
-	}
-
-	return s.DB.WithTx(ctx, func(ctx context.Context) error {
+	if err := s.DB.WithTx(ctx, func(ctx context.Context) error {
 		if err := s.AddonAssociationRepo.Update(ctx, association); err != nil {
 			return err
 		}
@@ -4483,7 +4541,23 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Issue wallet credit for unused prepaid time if proration is requested.
+	// Onetime addons (EndDate set) are skipped automatically inside LineItemProrationService.
+	if sub != nil && effectiveEndDate != nil {
+		if err := s.applyAddonRemoveProration(
+			ctx, sub, lineItems,
+			association.ID, *effectiveEndDate,
+			req.ProrationBehavior, endReason,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // createLineItemFromPrice creates a subscription line item from a price for addon additions
@@ -4536,6 +4610,93 @@ func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, price
 	lineItem.PriceUnit = price.PriceUnit
 
 	return lineItem
+}
+
+// addonPeriodEndForStartDate returns the end of the billing period that contains startDate.
+func addonPeriodEndForStartDate(sub *subscription.Subscription, startDate time.Time) (time.Time, error) {
+	p, err := types.FindPeriodForDate(
+		startDate,
+		sub.CurrentPeriodStart,
+		sub.CurrentPeriodEnd,
+		sub.BillingAnchor,
+		sub.BillingPeriodCount,
+		sub.BillingPeriod,
+	)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return p.End, nil
+}
+
+// applyAddonAddProration creates a one-off proration invoice when an addon is added mid-period.
+// It is a no-op when behavior is ProrationBehaviorNone. Usage-type prices are skipped.
+func (s *subscriptionService) applyAddonAddProration(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	lineItems []*subscription.SubscriptionLineItem,
+	effectiveDate time.Time,
+	behavior types.ProrationBehavior,
+) error {
+	priceSvc := NewPriceService(s.ServiceParams)
+
+	var entries []LineItemProrationEntry
+	for _, lineItem := range lineItems {
+		priceResp, err := priceSvc.GetPrice(ctx, lineItem.PriceID)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, LineItemProrationEntry{
+			LineItem: lineItem,
+			Price:    priceResp.Price,
+			Action:   types.ProrationActionAddItem,
+		})
+	}
+
+	return NewLineItemProrationService(s.ServiceParams).Apply(ctx, LineItemProrationRequest{
+		Subscription:  sub,
+		Entries:       entries,
+		EffectiveDate: effectiveDate,
+		Behavior:      behavior,
+	})
+}
+
+// applyAddonRemoveProration issues a wallet credit for unused prepaid time when a recurring addon
+// is removed mid-period. Onetime addons are rejected before reaching this point.
+// Usage-type prices are skipped by LineItemProrationService.
+func (s *subscriptionService) applyAddonRemoveProration(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	lineItems []*subscription.SubscriptionLineItem,
+	associationID string,
+	effectiveDate time.Time,
+	behavior types.ProrationBehavior,
+	reason string,
+) error {
+	priceSvc := NewPriceService(s.ServiceParams)
+
+	var entries []LineItemProrationEntry
+	for _, lineItem := range lineItems {
+		priceResp, err := priceSvc.GetPrice(ctx, lineItem.PriceID)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, LineItemProrationEntry{
+			LineItem: lineItem,
+			Price:    priceResp.Price,
+			Action:   types.ProrationActionRemoveItem,
+		})
+	}
+
+	idempotencyKey := fmt.Sprintf("addon_remove_%s_%d", associationID, effectiveDate.Unix())
+
+	return NewLineItemProrationService(s.ServiceParams).Apply(ctx, LineItemProrationRequest{
+		Subscription:   sub,
+		Entries:        entries,
+		EffectiveDate:  effectiveDate,
+		Behavior:       behavior,
+		Reason:         reason,
+		IdempotencyKey: idempotencyKey,
+	})
 }
 
 // ActivateIncompleteSubscription activates a subscription that is in incomplete status

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4181,7 +4181,7 @@ func (s *subscriptionService) addAddonToSubscription(
 	// Create line items for addon prices
 	lineItems := make([]*subscription.SubscriptionLineItem, 0, len(validPrices))
 	for _, priceResponse := range validPrices {
-		lineItem := s.createLineItemFromPrice(ctx, priceResponse, sub, req.AddonID, a.Addon.Name)
+		lineItem := s.createLineItemFromPrice(ctx, priceResponse, sub, req.AddonID, a.Addon.Name, addonAssociation.ID)
 
 		// Onetime: end at the period boundary containing the start date.
 		// Recurring: no end date (renews each period).
@@ -4448,6 +4448,7 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 	lineItemFilter.SubscriptionIDs = []string{association.EntityID}
 	lineItemFilter.EntityIDs = []string{association.AddonID}
 	lineItemFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+	lineItemFilter.AddonAssociationIDs = []string{association.ID}
 
 	lineItems, err := s.SubscriptionLineItemRepo.List(ctx, lineItemFilter)
 	if err != nil {
@@ -4560,8 +4561,8 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 	return nil
 }
 
-// createLineItemFromPrice creates a subscription line item from a price for addon additions
-func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, priceResponse *dto.PriceResponse, sub *subscription.Subscription, addonID, addonName string) *subscription.SubscriptionLineItem {
+// createLineItemFromPrice creates a subscription line item from a price for addon additions.
+func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, priceResponse *dto.PriceResponse, sub *subscription.Subscription, addonID, addonName, addonAssociationID string) *subscription.SubscriptionLineItem {
 	price := priceResponse.Price
 
 	lineItem := &subscription.SubscriptionLineItem{
@@ -4584,8 +4585,9 @@ func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, price
 			"addon_quantity":  "1",
 			"addon_status":    string(types.AddonStatusActive),
 		},
-		EnvironmentID: sub.EnvironmentID,
-		BaseModel:     types.GetDefaultBaseModel(ctx),
+		AddonAssociationID: lo.ToPtr(addonAssociationID),
+		EnvironmentID:      sub.EnvironmentID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
 
 	// Set display name from price (always use price display name)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4231,8 +4231,14 @@ func (s *subscriptionService) addAddonToSubscription(
 		effectiveDate = *req.StartDate
 	}
 
-	if err := s.applyAddonAddProration(ctx, sub, lineItems, effectiveDate, req.ProrationBehavior); err != nil {
-		return nil, err
+	addProrationKey := fmt.Sprintf("addon_add_%s_%d", addonAssociation.ID, effectiveDate.Unix())
+	if err := s.applyAddonAddProration(ctx, sub, lineItems, effectiveDate, req.ProrationBehavior, addProrationKey); err != nil {
+		s.Logger.WarnwCtx(ctx, "failed to create proration invoice for addon add; addon was persisted successfully",
+			"error", err,
+			"association_id", addonAssociation.ID,
+			"subscription_id", sub.ID,
+			"idempotency_key", addProrationKey,
+		)
 	}
 
 	return addonAssociation, nil
@@ -4554,7 +4560,11 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 			association.ID, *effectiveEndDate,
 			req.ProrationBehavior, endReason,
 		); err != nil {
-			return err
+			s.Logger.WarnwCtx(ctx, "failed to issue proration credit for addon remove; removal was persisted successfully",
+				"error", err,
+				"association_id", association.ID,
+				"subscription_id", sub.ID,
+			)
 		}
 	}
 
@@ -4632,13 +4642,19 @@ func addonPeriodEndForStartDate(sub *subscription.Subscription, startDate time.T
 
 // applyAddonAddProration creates a one-off proration invoice when an addon is added mid-period.
 // It is a no-op when behavior is ProrationBehaviorNone. Usage-type prices are skipped.
+// idempotencyKey must be stable across retries so duplicate charges cannot be created.
 func (s *subscriptionService) applyAddonAddProration(
 	ctx context.Context,
 	sub *subscription.Subscription,
 	lineItems []*subscription.SubscriptionLineItem,
 	effectiveDate time.Time,
 	behavior types.ProrationBehavior,
+	idempotencyKey string,
 ) error {
+	if behavior == types.ProrationBehaviorNone {
+		return nil
+	}
+
 	priceSvc := NewPriceService(s.ServiceParams)
 
 	var entries []LineItemProrationEntry
@@ -4655,10 +4671,11 @@ func (s *subscriptionService) applyAddonAddProration(
 	}
 
 	return NewLineItemProrationService(s.ServiceParams).Apply(ctx, LineItemProrationRequest{
-		Subscription:  sub,
-		Entries:       entries,
-		EffectiveDate: effectiveDate,
-		Behavior:      behavior,
+		Subscription:   sub,
+		Entries:        entries,
+		EffectiveDate:  effectiveDate,
+		Behavior:       behavior,
+		IdempotencyKey: idempotencyKey,
 	})
 }
 
@@ -4674,6 +4691,10 @@ func (s *subscriptionService) applyAddonRemoveProration(
 	behavior types.ProrationBehavior,
 	reason string,
 ) error {
+	if behavior == types.ProrationBehaviorNone {
+		return nil
+	}
+
 	priceSvc := NewPriceService(s.ServiceParams)
 
 	var entries []LineItemProrationEntry

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4176,6 +4176,10 @@ func (s *subscriptionService) addAddonToSubscription(
 		if periodErr != nil {
 			return nil, periodErr
 		}
+		// Mirror the same boundary on the association so it is self-consistent
+		// with its line items and so the remove-addon flow can identify the
+		// association as already-terminated without inspecting its line items.
+		addonAssociation.EndDate = &onetimePeriodEnd
 	}
 
 	// Create line items for addon prices

--- a/internal/service/subscription_line_item.go
+++ b/internal/service/subscription_line_item.go
@@ -87,6 +87,61 @@ func (s *subscriptionService) AddSubscriptionLineItem(ctx context.Context, subsc
 	if err != nil {
 		return nil, err
 	}
+
+	// Apply proration for the add if requested. Skip usage prices (unknown future consumption).
+	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations &&
+		lineItem.PriceType != types.PRICE_TYPE_USAGE {
+
+		effectiveDate := time.Now().UTC()
+		if req.StartDate != nil {
+			effectiveDate = req.StartDate.UTC()
+		}
+
+		// Find the billing period that contains effectiveDate so proration uses the right boundaries.
+		period, err := types.FindPeriodForDate(
+			effectiveDate,
+			sub.CurrentPeriodStart,
+			sub.CurrentPeriodEnd,
+			sub.BillingAnchor,
+			sub.BillingPeriodCount,
+			sub.BillingPeriod,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		priceSvc := NewPriceService(s.ServiceParams)
+		priceResp, err := priceSvc.GetPrice(ctx, lineItem.PriceID)
+		if err != nil {
+			return nil, err
+		}
+
+		// Temporarily override current period on a copy so LineItemProrationService
+		// uses the period that actually contains effectiveDate.
+		subCopy := *sub
+		subCopy.CurrentPeriodStart = period.Start
+		subCopy.CurrentPeriodEnd = period.End
+
+		prorationReq := LineItemProrationRequest{
+			Subscription:  &subCopy,
+			EffectiveDate: effectiveDate,
+			Behavior:      req.ProrationBehavior,
+			IdempotencyKey: types.GenerateUUIDWithPrefix("proration_add"),
+			Entries: []LineItemProrationEntry{
+				{
+					LineItem:    lineItem,
+					Price:       priceResp.Price,
+					Action:      types.ProrationActionAddItem,
+					NewQuantity: lineItem.Quantity,
+				},
+			},
+		}
+		if applyErr := NewLineItemProrationService(s.ServiceParams).Apply(ctx, prorationReq); applyErr != nil {
+			s.Logger.WarnwCtx(ctx, "proration apply failed for line item add",
+				"line_item_id", lineItem.ID, "error", applyErr)
+		}
+	}
+
 	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem}, nil
 }
 
@@ -240,10 +295,68 @@ func (s *subscriptionService) DeleteSubscriptionLineItem(ctx context.Context, li
 			Mark(ierr.ErrValidation)
 	}
 
+	// Capture a snapshot before mutating EndDate — the proration service uses EndDate==zero
+	// to distinguish "active recurring" from "onetime" (pre-existing EndDate at period boundary).
+	lineItemForProration := *lineItem
+
 	lineItem.EndDate = effectiveFrom
 
 	if err := s.SubscriptionLineItemRepo.Update(ctx, lineItem); err != nil {
 		return nil, err
+	}
+
+	// Apply proration for the removal if requested. Skip usage prices.
+	// Use lineItemForProration (EndDate still zero) so Compute doesn't treat this as onetime.
+	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations &&
+		lineItemForProration.PriceType != types.PRICE_TYPE_USAGE {
+
+		sub, err := s.SubRepo.Get(ctx, lineItem.SubscriptionID)
+		if err != nil {
+			s.Logger.WarnwCtx(ctx, "could not load subscription for delete proration",
+				"line_item_id", lineItemID, "error", err)
+		} else {
+			period, err := types.FindPeriodForDate(
+				effectiveFrom,
+				sub.CurrentPeriodStart,
+				sub.CurrentPeriodEnd,
+				sub.BillingAnchor,
+				sub.BillingPeriodCount,
+				sub.BillingPeriod,
+			)
+			if err != nil {
+				s.Logger.WarnwCtx(ctx, "could not find period for delete proration",
+					"line_item_id", lineItemID, "error", err)
+			} else {
+				priceSvc := NewPriceService(s.ServiceParams)
+				priceResp, err := priceSvc.GetPrice(ctx, lineItem.PriceID)
+				if err != nil {
+					s.Logger.WarnwCtx(ctx, "could not load price for delete proration",
+						"line_item_id", lineItemID, "error", err)
+				} else {
+					subCopy := *sub
+					subCopy.CurrentPeriodStart = period.Start
+					subCopy.CurrentPeriodEnd = period.End
+
+					prorationReq := LineItemProrationRequest{
+						Subscription:   &subCopy,
+						EffectiveDate:  effectiveFrom,
+						Behavior:       req.ProrationBehavior,
+						IdempotencyKey: types.GenerateUUIDWithPrefix("proration_del"),
+						Entries: []LineItemProrationEntry{
+							{
+								LineItem: &lineItemForProration,
+								Price:    priceResp.Price,
+								Action:   types.ProrationActionRemoveItem,
+							},
+						},
+					}
+					if applyErr := NewLineItemProrationService(s.ServiceParams).Apply(ctx, prorationReq); applyErr != nil {
+						s.Logger.WarnwCtx(ctx, "proration apply failed for line item delete",
+							"line_item_id", lineItemID, "error", applyErr)
+					}
+				}
+			}
+		}
 	}
 
 	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem}, nil

--- a/internal/service/subscription_line_item_test.go
+++ b/internal/service/subscription_line_item_test.go
@@ -478,8 +478,10 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_UsagePric
 // for the unused portion of the billing period.
 func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_WithCreateProrations_CreatesWalletCredit() {
 	ctx := s.GetContext()
-	// Use an effective_from that is valid (on or after line item start).
-	effectiveFrom := s.testData.lineItem.StartDate.Add(24 * time.Hour)
+	// effectiveFrom must be (a) >= lineItem.StartDate and (b) within the subscription's current
+	// billing period so that FindPeriodForDate can locate it by walking forward.
+	// CurrentPeriodStart + 1 hour satisfies both constraints.
+	effectiveFrom := s.testData.subscription.CurrentPeriodStart.Add(time.Hour)
 
 	req := dto.DeleteSubscriptionLineItemRequest{
 		EffectiveFrom:     &effectiveFrom,

--- a/internal/service/subscription_line_item_test.go
+++ b/internal/service/subscription_line_item_test.go
@@ -77,6 +77,7 @@ func (s *SubscriptionLineItemServiceSuite) setupService() {
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
 		ConnectionRepo:             s.GetStores().ConnectionRepo,
 		SettingsRepo:               s.GetStores().SettingsRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
 		EventPublisher:             s.GetPublisher(),
 		WebhookPublisher:           s.GetWebhookPublisher(),
 		ProrationCalculator:        s.GetCalculator(),

--- a/internal/service/subscription_line_item_test.go
+++ b/internal/service/subscription_line_item_test.go
@@ -336,6 +336,260 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_DateBound
 
 // TestAddSubscriptionLineItem_ValidationErrors covers invalid or out-of-bound values: both/neither price,
 // start after end, date bounds (line item and inline price), negative quantity.
+// ─── Proration integration – AddSubscriptionLineItem ─────────────────────────
+
+// TestAddSubscriptionLineItem_WithCreateProrations_CreatesInvoice verifies that
+// calling AddSubscriptionLineItem with ProrationBehavior=create_prorations creates
+// a ONE_OFF invoice for the prorated portion of the billing period.
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_WithCreateProrations_CreatesInvoice() {
+	ctx := s.GetContext()
+
+	// Create a second distinct price so we can add it as a new line item.
+	secondPrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(30),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, secondPrice))
+
+	req := dto.CreateSubscriptionLineItemRequest{
+		PriceID:              secondPrice.ID,
+		Quantity:             decimal.NewFromInt(1),
+		SkipEntitlementCheck: true,
+		ProrationBehavior:    types.ProrationBehaviorCreateProrations,
+	}
+
+	resp, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.NotEmpty(resp.SubscriptionLineItem.ID)
+
+	// A ONE_OFF proration invoice should have been created.
+	invoices, listErr := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	var prorationInvoices []*types.InvoiceFilter
+	_ = prorationInvoices
+	var found bool
+	for _, inv := range invoices {
+		if inv.InvoiceType == types.InvoiceTypeOneOff {
+			found = true
+			s.True(inv.AmountDue.GreaterThan(decimal.Zero),
+				"proration invoice amount must be positive, got %s", inv.AmountDue)
+			break
+		}
+	}
+	s.True(found, "expected a ONE_OFF proration invoice to be created")
+}
+
+// TestAddSubscriptionLineItem_NoneProration_NoInvoiceCreated confirms that
+// ProrationBehavior=none does not create any invoice.
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_NoneProration_NoInvoiceCreated() {
+	ctx := s.GetContext()
+
+	thirdPrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(40),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, thirdPrice))
+
+	req := dto.CreateSubscriptionLineItemRequest{
+		PriceID:              thirdPrice.ID,
+		Quantity:             decimal.NewFromInt(1),
+		SkipEntitlementCheck: true,
+		ProrationBehavior:    types.ProrationBehaviorNone,
+	}
+
+	_, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, req)
+	s.NoError(err)
+
+	invoices, listErr := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	for _, inv := range invoices {
+		s.NotEqual(types.InvoiceTypeOneOff, inv.InvoiceType,
+			"no ONE_OFF proration invoice expected for behavior=none")
+	}
+}
+
+// TestAddSubscriptionLineItem_UsagePrice_SkipsProration confirms that adding a
+// usage-type price with create_prorations does not produce a charge invoice
+// (future consumption is unknown).
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_UsagePrice_SkipsProration() {
+	ctx := s.GetContext()
+
+	usagePrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, usagePrice))
+
+	req := dto.CreateSubscriptionLineItemRequest{
+		PriceID:              usagePrice.ID,
+		SkipEntitlementCheck: true,
+		ProrationBehavior:    types.ProrationBehaviorCreateProrations,
+	}
+
+	_, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, req)
+	s.NoError(err)
+
+	invoices, listErr := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	for _, inv := range invoices {
+		s.NotEqual(types.InvoiceTypeOneOff, inv.InvoiceType,
+			"usage price add must not trigger a proration invoice")
+	}
+}
+
+// ─── Proration integration – DeleteSubscriptionLineItem ──────────────────────
+
+// TestDeleteSubscriptionLineItem_WithCreateProrations_CreatesWalletCredit verifies
+// that deleting a fixed-price line item with create_prorations issues a wallet credit
+// for the unused portion of the billing period.
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_WithCreateProrations_CreatesWalletCredit() {
+	ctx := s.GetContext()
+	// Use an effective_from that is valid (on or after line item start).
+	effectiveFrom := s.testData.lineItem.StartDate.Add(24 * time.Hour)
+
+	req := dto.DeleteSubscriptionLineItemRequest{
+		EffectiveFrom:     &effectiveFrom,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	}
+
+	resp, err := s.service.DeleteSubscriptionLineItem(ctx, s.testData.lineItem.ID, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.False(resp.SubscriptionLineItem.EndDate.IsZero())
+
+	// A wallet credit should have been issued.
+	wallets, listErr := s.GetStores().WalletRepo.GetWalletsByFilter(ctx, &types.WalletFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	s.Require().NotEmpty(wallets, "expected a wallet to be created for the proration credit")
+
+	w := wallets[0]
+	s.True(w.Balance.GreaterThan(decimal.Zero),
+		"wallet balance %s must be positive after proration credit", w.Balance)
+}
+
+// TestDeleteSubscriptionLineItem_NoneProration_NoWalletCredit confirms that
+// deleting with ProrationBehavior=none does not issue any wallet credit.
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_NoneProration_NoWalletCredit() {
+	ctx := s.GetContext()
+	effectiveFrom := s.testData.lineItem.StartDate.Add(24 * time.Hour)
+
+	req := dto.DeleteSubscriptionLineItemRequest{
+		EffectiveFrom:     &effectiveFrom,
+		ProrationBehavior: types.ProrationBehaviorNone,
+	}
+
+	_, err := s.service.DeleteSubscriptionLineItem(ctx, s.testData.lineItem.ID, req)
+	s.NoError(err)
+
+	wallets, listErr := s.GetStores().WalletRepo.GetWalletsByFilter(ctx, &types.WalletFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	s.Empty(wallets, "behavior=none must not create a wallet credit")
+}
+
+// TestDeleteSubscriptionLineItem_SnapshotBeforeMutation_OnetimeSkipped verifies
+// the critical invariant: the pre-mutation snapshot (EndDate==zero) is passed to
+// proration Compute so that onetime-cadence check works correctly.
+//
+// A line item with EndDate == effectiveFrom after the Update call would otherwise
+// be misidentified as a onetime addon and skipped. The snapshot must have EndDate==zero.
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_SnapshotBeforeMutation_OnetimeSkipped() {
+	ctx := s.GetContext()
+
+	// Create a fresh line item with a non-zero EndDate to simulate a onetime addon.
+	// Deleting it with create_prorations should produce NO credit (non-refundable).
+	onetimePrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(25),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_ONETIME,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, onetimePrice))
+
+	onetimeEnd := s.testData.subscription.CurrentPeriodEnd
+	onetimeItem := &subscription.SubscriptionLineItem{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID: s.testData.subscription.ID,
+		CustomerID:     s.testData.customer.ID,
+		EntityID:       s.testData.plan.ID,
+		EntityType:     types.SubscriptionLineItemEntityTypePlan,
+		PriceID:        onetimePrice.ID,
+		PriceType:      types.PRICE_TYPE_FIXED,
+		DisplayName:    "Onetime addon",
+		Quantity:       decimal.NewFromInt(1),
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_ONETIME,
+		InvoiceCadence: types.InvoiceCadenceAdvance,
+		StartDate:      s.testData.lineItem.StartDate,
+		EndDate:        onetimeEnd, // non-zero EndDate marks this as onetime/already-terminated
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, onetimeItem))
+
+	// The onetime item already has an EndDate, so DeleteSubscriptionLineItem should
+	// reject it as already terminated.
+	effectiveFrom := onetimeItem.StartDate.Add(time.Hour)
+	req := dto.DeleteSubscriptionLineItemRequest{
+		EffectiveFrom:     &effectiveFrom,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	}
+
+	_, err := s.service.DeleteSubscriptionLineItem(ctx, onetimeItem.ID, req)
+	s.Error(err, "deleting an already-terminated line item must return an error")
+	s.Contains(err.Error(), "already terminated")
+
+	// No wallet credit should have been issued.
+	wallets, listErr := s.GetStores().WalletRepo.GetWalletsByFilter(ctx, &types.WalletFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(listErr)
+	s.Empty(wallets, "no wallet credit expected for already-terminated (onetime) line item")
+}
+
 func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_ValidationErrors() {
 	ctx := s.GetContext()
 	subStart := s.testData.subscription.StartDate

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -117,7 +117,6 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionLineItemCommitments
 			LookupKey:   addonID,
 			Name:        "Test Addon",
 			Description: "Test Addon Description",
-			Type:        types.AddonTypeOnetime,
 			BaseModel:   types.GetDefaultBaseModel(ctx),
 		}
 		s.NoError(subService.AddonRepo.Create(ctx, a))
@@ -1793,7 +1792,6 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 			LookupKey:   addonID,
 			Name:        "Addon to cancel",
 			Description: "Addon cancelled with subscription",
-			Type:        types.AddonTypeOnetime,
 			BaseModel:   types.GetDefaultBaseModel(ctx),
 		}
 		s.NoError(subService.AddonRepo.Create(ctx, a))

--- a/internal/testutil/inmemory_addon_store.go
+++ b/internal/testutil/inmemory_addon_store.go
@@ -35,7 +35,6 @@ func copyAddon(a *addon.Addon) *addon.Addon {
 		LookupKey:     a.LookupKey,
 		Name:          a.Name,
 		Description:   a.Description,
-		Type:          a.Type,
 		Metadata:      lo.Assign(map[string]interface{}{}, a.Metadata),
 		BaseModel: types.BaseModel{
 			TenantID:  a.TenantID,
@@ -162,12 +161,6 @@ func addonFilterFn(ctx context.Context, a *addon.Addon, filter interface{}) bool
 		}
 	}
 
-	if f.AddonType != "" {
-		if a.Type != f.AddonType {
-			return false
-		}
-	}
-
 	if len(f.LookupKeys) > 0 {
 		if !lo.Contains(f.LookupKeys, a.LookupKey) {
 			return false
@@ -194,10 +187,6 @@ func applyAddonFilterCondition(a *addon.Addon, condition *types.FilterCondition)
 	case "lookup_key":
 		if condition.Value != nil && condition.Value.String != nil {
 			return strings.Contains(strings.ToLower(a.LookupKey), strings.ToLower(*condition.Value.String))
-		}
-	case "type":
-		if condition.Value != nil && condition.Value.String != nil {
-			return string(a.Type) == *condition.Value.String
 		}
 	case "status":
 		if condition.Value != nil && condition.Value.String != nil {

--- a/internal/types/addon.go
+++ b/internal/types/addon.go
@@ -5,27 +5,23 @@ import (
 	"github.com/samber/lo"
 )
 
-// AddonType represents the type of addon
-type AddonType string
+// AddonCadence controls whether an addon line item ends at the current period end
+// (onetime — billed once for the period) or has no end date and recurs each period (recurring).
+// This is set per-add request, not on the addon entity itself.
+type AddonCadence string
 
 const (
-	AddonTypeOnetime          AddonType = "onetime"
-	AddonTypeMultipleInstance AddonType = "multiple_instance"
+	AddonCadenceOnetime   AddonCadence = "onetime"
+	AddonCadenceRecurring AddonCadence = "recurring"
 )
 
-func (at AddonType) Validate() error {
-
-	allowedTypes := []AddonType{
-		AddonTypeOnetime,
-		AddonTypeMultipleInstance,
-	}
-
-	if !lo.Contains(allowedTypes, at) {
-		return ierr.NewError("invalid addon type").
-			WithHint("Addon type must be onetime or multiple_instance").
+func (c AddonCadence) Validate() error {
+	allowed := []AddonCadence{AddonCadenceOnetime, AddonCadenceRecurring}
+	if !lo.Contains(allowed, c) {
+		return ierr.NewError("invalid addon cadence").
+			WithHint("Addon cadence must be onetime or recurring").
 			Mark(ierr.ErrValidation)
 	}
-
 	return nil
 }
 
@@ -47,9 +43,8 @@ type AddonFilter struct {
 	Filters []*FilterCondition `json:"filters,omitempty" form:"filters" validate:"omitempty"`
 	Sort    []*SortCondition   `json:"sort,omitempty" form:"sort" validate:"omitempty"`
 
-	AddonIDs   []string  `json:"addon_ids,omitempty" form:"addon_ids" validate:"omitempty"`
-	AddonType  AddonType `json:"addon_type,omitempty" form:"addon_type" validate:"omitempty"`
-	LookupKeys []string  `json:"lookup_keys,omitempty" form:"lookup_keys" validate:"omitempty"`
+	AddonIDs   []string `json:"addon_ids,omitempty" form:"addon_ids" validate:"omitempty"`
+	LookupKeys []string `json:"lookup_keys,omitempty" form:"lookup_keys" validate:"omitempty"`
 }
 
 // NewAddonFilter creates a new addon filter with default options
@@ -92,12 +87,6 @@ func (f *AddonFilter) Validate() error {
 			return ierr.NewError("lookup key can not be empty").
 				WithHint("Lookup key can not be empty").
 				Mark(ierr.ErrValidation)
-		}
-	}
-
-	if f.AddonType != "" {
-		if err := f.AddonType.Validate(); err != nil {
-			return err
 		}
 	}
 

--- a/internal/types/addon.go
+++ b/internal/types/addon.go
@@ -31,8 +31,22 @@ type AddonStatus string
 const (
 	AddonStatusActive    AddonStatus = "active"
 	AddonStatusCancelled AddonStatus = "cancelled"
-	AddonStatusPaused    AddonStatus = "paused"
+	AddonStatusPending   AddonStatus = "pending"
 )
+
+func (s AddonStatus) Validate() error {
+	allowed := []AddonStatus{
+		AddonStatusActive,
+		AddonStatusCancelled,
+		AddonStatusPending,
+	}
+	if !lo.Contains(allowed, s) {
+		return ierr.NewError("invalid addon status").
+			WithHint("Addon status must be active, cancelled or pending").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
 
 // AddonFilter represents the filter options for addons
 type AddonFilter struct {

--- a/internal/types/date.go
+++ b/internal/types/date.go
@@ -611,3 +611,54 @@ func GetNextUsageResetAt(
 			Mark(ierr.ErrValidation)
 	}
 }
+
+// FindPeriodForDate returns the end of the billing period that contains target,
+// starting the search from knownPeriodStart/End and walking forward as needed.
+//
+// Unlike CalculateBillingPeriods, this function passes nil to NextBillingDate so
+// period ends are never capped — giving natural boundaries regardless of target.
+// Capped at 240 forward steps (~20 years of monthly billing).
+func FindPeriodForDate(
+	target time.Time,
+	knownPeriodStart time.Time,
+	knownPeriodEnd time.Time,
+	anchor time.Time,
+	periodCount int,
+	billingPeriod BillingPeriod,
+) (Period, error) {
+	inPeriod := func(t, start, end time.Time) bool {
+		return !t.Before(start) && t.Before(end)
+	}
+
+	periodStart := knownPeriodStart
+	periodEnd := knownPeriodEnd
+
+	// Fast path: target is already within the known period.
+	if inPeriod(target, periodStart, periodEnd) {
+		return Period{Start: periodStart, End: periodEnd}, nil
+	}
+
+	const maxIter = 240
+	for i := 0; i < maxIter; i++ {
+		nextEnd, err := NextBillingDate(periodEnd, anchor, periodCount, billingPeriod, nil)
+		if err != nil {
+			return Period{}, err
+		}
+		if nextEnd.Equal(periodEnd) {
+			break
+		}
+		periodStart, periodEnd = periodEnd, nextEnd
+		if inPeriod(target, periodStart, periodEnd) {
+			return Period{Start: periodStart, End: periodEnd}, nil
+		}
+	}
+
+	return Period{}, ierr.NewError("could not find billing period for date").
+		WithHint("The target date may be too far in the future or past relative to the known billing period").
+		WithReportableDetails(map[string]any{
+			"target":             target,
+			"known_period_start": knownPeriodStart,
+			"known_period_end":   knownPeriodEnd,
+		}).
+		Mark(ierr.ErrValidation)
+}

--- a/internal/types/proration.go
+++ b/internal/types/proration.go
@@ -154,7 +154,7 @@ var ProrationBehaviorValues = []ProrationBehavior{
 func (p ProrationBehavior) Validate() error {
 	if !lo.Contains(ProrationBehaviorValues, p) {
 		return ierr.NewError("invalid proration behavior").
-			WithHint("Proration behavior must be create_prorations, always_invoice, or none").
+			WithHint("Proration behavior must be create_prorations or none").
 			WithReportableDetails(map[string]any{
 				"allowed_values": ProrationBehaviorValues,
 				"provided_value": p,

--- a/internal/types/subscription_line_item_filter.go
+++ b/internal/types/subscription_line_item_filter.go
@@ -14,8 +14,9 @@ type SubscriptionLineItemFilter struct {
 	MeterIDs           []string                        `json:"meter_ids,omitempty" form:"meter_ids"`
 	Currencies         []string                        `json:"currencies,omitempty" form:"currencies"`
 	BillingPeriods     []string                        `json:"billing_periods,omitempty" form:"billing_periods"`
-	EntityIDs          []string                        `json:"entity_ids,omitempty" form:"entity_ids"`
-	EntityType         *SubscriptionLineItemEntityType `json:"entity_type,omitempty" form:"entity_type"`
+	EntityIDs            []string                        `json:"entity_ids,omitempty" form:"entity_ids"`
+	EntityType           *SubscriptionLineItemEntityType `json:"entity_type,omitempty" form:"entity_type"`
+	AddonAssociationIDs  []string                        `json:"addon_association_ids,omitempty" form:"addon_association_ids"`
 	ActiveFilter       bool                            `json:"active_filter,omitempty" form:"active_filter" default:"true"`
 	CurrentPeriodStart *time.Time                      `json:"current_period_start,omitempty" form:"current_period_start"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clone endpoints for environments, features, and plans; introduced addon cadence and proration_behavior with billing_anchor support.
  * New proration service for mid-period subscription line-item add/remove (compute + apply) producing one‑off invoices or wallet credits.
  * Subscription line items now support an addon association ID for traceability; cadence-aware onetime handling and period lookup added.

* **Documentation**
  * API docs updated to expose clone endpoints, cadence/proration_behavior, billing_anchor, and expanded change-tracking invoice responses.

* **Tests**
  * End-to-end and integration tests added for proration behavior and subscription line-item flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->