### PR TITLE
feat(subscriptions): add support for out of sync with the associated plan config

### DIFF
--- a/internal/domain/subscription/model.go
+++ b/internal/domain/subscription/model.go
@@ -136,6 +136,9 @@ type Subscription struct {
 	// SubscriptionType categorises the subscription within a customer hierarchy (standalone, parent, inherited).
 	SubscriptionType types.SubscriptionType `db:"subscription_type" json:"subscription_type"`
 
+	// OutOfSync is true if the subscription is out of sync with the plan. This is used to determine if the subscription is out of sync with the plan.
+	OutOfSync bool `json:"out_of_sync"`
+
 	types.BaseModel
 }
 

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1531,6 +1531,9 @@ func (s *subscriptionService) GetSubscription(ctx context.Context, id string) (*
 	}
 	response.CreditGrants = creditGrantsResponse.Items
 
+	// set out of sync
+	sub.OutOfSync = s.setOutOfSync(ctx, sub, sub.LineItems, plan.Prices)
+
 	return response, nil
 }
 
@@ -1648,6 +1651,14 @@ func (s *subscriptionService) GetSubscriptionV2(ctx context.Context, id string, 
 
 		response.LineItems = lineItemResponses
 	}
+
+	var planPrices []*dto.PriceResponse
+	if response.Plan != nil {
+		planPrices = response.Plan.Prices
+	}
+	// set out of sync
+	// lineItems is nil when not fetched — setOutOfSync fetches internally
+	sub.OutOfSync = s.setOutOfSync(ctx, sub, lineItems, planPrices)
 
 	return response, nil
 }
@@ -2163,6 +2174,9 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 					"available_customer_ids", lo.Keys(customerIDMap))
 			}
 		}
+
+		// set out of sync
+		sub.OutOfSync = s.setOutOfSync(ctx, sub, sub.LineItems, planResp.Prices)
 
 		response.Items[i] = &dto.SubscriptionResponse{
 			Subscription: sub,
@@ -7602,4 +7616,61 @@ func (s *subscriptionService) cascadeResumeToInherited(ctx context.Context, pare
 		}
 	}
 	return nil
+}
+
+// setOutOfSync marks sub.OutOfSync=true when the plan has a usage price with no matching subscription line item.
+// Pass the data you already have; nil means fetch internally. On any fetch error it marks sub.OutOfSync=true and logs the error.
+// sub.OutOfSync is set to false if every plan usage price has a matching subscription line item.
+func (s *subscriptionService) setOutOfSync(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	lineItems []*subscription.SubscriptionLineItem, // nil → fetched internally
+	planPrices []*dto.PriceResponse, // nil → fetched internally
+) bool {
+	if lineItems == nil {
+		liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+		liFilter.SubscriptionIDs = []string{sub.ID}
+		liFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+		var err error
+		lineItems, err = s.SubscriptionLineItemRepo.List(ctx, liFilter)
+		if err != nil {
+			s.Logger.ErrorwCtx(ctx, "setOutOfSync: failed to fetch line items", "subscription_id", sub.ID, "error", err)
+			return true
+		}
+	}
+
+	if planPrices == nil {
+		planSvc := NewPlanService(s.ServiceParams)
+		planFilter := types.NewNoLimitPlanFilter()
+		planFilter.PlanIDs = []string{sub.PlanID}
+		planFilter.Expand = lo.ToPtr(string(types.ExpandPrices))
+		plans, err := planSvc.GetPlans(ctx, planFilter)
+		if err != nil {
+			s.Logger.ErrorwCtx(ctx, "setOutOfSync: failed to fetch plan prices", "subscription_id", sub.ID, "plan_id", sub.PlanID, "error", err)
+			return true
+		}
+		if len(plans.Items) > 0 {
+			planPrices = plans.Items[0].Prices
+		}
+	}
+
+	if len(planPrices) == 0 {
+		return false
+	}
+
+	// Only usage charges are tracked for sync — skip flat/fixed prices on both sides
+	subPriceIDs := make(map[string]struct{}, len(lineItems))
+	for _, li := range lineItems {
+		if li.IsUsage() {
+			subPriceIDs[li.PriceID] = struct{}{}
+		}
+	}
+	for _, p := range planPrices {
+		if p.Price != nil && p.IsUsage() {
+			if _, ok := subPriceIDs[p.ID]; !ok {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscriptions now include an out-of-sync status indicating whether subscription line items match the associated plan's price configuration
  * Out-of-sync detection automatically runs when retrieving subscription data
  * System identifies when usage-type prices in a plan lack corresponding subscription line items

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1762)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->