### PR TITLE
feat(price-sync): initiate price sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,7 @@ vendor/
 
 # claude superpowers
 docs/superpowers/*
+
+# Postman
+postman/
+.postman/

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1393,6 +1393,7 @@ var (
 		{Name: "start_date", Type: field.TypeTime, Nullable: true},
 		{Name: "end_date", Type: field.TypeTime, Nullable: true},
 		{Name: "group_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "sequence", Type: field.TypeInt64, Default: schema.Expr("nextval('prices_sequence_seq')")},
 		{Name: "price_unit_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
 	// PricesTable holds the schema information for the "prices" table.
@@ -1403,7 +1404,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "prices_price_units_price_unit_edge",
-				Columns:    []*schema.Column{PricesColumns[40]},
+				Columns:    []*schema.Column{PricesColumns[41]},
 				RefColumns: []*schema.Column{PriceUnitsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1431,6 +1432,14 @@ var (
 				Name:    "price_tenant_id_environment_id_group_id",
 				Unique:  false,
 				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[39]},
+			},
+			{
+				Name:    "price_tenant_id_environment_id_entity_id_entity_type_sequence",
+				Unique:  false,
+				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[35], PricesColumns[34], PricesColumns[40]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "status = 'published'",
+				},
 			},
 		},
 	}
@@ -1628,6 +1637,7 @@ var (
 		{Name: "payment_terms", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(20)"}},
 		{Name: "subscription_type", Type: field.TypeString, Default: "standalone", SchemaType: map[string]string{"postgres": "varchar(20)"}},
 		{Name: "auto_invoice_threshold", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(20,6)"}},
+		{Name: "synced_price_sequence", Type: field.TypeInt64, Default: "0"},
 		{Name: "invoicing_customer_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
 	// SubscriptionsTable holds the schema information for the "subscriptions" table.
@@ -1666,6 +1676,14 @@ var (
 				Name:    "subscription_tenant_id_environment_id_current_period_end_subscription_status_status",
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[17], SubscriptionsColumns[11], SubscriptionsColumns[2]},
+			},
+			{
+				Name:    "subscription_tenant_id_environment_id_plan_id_synced_price_sequence",
+				Unique:  false,
+				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[10], SubscriptionsColumns[43]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "status = 'published' AND subscription_status IN ('active','trialing')",
+				},
 			},
 		},
 	}

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1648,7 +1648,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "subscriptions_customers_invoicing_customer",
-				Columns:    []*schema.Column{SubscriptionsColumns[44]},
+				Columns:    []*schema.Column{SubscriptionsColumns[45]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1680,9 +1680,9 @@ var (
 			{
 				Name:    "subscription_tenant_id_environment_id_plan_id_synced_price_sequence",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[10], SubscriptionsColumns[43]},
+				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[10], SubscriptionsColumns[44]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND subscription_status IN ('active','trialing')",
+					Where: "status = 'published'",
 				},
 			},
 		},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -37890,6 +37890,8 @@ type PriceMutation struct {
 	start_date                *time.Time
 	end_date                  *time.Time
 	group_id                  *string
+	sequence                  *int64
+	addsequence               *int64
 	clearedFields             map[string]struct{}
 	costsheet                 map[string]struct{}
 	removedcostsheet          map[string]struct{}
@@ -39842,6 +39844,62 @@ func (m *PriceMutation) ResetGroupID() {
 	delete(m.clearedFields, price.FieldGroupID)
 }
 
+// SetSequence sets the "sequence" field.
+func (m *PriceMutation) SetSequence(i int64) {
+	m.sequence = &i
+	m.addsequence = nil
+}
+
+// Sequence returns the value of the "sequence" field in the mutation.
+func (m *PriceMutation) Sequence() (r int64, exists bool) {
+	v := m.sequence
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSequence returns the old "sequence" field's value of the Price entity.
+// If the Price object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PriceMutation) OldSequence(ctx context.Context) (v int64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSequence is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSequence requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSequence: %w", err)
+	}
+	return oldValue.Sequence, nil
+}
+
+// AddSequence adds i to the "sequence" field.
+func (m *PriceMutation) AddSequence(i int64) {
+	if m.addsequence != nil {
+		*m.addsequence += i
+	} else {
+		m.addsequence = &i
+	}
+}
+
+// AddedSequence returns the value that was added to the "sequence" field in this mutation.
+func (m *PriceMutation) AddedSequence() (r int64, exists bool) {
+	v := m.addsequence
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetSequence resets all changes to the "sequence" field.
+func (m *PriceMutation) ResetSequence() {
+	m.sequence = nil
+	m.addsequence = nil
+}
+
 // AddCostsheetIDs adds the "costsheet" edge to the Costsheet entity by ids.
 func (m *PriceMutation) AddCostsheetIDs(ids ...string) {
 	if m.costsheet == nil {
@@ -39970,7 +40028,7 @@ func (m *PriceMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PriceMutation) Fields() []string {
-	fields := make([]string, 0, 40)
+	fields := make([]string, 0, 41)
 	if m.tenant_id != nil {
 		fields = append(fields, price.FieldTenantID)
 	}
@@ -40091,6 +40149,9 @@ func (m *PriceMutation) Fields() []string {
 	if m.group_id != nil {
 		fields = append(fields, price.FieldGroupID)
 	}
+	if m.sequence != nil {
+		fields = append(fields, price.FieldSequence)
+	}
 	return fields
 }
 
@@ -40179,6 +40240,8 @@ func (m *PriceMutation) Field(name string) (ent.Value, bool) {
 		return m.EndDate()
 	case price.FieldGroupID:
 		return m.GroupID()
+	case price.FieldSequence:
+		return m.Sequence()
 	}
 	return nil, false
 }
@@ -40268,6 +40331,8 @@ func (m *PriceMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldEndDate(ctx)
 	case price.FieldGroupID:
 		return m.OldGroupID(ctx)
+	case price.FieldSequence:
+		return m.OldSequence(ctx)
 	}
 	return nil, fmt.Errorf("unknown Price field %s", name)
 }
@@ -40557,6 +40622,13 @@ func (m *PriceMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetGroupID(v)
 		return nil
+	case price.FieldSequence:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSequence(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Price field %s", name)
 }
@@ -40571,6 +40643,9 @@ func (m *PriceMutation) AddedFields() []string {
 	if m.addtrial_period_days != nil {
 		fields = append(fields, price.FieldTrialPeriodDays)
 	}
+	if m.addsequence != nil {
+		fields = append(fields, price.FieldSequence)
+	}
 	return fields
 }
 
@@ -40583,6 +40658,8 @@ func (m *PriceMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedBillingPeriodCount()
 	case price.FieldTrialPeriodDays:
 		return m.AddedTrialPeriodDays()
+	case price.FieldSequence:
+		return m.AddedSequence()
 	}
 	return nil, false
 }
@@ -40605,6 +40682,13 @@ func (m *PriceMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddTrialPeriodDays(v)
+		return nil
+	case price.FieldSequence:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddSequence(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Price numeric field %s", name)
@@ -40905,6 +40989,9 @@ func (m *PriceMutation) ResetField(name string) error {
 		return nil
 	case price.FieldGroupID:
 		m.ResetGroupID()
+		return nil
+	case price.FieldSequence:
+		m.ResetSequence()
 		return nil
 	}
 	return fmt.Errorf("unknown Price field %s", name)
@@ -45542,6 +45629,8 @@ type SubscriptionMutation struct {
 	payment_terms              *types.PaymentTerms
 	subscription_type          *types.SubscriptionType
 	auto_invoice_threshold     *decimal.Decimal
+	synced_price_sequence      *int64
+	addsynced_price_sequence   *int64
 	clearedFields              map[string]struct{}
 	line_items                 map[string]struct{}
 	removedline_items          map[string]struct{}
@@ -47511,6 +47600,21 @@ func (m *SubscriptionMutation) AutoInvoiceThreshold() (r decimal.Decimal, exists
 	return *v, true
 }
 
+// SetSyncedPriceSequence sets the "synced_price_sequence" field.
+func (m *SubscriptionMutation) SetSyncedPriceSequence(i int64) {
+	m.synced_price_sequence = &i
+	m.addsynced_price_sequence = nil
+}
+
+// SyncedPriceSequence returns the value of the "synced_price_sequence" field in the mutation.
+func (m *SubscriptionMutation) SyncedPriceSequence() (r int64, exists bool) {
+	v := m.synced_price_sequence
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
 // OldAutoInvoiceThreshold returns the old "auto_invoice_threshold" field's value of the Subscription entity.
 // If the Subscription object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
@@ -47544,6 +47648,47 @@ func (m *SubscriptionMutation) AutoInvoiceThresholdCleared() bool {
 func (m *SubscriptionMutation) ResetAutoInvoiceThreshold() {
 	m.auto_invoice_threshold = nil
 	delete(m.clearedFields, subscription.FieldAutoInvoiceThreshold)
+}
+
+// OldSyncedPriceSequence returns the old "synced_price_sequence" field's value of the Subscription entity.
+// If the Subscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SubscriptionMutation) OldSyncedPriceSequence(ctx context.Context) (v int64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSyncedPriceSequence is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSyncedPriceSequence requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSyncedPriceSequence: %w", err)
+	}
+	return oldValue.SyncedPriceSequence, nil
+}
+
+// AddSyncedPriceSequence adds i to the "synced_price_sequence" field.
+func (m *SubscriptionMutation) AddSyncedPriceSequence(i int64) {
+	if m.addsynced_price_sequence != nil {
+		*m.addsynced_price_sequence += i
+	} else {
+		m.addsynced_price_sequence = &i
+	}
+}
+
+// AddedSyncedPriceSequence returns the value that was added to the "synced_price_sequence" field in this mutation.
+func (m *SubscriptionMutation) AddedSyncedPriceSequence() (r int64, exists bool) {
+	v := m.addsynced_price_sequence
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetSyncedPriceSequence resets all changes to the "synced_price_sequence" field.
+func (m *SubscriptionMutation) ResetSyncedPriceSequence() {
+	m.synced_price_sequence = nil
+	m.addsynced_price_sequence = nil
 }
 
 // AddLineItemIDs adds the "line_items" edge to the SubscriptionLineItem entity by ids.
@@ -48118,6 +48263,9 @@ func (m *SubscriptionMutation) Fields() []string {
 	if m.auto_invoice_threshold != nil {
 		fields = append(fields, subscription.FieldAutoInvoiceThreshold)
 	}
+	if m.synced_price_sequence != nil {
+		fields = append(fields, subscription.FieldSyncedPriceSequence)
+	}
 	return fields
 }
 
@@ -48214,6 +48362,8 @@ func (m *SubscriptionMutation) Field(name string) (ent.Value, bool) {
 		return m.SubscriptionType()
 	case subscription.FieldAutoInvoiceThreshold:
 		return m.AutoInvoiceThreshold()
+	case subscription.FieldSyncedPriceSequence:
+		return m.SyncedPriceSequence()
 	}
 	return nil, false
 }
@@ -48311,6 +48461,8 @@ func (m *SubscriptionMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldSubscriptionType(ctx)
 	case subscription.FieldAutoInvoiceThreshold:
 		return m.OldAutoInvoiceThreshold(ctx)
+	case subscription.FieldSyncedPriceSequence:
+		return m.OldSyncedPriceSequence(ctx)
 	}
 	return nil, fmt.Errorf("unknown Subscription field %s", name)
 }
@@ -48627,6 +48779,12 @@ func (m *SubscriptionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAutoInvoiceThreshold(v)
+	case subscription.FieldSyncedPriceSequence:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSyncedPriceSequence(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Subscription field %s", name)
@@ -48642,6 +48800,9 @@ func (m *SubscriptionMutation) AddedFields() []string {
 	if m.addversion != nil {
 		fields = append(fields, subscription.FieldVersion)
 	}
+	if m.addsynced_price_sequence != nil {
+		fields = append(fields, subscription.FieldSyncedPriceSequence)
+	}
 	return fields
 }
 
@@ -48654,6 +48815,8 @@ func (m *SubscriptionMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedBillingPeriodCount()
 	case subscription.FieldVersion:
 		return m.AddedVersion()
+	case subscription.FieldSyncedPriceSequence:
+		return m.AddedSyncedPriceSequence()
 	}
 	return nil, false
 }
@@ -48676,6 +48839,13 @@ func (m *SubscriptionMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddVersion(v)
+		return nil
+	case subscription.FieldSyncedPriceSequence:
+		v, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddSyncedPriceSequence(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Subscription numeric field %s", name)
@@ -48952,6 +49122,8 @@ func (m *SubscriptionMutation) ResetField(name string) error {
 		return nil
 	case subscription.FieldAutoInvoiceThreshold:
 		m.ResetAutoInvoiceThreshold()
+	case subscription.FieldSyncedPriceSequence:
+		m.ResetSyncedPriceSequence()
 		return nil
 	}
 	return fmt.Errorf("unknown Subscription field %s", name)

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -47600,21 +47600,6 @@ func (m *SubscriptionMutation) AutoInvoiceThreshold() (r decimal.Decimal, exists
 	return *v, true
 }
 
-// SetSyncedPriceSequence sets the "synced_price_sequence" field.
-func (m *SubscriptionMutation) SetSyncedPriceSequence(i int64) {
-	m.synced_price_sequence = &i
-	m.addsynced_price_sequence = nil
-}
-
-// SyncedPriceSequence returns the value of the "synced_price_sequence" field in the mutation.
-func (m *SubscriptionMutation) SyncedPriceSequence() (r int64, exists bool) {
-	v := m.synced_price_sequence
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
 // OldAutoInvoiceThreshold returns the old "auto_invoice_threshold" field's value of the Subscription entity.
 // If the Subscription object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
@@ -47648,6 +47633,21 @@ func (m *SubscriptionMutation) AutoInvoiceThresholdCleared() bool {
 func (m *SubscriptionMutation) ResetAutoInvoiceThreshold() {
 	m.auto_invoice_threshold = nil
 	delete(m.clearedFields, subscription.FieldAutoInvoiceThreshold)
+}
+
+// SetSyncedPriceSequence sets the "synced_price_sequence" field.
+func (m *SubscriptionMutation) SetSyncedPriceSequence(i int64) {
+	m.synced_price_sequence = &i
+	m.addsynced_price_sequence = nil
+}
+
+// SyncedPriceSequence returns the value of the "synced_price_sequence" field in the mutation.
+func (m *SubscriptionMutation) SyncedPriceSequence() (r int64, exists bool) {
+	v := m.synced_price_sequence
+	if v == nil {
+		return
+	}
+	return *v, true
 }
 
 // OldSyncedPriceSequence returns the old "synced_price_sequence" field's value of the Subscription entity.
@@ -48130,7 +48130,7 @@ func (m *SubscriptionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SubscriptionMutation) Fields() []string {
-	fields := make([]string, 0, 44)
+	fields := make([]string, 0, 45)
 	if m.tenant_id != nil {
 		fields = append(fields, subscription.FieldTenantID)
 	}
@@ -48779,6 +48779,7 @@ func (m *SubscriptionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAutoInvoiceThreshold(v)
+		return nil
 	case subscription.FieldSyncedPriceSequence:
 		v, ok := value.(int64)
 		if !ok {
@@ -49122,6 +49123,7 @@ func (m *SubscriptionMutation) ResetField(name string) error {
 		return nil
 	case subscription.FieldAutoInvoiceThreshold:
 		m.ResetAutoInvoiceThreshold()
+		return nil
 	case subscription.FieldSyncedPriceSequence:
 		m.ResetSyncedPriceSequence()
 		return nil

--- a/ent/price.go
+++ b/ent/price.go
@@ -101,6 +101,8 @@ type Price struct {
 	EndDate *time.Time `json:"end_date,omitempty"`
 	// GroupID holds the value of the "group_id" field.
 	GroupID *string `json:"group_id,omitempty"`
+	// Sequence holds the value of the "sequence" field.
+	Sequence int64 `json:"sequence,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the PriceQuery when eager-loading is set.
 	Edges        PriceEdges `json:"edges"`
@@ -149,7 +151,7 @@ func (*Price) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case price.FieldAmount:
 			values[i] = new(decimal.Decimal)
-		case price.FieldBillingPeriodCount, price.FieldTrialPeriodDays:
+		case price.FieldBillingPeriodCount, price.FieldTrialPeriodDays, price.FieldSequence:
 			values[i] = new(sql.NullInt64)
 		case price.FieldID, price.FieldTenantID, price.FieldStatus, price.FieldCreatedBy, price.FieldUpdatedBy, price.FieldEnvironmentID, price.FieldDisplayName, price.FieldCurrency, price.FieldDisplayAmount, price.FieldPriceUnitType, price.FieldPriceUnitID, price.FieldPriceUnit, price.FieldDisplayPriceUnitAmount, price.FieldType, price.FieldBillingPeriod, price.FieldBillingModel, price.FieldBillingCadence, price.FieldInvoiceCadence, price.FieldMeterID, price.FieldTierMode, price.FieldLookupKey, price.FieldDescription, price.FieldEntityType, price.FieldEntityID, price.FieldParentPriceID, price.FieldGroupID:
 			values[i] = new(sql.NullString)
@@ -437,6 +439,12 @@ func (pr *Price) assignValues(columns []string, values []any) error {
 				pr.GroupID = new(string)
 				*pr.GroupID = value.String
 			}
+		case price.FieldSequence:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field sequence", values[i])
+			} else if value.Valid {
+				pr.Sequence = value.Int64
+			}
 		default:
 			pr.selectValues.Set(columns[i], values[i])
 		}
@@ -624,6 +632,9 @@ func (pr *Price) String() string {
 		builder.WriteString("group_id=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	builder.WriteString("sequence=")
+	builder.WriteString(fmt.Sprintf("%v", pr.Sequence))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/price/price.go
+++ b/ent/price/price.go
@@ -96,6 +96,8 @@ const (
 	FieldEndDate = "end_date"
 	// FieldGroupID holds the string denoting the group_id field in the database.
 	FieldGroupID = "group_id"
+	// FieldSequence holds the string denoting the sequence field in the database.
+	FieldSequence = "sequence"
 	// EdgeCostsheet holds the string denoting the costsheet edge name in mutations.
 	EdgeCostsheet = "costsheet"
 	// EdgePriceUnitEdge holds the string denoting the price_unit_edge edge name in mutations.
@@ -161,6 +163,7 @@ var Columns = []string{
 	FieldStartDate,
 	FieldEndDate,
 	FieldGroupID,
+	FieldSequence,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -407,6 +410,11 @@ func ByEndDate(opts ...sql.OrderTermOption) OrderOption {
 // ByGroupID orders the results by the group_id field.
 func ByGroupID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldGroupID, opts...).ToFunc()
+}
+
+// BySequence orders the results by the sequence field.
+func BySequence(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSequence, opts...).ToFunc()
 }
 
 // ByCostsheetCount orders the results by costsheet count.

--- a/ent/price/where.go
+++ b/ent/price/where.go
@@ -250,6 +250,11 @@ func GroupID(v string) predicate.Price {
 	return predicate.Price(sql.FieldEQ(FieldGroupID, v))
 }
 
+// Sequence applies equality check predicate on the "sequence" field. It's identical to SequenceEQ.
+func Sequence(v int64) predicate.Price {
+	return predicate.Price(sql.FieldEQ(FieldSequence, v))
+}
+
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
 func TenantIDEQ(v string) predicate.Price {
 	return predicate.Price(sql.FieldEQ(FieldTenantID, v))
@@ -2675,6 +2680,46 @@ func GroupIDEqualFold(v string) predicate.Price {
 // GroupIDContainsFold applies the ContainsFold predicate on the "group_id" field.
 func GroupIDContainsFold(v string) predicate.Price {
 	return predicate.Price(sql.FieldContainsFold(FieldGroupID, v))
+}
+
+// SequenceEQ applies the EQ predicate on the "sequence" field.
+func SequenceEQ(v int64) predicate.Price {
+	return predicate.Price(sql.FieldEQ(FieldSequence, v))
+}
+
+// SequenceNEQ applies the NEQ predicate on the "sequence" field.
+func SequenceNEQ(v int64) predicate.Price {
+	return predicate.Price(sql.FieldNEQ(FieldSequence, v))
+}
+
+// SequenceIn applies the In predicate on the "sequence" field.
+func SequenceIn(vs ...int64) predicate.Price {
+	return predicate.Price(sql.FieldIn(FieldSequence, vs...))
+}
+
+// SequenceNotIn applies the NotIn predicate on the "sequence" field.
+func SequenceNotIn(vs ...int64) predicate.Price {
+	return predicate.Price(sql.FieldNotIn(FieldSequence, vs...))
+}
+
+// SequenceGT applies the GT predicate on the "sequence" field.
+func SequenceGT(v int64) predicate.Price {
+	return predicate.Price(sql.FieldGT(FieldSequence, v))
+}
+
+// SequenceGTE applies the GTE predicate on the "sequence" field.
+func SequenceGTE(v int64) predicate.Price {
+	return predicate.Price(sql.FieldGTE(FieldSequence, v))
+}
+
+// SequenceLT applies the LT predicate on the "sequence" field.
+func SequenceLT(v int64) predicate.Price {
+	return predicate.Price(sql.FieldLT(FieldSequence, v))
+}
+
+// SequenceLTE applies the LTE predicate on the "sequence" field.
+func SequenceLTE(v int64) predicate.Price {
+	return predicate.Price(sql.FieldLTE(FieldSequence, v))
 }
 
 // HasCostsheet applies the HasEdge predicate on the "costsheet" edge.

--- a/ent/price_create.go
+++ b/ent/price_create.go
@@ -496,6 +496,12 @@ func (pc *PriceCreate) SetNillableGroupID(s *string) *PriceCreate {
 	return pc
 }
 
+// SetSequence sets the "sequence" field.
+func (pc *PriceCreate) SetSequence(i int64) *PriceCreate {
+	pc.mutation.SetSequence(i)
+	return pc
+}
+
 // SetID sets the "id" field.
 func (pc *PriceCreate) SetID(s string) *PriceCreate {
 	pc.mutation.SetID(s)
@@ -933,6 +939,10 @@ func (pc *PriceCreate) createSpec() (*Price, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.GroupID(); ok {
 		_spec.SetField(price.FieldGroupID, field.TypeString, value)
 		_node.GroupID = &value
+	}
+	if value, ok := pc.mutation.Sequence(); ok {
+		_spec.SetField(price.FieldSequence, field.TypeInt64, value)
+		_node.Sequence = value
 	}
 	if nodes := pc.mutation.CostsheetIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/price_update.go
+++ b/ent/price_update.go
@@ -213,6 +213,27 @@ func (pu *PriceUpdate) ClearGroupID() *PriceUpdate {
 	return pu
 }
 
+// SetSequence sets the "sequence" field.
+func (pu *PriceUpdate) SetSequence(i int64) *PriceUpdate {
+	pu.mutation.ResetSequence()
+	pu.mutation.SetSequence(i)
+	return pu
+}
+
+// SetNillableSequence sets the "sequence" field if the given value is not nil.
+func (pu *PriceUpdate) SetNillableSequence(i *int64) *PriceUpdate {
+	if i != nil {
+		pu.SetSequence(*i)
+	}
+	return pu
+}
+
+// AddSequence adds i to the "sequence" field.
+func (pu *PriceUpdate) AddSequence(i int64) *PriceUpdate {
+	pu.mutation.AddSequence(i)
+	return pu
+}
+
 // AddCostsheetIDs adds the "costsheet" edge to the Costsheet entity by IDs.
 func (pu *PriceUpdate) AddCostsheetIDs(ids ...string) *PriceUpdate {
 	pu.mutation.AddCostsheetIDs(ids...)
@@ -403,6 +424,12 @@ func (pu *PriceUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if pu.mutation.GroupIDCleared() {
 		_spec.ClearField(price.FieldGroupID, field.TypeString)
+	}
+	if value, ok := pu.mutation.Sequence(); ok {
+		_spec.SetField(price.FieldSequence, field.TypeInt64, value)
+	}
+	if value, ok := pu.mutation.AddedSequence(); ok {
+		_spec.AddField(price.FieldSequence, field.TypeInt64, value)
 	}
 	if pu.mutation.CostsheetCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -653,6 +680,27 @@ func (puo *PriceUpdateOne) ClearGroupID() *PriceUpdateOne {
 	return puo
 }
 
+// SetSequence sets the "sequence" field.
+func (puo *PriceUpdateOne) SetSequence(i int64) *PriceUpdateOne {
+	puo.mutation.ResetSequence()
+	puo.mutation.SetSequence(i)
+	return puo
+}
+
+// SetNillableSequence sets the "sequence" field if the given value is not nil.
+func (puo *PriceUpdateOne) SetNillableSequence(i *int64) *PriceUpdateOne {
+	if i != nil {
+		puo.SetSequence(*i)
+	}
+	return puo
+}
+
+// AddSequence adds i to the "sequence" field.
+func (puo *PriceUpdateOne) AddSequence(i int64) *PriceUpdateOne {
+	puo.mutation.AddSequence(i)
+	return puo
+}
+
 // AddCostsheetIDs adds the "costsheet" edge to the Costsheet entity by IDs.
 func (puo *PriceUpdateOne) AddCostsheetIDs(ids ...string) *PriceUpdateOne {
 	puo.mutation.AddCostsheetIDs(ids...)
@@ -873,6 +921,12 @@ func (puo *PriceUpdateOne) sqlSave(ctx context.Context) (_node *Price, err error
 	}
 	if puo.mutation.GroupIDCleared() {
 		_spec.ClearField(price.FieldGroupID, field.TypeString)
+	}
+	if value, ok := puo.mutation.Sequence(); ok {
+		_spec.SetField(price.FieldSequence, field.TypeInt64, value)
+	}
+	if value, ok := puo.mutation.AddedSequence(); ok {
+		_spec.AddField(price.FieldSequence, field.TypeInt64, value)
 	}
 	if puo.mutation.CostsheetCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -1673,6 +1673,10 @@ func init() {
 	subscriptionDescSubscriptionType := subscriptionFields[36].Descriptor()
 	// subscription.DefaultSubscriptionType holds the default value on creation for the subscription_type field.
 	subscription.DefaultSubscriptionType = types.SubscriptionType(subscriptionDescSubscriptionType.Default.(string))
+	// subscriptionDescSyncedPriceSequence is the schema descriptor for synced_price_sequence field.
+	subscriptionDescSyncedPriceSequence := subscriptionFields[37].Descriptor()
+	// subscription.DefaultSyncedPriceSequence holds the default value on creation for the synced_price_sequence field.
+	subscription.DefaultSyncedPriceSequence = subscriptionDescSyncedPriceSequence.Default.(int64)
 	subscriptionlineitemMixin := schema.SubscriptionLineItem{}.Mixin()
 	subscriptionlineitemMixinFields0 := subscriptionlineitemMixin[0].Fields()
 	_ = subscriptionlineitemMixinFields0

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -1674,7 +1674,7 @@ func init() {
 	// subscription.DefaultSubscriptionType holds the default value on creation for the subscription_type field.
 	subscription.DefaultSubscriptionType = types.SubscriptionType(subscriptionDescSubscriptionType.Default.(string))
 	// subscriptionDescSyncedPriceSequence is the schema descriptor for synced_price_sequence field.
-	subscriptionDescSyncedPriceSequence := subscriptionFields[37].Descriptor()
+	subscriptionDescSyncedPriceSequence := subscriptionFields[38].Descriptor()
 	// subscription.DefaultSyncedPriceSequence holds the default value on creation for the synced_price_sequence field.
 	subscription.DefaultSyncedPriceSequence = subscriptionDescSyncedPriceSequence.Default.(int64)
 	subscriptionlineitemMixin := schema.SubscriptionLineItem{}.Mixin()

--- a/ent/schema/price.go
+++ b/ent/schema/price.go
@@ -266,6 +266,13 @@ func (Price) Fields() []ent.Field {
 			}).
 			Optional().
 			Nillable(),
+
+		// Monotonic sequence stamped on every plan-price state change that
+		// subscriptions need to react to (create, end_date set, compat edit).
+		// Used by the plan-price sync to find prices changed since each
+		// subscription's last reconciliation.
+		field.Int64("sequence").
+			Annotations(entsql.DefaultExpr("nextval('prices_sequence_seq')")),
 	}
 }
 
@@ -289,5 +296,8 @@ func (Price) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id"),
 		index.Fields("start_date", "end_date"),
 		index.Fields("tenant_id", "environment_id", "group_id"),
+		// To get "what changed since the sub's last synced_price_sequence?"
+		index.Fields("tenant_id", "environment_id", "entity_id", "entity_type", "sequence").
+			Annotations(entsql.IndexWhere("status = 'published'")),
 	}
 }

--- a/ent/schema/subscription.go
+++ b/ent/schema/subscription.go
@@ -209,6 +209,13 @@ func (Subscription) Fields() []ent.Field {
 				"postgres": "decimal(20,6)",
 			}).
 			Comment("Threshold usage amount (in subscription currency) that triggers an intermediate invoice. Overrides plan-level threshold when set."),
+
+		// Plan-price sequence up to which this subscription's line items
+		// have been reconciled with its plan's prices. Bumped by the
+		// plan-price sync after a successful reconciliation pass.
+		field.Int64("synced_price_sequence").
+			Default(0).
+			Annotations(entsql.Default("0")),
 	}
 }
 
@@ -242,5 +249,8 @@ func (Subscription) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "subscription_status", "status"),
 		// For billing period updates
 		index.Fields("tenant_id", "environment_id", "current_period_end", "subscription_status", "status"),
+		// Drives the plan-price sync's "which subs are behind?" lookup.
+		index.Fields("tenant_id", "environment_id", "plan_id", "synced_price_sequence").
+			Annotations(entsql.IndexWhere("status = 'published'")),
 	}
 }

--- a/ent/subscription.go
+++ b/ent/subscription.go
@@ -109,6 +109,8 @@ type Subscription struct {
 	SubscriptionType types.SubscriptionType `json:"subscription_type,omitempty"`
 	// Threshold usage amount (in subscription currency) that triggers an intermediate invoice. Overrides plan-level threshold when set.
 	AutoInvoiceThreshold *decimal.Decimal `json:"auto_invoice_threshold,omitempty"`
+	// SyncedPriceSequence holds the value of the "synced_price_sequence" field.
+	SyncedPriceSequence int64 `json:"synced_price_sequence,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SubscriptionQuery when eager-loading is set.
 	Edges        SubscriptionEdges `json:"edges"`
@@ -223,7 +225,7 @@ func (*Subscription) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case subscription.FieldCancelAtPeriodEnd, subscription.FieldEnableTrueUp:
 			values[i] = new(sql.NullBool)
-		case subscription.FieldBillingPeriodCount, subscription.FieldVersion:
+		case subscription.FieldBillingPeriodCount, subscription.FieldVersion, subscription.FieldSyncedPriceSequence:
 			values[i] = new(sql.NullInt64)
 		case subscription.FieldID, subscription.FieldTenantID, subscription.FieldStatus, subscription.FieldCreatedBy, subscription.FieldUpdatedBy, subscription.FieldEnvironmentID, subscription.FieldLookupKey, subscription.FieldCustomerID, subscription.FieldPlanID, subscription.FieldSubscriptionStatus, subscription.FieldCurrency, subscription.FieldBillingCadence, subscription.FieldBillingPeriod, subscription.FieldPauseStatus, subscription.FieldActivePauseID, subscription.FieldBillingCycle, subscription.FieldCommitmentDuration, subscription.FieldPaymentBehavior, subscription.FieldCollectionMethod, subscription.FieldGatewayPaymentMethodID, subscription.FieldCustomerTimezone, subscription.FieldProrationBehavior, subscription.FieldInvoicingCustomerID, subscription.FieldParentSubscriptionID, subscription.FieldPaymentTerms, subscription.FieldSubscriptionType:
 			values[i] = new(sql.NullString)
@@ -529,6 +531,12 @@ func (s *Subscription) assignValues(columns []string, values []any) error {
 				s.AutoInvoiceThreshold = new(decimal.Decimal)
 				*s.AutoInvoiceThreshold = *value.S.(*decimal.Decimal)
 			}
+		case subscription.FieldSyncedPriceSequence:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field synced_price_sequence", values[i])
+			} else if value.Valid {
+				s.SyncedPriceSequence = value.Int64
+			}
 		default:
 			s.selectValues.Set(columns[i], values[i])
 		}
@@ -762,6 +770,8 @@ func (s *Subscription) String() string {
 		builder.WriteString("auto_invoice_threshold=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
+	builder.WriteString("synced_price_sequence=")
+	builder.WriteString(fmt.Sprintf("%v", s.SyncedPriceSequence))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/subscription.go
+++ b/ent/subscription.go
@@ -770,6 +770,7 @@ func (s *Subscription) String() string {
 		builder.WriteString("auto_invoice_threshold=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
+	builder.WriteString(", ")
 	builder.WriteString("synced_price_sequence=")
 	builder.WriteString(fmt.Sprintf("%v", s.SyncedPriceSequence))
 	builder.WriteByte(')')

--- a/ent/subscription/subscription.go
+++ b/ent/subscription/subscription.go
@@ -104,6 +104,8 @@ const (
 	FieldSubscriptionType = "subscription_type"
 	// FieldAutoInvoiceThreshold holds the string denoting the auto_invoice_threshold field in the database.
 	FieldAutoInvoiceThreshold = "auto_invoice_threshold"
+	// FieldSyncedPriceSequence holds the string denoting the synced_price_sequence field in the database.
+	FieldSyncedPriceSequence = "synced_price_sequence"
 	// EdgeLineItems holds the string denoting the line_items edge name in mutations.
 	EdgeLineItems = "line_items"
 	// EdgePauses holds the string denoting the pauses edge name in mutations.
@@ -227,6 +229,7 @@ var Columns = []string{
 	FieldPaymentTerms,
 	FieldSubscriptionType,
 	FieldAutoInvoiceThreshold,
+	FieldSyncedPriceSequence,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -300,6 +303,8 @@ var (
 	DefaultEnableTrueUp bool
 	// DefaultSubscriptionType holds the default value on creation for the "subscription_type" field.
 	DefaultSubscriptionType types.SubscriptionType
+	// DefaultSyncedPriceSequence holds the default value on creation for the "synced_price_sequence" field.
+	DefaultSyncedPriceSequence int64
 )
 
 // OrderOption defines the ordering options for the Subscription queries.
@@ -523,6 +528,11 @@ func BySubscriptionType(opts ...sql.OrderTermOption) OrderOption {
 // ByAutoInvoiceThreshold orders the results by the auto_invoice_threshold field.
 func ByAutoInvoiceThreshold(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAutoInvoiceThreshold, opts...).ToFunc()
+}
+
+// BySyncedPriceSequence orders the results by the synced_price_sequence field.
+func BySyncedPriceSequence(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSyncedPriceSequence, opts...).ToFunc()
 }
 
 // ByLineItemsCount orders the results by line_items count.

--- a/ent/subscription/where.go
+++ b/ent/subscription/where.go
@@ -293,6 +293,11 @@ func AutoInvoiceThreshold(v decimal.Decimal) predicate.Subscription {
 	return predicate.Subscription(sql.FieldEQ(FieldAutoInvoiceThreshold, v))
 }
 
+// SyncedPriceSequence applies equality check predicate on the "synced_price_sequence" field. It's identical to SyncedPriceSequenceEQ.
+func SyncedPriceSequence(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldEQ(FieldSyncedPriceSequence, v))
+}
+
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
 func TenantIDEQ(v string) predicate.Subscription {
 	return predicate.Subscription(sql.FieldEQ(FieldTenantID, v))
@@ -2975,6 +2980,46 @@ func AutoInvoiceThresholdIsNil() predicate.Subscription {
 // AutoInvoiceThresholdNotNil applies the NotNil predicate on the "auto_invoice_threshold" field.
 func AutoInvoiceThresholdNotNil() predicate.Subscription {
 	return predicate.Subscription(sql.FieldNotNull(FieldAutoInvoiceThreshold))
+}
+
+// SyncedPriceSequenceEQ applies the EQ predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceEQ(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldEQ(FieldSyncedPriceSequence, v))
+}
+
+// SyncedPriceSequenceNEQ applies the NEQ predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceNEQ(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldNEQ(FieldSyncedPriceSequence, v))
+}
+
+// SyncedPriceSequenceIn applies the In predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceIn(vs ...int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldIn(FieldSyncedPriceSequence, vs...))
+}
+
+// SyncedPriceSequenceNotIn applies the NotIn predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceNotIn(vs ...int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldNotIn(FieldSyncedPriceSequence, vs...))
+}
+
+// SyncedPriceSequenceGT applies the GT predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceGT(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldGT(FieldSyncedPriceSequence, v))
+}
+
+// SyncedPriceSequenceGTE applies the GTE predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceGTE(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldGTE(FieldSyncedPriceSequence, v))
+}
+
+// SyncedPriceSequenceLT applies the LT predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceLT(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldLT(FieldSyncedPriceSequence, v))
+}
+
+// SyncedPriceSequenceLTE applies the LTE predicate on the "synced_price_sequence" field.
+func SyncedPriceSequenceLTE(v int64) predicate.Subscription {
+	return predicate.Subscription(sql.FieldLTE(FieldSyncedPriceSequence, v))
 }
 
 // HasLineItems applies the HasEdge predicate on the "line_items" edge.

--- a/ent/subscription_create.go
+++ b/ent/subscription_create.go
@@ -590,6 +590,20 @@ func (sc *SubscriptionCreate) SetNillableAutoInvoiceThreshold(d *decimal.Decimal
 	return sc
 }
 
+// SetSyncedPriceSequence sets the "synced_price_sequence" field.
+func (sc *SubscriptionCreate) SetSyncedPriceSequence(i int64) *SubscriptionCreate {
+	sc.mutation.SetSyncedPriceSequence(i)
+	return sc
+}
+
+// SetNillableSyncedPriceSequence sets the "synced_price_sequence" field if the given value is not nil.
+func (sc *SubscriptionCreate) SetNillableSyncedPriceSequence(i *int64) *SubscriptionCreate {
+	if i != nil {
+		sc.SetSyncedPriceSequence(*i)
+	}
+	return sc
+}
+
 // SetID sets the "id" field.
 func (sc *SubscriptionCreate) SetID(s string) *SubscriptionCreate {
 	sc.mutation.SetID(s)
@@ -825,6 +839,10 @@ func (sc *SubscriptionCreate) defaults() {
 		v := subscription.DefaultSubscriptionType
 		sc.mutation.SetSubscriptionType(v)
 	}
+	if _, ok := sc.mutation.SyncedPriceSequence(); !ok {
+		v := subscription.DefaultSyncedPriceSequence
+		sc.mutation.SetSyncedPriceSequence(v)
+	}
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -978,6 +996,9 @@ func (sc *SubscriptionCreate) check() error {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "subscription_type", err: fmt.Errorf(`ent: validator failed for field "Subscription.subscription_type": %w`, err)}
 		}
+	}
+	if _, ok := sc.mutation.SyncedPriceSequence(); !ok {
+		return &ValidationError{Name: "synced_price_sequence", err: errors.New(`ent: missing required field "Subscription.synced_price_sequence"`)}
 	}
 	return nil
 }
@@ -1185,6 +1206,10 @@ func (sc *SubscriptionCreate) createSpec() (*Subscription, *sqlgraph.CreateSpec)
 	if value, ok := sc.mutation.AutoInvoiceThreshold(); ok {
 		_spec.SetField(subscription.FieldAutoInvoiceThreshold, field.TypeOther, value)
 		_node.AutoInvoiceThreshold = &value
+	}
+	if value, ok := sc.mutation.SyncedPriceSequence(); ok {
+		_spec.SetField(subscription.FieldSyncedPriceSequence, field.TypeInt64, value)
+		_node.SyncedPriceSequence = value
 	}
 	if nodes := sc.mutation.LineItemsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/subscription_update.go
+++ b/ent/subscription_update.go
@@ -573,6 +573,12 @@ func (su *SubscriptionUpdate) SetNillableAutoInvoiceThreshold(d *decimal.Decimal
 	return su
 }
 
+// ClearAutoInvoiceThreshold clears the value of the "auto_invoice_threshold" field.
+func (su *SubscriptionUpdate) ClearAutoInvoiceThreshold() *SubscriptionUpdate {
+	su.mutation.ClearAutoInvoiceThreshold()
+	return su
+}
+
 // SetSyncedPriceSequence sets the "synced_price_sequence" field.
 func (su *SubscriptionUpdate) SetSyncedPriceSequence(i int64) *SubscriptionUpdate {
 	su.mutation.ResetSyncedPriceSequence()
@@ -585,12 +591,6 @@ func (su *SubscriptionUpdate) SetNillableSyncedPriceSequence(i *int64) *Subscrip
 	if i != nil {
 		su.SetSyncedPriceSequence(*i)
 	}
-	return su
-}
-
-// ClearAutoInvoiceThreshold clears the value of the "auto_invoice_threshold" field.
-func (su *SubscriptionUpdate) ClearAutoInvoiceThreshold() *SubscriptionUpdate {
-	su.mutation.ClearAutoInvoiceThreshold()
 	return su
 }
 
@@ -1968,6 +1968,12 @@ func (suo *SubscriptionUpdateOne) SetNillableAutoInvoiceThreshold(d *decimal.Dec
 	return suo
 }
 
+// ClearAutoInvoiceThreshold clears the value of the "auto_invoice_threshold" field.
+func (suo *SubscriptionUpdateOne) ClearAutoInvoiceThreshold() *SubscriptionUpdateOne {
+	suo.mutation.ClearAutoInvoiceThreshold()
+	return suo
+}
+
 // SetSyncedPriceSequence sets the "synced_price_sequence" field.
 func (suo *SubscriptionUpdateOne) SetSyncedPriceSequence(i int64) *SubscriptionUpdateOne {
 	suo.mutation.ResetSyncedPriceSequence()
@@ -1980,12 +1986,6 @@ func (suo *SubscriptionUpdateOne) SetNillableSyncedPriceSequence(i *int64) *Subs
 	if i != nil {
 		suo.SetSyncedPriceSequence(*i)
 	}
-	return suo
-}
-
-// ClearAutoInvoiceThreshold clears the value of the "auto_invoice_threshold" field.
-func (suo *SubscriptionUpdateOne) ClearAutoInvoiceThreshold() *SubscriptionUpdateOne {
-	suo.mutation.ClearAutoInvoiceThreshold()
 	return suo
 }
 

--- a/ent/subscription_update.go
+++ b/ent/subscription_update.go
@@ -573,9 +573,30 @@ func (su *SubscriptionUpdate) SetNillableAutoInvoiceThreshold(d *decimal.Decimal
 	return su
 }
 
+// SetSyncedPriceSequence sets the "synced_price_sequence" field.
+func (su *SubscriptionUpdate) SetSyncedPriceSequence(i int64) *SubscriptionUpdate {
+	su.mutation.ResetSyncedPriceSequence()
+	su.mutation.SetSyncedPriceSequence(i)
+	return su
+}
+
+// SetNillableSyncedPriceSequence sets the "synced_price_sequence" field if the given value is not nil.
+func (su *SubscriptionUpdate) SetNillableSyncedPriceSequence(i *int64) *SubscriptionUpdate {
+	if i != nil {
+		su.SetSyncedPriceSequence(*i)
+	}
+	return su
+}
+
 // ClearAutoInvoiceThreshold clears the value of the "auto_invoice_threshold" field.
 func (su *SubscriptionUpdate) ClearAutoInvoiceThreshold() *SubscriptionUpdate {
 	su.mutation.ClearAutoInvoiceThreshold()
+	return su
+}
+
+// AddSyncedPriceSequence adds i to the "synced_price_sequence" field.
+func (su *SubscriptionUpdate) AddSyncedPriceSequence(i int64) *SubscriptionUpdate {
+	su.mutation.AddSyncedPriceSequence(i)
 	return su
 }
 
@@ -1041,6 +1062,12 @@ func (su *SubscriptionUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if su.mutation.AutoInvoiceThresholdCleared() {
 		_spec.ClearField(subscription.FieldAutoInvoiceThreshold, field.TypeOther)
+	}
+	if value, ok := su.mutation.SyncedPriceSequence(); ok {
+		_spec.SetField(subscription.FieldSyncedPriceSequence, field.TypeInt64, value)
+	}
+	if value, ok := su.mutation.AddedSyncedPriceSequence(); ok {
+		_spec.AddField(subscription.FieldSyncedPriceSequence, field.TypeInt64, value)
 	}
 	if su.mutation.LineItemsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1941,9 +1968,30 @@ func (suo *SubscriptionUpdateOne) SetNillableAutoInvoiceThreshold(d *decimal.Dec
 	return suo
 }
 
+// SetSyncedPriceSequence sets the "synced_price_sequence" field.
+func (suo *SubscriptionUpdateOne) SetSyncedPriceSequence(i int64) *SubscriptionUpdateOne {
+	suo.mutation.ResetSyncedPriceSequence()
+	suo.mutation.SetSyncedPriceSequence(i)
+	return suo
+}
+
+// SetNillableSyncedPriceSequence sets the "synced_price_sequence" field if the given value is not nil.
+func (suo *SubscriptionUpdateOne) SetNillableSyncedPriceSequence(i *int64) *SubscriptionUpdateOne {
+	if i != nil {
+		suo.SetSyncedPriceSequence(*i)
+	}
+	return suo
+}
+
 // ClearAutoInvoiceThreshold clears the value of the "auto_invoice_threshold" field.
 func (suo *SubscriptionUpdateOne) ClearAutoInvoiceThreshold() *SubscriptionUpdateOne {
 	suo.mutation.ClearAutoInvoiceThreshold()
+	return suo
+}
+
+// AddSyncedPriceSequence adds i to the "synced_price_sequence" field.
+func (suo *SubscriptionUpdateOne) AddSyncedPriceSequence(i int64) *SubscriptionUpdateOne {
+	suo.mutation.AddSyncedPriceSequence(i)
 	return suo
 }
 
@@ -2439,6 +2487,12 @@ func (suo *SubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *Subscript
 	}
 	if suo.mutation.AutoInvoiceThresholdCleared() {
 		_spec.ClearField(subscription.FieldAutoInvoiceThreshold, field.TypeOther)
+	}
+	if value, ok := suo.mutation.SyncedPriceSequence(); ok {
+		_spec.SetField(subscription.FieldSyncedPriceSequence, field.TypeInt64, value)
+	}
+	if value, ok := suo.mutation.AddedSyncedPriceSequence(); ok {
+		_spec.AddField(subscription.FieldSyncedPriceSequence, field.TypeInt64, value)
 	}
 	if suo.mutation.LineItemsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/domain/price/model.go
+++ b/internal/domain/price/model.go
@@ -129,6 +129,12 @@ type Price struct {
 	// EndDate is the end date of the price
 	EndDate *time.Time `db:"end_date" json:"end_date,omitempty"`
 
+	// Sequence is the monotonic stamp bumped on every state change that
+	// subscription line items need to react to. Read by the plan-price sync;
+	// set by the database (DEFAULT nextval) on create and by the price
+	// repository on termination / compatibility-affecting edits.
+	Sequence int64 `db:"sequence" json:"sequence,omitempty"`
+
 	types.BaseModel
 }
 
@@ -505,6 +511,7 @@ func FromEnt(e *ent.Price) *Price {
 		GroupID:                lo.FromPtr(e.GroupID),
 		StartDate:              e.StartDate,
 		EndDate:                e.EndDate,
+		Sequence:               e.Sequence,
 		MinQuantity:            e.MinQuantity,
 		BaseModel: types.BaseModel{
 			TenantID:  e.TenantID,

--- a/internal/domain/price/repository.go
+++ b/internal/domain/price/repository.go
@@ -15,7 +15,7 @@ type Repository interface {
 	List(ctx context.Context, filter *types.PriceFilter) ([]*Price, error)
 	Count(ctx context.Context, filter *types.PriceFilter) (int, error)
 	ListAll(ctx context.Context, filter *types.PriceFilter) ([]*Price, error)
-	Update(ctx context.Context, price *Price) error
+	Update(ctx context.Context, price *Price, bumpSequence bool) error
 	Delete(ctx context.Context, id string) error
 
 	// Bulk operations

--- a/internal/domain/subscription/model.go
+++ b/internal/domain/subscription/model.go
@@ -141,6 +141,11 @@ type Subscription struct {
 	// Nil means: inherit from the plan's threshold (which may also be nil = disabled).
 	AutoInvoiceThreshold *decimal.Decimal `db:"auto_invoice_threshold" json:"auto_invoice_threshold,omitempty" swaggertype:"string"`
 
+	// SyncedPriceSequence is the plan-price sequence up to which this
+	// subscription's line items have been reconciled. Bumped by the
+	// plan-price sync after a successful pass.
+	SyncedPriceSequence int64 `db:"synced_price_sequence" json:"synced_price_sequence,omitempty"`
+
 	types.BaseModel
 }
 
@@ -263,6 +268,7 @@ func GetSubscriptionFromEnt(sub *ent.Subscription) *Subscription {
 		PaymentTerms:         sub.PaymentTerms,
 		SubscriptionType:     types.SubscriptionType(sub.SubscriptionType),
 		AutoInvoiceThreshold: sub.AutoInvoiceThreshold,
+		SyncedPriceSequence:  sub.SyncedPriceSequence,
 		BaseModel: types.BaseModel{
 			TenantID:  sub.TenantID,
 			Status:    types.Status(sub.Status),

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/postgres"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/lib/pq"
 	"github.com/samber/lo"
 )
 
@@ -267,18 +268,20 @@ func (r *priceRepository) ListAll(ctx context.Context, filter *types.PriceFilter
 	return r.List(ctx, filter)
 }
 
-func (r *priceRepository) Update(ctx context.Context, p *domainPrice.Price) error {
+func (r *priceRepository) Update(ctx context.Context, p *domainPrice.Price, bumpSequence bool) error {
 	client := r.client.Writer(ctx)
 
 	r.log.Debugw("updating price",
 		"price_id", p.ID,
 		"tenant_id", p.TenantID,
+		"bump_sequence", bumpSequence,
 	)
 
 	// Start a span for this repository operation
 	span := StartRepositorySpan(ctx, "price", "update", map[string]interface{}{
-		"price_id":  p.ID,
-		"tenant_id": p.TenantID,
+		"price_id":      p.ID,
+		"tenant_id":     p.TenantID,
+		"bump_sequence": bumpSequence,
 	})
 	defer FinishSpan(span)
 
@@ -296,6 +299,18 @@ func (r *priceRepository) Update(ctx context.Context, p *domainPrice.Price) erro
 		SetMetadata(map[string]string(p.Metadata)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx))
+
+	// Caller asserts a sync-relevant field is changing (i.e. end_date being
+	// set or cleared). Update prices.sequence for plan-price sync.
+	if bumpSequence {
+		nextSeq, err := r.nextPriceSequence(ctx)
+		if err != nil {
+			SetSpanError(span, err)
+			return err
+		}
+		update = update.SetSequence(nextSeq)
+		p.Sequence = nextSeq
+	}
 
 	// Handle group_id: empty string clears (NULL), non-empty sets the value
 	if p.GroupID == "" {
@@ -326,6 +341,37 @@ func (r *priceRepository) Update(ctx context.Context, p *domainPrice.Price) erro
 	return nil
 }
 
+// nextPriceSequence fetches the next value from prices_sequence_seq, used to
+// stamp prices.sequence on state changes that subscriptions need to react to.
+// The sequence is defined in migrations/postgres/V4_prices_sequence.up.sql and
+// referenced as the DB-side DEFAULT on prices.sequence.
+func (r *priceRepository) nextPriceSequence(ctx context.Context) (int64, error) {
+	rows, err := r.client.Writer(ctx).QueryContext(ctx, "SELECT nextval('prices_sequence_seq')")
+	if err != nil {
+		return 0, ierr.WithError(err).
+			WithHint("Failed to advance price sequence").
+			Mark(ierr.ErrDatabase)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if rowsErr := rows.Err(); rowsErr != nil {
+			return 0, ierr.WithError(rowsErr).
+				WithHint("Failed to advance price sequence").
+				Mark(ierr.ErrDatabase)
+		}
+		return 0, ierr.NewError("no sequence value returned").Mark(ierr.ErrInternal)
+	}
+
+	var next int64
+	if scanErr := rows.Scan(&next); scanErr != nil {
+		return 0, ierr.WithError(scanErr).
+			WithHint("Failed to read price sequence value").
+			Mark(ierr.ErrDatabase)
+	}
+	return next, nil
+}
+
 func (r *priceRepository) Delete(ctx context.Context, id string) error {
 	client := r.client.Writer(ctx)
 
@@ -341,12 +387,21 @@ func (r *priceRepository) Delete(ctx context.Context, id string) error {
 	})
 	defer FinishSpan(span)
 
-	_, err := client.Price.Update().
+	// Archival is a state change subs need to react to (the price drops out
+	// of the published set the sync looks at). Bump the sequence so the next
+	// sync sees the change.
+	nextSeq, err := r.nextPriceSequence(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Price.Update().
 		Where(
 			price.ID(id),
 			price.TenantID(types.GetTenantID(ctx)),
 			price.EnvironmentID(types.GetEnvironmentID(ctx)),
 		).
+		SetSequence(nextSeq).
 		SetStatus(string(types.StatusArchived)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
@@ -449,8 +504,6 @@ func (r *priceRepository) CreateBulk(ctx context.Context, prices []*domainPrice.
 }
 
 func (r *priceRepository) DeleteBulk(ctx context.Context, ids []string) error {
-	client := r.client.Writer(ctx)
-
 	r.log.Debugw("bulk deleting prices",
 		"count", len(ids),
 		"tenant_id", types.GetTenantID(ctx),
@@ -467,18 +520,29 @@ func (r *priceRepository) DeleteBulk(ctx context.Context, ids []string) error {
 		return nil
 	}
 
-	_, err := client.Price.Update().
-		Where(
-			price.IDIn(ids...),
-			price.TenantID(types.GetTenantID(ctx)),
-			price.EnvironmentID(types.GetEnvironmentID(ctx)),
-		).
-		SetStatus(string(types.StatusArchived)).
-		SetUpdatedAt(time.Now().UTC()).
-		SetUpdatedBy(types.GetUserID(ctx)).
-		Save(ctx)
-
+	// Bump prices.sequence per row by inlining nextval() in the UPDATE so each
+	// archived price gets a distinct sequence value. Done via raw SQL because
+	// Ent's typed Update doesn't expose SQL function expressions.
+	query := `
+		UPDATE prices
+		SET sequence   = nextval('prices_sequence_seq'),
+		    status     = $1,
+		    updated_at = NOW(),
+		    updated_by = $2
+		WHERE id = ANY($3)
+		  AND tenant_id      = $4
+		  AND environment_id = $5
+	`
+	_, err := r.client.Writer(ctx).ExecContext(
+		ctx, query,
+		string(types.StatusArchived),
+		types.GetUserID(ctx),
+		pq.Array(ids),
+		types.GetTenantID(ctx),
+		types.GetEnvironmentID(ctx),
+	)
 	if err != nil {
+		SetSpanError(span, err)
 		return ierr.WithError(err).
 			WithHint("Failed to delete prices in bulk").
 			Mark(ierr.ErrDatabase)

--- a/internal/service/invoice_test.go
+++ b/internal/service/invoice_test.go
@@ -390,10 +390,10 @@ func (s *InvoiceServiceSuite) TestCreateSubscriptionInvoice() {
 
 				// Update the prices to have arrear invoice cadence
 				s.testData.prices.apiCalls.InvoiceCadence = types.InvoiceCadenceArrear
-				s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls))
+				s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls, false))
 
 				s.testData.prices.storage.InvoiceCadence = types.InvoiceCadenceArrear
-				s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.storage))
+				s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.storage, false))
 
 				// Create some usage events for the current period
 				for i := 0; i < 100; i++ {

--- a/internal/service/plan_test.go
+++ b/internal/service/plan_test.go
@@ -215,9 +215,9 @@ func (s *PlanServiceSuite) TestSyncPlanPrices_Price_Synchronization() {
 		err = s.GetStores().SubscriptionRepo.Create(s.GetContext(), testSub)
 		s.NoError(err)
 
-		// Terminate the price
+		// Terminate the price (bumpSequence=true: end_date is being set)
 		priceToTerminate.EndDate = lo.ToPtr(time.Now().UTC().AddDate(0, 0, 1))
-		err = s.GetStores().PriceRepo.Update(s.GetContext(), priceToTerminate)
+		err = s.GetStores().PriceRepo.Update(s.GetContext(), priceToTerminate, true)
 		s.NoError(err)
 
 		// Sync should end line item for terminated price
@@ -283,9 +283,9 @@ func (s *PlanServiceSuite) TestSyncPlanPrices_Price_Synchronization() {
 		err = s.GetStores().PriceRepo.Create(s.GetContext(), overridePrice)
 		s.NoError(err)
 
-		// Terminate parent price
+		// Terminate parent price (bumpSequence=true: end_date is being set)
 		parentPrice.EndDate = lo.ToPtr(time.Now().UTC().AddDate(0, 0, 1))
-		err = s.GetStores().PriceRepo.Update(s.GetContext(), parentPrice)
+		err = s.GetStores().PriceRepo.Update(s.GetContext(), parentPrice, true)
 		s.NoError(err)
 
 		// Sync should preserve override line item

--- a/internal/service/price.go
+++ b/internal/service/price.go
@@ -833,6 +833,9 @@ func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.Updat
 		}
 
 		if err := s.DB.WithTx(ctx, func(ctx context.Context) error {
+			// bumpSequence when end date is changed
+			bumpSequence := existingPrice.EndDate == nil || !terminationEndDate.Equal(*existingPrice.EndDate)
+
 			// Terminate the existing price
 			existingPrice.EndDate = &terminationEndDate
 
@@ -847,7 +850,7 @@ func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.Updat
 				}
 			}
 
-			if err := s.PriceRepo.Update(ctx, existingPrice); err != nil {
+			if err := s.PriceRepo.Update(ctx, existingPrice, bumpSequence); err != nil {
 				return err
 			}
 
@@ -888,6 +891,8 @@ func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.Updat
 	} else {
 		// No critical fields - simple update
 
+		bumpSequence := false
+
 		// Update non-critical fields
 		if req.LookupKey != "" {
 			existingPrice.LookupKey = req.LookupKey
@@ -903,6 +908,7 @@ func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.Updat
 		}
 		if req.EffectiveFrom != nil {
 			existingPrice.EndDate = req.EffectiveFrom
+			bumpSequence = true
 		}
 
 		// Handle group update: nil = don't change, "" = clear, "group-id" = set and validate
@@ -916,8 +922,7 @@ func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.Updat
 			}
 		}
 
-		// Update the price in database
-		if err := s.PriceRepo.Update(ctx, existingPrice); err != nil {
+		if err := s.PriceRepo.Update(ctx, existingPrice, bumpSequence); err != nil {
 			return nil, err
 		}
 
@@ -970,7 +975,8 @@ func (s *priceService) DeletePrice(ctx context.Context, id string, req dto.Delet
 
 	price.EndDate = &endDate
 
-	if err := s.PriceRepo.Update(ctx, price); err != nil {
+	// bumpSequence=true: DeletePrice is a termination event (end_date being set).
+	if err := s.PriceRepo.Update(ctx, price, true); err != nil {
 		return err
 	}
 

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -4337,10 +4337,10 @@ func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod() {
 	// Now let's test a successful scenario by setting up proper line items with arrear invoice cadence
 	// Update the prices to have arrear invoice cadence
 	s.testData.prices.apiCalls.InvoiceCadence = types.InvoiceCadenceArrear
-	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls))
+	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls, false))
 
 	s.testData.prices.storage.InvoiceCadence = types.InvoiceCadenceArrear
-	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.storage))
+	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.storage, false))
 
 	// Create some usage events for the current period
 	for i := 0; i < 100; i++ {
@@ -5906,7 +5906,7 @@ func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriodWithInvoicingCus
 
 	// Update prices to have arrear invoice cadence
 	s.testData.prices.apiCalls.InvoiceCadence = types.InvoiceCadenceArrear
-	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls))
+	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls, false))
 
 	// Create usage events (tracked by subscription customer)
 	for i := 0; i < 100; i++ {
@@ -6126,7 +6126,7 @@ func (s *SubscriptionServiceSuite) TestUpdateBillingPeriodsWithInvoicingCustomer
 
 	// Update prices to have arrear invoice cadence
 	s.testData.prices.apiCalls.InvoiceCadence = types.InvoiceCadenceArrear
-	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls))
+	s.NoError(s.GetStores().PriceRepo.Update(s.GetContext(), s.testData.prices.apiCalls, false))
 
 	// Create usage events
 	for i := 0; i < 50; i++ {

--- a/internal/testutil/inmemory_price_store.go
+++ b/internal/testutil/inmemory_price_store.go
@@ -155,11 +155,17 @@ func (s *InMemoryPriceStore) Count(ctx context.Context, filter *types.PriceFilte
 	return count, nil
 }
 
-func (s *InMemoryPriceStore) Update(ctx context.Context, p *price.Price) error {
+func (s *InMemoryPriceStore) Update(ctx context.Context, p *price.Price, bumpSequence bool) error {
 	if p == nil {
 		return ierr.NewError("price cannot be nil").
 			WithHint("Price data is required").
 			Mark(ierr.ErrValidation)
+	}
+	// bumpSequence is a no-op for the in-memory store; the sequence column
+	// is only meaningful when run against Postgres where the plan-price sync
+	// observes it.
+	if bumpSequence {
+		p.Sequence++
 	}
 
 	err := s.InMemoryStore.Update(ctx, p.ID, p)
@@ -274,7 +280,7 @@ func (s *InMemoryPriceStore) ClearGroupIDsBulk(ctx context.Context, ids []string
 			return err
 		}
 		p.GroupID = ""
-		if err := s.Update(ctx, p); err != nil {
+		if err := s.Update(ctx, p, false); err != nil {
 			return ierr.WithError(err).
 				WithHint("Failed to clear group IDs in bulk").
 				Mark(ierr.ErrDatabase)
@@ -294,7 +300,7 @@ func (s *InMemoryPriceStore) ClearByGroupID(ctx context.Context, groupID string)
 	// Clear group ID for each price
 	for _, p := range prices {
 		p.GroupID = ""
-		if err := s.Update(ctx, p); err != nil {
+		if err := s.Update(ctx, p, false); err != nil {
 			return ierr.WithError(err).
 				WithHint("Failed to clear group ID by group ID").
 				Mark(ierr.ErrDatabase)

--- a/migrations/postgres/V4_prices_sequence.up.sql
+++ b/migrations/postgres/V4_prices_sequence.up.sql
@@ -1,0 +1,15 @@
+--
+-- Plan-price sync sequence.
+--
+-- Source of monotonic numbers stamped on `prices.sequence` whenever a
+-- plan-price's state changes in a way subscriptions need to react to:
+-- create, end_date set, or compatibility-affecting edit (currency,
+-- billing_period, billing_period_count, type).
+--
+-- The `prices.sequence` column is declared and managed by the Ent
+-- schema (ent/schema/price.go) with `DEFAULT nextval('prices_sequence_seq')`,
+-- which is why the sequence must exist before `make migrate-ent` runs.
+-- `migrate-postgres` runs first per the init-db ordering in the Makefile.
+--
+
+CREATE SEQUENCE IF NOT EXISTS prices_sequence_seq;


### PR DESCRIPTION
## 📝 Description
Introducing `sequence ` number in prices and `synced_price_sequence` in subscriptions to keep track of following:
1. Know which pices are not synced with subscriptions yet
2. Know which subscriptions are out-of-sync with latest prices

---

## 🔨 Changes Made
- [x] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [x] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monotonic price sequence added to track price versioning.
  * Subscription synced-price sequence added to record applied price updates.
  * New partial indexes to speed “published” price and subscription sync lookups.

* **Chores**
  * Database migration to create sequence and schema updates; updated .gitignore.

* **API**
  * Price update API adjusted to accept an explicit sequence-bump flag (usage sites and tests updated).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1780)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->