### PR TITLE
fix(paddle): use only finalized invoices and add amount guard in resync

### DIFF
--- a/internal/integration/paddle/sync_service.go
+++ b/internal/integration/paddle/sync_service.go
@@ -1093,7 +1093,54 @@ func (s *PaddleSyncService) ProcessSubscriptionActivatedWebhook(
 			"sub_id", flexSubID, "status", sub.SubscriptionStatus, "paddle_sub_id", paddleSubID)
 	}
 
+	s.resyncPendingInvoicesForSubscription(ctx, flexSubID)
 	return nil
+}
+
+// resyncPendingInvoicesForSubscription attempts to sync all draft/finalized+pending invoices
+// for the given subscription. Called after subscription.activated is processed so that invoices
+// created before the Paddle mapping existed can be synced and auto-charged.
+// All errors are soft-fail: each invoice is tried independently; failures are logged.
+func (s *PaddleSyncService) resyncPendingInvoicesForSubscription(ctx context.Context, subscriptionID string) {
+	filter := types.NewNoLimitInvoiceFilter()
+	filter.SubscriptionID = subscriptionID
+	filter.InvoiceStatus = []types.InvoiceStatus{
+		types.InvoiceStatusDraft,
+		types.InvoiceStatusFinalized,
+	}
+	filter.PaymentStatus = []types.PaymentStatus{
+		types.PaymentStatusPending,
+	}
+
+	invoices, err := s.invoiceRepo.List(ctx, filter)
+	if err != nil {
+		s.logger.Warnw("failed to list invoices for post-activation resync",
+			"subscription_id", subscriptionID, "error", err)
+		return
+	}
+
+	if len(invoices) == 0 {
+		return
+	}
+
+	s.logger.Infow("resyncing pending invoices after subscription.activated",
+		"subscription_id", subscriptionID, "count", len(invoices))
+
+	succeeded := 0
+	for _, inv := range invoices {
+		_, syncErr := s.SyncInvoice(ctx, SyncInvoiceRequest{InvoiceID: inv.ID})
+		if syncErr != nil {
+			s.logger.Warnw("failed to resync invoice after subscription.activated",
+				"subscription_id", subscriptionID, "invoice_id", inv.ID, "error", syncErr)
+			continue
+		}
+		succeeded++
+	}
+
+	s.logger.Infow("completed post-activation invoice resync",
+		"subscription_id", subscriptionID,
+		"attempted", len(invoices),
+		"succeeded", succeeded)
 }
 
 func syncableInvoiceLineItems(items []*invoice.InvoiceLineItem) []*invoice.InvoiceLineItem {

--- a/internal/integration/paddle/sync_service.go
+++ b/internal/integration/paddle/sync_service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 )
 
 // PaddleSyncService orchestrates syncing FlexPrice entities to Paddle.
@@ -1097,7 +1098,7 @@ func (s *PaddleSyncService) ProcessSubscriptionActivatedWebhook(
 	return nil
 }
 
-// resyncPendingInvoicesForSubscription attempts to sync all draft/finalized+pending invoices
+// resyncPendingInvoicesForSubscription attempts to sync all finalized+pending invoices
 // for the given subscription. Called after subscription.activated is processed so that invoices
 // created before the Paddle mapping existed can be synced and auto-charged.
 // All errors are soft-fail: each invoice is tried independently; failures are logged.
@@ -1105,12 +1106,13 @@ func (s *PaddleSyncService) resyncPendingInvoicesForSubscription(ctx context.Con
 	filter := types.NewNoLimitInvoiceFilter()
 	filter.SubscriptionID = subscriptionID
 	filter.InvoiceStatus = []types.InvoiceStatus{
-		types.InvoiceStatusDraft,
 		types.InvoiceStatusFinalized,
 	}
 	filter.PaymentStatus = []types.PaymentStatus{
 		types.PaymentStatusPending,
 	}
+	filter.AmountRemainingGt = lo.ToPtr(decimal.NewFromInt(0))
+	filter.SkipLineItems = true
 
 	invoices, err := s.invoiceRepo.List(ctx, filter)
 	if err != nil {
@@ -1140,7 +1142,8 @@ func (s *PaddleSyncService) resyncPendingInvoicesForSubscription(ctx context.Con
 	s.logger.Infow("completed post-activation invoice resync",
 		"subscription_id", subscriptionID,
 		"attempted", len(invoices),
-		"succeeded", succeeded)
+		"succeeded", succeeded,
+		"failed", len(invoices)-succeeded)
 }
 
 func syncableInvoiceLineItems(items []*invoice.InvoiceLineItem) []*invoice.InvoiceLineItem {

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -20,6 +20,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	paddleint "github.com/flexprice/flexprice/internal/integration/paddle"
 	"github.com/flexprice/flexprice/internal/temporal/models"
 	invoiceTemporalModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
 	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
@@ -484,6 +485,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionDraftCreated, sub.ID)
 	} else {
 		s.triggerHubSpotDealSyncWorkflow(ctx, sub.ID, customer.ID)
+		s.runPaddleSubscriptionSync(ctx, sub)
 		s.publishSubscriptionCreatedEvent(ctx, sub)
 	}
 	return response, nil
@@ -7475,4 +7477,60 @@ func (s *subscriptionService) processAutoInvoiceThresholdSubscription(
 		item.InvoiceID = inv.ID
 	}
 	return nil
+}
+
+// runPaddleSubscriptionSync synchronously bootstraps a Paddle subscription for the given
+// subscription. It is called inline from CreateSubscription so the checkout URL is available
+// in the response without a round-trip through Temporal. All errors are soft-fail: the
+// subscription has already been persisted, so we only log and continue.
+//
+// On success, EnsureSubscriptionSynced mutates sub.Metadata in place and persists the change,
+// so the caller's response pointer automatically reflects paddle_checkout_url and
+// paddle_transaction_id with no extra work.
+func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub *subscription.Subscription) {
+	paddleInt, err := s.IntegrationFactory.GetPaddleIntegration(ctx)
+	if err != nil {
+		if ierr.IsNotFound(err) {
+			return // Paddle not configured for this environment — skip silently
+		}
+		s.Logger.WarnwCtx(ctx, "failed to get Paddle integration for inline sync, subscription created without checkout URL",
+			"subscription_id", sub.ID, "error", err)
+		return
+	}
+
+	productItems := make([]paddleint.EnsureBulkProductSyncedItem, 0, len(sub.LineItems))
+	for _, li := range sub.LineItems {
+		if li == nil || li.PriceID == "" {
+			continue
+		}
+		name := li.PriceID
+		if li.DisplayName != "" {
+			name = li.DisplayName
+		}
+		productItems = append(productItems, paddleint.EnsureBulkProductSyncedItem{
+			PriceID: li.PriceID,
+			Name:    name,
+		})
+	}
+
+	productsResp, err := paddleInt.SyncSvc.EnsureBulkProductSynced(ctx, paddleint.EnsureBulkProductSyncedRequest{Items: productItems})
+	if err != nil {
+		s.Logger.WarnwCtx(ctx, "paddle product sync failed during inline subscription sync",
+			"subscription_id", sub.ID, "error", err)
+		return
+	}
+
+	_, err = paddleInt.SyncSvc.EnsureSubscriptionSynced(ctx, paddleint.EnsureSubscriptionSyncedRequest{
+		Subscription:       sub,
+		PriceIDToProductID: productsResp.PriceIDToPaddleProductID,
+	})
+	if err != nil {
+		s.Logger.WarnwCtx(ctx, "paddle subscription sync failed during inline subscription sync",
+			"subscription_id", sub.ID, "error", err)
+		return
+	}
+
+	s.Logger.InfowCtx(ctx, "paddle subscription synced synchronously",
+		"subscription_id", sub.ID,
+		"checkout_url_present", sub.Metadata["paddle_checkout_url"] != "")
 }

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -7484,9 +7484,9 @@ func (s *subscriptionService) processAutoInvoiceThresholdSubscription(
 // in the response without a round-trip through Temporal. All errors are soft-fail: the
 // subscription has already been persisted, so we only log and continue.
 //
-// On success, EnsureSubscriptionSynced mutates sub.Metadata in place and persists the change,
-// so the caller's response pointer automatically reflects paddle_checkout_url and
-// paddle_transaction_id with no extra work.
+// On success, EnsureSubscriptionSynced persists paddle checkout metadata; it is copied back
+// onto the caller's sub so the create response includes paddle_checkout_url and
+// paddle_transaction_id.
 func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub *subscription.Subscription) {
 	if s.IntegrationFactory == nil {
 		return
@@ -7501,8 +7501,16 @@ func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub
 		return
 	}
 
-	productItems := make([]paddleint.EnsureBulkProductSyncedItem, 0, len(sub.LineItems))
-	for _, li := range sub.LineItems {
+	reloadedSub, lineItems, err := s.SubRepo.GetWithLineItems(ctx, sub.ID)
+	if err != nil {
+		s.Logger.WarnwCtx(ctx, "failed to reload subscription for paddle inline sync",
+			"subscription_id", sub.ID, "error", err)
+		return
+	}
+	reloadedSub.LineItems = lineItems
+
+	productItems := make([]paddleint.EnsureBulkProductSyncedItem, 0, len(reloadedSub.LineItems))
+	for _, li := range reloadedSub.LineItems {
 		if li == nil || li.PriceID == "" {
 			continue
 		}
@@ -7524,13 +7532,26 @@ func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub
 	}
 
 	_, err = paddleInt.SyncSvc.EnsureSubscriptionSynced(ctx, paddleint.EnsureSubscriptionSyncedRequest{
-		Subscription:       sub,
+		Subscription:       reloadedSub,
 		PriceIDToProductID: productsResp.PriceIDToPaddleProductID,
 	})
 	if err != nil {
 		s.Logger.WarnwCtx(ctx, "paddle subscription sync failed during inline subscription sync",
 			"subscription_id", sub.ID, "error", err)
 		return
+	}
+
+	// EnsureSubscriptionSynced mutates metadata on reloadedSub; copy to caller sub for response.
+	if reloadedSub.Metadata != nil {
+		if sub.Metadata == nil {
+			sub.Metadata = make(types.Metadata)
+		}
+		if v := reloadedSub.Metadata[paddleint.MetaKeyPaddleTransactionID]; v != "" {
+			sub.Metadata[paddleint.MetaKeyPaddleTransactionID] = v
+		}
+		if v := reloadedSub.Metadata[paddleint.MetaKeyPaddleCheckoutURL]; v != "" {
+			sub.Metadata[paddleint.MetaKeyPaddleCheckoutURL] = v
+		}
 	}
 
 	s.Logger.InfowCtx(ctx, "paddle subscription synced synchronously",

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -7488,6 +7488,9 @@ func (s *subscriptionService) processAutoInvoiceThresholdSubscription(
 // so the caller's response pointer automatically reflects paddle_checkout_url and
 // paddle_transaction_id with no extra work.
 func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub *subscription.Subscription) {
+	if s.IntegrationFactory == nil {
+		return
+	}
 	paddleInt, err := s.IntegrationFactory.GetPaddleIntegration(ctx)
 	if err != nil {
 		if ierr.IsNotFound(err) {
@@ -7532,5 +7535,5 @@ func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub
 
 	s.Logger.InfowCtx(ctx, "paddle subscription synced synchronously",
 		"subscription_id", sub.ID,
-		"checkout_url_present", sub.Metadata["paddle_checkout_url"] != "")
+		"checkout_url_present", sub.Metadata[paddleint.MetaKeyPaddleCheckoutURL] != "")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions now automatically synchronize with the payment provider during creation to populate checkout URL and transaction metadata in responses.
  * When a subscription is activated, the system automatically rescans and syncs finalized invoices with pending payments to ensure invoices and payment status are up to date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->