### PR TITLE
fix(events): trim whitespace from event names in various components for consistency

### DIFF
--- a/internal/api/dto/meter.go
+++ b/internal/api/dto/meter.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/meter"
@@ -72,7 +73,7 @@ func ToMeterResponse(m *meter.Meter) *MeterResponse {
 // Convert CreateMeterRequest to domain Meter
 func (r *CreateMeterRequest) ToMeter(tenantID, createdBy string) *meter.Meter {
 	m := meter.NewMeter(r.Name, tenantID, createdBy)
-	m.EventName = r.EventName
+	m.EventName = strings.TrimSpace(r.EventName)
 	m.Aggregation = r.Aggregation
 	m.Filters = r.Filters
 	m.ResetUsage = r.ResetUsage

--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"strings"
 	"time"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -186,7 +187,7 @@ func NewEvent(
 		CustomerID:         customerID,
 		ExternalCustomerID: externalCustomerID,
 		Source:             source,
-		EventName:          eventName,
+		EventName:          strings.TrimSpace(eventName),
 		Timestamp:          timestamp,
 		Properties:         properties,
 		EnvironmentID:      environmentID,

--- a/internal/domain/events/transform/transformer.go
+++ b/internal/domain/events/transform/transformer.go
@@ -190,7 +190,7 @@ func TransformBentoToEvent(payload string, tenantID, environmentID string) (*eve
 		TenantID:           tenantID,
 		EnvironmentID:      environmentID,
 		ExternalCustomerID: input.OrgID,
-		EventName:          eventName,
+		EventName:          strings.TrimSpace(eventName),
 		Properties:         properties,
 		Source:             source,
 		Timestamp:          timestamp,

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -2,8 +2,11 @@ package ent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/meter"
 	"github.com/flexprice/flexprice/internal/cache"
@@ -31,6 +34,8 @@ func NewMeterRepository(client postgres.IClient, logger *logger.Logger, cache ca
 }
 
 func (r *meterRepository) CreateMeter(ctx context.Context, m *domainMeter.Meter) error {
+	m.EventName = strings.TrimSpace(m.EventName)
+
 	client := r.client.Writer(ctx)
 
 	// Start a span for this repository operation
@@ -366,7 +371,17 @@ func (o MeterQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.M
 	}
 
 	if f.EventName != "" {
-		query = query.Where(meter.EventName(string(f.EventName)))
+		trimmed := strings.TrimSpace(f.EventName)
+		if trimmed == "" {
+			// Preserve exact match for whitespace-only (edge case).
+			query = query.Where(meter.EventName(string(f.EventName)))
+		} else {
+			// Event names are compared in SQL after BTRIM so stored meters/events with
+			// accidental leading/trailing spaces still match.
+			query = query.Where(func(s *sql.Selector) {
+				s.Where(sql.ExprP(fmt.Sprintf("BTRIM(%s) = ?", s.C(meter.FieldEventName)), trimmed))
+			})
+		}
 	}
 
 	if len(f.MeterIDs) > 0 {

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -372,16 +372,9 @@ func (o MeterQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.M
 
 	if f.EventName != "" {
 		trimmed := strings.TrimSpace(f.EventName)
-		if trimmed == "" {
-			// Preserve exact match for whitespace-only (edge case).
-			query = query.Where(meter.EventName(string(f.EventName)))
-		} else {
-			// Event names are compared in SQL after BTRIM so stored meters/events with
-			// accidental leading/trailing spaces still match.
-			query = query.Where(func(s *sql.Selector) {
-				s.Where(sql.ExprP(fmt.Sprintf("BTRIM(%s) = ?", s.C(meter.FieldEventName)), trimmed))
-			})
-		}
+		query = query.Where(func(s *sql.Selector) {
+			s.Where(sql.ExprP(fmt.Sprintf("BTRIM(%s) = ?", s.C(meter.FieldEventName)), trimmed))
+		})
 	}
 
 	if len(f.MeterIDs) > 0 {

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -2,11 +2,9 @@ package ent
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
-	"entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/meter"
 	"github.com/flexprice/flexprice/internal/cache"
@@ -372,9 +370,7 @@ func (o MeterQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.M
 
 	if f.EventName != "" {
 		trimmed := strings.TrimSpace(f.EventName)
-		query = query.Where(func(s *sql.Selector) {
-			s.Where(sql.ExprP(fmt.Sprintf("BTRIM(%s) = ?", s.C(meter.FieldEventName)), trimmed))
-		})
+		query = query.Where(meter.EventName(trimmed))
 	}
 
 	if len(f.MeterIDs) > 0 {

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -355,6 +355,8 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 		environmentID = event.EnvironmentID
 	}
 
+	event.EventName = strings.TrimSpace(event.EventName)
+
 	// Create a background context with tenant ID
 	ctx := context.Background()
 	if tenantID != "" {

--- a/internal/service/meter.go
+++ b/internal/service/meter.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/meter"
@@ -33,6 +34,7 @@ func (s *meterService) CreateMeter(ctx context.Context, req *dto.CreateMeterRequ
 			Mark(ierr.ErrValidation)
 	}
 
+	req.EventName = strings.TrimSpace(req.EventName)
 	if req.EventName == "" {
 		return nil, ierr.NewError("event_name is required").
 			WithHint("Event name is required").

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -169,6 +170,8 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 		environmentID = event.EnvironmentID
 	}
 
+	event.EventName = strings.TrimSpace(event.EventName)
+
 	if tenantID == "" || environmentID == "" {
 		s.Logger.Errorw("tenant_id and environment_id are required for meter usage tracking",
 			"event_id", event.ID,
@@ -198,6 +201,7 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 // on every Kafka message. The cache is nil-safe: if the service was constructed
 // without a cache (e.g. directly in unit tests) it falls through to the repo.
 func (s *meterUsageTrackingService) getMetersForEvent(ctx context.Context, eventName string) ([]*meter.Meter, error) {
+	eventName = strings.TrimSpace(eventName)
 	if s.meterListCache != nil {
 		tenantID := types.GetTenantID(ctx)
 		environmentID := types.GetEnvironmentID(ctx)

--- a/internal/testutil/inmemory_meter_store.go
+++ b/internal/testutil/inmemory_meter_store.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"strings"
 
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -57,6 +58,8 @@ func (s *InMemoryMeterStore) CreateMeter(ctx context.Context, m *meter.Meter) er
 	if m.EnvironmentID == "" {
 		m.EnvironmentID = types.GetEnvironmentID(ctx)
 	}
+
+	m.EventName = strings.TrimSpace(m.EventName)
 
 	err := s.InMemoryStore.Create(ctx, m.ID, copyMeter(m))
 	if err != nil {
@@ -221,8 +224,8 @@ func meterFilterFn(ctx context.Context, m *meter.Meter, filter interface{}) bool
 		return false
 	}
 
-	// Apply event name filter
-	if f.EventName != "" && m.EventName != f.EventName {
+	// Apply event name filter (trimmed, consistent with ent meter List)
+	if f.EventName != "" && strings.TrimSpace(m.EventName) != strings.TrimSpace(f.EventName) {
 		return false
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event name whitespace handling across the platform. Leading/trailing spaces in event names are now normalized during creation, transformation, lookup, filtering, caching, and message processing. This prevents duplicate events, improves deduplication accuracy, and ensures consistent metering and usage analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->