### PR TITLE
feat(webhook): implement retry mechanism for undelivered webhooks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -518,7 +518,7 @@ func startServer(
 		// Register all handlers and start router once
 		registerRouterHandlers(router, webhookService, integrationEventService, onboardingService, eventPostProcessingSvc, eventConsumptionSvc, featureUsageSvc, costSheetUsageSvc, walletBalanceAlertSvc, rawEventConsumptionSvc, meterUsageTrackingSvc, usageBenchmarkSvc, cfg, true)
 		startRouter(lc, router, log)
-		startTemporalWorker(lc, log, temporalClient, temporalService, params)
+		startTemporalWorker(lc, log, temporalClient, temporalService, params, webhookService)
 	case types.ModeAPI:
 		startAPIServer(lc, r, cfg, log)
 
@@ -532,7 +532,7 @@ func startServer(
 		// consumed and delivered via Svix/native in the same process.
 		registerRouterHandlers(router, webhookService, integrationEventService, onboardingService, eventPostProcessingSvc, eventConsumptionSvc, featureUsageSvc, costSheetUsageSvc, walletBalanceAlertSvc, rawEventConsumptionSvc, meterUsageTrackingSvc, usageBenchmarkSvc, cfg, false)
 		startRouter(lc, router, log)
-		startTemporalWorker(lc, log, temporalClient, temporalService, params)
+		startTemporalWorker(lc, log, temporalClient, temporalService, params, webhookService)
 	case types.ModeConsumer:
 		if consumer == nil {
 			log.Fatal("Kafka consumer required for consumer mode")
@@ -552,6 +552,7 @@ func startTemporalWorker(
 	temporalClient client.TemporalClient,
 	temporalService temporalservice.TemporalService,
 	params service.ServiceParams,
+	webhookService *webhook.WebhookService,
 ) {
 	lc.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -560,7 +561,7 @@ func startTemporalWorker(
 			}
 
 			// Register workflows and activities first (this creates the workers)
-			if err := temporal.RegisterWorkflowsAndActivities(temporalService, params); err != nil {
+			if err := temporal.RegisterWorkflowsAndActivities(temporalService, params, webhookService); err != nil {
 				return fmt.Errorf("failed to register workflows and activities: %w", err)
 			}
 

--- a/internal/repository/ent/systemevent.go
+++ b/internal/repository/ent/systemevent.go
@@ -31,6 +31,24 @@ func (r *SystemEventRepository) GetByID(ctx context.Context, tenantID, environme
 		Only(ctx)
 }
 
+// ListStaleUndeliveredWebhooks returns system_events rows that were consumed but never
+// delivered (no published_at / webhook_message_id), with created_at strictly before olderThan.
+// Results are ordered by created_at ascending. Pass limit > 0 (caller caps page size).
+func (r *SystemEventRepository) ListStaleUndeliveredWebhooks(ctx context.Context, olderThan time.Time, limit int) ([]*flexent.SystemEvent, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	return r.client.Reader(ctx).SystemEvent.Query().
+		Where(
+			systemevent.WebhookMessageIDIsNil(),
+			systemevent.PublishedAtIsNil(),
+			systemevent.CreatedAtLT(olderThan),
+		).
+		Order(flexent.Asc(systemevent.FieldCreatedAt)).
+		Limit(limit).
+		All(ctx)
+}
+
 // OnConsumed creates a full system_events row when the consumer reads the Kafka message.
 // All fields are populated from the event — only webhook_message_id and published_at are left
 // empty until the webhook is actually delivered (see OnDelivered).

--- a/internal/temporal/activities/cron/webhook_outbound_retry_activities.go
+++ b/internal/temporal/activities/cron/webhook_outbound_retry_activities.go
@@ -1,0 +1,47 @@
+package cron
+
+import (
+	"context"
+
+	"github.com/flexprice/flexprice/internal/logger"
+	cronModels "github.com/flexprice/flexprice/internal/temporal/models"
+	"github.com/flexprice/flexprice/internal/webhook"
+)
+
+// WebhookOutboundRetryActivities runs scheduled outbound webhook recovery.
+type WebhookOutboundRetryActivities struct {
+	webhookService *webhook.WebhookService
+	logger         *logger.Logger
+}
+
+// NewWebhookOutboundRetryActivities constructs WebhookOutboundRetryActivities.
+func NewWebhookOutboundRetryActivities(webhookService *webhook.WebhookService, log *logger.Logger) *WebhookOutboundRetryActivities {
+	return &WebhookOutboundRetryActivities{
+		webhookService: webhookService,
+		logger:         log,
+	}
+}
+
+// RetryStaleOutboundWebhooksActivity delegates to WebhookService.RetryStalePendingWebhooks.
+func (a *WebhookOutboundRetryActivities) RetryStaleOutboundWebhooksActivity(ctx context.Context) (*cronModels.OutboundWebhookStaleRetryWorkflowResult, error) {
+	a.logger.Infow("starting stale outbound webhook retry cron job")
+
+	res, err := a.webhookService.RetryStalePendingWebhooks(ctx)
+	if err != nil {
+		a.logger.Errorw("stale outbound webhook retry activity failed", "error", err)
+		return nil, err
+	}
+
+	out := &cronModels.OutboundWebhookStaleRetryWorkflowResult{
+		Total:     res.Total,
+		Succeeded: res.Succeeded,
+		Failed:    res.Failed,
+	}
+
+	a.logger.Infow("completed stale outbound webhook retry cron job",
+		"total", out.Total,
+		"succeeded", out.Succeeded,
+		"failed", out.Failed,
+	)
+	return out, nil
+}

--- a/internal/temporal/models/cron.go
+++ b/internal/temporal/models/cron.go
@@ -47,3 +47,15 @@ type SubscriptionRenewalDueAlertsWorkflowInput struct{}
 
 // SubscriptionRenewalDueAlertsWorkflowResult is a placeholder.
 type SubscriptionRenewalDueAlertsWorkflowResult struct{}
+
+// ===================== Outbound webhook stale retry =====================
+
+// OutboundWebhookStaleRetryWorkflowInput is the input for OutboundWebhookStaleRetryWorkflow.
+type OutboundWebhookStaleRetryWorkflowInput struct{}
+
+// OutboundWebhookStaleRetryWorkflowResult captures bulk retry metrics.
+type OutboundWebhookStaleRetryWorkflowResult struct {
+	Total     int `json:"total"`
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+}

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -32,6 +32,7 @@ import (
 	invoiceWorkflows "github.com/flexprice/flexprice/internal/temporal/workflows/invoice"
 	subscriptionWorkflows "github.com/flexprice/flexprice/internal/temporal/workflows/subscription"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/flexprice/flexprice/internal/webhook"
 )
 
 // WorkerConfig defines the configuration for a specific task queue worker
@@ -43,13 +44,14 @@ type WorkerConfig struct {
 
 // cronActivityBundle groups activities registered on the Temporal "cron" task queue only.
 type cronActivityBundle struct {
-	creditGrant        *cronActivities.CreditGrantActivities
-	subscription       *cronActivities.SubscriptionCronActivities
-	walletCreditExpiry *cronActivities.WalletCreditExpiryActivities
+	creditGrant          *cronActivities.CreditGrantActivities
+	subscription         *cronActivities.SubscriptionCronActivities
+	walletCreditExpiry   *cronActivities.WalletCreditExpiryActivities
+	webhookOutboundRetry *cronActivities.WebhookOutboundRetryActivities
 }
 
 // RegisterWorkflowsAndActivities registers all workflows and activities with the temporal service
-func RegisterWorkflowsAndActivities(temporalService temporalService.TemporalService, params service.ServiceParams) error {
+func RegisterWorkflowsAndActivities(temporalService temporalService.TemporalService, params service.ServiceParams, webhookService *webhook.WebhookService) error {
 	// Create workflow tracking activity (follows standard activity pattern)
 	workflowTrackingActivities := workflowActivities.NewWorkflowTrackingActivities(
 		params,
@@ -228,9 +230,10 @@ func RegisterWorkflowsAndActivities(temporalService temporalService.TemporalServ
 	settingsService := service.NewSettingsService(params)
 	environmentService := service.NewEnvironmentService(params.EnvironmentRepo, envAccessService, settingsService, params)
 	cronBundle := &cronActivityBundle{
-		creditGrant:        cronActivities.NewCreditGrantActivities(creditGrantService),
-		subscription:       cronActivities.NewSubscriptionCronActivities(subscriptionService, params.Logger),
-		walletCreditExpiry: cronActivities.NewWalletCreditExpiryActivities(walletService, tenantService, environmentService, params.Logger),
+		creditGrant:          cronActivities.NewCreditGrantActivities(creditGrantService),
+		subscription:         cronActivities.NewSubscriptionCronActivities(subscriptionService, params.Logger),
+		walletCreditExpiry:   cronActivities.NewWalletCreditExpiryActivities(walletService, tenantService, environmentService, params.Logger),
+		webhookOutboundRetry: cronActivities.NewWebhookOutboundRetryActivities(webhookService, params.Logger),
 	}
 
 	// Get all task queues and register workflows/activities for each
@@ -439,6 +442,7 @@ func buildWorkerConfig(
 			cronWorkflows.WalletCreditExpiryWorkflow,
 			cronWorkflows.SubscriptionBillingPeriodsWorkflow,
 			cronWorkflows.SubscriptionRenewalDueAlertsWorkflow,
+			cronWorkflows.OutboundWebhookStaleRetryWorkflow,
 		)
 		activitiesList = append(activitiesList,
 			cron.creditGrant.ProcessScheduledCreditGrantApplicationsActivity,
@@ -446,6 +450,7 @@ func buildWorkerConfig(
 			cron.walletCreditExpiry.ExpireCreditsActivity,
 			cron.subscription.UpdateBillingPeriodsActivity,
 			cron.subscription.ProcessRenewalDueAlertsActivity,
+			cron.webhookOutboundRetry.RetryStaleOutboundWebhooksActivity,
 		)
 	}
 	return WorkerConfig{

--- a/internal/temporal/service/schedules.go
+++ b/internal/temporal/service/schedules.go
@@ -55,6 +55,13 @@ func AllTemporalScheduleConfigs() []types.ScheduleConfig {
 			Input:     models.SubscriptionRenewalDueAlertsWorkflowInput{},
 			TaskQueue: types.TemporalTaskQueueCron,
 		},
+		{
+			ID:        types.ScheduleIDOutboundWebhookStaleRetry,
+			Interval:  15 * time.Minute,
+			Workflow:  cronWorkflows.OutboundWebhookStaleRetryWorkflow,
+			Input:     models.OutboundWebhookStaleRetryWorkflowInput{},
+			TaskQueue: types.TemporalTaskQueueCron,
+		},
 	}
 }
 

--- a/internal/temporal/workflows/cron/outbound_webhook_stale_retry_workflow.go
+++ b/internal/temporal/workflows/cron/outbound_webhook_stale_retry_workflow.go
@@ -1,0 +1,44 @@
+package cron
+
+import (
+	"time"
+
+	cronModels "github.com/flexprice/flexprice/internal/temporal/models"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	ActivityRetryStaleOutboundWebhooks = "RetryStaleOutboundWebhooksActivity"
+)
+
+// OutboundWebhookStaleRetryWorkflow retries system_events that were never published after a grace period.
+// Triggered by a Temporal schedule every 15 minutes.
+func OutboundWebhookStaleRetryWorkflow(ctx workflow.Context, _ cronModels.OutboundWebhookStaleRetryWorkflowInput) (*cronModels.OutboundWebhookStaleRetryWorkflowResult, error) {
+	log := workflow.GetLogger(ctx)
+	log.Info("Starting OutboundWebhookStaleRetryWorkflow")
+
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    10 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    5 * time.Minute,
+			MaximumAttempts:    3,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var result cronModels.OutboundWebhookStaleRetryWorkflowResult
+	if err := workflow.ExecuteActivity(ctx, ActivityRetryStaleOutboundWebhooks).Get(ctx, &result); err != nil {
+		log.Error("OutboundWebhookStaleRetryWorkflow activity failed", "error", err)
+		return nil, err
+	}
+
+	log.Info("OutboundWebhookStaleRetryWorkflow completed",
+		"total", result.Total,
+		"succeeded", result.Succeeded,
+		"failed", result.Failed,
+	)
+	return &result, nil
+}

--- a/internal/types/schedule.go
+++ b/internal/types/schedule.go
@@ -18,6 +18,7 @@ const (
 	ScheduleIDWalletCreditExpiry           ScheduleID = "wallet-credit-expiry"
 	ScheduleIDSubscriptionBillingPeriods   ScheduleID = "subscription-billing-periods"
 	ScheduleIDSubscriptionRenewalAlerts    ScheduleID = "subscription-renewal-due-alerts"
+	ScheduleIDOutboundWebhookStaleRetry    ScheduleID = "webhook-stale-retry"
 )
 
 // String returns the raw schedule id.
@@ -32,6 +33,7 @@ func AllTemporalServerScheduleIDs() []ScheduleID {
 		ScheduleIDWalletCreditExpiry,
 		ScheduleIDSubscriptionBillingPeriods,
 		ScheduleIDSubscriptionRenewalAlerts,
+		ScheduleIDOutboundWebhookStaleRetry,
 	}
 }
 

--- a/internal/types/schedule_test.go
+++ b/internal/types/schedule_test.go
@@ -44,9 +44,10 @@ func TestAllTemporalServerScheduleIDs_covers_all_consts(t *testing.T) {
 		ScheduleIDWalletCreditExpiry,
 		ScheduleIDSubscriptionBillingPeriods,
 		ScheduleIDSubscriptionRenewalAlerts,
+		ScheduleIDOutboundWebhookStaleRetry,
 	} {
 		_, ok := seen[c]
 		require.True(t, ok, "const %q must appear in AllTemporalServerScheduleIDs", c)
 	}
-	require.Equal(t, 5, len(ids), "expected five managed server schedule ids")
+	require.Equal(t, 6, len(ids), "expected six managed server schedule ids")
 }

--- a/internal/types/temporal.go
+++ b/internal/types/temporal.go
@@ -58,6 +58,7 @@ const (
 	TemporalWalletCreditExpiryWorkflow                 TemporalWorkflowType = "WalletCreditExpiryWorkflow"
 	TemporalSubscriptionBillingPeriodsWorkflow         TemporalWorkflowType = "SubscriptionBillingPeriodsWorkflow"
 	TemporalSubscriptionRenewalDueAlertsWorkflow       TemporalWorkflowType = "SubscriptionRenewalDueAlertsWorkflow"
+	TemporalOutboundWebhookStaleRetryWorkflow          TemporalWorkflowType = "OutboundWebhookStaleRetryWorkflow"
 	TemporalChargebeeCustomerSyncWorkflow              TemporalWorkflowType = "ChargebeeCustomerSyncWorkflow"
 	TemporalChargebeeInvoiceSyncWorkflow               TemporalWorkflowType = "ChargebeeInvoiceSyncWorkflow"
 	TemporalComputeInvoiceWorkflow                     TemporalWorkflowType = "ComputeInvoiceWorkflow"
@@ -106,6 +107,7 @@ var temporalCronWorkflowTypes = []TemporalWorkflowType{
 	TemporalWalletCreditExpiryWorkflow,
 	TemporalSubscriptionBillingPeriodsWorkflow,
 	TemporalSubscriptionRenewalDueAlertsWorkflow,
+	TemporalOutboundWebhookStaleRetryWorkflow,
 }
 
 var workflowTypesExcludedFromTrackingCore = []TemporalWorkflowType{

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	flexent "github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/internal/config"
@@ -17,6 +18,18 @@ import (
 	"github.com/flexprice/flexprice/internal/webhook/payload"
 	"github.com/flexprice/flexprice/internal/webhook/publisher"
 )
+
+const (
+	staleWebhookGracePeriod = 15 * time.Minute
+	staleWebhookPageSize    = 500
+)
+
+// RetryStalePendingWebhooksResult counts bulk retry outcomes for stale undelivered system_events.
+type RetryStalePendingWebhooksResult struct {
+	Total     int `json:"total"`
+	Succeeded int `json:"succeeded"`
+	Failed    int `json:"failed"`
+}
 
 // WebhookService orchestrates webhook operations
 type WebhookService struct {
@@ -79,6 +92,45 @@ func (s *WebhookService) RetriggerSystemEvent(ctx context.Context, tenantID, env
 	}
 
 	return s.handler.DeliverWebhook(ctx, ev)
+}
+
+// RetryStalePendingWebhooks loads undelivered system_events older than the grace period and
+// delivers each via RetriggerSystemEvent. Pages until a batch smaller than staleWebhookPageSize.
+func (s *WebhookService) RetryStalePendingWebhooks(ctx context.Context) (RetryStalePendingWebhooksResult, error) {
+	var out RetryStalePendingWebhooksResult
+	if !s.config.Webhook.Enabled {
+		return out, nil
+	}
+
+	cutoff := time.Now().UTC().Add(-staleWebhookGracePeriod)
+
+	for {
+		rows, err := s.systemEventRepo.ListStaleUndeliveredWebhooks(ctx, cutoff, staleWebhookPageSize)
+		if err != nil {
+			return out, err
+		}
+
+		for _, se := range rows {
+			out.Total++
+			if err := s.RetriggerSystemEvent(ctx, se.TenantID, se.EnvironmentID, se.ID); err != nil {
+				out.Failed++
+				s.logger.Errorw("stale webhook retry failed",
+					"error", err,
+					"system_event_id", se.ID,
+					"tenant_id", se.TenantID,
+					"environment_id", se.EnvironmentID,
+				)
+				continue
+			}
+			out.Succeeded++
+		}
+
+		if len(rows) < staleWebhookPageSize {
+			break
+		}
+	}
+
+	return out, nil
 }
 
 // Start starts the webhook service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated scheduled retry of undelivered webhooks, running every 15 minutes to ensure better delivery reliability.
  * Failed webhooks now automatically retry with exponential backoff strategy (initial 10-second delay, capped at 5 minutes) with a maximum of 3 retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->