### PR TITLE
fix(subscription): persist metadata on create

### DIFF
--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -93,6 +93,7 @@ func (r *subscriptionRepository) Create(ctx context.Context, sub *domainSub.Subs
 		SetNillableInvoicingCustomerID(sub.InvoicingCustomerID).
 		SetNillableParentSubscriptionID(sub.ParentSubscriptionID).
 		SetNillablePaymentTerms(sub.PaymentTerms).
+		SetMetadata(sub.Metadata).
 		Save(ctx)
 
 	if err != nil {

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -864,6 +864,23 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 			wantErr: false,
 		},
 		{
+			name: "metadata_is_persisted_on_create",
+			input: dto.CreateSubscriptionRequest{
+				CustomerID:         s.testData.customer.ID,
+				PlanID:             s.testData.plan.ID,
+				StartDate:          lo.ToPtr(s.testData.now),
+				EndDate:            lo.ToPtr(s.testData.now.Add(30 * 24 * time.Hour)),
+				Currency:           "usd",
+				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+				BillingPeriodCount: 1,
+				BillingCycle:       types.BillingCycleAnniversary,
+				Metadata: map[string]string{
+					"xyz": "123",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "both_customer_id_and_external_id_present",
 			input: dto.CreateSubscriptionRequest{
 				CustomerID:         s.testData.customer.ID,
@@ -1032,6 +1049,10 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription() {
 				s.Equal(s.testData.customer.ID, resp.CustomerID)
 			}
 			s.Equal(tc.input.PlanID, resp.PlanID)
+
+			if len(tc.input.Metadata) > 0 {
+				s.Equal(tc.input.Metadata, resp.Metadata)
+			}
 
 			// Verify collection method behavior
 			if tc.input.CollectionMethod != nil {


### PR DESCRIPTION
Subscription metadata from CreateSubscriptionRequest was not persisted because the Ent create builder did not set metadata. Add SetMetadata on create and cover with a regression test.

Fixes #1637 


## 📝 Description
When creating a subscription via API, metadata was accepted in the request but discarded during persistence because the repository create builder didn’t call SetMetadata. This PR ensures metadata is saved on subscription creation.
---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscriptions now support storing and persisting custom metadata, enabling users to attach additional context to subscription records.

* **Tests**
  * Added test coverage to verify metadata is correctly persisted when creating subscriptions with metadata information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->