### PR TITLE
fix: handle environment type update

### DIFF
--- a/internal/service/environment.go
+++ b/internal/service/environment.go
@@ -173,8 +173,10 @@ func (s *environmentService) UpdateEnvironment(ctx context.Context, id string, r
 	if req.Name != "" {
 		env.Name = req.Name
 	}
-	if req.Type != "" {
-		env.Type = types.EnvironmentType(req.Type)
+	if req.Type != "" && types.EnvironmentType(req.Type) != env.Type {
+		return nil, ierr.NewError("environment type cannot be changed").
+			WithHintf("type is immutable; current type is %q", env.Type).
+			Mark(ierr.ErrValidation)
 	}
 	env.UpdatedAt = time.Now()
 

--- a/internal/service/environment_test.go
+++ b/internal/service/environment_test.go
@@ -105,14 +105,26 @@ func (s *EnvironmentServiceSuite) TestUpdateEnvironment() {
 	}
 	_ = s.environmentRepo.Create(s.ctx, env)
 
-	updateReq := dto.UpdateEnvironmentRequest{
+	// Name updates and an unchanged type should succeed; type stays as it was.
+	resp, err := s.environmentService.UpdateEnvironment(s.ctx, "env-1", dto.UpdateEnvironmentRequest{
 		Name: "Updated Development",
-		Type: "updated-type",
-	}
-
-	resp, err := s.environmentService.UpdateEnvironment(s.ctx, "env-1", updateReq)
+		Type: string(types.EnvironmentDevelopment),
+	})
 	s.NoError(err)
 	s.NotNil(resp)
-	s.Equal(updateReq.Name, resp.Name)
-	s.Equal(updateReq.Type, resp.Type)
+	s.Equal("Updated Development", resp.Name)
+	s.Equal(string(types.EnvironmentDevelopment), resp.Type)
+
+	// Omitting type should also work and leave the type intact.
+	resp, err = s.environmentService.UpdateEnvironment(s.ctx, "env-1", dto.UpdateEnvironmentRequest{
+		Name: "Renamed Again",
+	})
+	s.NoError(err)
+	s.Equal(string(types.EnvironmentDevelopment), resp.Type)
+
+	// Attempting to change the type must be rejected.
+	_, err = s.environmentService.UpdateEnvironment(s.ctx, "env-1", dto.UpdateEnvironmentRequest{
+		Type: string(types.EnvironmentProduction),
+	})
+	s.Error(err)
 }


### PR DESCRIPTION
## 📝 Description
Updating `environment type` string does not actually change the type of of the environment and there was not validation of incoming environment type against select enums of supported environment types.

---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [x] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

| Case | Screenshot |
| --- | --- |
| Environment dropdown (edit icon) | <img width="267" height="591" alt="image" src="https://github.com/user-attachments/assets/48190e15-bfa3-4c22-b8b6-22fbdaef6433" /> |
| Popup to ask for new environment name | <img width="1230" height="714" alt="image" src="https://github.com/user-attachments/assets/628e254e-04cd-44f3-b1fe-d9725d072cad" /> |

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment type is now immutable. Once created, an environment's type cannot be modified. Attempts to change the type will return a validation error that displays the current type value. This ensures configuration stability and consistency. Users can still update other environment properties as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->