### PR TITLE
fix(redis): branch standalone vs cluster client via Redis.ClusterMode…

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -26,6 +26,7 @@ const (
 type RedisCache struct {
 	client redis.UniversalClient
 	config *config.Configuration
+	log    *logger.Logger
 }
 
 // Redis cache instance
@@ -41,20 +42,22 @@ func NewRedisCache() *RedisCache {
 
 // InitializeRedisCache initializes the global Redis cache instance
 func InitializeRedisCache() {
-	config, err := config.NewConfig()
+	log := logger.GetLogger()
+	cfg, err := config.NewConfig()
 	if err != nil {
-		fmt.Println("Failed to initialize Redis cache", "error", err)
+		log.Errorw("Failed to initialize Redis cache", "error", err)
 		return
 	}
 	if redisCache == nil {
-		redisClient, err := redisClient.NewClient(config, logger.GetLogger())
+		client, err := redisClient.NewClient(cfg, log)
 		if err != nil {
-			fmt.Println("Failed to create Redis client", "error", err)
+			log.Errorw("Failed to create Redis client", "error", err)
 			return
 		}
 		redisCache = &RedisCache{
-			client: redisClient.GetClient(),
-			config: config,
+			client: client.GetClient(),
+			config: cfg,
+			log:    log,
 		}
 	}
 }
@@ -79,7 +82,7 @@ func (c *RedisCache) GetRedisKey(key string) string {
 func (c *RedisCache) Get(ctx context.Context, key string) (interface{}, bool) {
 
 	if !c.config.Cache.Enabled {
-		fmt.Println("Cache is disabled")
+		c.log.Debugw("Cache is disabled")
 		return nil, false
 	}
 
@@ -91,7 +94,7 @@ func (c *RedisCache) Get(ctx context.Context, key string) (interface{}, bool) {
 			// Key does not exist
 			return nil, false
 		}
-		fmt.Print("Redis GET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis GET error", "key", redisKey, "error", err)
 		return nil, false
 	}
 
@@ -102,7 +105,7 @@ func (c *RedisCache) Get(ctx context.Context, key string) (interface{}, bool) {
 func (c *RedisCache) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) {
 
 	if !c.config.Cache.Enabled {
-		fmt.Println("Cache is disabled")
+		c.log.Debugw("Cache is disabled")
 		return
 	}
 	// Use default expiration if none specified
@@ -122,14 +125,14 @@ func (c *RedisCache) Set(ctx context.Context, key string, value interface{}, exp
 		// Marshal non-string values to JSON
 		jsonBytes, err := json.Marshal(value)
 		if err != nil {
-			fmt.Println("Failed to marshal cache value", "key", redisKey, "error", err)
+			c.log.Errorw("Failed to marshal cache value", "key", redisKey, "error", err)
 			return
 		}
 		strValue = string(jsonBytes)
 	}
 
 	if err := c.client.Set(ctx, redisKey, strValue, expiration).Err(); err != nil {
-		fmt.Println("Redis SET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis SET error", "key", redisKey, "error", err)
 	}
 }
 
@@ -139,7 +142,7 @@ func (c *RedisCache) Delete(ctx context.Context, key string) {
 	redisKey := c.GetRedisKey(key)
 	err := c.delete(ctx, redisKey)
 	if err != nil {
-		fmt.Println("Redis DELETE failed, retrying...", "key", redisKey, "error", err)
+		c.log.Warnw("Redis DELETE failed, retrying...", "key", redisKey, "error", err)
 
 		// Create a new context with timeout for the retry
 		retryCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -150,7 +153,7 @@ func (c *RedisCache) Delete(ctx context.Context, key string) {
 
 		// Retry once
 		if retryErr := c.delete(retryCtx, redisKey); retryErr != nil {
-			fmt.Println("Redis DELETE retry failed", "key", redisKey, "error", retryErr)
+			c.log.Errorw("Redis DELETE retry failed", "key", redisKey, "error", retryErr)
 		}
 	}
 }
@@ -218,7 +221,7 @@ func (c *RedisCache) DeleteByPrefix(ctx context.Context, prefix string) {
 // Flush removes all items from the cache
 func (c *RedisCache) Flush(ctx context.Context) {
 	if err := c.client.FlushDB(ctx).Err(); err != nil {
-		fmt.Println("Redis FLUSHDB error", "error", err)
+		c.log.Errorw("Redis FLUSHDB error", "error", err)
 	}
 }
 
@@ -231,7 +234,7 @@ func (c *RedisCache) ForceCacheGet(ctx context.Context, key string) (interface{}
 			// Key does not exist
 			return nil, false
 		}
-		fmt.Println("Redis GET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis GET error", "key", redisKey, "error", err)
 		return nil, false
 	}
 
@@ -246,13 +249,13 @@ func (c *RedisCache) ForceCacheGetWithTTL(ctx context.Context, key string) (inte
 		if errors.Is(err, redis.Nil) {
 			return nil, 0, false
 		}
-		fmt.Println("Redis GET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis GET error", "key", redisKey, "error", err)
 		return nil, 0, false
 	}
 
 	ttl, err := c.client.TTL(ctx, redisKey).Result()
 	if err != nil {
-		fmt.Println("Redis TTL error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis TTL error", "key", redisKey, "error", err)
 		// Still return the value even if TTL lookup fails
 		return value, 0, true
 	}
@@ -279,13 +282,13 @@ func (c *RedisCache) ForceCacheSet(ctx context.Context, key string, value interf
 		// Marshal non-string values to JSON
 		jsonBytes, err := json.Marshal(value)
 		if err != nil {
-			fmt.Println("Failed to marshal cache value", "key", redisKey, "error", err)
+			c.log.Errorw("Failed to marshal cache value", "key", redisKey, "error", err)
 			return
 		}
 		strValue = string(jsonBytes)
 	}
 
 	if err := c.client.Set(ctx, redisKey, strValue, expiration).Err(); err != nil {
-		fmt.Println("Redis SET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis SET error", "key", redisKey, "error", err)
 	}
 }

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -21,9 +21,10 @@ const (
 	ScanCount = 100
 )
 
-// RedisCache implements the Cache interface using Redis
+// RedisCache implements the Cache interface using Redis.
+// The client is a UniversalClient so it works for both standalone and cluster deployments.
 type RedisCache struct {
-	client *redis.ClusterClient
+	client redis.UniversalClient
 	config *config.Configuration
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,7 +343,12 @@ type RedisConfig struct {
 	PoolSize    int           `mapstructure:"pool_size" default:"10"`
 	Timeout     time.Duration `mapstructure:"timeout" default:"5s"`
 	KeyPrefix   string        `mapstructure:"key_prefix" default:"flexprice"`
-	ClusterMode bool          `mapstructure:"cluster_mode" default:"false"`
+	// ClusterMode: true → *redis.ClusterClient (Redis Cluster, ElastiCache
+	// cluster-mode enabled). false → standalone *redis.Client. Default is
+	// true to preserve the pre-1.1 hardcoded behaviour; flip to false for
+	// single-node Redis. Baked default lives in config.yaml; env override:
+	// FLEXPRICE_REDIS_CLUSTER_MODE.
+	ClusterMode bool          `mapstructure:"cluster_mode"`
 }
 
 func NewConfig() (*Configuration, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -335,14 +335,15 @@ type CustomerPortalConfig struct {
 
 // RedisConfig holds configuration for Redis
 type RedisConfig struct {
-	Host      string        `mapstructure:"host" default:"localhost"`
-	Port      int           `mapstructure:"port" default:"6379"`
-	Password  string        `mapstructure:"password" default:""`
-	DB        int           `mapstructure:"db" default:"0"`
-	UseTLS    bool          `mapstructure:"use_tls" default:"false"`
-	PoolSize  int           `mapstructure:"pool_size" default:"10"`
-	Timeout   time.Duration `mapstructure:"timeout" default:"5s"`
-	KeyPrefix string        `mapstructure:"key_prefix" default:"flexprice"`
+	Host        string        `mapstructure:"host" default:"localhost"`
+	Port        int           `mapstructure:"port" default:"6379"`
+	Password    string        `mapstructure:"password" default:""`
+	DB          int           `mapstructure:"db" default:"0"`
+	UseTLS      bool          `mapstructure:"use_tls" default:"false"`
+	PoolSize    int           `mapstructure:"pool_size" default:"10"`
+	Timeout     time.Duration `mapstructure:"timeout" default:"5s"`
+	KeyPrefix   string        `mapstructure:"key_prefix" default:"flexprice"`
+	ClusterMode bool          `mapstructure:"cluster_mode" default:"false"`
 }
 
 func NewConfig() (*Configuration, error) {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -272,6 +272,10 @@ redis:
   pool_size: 10 # Maximum number of connections in the pool
   timeout: 5s # Timeout for Redis operations
   key_prefix: "flexprice:local"
+  # cluster_mode preserves the pre-existing hardcoded behaviour (the client
+  # was always *redis.ClusterClient). Set to false when targeting a single-node
+  # Redis (in-cluster bitnami/redis chart, single-node ElastiCache).
+  cluster_mode: true
 
 # Raw events reprocessing configuration
 raw_events_reprocessing:

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -10,46 +10,54 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// Client wraps Redis client functionality
+// Client wraps a Redis client. The underlying *redis.UniversalClient transparently
+// targets a standalone node or a Redis Cluster based on RedisConfig.ClusterMode.
 type Client struct {
-	rdb *redis.ClusterClient
+	rdb redis.UniversalClient
 	log *logger.Logger
 }
 
-// NewClient creates a new Redis client
+// NewClient creates a new Redis client. Set RedisConfig.ClusterMode=true for
+// Redis Cluster (e.g. AWS ElastiCache cluster mode enabled); leave false for
+// standalone Redis (single ElastiCache node, in-cluster redis, Redis sentinel
+// via the universal client's failover path).
 func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error) {
-
-	// Test connection
 	ctx, cancel := context.WithTimeout(context.Background(), config.Redis.Timeout)
 	defer cancel()
 
-	// Create cluster client
-	clusterOpts := &redis.ClusterOptions{
-		Addrs:        []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)},
-		Password:     config.Redis.Password,
-		ReadTimeout:  config.Redis.Timeout,
-		WriteTimeout: config.Redis.Timeout,
-		PoolSize:     config.Redis.PoolSize,
-	}
-
+	var tlsConfig *tls.Config
 	if config.Redis.UseTLS {
-		clusterOpts.TLSConfig = &tls.Config{
+		tlsConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true, // Required for AWS ElastiCache wildcard certificates
 		}
 	}
 
-	rdb := redis.NewClusterClient(clusterOpts)
+	opts := &redis.UniversalOptions{
+		Addrs:        []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)},
+		Password:     config.Redis.Password,
+		DB:           config.Redis.DB,
+		ReadTimeout:  config.Redis.Timeout,
+		WriteTimeout: config.Redis.Timeout,
+		PoolSize:     config.Redis.PoolSize,
+		TLSConfig:    tlsConfig,
+	}
+
+	var rdb redis.UniversalClient
+	if config.Redis.ClusterMode {
+		rdb = redis.NewClusterClient(opts.Cluster())
+	} else {
+		// UniversalOptions.Simple() routes to a standalone *redis.Client; DB index applies.
+		rdb = redis.NewClient(opts.Simple())
+	}
 
 	result, err := rdb.Ping(ctx).Result()
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create redis client: %w", err)
 	}
 
-	log.Infow("PING result", "result", result)
-
-	log.Infow("Connected to Redis Cluster successfully", "addr", clusterOpts.Addrs)
+	log.Infow("PING result", "result", result, "cluster_mode", config.Redis.ClusterMode)
+	log.Infow("Connected to Redis successfully", "addr", opts.Addrs, "cluster_mode", config.Redis.ClusterMode)
 
 	return &Client{
 		rdb: rdb,
@@ -57,8 +65,10 @@ func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error
 	}, nil
 }
 
-// GetClient returns the underlying Redis client
-func (c *Client) GetClient() *redis.ClusterClient {
+// GetClient returns the underlying Redis client. Callers should depend on
+// redis.UniversalClient (or redis.Cmdable) rather than the concrete type so
+// they work for both cluster and standalone deployments.
+func (c *Client) GetClient() redis.UniversalClient {
 	return c.rdb
 }
 


### PR DESCRIPTION
… config

The Redis client unconditionally created a *redis.ClusterClient regardless of the deployment topology, which breaks against single-node Redis (e.g. AWS ElastiCache cluster-mode-disabled) where MOVED redirects never arrive and the client times out probing slot routing.

By default we are supporting Cluster mode. To explicity switch it off for standalone Redis, set FLEXPRICE_REDIS_CLUSTER_MODE=false

---

## 🔨 Changes Made
- [x] Feature 1

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [x] I have updated documentation (if needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for both Redis standalone and cluster deployments; new config option to select cluster mode.

* **Improvements**
  * Improved connection validation and reliability when connecting to Redis.
  * Enhanced logging and error reporting for cache/Redis operations to aid troubleshooting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1754)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->