### PR TITLE
fix(subscription): cancel subscription line items upon subscription cancellation

### DIFF
--- a/internal/domain/subscription/line_item_repository.go
+++ b/internal/domain/subscription/line_item_repository.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/types"
 )
@@ -19,6 +20,9 @@ type LineItemRepository interface {
 
 	// Update updates an existing subscription line item
 	Update(ctx context.Context, lineItem *SubscriptionLineItem) error
+
+	// BulkTerminate terminates all subscription line items for a subscription up to a given date
+	BulkTerminate(ctx context.Context, subscriptionID string, effectiveDate time.Time) (int, error)
 
 	// Delete deletes a subscription line item by ID
 	Delete(ctx context.Context, id string) error

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -283,6 +283,42 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 	return nil
 }
 
+// BulkTerminate terminates all subscription line items for a subscription up to a given date
+func (r *subscriptionLineItemRepository) BulkTerminate(ctx context.Context, subscriptionID string, effectiveDate time.Time) (int, error) {
+	span := StartRepositorySpan(ctx, "subscription_line_item", "bulk_terminate", map[string]interface{}{
+		"subscription_id": subscriptionID,
+		"effective_date":  effectiveDate,
+	})
+	defer FinishSpan(span)
+
+	client := r.client.Writer(ctx)
+	affected, err := client.SubscriptionLineItem.Update().
+		SetNillableEndDate(types.ToNillableTime(effectiveDate)).
+		SetStatus(string(types.StatusPublished)).
+		Where(
+			subscriptionlineitem.SubscriptionID(subscriptionID),
+			subscriptionlineitem.Or(
+				subscriptionlineitem.EndDateIsNil(),
+				subscriptionlineitem.EndDateGT(effectiveDate),
+			),
+		).
+		Save(ctx)
+	if err != nil {
+		SetSpanError(span, err)
+		if ent.IsNotFound(err) {
+			return 0, ierr.NewError("no subscription line items terminated").
+				WithHint("No subscription line items were terminated").
+				Mark(ierr.ErrNotFound)
+		}
+		return 0, ierr.WithError(err).
+			WithHint("Failed to terminate subscription line items").
+			Mark(ierr.ErrDatabase)
+	}
+
+	SetSpanSuccess(span)
+	return affected, nil
+}
+
 // Delete deletes a subscription line item
 func (r *subscriptionLineItemRepository) Delete(ctx context.Context, id string) error {
 	// Start a span for this repository operation

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -296,6 +296,8 @@ func (r *subscriptionLineItemRepository) BulkTerminate(ctx context.Context, subs
 		SetNillableEndDate(types.ToNillableTime(effectiveDate)).
 		SetStatus(string(types.StatusPublished)).
 		Where(
+			subscriptionlineitem.TenantID(types.GetTenantID(ctx)),
+			subscriptionlineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 			subscriptionlineitem.SubscriptionID(subscriptionID),
 			subscriptionlineitem.Or(
 				subscriptionlineitem.EndDateIsNil(),

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1905,7 +1905,7 @@ func (s *subscriptionService) CancelSubscription(
 
 		// Step 7b: Terminate plan and subscription-scoped line items (set EndDate = effectiveDate).
 		// Addon line items are already terminated by cancelAddonsForSubscription above.
-		if err := s.cancelNonAddonLineItemsForSubscription(ctx, subscription.ID, effectiveDate); err != nil {
+		if err := s.cancelAllLineItemsForSubscription(ctx, subscription.ID, effectiveDate); err != nil {
 			return err
 		}
 
@@ -6933,18 +6933,17 @@ func (s *subscriptionService) TriggerSubscriptionDraftAndComputeWorkflow(ctx con
 	}, nil
 }
 
-// cancelNonAddonLineItemsForSubscription sets EndDate on plan and subscription-scoped line
+// cancelAllLineItemsForSubscription sets EndDate on plan and subscription-scoped line
 // items for the subscription up to effectiveDate. Items that have not yet started
 // (StartDate > effectiveDate) are skipped because they never became active; the
-// subscription-level EndDate already protects billing. Addon line items are skipped because
-// they are terminated by cancelAddonsForSubscription via DeleteSubscriptionLineItem.
+// subscription-level EndDate already protects billing.
 // Uses direct repository update (not DeleteSubscriptionLineItem) to avoid the effectiveFrom
 // validation in that service function.
 //
 // Setting EndDate on subscription-scoped line items is required so that meter usage queries
 // (see GetSubscriptionMeterUsage) clip the ClickHouse query window at the cancellation date —
 // without it, usage events after cancellation would still be picked up.
-func (s *subscriptionService) cancelNonAddonLineItemsForSubscription(
+func (s *subscriptionService) cancelAllLineItemsForSubscription(
 	ctx context.Context,
 	subscriptionID string,
 	effectiveDate time.Time,
@@ -6967,11 +6966,6 @@ func (s *subscriptionService) cancelNonAddonLineItemsForSubscription(
 
 	terminated := 0
 	for _, item := range lineItems {
-		// Addon line items are handled by cancelAddonsForSubscription
-		if item.EntityType == types.SubscriptionLineItemEntityTypeAddon {
-			continue
-		}
-
 		// Skip items that haven't started yet — they never became active
 		if item.StartDate.After(effectiveDate) {
 			logger.Debugw("skipping line item not yet started",

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -6953,46 +6953,12 @@ func (s *subscriptionService) cancelAllLineItemsForSubscription(
 		zap.Time("effective_date", effectiveDate),
 	)
 
-	lineItemFilter := types.NewNoLimitSubscriptionLineItemFilter()
-	lineItemFilter.SubscriptionIDs = []string{subscriptionID}
-
-	lineItems, err := s.SubscriptionLineItemRepo.List(ctx, lineItemFilter)
+	terminated, err := s.SubscriptionLineItemRepo.BulkTerminate(ctx, subscriptionID, effectiveDate)
 	if err != nil {
-		logger.Errorw("failed to list line items for cancellation", "error", err)
+		logger.Errorw("failed to terminate line items for subscription", "error", err)
 		return ierr.WithError(err).
-			WithHint("Failed to list line items for cancellation").
+			WithHint("Failed to terminate line items for subscription").
 			Mark(ierr.ErrDatabase)
-	}
-
-	terminated := 0
-	for _, item := range lineItems {
-		// Skip items that haven't started yet — they never became active
-		if item.StartDate.After(effectiveDate) {
-			logger.Debugw("skipping line item not yet started",
-				"line_item_id", item.ID,
-				"entity_type", item.EntityType,
-				"start_date", item.StartDate)
-			continue
-		}
-		// Skip items already terminated at or before effectiveDate
-		if !item.EndDate.IsZero() && !item.EndDate.After(effectiveDate) {
-			logger.Debugw("skipping line item already terminated",
-				"line_item_id", item.ID,
-				"entity_type", item.EntityType,
-				"end_date", item.EndDate)
-			continue
-		}
-		item.EndDate = effectiveDate
-		if err := s.SubscriptionLineItemRepo.Update(ctx, item); err != nil {
-			logger.Errorw("failed to update line item end date",
-				"line_item_id", item.ID,
-				"entity_type", item.EntityType,
-				"error", err)
-			return ierr.WithError(err).
-				WithHintf("Failed to set EndDate on line item %s", item.ID).
-				Mark(ierr.ErrDatabase)
-		}
-		terminated++
 	}
 
 	logger.Infow("terminated line items for subscription", "line_items_terminated", terminated)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1903,8 +1903,9 @@ func (s *subscriptionService) CancelSubscription(
 			return err
 		}
 
-		// Step 7b: Terminate plan line items (set EndDate = effectiveDate)
-		if err := s.cancelPlanLineItemsForSubscription(ctx, subscription.ID, effectiveDate); err != nil {
+		// Step 7b: Terminate plan and subscription-scoped line items (set EndDate = effectiveDate).
+		// Addon line items are already terminated by cancelAddonsForSubscription above.
+		if err := s.cancelNonAddonLineItemsForSubscription(ctx, subscription.ID, effectiveDate); err != nil {
 			return err
 		}
 
@@ -6054,7 +6055,6 @@ func (s *subscriptionService) GetMeterUsageBySubscription(ctx context.Context, r
 	return response, nil
 }
 
-
 // GetSubscriptionEntitlements retrieves all entitlements associated with a subscription
 // This includes entitlements from:
 // 1. The subscription's plan
@@ -6933,12 +6933,18 @@ func (s *subscriptionService) TriggerSubscriptionDraftAndComputeWorkflow(ctx con
 	}, nil
 }
 
-// cancelPlanLineItemsForSubscription sets EndDate on all plan line items for the subscription
-// up to effectiveDate. Items that have not yet started (StartDate > effectiveDate) are skipped
-// because they never became active; the subscription-level EndDate already protects billing.
+// cancelNonAddonLineItemsForSubscription sets EndDate on plan and subscription-scoped line
+// items for the subscription up to effectiveDate. Items that have not yet started
+// (StartDate > effectiveDate) are skipped because they never became active; the
+// subscription-level EndDate already protects billing. Addon line items are skipped because
+// they are terminated by cancelAddonsForSubscription via DeleteSubscriptionLineItem.
 // Uses direct repository update (not DeleteSubscriptionLineItem) to avoid the effectiveFrom
 // validation in that service function.
-func (s *subscriptionService) cancelPlanLineItemsForSubscription(
+//
+// Setting EndDate on subscription-scoped line items is required so that meter usage queries
+// (see GetSubscriptionMeterUsage) clip the ClickHouse query window at the cancellation date —
+// without it, usage events after cancellation would still be picked up.
+func (s *subscriptionService) cancelNonAddonLineItemsForSubscription(
 	ctx context.Context,
 	subscriptionID string,
 	effectiveDate time.Time,
@@ -6950,46 +6956,52 @@ func (s *subscriptionService) cancelPlanLineItemsForSubscription(
 
 	lineItemFilter := types.NewNoLimitSubscriptionLineItemFilter()
 	lineItemFilter.SubscriptionIDs = []string{subscriptionID}
-	lineItemFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypePlan)
 
 	lineItems, err := s.SubscriptionLineItemRepo.List(ctx, lineItemFilter)
 	if err != nil {
-		logger.Errorw("failed to list plan line items for cancellation", "error", err)
+		logger.Errorw("failed to list line items for cancellation", "error", err)
 		return ierr.WithError(err).
-			WithHint("Failed to list plan line items for cancellation").
+			WithHint("Failed to list line items for cancellation").
 			Mark(ierr.ErrDatabase)
 	}
 
 	terminated := 0
 	for _, item := range lineItems {
+		// Addon line items are handled by cancelAddonsForSubscription
+		if item.EntityType == types.SubscriptionLineItemEntityTypeAddon {
+			continue
+		}
+
 		// Skip items that haven't started yet — they never became active
 		if item.StartDate.After(effectiveDate) {
-			logger.Debugw("skipping plan line item not yet started",
+			logger.Debugw("skipping line item not yet started",
 				"line_item_id", item.ID,
+				"entity_type", item.EntityType,
 				"start_date", item.StartDate)
 			continue
 		}
 		// Skip items already terminated at or before effectiveDate
 		if !item.EndDate.IsZero() && !item.EndDate.After(effectiveDate) {
-			logger.Debugw("skipping plan line item already terminated",
+			logger.Debugw("skipping line item already terminated",
 				"line_item_id", item.ID,
+				"entity_type", item.EntityType,
 				"end_date", item.EndDate)
 			continue
 		}
 		item.EndDate = effectiveDate
 		if err := s.SubscriptionLineItemRepo.Update(ctx, item); err != nil {
-			logger.Errorw("failed to update plan line item end date",
+			logger.Errorw("failed to update line item end date",
 				"line_item_id", item.ID,
+				"entity_type", item.EntityType,
 				"error", err)
 			return ierr.WithError(err).
-				WithHintf("Failed to set EndDate on plan line item %s", item.ID).
+				WithHintf("Failed to set EndDate on line item %s", item.ID).
 				Mark(ierr.ErrDatabase)
 		}
 		terminated++
 	}
 
-	logger.Infow("terminated plan line items for subscription",
-		"line_items_terminated", terminated)
+	logger.Infow("terminated line items for subscription", "line_items_terminated", terminated)
 	return nil
 }
 

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -193,6 +194,35 @@ func (s *InMemorySubscriptionLineItemStore) Update(ctx context.Context, item *su
 			Mark(ierr.ErrDatabase)
 	}
 	return nil
+}
+
+// BulkTerminate terminates all subscription line items for a subscription up to a given date
+func (s *InMemorySubscriptionLineItemStore) BulkTerminate(ctx context.Context, subscriptionID string, effectiveDate time.Time) (int, error) {
+	items, err := s.ListBySubscription(ctx, &subscription.Subscription{ID: subscriptionID})
+	if err != nil {
+		return 0, ierr.WithError(err).
+			WithHint("Failed to list subscription line items").
+			Mark(ierr.ErrDatabase)
+	}
+
+	affected := 0
+	for _, item := range items {
+		if !item.EndDate.IsZero() && item.EndDate.Before(effectiveDate) {
+			continue
+		}
+
+		affected++
+		item.EndDate = effectiveDate
+		if err := s.Update(ctx, item); err != nil {
+			return 0, ierr.WithError(err).
+				WithHint("Failed to update subscription line item").
+				WithReportableDetails(map[string]interface{}{
+					"line_item_id": item.ID,
+				}).
+				Mark(ierr.ErrDatabase)
+		}
+	}
+	return affected, nil
 }
 
 // Delete deletes a subscription line item


### PR DESCRIPTION
## 📝 Description
Enables meter usage rollout so clickhouse queries will have right timestamp range for meter aggregations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription cancellation now bulk-terminates all applicable line items as of the effective date, skipping items that haven't started or already ended; includes improved logging and clearer error handling when no items or database errors occur.
* **Tests**
  * In-memory test utilities updated to mirror the new bulk-termination behavior and validate termination counts and error mapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->