### PR TITLE
fix(ch-sync): align trial_period column handling with PG reality

### DIFF
--- a/migrations/clickhouse-postgres-sync/README.md
+++ b/migrations/clickhouse-postgres-sync/README.md
@@ -13,7 +13,7 @@ so analytics queries can JOIN them with `feature_usage` / `events_processed` wit
 
 ## Upgrading existing ClickHouse (trial column rename)
 
-PostgreSQL uses `trial_period_days` on `prices` and `subscription_line_items`. If your ClickHouse tables still have `trial_period`, rename before running updated sync SQL:
+CH schemas in this directory use `trial_period_days` for both `prices` and `subscription_line_items`. If your ClickHouse tables still have the old `trial_period`, rename before running updated sync SQL:
 
 ```sql
 ALTER TABLE flexprice.prices RENAME COLUMN trial_period TO trial_period_days;
@@ -21,6 +21,15 @@ ALTER TABLE flexprice.subscription_line_items RENAME COLUMN trial_period TO tria
 ```
 
 New deployments should apply `001_schema_*.sql` / `003_schema_*.sql` as-is.
+
+### PG ↔ CH column reality (as of 2026-05)
+
+| Table | PG column | CH column | How sync SQL bridges it |
+|---|---|---|---|
+| `prices` | `trial_period_days` (V3 PG migration renamed it; see `migrations/postgres/V3__rename_trial_period_to_trial_period_days.up.sql`) | `trial_period_days` | direct select, no alias |
+| `subscription_line_items` | `trial_period` (Ent schema has no trial field; V3 migration's `IF EXISTS` guard didn't fire on this table on most envs, so PG still has the old name) | `trial_period_days` | `sync_subscription_line_items.sql` aliases on read: `SELECT trial_period AS trial_period_days` |
+
+If PG eventually renames `subscription_line_items.trial_period → trial_period_days`, drop the alias in `sync_subscription_line_items.sql`.
 
 ## Setup
 

--- a/migrations/clickhouse-postgres-sync/sync_subscription_line_items.sql
+++ b/migrations/clickhouse-postgres-sync/sync_subscription_line_items.sql
@@ -1,6 +1,12 @@
 -- Sync subscription_line_items from PostgreSQL to ClickHouse
 -- LARGE table (~120M+ rows) — sync.sh batches this by monthly updated_at windows
 -- Parameters: {after:String} inclusive lower bound, {before:String} exclusive upper bound
+--
+-- Column note: PG currently has `trial_period` on this table (NOT `trial_period_days`).
+-- The Ent schema does not define a trial field for subscription_line_items, and the
+-- V3__rename_trial_period_to_trial_period_days.up.sql PG migration only fires if the
+-- column exists at run-time. CH uses `trial_period_days` for consistency with prices,
+-- so we alias on read. If PG ever renames the column, drop the alias.
 
 INSERT INTO flexprice.subscription_line_items (
     id, tenant_id, environment_id, status, subscription_id, customer_id,
@@ -19,7 +25,7 @@ SELECT
     entity_id, entity_type, plan_display_name, price_id, price_type,
     meter_id, meter_display_name, price_unit_id, price_unit,
     display_name, quantity, currency,
-    billing_period, billing_period_count, invoice_cadence, trial_period_days,
+    billing_period, billing_period_count, invoice_cadence, trial_period AS trial_period_days,
     start_date, end_date, subscription_phase_id,
     CAST(metadata AS Nullable(String)), commitment_amount, commitment_quantity,
     commitment_type, commitment_overage_factor,


### PR DESCRIPTION
## Summary

- PG `subscription_line_items.trial_period` was never renamed (V3 migration's `IF EXISTS` guard didn't fire and the Ent schema has no trial field), so the existing sync SQL — which selected `trial_period_days` from PG via `postgresql()` — failed with `UNKNOWN_IDENTIFIER`.
- CH schema files in this dir already use `trial_period_days` for both `prices` and `subscription_line_items`, so we keep the CH side as-is and alias on the PG read.
- Updated the README's "Upgrading existing ClickHouse" section: the old text claimed PG used `trial_period_days` on both tables, which is wrong for `subscription_line_items`. Added a truth table covering the current PG↔CH column reality and a note about when the alias can be dropped.

## Why

Discovered while running a one-shot PG → CH sync of `prices` / `subscriptions` / `subscription_line_items` on production. `prices` and `subscriptions` synced cleanly; `subscription_line_items` errored on the first batch with:

> `DB::Exception: Unknown expression identifier 'trial_period_days' ... Maybe you meant: ['trial_period']`

With this alias, the same sync completed end-to-end (4 monthly batches from CH's max `updated_at`).

## Test plan

- [x] `migrations/clickhouse-postgres-sync/sync.sh --table subscription_line_items --after "<ch_max_updated_at>"` runs without column errors.
- [x] Confirm the comment in `sync_subscription_line_items.sql` correctly describes the failure mode and the trigger to drop the alias.
- [ ] Reviewer to sanity-check the truth table in the README vs the current state of their PG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified column naming differences between PostgreSQL and ClickHouse for database synchronization.
  * Added guidance on handling `trial_period` vs `trial_period_days` column mappings during sync operations.

* **Bug Fixes**
  * Updated sync SQL to correctly map mismatched column names between PostgreSQL and ClickHouse via aliasing for runtime consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1788)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->