### PR TITLE
fix(report): add handling for commitment enabled customers in analytics export

### DIFF
--- a/internal/domain/subscription/line_item_repository.go
+++ b/internal/domain/subscription/line_item_repository.go
@@ -31,4 +31,8 @@ type LineItemRepository interface {
 
 	// Count counts subscription line items matching the filter (same predicates as List).
 	Count(ctx context.Context, filter *types.SubscriptionLineItemFilter) (int, error)
+
+	// GetDistinctCustomerIDsWithCommitmentTrueUp returns distinct customer IDs from published
+	// line items where commitment_true_up_enabled is true.
+	GetDistinctCustomerIDsWithCommitmentTrueUp(ctx context.Context) ([]string, error)
 }

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -543,6 +543,58 @@ func (r *subscriptionLineItemRepository) Count(ctx context.Context, filter *type
 	return count, nil
 }
 
+// GetDistinctCustomerIDsWithCommitmentTrueUp returns distinct customer IDs from published
+// subscription line items with commitment true-up enabled.
+func (r *subscriptionLineItemRepository) GetDistinctCustomerIDsWithCommitmentTrueUp(ctx context.Context) ([]string, error) {
+	tenantID := types.GetTenantID(ctx)
+	envID := types.GetEnvironmentID(ctx)
+
+	span := StartRepositorySpan(ctx, "subscription_line_item", "get_distinct_customer_ids_commitment_true_up", map[string]interface{}{
+		"tenant_id":      tenantID,
+		"environment_id": envID,
+	})
+	defer FinishSpan(span)
+
+	const query = `
+		SELECT DISTINCT customer_id
+		FROM subscription_line_items
+		WHERE tenant_id = $1
+			AND environment_id = $2
+			AND status = $3
+			AND commitment_true_up_enabled = true
+	`
+
+	rows, err := r.client.Reader(ctx).QueryContext(ctx, query, tenantID, envID, string(types.StatusPublished))
+	if err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to get distinct customer ids with commitment true-up").
+			Mark(ierr.ErrDatabase)
+	}
+	defer rows.Close()
+
+	var customerIDs []string
+	for rows.Next() {
+		var customerID string
+		if err := rows.Scan(&customerID); err != nil {
+			SetSpanError(span, err)
+			return nil, ierr.WithError(err).
+				WithHint("Failed to scan customer id").
+				Mark(ierr.ErrDatabase)
+		}
+		customerIDs = append(customerIDs, customerID)
+	}
+	if err := rows.Err(); err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to iterate customer ids").
+			Mark(ierr.ErrDatabase)
+	}
+
+	SetSpanSuccess(span)
+	return customerIDs, nil
+}
+
 // SubscriptionLineItemQuery type alias for better readability
 type SubscriptionLineItemQuery = *ent.SubscriptionLineItemQuery
 

--- a/internal/service/sync/export/base.go
+++ b/internal/service/sync/export/base.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/integration"
@@ -34,11 +35,12 @@ type ExportService struct {
 	walletRepo           wallet.Repository
 	walletBalanceGetter  WalletBalanceGetter
 	customerRepo         customer.Repository
-	usageAnalyticsGetter UsageAnalyticsGetter
-	connectionRepo       connection.Repository
-	integrationFactory   *integration.Factory
-	logger               *logger.Logger
-	eventRepo            events.Repository
+	usageAnalyticsGetter     UsageAnalyticsGetter
+	connectionRepo           connection.Repository
+	integrationFactory       *integration.Factory
+	logger                   *logger.Logger
+	eventRepo                events.Repository
+	subscriptionLineItemRepo subscription.LineItemRepository
 }
 
 // NewExportService creates a new export service
@@ -76,19 +78,21 @@ func NewExportServiceWithWallet(
 	logger *logger.Logger,
 	usageAnalyticsGetter UsageAnalyticsGetter,
 	eventRepo events.Repository,
+	subscriptionLineItemRepo subscription.LineItemRepository,
 ) *ExportService {
 	return &ExportService{
-		featureUsageRepo:     featureUsageRepo,
-		priceRepo:            priceRepo,
-		invoiceRepo:          invoiceRepo,
-		walletRepo:           walletRepo,
-		walletBalanceGetter:  walletBalanceGetter,
-		customerRepo:         customerRepo,
-		connectionRepo:       connectionRepo,
-		integrationFactory:   integrationFactory,
-		logger:               logger,
-		usageAnalyticsGetter: usageAnalyticsGetter,
-		eventRepo:            eventRepo,
+		featureUsageRepo:         featureUsageRepo,
+		priceRepo:                priceRepo,
+		invoiceRepo:              invoiceRepo,
+		walletRepo:               walletRepo,
+		walletBalanceGetter:      walletBalanceGetter,
+		customerRepo:             customerRepo,
+		connectionRepo:           connectionRepo,
+		integrationFactory:       integrationFactory,
+		logger:                   logger,
+		usageAnalyticsGetter:     usageAnalyticsGetter,
+		eventRepo:                eventRepo,
+		subscriptionLineItemRepo: subscriptionLineItemRepo,
 	}
 }
 
@@ -239,11 +243,13 @@ func (s *ExportService) getExporter(entityType types.ScheduledTaskEntityType) Ex
 		}
 		return NewCreditUsageExporter(s.walletRepo, s.customerRepo, s.walletBalanceGetter, s.integrationFactory, s.logger)
 	case types.ScheduledTaskEntityTypeUsageAnalytics:
-		if s.customerRepo == nil {
-			s.logger.Errorw("customer repository not configured for usage analytics export")
+		if s.customerRepo == nil || s.subscriptionLineItemRepo == nil {
+			s.logger.Errorw("customer or subscription line item repository not configured for usage analytics export",
+				"customer_repo_nil", s.customerRepo == nil,
+				"subscription_line_item_repo_nil", s.subscriptionLineItemRepo == nil)
 			return nil
 		}
-		return NewUsageAnalyticsExporter(s.customerRepo, s.eventRepo, s.usageAnalyticsGetter, s.logger)
+		return NewUsageAnalyticsExporter(s.customerRepo, s.eventRepo, s.subscriptionLineItemRepo, s.usageAnalyticsGetter, s.logger)
 	default:
 		return nil
 	}

--- a/internal/service/sync/export/usage_analytics_export.go
+++ b/internal/service/sync/export/usage_analytics_export.go
@@ -10,9 +10,11 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
 
@@ -25,6 +27,7 @@ type UsageAnalyticsGetter interface {
 type UsageAnalyticsExporter struct {
 	customerRepo         customer.Repository
 	eventRepo            events.Repository
+	lineItemRepo         subscription.LineItemRepository
 	usageAnalyticsGetter UsageAnalyticsGetter
 	logger               *logger.Logger
 }
@@ -33,12 +36,14 @@ type UsageAnalyticsExporter struct {
 func NewUsageAnalyticsExporter(
 	customerRepo customer.Repository,
 	eventRepo events.Repository,
+	lineItemRepo subscription.LineItemRepository,
 	usageAnalyticsGetter UsageAnalyticsGetter,
 	logger *logger.Logger,
 ) *UsageAnalyticsExporter {
 	return &UsageAnalyticsExporter{
 		customerRepo:         customerRepo,
 		eventRepo:            eventRepo,
+		lineItemRepo:         lineItemRepo,
 		usageAnalyticsGetter: usageAnalyticsGetter,
 		logger:               logger,
 	}
@@ -129,16 +134,13 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 			Mark(ierr.ErrInternal)
 	}
 
-	externalCustomerIDs, err := e.eventRepo.GetDistinctExternalCustomerIDs(ctx, request.StartTime, request.EndTime)
+	customers, err := e.resolveExportCustomers(ctx, request.StartTime, request.EndTime)
 	if err != nil {
-		return nil, 0, ierr.WithError(err).
-			WithHint("Failed to get distinct external customer ids").
-			Mark(ierr.ErrDatabase)
+		return nil, 0, err
 	}
 
-	// if no external customer ids found, return empty CSV with headers only
-	if len(externalCustomerIDs) == 0 {
-		e.logger.Infow("no external customer ids found, uploading empty CSV with headers only",
+	if len(customers) == 0 {
+		e.logger.Infow("no customers found for usage analytics export, uploading empty CSV with headers only",
 			"tenant_id", request.TenantID,
 			"env_id", request.EnvID,
 			"start_time", request.StartTime,
@@ -150,16 +152,6 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 				Mark(ierr.ErrInternal)
 		}
 		return buf.Bytes(), 0, nil
-	}
-
-	filter := types.NewCustomerFilter()
-	filter.ExternalIDs = externalCustomerIDs
-
-	customers, err := e.customerRepo.ListAll(ctx, filter)
-	if err != nil {
-		return nil, 0, ierr.WithError(err).
-			WithHint("Failed to list customers").
-			Mark(ierr.ErrDatabase)
 	}
 
 	e.logger.Infow("found customers to process",
@@ -244,6 +236,54 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 	}
 
 	return csvBytes, recordCount, nil
+}
+
+// resolveExportCustomers returns the union of customers that had events in the export window
+// and customers with published commitment true-up subscription line items.
+func (e *UsageAnalyticsExporter) resolveExportCustomers(ctx context.Context, startTime, endTime time.Time) ([]*customer.Customer, error) {
+	externalCustomerIDs, err := e.eventRepo.GetDistinctExternalCustomerIDs(ctx, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+
+	trueUpCustomerIDs, err := e.lineItemRepo.GetDistinctCustomerIDsWithCommitmentTrueUp(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var customers []*customer.Customer
+
+	if len(externalCustomerIDs) > 0 {
+		eventFilter := types.NewCustomerFilter()
+		eventFilter.ExternalIDs = externalCustomerIDs
+		eventCustomers, err := e.customerRepo.ListAll(ctx, eventFilter)
+		if err != nil {
+			return nil, err
+		}
+		customers = append(customers, eventCustomers...)
+	}
+
+	remainingTrueUpCustomerIDs := trueUpCustomerIDs
+	if len(customers) > 0 {
+		fetchedCustomerIDs := lo.Map(customers, func(c *customer.Customer, _ int) string {
+			return c.ID
+		})
+		remainingTrueUpCustomerIDs = lo.Without(trueUpCustomerIDs, fetchedCustomerIDs...)
+	}
+
+	if len(remainingTrueUpCustomerIDs) > 0 {
+		trueUpFilter := types.NewCustomerFilter()
+		trueUpFilter.CustomerIDs = remainingTrueUpCustomerIDs
+		trueUpCustomers, err := e.customerRepo.ListAll(ctx, trueUpFilter)
+		if err != nil {
+			return nil, err
+		}
+		customers = append(customers, trueUpCustomers...)
+	}
+
+	return lo.UniqBy(customers, func(c *customer.Customer) string {
+		return c.ID
+	}), nil
 }
 
 // resolveHeaders returns the full CSV header row: static columns followed by one column per

--- a/internal/service/sync/export/usage_analytics_export_test.go
+++ b/internal/service/sync/export/usage_analytics_export_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/group"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
@@ -41,6 +42,7 @@ type usageAnalyticsTestEnv struct {
 	exporter        *UsageAnalyticsExporter
 	customerStore   *testutil.InMemoryCustomerStore
 	eventRepo       *testutil.InMemoryEventStore
+	lineItemStore   *testutil.InMemorySubscriptionLineItemStore
 	analyticsGetter *inMemoryUsageAnalyticsGetter
 	req             *dto.ExportRequest
 	ctx             context.Context
@@ -48,6 +50,7 @@ type usageAnalyticsTestEnv struct {
 	envID           string
 	now             time.Time
 	eventSeq        int
+	lineItemSeq     int
 }
 
 func newUsageAnalyticsTestEnv(t *testing.T) *usageAnalyticsTestEnv {
@@ -60,11 +63,12 @@ func newUsageAnalyticsTestEnv(t *testing.T) *usageAnalyticsTestEnv {
 	ctx = types.SetEnvironmentID(ctx, envID)
 
 	customerStore := testutil.NewInMemoryCustomerStore()
+	eventRepo := testutil.NewInMemoryEventStore()
+	lineItemStore := testutil.NewInMemorySubscriptionLineItemStore()
 	analyticsGetter := newInMemoryUsageAnalyticsGetter()
 	log := logger.GetLogger()
-	eventRepo := testutil.NewInMemoryEventStore()
 
-	exporter := NewUsageAnalyticsExporter(customerStore, eventRepo, analyticsGetter, log)
+	exporter := NewUsageAnalyticsExporter(customerStore, eventRepo, lineItemStore, analyticsGetter, log)
 
 	now := time.Now().UTC()
 	req := &dto.ExportRequest{
@@ -80,6 +84,7 @@ func newUsageAnalyticsTestEnv(t *testing.T) *usageAnalyticsTestEnv {
 		exporter:        exporter,
 		customerStore:   customerStore,
 		eventRepo:       eventRepo,
+		lineItemStore:   lineItemStore,
 		analyticsGetter: analyticsGetter,
 		req:             req,
 		ctx:             ctx,
@@ -123,6 +128,30 @@ func (e *usageAnalyticsTestEnv) addEvent(t *testing.T, externalCustomerID string
 	}
 	if err := e.eventRepo.InsertEvent(e.ctx, event); err != nil {
 		t.Fatalf("insert event for external customer %s: %v", externalCustomerID, err)
+	}
+}
+
+func (e *usageAnalyticsTestEnv) addCommitmentTrueUpLineItem(t *testing.T, customerID string) {
+	t.Helper()
+	e.lineItemSeq++
+	item := &subscription.SubscriptionLineItem{
+		ID:                      fmt.Sprintf("sli-%s-%d", customerID, e.lineItemSeq),
+		SubscriptionID:          fmt.Sprintf("sub-%s", customerID),
+		CustomerID:              customerID,
+		PriceID:                 "price-1",
+		Currency:                "USD",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		EnvironmentID:           e.envID,
+		CommitmentTrueUpEnabled: true,
+		BaseModel: types.BaseModel{
+			TenantID:  e.tenantID,
+			Status:    types.StatusPublished,
+			CreatedAt: e.now,
+			UpdatedAt: e.now,
+		},
+	}
+	if err := e.lineItemStore.Create(e.ctx, item); err != nil {
+		t.Fatalf("create commitment true-up line item for customer %s: %v", customerID, err)
 	}
 }
 
@@ -173,18 +202,30 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			},
 		},
 		{
-			name: "customer with no events in window produces no rows",
+			name: "customer with events in window but no commitment true-up line item",
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
-				env.addCustomer(t, "cust-1", "ext-1", "Idle Corp", nil)
+				c := env.addCustomer(t, "cust-1", "ext-1", "Event Only Corp", nil)
+				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.setAnalytics(c.ExternalID, []dto.UsageAnalyticItem{
+					{FeatureID: "feat-1", FeatureName: "API Calls", EventName: "api_call", EventCount: 3, TotalUsage: decimal.NewFromInt(3), TotalCost: decimal.NewFromInt(1), Currency: "USD"},
+				})
+			},
+			wantCount: 1,
+			wantRows:  1,
+		},
+		{
+			name: "customer without events or commitment true-up produces no rows",
+			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
+				env.addCustomer(t, "cust-idle", "ext-idle", "Idle Corp", nil)
 			},
 			wantCount: 0,
 			wantRows:  0,
 		},
 		{
-			name: "customer with events but empty analytics produces no rows",
+			name: "customer with commitment true-up but empty analytics produces no rows",
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c := env.addCustomer(t, "cust-ghost", "ext-ghost", "Ghost Corp", nil)
-				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c.ID)
 				// No explicit setAnalytics call: getter returns empty Items by default.
 			},
 			wantCount: 0,
@@ -195,6 +236,7 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c := env.addCustomer(t, "cust-2", "ext-2", "Acme Corp", nil)
 				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c.ID)
 				env.setAnalytics(c.ExternalID, []dto.UsageAnalyticItem{
 					{
 						FeatureID:       "feat-1",
@@ -254,7 +296,7 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			name: "feature group name and aggregation field populated",
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c := env.addCustomer(t, "cust-grp", "ext-grp", "Group Corp", nil)
-				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c.ID)
 				env.setAnalytics(c.ExternalID, []dto.UsageAnalyticItem{
 					{
 						FeatureID:       "feat-grp",
@@ -286,8 +328,8 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c1 := env.addCustomer(t, "cust-3", "ext-3", "Alpha Inc", nil)
 				c2 := env.addCustomer(t, "cust-4", "ext-4", "Beta Ltd", nil)
-				env.addEvent(t, c1.ExternalID, env.req.StartTime.Add(1*time.Minute))
-				env.addEvent(t, c2.ExternalID, env.req.StartTime.Add(2*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c1.ID)
+				env.addCommitmentTrueUpLineItem(t, c2.ID)
 				env.setAnalytics(c1.ExternalID, []dto.UsageAnalyticItem{
 					{FeatureID: "feat-a", FeatureName: "Storage", EventName: "storage_write", EventCount: 10, TotalUsage: decimal.NewFromInt(10), TotalCost: decimal.NewFromInt(1), Currency: "USD"},
 					{FeatureID: "feat-b", FeatureName: "Compute", EventName: "compute_run", EventCount: 5, TotalUsage: decimal.NewFromInt(5), TotalCost: decimal.NewFromFloat(0.5), Currency: "USD"},
@@ -303,7 +345,7 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			name: "customer metadata dynamic columns",
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c := env.addCustomer(t, "cust-5", "ext-5", "Meta Corp", map[string]string{"plan_tier": "enterprise", "region": "us-east"})
-				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c.ID)
 				env.setAnalytics(c.ExternalID, []dto.UsageAnalyticItem{
 					{FeatureID: "feat-1", FeatureName: "API Calls", EventName: "api_call", EventCount: 100, TotalUsage: decimal.NewFromInt(100), TotalCost: decimal.NewFromInt(10), Currency: "USD"},
 				})
@@ -351,7 +393,7 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			name: "source column populated when analytics returns source",
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c := env.addCustomer(t, "cust-src", "ext-src", "Source Corp", nil)
-				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c.ID)
 				env.setAnalytics(c.ExternalID, []dto.UsageAnalyticItem{
 					{FeatureID: "feat-1", FeatureName: "LLM Calls", EventName: "llm_call", Source: "gemma4_389f6963-c14f-44d0-afc3-d7e89c6a5ab8", EventCount: 10, TotalUsage: decimal.NewFromInt(10), TotalCost: decimal.NewFromInt(1), Currency: "USD"},
 					{FeatureID: "feat-1", FeatureName: "LLM Calls", EventName: "llm_call", Source: "gpt4o_7a2b1c3d-beef-cafe-dead-000000000001", EventCount: 5, TotalUsage: decimal.NewFromInt(5), TotalCost: decimal.NewFromFloat(0.5), Currency: "USD"},
@@ -375,7 +417,7 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 			name: "missing metadata key produces empty cell",
 			setup: func(t *testing.T, env *usageAnalyticsTestEnv) {
 				c := env.addCustomer(t, "cust-6", "ext-6", "Sparse Corp", map[string]string{"plan_tier": "starter"})
-				env.addEvent(t, c.ExternalID, env.req.StartTime.Add(1*time.Minute))
+				env.addCommitmentTrueUpLineItem(t, c.ID)
 				env.setAnalytics(c.ExternalID, []dto.UsageAnalyticItem{
 					{FeatureID: "feat-1", FeatureName: "API Calls", EventName: "api_call", EventCount: 1, TotalUsage: decimal.NewFromInt(1), TotalCost: decimal.NewFromFloat(0.1), Currency: "USD"},
 				})

--- a/internal/temporal/activities/export/export_activity.go
+++ b/internal/temporal/activities/export/export_activity.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	"github.com/flexprice/flexprice/internal/integration"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -28,8 +29,9 @@ type ExportActivity struct {
 	connectionRepo       connection.Repository
 	integrationFactory   *integration.Factory
 	logger               *logger.Logger
-	usageAnalyticsGetter syncExport.UsageAnalyticsGetter
-	eventRepo            events.Repository
+	usageAnalyticsGetter     syncExport.UsageAnalyticsGetter
+	eventRepo                events.Repository
+	subscriptionLineItemRepo subscription.LineItemRepository
 }
 
 // NewExportActivity creates a new export activity
@@ -45,19 +47,21 @@ func NewExportActivity(
 	logger *logger.Logger,
 	usageAnalyticsGetter syncExport.UsageAnalyticsGetter,
 	eventRepo events.Repository,
+	subscriptionLineItemRepo subscription.LineItemRepository,
 ) *ExportActivity {
 	return &ExportActivity{
-		featureUsageRepo:     featureUsageRepo,
-		priceRepo:            priceRepo,
-		invoiceRepo:          invoiceRepo,
-		walletRepo:           walletRepo,
-		walletBalanceGetter:  walletBalanceGetter,
-		customerRepo:         customerRepo,
-		connectionRepo:       connectionRepo,
-		integrationFactory:   integrationFactory,
-		logger:               logger,
-		usageAnalyticsGetter: usageAnalyticsGetter,
-		eventRepo:            eventRepo,
+		featureUsageRepo:         featureUsageRepo,
+		priceRepo:                priceRepo,
+		invoiceRepo:              invoiceRepo,
+		walletRepo:               walletRepo,
+		walletBalanceGetter:      walletBalanceGetter,
+		customerRepo:             customerRepo,
+		connectionRepo:           connectionRepo,
+		integrationFactory:       integrationFactory,
+		logger:                   logger,
+		usageAnalyticsGetter:     usageAnalyticsGetter,
+		eventRepo:                eventRepo,
+		subscriptionLineItemRepo: subscriptionLineItemRepo,
 	}
 }
 
@@ -104,7 +108,7 @@ func (a *ExportActivity) ExportData(ctx context.Context, input ExportDataInput) 
 	}
 
 	// Use the ExportService which handles routing to the correct exporter
-	exportService := syncExport.NewExportServiceWithWallet(a.featureUsageRepo, a.priceRepo, a.invoiceRepo, a.walletRepo, a.walletBalanceGetter, a.customerRepo, a.connectionRepo, a.integrationFactory, a.logger, a.usageAnalyticsGetter, a.eventRepo)
+	exportService := syncExport.NewExportServiceWithWallet(a.featureUsageRepo, a.priceRepo, a.invoiceRepo, a.walletRepo, a.walletBalanceGetter, a.customerRepo, a.connectionRepo, a.integrationFactory, a.logger, a.usageAnalyticsGetter, a.eventRepo, a.subscriptionLineItemRepo)
 	response, err := exportService.Export(ctx, request)
 	if err != nil {
 		a.logger.Errorw("export failed", "error", err, "entity_type", input.EntityType)

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -117,6 +117,7 @@ func RegisterWorkflowsAndActivities(temporalService temporalService.TemporalServ
 		params.Logger,
 		featureUsageTrackingService,
 		params.EventRepo,
+		params.SubscriptionLineItemRepo,
 	)
 
 	// HubSpot activities - clean and simple, delegates to existing services

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -255,6 +255,35 @@ func (s *InMemorySubscriptionLineItemStore) List(ctx context.Context, filter *ty
 	return items, nil
 }
 
+// GetDistinctCustomerIDsWithCommitmentTrueUp returns distinct customer IDs from published
+// line items where commitment_true_up_enabled is true.
+func (s *InMemorySubscriptionLineItemStore) GetDistinctCustomerIDsWithCommitmentTrueUp(ctx context.Context) ([]string, error) {
+	filter := types.NewNoLimitSubscriptionLineItemFilter()
+	filter.ActiveFilter = false
+	if filter.QueryFilter != nil {
+		filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+	}
+
+	items, err := s.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	var customerIDs []string
+	for _, item := range items {
+		if !item.CommitmentTrueUpEnabled {
+			continue
+		}
+		if _, ok := seen[item.CustomerID]; ok {
+			continue
+		}
+		seen[item.CustomerID] = struct{}{}
+		customerIDs = append(customerIDs, item.CustomerID)
+	}
+	return customerIDs, nil
+}
+
 // Count counts subscription line items based on filter
 func (s *InMemorySubscriptionLineItemStore) Count(ctx context.Context, filter *types.SubscriptionLineItemFilter) (int, error) {
 	count, err := s.InMemoryStore.Count(ctx, filter, lineItemFilterFn)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage analytics exports now include customers with commitment true-up subscription line items enabled, providing more comprehensive customer data coverage in export reports.

* **Refactor**
  * Enhanced export service infrastructure and temporal workflows with additional repository dependencies to identify and include customers with active commitment true-up subscriptions in analytics exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1796)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->