### PR TITLE
fix(price): guard EntityIDIn with len > 0 to prevent WHERE FALSE

### DIFF
--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -557,7 +557,7 @@ func (o PriceQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.P
 	}
 
 	// entity id filter
-	if f.EntityIDs != nil {
+	if len(f.EntityIDs) > 0 {
 		query = query.Where(price.EntityIDIn(f.EntityIDs...))
 	}
 

--- a/internal/service/price_test.go
+++ b/internal/service/price_test.go
@@ -190,6 +190,95 @@ func (s *PriceServiceSuite) TestGetPrices() {
 	s.Len(resp.Items, 0) // Ensure no prices are retrieved
 }
 
+// TestGetPrices_EmptyEntityIDsDoesNotSuppressResults is a regression test for the bug where
+// an empty (non-nil) EntityIDs slice caused the ent query builder to emit
+// "WHERE entity_id IN ()" which PostgreSQL evaluates as WHERE FALSE, silently
+// returning zero rows regardless of any other filters (e.g. price_ids).
+// Root fix: guard changed from `f.EntityIDs != nil` to `len(f.EntityIDs) > 0`
+// in internal/repository/ent/price.go (applyEntityQueryOptions).
+func (s *PriceServiceSuite) TestGetPrices_EmptyEntityIDsDoesNotSuppressResults() {
+	_ = s.priceRepo.Create(s.ctx, &price.Price{
+		ID:         "price-reg-1",
+		Amount:     decimal.NewFromInt(100),
+		Currency:   "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:   "plan-1",
+		BaseModel:  types.GetDefaultBaseModel(s.ctx),
+	})
+	_ = s.priceRepo.Create(s.ctx, &price.Price{
+		ID:         "price-reg-2",
+		Amount:     decimal.NewFromInt(200),
+		Currency:   "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:   "plan-2",
+		BaseModel:  types.GetDefaultBaseModel(s.ctx),
+	})
+
+	tests := []struct {
+		name      string
+		filter    *types.PriceFilter
+		wantTotal int
+		wantIDs   []string
+	}{
+		{
+			name: "price_ids only - baseline",
+			filter: &types.PriceFilter{
+				QueryFilter: types.NewDefaultQueryFilter(),
+				PriceIDs:    []string{"price-reg-1"},
+			},
+			wantTotal: 1,
+			wantIDs:   []string{"price-reg-1"},
+		},
+		{
+			name: "price_ids with empty entity_ids (the regression case - was WHERE FALSE)",
+			filter: &types.PriceFilter{
+				QueryFilter: types.NewDefaultQueryFilter(),
+				PriceIDs:    []string{"price-reg-1"},
+				EntityIDs:   []string{}, // explicitly empty, non-nil - the actual bug trigger
+			},
+			wantTotal: 1,
+			wantIDs:   []string{"price-reg-1"},
+		},
+		{
+			name: "price_ids with matching entity_ids - both filters satisfied",
+			filter: &types.PriceFilter{
+				QueryFilter: types.NewDefaultQueryFilter(),
+				PriceIDs:    []string{"price-reg-1"},
+				EntityIDs:   []string{"plan-1"},
+			},
+			wantTotal: 1,
+			wantIDs:   []string{"price-reg-1"},
+		},
+		{
+			name: "price_ids with non-matching entity_ids - AND produces empty result",
+			filter: &types.PriceFilter{
+				QueryFilter: types.NewDefaultQueryFilter(),
+				PriceIDs:    []string{"price-reg-1"},
+				EntityIDs:   []string{"plan-2"}, // price-reg-1 belongs to plan-1, not plan-2
+			},
+			wantTotal: 0,
+			wantIDs:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			resp, err := s.priceService.GetPrices(s.ctx, tt.filter)
+			s.NoError(err)
+			s.NotNil(resp)
+			s.Equal(tt.wantTotal, resp.Pagination.Total, "unexpected total count")
+			s.Len(resp.Items, len(tt.wantIDs), "unexpected items count")
+			if len(tt.wantIDs) > 0 {
+				gotIDs := make([]string, len(resp.Items))
+				for i, item := range resp.Items {
+					gotIDs[i] = item.ID
+				}
+				s.ElementsMatch(tt.wantIDs, gotIDs)
+			}
+		})
+	}
+}
+
 func (s *PriceServiceSuite) TestUpdatePrice() {
 	// Create a price
 	price := &price.Price{

--- a/internal/testutil/inmemory_price_store.go
+++ b/internal/testutil/inmemory_price_store.go
@@ -48,14 +48,14 @@ func priceFilterFn(ctx context.Context, p *price.Price, filter interface{}) bool
 		return false
 	}
 
-	// Filter by plan IDs
+	// Filter by entity IDs
 	if len(f.EntityIDs) > 0 {
 		if !lo.Contains(f.EntityIDs, p.EntityID) {
 			return false
 		}
 	}
 
-	// filter by price ids
+	// Filter by price IDs
 	if len(f.PriceIDs) > 0 {
 		if !lo.Contains(f.PriceIDs, p.ID) {
 			return false


### PR DESCRIPTION
Fixes #1638


## 📝 Description
Fix: change guard from f.EntityIDs != nil to len(f.EntityIDs) > 0 in
applyEntityQueryOptions, consistent with every other list filter in the
same function and across the repository layer.

Also updates inmemory_price_store to fix a stale comment, and adds a
regression test covering the empty entity_ids case.

---

## 🔨 Changes Made
- [x] Bug Fix

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.

---

## 📷 Screenshots / Demo (if applicable)
- [x] New tests pass.

### Logs:
go test -v -race ./internal/service -run "TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults" 2>&1
=== RUN   TestPriceService
=== RUN   TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults
=== RUN   TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_only_-_baseline
=== RUN   TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_with_empty_entity_ids_(the_regression_case_-_was_WHERE_FALSE)
=== RUN   TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_with_matching_entity_ids_-_both_filters_satisfied
=== RUN   TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_with_non-matching_entity_ids_-_AND_produces_empty_result
--- PASS: TestPriceService (0.00s)
    --- PASS: TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults (0.00s)
        --- PASS: TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_only_-_baseline (0.00s)
        --- PASS: TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_with_empty_entity_ids_(the_regression_case_-_was_WHERE_FALSE) (0.00s)
        --- PASS: TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_with_matching_entity_ids_-_both_filters_satisfied (0.00s)
        --- PASS: TestPriceService/TestGetPrices_EmptyEntityIDsDoesNotSuppressResults/price_ids_with_non-matching_entity_ids_-_AND_produces_empty_result (0.00s)
PASS
ok  	github.com/flexprice/flexprice/internal/service	1.072s

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect price filtering behavior when entity IDs were not specified or empty, ensuring price lookups by ID work correctly in all scenarios.

* **Tests**
  * Added regression test to verify correct filtering behavior with empty entity ID parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->