### PR TITLE
fix(sub-line-items): exclude end date equal as active

### DIFF
--- a/internal/domain/subscription/line_item.go
+++ b/internal/domain/subscription/line_item.go
@@ -54,6 +54,7 @@ type SubscriptionLineItem struct {
 // IsActive returns true if the line item is active
 // to check if the line item is active and is mostly used with time.Now()
 // and in case of event post processing, we pass the event timestamp
+// the logic is start_date <= t < end_date
 func (li *SubscriptionLineItem) IsActive(t time.Time) bool {
 	if li.Status != types.StatusPublished {
 		return false
@@ -66,7 +67,7 @@ func (li *SubscriptionLineItem) IsActive(t time.Time) bool {
 		return false
 	}
 
-	if !li.EndDate.IsZero() && li.EndDate.Before(t) {
+	if !li.EndDate.IsZero() && (li.EndDate.Before(t) || li.EndDate.Equal(t)) {
 		return false
 	}
 	return true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed subscription line item status calculation to accurately mark items as inactive starting from their end date, improving subscription status tracking precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->