### PR TITLE
feat(subscription): allow standalone parent in grouped invoicing

### DIFF
--- a/internal/service/subscription_grouped_invoicing.go
+++ b/internal/service/subscription_grouped_invoicing.go
@@ -51,10 +51,11 @@ func (s *subscriptionService) validateAddToGroupedInvoicing(
 			Mark(ierr.ErrValidation)
 	}
 
-	// 4. parent must have type "parent"
-	if parentSub.SubscriptionType != types.SubscriptionTypeParent {
-		return ierr.NewError("parent subscription must have type 'parent'").
-			WithHint("The target parent subscription does not have the correct type").
+	// 4. parent must have type "parent" or "standalone" (standalone will be promoted to parent)
+	if parentSub.SubscriptionType != types.SubscriptionTypeParent &&
+		parentSub.SubscriptionType != types.SubscriptionTypeStandalone {
+		return ierr.NewError("parent subscription must have type 'parent' or 'standalone'").
+			WithHint("Only parent or standalone subscriptions can act as a grouped invoicing parent; standalone subscriptions are automatically promoted").
 			WithReportableDetails(map[string]any{
 				"parent_subscription_id":   parentSub.ID,
 				"parent_subscription_type": parentSub.SubscriptionType,
@@ -157,6 +158,14 @@ func (s *subscriptionService) addToGroupedInvoicing(
 
 	if err := s.validateAddToGroupedInvoicing(ctx, parentSub, child); err != nil {
 		return err
+	}
+
+	// Promote standalone parent to parent type on first child attachment
+	if parentSub.SubscriptionType == types.SubscriptionTypeStandalone {
+		parentSub.SubscriptionType = types.SubscriptionTypeParent
+		if err := s.SubRepo.Update(ctx, parentSub); err != nil {
+			return err
+		}
 	}
 
 	child.SubscriptionType = types.SubscriptionTypeGroupedInvoicing

--- a/internal/service/subscription_grouped_invoicing_test.go
+++ b/internal/service/subscription_grouped_invoicing_test.go
@@ -236,23 +236,6 @@ func (s *SubscriptionGroupedInvoicingTestSuite) TestAddToGroupedInvoicing_Reject
 	require.True(s.T(), ierr.IsValidation(err), "expected validation error, got: %v", err)
 }
 
-func (s *SubscriptionGroupedInvoicingTestSuite) TestAddToGroupedInvoicing_RejectsNonParentParentSub() {
-	ctx := s.GetContext()
-	cust := s.createTestCustomer()
-
-	// parent sub is actually standalone, not parent type
-	parent := s.makeParentSub(cust.ID, baseAnchor, baseAnchor)
-	// override in DB
-	parent.SubscriptionType = types.SubscriptionTypeStandalone
-	require.NoError(s.T(), s.GetStores().SubscriptionRepo.Update(ctx, parent))
-
-	child := s.makeChildSub(cust.ID, baseAnchor, baseAnchor)
-
-	err := s.subscriptionService.addToGroupedInvoicing(ctx, parent, child.ID)
-	require.Error(s.T(), err)
-	require.True(s.T(), ierr.IsValidation(err), "expected validation error, got: %v", err)
-}
-
 func (s *SubscriptionGroupedInvoicingTestSuite) TestAddToGroupedInvoicing_RejectsBillingAnchorMismatch() {
 	ctx := s.GetContext()
 	cust := s.createTestCustomer()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Grouped invoicing now accepts standalone subscriptions as parent subscriptions; standalone subscriptions will be automatically promoted to parent when added to a grouped invoicing arrangement, allowing more flexible subscription grouping.

* **Tests**
  * Test suite updated to reflect the new acceptance of standalone-to-parent promotions in grouped invoicing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1767)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->