### PR TITLE
fix(meter-usage): Aggregations and unique field condition

### DIFF
--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -33,11 +33,11 @@ type MeterUsageQueryParams struct {
 	ExternalCustomerIDs []string
 	MeterID             string
 	MeterIDs            []string
-	StartTime          time.Time
-	EndTime            time.Time
-	AggregationType    types.AggregationType
-	WindowSize         types.WindowSize
-	BillingAnchor      *time.Time
+	StartTime           time.Time
+	EndTime             time.Time
+	AggregationType     types.AggregationType
+	WindowSize          types.WindowSize
+	BillingAnchor       *time.Time
 	// GroupByProperty is the JSON property key for group-by aggregation (e.g. for bucketed MAX meters)
 	GroupByProperty string
 	// UseFinal enables FINAL for ReplacingMergeTree deduplication (use for billing queries)

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -403,6 +403,7 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 				}
 				if r != nil {
 					usage.Usage = r.TotalValue
+					usage.EventCount = r.EventCount
 				}
 				result.LineItemUsages = append(result.LineItemUsages, usage)
 			}
@@ -902,7 +903,6 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 	}
 
 	for _, analytic := range data.Analytics {
-		totalUsage := getCorrectMeterUsageValue(analytic)
 
 		item := dto.UsageAnalyticItem{
 			FeatureID:       analytic.FeatureID,
@@ -917,7 +917,7 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 			Unit:            analytic.Unit,
 			UnitPlural:      analytic.UnitPlural,
 			AggregationType: analytic.AggregationType,
-			TotalUsage:      totalUsage,
+			TotalUsage:      analytic.TotalUsage,
 			TotalCost:       analytic.TotalCost,
 			Currency:        analytic.Currency,
 			EventCount:      analytic.EventCount,
@@ -966,23 +966,6 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-// getCorrectMeterUsageValue returns the correct usage value based on the aggregation type.
-func getCorrectMeterUsageValue(item *events.DetailedUsageAnalytic) decimal.Decimal {
-	switch item.AggregationType {
-	case types.AggregationCountUnique:
-		return decimal.NewFromInt(int64(item.CountUniqueUsage))
-	case types.AggregationMax:
-		if !item.TotalUsage.IsZero() {
-			return item.TotalUsage
-		}
-		return item.MaxUsage
-	case types.AggregationLatest:
-		return item.LatestUsage
-	default:
-		return item.TotalUsage
-	}
-}
 
 // getUsageValueFromDetailedResult extracts the correct scalar usage from a
 // MeterUsageDetailedResult based on aggregation type.
@@ -1559,8 +1542,6 @@ func (s *meterUsageService) sumPointCosts(points []events.UsageAnalyticPoint) de
 
 // calculateRegularCost calculates cost for regular (non-bucketed) meters.
 func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, m *meter.Meter, p *price.Price, data *AnalyticsData) {
-	item.TotalUsage = s.getCorrectUsageValue(item, m.Aggregation.Type)
-
 	cost := priceService.CalculateCost(ctx, p, item.TotalUsage)
 
 	if item.SubLineItemID != "" {

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -354,14 +354,14 @@ func (s *meterUsageTrackingService) checkMeterFilters(event *events.Event, filte
 func (s *meterUsageTrackingService) generateUniqueHash(event *events.Event, m *meter.Meter) string {
 	var hashStr string
 
-	if m.Aggregation.Type == types.AggregationCountUnique && m.Aggregation.Field != "" {
+	if m.Aggregation.Type == types.AggregationCountUnique {
 		if fieldValue, ok := event.Properties[m.Aggregation.Field]; ok {
 			hashStr = fmt.Sprintf("%s:%s:%v", event.EventName, m.Aggregation.Field, fieldValue)
 		}
 	}
 
 	if hashStr == "" {
-		hashStr = event.EventName + ":" + event.ID
+		return ""
 	}
 
 	hash := sha256.Sum256([]byte(hashStr))

--- a/internal/service/meter_usage_tracking_test.go
+++ b/internal/service/meter_usage_tracking_test.go
@@ -70,8 +70,7 @@ func (s *MeterUsageTrackingSuite) TestGenerateUniqueHash_NonCountUnique() {
 	m := &meter.Meter{Aggregation: meter.Aggregation{Type: types.AggregationSum, Field: "duration"}}
 
 	hash := s.svc.generateUniqueHash(event, m)
-	assert.NotEmpty(s.T(), hash)
-	assert.Len(s.T(), hash, 64) // SHA256 hex
+	assert.Empty(s.T(), hash)
 
 	// Same input produces same hash
 	hash2 := s.svc.generateUniqueHash(event, m)
@@ -340,6 +339,6 @@ func (s *MeterUsageTrackingSuite) TestProcessEvent_MatchesMeters() {
 
 	// Verify unique hash is event-based for SUM
 	hash1 := s.svc.generateUniqueHash(event, m1)
-	assert.NotEmpty(s.T(), hash1)
+	assert.Empty(s.T(), hash1)
 	assert.NotEqual(s.T(), hash1, hash2)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of meter usage calculations by correctly propagating event counts for standard meter queries.
  * Fixed analytics response conversion so total usage is reported from analytics data (avoids double-aggregation).
  * Refined deduplication behavior: only unique-count meters now produce a deduplication identifier; non-unique meters will not generate one.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->