### PR TITLE
Revert "fix(sub-line-items): exclude end date equal as active"

### DIFF
--- a/internal/domain/subscription/line_item.go
+++ b/internal/domain/subscription/line_item.go
@@ -54,7 +54,6 @@ type SubscriptionLineItem struct {
 // IsActive returns true if the line item is active
 // to check if the line item is active and is mostly used with time.Now()
 // and in case of event post processing, we pass the event timestamp
-// the logic is start_date <= t < end_date
 func (li *SubscriptionLineItem) IsActive(t time.Time) bool {
 	if li.Status != types.StatusPublished {
 		return false
@@ -67,7 +66,7 @@ func (li *SubscriptionLineItem) IsActive(t time.Time) bool {
 		return false
 	}
 
-	if !li.EndDate.IsZero() && (li.EndDate.Before(t) || li.EndDate.Equal(t)) {
+	if !li.EndDate.IsZero() && li.EndDate.Before(t) {
 		return false
 	}
 	return true


### PR DESCRIPTION
Reverts flexprice/flexprice#1703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed subscription expiration boundary handling. Subscriptions are now correctly considered active through their designated end date. Previously, subscriptions would incorrectly expire at the exact moment of the end date timestamp. This update ensures subscriptions remain active until after the end date passes, providing more accurate and predictable subscription state determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->