### PR TITLE
feat(customer): add metadata filtering to customer list API

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -711,6 +711,14 @@ var (
 					Where: "email IS NOT NULL AND email != '' AND status = 'published'",
 				},
 			},
+			{
+				Name:    "idx_customer_metadata_gin",
+				Unique:  false,
+				Columns: []*schema.Column{CustomersColumns[8]},
+				Annotation: &entsql.IndexAnnotation{
+					Type: "GIN",
+				},
+			},
 		},
 	}
 	// EntitlementsColumns holds the columns for the "entitlements" table.

--- a/ent/schema/customer.go
+++ b/ent/schema/customer.go
@@ -99,5 +99,9 @@ func (Customer) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "email").
 			Annotations(entsql.IndexWhere("email IS NOT NULL AND email != '' AND status = 'published'")).
 			StorageKey("idx_customer_tenant_environment_email"),
+		// GIN index for efficient JSONB containment queries on metadata (@> operator)
+		index.Fields("metadata").
+			Annotations(entsql.IndexAnnotation{Type: "GIN"}).
+			StorageKey("idx_customer_metadata_gin"),
 	}
 }

--- a/internal/repository/ent/customer.go
+++ b/internal/repository/ent/customer.go
@@ -505,6 +505,10 @@ func (o CustomerQueryOptions) applyEntityQueryOptions(_ context.Context, f *type
 		query = query.Where(customer.ExternalIDIn(f.ExternalIDs...))
 	}
 
+	if len(f.MetadataFilter) > 0 {
+		query = query.Where(predicate.Customer(JSONBContains("metadata", f.MetadataFilter)))
+	}
+
 	if f.Filters != nil {
 		query, err = dsl.ApplyFilters[CustomerQuery, predicate.Customer](
 			query,

--- a/internal/repository/ent/jsonb_helpers.go
+++ b/internal/repository/ent/jsonb_helpers.go
@@ -1,0 +1,21 @@
+package ent
+
+import (
+	"encoding/json"
+
+	"entgo.io/ent/dialect/sql"
+)
+
+// JSONBContains returns an Ent SQL selector predicate that filters rows where
+// the given JSONB column contains all key-value pairs in kv (PostgreSQL @> operator).
+// The generated SQL is: <column> @> $1 — fully parameterized and GIN-index eligible.
+//
+// Usage:
+//
+//	query.Where(predicate.Customer(JSONBContains("metadata", f.MetadataFilter)))
+func JSONBContains(column string, kv map[string]string) func(*sql.Selector) {
+	return func(s *sql.Selector) {
+		jsonBytes, _ := json.Marshal(kv)
+		s.Where(sql.ExprP(s.C(column)+" @> ?", string(jsonBytes)))
+	}
+}

--- a/internal/service/customer_test.go
+++ b/internal/service/customer_test.go
@@ -478,6 +478,100 @@ func (s *CustomerServiceSuite) TestDeleteCustomer() {
 	}
 }
 
+func (s *CustomerServiceSuite) TestGetCustomersMetadataFilter() {
+	s.SetupTest()
+
+	customers := []*domainCustomer.Customer{
+		{
+			ID:         "cust-meta-1",
+			Name:       "Enterprise US",
+			ExternalID: "ext-meta-1",
+			Metadata:   map[string]string{"plan": "enterprise", "region": "us-east"},
+		},
+		{
+			ID:         "cust-meta-2",
+			Name:       "Enterprise EU",
+			ExternalID: "ext-meta-2",
+			Metadata:   map[string]string{"plan": "enterprise", "region": "eu-west"},
+		},
+		{
+			ID:         "cust-meta-3",
+			Name:       "Starter US",
+			ExternalID: "ext-meta-3",
+			Metadata:   map[string]string{"plan": "starter", "region": "us-east"},
+		},
+		{
+			ID:         "cust-meta-4",
+			Name:       "No Metadata",
+			ExternalID: "ext-meta-4",
+		},
+	}
+	for _, c := range customers {
+		s.Require().NoError(s.GetStores().CustomerRepo.Create(s.ctx, c))
+	}
+
+	baseFilter := func(meta map[string]string) *types.CustomerFilter {
+		return &types.CustomerFilter{
+			QueryFilter:    types.NewDefaultQueryFilter(),
+			MetadataFilter: meta,
+		}
+	}
+
+	testCases := []struct {
+		name          string
+		filter        *types.CustomerFilter
+		expectedIDs   []string
+		expectedCount int
+	}{
+		{
+			name:          "single_key_match",
+			filter:        baseFilter(map[string]string{"plan": "enterprise"}),
+			expectedCount: 2,
+			expectedIDs:   []string{"cust-meta-1", "cust-meta-2"},
+		},
+		{
+			name:          "multiple_keys_and_semantics",
+			filter:        baseFilter(map[string]string{"plan": "enterprise", "region": "us-east"}),
+			expectedCount: 1,
+			expectedIDs:   []string{"cust-meta-1"},
+		},
+		{
+			name:          "no_match",
+			filter:        baseFilter(map[string]string{"plan": "pro"}),
+			expectedCount: 0,
+			expectedIDs:   []string{},
+		},
+		{
+			name:          "region_only",
+			filter:        baseFilter(map[string]string{"region": "us-east"}),
+			expectedCount: 2,
+			expectedIDs:   []string{"cust-meta-1", "cust-meta-3"},
+		},
+		{
+			name:          "empty_filter_returns_all",
+			filter:        baseFilter(nil),
+			expectedCount: 4,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp, err := s.service.GetCustomers(s.ctx, tc.filter)
+			s.Require().NoError(err)
+			s.Require().NotNil(resp)
+			s.Equal(tc.expectedCount, len(resp.Items), "unexpected result count")
+
+			if len(tc.expectedIDs) > 0 {
+				gotIDs := make([]string, len(resp.Items))
+				for i, item := range resp.Items {
+					gotIDs[i] = item.ID
+				}
+				s.ElementsMatch(tc.expectedIDs, gotIDs)
+			}
+		})
+	}
+}
+
 func (s *CustomerServiceSuite) TestGetCustomerByLookupKey() {
 	customer := &domainCustomer.Customer{
 		ID:                "cust-1",

--- a/internal/testutil/inmemory_customer_store.go
+++ b/internal/testutil/inmemory_customer_store.go
@@ -161,9 +161,10 @@ func customerFilterFn(ctx context.Context, c *customer.Customer, filter interfac
 		return false
 	}
 
-	// Apply metadata filter (all key-value pairs must match — AND semantics)
+	// Apply metadata filter (all key-value pairs must match — AND semantics, mirrors @> JSONB semantics)
 	for k, v := range f.MetadataFilter {
-		if c.Metadata[k] != v {
+		actual, ok := c.Metadata[k]
+		if !ok || actual != v {
 			return false
 		}
 	}

--- a/internal/testutil/inmemory_customer_store.go
+++ b/internal/testutil/inmemory_customer_store.go
@@ -161,6 +161,13 @@ func customerFilterFn(ctx context.Context, c *customer.Customer, filter interfac
 		return false
 	}
 
+	// Apply metadata filter (all key-value pairs must match — AND semantics)
+	for k, v := range f.MetadataFilter {
+		if c.Metadata[k] != v {
+			return false
+		}
+	}
+
 	// Apply time range filter if present
 	if f.TimeRangeFilter != nil {
 		if f.StartTime != nil && c.CreatedAt.Before(*f.StartTime) {

--- a/internal/types/customer.go
+++ b/internal/types/customer.go
@@ -19,6 +19,7 @@ type CustomerFilter struct {
 	ExternalIDs       []string           `json:"external_ids,omitempty" form:"external_ids" validate:"omitempty"`
 	ExternalID        string             `json:"external_id,omitempty" form:"external_id" validate:"omitempty"`
 	Email             string             `json:"email,omitempty" form:"email" validate:"omitempty,email"`
+	MetadataFilter    map[string]string  `json:"metadata,omitempty" form:"metadata"`
 }
 
 // NewCustomerFilter creates a new CustomerFilter with default values


### PR DESCRIPTION
## Summary

- Adds `?metadata[key]=value` filtering to `GET /v1/customers` — multiple pairs use AND semantics (all must match)
- Backed by a PostgreSQL GIN index on `customers.metadata` for efficient `@>` containment queries at 50k–100k row scale
- Introduces a reusable `JSONBContains` helper that other entities (subscriptions, invoices) can adopt with one line

## What changed

| File | Change |
|------|--------|
| `ent/schema/customer.go` | GIN index declared via `entsql.IndexAnnotation{Type: "GIN"}` — co-located with all other indexes |
| `ent/migrate/schema.go` | Auto-generated by `make generate-ent` |
| `internal/types/customer.go` | `MetadataFilter map[string]string` added to `CustomerFilter` with `form:"metadata"` binding |
| `internal/repository/ent/jsonb_helpers.go` | New `JSONBContains(column, kv)` helper — parameterized `@>` predicate, GIN-index eligible |
| `internal/repository/ent/customer.go` | Calls `JSONBContains` in `applyEntityQueryOptions` |
| `internal/testutil/inmemory_customer_store.go` | In-memory `customerFilterFn` updated to mirror AND semantics |
| `internal/service/customer_test.go` | `TestGetCustomersMetadataFilter` — 5 table-driven cases |

## How to use

```
GET /v1/customers?metadata[plan]=enterprise
GET /v1/customers?metadata[plan]=enterprise&metadata[region]=us-east
```

## Production index note

Run this **before** deploying the Ent migration on existing databases to avoid a table lock:
```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_customer_metadata_gin ON customers USING GIN (metadata);
```
Fresh installations get the index automatically via the Ent migration.

## Test plan

- [x] `TestGetCustomersMetadataFilter` — single key, multi-key AND, no match, region-only, empty filter
- [x] All existing `TestCustomerService` cases pass
- [x] Full `./internal/...` test suite passes with no failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customers can be filtered by metadata key/value pairs in listing queries for finer segmentation.

* **Performance Improvements**
  * Added a PostgreSQL GIN index on customer metadata to speed metadata-based queries.

* **Tests**
  * Added tests validating metadata-filter behavior (single/multi-key, no-match, and empty-filter cases).

* **Chores**
  * In-memory test store updated to respect metadata filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->