### PR TITLE
fix(subscription): adjust billing anchor for anniversary billing

### DIFF
--- a/internal/service/subscription_change.go
+++ b/internal/service/subscription_change.go
@@ -735,6 +735,15 @@ func (s *subscriptionChangeService) createNewSubscription(
 		}
 	}
 
+	// For anniversary billing, anchor the new subscription to the effective (upgrade) date,
+	// not the old sub's anchor. Inheriting the old anchor would create a short first billing
+	// period (old-anchor-day vs effective-day), causing prorated advance charges instead of
+	// a full-period invoice.
+	var newBillingAnchor *time.Time
+	if req.BillingCycle == types.BillingCycleAnniversary {
+		newBillingAnchor = &effectiveDate
+	}
+
 	// Create new subscription request
 	createSubReq := dto.CreateSubscriptionRequest{
 		CustomerID:         currentSub.CustomerID,
@@ -745,7 +754,7 @@ func (s *subscriptionChangeService) createNewSubscription(
 		BillingPeriod:      req.BillingPeriod,
 		BillingPeriodCount: req.BillingPeriodCount,
 		BillingCycle:       req.BillingCycle,
-		BillingAnchor:      &currentSub.BillingAnchor,
+		BillingAnchor:      newBillingAnchor,
 		StartDate:          &effectiveDate,
 		Metadata:           req.Metadata,
 		ProrationBehavior:  req.ProrationBehavior,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing anchor calculation for anniversary billing cycle subscription changes to correctly align with the effective upgrade date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->