### PR TITLE
fix(addon): enhance date handling for subscription entity types

### DIFF
--- a/internal/service/addon.go
+++ b/internal/service/addon.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addon"
@@ -480,14 +479,6 @@ func (s *addonService) GetActiveAddonAssociation(ctx context.Context, req dto.Ge
 		if periodEnd == nil {
 			t := sub.CurrentPeriodEnd
 			periodEnd = &t
-		}
-	} else {
-		if periodStart == nil {
-			now := time.Now()
-			periodStart = &now
-		}
-		if periodEnd == nil {
-			periodEnd = periodStart
 		}
 	}
 

--- a/internal/service/addon.go
+++ b/internal/service/addon.go
@@ -465,17 +465,30 @@ func (s *addonService) GetActiveAddonAssociation(ctx context.Context, req dto.Ge
 		return nil, err
 	}
 
-	// Use the start date from request, or default to current time
 	periodStart := req.StartDate
-	if periodStart == nil {
-		now := time.Now()
-		periodStart = &now
-	}
-
-	// Use end date if provided; if nil we treat it as point-in-time at start
 	periodEnd := req.EndDate
-	if periodEnd == nil {
-		periodEnd = periodStart
+
+	if req.EntityType == types.AddonAssociationEntityTypeSubscription && (periodStart == nil || periodEnd == nil) {
+		sub, err := s.SubRepo.Get(ctx, req.EntityID)
+		if err != nil {
+			return nil, err
+		}
+		if periodStart == nil {
+			t := sub.CurrentPeriodStart
+			periodStart = &t
+		}
+		if periodEnd == nil {
+			t := sub.CurrentPeriodEnd
+			periodEnd = &t
+		}
+	} else {
+		if periodStart == nil {
+			now := time.Now()
+			periodStart = &now
+		}
+		if periodEnd == nil {
+			periodEnd = periodStart
+		}
 	}
 
 	// Build filter to fetch active addon associations using the generic list method


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed time-window handling when retrieving active addon associations for subscriptions: missing start/end dates are now populated from the subscription's current period (instead of defaulting to now or forcing end=start), and lookup errors are surfaced. Other entity types continue to use provided dates as-is.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->