### PR TITLE
feat(bucketed-commitment): Allow time range conditions on commitments

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1728,6 +1728,7 @@ var (
 		{Name: "commitment_true_up_enabled", Type: field.TypeBool, Default: false},
 		{Name: "commitment_windowed", Type: field.TypeBool, Default: false},
 		{Name: "commitment_duration", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "commitment_time_buckets", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "subscription_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
 	// SubscriptionLineItemsTable holds the schema information for the "subscription_line_items" table.
@@ -1738,7 +1739,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "subscription_line_items_subscriptions_line_items",
-				Columns:    []*schema.Column{SubscriptionLineItemsColumns[36]},
+				Columns:    []*schema.Column{SubscriptionLineItemsColumns[37]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -1747,7 +1748,7 @@ var (
 			{
 				Name:    "subscriptionlineitem_tenant_id_environment_id_subscription_id_status",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionLineItemsColumns[1], SubscriptionLineItemsColumns[7], SubscriptionLineItemsColumns[36], SubscriptionLineItemsColumns[2]},
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[1], SubscriptionLineItemsColumns[7], SubscriptionLineItemsColumns[37], SubscriptionLineItemsColumns[2]},
 			},
 			{
 				Name:    "subscriptionlineitem_tenant_id_environment_id_customer_id_status",
@@ -1777,7 +1778,7 @@ var (
 			{
 				Name:    "subscriptionlineitem_subscription_id_status",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionLineItemsColumns[36], SubscriptionLineItemsColumns[2]},
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[37], SubscriptionLineItemsColumns[2]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -49611,54 +49611,56 @@ func (m *SubscriptionMutation) ResetEdge(name string) error {
 // SubscriptionLineItemMutation represents an operation that mutates the SubscriptionLineItem nodes in the graph.
 type SubscriptionLineItemMutation struct {
 	config
-	op                         Op
-	typ                        string
-	id                         *string
-	tenant_id                  *string
-	status                     *string
-	created_at                 *time.Time
-	updated_at                 *time.Time
-	created_by                 *string
-	updated_by                 *string
-	environment_id             *string
-	customer_id                *string
-	entity_id                  *string
-	entity_type                *types.InvoiceLineItemEntityType
-	plan_display_name          *string
-	price_id                   *string
-	price_type                 *types.PriceType
-	meter_id                   *string
-	meter_display_name         *string
-	price_unit_id              *string
-	price_unit                 *string
-	display_name               *string
-	quantity                   *decimal.Decimal
-	currency                   *string
-	billing_period             *types.BillingPeriod
-	billing_period_count       *int
-	addbilling_period_count    *int
-	invoice_cadence            *types.InvoiceCadence
-	start_date                 *time.Time
-	end_date                   *time.Time
-	subscription_phase_id      *string
-	addon_association_id       *string
-	metadata                   *map[string]string
-	commitment_amount          *decimal.Decimal
-	commitment_quantity        *decimal.Decimal
-	commitment_type            *string
-	commitment_overage_factor  *decimal.Decimal
-	commitment_true_up_enabled *bool
-	commitment_windowed        *bool
-	commitment_duration        *types.BillingPeriod
-	clearedFields              map[string]struct{}
-	subscription               *string
-	clearedsubscription        bool
-	coupon_associations        map[string]struct{}
-	removedcoupon_associations map[string]struct{}
-	clearedcoupon_associations bool
-	done                       bool
-	oldValue                   func(context.Context) (*SubscriptionLineItem, error)
-	predicates                 []predicate.SubscriptionLineItem
+	op                            Op
+	typ                           string
+	id                            *string
+	tenant_id                     *string
+	status                        *string
+	created_at                    *time.Time
+	updated_at                    *time.Time
+	created_by                    *string
+	updated_by                    *string
+	environment_id                *string
+	customer_id                   *string
+	entity_id                     *string
+	entity_type                   *types.InvoiceLineItemEntityType
+	plan_display_name             *string
+	price_id                      *string
+	price_type                    *types.PriceType
+	meter_id                      *string
+	meter_display_name            *string
+	price_unit_id                 *string
+	price_unit                    *string
+	display_name                  *string
+	quantity                      *decimal.Decimal
+	currency                      *string
+	billing_period                *types.BillingPeriod
+	billing_period_count          *int
+	addbilling_period_count       *int
+	invoice_cadence               *types.InvoiceCadence
+	start_date                    *time.Time
+	end_date                      *time.Time
+	subscription_phase_id         *string
+	addon_association_id          *string
+	metadata                      *map[string]string
+	commitment_amount             *decimal.Decimal
+	commitment_quantity           *decimal.Decimal
+	commitment_type               *string
+	commitment_overage_factor     *decimal.Decimal
+	commitment_true_up_enabled    *bool
+	commitment_windowed           *bool
+	commitment_duration           *types.BillingPeriod
+	commitment_time_buckets       *types.TimeOfDayBuckets
+	appendcommitment_time_buckets types.TimeOfDayBuckets
+	clearedFields                 map[string]struct{}
+	subscription                  *string
+	clearedsubscription           bool
+	coupon_associations           map[string]struct{}
+	removedcoupon_associations    map[string]struct{}
+	clearedcoupon_associations    bool
+	done                          bool
+	oldValue                      func(context.Context) (*SubscriptionLineItem, error)
+	predicates                    []predicate.SubscriptionLineItem
 }
 
 var _ ent.Mutation = (*SubscriptionLineItemMutation)(nil)
@@ -51367,6 +51369,71 @@ func (m *SubscriptionLineItemMutation) ResetCommitmentDuration() {
 	delete(m.clearedFields, subscriptionlineitem.FieldCommitmentDuration)
 }
 
+// SetCommitmentTimeBuckets sets the "commitment_time_buckets" field.
+func (m *SubscriptionLineItemMutation) SetCommitmentTimeBuckets(todb types.TimeOfDayBuckets) {
+	m.commitment_time_buckets = &todb
+	m.appendcommitment_time_buckets = nil
+}
+
+// CommitmentTimeBuckets returns the value of the "commitment_time_buckets" field in the mutation.
+func (m *SubscriptionLineItemMutation) CommitmentTimeBuckets() (r types.TimeOfDayBuckets, exists bool) {
+	v := m.commitment_time_buckets
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCommitmentTimeBuckets returns the old "commitment_time_buckets" field's value of the SubscriptionLineItem entity.
+// If the SubscriptionLineItem object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SubscriptionLineItemMutation) OldCommitmentTimeBuckets(ctx context.Context) (v types.TimeOfDayBuckets, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCommitmentTimeBuckets is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCommitmentTimeBuckets requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCommitmentTimeBuckets: %w", err)
+	}
+	return oldValue.CommitmentTimeBuckets, nil
+}
+
+// AppendCommitmentTimeBuckets adds todb to the "commitment_time_buckets" field.
+func (m *SubscriptionLineItemMutation) AppendCommitmentTimeBuckets(todb types.TimeOfDayBuckets) {
+	m.appendcommitment_time_buckets = append(m.appendcommitment_time_buckets, todb...)
+}
+
+// AppendedCommitmentTimeBuckets returns the list of values that were appended to the "commitment_time_buckets" field in this mutation.
+func (m *SubscriptionLineItemMutation) AppendedCommitmentTimeBuckets() (types.TimeOfDayBuckets, bool) {
+	if len(m.appendcommitment_time_buckets) == 0 {
+		return nil, false
+	}
+	return m.appendcommitment_time_buckets, true
+}
+
+// ClearCommitmentTimeBuckets clears the value of the "commitment_time_buckets" field.
+func (m *SubscriptionLineItemMutation) ClearCommitmentTimeBuckets() {
+	m.commitment_time_buckets = nil
+	m.appendcommitment_time_buckets = nil
+	m.clearedFields[subscriptionlineitem.FieldCommitmentTimeBuckets] = struct{}{}
+}
+
+// CommitmentTimeBucketsCleared returns if the "commitment_time_buckets" field was cleared in this mutation.
+func (m *SubscriptionLineItemMutation) CommitmentTimeBucketsCleared() bool {
+	_, ok := m.clearedFields[subscriptionlineitem.FieldCommitmentTimeBuckets]
+	return ok
+}
+
+// ResetCommitmentTimeBuckets resets all changes to the "commitment_time_buckets" field.
+func (m *SubscriptionLineItemMutation) ResetCommitmentTimeBuckets() {
+	m.commitment_time_buckets = nil
+	m.appendcommitment_time_buckets = nil
+	delete(m.clearedFields, subscriptionlineitem.FieldCommitmentTimeBuckets)
+}
+
 // ClearSubscription clears the "subscription" edge to the Subscription entity.
 func (m *SubscriptionLineItemMutation) ClearSubscription() {
 	m.clearedsubscription = true
@@ -51482,7 +51549,7 @@ func (m *SubscriptionLineItemMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SubscriptionLineItemMutation) Fields() []string {
-	fields := make([]string, 0, 36)
+	fields := make([]string, 0, 37)
 	if m.tenant_id != nil {
 		fields = append(fields, subscriptionlineitem.FieldTenantID)
 	}
@@ -51591,6 +51658,9 @@ func (m *SubscriptionLineItemMutation) Fields() []string {
 	if m.commitment_duration != nil {
 		fields = append(fields, subscriptionlineitem.FieldCommitmentDuration)
 	}
+	if m.commitment_time_buckets != nil {
+		fields = append(fields, subscriptionlineitem.FieldCommitmentTimeBuckets)
+	}
 	return fields
 }
 
@@ -51671,6 +51741,8 @@ func (m *SubscriptionLineItemMutation) Field(name string) (ent.Value, bool) {
 		return m.CommitmentWindowed()
 	case subscriptionlineitem.FieldCommitmentDuration:
 		return m.CommitmentDuration()
+	case subscriptionlineitem.FieldCommitmentTimeBuckets:
+		return m.CommitmentTimeBuckets()
 	}
 	return nil, false
 }
@@ -51752,6 +51824,8 @@ func (m *SubscriptionLineItemMutation) OldField(ctx context.Context, name string
 		return m.OldCommitmentWindowed(ctx)
 	case subscriptionlineitem.FieldCommitmentDuration:
 		return m.OldCommitmentDuration(ctx)
+	case subscriptionlineitem.FieldCommitmentTimeBuckets:
+		return m.OldCommitmentTimeBuckets(ctx)
 	}
 	return nil, fmt.Errorf("unknown SubscriptionLineItem field %s", name)
 }
@@ -52013,6 +52087,13 @@ func (m *SubscriptionLineItemMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetCommitmentDuration(v)
 		return nil
+	case subscriptionlineitem.FieldCommitmentTimeBuckets:
+		v, ok := value.(types.TimeOfDayBuckets)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCommitmentTimeBuckets(v)
+		return nil
 	}
 	return fmt.Errorf("unknown SubscriptionLineItem field %s", name)
 }
@@ -52124,6 +52205,9 @@ func (m *SubscriptionLineItemMutation) ClearedFields() []string {
 	if m.FieldCleared(subscriptionlineitem.FieldCommitmentDuration) {
 		fields = append(fields, subscriptionlineitem.FieldCommitmentDuration)
 	}
+	if m.FieldCleared(subscriptionlineitem.FieldCommitmentTimeBuckets) {
+		fields = append(fields, subscriptionlineitem.FieldCommitmentTimeBuckets)
+	}
 	return fields
 }
 
@@ -52203,6 +52287,9 @@ func (m *SubscriptionLineItemMutation) ClearField(name string) error {
 		return nil
 	case subscriptionlineitem.FieldCommitmentDuration:
 		m.ClearCommitmentDuration()
+		return nil
+	case subscriptionlineitem.FieldCommitmentTimeBuckets:
+		m.ClearCommitmentTimeBuckets()
 		return nil
 	}
 	return fmt.Errorf("unknown SubscriptionLineItem nullable field %s", name)
@@ -52319,6 +52406,9 @@ func (m *SubscriptionLineItemMutation) ResetField(name string) error {
 		return nil
 	case subscriptionlineitem.FieldCommitmentDuration:
 		m.ResetCommitmentDuration()
+		return nil
+	case subscriptionlineitem.FieldCommitmentTimeBuckets:
+		m.ResetCommitmentTimeBuckets()
 		return nil
 	}
 	return fmt.Errorf("unknown SubscriptionLineItem field %s", name)

--- a/ent/schema/subscription_line_item.go
+++ b/ent/schema/subscription_line_item.go
@@ -185,6 +185,11 @@ func (SubscriptionLineItem) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			GoType(types.BillingPeriod("")),
+		field.JSON("commitment_time_buckets", types.TimeOfDayBuckets{}).
+			Optional().
+			SchemaType(map[string]string{
+				"postgres": "jsonb",
+			}),
 	}
 }
 

--- a/ent/subscriptionlineitem.go
+++ b/ent/subscriptionlineitem.go
@@ -93,6 +93,8 @@ type SubscriptionLineItem struct {
 	CommitmentWindowed bool `json:"commitment_windowed,omitempty"`
 	// CommitmentDuration holds the value of the "commitment_duration" field.
 	CommitmentDuration *types.BillingPeriod `json:"commitment_duration,omitempty"`
+	// CommitmentTimeBuckets holds the value of the "commitment_time_buckets" field.
+	CommitmentTimeBuckets types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the SubscriptionLineItemQuery when eager-loading is set.
 	Edges        SubscriptionLineItemEdges `json:"edges"`
@@ -137,7 +139,7 @@ func (*SubscriptionLineItem) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case subscriptionlineitem.FieldCommitmentAmount, subscriptionlineitem.FieldCommitmentQuantity, subscriptionlineitem.FieldCommitmentOverageFactor:
 			values[i] = &sql.NullScanner{S: new(decimal.Decimal)}
-		case subscriptionlineitem.FieldMetadata:
+		case subscriptionlineitem.FieldMetadata, subscriptionlineitem.FieldCommitmentTimeBuckets:
 			values[i] = new([]byte)
 		case subscriptionlineitem.FieldQuantity:
 			values[i] = new(decimal.Decimal)
@@ -405,6 +407,14 @@ func (sli *SubscriptionLineItem) assignValues(columns []string, values []any) er
 				sli.CommitmentDuration = new(types.BillingPeriod)
 				*sli.CommitmentDuration = types.BillingPeriod(value.String)
 			}
+		case subscriptionlineitem.FieldCommitmentTimeBuckets:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field commitment_time_buckets", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &sli.CommitmentTimeBuckets); err != nil {
+					return fmt.Errorf("unmarshal field commitment_time_buckets: %w", err)
+				}
+			}
 		default:
 			sli.selectValues.Set(columns[i], values[i])
 		}
@@ -592,6 +602,9 @@ func (sli *SubscriptionLineItem) String() string {
 		builder.WriteString("commitment_duration=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
+	builder.WriteString(", ")
+	builder.WriteString("commitment_time_buckets=")
+	builder.WriteString(fmt.Sprintf("%v", sli.CommitmentTimeBuckets))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/subscriptionlineitem/subscriptionlineitem.go
+++ b/ent/subscriptionlineitem/subscriptionlineitem.go
@@ -88,6 +88,8 @@ const (
 	FieldCommitmentWindowed = "commitment_windowed"
 	// FieldCommitmentDuration holds the string denoting the commitment_duration field in the database.
 	FieldCommitmentDuration = "commitment_duration"
+	// FieldCommitmentTimeBuckets holds the string denoting the commitment_time_buckets field in the database.
+	FieldCommitmentTimeBuckets = "commitment_time_buckets"
 	// EdgeSubscription holds the string denoting the subscription edge name in mutations.
 	EdgeSubscription = "subscription"
 	// EdgeCouponAssociations holds the string denoting the coupon_associations edge name in mutations.
@@ -149,6 +151,7 @@ var Columns = []string{
 	FieldCommitmentTrueUpEnabled,
 	FieldCommitmentWindowed,
 	FieldCommitmentDuration,
+	FieldCommitmentTimeBuckets,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/ent/subscriptionlineitem/where.go
+++ b/ent/subscriptionlineitem/where.go
@@ -2502,6 +2502,16 @@ func CommitmentDurationContainsFold(v types.BillingPeriod) predicate.Subscriptio
 	return predicate.SubscriptionLineItem(sql.FieldContainsFold(FieldCommitmentDuration, vc))
 }
 
+// CommitmentTimeBucketsIsNil applies the IsNil predicate on the "commitment_time_buckets" field.
+func CommitmentTimeBucketsIsNil() predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldIsNull(FieldCommitmentTimeBuckets))
+}
+
+// CommitmentTimeBucketsNotNil applies the NotNil predicate on the "commitment_time_buckets" field.
+func CommitmentTimeBucketsNotNil() predicate.SubscriptionLineItem {
+	return predicate.SubscriptionLineItem(sql.FieldNotNull(FieldCommitmentTimeBuckets))
+}
+
 // HasSubscription applies the HasEdge predicate on the "subscription" edge.
 func HasSubscription() predicate.SubscriptionLineItem {
 	return predicate.SubscriptionLineItem(func(s *sql.Selector) {

--- a/ent/subscriptionlineitem_create.go
+++ b/ent/subscriptionlineitem_create.go
@@ -472,6 +472,12 @@ func (slic *SubscriptionLineItemCreate) SetNillableCommitmentDuration(tp *types.
 	return slic
 }
 
+// SetCommitmentTimeBuckets sets the "commitment_time_buckets" field.
+func (slic *SubscriptionLineItemCreate) SetCommitmentTimeBuckets(todb types.TimeOfDayBuckets) *SubscriptionLineItemCreate {
+	slic.mutation.SetCommitmentTimeBuckets(todb)
+	return slic
+}
+
 // SetID sets the "id" field.
 func (slic *SubscriptionLineItemCreate) SetID(s string) *SubscriptionLineItemCreate {
 	slic.mutation.SetID(s)
@@ -837,6 +843,10 @@ func (slic *SubscriptionLineItemCreate) createSpec() (*SubscriptionLineItem, *sq
 	if value, ok := slic.mutation.CommitmentDuration(); ok {
 		_spec.SetField(subscriptionlineitem.FieldCommitmentDuration, field.TypeString, value)
 		_node.CommitmentDuration = &value
+	}
+	if value, ok := slic.mutation.CommitmentTimeBuckets(); ok {
+		_spec.SetField(subscriptionlineitem.FieldCommitmentTimeBuckets, field.TypeJSON, value)
+		_node.CommitmentTimeBuckets = value
 	}
 	if nodes := slic.mutation.SubscriptionIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/ent/subscriptionlineitem_update.go
+++ b/ent/subscriptionlineitem_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/couponassociation"
 	"github.com/flexprice/flexprice/ent/predicate"
@@ -488,6 +489,24 @@ func (sliu *SubscriptionLineItemUpdate) ClearCommitmentDuration() *SubscriptionL
 	return sliu
 }
 
+// SetCommitmentTimeBuckets sets the "commitment_time_buckets" field.
+func (sliu *SubscriptionLineItemUpdate) SetCommitmentTimeBuckets(todb types.TimeOfDayBuckets) *SubscriptionLineItemUpdate {
+	sliu.mutation.SetCommitmentTimeBuckets(todb)
+	return sliu
+}
+
+// AppendCommitmentTimeBuckets appends todb to the "commitment_time_buckets" field.
+func (sliu *SubscriptionLineItemUpdate) AppendCommitmentTimeBuckets(todb types.TimeOfDayBuckets) *SubscriptionLineItemUpdate {
+	sliu.mutation.AppendCommitmentTimeBuckets(todb)
+	return sliu
+}
+
+// ClearCommitmentTimeBuckets clears the value of the "commitment_time_buckets" field.
+func (sliu *SubscriptionLineItemUpdate) ClearCommitmentTimeBuckets() *SubscriptionLineItemUpdate {
+	sliu.mutation.ClearCommitmentTimeBuckets()
+	return sliu
+}
+
 // AddCouponAssociationIDs adds the "coupon_associations" edge to the CouponAssociation entity by IDs.
 func (sliu *SubscriptionLineItemUpdate) AddCouponAssociationIDs(ids ...string) *SubscriptionLineItemUpdate {
 	sliu.mutation.AddCouponAssociationIDs(ids...)
@@ -756,6 +775,17 @@ func (sliu *SubscriptionLineItemUpdate) sqlSave(ctx context.Context) (n int, err
 	}
 	if sliu.mutation.CommitmentDurationCleared() {
 		_spec.ClearField(subscriptionlineitem.FieldCommitmentDuration, field.TypeString)
+	}
+	if value, ok := sliu.mutation.CommitmentTimeBuckets(); ok {
+		_spec.SetField(subscriptionlineitem.FieldCommitmentTimeBuckets, field.TypeJSON, value)
+	}
+	if value, ok := sliu.mutation.AppendedCommitmentTimeBuckets(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, subscriptionlineitem.FieldCommitmentTimeBuckets, value)
+		})
+	}
+	if sliu.mutation.CommitmentTimeBucketsCleared() {
+		_spec.ClearField(subscriptionlineitem.FieldCommitmentTimeBuckets, field.TypeJSON)
 	}
 	if sliu.mutation.CouponAssociationsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1279,6 +1309,24 @@ func (sliuo *SubscriptionLineItemUpdateOne) ClearCommitmentDuration() *Subscript
 	return sliuo
 }
 
+// SetCommitmentTimeBuckets sets the "commitment_time_buckets" field.
+func (sliuo *SubscriptionLineItemUpdateOne) SetCommitmentTimeBuckets(todb types.TimeOfDayBuckets) *SubscriptionLineItemUpdateOne {
+	sliuo.mutation.SetCommitmentTimeBuckets(todb)
+	return sliuo
+}
+
+// AppendCommitmentTimeBuckets appends todb to the "commitment_time_buckets" field.
+func (sliuo *SubscriptionLineItemUpdateOne) AppendCommitmentTimeBuckets(todb types.TimeOfDayBuckets) *SubscriptionLineItemUpdateOne {
+	sliuo.mutation.AppendCommitmentTimeBuckets(todb)
+	return sliuo
+}
+
+// ClearCommitmentTimeBuckets clears the value of the "commitment_time_buckets" field.
+func (sliuo *SubscriptionLineItemUpdateOne) ClearCommitmentTimeBuckets() *SubscriptionLineItemUpdateOne {
+	sliuo.mutation.ClearCommitmentTimeBuckets()
+	return sliuo
+}
+
 // AddCouponAssociationIDs adds the "coupon_associations" edge to the CouponAssociation entity by IDs.
 func (sliuo *SubscriptionLineItemUpdateOne) AddCouponAssociationIDs(ids ...string) *SubscriptionLineItemUpdateOne {
 	sliuo.mutation.AddCouponAssociationIDs(ids...)
@@ -1577,6 +1625,17 @@ func (sliuo *SubscriptionLineItemUpdateOne) sqlSave(ctx context.Context) (_node 
 	}
 	if sliuo.mutation.CommitmentDurationCleared() {
 		_spec.ClearField(subscriptionlineitem.FieldCommitmentDuration, field.TypeString)
+	}
+	if value, ok := sliuo.mutation.CommitmentTimeBuckets(); ok {
+		_spec.SetField(subscriptionlineitem.FieldCommitmentTimeBuckets, field.TypeJSON, value)
+	}
+	if value, ok := sliuo.mutation.AppendedCommitmentTimeBuckets(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, subscriptionlineitem.FieldCommitmentTimeBuckets, value)
+		})
+	}
+	if sliuo.mutation.CommitmentTimeBucketsCleared() {
+		_spec.ClearField(subscriptionlineitem.FieldCommitmentTimeBuckets, field.TypeJSON)
 	}
 	if sliuo.mutation.CouponAssociationsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -100,6 +100,11 @@ type LineItemCommitmentConfig struct {
 
 	// CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)
 	CommitmentDuration *types.BillingPeriod `json:"commitment_duration,omitempty"`
+
+	// CommitmentTimeBuckets restricts commitment treatment to windows whose start
+	// UTC hour falls within one of the configured buckets. Empty/omitted = no
+	// restriction (commitment applies 24/7). Requires IsWindowCommitment=true.
+	CommitmentTimeBuckets types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
 
 // validateLineItemCommitments validates a map of price_id -> commitment configuration.
@@ -233,6 +238,19 @@ func (c *LineItemCommitmentConfig) Validate() error {
 				"commitment_quantity": c.CommitmentQuantity,
 			}).
 			Mark(ierr.ErrValidation)
+	}
+
+	// Rule 5: commitment_time_buckets only constrains the per-window application
+	// path — it has no meaning without is_window_commitment=true.
+	if len(c.CommitmentTimeBuckets) > 0 {
+		if c.IsWindowCommitment == nil || !*c.IsWindowCommitment {
+			return ierr.NewError("commitment_time_buckets requires is_window_commitment=true").
+				WithHint("Set is_window_commitment=true to apply commitment only during the configured hours").
+				Mark(ierr.ErrValidation)
+		}
+		if err := validateTimeOfDayBuckets(c.CommitmentTimeBuckets); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1330,13 +1330,14 @@ type SubscriptionLineItemRequest struct {
 	Metadata    map[string]string `json:"metadata,omitempty"`
 
 	// Commitment fields
-	CommitmentAmount        *decimal.Decimal     `json:"commitment_amount,omitempty"`
-	CommitmentQuantity      *decimal.Decimal     `json:"commitment_quantity,omitempty"`
-	CommitmentType          types.CommitmentType `json:"commitment_type,omitempty"`
-	CommitmentOverageFactor *decimal.Decimal     `json:"commitment_overage_factor,omitempty"`
-	CommitmentTrueUpEnabled bool                 `json:"commitment_true_up_enabled,omitempty"`
-	CommitmentWindowed      bool                 `json:"commitment_windowed,omitempty"`
-	CommitmentDuration      *types.BillingPeriod `json:"commitment_duration,omitempty"`
+	CommitmentAmount        *decimal.Decimal       `json:"commitment_amount,omitempty"`
+	CommitmentQuantity      *decimal.Decimal       `json:"commitment_quantity,omitempty"`
+	CommitmentType          types.CommitmentType   `json:"commitment_type,omitempty"`
+	CommitmentOverageFactor *decimal.Decimal       `json:"commitment_overage_factor,omitempty"`
+	CommitmentTrueUpEnabled bool                   `json:"commitment_true_up_enabled,omitempty"`
+	CommitmentWindowed      bool                   `json:"commitment_windowed,omitempty"`
+	CommitmentDuration      *types.BillingPeriod   `json:"commitment_duration,omitempty"`
+	CommitmentTimeBuckets   types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
 
 // SubscriptionLineItemResponse represents the response for a subscription line item
@@ -1757,6 +1758,9 @@ func (r *SubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.Context
 	lineItem.CommitmentWindowed = r.CommitmentWindowed
 	if r.CommitmentDuration != nil {
 		lineItem.CommitmentDuration = r.CommitmentDuration
+	}
+	if len(r.CommitmentTimeBuckets) > 0 {
+		lineItem.CommitmentTimeBuckets = r.CommitmentTimeBuckets
 	}
 
 	return lineItem

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1330,14 +1330,15 @@ type SubscriptionLineItemRequest struct {
 	Metadata    map[string]string `json:"metadata,omitempty"`
 
 	// Commitment fields
-	CommitmentAmount        *decimal.Decimal       `json:"commitment_amount,omitempty"`
-	CommitmentQuantity      *decimal.Decimal       `json:"commitment_quantity,omitempty"`
-	CommitmentType          types.CommitmentType   `json:"commitment_type,omitempty"`
-	CommitmentOverageFactor *decimal.Decimal       `json:"commitment_overage_factor,omitempty"`
-	CommitmentTrueUpEnabled bool                   `json:"commitment_true_up_enabled,omitempty"`
-	CommitmentWindowed      bool                   `json:"commitment_windowed,omitempty"`
-	CommitmentDuration      *types.BillingPeriod   `json:"commitment_duration,omitempty"`
-	CommitmentTimeBuckets   types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
+	CommitmentAmount        *decimal.Decimal     `json:"commitment_amount,omitempty"`
+	CommitmentQuantity      *decimal.Decimal     `json:"commitment_quantity,omitempty"`
+	CommitmentType          types.CommitmentType `json:"commitment_type,omitempty"`
+	CommitmentOverageFactor *decimal.Decimal     `json:"commitment_overage_factor,omitempty"`
+	CommitmentTrueUpEnabled bool                 `json:"commitment_true_up_enabled,omitempty"`
+	CommitmentWindowed      bool                 `json:"commitment_windowed,omitempty"`
+	CommitmentDuration      *types.BillingPeriod `json:"commitment_duration,omitempty"`
+	// CommitmentTimeBuckets - if provided, applies commitment only in specified time buckets
+	CommitmentTimeBuckets types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
 
 // SubscriptionLineItemResponse represents the response for a subscription line item

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -137,13 +137,13 @@ type UpdateSubscriptionLineItemRequest struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 
 	// Commitment fields
-	CommitmentAmount        *decimal.Decimal       `json:"commitment_amount,omitempty"`
-	CommitmentQuantity      *decimal.Decimal       `json:"commitment_quantity,omitempty"`
-	CommitmentType          types.CommitmentType   `json:"commitment_type,omitempty"`
-	CommitmentOverageFactor *decimal.Decimal       `json:"commitment_overage_factor,omitempty"`
-	CommitmentTrueUpEnabled *bool                  `json:"commitment_true_up_enabled,omitempty"`
-	CommitmentWindowed      *bool                  `json:"commitment_windowed,omitempty"`
-	CommitmentDuration      *types.BillingPeriod    `json:"commitment_duration,omitempty"`
+	CommitmentAmount        *decimal.Decimal     `json:"commitment_amount,omitempty"`
+	CommitmentQuantity      *decimal.Decimal     `json:"commitment_quantity,omitempty"`
+	CommitmentType          types.CommitmentType `json:"commitment_type,omitempty"`
+	CommitmentOverageFactor *decimal.Decimal     `json:"commitment_overage_factor,omitempty"`
+	CommitmentTrueUpEnabled *bool                `json:"commitment_true_up_enabled,omitempty"`
+	CommitmentWindowed      *bool                `json:"commitment_windowed,omitempty"`
+	CommitmentDuration      *types.BillingPeriod `json:"commitment_duration,omitempty"`
 	// Pointer so an explicit empty array can clear existing buckets (omission keeps them).
 	CommitmentTimeBuckets *types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
@@ -442,6 +442,9 @@ func (r *CreateSubscriptionLineItemRequest) validateCommitmentFields() error {
 			WithHint("Set commitment_windowed=true to apply commitment only during the configured hours").
 			Mark(ierr.ErrValidation)
 	}
+	if err := validateTimeOfDayBuckets(r.CommitmentTimeBuckets); err != nil {
+		return err
+	}
 
 	// Auto-set commitment type if not provided (only for create requests)
 	if r.HasCommitment() && r.CommitmentType == "" {
@@ -582,7 +585,9 @@ func (r *CreateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 		lineItem.CommitmentDuration = r.CommitmentDuration
 	}
 	if len(r.CommitmentTimeBuckets) > 0 {
-		lineItem.CommitmentTimeBuckets = r.CommitmentTimeBuckets
+		// Copy to avoid aliasing the request's backing array — mutations to r
+		// after validation must not bleed into the domain object.
+		lineItem.CommitmentTimeBuckets = append(types.TimeOfDayBuckets(nil), r.CommitmentTimeBuckets...)
 	}
 
 	return lineItem
@@ -631,6 +636,60 @@ func (r *UpdateSubscriptionLineItemRequest) validateCommitmentFields() error {
 		r.CommitmentWindowed != nil && !*r.CommitmentWindowed {
 		return ierr.NewError("commitment_time_buckets requires commitment_windowed=true").
 			WithHint("Set commitment_windowed=true to apply commitment only during the configured hours").
+			Mark(ierr.ErrValidation)
+	}
+	if r.CommitmentTimeBuckets != nil {
+		if err := validateTimeOfDayBuckets(*r.CommitmentTimeBuckets); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateTimeOfDayBuckets enforces per-bucket Hour ∈ [0, 24] and Minute ∈ [0, 59],
+// rejecting Hour=24 combined with Minute>0 (only 24:00 is a meaningful end-of-day).
+func validateTimeOfDayBuckets(buckets types.TimeOfDayBuckets) error {
+	for i, b := range buckets {
+		if err := validateBucketPoint(b.Start, "start_bucket", i); err != nil {
+			return err
+		}
+		if err := validateBucketPoint(b.End, "end_bucket", i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBucketPoint(b types.Bucket, field string, idx int) error {
+	if b.Hour < 0 || b.Hour > 24 {
+		return ierr.NewError("commitment_time_buckets: hour out of range").
+			WithHint("Hour must be in [0, 24]").
+			WithReportableDetails(map[string]interface{}{
+				"index": idx,
+				"field": field,
+				"hour":  b.Hour,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	if b.Minute < 0 || b.Minute > 59 {
+		return ierr.NewError("commitment_time_buckets: minute out of range").
+			WithHint("Minute must be in [0, 59]").
+			WithReportableDetails(map[string]interface{}{
+				"index":  idx,
+				"field":  field,
+				"minute": b.Minute,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	if b.Hour == 24 && b.Minute > 0 {
+		return ierr.NewError("commitment_time_buckets: 24:00 is the only allowed end-of-day value").
+			WithHint("Hour=24 must have Minute=0").
+			WithReportableDetails(map[string]interface{}{
+				"index":  idx,
+				"field":  field,
+				"hour":   b.Hour,
+				"minute": b.Minute,
+			}).
 			Mark(ierr.ErrValidation)
 	}
 	return nil

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -143,8 +143,9 @@ type UpdateSubscriptionLineItemRequest struct {
 	CommitmentOverageFactor *decimal.Decimal       `json:"commitment_overage_factor,omitempty"`
 	CommitmentTrueUpEnabled *bool                  `json:"commitment_true_up_enabled,omitempty"`
 	CommitmentWindowed      *bool                  `json:"commitment_windowed,omitempty"`
-	CommitmentDuration      *types.BillingPeriod   `json:"commitment_duration,omitempty"`
-	CommitmentTimeBuckets   types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
+	CommitmentDuration      *types.BillingPeriod    `json:"commitment_duration,omitempty"`
+	// Pointer so an explicit empty array can clear existing buckets (omission keeps them).
+	CommitmentTimeBuckets *types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
 
 // LineItemParams contains all necessary parameters for creating a line item
@@ -434,6 +435,14 @@ func (r *CreateSubscriptionLineItemRequest) validateCommitmentFields() error {
 		return err
 	}
 
+	// commitment_time_buckets only constrains the commitment-application window —
+	// it has no meaning unless commitment_windowed is true.
+	if len(r.CommitmentTimeBuckets) > 0 && !r.CommitmentWindowed {
+		return ierr.NewError("commitment_time_buckets requires commitment_windowed=true").
+			WithHint("Set commitment_windowed=true to apply commitment only during the configured hours").
+			Mark(ierr.ErrValidation)
+	}
+
 	// Auto-set commitment type if not provided (only for create requests)
 	if r.HasCommitment() && r.CommitmentType == "" {
 		hasAmountCommitment := r.CommitmentAmount != nil && r.CommitmentAmount.GreaterThan(decimal.Zero)
@@ -604,13 +613,27 @@ func (r *UpdateSubscriptionLineItemRequest) Validate() error {
 // validateCommitmentFields validates commitment-related fields for update request
 func (r *UpdateSubscriptionLineItemRequest) validateCommitmentFields() error {
 	// Use shared validation logic (update requests require explicit commitment type)
-	return validateCommitmentFieldsCommon(
+	if err := validateCommitmentFieldsCommon(
 		r.CommitmentAmount,
 		r.CommitmentQuantity,
 		r.CommitmentType,
 		r.CommitmentOverageFactor,
 		false, // isCreateRequest
-	)
+	); err != nil {
+		return err
+	}
+
+	// commitment_time_buckets only constrains the commitment-application window —
+	// it has no meaning unless commitment_windowed is true. We can only enforce this
+	// when both fields are explicitly provided in the update; cross-checks against
+	// the existing line item's windowed flag happen at the service layer.
+	if r.CommitmentTimeBuckets != nil && len(*r.CommitmentTimeBuckets) > 0 &&
+		r.CommitmentWindowed != nil && !*r.CommitmentWindowed {
+		return ierr.NewError("commitment_time_buckets requires commitment_windowed=true").
+			WithHint("Set commitment_windowed=true to apply commitment only during the configured hours").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
 }
 
 // ShouldCreateNewLineItem checks if the request contains any critical fields that require creating a new line item
@@ -625,7 +648,7 @@ func (r *UpdateSubscriptionLineItemRequest) ShouldCreateNewLineItem() bool {
 		r.CommitmentTrueUpEnabled != nil ||
 		r.CommitmentWindowed != nil ||
 		r.CommitmentDuration != nil ||
-		len(r.CommitmentTimeBuckets) > 0
+		r.CommitmentTimeBuckets != nil
 }
 
 // ToSubscriptionLineItem converts the update request to a domain subscription line item
@@ -702,8 +725,8 @@ func (r *UpdateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 		newLineItem.CommitmentDuration = existingLineItem.CommitmentDuration
 	}
 
-	if len(r.CommitmentTimeBuckets) > 0 {
-		newLineItem.CommitmentTimeBuckets = r.CommitmentTimeBuckets
+	if r.CommitmentTimeBuckets != nil {
+		newLineItem.CommitmentTimeBuckets = append(types.TimeOfDayBuckets(nil), (*r.CommitmentTimeBuckets)...)
 	} else {
 		newLineItem.CommitmentTimeBuckets = existingLineItem.CommitmentTimeBuckets
 	}

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -97,13 +97,14 @@ type CreateSubscriptionLineItemRequest struct {
 	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
 
 	// Commitment fields
-	CommitmentAmount        *decimal.Decimal     `json:"commitment_amount,omitempty"`
-	CommitmentQuantity      *decimal.Decimal     `json:"commitment_quantity,omitempty"`
-	CommitmentType          types.CommitmentType `json:"commitment_type,omitempty"`
-	CommitmentOverageFactor *decimal.Decimal     `json:"commitment_overage_factor,omitempty"`
-	CommitmentTrueUpEnabled bool                 `json:"commitment_true_up_enabled,omitempty"`
-	CommitmentWindowed      bool                 `json:"commitment_windowed,omitempty"`
-	CommitmentDuration      *types.BillingPeriod `json:"commitment_duration,omitempty"`
+	CommitmentAmount        *decimal.Decimal       `json:"commitment_amount,omitempty"`
+	CommitmentQuantity      *decimal.Decimal       `json:"commitment_quantity,omitempty"`
+	CommitmentType          types.CommitmentType   `json:"commitment_type,omitempty"`
+	CommitmentOverageFactor *decimal.Decimal       `json:"commitment_overage_factor,omitempty"`
+	CommitmentTrueUpEnabled bool                   `json:"commitment_true_up_enabled,omitempty"`
+	CommitmentWindowed      bool                   `json:"commitment_windowed,omitempty"`
+	CommitmentDuration      *types.BillingPeriod   `json:"commitment_duration,omitempty"`
+	CommitmentTimeBuckets   types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
 
 // DeleteSubscriptionLineItemRequest represents the request to delete a subscription line item
@@ -136,13 +137,14 @@ type UpdateSubscriptionLineItemRequest struct {
 	Metadata map[string]string `json:"metadata,omitempty"`
 
 	// Commitment fields
-	CommitmentAmount        *decimal.Decimal     `json:"commitment_amount,omitempty"`
-	CommitmentQuantity      *decimal.Decimal     `json:"commitment_quantity,omitempty"`
-	CommitmentType          types.CommitmentType `json:"commitment_type,omitempty"`
-	CommitmentOverageFactor *decimal.Decimal     `json:"commitment_overage_factor,omitempty"`
-	CommitmentTrueUpEnabled *bool                `json:"commitment_true_up_enabled,omitempty"`
-	CommitmentWindowed      *bool                `json:"commitment_windowed,omitempty"`
-	CommitmentDuration      *types.BillingPeriod `json:"commitment_duration,omitempty"`
+	CommitmentAmount        *decimal.Decimal       `json:"commitment_amount,omitempty"`
+	CommitmentQuantity      *decimal.Decimal       `json:"commitment_quantity,omitempty"`
+	CommitmentType          types.CommitmentType   `json:"commitment_type,omitempty"`
+	CommitmentOverageFactor *decimal.Decimal       `json:"commitment_overage_factor,omitempty"`
+	CommitmentTrueUpEnabled *bool                  `json:"commitment_true_up_enabled,omitempty"`
+	CommitmentWindowed      *bool                  `json:"commitment_windowed,omitempty"`
+	CommitmentDuration      *types.BillingPeriod   `json:"commitment_duration,omitempty"`
+	CommitmentTimeBuckets   types.TimeOfDayBuckets `json:"commitment_time_buckets,omitempty"`
 }
 
 // LineItemParams contains all necessary parameters for creating a line item
@@ -570,6 +572,9 @@ func (r *CreateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 	if r.CommitmentDuration != nil {
 		lineItem.CommitmentDuration = r.CommitmentDuration
 	}
+	if len(r.CommitmentTimeBuckets) > 0 {
+		lineItem.CommitmentTimeBuckets = r.CommitmentTimeBuckets
+	}
 
 	return lineItem
 }
@@ -619,7 +624,8 @@ func (r *UpdateSubscriptionLineItemRequest) ShouldCreateNewLineItem() bool {
 		r.CommitmentOverageFactor != nil ||
 		r.CommitmentTrueUpEnabled != nil ||
 		r.CommitmentWindowed != nil ||
-		r.CommitmentDuration != nil
+		r.CommitmentDuration != nil ||
+		len(r.CommitmentTimeBuckets) > 0
 }
 
 // ToSubscriptionLineItem converts the update request to a domain subscription line item
@@ -694,6 +700,12 @@ func (r *UpdateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 		newLineItem.CommitmentDuration = r.CommitmentDuration
 	} else {
 		newLineItem.CommitmentDuration = existingLineItem.CommitmentDuration
+	}
+
+	if len(r.CommitmentTimeBuckets) > 0 {
+		newLineItem.CommitmentTimeBuckets = r.CommitmentTimeBuckets
+	} else {
+		newLineItem.CommitmentTimeBuckets = existingLineItem.CommitmentTimeBuckets
 	}
 
 	return newLineItem

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -587,7 +587,9 @@ func (r *CreateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 	if len(r.CommitmentTimeBuckets) > 0 {
 		// Copy to avoid aliasing the request's backing array — mutations to r
 		// after validation must not bleed into the domain object.
-		lineItem.CommitmentTimeBuckets = append(types.TimeOfDayBuckets(nil), r.CommitmentTimeBuckets...)
+		commitmentTimeBuckets := make(types.TimeOfDayBuckets, len(r.CommitmentTimeBuckets))
+		copy(commitmentTimeBuckets, r.CommitmentTimeBuckets)
+		lineItem.CommitmentTimeBuckets = commitmentTimeBuckets
 	}
 
 	return lineItem
@@ -650,23 +652,22 @@ func (r *UpdateSubscriptionLineItemRequest) validateCommitmentFields() error {
 // rejecting Hour=24 combined with Minute>0 (only 24:00 is a meaningful end-of-day).
 func validateTimeOfDayBuckets(buckets types.TimeOfDayBuckets) error {
 	for i, b := range buckets {
-		if err := validateBucketPoint(b.Start, "start_bucket", i); err != nil {
+		if err := validateBucketPoint(b.Start, i); err != nil {
 			return err
 		}
-		if err := validateBucketPoint(b.End, "end_bucket", i); err != nil {
+		if err := validateBucketPoint(b.End, i); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateBucketPoint(b types.Bucket, field string, idx int) error {
+func validateBucketPoint(b types.Bucket, idx int) error {
 	if b.Hour < 0 || b.Hour > 24 {
 		return ierr.NewError("commitment_time_buckets: hour out of range").
 			WithHint("Hour must be in [0, 24]").
 			WithReportableDetails(map[string]interface{}{
 				"index": idx,
-				"field": field,
 				"hour":  b.Hour,
 			}).
 			Mark(ierr.ErrValidation)
@@ -676,7 +677,6 @@ func validateBucketPoint(b types.Bucket, field string, idx int) error {
 			WithHint("Minute must be in [0, 59]").
 			WithReportableDetails(map[string]interface{}{
 				"index":  idx,
-				"field":  field,
 				"minute": b.Minute,
 			}).
 			Mark(ierr.ErrValidation)
@@ -686,7 +686,6 @@ func validateBucketPoint(b types.Bucket, field string, idx int) error {
 			WithHint("Hour=24 must have Minute=0").
 			WithReportableDetails(map[string]interface{}{
 				"index":  idx,
-				"field":  field,
 				"hour":   b.Hour,
 				"minute": b.Minute,
 			}).
@@ -785,7 +784,9 @@ func (r *UpdateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 	}
 
 	if r.CommitmentTimeBuckets != nil {
-		newLineItem.CommitmentTimeBuckets = append(types.TimeOfDayBuckets(nil), (*r.CommitmentTimeBuckets)...)
+		commitmentTimeBuckets := make(types.TimeOfDayBuckets, len(*r.CommitmentTimeBuckets))
+		copy(commitmentTimeBuckets, *r.CommitmentTimeBuckets)
+		newLineItem.CommitmentTimeBuckets = commitmentTimeBuckets
 	} else {
 		newLineItem.CommitmentTimeBuckets = existingLineItem.CommitmentTimeBuckets
 	}

--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -46,9 +46,6 @@ type MeterUsageQueryParams struct {
 	PropertyFilters map[string][]string
 	// Sources restricts events to those whose source is in the list.
 	Sources []string
-	// CommitmentTimeBuckets restricts counted events to those whose UTC hour falls
-	// within one of the configured buckets. Empty = no restriction.
-	CommitmentTimeBuckets types.TimeOfDayBuckets
 }
 
 // MeterUsageResult represents a single time-bucketed aggregation point

--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -46,6 +46,9 @@ type MeterUsageQueryParams struct {
 	PropertyFilters map[string][]string
 	// Sources restricts events to those whose source is in the list.
 	Sources []string
+	// CommitmentTimeBuckets restricts counted events to those whose UTC hour falls
+	// within one of the configured buckets. Empty = no restriction.
+	CommitmentTimeBuckets types.TimeOfDayBuckets
 }
 
 // MeterUsageResult represents a single time-bucketed aggregation point

--- a/internal/domain/subscription/line_item.go
+++ b/internal/domain/subscription/line_item.go
@@ -38,14 +38,14 @@ type SubscriptionLineItem struct {
 	EnvironmentID       string                               `db:"environment_id" json:"environment_id"`
 
 	// Commitment fields
-	CommitmentAmount        *decimal.Decimal     `db:"commitment_amount" json:"commitment_amount,omitempty" swaggertype:"string"`
-	CommitmentQuantity      *decimal.Decimal     `db:"commitment_quantity" json:"commitment_quantity,omitempty" swaggertype:"string"`
-	CommitmentType          types.CommitmentType `db:"commitment_type" json:"commitment_type,omitempty"`
-	CommitmentOverageFactor *decimal.Decimal     `db:"commitment_overage_factor" json:"commitment_overage_factor,omitempty" swaggertype:"string"`
-	CommitmentTrueUpEnabled bool                 `db:"commitment_true_up_enabled" json:"commitment_true_up_enabled"`
-	CommitmentWindowed      bool                 `db:"commitment_windowed" json:"commitment_windowed"`
+	CommitmentAmount        *decimal.Decimal       `db:"commitment_amount" json:"commitment_amount,omitempty" swaggertype:"string"`
+	CommitmentQuantity      *decimal.Decimal       `db:"commitment_quantity" json:"commitment_quantity,omitempty" swaggertype:"string"`
+	CommitmentType          types.CommitmentType   `db:"commitment_type" json:"commitment_type,omitempty"`
+	CommitmentOverageFactor *decimal.Decimal       `db:"commitment_overage_factor" json:"commitment_overage_factor,omitempty" swaggertype:"string"`
+	CommitmentTrueUpEnabled bool                   `db:"commitment_true_up_enabled" json:"commitment_true_up_enabled"`
+	CommitmentWindowed      bool                   `db:"commitment_windowed" json:"commitment_windowed"`
 	CommitmentDuration      *types.BillingPeriod   `db:"commitment_duration" json:"commitment_duration,omitempty"`
-	CommitmentTimeBuckets  types.TimeOfDayBuckets `db:"commitment_time_buckets" json:"commitment_time_buckets,omitempty"`
+	CommitmentTimeBuckets   types.TimeOfDayBuckets `db:"commitment_time_buckets" json:"commitment_time_buckets,omitempty"`
 
 	Price *price.Price `json:"price,omitempty"`
 
@@ -194,8 +194,8 @@ func SubscriptionLineItemFromEnt(e *ent.SubscriptionLineItem) *SubscriptionLineI
 		CommitmentOverageFactor: e.CommitmentOverageFactor,
 		CommitmentTrueUpEnabled: e.CommitmentTrueUpEnabled,
 		CommitmentWindowed:      e.CommitmentWindowed,
-		CommitmentDuration:     commitmentDuration,
-		CommitmentTimeBuckets: e.CommitmentTimeBuckets,
+		CommitmentDuration:      commitmentDuration,
+		CommitmentTimeBuckets:   e.CommitmentTimeBuckets,
 		BaseModel: types.BaseModel{
 			TenantID:  e.TenantID,
 			Status:    types.Status(e.Status),

--- a/internal/domain/subscription/line_item.go
+++ b/internal/domain/subscription/line_item.go
@@ -44,7 +44,8 @@ type SubscriptionLineItem struct {
 	CommitmentOverageFactor *decimal.Decimal     `db:"commitment_overage_factor" json:"commitment_overage_factor,omitempty" swaggertype:"string"`
 	CommitmentTrueUpEnabled bool                 `db:"commitment_true_up_enabled" json:"commitment_true_up_enabled"`
 	CommitmentWindowed      bool                 `db:"commitment_windowed" json:"commitment_windowed"`
-	CommitmentDuration      *types.BillingPeriod `db:"commitment_duration" json:"commitment_duration,omitempty"`
+	CommitmentDuration      *types.BillingPeriod   `db:"commitment_duration" json:"commitment_duration,omitempty"`
+	CommitmentTimeBuckets  types.TimeOfDayBuckets `db:"commitment_time_buckets" json:"commitment_time_buckets,omitempty"`
 
 	Price *price.Price `json:"price,omitempty"`
 
@@ -80,6 +81,11 @@ func (li *SubscriptionLineItem) IsUsage() bool {
 // (i.e. BillingPeriod == BILLING_PERIOD_ONETIME).
 func (li *SubscriptionLineItem) IsOneTime() bool {
 	return li.BillingPeriod == types.BILLING_PERIOD_ONETIME
+}
+
+// HasCommitmentTimeBuckets returns true when time-of-day filtering is configured.
+func (li *SubscriptionLineItem) HasCommitmentTimeBuckets() bool {
+	return len(li.CommitmentTimeBuckets) > 0
 }
 
 // HasCommitment returns true if the line item has commitment configured
@@ -188,7 +194,8 @@ func SubscriptionLineItemFromEnt(e *ent.SubscriptionLineItem) *SubscriptionLineI
 		CommitmentOverageFactor: e.CommitmentOverageFactor,
 		CommitmentTrueUpEnabled: e.CommitmentTrueUpEnabled,
 		CommitmentWindowed:      e.CommitmentWindowed,
-		CommitmentDuration:      commitmentDuration,
+		CommitmentDuration:     commitmentDuration,
+		CommitmentTimeBuckets: e.CommitmentTimeBuckets,
 		BaseModel: types.BaseModel{
 			TenantID:  e.TenantID,
 			Status:    types.Status(e.Status),

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -118,6 +118,26 @@ func (qb *MeterUsageQueryBuilder) BuildWhereClause(params *events.MeterUsageQuer
 		args = append(args, addArgs...)
 	}
 
+	// Commitment time-of-day buckets: restrict to events within configured hour ranges.
+	// Uses ClickHouse toHour(timestamp) which returns 0-23 based on UTC.
+	// Multiple buckets are OR'd; literals are used (not bind params) since toHour returns int.
+	if len(params.CommitmentTimeBuckets) > 0 {
+		parts := make([]string, 0, len(params.CommitmentTimeBuckets))
+		for _, b := range params.CommitmentTimeBuckets {
+			if b.StartHour < b.EndHour {
+				parts = append(parts, fmt.Sprintf(
+					"(toHour(timestamp) >= %d AND toHour(timestamp) < %d)",
+					b.StartHour, b.EndHour))
+			} else {
+				// Midnight-wrapping bucket: e.g. {22, 6}
+				parts = append(parts, fmt.Sprintf(
+					"(toHour(timestamp) >= %d OR toHour(timestamp) < %d)",
+					b.StartHour, b.EndHour))
+			}
+		}
+		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
+	}
+
 	return strings.Join(conditions, " AND "), args
 }
 

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -118,26 +118,6 @@ func (qb *MeterUsageQueryBuilder) BuildWhereClause(params *events.MeterUsageQuer
 		args = append(args, addArgs...)
 	}
 
-	// Commitment time-of-day buckets: restrict to events within configured hour ranges.
-	// Uses ClickHouse toHour(timestamp) which returns 0-23 based on UTC.
-	// Multiple buckets are OR'd; literals are used (not bind params) since toHour returns int.
-	if len(params.CommitmentTimeBuckets) > 0 {
-		parts := make([]string, 0, len(params.CommitmentTimeBuckets))
-		for _, b := range params.CommitmentTimeBuckets {
-			if b.StartHour < b.EndHour {
-				parts = append(parts, fmt.Sprintf(
-					"(toHour(timestamp) >= %d AND toHour(timestamp) < %d)",
-					b.StartHour, b.EndHour))
-			} else {
-				// Midnight-wrapping bucket: e.g. {22, 6}
-				parts = append(parts, fmt.Sprintf(
-					"(toHour(timestamp) >= %d OR toHour(timestamp) < %d)",
-					b.StartHour, b.EndHour))
-			}
-		}
-		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
-	}
-
 	return strings.Join(conditions, " AND "), args
 }
 

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -423,6 +423,7 @@ func (r *subscriptionLineItemRepository) CreateBulk(ctx context.Context, items [
 			SetNillableEndDate(types.ToNillableTime(item.EndDate)).
 			SetNillableSubscriptionPhaseID(item.SubscriptionPhaseID).
 			SetMetadata(item.Metadata).
+			SetCommitmentTimeBuckets(item.CommitmentTimeBuckets).
 			SetTenantID(item.TenantID).
 			SetEnvironmentID(item.EnvironmentID).
 			SetStatus(string(item.Status)).

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -120,6 +120,7 @@ func (r *subscriptionLineItemRepository) Create(ctx context.Context, item *subsc
 		SetNillableCommitmentOverageFactor(item.CommitmentOverageFactor).
 		SetCommitmentTrueUpEnabled(item.CommitmentTrueUpEnabled).
 		SetCommitmentWindowed(item.CommitmentWindowed).
+		SetCommitmentTimeBuckets(item.CommitmentTimeBuckets).
 		SetTenantID(item.TenantID).
 		SetEnvironmentID(item.EnvironmentID).
 		SetStatus(string(item.Status)).
@@ -254,6 +255,7 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 		SetNillableCommitmentOverageFactor(item.CommitmentOverageFactor).
 		SetCommitmentTrueUpEnabled(item.CommitmentTrueUpEnabled).
 		SetCommitmentWindowed(item.CommitmentWindowed).
+		SetCommitmentTimeBuckets(item.CommitmentTimeBuckets).
 		SetStatus(string(item.Status)).
 		SetUpdatedBy(item.UpdatedBy).
 		SetUpdatedAt(time.Now()).

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -785,7 +785,7 @@ func (s *billingService) CalculateUsageCharges(
 							return nil, err
 						}
 
-						bucketedValues := s.fillBucketedValuesForWindowedCommitment(
+						bucketedValues, bucketStarts := s.fillBucketedValuesForWindowedCommitment(
 							item,
 							usageResult,
 							item.GetPeriodStart(periodStart),
@@ -797,7 +797,7 @@ func (s *billingService) CalculateUsageCharges(
 
 						// Apply window-based commitment
 						adjustedAmount, info, err := commitmentCalc.applyWindowCommitmentToLineItem(
-							ctx, item, bucketedValues, matchingCharge.Price)
+							ctx, item, bucketedValues, bucketStarts, matchingCharge.Price)
 						if err != nil {
 							return nil, err
 						}
@@ -1054,6 +1054,10 @@ func aggregateUsageResultsByWindow(results []events.UsageResult, aggType types.A
 // value per window using aggType (SUM or MAX). When CommitmentTrueUpEnabled is true, fills
 // missing buckets (no usage) with zero so that windowed commitment true-up is applied to
 // every window. Otherwise returns one value per unique window in sorted order.
+// fillBucketedValuesForWindowedCommitment returns parallel slices of bucket values
+// and their corresponding window starts. The two slices are 1:1 — bucketStarts[i] is
+// the start timestamp of the window whose usage is bucketedValues[i]. Returns
+// (nil, nil) when there is no usage data to bucket.
 func (s *billingService) fillBucketedValuesForWindowedCommitment(
 	item *subscription.SubscriptionLineItem,
 	usageResult *events.AggregationResult,
@@ -1061,9 +1065,9 @@ func (s *billingService) fillBucketedValuesForWindowedCommitment(
 	bucketSize types.WindowSize,
 	billingAnchor *time.Time,
 	aggType types.AggregationType,
-) []decimal.Decimal {
+) ([]decimal.Decimal, []time.Time) {
 	if usageResult == nil {
-		return nil
+		return nil, nil
 	}
 	usageByWindow := aggregateUsageResultsByWindow(usageResult.Results, aggType)
 	if !item.CommitmentTrueUpEnabled {
@@ -1077,11 +1081,11 @@ func (s *billingService) fillBucketedValuesForWindowedCommitment(
 		for i, t := range keys {
 			bucketedValues[i] = usageByWindow[t]
 		}
-		return bucketedValues
+		return bucketedValues, keys
 	}
 	expectedStarts := generateBucketStarts(periodStart, periodEnd, bucketSize, billingAnchor)
 	if len(expectedStarts) == 0 {
-		return nil
+		return nil, nil
 	}
 	bucketedValues := make([]decimal.Decimal, 0, len(expectedStarts))
 	for _, t := range expectedStarts {
@@ -1091,7 +1095,7 @@ func (s *billingService) fillBucketedValuesForWindowedCommitment(
 			bucketedValues = append(bucketedValues, decimal.Zero)
 		}
 	}
-	return bucketedValues
+	return bucketedValues, expectedStarts
 }
 
 func (s *billingService) CalculateFeatureUsageCharges(
@@ -1609,7 +1613,7 @@ func (s *billingService) CalculateFeatureUsageCharges(
 							commitmentUsageResult = fetchedResult
 						}
 
-						bucketedValues := s.fillBucketedValuesForWindowedCommitment(
+						bucketedValues, bucketStarts := s.fillBucketedValuesForWindowedCommitment(
 							item,
 							commitmentUsageResult,
 							linePeriodStart,
@@ -1620,8 +1624,7 @@ func (s *billingService) CalculateFeatureUsageCharges(
 						)
 
 						// Apply window-based commitment
-						adjustedAmount, info, err := commitmentCalc.applyWindowCommitmentToLineItem(
-							ctx, item, bucketedValues, matchingCharge.Price)
+						adjustedAmount, info, err := commitmentCalc.applyWindowCommitmentToLineItem(ctx, item, bucketedValues, bucketStarts, matchingCharge.Price)
 						if err != nil {
 							return nil, err
 						}

--- a/internal/service/billing_commitment.go
+++ b/internal/service/billing_commitment.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
@@ -227,14 +228,36 @@ func (c *commitmentCalculator) applyCommitmentToLineItem(
 	return finalCharge, info, nil
 }
 
-// applyWindowCommitmentToLineItem applies window-based commitment logic
-// Processes each bucket individually and applies commitment per window
+// applyWindowCommitmentToLineItem applies window-based commitment logic.
+// Processes each bucket individually and applies commitment per window.
+//
+// bucketStarts is the start timestamp of each window in bucketedValues. Pass nil
+// when the caller has no per-window timestamps (in which case time-of-day filtering
+// is skipped and every window goes through the normal commitment path). When
+// non-nil, bucketStarts MUST be the same length as bucketedValues — the two slices
+// are 1:1 (bucketStarts[i] is the start of the window whose usage is bucketedValues[i]).
+//
+// When lineItem.CommitmentTimeBuckets is set AND bucketStarts is provided, windows
+// whose start hour falls outside the configured buckets are billed at the base
+// usage rate with no commitment credit, no overage premium, and no true-up.
 func (c *commitmentCalculator) applyWindowCommitmentToLineItem(
 	ctx context.Context,
 	lineItem *subscription.SubscriptionLineItem,
 	bucketedValues []decimal.Decimal,
+	bucketStarts []time.Time,
 	priceObj *price.Price,
 ) (decimal.Decimal, *types.CommitmentInfo, error) {
+	// Defensive: when starts are provided, they must align with values.
+	if bucketStarts != nil && len(bucketStarts) != len(bucketedValues) {
+		return decimal.Zero, nil, ierr.NewError("bucketStarts/bucketedValues length mismatch").
+			WithHint("When bucketStarts is non-nil, it must have the same length as bucketedValues").
+			WithReportableDetails(map[string]interface{}{
+				"bucket_starts": len(bucketStarts),
+				"bucket_values": len(bucketedValues),
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
 	// Normalize commitment to amount (this is the per-window commitment)
 	commitmentAmountPerWindow, err := c.normalizeCommitmentToAmount(ctx, lineItem, priceObj)
 	if err != nil {
@@ -258,10 +281,20 @@ func (c *commitmentCalculator) applyWindowCommitmentToLineItem(
 	windowsWithOverage := 0
 	windowsWithTrueUp := 0
 
+	// Time-of-day filter applies only when the line item has buckets configured
+	// AND the caller provided per-window timestamps to check against.
+	hasTimeBuckets := lineItem.HasCommitmentTimeBuckets() && bucketStarts != nil
+
 	// Process each window independently
-	for _, bucketValue := range bucketedValues {
+	for i, bucketValue := range bucketedValues {
 		// Calculate cost for this window
 		windowCost := c.priceService.CalculateCost(ctx, priceObj, bucketValue)
+
+		// Out-of-bucket windows: bill at base usage rate, no commitment logic.
+		if hasTimeBuckets && !lineItem.CommitmentTimeBuckets.ContainsTime(bucketStarts[i]) {
+			totalCharge = totalCharge.Add(windowCost)
+			continue
+		}
 
 		var windowCharge decimal.Decimal
 

--- a/internal/service/billing_commitment.go
+++ b/internal/service/billing_commitment.go
@@ -335,13 +335,13 @@ func (c *commitmentCalculator) applyWindowCommitmentToLineItem(
 
 // CumulativeSubscriptionCommitmentResult holds the result of applying cumulative subscription commitment
 type CumulativeSubscriptionCommitmentResult struct {
-	TotalCharge            decimal.Decimal
-	CommitmentUtilized     decimal.Decimal
-	OverageAmount          decimal.Decimal
-	TrueUpAmount           decimal.Decimal
-	WithinCommitment       decimal.Decimal
-	OverageBase            decimal.Decimal
-	CommitmentRemaining    decimal.Decimal
+	TotalCharge         decimal.Decimal
+	CommitmentUtilized  decimal.Decimal
+	OverageAmount       decimal.Decimal
+	TrueUpAmount        decimal.Decimal
+	WithinCommitment    decimal.Decimal
+	OverageBase         decimal.Decimal
+	CommitmentRemaining decimal.Decimal
 }
 
 // applyCumulativeSubscriptionCommitment applies cumulative commitment logic at subscription level.

--- a/internal/service/billing_commitment_test.go
+++ b/internal/service/billing_commitment_test.go
@@ -4,7 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,4 +86,193 @@ func TestGenerateBucketStarts_Month_WithAnchor_StartBeforeAnchorDay(t *testing.T
 	assert.True(t, out[0].Equal(time.Date(2023, 12, 5, 0, 0, 0, 0, time.UTC)))
 	assert.True(t, out[1].Equal(time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)))
 	assert.True(t, out[2].Equal(time.Date(2024, 2, 5, 0, 0, 0, 0, time.UTC)))
+}
+
+// newCommitmentCalculatorForTest builds a calculator with a real PriceService
+// backed by in-memory stores so flat-fee CalculateCost works deterministically.
+func newCommitmentCalculatorForTest(t *testing.T) *commitmentCalculator {
+	t.Helper()
+	log := logger.GetLogger()
+	params := ServiceParams{
+		Logger:        log,
+		DB:            testutil.NewMockPostgresClient(log),
+		PriceRepo:     testutil.NewInMemoryPriceStore(),
+		MeterRepo:     testutil.NewInMemoryMeterStore(),
+		PlanRepo:      testutil.NewInMemoryPlanStore(),
+		PriceUnitRepo: testutil.NewInMemoryPriceUnitStore(),
+		AddonRepo:     testutil.NewInMemoryAddonStore(),
+		SubRepo:       testutil.NewInMemorySubscriptionStore(),
+	}
+	return newCommitmentCalculator(log, NewPriceService(params))
+}
+
+// flatFeePrice returns a flat-fee USAGE price priced at unitAmount per unit.
+// Used by windowed-commitment tests where CalculateCost must be linear.
+func flatFeePrice(unitAmount decimal.Decimal) *price.Price {
+	amt := unitAmount
+	return &price.Price{
+		ID:           "price_flat_test",
+		Amount:       amt,
+		Currency:     "usd",
+		Type:         types.PRICE_TYPE_USAGE,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE,
+	}
+}
+
+// TestApplyWindowCommitment_TimeBuckets_FilterOutOfBucketWindow exercises the
+// invoice/billing pipeline contract: windows whose start hour falls outside the
+// configured CommitmentTimeBuckets are billed at base usage rate, with no
+// commitment credit, no overage premium, and no true-up.
+func TestApplyWindowCommitment_TimeBuckets_FilterOutOfBucketWindow(t *testing.T) {
+	ctx := testutil.SetupContext()
+	calc := newCommitmentCalculatorForTest(t)
+
+	commitmentAmount := decimal.NewFromInt(10) // $10 commitment per window
+	overageFactor := decimal.NewFromInt(2)
+	lineItem := &subscription.SubscriptionLineItem{
+		ID:                      "sub_li_tb_test",
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		CommitmentWindowed:      true,
+		// Business hours window: only 09:00-17:00 UTC gets commitment treatment.
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{Start: types.Bucket{Hour: 9, Minute: 0}, End: types.Bucket{Hour: 17, Minute: 0}},
+		},
+	}
+
+	unitAmount := decimal.NewFromInt(2) // $2/unit → 5 units == commitment
+	p := flatFeePrice(unitAmount)
+
+	// Three windows: two inside the business-hours bucket, one outside.
+	day := time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC)
+	bucketStarts := []time.Time{
+		day.Add(10 * time.Hour), // 10:00 UTC — in-bucket, under-utilized (true-up fires)
+		day.Add(18 * time.Hour), // 18:00 UTC — OUT-of-bucket (charge base rate only)
+		day.Add(12 * time.Hour), // 12:00 UTC — in-bucket, over-utilized (overage fires)
+	}
+	bucketedValues := []decimal.Decimal{
+		decimal.NewFromInt(2), // cost $4  → < commitment $10 → true-up to $10
+		decimal.NewFromInt(2), // cost $4  → out-of-bucket → bill $4 (no true-up)
+		decimal.NewFromInt(8), // cost $16 → > commitment $10 → $10 + ($6 * 2) = $22
+	}
+
+	total, info, err := calc.applyWindowCommitmentToLineItem(ctx, lineItem, bucketedValues, bucketStarts, p)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	// $10 + $4 + $22 = $36. Without time-bucket filtering the out-of-bucket
+	// window would also true-up to $10, giving $42 — so a $36 result proves
+	// the filter is honored end-to-end.
+	assert.True(t, decimal.NewFromInt(36).Equal(total),
+		"expected total $36 (in-bucket true-up + out-of-bucket base + in-bucket overage), got %s", total)
+	assert.True(t, info.IsWindowed)
+
+	// Computed breakdown should reflect only the two in-bucket windows:
+	//   commitment utilized = $4 (under-utilized: tracks windowCost) + $10 (over: tracks commitment) = $14
+	//   overage             = $6 * 2 = $12
+	//   true-up             = $10 - $4 = $6
+	assert.True(t, decimal.NewFromInt(14).Equal(info.ComputedCommitmentUtilizedAmount),
+		"expected commitment utilized $14, got %s", info.ComputedCommitmentUtilizedAmount)
+	assert.True(t, decimal.NewFromInt(12).Equal(info.ComputedOverageAmount),
+		"expected overage $12, got %s", info.ComputedOverageAmount)
+	assert.True(t, decimal.NewFromInt(6).Equal(info.ComputedTrueUpAmount),
+		"expected true-up $6, got %s", info.ComputedTrueUpAmount)
+}
+
+// TestApplyWindowCommitment_TimeBuckets_NilBucketStarts confirms that when the
+// caller passes nil bucketStarts (single-bucket / period-aggregate path), the
+// time-bucket filter is skipped — commitment applies 24/7 as if no buckets
+// were configured. Documented behavior in applyWindowCommitmentToLineItem.
+func TestApplyWindowCommitment_TimeBuckets_NilBucketStarts(t *testing.T) {
+	ctx := testutil.SetupContext()
+	calc := newCommitmentCalculatorForTest(t)
+
+	commitmentAmount := decimal.NewFromInt(10)
+	overageFactor := decimal.NewFromInt(2)
+	lineItem := &subscription.SubscriptionLineItem{
+		ID:                      "sub_li_tb_nil_starts",
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		CommitmentWindowed:      true,
+		// Buckets configured, but the caller signals "no per-window timestamps".
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{Start: types.Bucket{Hour: 9, Minute: 0}, End: types.Bucket{Hour: 17, Minute: 0}},
+		},
+	}
+
+	p := flatFeePrice(decimal.NewFromInt(2)) // $2/unit
+	bucketedValues := []decimal.Decimal{
+		decimal.NewFromInt(2), // cost $4 → true-up to $10
+		decimal.NewFromInt(8), // cost $16 → $10 + $12 = $22
+	}
+
+	total, _, err := calc.applyWindowCommitmentToLineItem(ctx, lineItem, bucketedValues, nil, p)
+	require.NoError(t, err)
+
+	// Both windows get commitment treatment (no filtering): $10 + $22 = $32.
+	assert.True(t, decimal.NewFromInt(32).Equal(total),
+		"expected total $32 with nil bucketStarts (filter skipped), got %s", total)
+}
+
+// TestApplyWindowCommitment_TimeBuckets_NoBucketsConfigured guards against
+// regressions where an empty TimeOfDayBuckets accidentally filters everything.
+// Empty TimeBuckets must be the "no restriction" sentinel — every window
+// goes through the normal commitment path.
+func TestApplyWindowCommitment_TimeBuckets_NoBucketsConfigured(t *testing.T) {
+	ctx := testutil.SetupContext()
+	calc := newCommitmentCalculatorForTest(t)
+
+	commitmentAmount := decimal.NewFromInt(10)
+	overageFactor := decimal.NewFromInt(2)
+	lineItem := &subscription.SubscriptionLineItem{
+		ID:                      "sub_li_no_buckets",
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		CommitmentWindowed:      true,
+		// No TimeBuckets configured.
+	}
+
+	p := flatFeePrice(decimal.NewFromInt(2))
+
+	// All hours of the day should get commitment treatment.
+	day := time.Date(2026, time.June, 2, 0, 0, 0, 0, time.UTC)
+	bucketStarts := []time.Time{day.Add(3 * time.Hour), day.Add(20 * time.Hour)}
+	bucketedValues := []decimal.Decimal{decimal.NewFromInt(2), decimal.NewFromInt(2)}
+
+	total, _, err := calc.applyWindowCommitmentToLineItem(ctx, lineItem, bucketedValues, bucketStarts, p)
+	require.NoError(t, err)
+	// Both windows true-up to $10 → $20 total.
+	assert.True(t, decimal.NewFromInt(20).Equal(total),
+		"expected $20 total when no time buckets configured, got %s", total)
+}
+
+// TestApplyWindowCommitment_TimeBuckets_LengthMismatch verifies the defensive
+// guard rejects misaligned slices instead of producing wrong charges silently.
+func TestApplyWindowCommitment_TimeBuckets_LengthMismatch(t *testing.T) {
+	ctx := testutil.SetupContext()
+	calc := newCommitmentCalculatorForTest(t)
+
+	commitmentAmount := decimal.NewFromInt(10)
+	overageFactor := decimal.NewFromInt(2)
+	lineItem := &subscription.SubscriptionLineItem{
+		ID:                      "sub_li_mismatch",
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		CommitmentWindowed:      true,
+	}
+
+	p := flatFeePrice(decimal.NewFromInt(2))
+	bucketedValues := []decimal.Decimal{decimal.NewFromInt(1), decimal.NewFromInt(2)}
+	bucketStarts := []time.Time{time.Now().UTC()} // length 1 vs values length 2
+
+	_, _, err := calc.applyWindowCommitmentToLineItem(ctx, lineItem, bucketedValues, bucketStarts, p)
+	require.Error(t, err, "mismatched bucketStarts/bucketedValues must be rejected")
 }

--- a/internal/service/billing_meter_usage.go
+++ b/internal/service/billing_meter_usage.go
@@ -502,12 +502,12 @@ func (s *billingService) applyMeterUsageCommitment(
 		}
 	}
 
-	bucketedValues := s.fillBucketedValuesForWindowedCommitment(
+	bucketedValues, bucketStarts := s.fillBucketedValuesForWindowedCommitment(
 		item, usageResult, linePeriodStart, effectiveEnd,
 		m.Aggregation.BucketSize, &sub.BillingAnchor, m.Aggregation.Type,
 	)
 
-	adjustedAmount, info, err := commitmentCalc.applyWindowCommitmentToLineItem(ctx, item, bucketedValues, matchingCharge.Price)
+	adjustedAmount, info, err := commitmentCalc.applyWindowCommitmentToLineItem(ctx, item, bucketedValues, bucketStarts, matchingCharge.Price)
 	if err != nil {
 		return decimal.Zero, nil, err
 	}

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -2154,7 +2154,8 @@ func (s *featureUsageTrackingService) processPointsWithBuckets(
 	case isWindowed:
 		cost = decimal.Zero // Will be summed from points after processing
 	default:
-		cost = s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, decimal.Zero)
+		// Non-windowed (cumulative) commitment — TimeBuckets is windowed-only.
+		cost = s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, nil, decimal.Zero)
 	}
 
 	// Calculate per-point costs
@@ -2188,7 +2189,11 @@ func (s *featureUsageTrackingService) processSingleBucket(
 		bucketedValues := []decimal.Decimal{totalUsage}
 		baseCost := p.priceService.CalculateBucketedCost(p.ctx, p.price, bucketedValues)
 		if hasCommitment {
-			return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, baseCost)
+			// Single-bucket path: the value is a period-wide aggregate with no per-window
+			// timestamps. We cannot determine which UTC hours the events occurred in, so
+			// any proxy timestamp would be arbitrary. Pass nil to skip TimeBucket filtering
+			// — commitment applies normally (24/7) in this degenerate case.
+			return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, nil, baseCost)
 		}
 		return baseCost
 	}
@@ -2202,7 +2207,7 @@ func (s *featureUsageTrackingService) processSingleBucket(
 		return s.fillZeroUsageWindows(p, lineItem)
 	}
 
-	return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, nil, decimal.Zero)
+	return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, nil, nil, decimal.Zero)
 }
 
 // extractBucketValues extracts usage values from points based on aggregation type.
@@ -2227,7 +2232,7 @@ func (s *featureUsageTrackingService) calculatePointCosts(p *bucketedCostParams,
 	commitmentCalc := newCommitmentCalculator(s.Logger, p.priceService)
 	for i := range p.item.Points {
 		usage := s.getCorrectUsageValueForPoint(p.item.Points[i], p.aggType)
-		pointCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{usage}, p.price)
+		pointCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{usage}, []time.Time{p.item.Points[i].Timestamp}, p.price)
 		if err != nil {
 			s.Logger.Warnw("failed to apply window commitment to point", "error", err, "point_index", i, "line_item_id", lineItem.ID)
 			pointCost = p.priceService.CalculateCost(p.ctx, p.price, usage)
@@ -2268,7 +2273,7 @@ func (s *featureUsageTrackingService) fillMissingWindowsAndRecalculate(p *bucket
 	}
 
 	p.item.Points = filledPoints
-	if totalCost, _, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, p.price); err == nil {
+	if totalCost, _, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, expectedStarts, p.price); err == nil {
 		return totalCost
 	}
 	return decimal.Zero
@@ -2284,7 +2289,7 @@ func (s *featureUsageTrackingService) fillZeroUsageWindows(p *bucketedCostParams
 	filled := make([]decimal.Decimal, len(expectedStarts))
 	commitmentCalc := newCommitmentCalculator(s.Logger, p.priceService)
 
-	totalCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, p.price)
+	totalCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, expectedStarts, p.price)
 	if err != nil {
 		return decimal.Zero
 	}
@@ -2307,7 +2312,7 @@ func (s *featureUsageTrackingService) createFillPoint(
 	billingAnchor *time.Time,
 	calc *commitmentCalculator,
 ) events.UsageAnalyticPoint {
-	pointCost, info, _ := calc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{decimal.Zero}, p.price)
+	pointCost, info, _ := calc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{decimal.Zero}, []time.Time{timestamp}, p.price)
 	windowStart := truncateToBucketStart(timestamp, p.data.Params.WindowSize, billingAnchor)
 
 	pt := events.UsageAnalyticPoint{
@@ -2382,19 +2387,21 @@ func (s *featureUsageTrackingService) calculateRegularCost(ctx context.Context, 
 				// Let's support it if points exist
 				if len(item.Points) > 0 {
 					bucketedValues := make([]decimal.Decimal, len(item.Points))
+					bucketStarts := make([]time.Time, len(item.Points))
 					for i, point := range item.Points {
 						bucketedValues[i] = s.getCorrectUsageValueForPoint(point, meter.Aggregation.Type)
+						bucketStarts[i] = point.Timestamp
 					}
 
-					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, price, bucketedValues, decimal.Zero)
+					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, price, bucketedValues, bucketStarts, decimal.Zero)
 				} else {
 					// Fallback to standard commitment if no points (single window)
 					// We pass empty bucketedValues to hint that it's not a bucketed calculation unless default cost is zero
-					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, price, nil, cost)
+					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, price, nil, nil, cost)
 				}
 			} else {
 				// Non-window commitment
-				cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, price, nil, cost)
+				cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, price, nil, nil, cost)
 			}
 		}
 	}
@@ -3387,7 +3394,9 @@ func (s *featureUsageTrackingService) GetHuggingFaceBillingData(ctx context.Cont
 	}, nil
 }
 
-// applyLineItemCommitment applies commitment logic to the calculated cost
+// applyLineItemCommitment applies commitment logic to the calculated cost.
+// bucketStarts (optional) is paired 1:1 with bucketedValues and enables time-of-day
+// filtering on lineItem.CommitmentTimeBuckets in the windowed path.
 func (s *featureUsageTrackingService) applyLineItemCommitment(
 	ctx context.Context,
 	priceService PriceService,
@@ -3395,6 +3404,7 @@ func (s *featureUsageTrackingService) applyLineItemCommitment(
 	lineItem *subscription.SubscriptionLineItem,
 	price *price.Price,
 	bucketedValues []decimal.Decimal,
+	bucketStarts []time.Time,
 	defaultCost decimal.Decimal,
 ) decimal.Decimal {
 	commitmentCalc := newCommitmentCalculator(s.Logger, priceService)
@@ -3404,7 +3414,7 @@ func (s *featureUsageTrackingService) applyLineItemCommitment(
 
 	if lineItem.CommitmentWindowed {
 		cost, commitmentInfo, err = commitmentCalc.applyWindowCommitmentToLineItem(
-			ctx, lineItem, bucketedValues, price)
+			ctx, lineItem, bucketedValues, bucketStarts, price)
 		if err == nil {
 			item.CommitmentInfo = commitmentInfo
 			return cost

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -121,12 +121,11 @@ type GetSubscriptionMeterUsageRequest struct {
 }
 
 // dateRangeGroup is the key used to batch standard-meter queries that share
-// the same effective time range, aggregation type, and commitment time buckets.
+// the same effective time range and aggregation type.
 type dateRangeGroup struct {
-	Start          time.Time
-	End            time.Time
-	AggType        types.AggregationType
-	TimeBucketsKey string // Fingerprint() of CommitmentTimeBuckets; "" = no restriction
+	Start   time.Time
+	End     time.Time
+	AggType types.AggregationType
 }
 
 // lineItemWithMeter pairs a line item with its meter ID for grouping.
@@ -334,10 +333,9 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			start := item.GetPeriodStart(usageStartTime)
 			end := item.GetPeriodEnd(usageEndTime)
 			key := dateRangeGroup{
-				Start:          start,
-				End:            end,
-				AggType:        meterAggType[meterID],
-				TimeBucketsKey: item.CommitmentTimeBuckets.ToString(),
+				Start:   start,
+				End:     end,
+				AggType: meterAggType[meterID],
 			}
 			standardGroups[key] = append(standardGroups[key], &lineItemWithMeter{Item: item, MeterID: meterID})
 		}
@@ -395,24 +393,15 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			// Scalar billing query — use GetUsageMultiMeter for batch efficiency.
 			// Analytics-only filters (PropertyFilters, Sources, GroupBy) are never
 			// set by billing callers, so nothing is lost here.
-			// All items in a group share the same TimeBucketsKey, so pull buckets from the first.
-			var groupTimeBuckets types.TimeOfDayBuckets
-			for _, liw := range lineItemsInGroup {
-				if liw.Item.HasCommitmentTimeBuckets() {
-					groupTimeBuckets = liw.Item.CommitmentTimeBuckets
-					break
-				}
-			}
 			queryParams := &events.MeterUsageQueryParams{
-				TenantID:              types.GetTenantID(ctx),
-				EnvironmentID:         types.GetEnvironmentID(ctx),
-				ExternalCustomerIDs:   externalCustomerIDs,
-				MeterIDs:              meterIDs,
-				StartTime:             group.Start,
-				EndTime:               group.End,
-				AggregationType:       group.AggType,
-				UseFinal:              req.UseFinal,
-				CommitmentTimeBuckets: groupTimeBuckets,
+				TenantID:            types.GetTenantID(ctx),
+				EnvironmentID:       types.GetEnvironmentID(ctx),
+				ExternalCustomerIDs: externalCustomerIDs,
+				MeterIDs:            meterIDs,
+				StartTime:           group.Start,
+				EndTime:             group.End,
+				AggregationType:     group.AggType,
+				UseFinal:            req.UseFinal,
 			}
 
 			results, err := s.repo.GetUsageMultiMeter(ctx, queryParams)
@@ -1752,14 +1741,19 @@ func (s *meterUsageService) calculateBucketedCost(ctx context.Context, priceServ
 	lineItem := data.SubscriptionLineItems[item.SubLineItemID]
 	hasCommitment := !skipCommitment && lineItem != nil && lineItem.HasCommitment()
 	isWindowed := hasCommitment && lineItem.CommitmentWindowed
-	hasTrueUp := isWindowed && lineItem.CommitmentTrueUpEnabled
+	// needsWindowedFill gates the per-window fill paths (fillMissingWindowsAndRecalculate,
+	// fillZeroUsageWindows). True-up requires filling missing windows so commitment can be
+	// charged for them too — but only meaningful when the commitment is itself windowed.
+	// Non-windowed commitments with TrueUpEnabled still get true-up applied at the
+	// aggregate level inside applyCommitmentToLineItem; no per-window fill needed.
+	needsWindowedFill := isWindowed && lineItem.CommitmentTrueUpEnabled
 
 	var cost decimal.Decimal
 
 	if len(item.Points) > 0 {
-		cost = s.processPointsWithBuckets(params, lineItem, hasCommitment, isWindowed, hasTrueUp)
+		cost = s.processPointsWithBuckets(params, lineItem, hasCommitment, isWindowed, needsWindowedFill)
 	} else {
-		cost = s.processSingleBucket(params, lineItem, hasCommitment, isWindowed, hasTrueUp)
+		cost = s.processSingleBucket(params, lineItem, hasCommitment, isWindowed, needsWindowedFill)
 	}
 
 	item.TotalCost = cost
@@ -1767,10 +1761,13 @@ func (s *meterUsageService) calculateBucketedCost(ctx context.Context, priceServ
 }
 
 // processPointsWithBuckets handles the case where we have time-series points to process.
+// needsWindowedFill is true when isWindowed AND CommitmentTrueUpEnabled; it gates the
+// fillMissingWindowsAndRecalculate path that materializes empty windows for windowed
+// true-up commitments.
 func (s *meterUsageService) processPointsWithBuckets(
 	p *meterUsageBucketedCostParams,
 	lineItem *subscription.SubscriptionLineItem,
-	hasCommitment, isWindowed, hasTrueUp bool,
+	hasCommitment, isWindowed, needsWindowedFill bool,
 ) decimal.Decimal {
 	bucketedValues := s.extractBucketValues(p.item.Points, p.aggType)
 
@@ -1781,18 +1778,19 @@ func (s *meterUsageService) processPointsWithBuckets(
 	case isWindowed:
 		cost = decimal.Zero // Will be summed from points after processing
 	default:
-		cost = s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, decimal.Zero)
+		// Non-windowed (cumulative) commitment — TimeBuckets is windowed-only.
+		cost = s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, nil, decimal.Zero)
 	}
 
 	s.calculatePointCosts(p, lineItem, isWindowed)
 
-	if hasTrueUp && p.bucketSize != "" {
+	if needsWindowedFill && p.bucketSize != "" {
 		cost = s.fillMissingWindowsAndRecalculate(p, lineItem)
 	}
 
 	p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType)
 
-	if isWindowed && !hasTrueUp {
+	if isWindowed && !needsWindowedFill {
 		cost = s.sumPointCosts(p.item.Points)
 	}
 
@@ -1800,10 +1798,12 @@ func (s *meterUsageService) processPointsWithBuckets(
 }
 
 // processSingleBucket handles the case where there are no time-series points.
+// needsWindowedFill is true when isWindowed AND CommitmentTrueUpEnabled; it gates the
+// fillZeroUsageWindows path used for windowed true-up when there's no usage at all.
 func (s *meterUsageService) processSingleBucket(
 	p *meterUsageBucketedCostParams,
 	lineItem *subscription.SubscriptionLineItem,
-	hasCommitment, isWindowed, hasTrueUp bool,
+	hasCommitment, isWindowed, needsWindowedFill bool,
 ) decimal.Decimal {
 	// p.item.TotalUsage is the primary aggregation value (see
 	// buildMeterUsageAggregationColumns) — bucketed-max meters also write it from
@@ -1814,7 +1814,11 @@ func (s *meterUsageService) processSingleBucket(
 		bucketedValues := []decimal.Decimal{totalUsage}
 		baseCost := p.priceService.CalculateBucketedCost(p.ctx, p.price, bucketedValues)
 		if hasCommitment {
-			return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, baseCost)
+			// Single-bucket path: the value is a period-wide aggregate with no per-window
+			// timestamps. We cannot determine which UTC hours the events occurred in, so
+			// any proxy timestamp would be arbitrary. Pass nil to skip TimeBucket filtering
+			// — commitment applies normally (24/7) in this degenerate case.
+			return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, bucketedValues, nil, baseCost)
 		}
 		return baseCost
 	}
@@ -1823,11 +1827,11 @@ func (s *meterUsageService) processSingleBucket(
 		return decimal.Zero
 	}
 
-	if hasTrueUp && p.bucketSize != "" {
+	if needsWindowedFill && p.bucketSize != "" {
 		return s.fillZeroUsageWindows(p, lineItem)
 	}
 
-	return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, nil, decimal.Zero)
+	return s.applyLineItemCommitment(p.ctx, p.priceService, p.item, lineItem, p.price, nil, nil, decimal.Zero)
 }
 
 // extractBucketValues extracts usage values from points based on aggregation type.
@@ -1851,8 +1855,8 @@ func (s *meterUsageService) calculatePointCosts(p *meterUsageBucketedCostParams,
 
 	commitmentCalc := newCommitmentCalculator(s.logger, p.priceService)
 	for i := range p.item.Points {
-		usage := p.item.Points[i].Usage
-		pointCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{usage}, p.price)
+		usage := s.getCorrectUsageValueForPoint(p.item.Points[i], p.aggType)
+		pointCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{usage}, []time.Time{p.item.Points[i].Timestamp}, p.price)
 		if err != nil {
 			s.logger.Warnw("failed to apply window commitment to point", "error", err, "point_index", i, "line_item_id", lineItem.ID)
 			pointCost = p.priceService.CalculateCost(p.ctx, p.price, usage)
@@ -1866,29 +1870,12 @@ func (s *meterUsageService) calculatePointCosts(p *meterUsageBucketedCostParams,
 	}
 }
 
-// generateInBucketStarts returns bucket start times filtered to those within the configured
-// time-of-day buckets. When timeBuckets is empty, all starts are returned unchanged.
-// This is used for windowed true-up so phantom charges are not applied to out-of-bucket windows.
-func generateInBucketStarts(start, end time.Time, bucketSize types.WindowSize, billingAnchor *time.Time, timeBuckets types.TimeOfDayBuckets) []time.Time {
-	all := generateBucketStarts(start, end, bucketSize, billingAnchor)
-	if len(timeBuckets) == 0 {
-		return all
-	}
-	filtered := make([]time.Time, 0, len(all))
-	for _, t := range all {
-		if timeBuckets.ContainsHour(t.UTC().Hour()) {
-			filtered = append(filtered, t)
-		}
-	}
-	return filtered
-}
-
 // fillMissingWindowsAndRecalculate fills gaps in bucket windows and recalculates total cost.
 func (s *meterUsageService) fillMissingWindowsAndRecalculate(p *meterUsageBucketedCostParams, lineItem *subscription.SubscriptionLineItem) decimal.Decimal {
 	billingAnchor := s.getBillingAnchorFromData(p.data, lineItem.SubscriptionID)
 	periodStart := lineItem.GetPeriodStart(p.data.Params.StartTime)
 	periodEnd := lineItem.GetPeriodEnd(p.data.Params.EndTime)
-	expectedStarts := generateInBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor, lineItem.CommitmentTimeBuckets)
+	expectedStarts := generateBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor)
 
 	pointsByBucket := make(map[time.Time]events.UsageAnalyticPoint, len(p.item.Points))
 	for _, pt := range p.item.Points {
@@ -1910,7 +1897,7 @@ func (s *meterUsageService) fillMissingWindowsAndRecalculate(p *meterUsageBucket
 	}
 
 	p.item.Points = filledPoints
-	if totalCost, _, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, p.price); err == nil {
+	if totalCost, _, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, expectedStarts, p.price); err == nil {
 		return totalCost
 	}
 	return decimal.Zero
@@ -1921,12 +1908,12 @@ func (s *meterUsageService) fillZeroUsageWindows(p *meterUsageBucketedCostParams
 	billingAnchor := s.getBillingAnchorFromData(p.data, lineItem.SubscriptionID)
 	periodStart := lineItem.GetPeriodStart(p.data.Params.StartTime)
 	periodEnd := lineItem.GetPeriodEnd(p.data.Params.EndTime)
-	expectedStarts := generateInBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor, lineItem.CommitmentTimeBuckets)
+	expectedStarts := generateBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor)
 
 	filled := make([]decimal.Decimal, len(expectedStarts))
 	commitmentCalc := newCommitmentCalculator(s.logger, p.priceService)
 
-	totalCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, p.price)
+	totalCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, filled, expectedStarts, p.price)
 	if err != nil {
 		return decimal.Zero
 	}
@@ -1949,7 +1936,7 @@ func (s *meterUsageService) createFillPoint(
 	billingAnchor *time.Time,
 	calc *commitmentCalculator,
 ) events.UsageAnalyticPoint {
-	pointCost, info, _ := calc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{decimal.Zero}, p.price)
+	pointCost, info, _ := calc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{decimal.Zero}, []time.Time{timestamp}, p.price)
 	windowStart := truncateToBucketStart(timestamp, p.data.Params.WindowSize, billingAnchor)
 
 	pt := events.UsageAnalyticPoint{
@@ -1999,15 +1986,17 @@ func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceServi
 			if lineItem.CommitmentWindowed {
 				if len(item.Points) > 0 {
 					bucketedValues := make([]decimal.Decimal, len(item.Points))
+					bucketStarts := make([]time.Time, len(item.Points))
 					for i, point := range item.Points {
-						bucketedValues[i] = point.Usage
+						bucketedValues[i] = s.getCorrectUsageValueForPoint(point, m.Aggregation.Type)
+						bucketStarts[i] = point.Timestamp
 					}
-					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, bucketedValues, decimal.Zero)
+					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, bucketedValues, bucketStarts, decimal.Zero)
 				} else {
-					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, nil, cost)
+					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, nil, nil, cost)
 				}
 			} else {
-				cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, nil, cost)
+				cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, nil, nil, cost)
 			}
 		}
 	}
@@ -2023,6 +2012,8 @@ func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceServi
 }
 
 // applyLineItemCommitment applies commitment logic to the calculated cost.
+// bucketStarts (optional) is paired 1:1 with bucketedValues and enables time-of-day
+// filtering on lineItem.CommitmentTimeBuckets in the windowed path.
 func (s *meterUsageService) applyLineItemCommitment(
 	ctx context.Context,
 	priceService PriceService,
@@ -2030,6 +2021,7 @@ func (s *meterUsageService) applyLineItemCommitment(
 	lineItem *subscription.SubscriptionLineItem,
 	p *price.Price,
 	bucketedValues []decimal.Decimal,
+	bucketStarts []time.Time,
 	defaultCost decimal.Decimal,
 ) decimal.Decimal {
 	commitmentCalc := newCommitmentCalculator(s.logger, priceService)
@@ -2038,8 +2030,7 @@ func (s *meterUsageService) applyLineItemCommitment(
 	var err error
 
 	if lineItem.CommitmentWindowed {
-		cost, commitmentInfo, err = commitmentCalc.applyWindowCommitmentToLineItem(
-			ctx, lineItem, bucketedValues, p)
+		cost, commitmentInfo, err = commitmentCalc.applyWindowCommitmentToLineItem(ctx, lineItem, bucketedValues, bucketStarts, p)
 		if err == nil {
 			item.CommitmentInfo = commitmentInfo
 			return cost

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -448,7 +448,6 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 				ctx, m, externalCustomerIDs,
 				itemStart, itemEnd, req.BillingAnchor, req.UseFinal,
 				req.PropertyFilters, req.Sources,
-				item.CommitmentTimeBuckets,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query bucketed meter usage for meter %s: %w", meterID, err)
@@ -635,7 +634,6 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	useFinal bool,
 	propertyFilters map[string][]string,
 	sources []string,
-	timeBuckets types.TimeOfDayBuckets,
 ) (*events.AggregationResult, error) {
 	aggType := m.Aggregation.Type
 	groupBy := m.Aggregation.GroupBy
@@ -644,20 +642,19 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 		groupBy = ""
 	}
 	return s.repo.GetUsageForBucketedMeters(ctx, &events.MeterUsageQueryParams{
-		TenantID:              types.GetTenantID(ctx),
-		EnvironmentID:         types.GetEnvironmentID(ctx),
-		ExternalCustomerIDs:   externalCustomerIDs,
-		MeterID:               m.ID,
-		StartTime:             periodStart,
-		EndTime:               periodEnd,
-		AggregationType:       aggType,
-		WindowSize:            m.Aggregation.BucketSize,
-		BillingAnchor:         billingAnchor,
-		GroupByProperty:       groupBy,
-		UseFinal:              useFinal,
-		PropertyFilters:       propertyFilters,
-		Sources:               sources,
-		CommitmentTimeBuckets: timeBuckets,
+		TenantID:            types.GetTenantID(ctx),
+		EnvironmentID:       types.GetEnvironmentID(ctx),
+		ExternalCustomerIDs: externalCustomerIDs,
+		MeterID:             m.ID,
+		StartTime:           periodStart,
+		EndTime:             periodEnd,
+		AggregationType:     aggType,
+		WindowSize:          m.Aggregation.BucketSize,
+		BillingAnchor:       billingAnchor,
+		GroupByProperty:     groupBy,
+		UseFinal:            useFinal,
+		PropertyFilters:     propertyFilters,
+		Sources:             sources,
 	})
 }
 

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1066,8 +1066,7 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 		}
 	}
 
-	var allResults []*events.MeterUsageDetailedResult
-
+	allResults := make([]*events.MeterUsageDetailedResult, 0, len(bucketedMeterIDs)+len(standardMeterIDs))
 	for _, meterID := range bucketedMeterIDs {
 		results, err := s.getBucketedMeterAnalytics(ctx, params, meterMap[meterID])
 		if err != nil {
@@ -1174,13 +1173,18 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 		}
 	}
 
-	// Convert results to analytics. r.TotalUsage / p.TotalUsage hold the primary
-	// aggregation value courtesy of buildMeterUsageAggregationColumns, so no
-	// per-aggregation routing is needed here.
+	// Convert results to analytics. TotalUsage / Usage hold the aggregation-aware
+	// value (mirrors the subscription-context path), so downstream consumers can
+	// read .TotalUsage / .Usage without knowing the meter's aggregation type.
 	for _, r := range allResults {
+		aggType := types.AggregationSum
+		if m, ok := meterMap[r.MeterID]; ok {
+			aggType = m.Aggregation.Type
+		}
+
 		analytic := &events.DetailedUsageAnalytic{
 			MeterID:          r.MeterID,
-			TotalUsage:       r.TotalUsage,
+			TotalUsage:       getUsageValueFromDetailedResult(r, aggType),
 			MaxUsage:         r.MaxUsage,
 			LatestUsage:      r.LatestUsage,
 			CountUniqueUsage: r.CountUniqueUsage,
@@ -1188,10 +1192,10 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 			Source:           r.Source,
 			Sources:          r.Sources,
 			Properties:       r.Properties,
+			AggregationType:  aggType,
 		}
 		if m, ok := meterMap[r.MeterID]; ok {
 			analytic.EventName = m.EventName
-			analytic.AggregationType = m.Aggregation.Type
 		}
 		if f, ok := meterToFeature[r.MeterID]; ok {
 			analytic.FeatureID = f.ID
@@ -1205,7 +1209,7 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 				analytic.Points = append(analytic.Points, events.UsageAnalyticPoint{
 					Timestamp:        p.WindowStart,
 					WindowStart:      p.WindowStart,
-					Usage:            p.TotalUsage,
+					Usage:            getUsageValueFromDetailedPoint(p, aggType),
 					MaxUsage:         p.MaxUsage,
 					LatestUsage:      p.LatestUsage,
 					CountUniqueUsage: p.CountUniqueUsage,
@@ -1390,6 +1394,48 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// getUsageValueFromDetailedResult extracts the correct scalar usage from a
+// MeterUsageDetailedResult based on aggregation type.
+//
+// For COUNT meters, buildConditionalAggregationColumns emits total_usage as a
+// literal zero — the actual count lives in the event_count column.
+func getUsageValueFromDetailedResult(r *events.MeterUsageDetailedResult, aggType types.AggregationType) decimal.Decimal {
+	switch aggType {
+	case types.AggregationCount:
+		return decimal.NewFromInt(int64(r.EventCount))
+	case types.AggregationCountUnique:
+		return decimal.NewFromInt(int64(r.CountUniqueUsage))
+	case types.AggregationMax:
+		if !r.TotalUsage.IsZero() {
+			return r.TotalUsage
+		}
+		return r.MaxUsage
+	case types.AggregationLatest:
+		return r.LatestUsage
+	default:
+		return r.TotalUsage
+	}
+}
+
+// getUsageValueFromDetailedPoint mirrors getUsageValueFromDetailedResult for a
+// single time-series point so consumers can read point.Usage without knowing
+// the meter's aggregation type.
+func getUsageValueFromDetailedPoint(p events.MeterUsageDetailedPoint, aggType types.AggregationType) decimal.Decimal {
+	switch aggType {
+	case types.AggregationCountUnique:
+		return decimal.NewFromInt(int64(p.CountUniqueUsage))
+	case types.AggregationMax:
+		if !p.TotalUsage.IsZero() {
+			return p.TotalUsage
+		}
+		return p.MaxUsage
+	case types.AggregationLatest:
+		return p.LatestUsage
+	default:
+		return p.TotalUsage
+	}
+}
 
 // fetchMeters fetches meter configurations for the requested meter IDs.
 func (s *meterUsageService) fetchMeters(ctx context.Context, params *events.MeterUsageDetailedAnalyticsParams) ([]*meter.Meter, error) {

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1898,7 +1898,7 @@ func (s *meterUsageService) calculatePointCosts(p *meterUsageBucketedCostParams,
 
 	commitmentCalc := newCommitmentCalculator(s.logger, p.priceService)
 	for i := range p.item.Points {
-		usage := s.getCorrectUsageValueForPoint(p.item.Points[i], p.aggType)
+		usage := p.item.Points[i].Usage
 		pointCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{usage}, []time.Time{p.item.Points[i].Timestamp}, p.price)
 		if err != nil {
 			s.logger.Warnw("failed to apply window commitment to point", "error", err, "point_index", i, "line_item_id", lineItem.ID)
@@ -2031,7 +2031,7 @@ func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceServi
 					bucketedValues := make([]decimal.Decimal, len(item.Points))
 					bucketStarts := make([]time.Time, len(item.Points))
 					for i, point := range item.Points {
-						bucketedValues[i] = s.getCorrectUsageValueForPoint(point, m.Aggregation.Type)
+						bucketedValues[i] = point.Usage
 						bucketStarts[i] = point.Timestamp
 					}
 					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, bucketedValues, bucketStarts, decimal.Zero)

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -121,11 +121,12 @@ type GetSubscriptionMeterUsageRequest struct {
 }
 
 // dateRangeGroup is the key used to batch standard-meter queries that share
-// the same effective time range and aggregation type.
+// the same effective time range, aggregation type, and commitment time buckets.
 type dateRangeGroup struct {
-	Start   time.Time
-	End     time.Time
-	AggType types.AggregationType
+	Start          time.Time
+	End            time.Time
+	AggType        types.AggregationType
+	TimeBucketsKey string // Fingerprint() of CommitmentTimeBuckets; "" = no restriction
 }
 
 // lineItemWithMeter pairs a line item with its meter ID for grouping.
@@ -332,7 +333,12 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 		for _, item := range items {
 			start := item.GetPeriodStart(usageStartTime)
 			end := item.GetPeriodEnd(usageEndTime)
-			key := dateRangeGroup{Start: start, End: end, AggType: meterAggType[meterID]}
+			key := dateRangeGroup{
+				Start:          start,
+				End:            end,
+				AggType:        meterAggType[meterID],
+				TimeBucketsKey: item.CommitmentTimeBuckets.ToString(),
+			}
 			standardGroups[key] = append(standardGroups[key], &lineItemWithMeter{Item: item, MeterID: meterID})
 		}
 	}
@@ -389,15 +395,24 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			// Scalar billing query — use GetUsageMultiMeter for batch efficiency.
 			// Analytics-only filters (PropertyFilters, Sources, GroupBy) are never
 			// set by billing callers, so nothing is lost here.
+			// All items in a group share the same TimeBucketsKey, so pull buckets from the first.
+			var groupTimeBuckets types.TimeOfDayBuckets
+			for _, liw := range lineItemsInGroup {
+				if liw.Item.HasCommitmentTimeBuckets() {
+					groupTimeBuckets = liw.Item.CommitmentTimeBuckets
+					break
+				}
+			}
 			queryParams := &events.MeterUsageQueryParams{
-				TenantID:            types.GetTenantID(ctx),
-				EnvironmentID:       types.GetEnvironmentID(ctx),
-				ExternalCustomerIDs: externalCustomerIDs,
-				MeterIDs:            meterIDs,
-				StartTime:           group.Start,
-				EndTime:             group.End,
-				AggregationType:     group.AggType,
-				UseFinal:            req.UseFinal,
+				TenantID:              types.GetTenantID(ctx),
+				EnvironmentID:         types.GetEnvironmentID(ctx),
+				ExternalCustomerIDs:   externalCustomerIDs,
+				MeterIDs:              meterIDs,
+				StartTime:             group.Start,
+				EndTime:               group.End,
+				AggregationType:       group.AggType,
+				UseFinal:              req.UseFinal,
+				CommitmentTimeBuckets: groupTimeBuckets,
 			}
 
 			results, err := s.repo.GetUsageMultiMeter(ctx, queryParams)
@@ -444,6 +459,7 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 				ctx, m, externalCustomerIDs,
 				itemStart, itemEnd, req.BillingAnchor, req.UseFinal,
 				req.PropertyFilters, req.Sources,
+				item.CommitmentTimeBuckets,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query bucketed meter usage for meter %s: %w", meterID, err)
@@ -630,6 +646,7 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	useFinal bool,
 	propertyFilters map[string][]string,
 	sources []string,
+	timeBuckets types.TimeOfDayBuckets,
 ) (*events.AggregationResult, error) {
 	aggType := m.Aggregation.Type
 	groupBy := m.Aggregation.GroupBy
@@ -638,19 +655,20 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 		groupBy = ""
 	}
 	return s.repo.GetUsageForBucketedMeters(ctx, &events.MeterUsageQueryParams{
-		TenantID:            types.GetTenantID(ctx),
-		EnvironmentID:       types.GetEnvironmentID(ctx),
-		ExternalCustomerIDs: externalCustomerIDs,
-		MeterID:             m.ID,
-		StartTime:           periodStart,
-		EndTime:             periodEnd,
-		AggregationType:     aggType,
-		WindowSize:          m.Aggregation.BucketSize,
-		BillingAnchor:       billingAnchor,
-		GroupByProperty:     groupBy,
-		UseFinal:            useFinal,
-		PropertyFilters:     propertyFilters,
-		Sources:             sources,
+		TenantID:              types.GetTenantID(ctx),
+		EnvironmentID:         types.GetEnvironmentID(ctx),
+		ExternalCustomerIDs:   externalCustomerIDs,
+		MeterID:               m.ID,
+		StartTime:             periodStart,
+		EndTime:               periodEnd,
+		AggregationType:       aggType,
+		WindowSize:            m.Aggregation.BucketSize,
+		BillingAnchor:         billingAnchor,
+		GroupByProperty:       groupBy,
+		UseFinal:              useFinal,
+		PropertyFilters:       propertyFilters,
+		Sources:               sources,
+		CommitmentTimeBuckets: timeBuckets,
 	})
 }
 
@@ -1848,12 +1866,29 @@ func (s *meterUsageService) calculatePointCosts(p *meterUsageBucketedCostParams,
 	}
 }
 
+// generateInBucketStarts returns bucket start times filtered to those within the configured
+// time-of-day buckets. When timeBuckets is empty, all starts are returned unchanged.
+// This is used for windowed true-up so phantom charges are not applied to out-of-bucket windows.
+func generateInBucketStarts(start, end time.Time, bucketSize types.WindowSize, billingAnchor *time.Time, timeBuckets types.TimeOfDayBuckets) []time.Time {
+	all := generateBucketStarts(start, end, bucketSize, billingAnchor)
+	if len(timeBuckets) == 0 {
+		return all
+	}
+	filtered := make([]time.Time, 0, len(all))
+	for _, t := range all {
+		if timeBuckets.ContainsHour(t.UTC().Hour()) {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
 // fillMissingWindowsAndRecalculate fills gaps in bucket windows and recalculates total cost.
 func (s *meterUsageService) fillMissingWindowsAndRecalculate(p *meterUsageBucketedCostParams, lineItem *subscription.SubscriptionLineItem) decimal.Decimal {
 	billingAnchor := s.getBillingAnchorFromData(p.data, lineItem.SubscriptionID)
 	periodStart := lineItem.GetPeriodStart(p.data.Params.StartTime)
 	periodEnd := lineItem.GetPeriodEnd(p.data.Params.EndTime)
-	expectedStarts := generateBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor)
+	expectedStarts := generateInBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor, lineItem.CommitmentTimeBuckets)
 
 	pointsByBucket := make(map[time.Time]events.UsageAnalyticPoint, len(p.item.Points))
 	for _, pt := range p.item.Points {
@@ -1886,7 +1921,7 @@ func (s *meterUsageService) fillZeroUsageWindows(p *meterUsageBucketedCostParams
 	billingAnchor := s.getBillingAnchorFromData(p.data, lineItem.SubscriptionID)
 	periodStart := lineItem.GetPeriodStart(p.data.Params.StartTime)
 	periodEnd := lineItem.GetPeriodEnd(p.data.Params.EndTime)
-	expectedStarts := generateBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor)
+	expectedStarts := generateInBucketStarts(periodStart, periodEnd, p.bucketSize, billingAnchor, lineItem.CommitmentTimeBuckets)
 
 	filled := make([]decimal.Decimal, len(expectedStarts))
 	commitmentCalc := newCommitmentCalculator(s.logger, p.priceService)

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1170,18 +1170,13 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 		}
 	}
 
-	// Convert results to analytics. TotalUsage / Usage hold the aggregation-aware
-	// value (mirrors the subscription-context path), so downstream consumers can
-	// read .TotalUsage / .Usage without knowing the meter's aggregation type.
+	// Convert results to analytics. r.TotalUsage / p.TotalUsage hold the primary
+	// aggregation value courtesy of buildMeterUsageAggregationColumns, so no
+	// per-aggregation routing is needed here.
 	for _, r := range allResults {
-		aggType := types.AggregationSum
-		if m, ok := meterMap[r.MeterID]; ok {
-			aggType = m.Aggregation.Type
-		}
-
 		analytic := &events.DetailedUsageAnalytic{
 			MeterID:          r.MeterID,
-			TotalUsage:       getUsageValueFromDetailedResult(r, aggType),
+			TotalUsage:       r.TotalUsage,
 			MaxUsage:         r.MaxUsage,
 			LatestUsage:      r.LatestUsage,
 			CountUniqueUsage: r.CountUniqueUsage,
@@ -1189,10 +1184,10 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 			Source:           r.Source,
 			Sources:          r.Sources,
 			Properties:       r.Properties,
-			AggregationType:  aggType,
 		}
 		if m, ok := meterMap[r.MeterID]; ok {
 			analytic.EventName = m.EventName
+			analytic.AggregationType = m.Aggregation.Type
 		}
 		if f, ok := meterToFeature[r.MeterID]; ok {
 			analytic.FeatureID = f.ID
@@ -1206,7 +1201,7 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 				analytic.Points = append(analytic.Points, events.UsageAnalyticPoint{
 					Timestamp:        p.WindowStart,
 					WindowStart:      p.WindowStart,
-					Usage:            getUsageValueFromDetailedPoint(p, aggType),
+					Usage:            p.TotalUsage,
 					MaxUsage:         p.MaxUsage,
 					LatestUsage:      p.LatestUsage,
 					CountUniqueUsage: p.CountUniqueUsage,
@@ -1391,48 +1386,6 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-// getUsageValueFromDetailedResult extracts the correct scalar usage from a
-// MeterUsageDetailedResult based on aggregation type.
-//
-// For COUNT meters, buildConditionalAggregationColumns emits total_usage as a
-// literal zero — the actual count lives in the event_count column.
-func getUsageValueFromDetailedResult(r *events.MeterUsageDetailedResult, aggType types.AggregationType) decimal.Decimal {
-	switch aggType {
-	case types.AggregationCount:
-		return decimal.NewFromInt(int64(r.EventCount))
-	case types.AggregationCountUnique:
-		return decimal.NewFromInt(int64(r.CountUniqueUsage))
-	case types.AggregationMax:
-		if !r.TotalUsage.IsZero() {
-			return r.TotalUsage
-		}
-		return r.MaxUsage
-	case types.AggregationLatest:
-		return r.LatestUsage
-	default:
-		return r.TotalUsage
-	}
-}
-
-// getUsageValueFromDetailedPoint mirrors getUsageValueFromDetailedResult for a
-// single time-series point so consumers can read point.Usage without knowing
-// the meter's aggregation type.
-func getUsageValueFromDetailedPoint(p events.MeterUsageDetailedPoint, aggType types.AggregationType) decimal.Decimal {
-	switch aggType {
-	case types.AggregationCountUnique:
-		return decimal.NewFromInt(int64(p.CountUniqueUsage))
-	case types.AggregationMax:
-		if !p.TotalUsage.IsZero() {
-			return p.TotalUsage
-		}
-		return p.MaxUsage
-	case types.AggregationLatest:
-		return p.LatestUsage
-	default:
-		return p.TotalUsage
-	}
-}
 
 // fetchMeters fetches meter configurations for the requested meter IDs.
 func (s *meterUsageService) fetchMeters(ctx context.Context, params *events.MeterUsageDetailedAnalyticsParams) ([]*meter.Meter, error) {

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -1979,3 +1979,344 @@ func (s *MeterUsageServiceSuite) TestGroupByFeatureIDAndMeterID_Deduplicates() {
 	s.Require().Len(resp.Items, 1)
 	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(42)))
 }
+
+// TestWindowCommitment_TimeBuckets_OutOfBucketBilledAtBaseRate verifies that
+// when a line item has CommitmentTimeBuckets configured, only windows whose
+// start hour falls within a configured bucket get commitment treatment
+// (commitment credit + overage premium). Windows outside the buckets are
+// billed at the base usage rate with no commitment, no overage, no true-up.
+//
+// Setup: hourly-bucketed SUM meter, $1/unit, $5 commitment per window with 2x
+// overage factor, time buckets restricted to 09:00-17:00 UTC. True-up is
+// disabled to keep the assertion focused on overage behavior — under the
+// no-true-up rule, windows with no events contribute $0 regardless of whether
+// they're in-bucket, so the test isolates the overage-premium difference.
+//
+// Two events of 10 units each:
+//   - 10:00 UTC (in-bucket):   cost $10 > commitment $5 → $5 + ($5 * 2) = $15
+//   - 18:00 UTC (out-of-bucket): cost $10 → billed at base rate $10 (no premium)
+//
+// Expected TotalCost = $25. Without the time-bucket filter both windows would
+// take the overage path and total $30, so a $25 result proves the filter is
+// honored on the analytics pipeline.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_TimeBuckets_OutOfBucketBilledAtBaseRate() {
+	ctx := s.GetContext()
+
+	// Hourly-bucketed SUM meter — required for windowed-commitment code path.
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_tb_window",
+		Name:      "Hourly Bucketed SUM",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	// $1/unit flat fee so window cost = quantity.
+	flatPrice := &price.Price{
+		ID:             "price_tb_window",
+		Amount:         decimal.NewFromInt(1),
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, flatPrice))
+
+	commitmentAmount := decimal.NewFromInt(5) // $5 commitment per window
+	overageFactor := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_tb_window",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 flatPrice.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 bucketedMeter.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: false,
+		CommitmentWindowed:      true,
+		// Business hours only.
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{Start: types.Bucket{Hour: 9, Minute: 0}, End: types.Bucket{Hour: 17, Minute: 0}},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// 10:00 UTC: in-bucket, 10 units → cost $10 → over $5 commitment → $5 + ($5 * 2) = $15
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10)
+	// 18:00 UTC: out-of-bucket, 10 units → billed at base rate $10
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 18, 0, 0, 0, time.UTC), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_tb_window" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for committed line item")
+
+	// In-bucket overage ($15) + out-of-bucket base rate ($10) = $25.
+	// Without the time-bucket filter the out-of-bucket window would also take
+	// the overage path and the total would be $30.
+	expectedTotal := decimal.NewFromInt(25)
+	s.True(item.TotalCost.Equal(expectedTotal),
+		"expected $25 (in-bucket overage $15 + out-of-bucket base $10); got %s",
+		item.TotalCost)
+}
+
+// TestWindowCommitment_TimeBuckets_WithTrueUp verifies time-bucket filtering
+// when CommitmentTrueUpEnabled=true — the path that fills every expected
+// window in the period (fillMissingWindowsAndRecalculate). Out-of-bucket
+// windows must NOT contribute a true-up charge; they're billed at base usage
+// rate (which is $0 for empty windows, and the raw quantity cost for windows
+// containing events).
+//
+// Setup: hourly-bucketed SUM meter, $1/unit, $5 commitment per window with 2x
+// overage factor, true-up ENABLED, time buckets = 09:00-17:00 UTC. The line
+// item is scoped to a 1-day window (Jan 5 00:00 - Jan 6 00:00 UTC) so the
+// expected-window math is tractable: 24 hourly windows, 8 in-bucket, 16
+// out-of-bucket.
+//
+// Two events of 10 units each:
+//   - 10:00 UTC (in-bucket):    cost $10 > $5 commitment → $5 + ($5*2) = $15
+//   - 18:00 UTC (out-of-bucket): cost $10 → billed at base $10 (no commitment)
+//
+// Empty windows:
+//   - 7 in-bucket empty hours → each true-ups to $5 → $35
+//   - 15 out-of-bucket empty hours → each contributes $0
+//
+// Expected TotalCost = $35 + $15 + $10 = $60. Without the time-bucket filter
+// every window would take the commitment path: 22 empty windows × $5 true-up
+// + 2 events × $15 overage = $140. A $60 result proves the filter is honored
+// on the true-up path too.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_TimeBuckets_WithTrueUp() {
+	ctx := s.GetContext()
+
+	// Hourly-bucketed SUM meter.
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_tb_trueup",
+		Name:      "Hourly Bucketed SUM (true-up)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	flatPrice := &price.Price{
+		ID:             "price_tb_trueup",
+		Amount:         decimal.NewFromInt(1), // $1/unit
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, flatPrice))
+
+	// Line item scoped to a single UTC day so the expected-window count is 24
+	// (8 in-bucket + 16 out-of-bucket) and the assertion math stays tractable.
+	dayStart := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	dayEnd := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+
+	commitmentAmount := decimal.NewFromInt(5) // $5 commitment per window
+	overageFactor := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_tb_trueup",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 flatPrice.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 bucketedMeter.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               dayStart,
+		EndDate:                 dayEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		CommitmentWindowed:      true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{Start: types.Bucket{Hour: 9, Minute: 0}, End: types.Bucket{Hour: 17, Minute: 0}},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// 10:00 UTC: in-bucket, 10 units → overage $15
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		dayStart.Add(10*time.Hour), 10)
+	// 18:00 UTC: out-of-bucket, 10 units → base rate $10
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		dayStart.Add(18*time.Hour), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_tb_trueup" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for true-up line item")
+
+	// $35 (7 empty in-bucket true-ups) + $15 (10:00 overage) + $10 (18:00 base) = $60
+	expectedTotal := decimal.NewFromInt(60)
+	s.True(item.TotalCost.Equal(expectedTotal),
+		"expected $60 with time-bucket filter (without filter would be $140); got %s",
+		item.TotalCost)
+}
+
+// TestWindowCommitment_TimeBuckets_QuantityBased verifies the time-bucket
+// filter works when commitment is expressed as a quantity (not an amount).
+// Internally normalizeCommitmentToAmount converts the quantity to a per-window
+// dollar amount via priceService.CalculateCost; the time-bucket filter then
+// applies that amount on in-bucket windows only.
+//
+// Setup: hourly-bucketed SUM meter, $2/unit, commitment = 5 units/window
+// (normalized to $10 per window), 2x overage, true-up disabled, time buckets
+// = 09:00-17:00 UTC.
+//
+// Two events of 8 units each:
+//   - 10:00 UTC (in-bucket):    cost $16 > $10 commitment → $10 + ($6*2) = $22
+//   - 18:00 UTC (out-of-bucket): cost $16 → billed at base $16 (no premium)
+//
+// Expected TotalCost = $22 + $16 = $38. Without the filter both windows would
+// take the overage path and total $44 — so a $38 result proves time buckets
+// honor quantity-based commitments end-to-end.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_TimeBuckets_QuantityBased() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_tb_qty",
+		Name:      "Hourly Bucketed SUM (qty commitment)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	flatPrice := &price.Price{
+		ID:             "price_tb_qty",
+		Amount:         decimal.NewFromInt(2), // $2/unit → 5 units == $10 commitment
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, flatPrice))
+
+	commitmentQuantity := decimal.NewFromInt(5) // 5 units/window — NOT an amount
+	overageFactor := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_tb_qty",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 flatPrice.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 bucketedMeter.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentType:          types.COMMITMENT_TYPE_QUANTITY,
+		CommitmentQuantity:      &commitmentQuantity,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: false,
+		CommitmentWindowed:      true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{Start: types.Bucket{Hour: 9, Minute: 0}, End: types.Bucket{Hour: 17, Minute: 0}},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 8) // in-bucket overage
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 18, 0, 0, 0, time.UTC), 8) // out-of-bucket base
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_tb_qty" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for quantity-commitment line item")
+
+	// $22 (in-bucket overage) + $16 (out-of-bucket base) = $38.
+	// Without the filter both windows would overage: $22 + $22 = $44.
+	expectedTotal := decimal.NewFromInt(38)
+	s.True(item.TotalCost.Equal(expectedTotal),
+		"expected $38 with quantity commitment + time-bucket filter; got %s",
+		item.TotalCost)
+}

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -2320,3 +2320,231 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_TimeBuckets_QuantityBased(
 		"expected $38 with quantity commitment + time-bucket filter; got %s",
 		item.TotalCost)
 }
+
+// TestWindowCommitment_NoTimeBuckets_AppliesToAllWindows is the baseline for
+// the time-bucket filter tests: when CommitmentTimeBuckets is omitted, every
+// window with usage takes the commitment path regardless of hour-of-day. This
+// guards against regressions where an empty/nil TimeBuckets accidentally
+// filters everything out, and serves as the "without filter" baseline that
+// TestWindowCommitment_TimeBuckets_OutOfBucketBilledAtBaseRate compares against.
+//
+// Setup mirrors TestWindowCommitment_TimeBuckets_OutOfBucketBilledAtBaseRate
+// exactly except that commitment_time_buckets is omitted:
+//   - hourly SUM meter, $1/unit
+//   - $5 commitment per window, 2x overage factor, true-up disabled
+//   - 10:00 UTC event: 10 units → cost $10 > $5 → $5 + ($5*2) = $15
+//   - 18:00 UTC event: 10 units → cost $10 > $5 → $5 + ($5*2) = $15 (now ALSO overage)
+//
+// Expected TotalCost = $30, which is exactly the "would-be" total the filtered
+// test cites as proof that the filter shaves $5 off the out-of-bucket window.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_NoTimeBuckets_AppliesToAllWindows() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_no_tb",
+		Name:      "Hourly Bucketed SUM (no time buckets)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	flatPrice := &price.Price{
+		ID:             "price_no_tb",
+		Amount:         decimal.NewFromInt(1),
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, flatPrice))
+
+	commitmentAmount := decimal.NewFromInt(5)
+	overageFactor := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_no_tb",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 flatPrice.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 bucketedMeter.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: false,
+		CommitmentWindowed:      true,
+		// CommitmentTimeBuckets intentionally omitted — no time-of-day restriction.
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// Same two events as the time-bucket test, deliberately at hours that
+	// would be in- and out-of-bucket under a 09:00-17:00 restriction.
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 18, 0, 0, 0, time.UTC), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_no_tb" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for no-time-bucket line item")
+
+	// Both windows take the overage path: $15 + $15 = $30.
+	expectedTotal := decimal.NewFromInt(30)
+	s.True(item.TotalCost.Equal(expectedTotal),
+		"expected $30 (both windows in overage; no time-bucket restriction); got %s",
+		item.TotalCost)
+}
+
+// TestWindowCommitment_TimeBuckets_NoBucketSizeOnMeter verifies the windowed
+// commitment + time-bucket flow on the REGULAR (non-bucketed) meter path:
+// when the meter has no Aggregation.BucketSize, calculateRegularCost still
+// applies windowed commitment per-point as long as the analytics query
+// requests a WindowSize. Each request-window point goes through
+// applyWindowCommitmentToLineItem, so time-bucket filtering works the same
+// way it does for bucketed meters.
+//
+// Notes:
+//   - In production, validateLineItemCommitment requires the meter to have
+//     BucketSize when commitment_windowed=true, so this configuration cannot
+//     be created via the public API. The test bypasses that by inserting the
+//     line item directly through SubscriptionLineItemRepo, mirroring the
+//     pattern used elsewhere in this suite.
+//   - True-up is disabled because the fill path
+//     (fillMissingWindowsAndRecalculate) is gated on the meter's bucket size;
+//     without it, empty windows aren't materialized for true-up. Out-of-bucket
+//     billing is the more useful invariant to exercise here.
+//
+// Setup: regular SUM meter (NO BucketSize), $1/unit, $5 commitment per
+// request-window with 2x overage, time buckets = 09:00-17:00 UTC. Analytics
+// query passes WindowSize=Hour so the result has hourly request-window points.
+//
+// Two events of 10 units each:
+//   - 10:00 UTC (in-bucket):    cost $10 → $5 + ($5*2) = $15
+//   - 18:00 UTC (out-of-bucket): cost $10 → billed at base $10
+//
+// Expected TotalCost = $25 — same number as the bucketed-meter overage test,
+// proving the bucketed/non-bucketed paths converge on identical commitment
+// math once per-window points exist.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_TimeBuckets_NoBucketSizeOnMeter() {
+	ctx := s.GetContext()
+
+	// Regular (non-bucketed) SUM meter — NO BucketSize on the aggregation.
+	regularMeter := &meter.Meter{
+		ID:        "meter_tb_regular",
+		Name:      "Regular SUM (no BucketSize)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationSum,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, regularMeter))
+
+	flatPrice := &price.Price{
+		ID:             "price_tb_regular",
+		Amount:         decimal.NewFromInt(1),
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        regularMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, flatPrice))
+
+	commitmentAmount := decimal.NewFromInt(5)
+	overageFactor := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_tb_regular",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 flatPrice.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 regularMeter.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: false,
+		CommitmentWindowed:      true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{Start: types.Bucket{Hour: 9, Minute: 0}, End: types.Bucket{Hour: 17, Minute: 0}},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// 10:00 UTC: in-bucket, 10 units → overage $15
+	s.insertMeterUsage(ctx, regularMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10)
+	// 18:00 UTC: out-of-bucket, 10 units → base rate $10
+	s.insertMeterUsage(ctx, regularMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 18, 0, 0, 0, time.UTC), 10)
+
+	// WindowSize=Hour on the analytics query is what makes Points get populated
+	// for a non-bucketed meter; without it, calculateRegularCost would see no
+	// points and fall through to the aggregate path (no per-window commitment).
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{regularMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeHour,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_tb_regular" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for regular-meter line item")
+
+	// In-bucket overage ($15) + out-of-bucket base rate ($10) = $25.
+	expectedTotal := decimal.NewFromInt(25)
+	s.True(item.TotalCost.Equal(expectedTotal),
+		"expected $25 (regular meter; in-bucket overage $15 + out-of-bucket base $10); got %s",
+		item.TotalCost)
+}

--- a/internal/service/subscription_line_item.go
+++ b/internal/service/subscription_line_item.go
@@ -714,6 +714,13 @@ func (s *subscriptionService) applyLineItemCommitmentFromMap(
 	if cfg.CommitmentDuration != nil {
 		lineItem.CommitmentDuration = cfg.CommitmentDuration
 	}
+	if len(cfg.CommitmentTimeBuckets) > 0 {
+		// Copy to avoid aliasing the config's backing array — mutations to cfg
+		// after this point must not bleed into the domain object.
+		buckets := make(types.TimeOfDayBuckets, len(cfg.CommitmentTimeBuckets))
+		copy(buckets, cfg.CommitmentTimeBuckets)
+		lineItem.CommitmentTimeBuckets = buckets
+	}
 	if err := s.validateLineItemCommitment(ctx, lineItem); err != nil {
 		return err
 	}

--- a/internal/types/commitment.go
+++ b/internal/types/commitment.go
@@ -1,9 +1,7 @@
 package types
 
 import (
-	"fmt"
-	"sort"
-	"strings"
+	"time"
 
 	"github.com/shopspring/decimal"
 )
@@ -33,53 +31,58 @@ func (ct CommitmentType) String() string {
 	return string(ct)
 }
 
-// TimeOfDayBucket defines a [StartHour, EndHour) half-open hour range within a UTC day.
-// Hours are integers in [0, 24].
-// When StartHour < EndHour: normal range (e.g. {0, 12} = midnight to noon).
-// When StartHour >= EndHour: wraps midnight (e.g. {22, 6} = 10pm to 6am next day).
-type TimeOfDayBucket struct {
-	StartHour int `json:"start_hour"`
-	EndHour   int `json:"end_hour"`
+// Bucket is a point in a UTC day expressed as Hour (0-24) and Minute (0-59).
+// Hour=24 with Minute=0 is allowed so callers can express "end of day"
+// (e.g. {Start: {0, 0}, End: {24, 0}} = the whole day).
+type Bucket struct {
+	Hour   int `json:"hour"`
+	Minute int `json:"minute"`
 }
 
-// ContainsHour reports whether the given UTC hour (0–23) falls within this bucket.
-func (b TimeOfDayBucket) ContainsHour(hour int) bool {
-	if b.StartHour < b.EndHour {
-		return hour >= b.StartHour && hour < b.EndHour
+// MinuteOfDay returns the bucket's position in the day as Hour*60 + Minute,
+// in the range [0, 1440]. Used for ordering and overlap checks.
+func (b Bucket) MinuteOfDay() int {
+	return b.Hour*60 + b.Minute
+}
+
+// TimeOfDayBucket defines a [Start, End) half-open range within a UTC day.
+// When Start.MinuteOfDay() < End.MinuteOfDay(): normal range (e.g. 09:00-17:00).
+// When Start.MinuteOfDay() > End.MinuteOfDay(): wraps midnight (e.g. 22:00-06:00).
+// When equal: empty range — matches nothing.
+type TimeOfDayBucket struct {
+	Start Bucket `json:"start_bucket"`
+	End   Bucket `json:"end_bucket"`
+}
+
+// ContainsTime reports whether t falls within this bucket. The check uses the
+// UTC hour and minute of t.
+func (b TimeOfDayBucket) ContainsTime(t time.Time) bool {
+	utc := t.UTC()
+	cur := utc.Hour()*60 + utc.Minute()
+	start := b.Start.MinuteOfDay()
+	end := b.End.MinuteOfDay()
+	if start == end {
+		// Half-open [n, n) — empty range.
+		return false
 	}
-	// Midnight-wrapping: e.g. {22, 6} covers hours 22, 23, 0, 1, 2, 3, 4, 5
-	return hour >= b.StartHour || hour < b.EndHour
+	if start < end {
+		return cur >= start && cur < end
+	}
+	// Midnight-wrapping: e.g. {22:00, 06:00} covers 22:00..23:59 and 00:00..05:59.
+	return cur >= start || cur < end
 }
 
 // TimeOfDayBuckets is a slice of TimeOfDayBucket.
 type TimeOfDayBuckets []TimeOfDayBucket
 
-// ContainsHour reports whether the given UTC hour falls within any configured bucket.
-func (bs TimeOfDayBuckets) ContainsHour(hour int) bool {
+// ContainsTime reports whether t falls within any configured bucket.
+func (bs TimeOfDayBuckets) ContainsTime(t time.Time) bool {
 	for _, b := range bs {
-		if b.ContainsHour(hour) {
+		if b.ContainsTime(t) {
 			return true
 		}
 	}
 	return false
-}
-
-// ToString returns a deterministic string suitable for use as a Go map key.
-// Returns "" for an empty slice. Example: "0-12", "0-2,8-14".
-func (bs TimeOfDayBuckets) ToString() string {
-	if len(bs) == 0 {
-		return ""
-	}
-	sorted := make(TimeOfDayBuckets, len(bs))
-	copy(sorted, bs)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].StartHour < sorted[j].StartHour
-	})
-	parts := make([]string, len(sorted))
-	for i, b := range sorted {
-		parts[i] = fmt.Sprintf("%d-%d", b.StartHour, b.EndHour)
-	}
-	return strings.Join(parts, ",")
 }
 
 // CommitmentInfo holds information about a commitment

--- a/internal/types/commitment.go
+++ b/internal/types/commitment.go
@@ -1,6 +1,12 @@
 package types
 
-import "github.com/shopspring/decimal"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
 
 // CommitmentType defines how commitment is specified - either as an amount or quantity
 type CommitmentType string
@@ -25,6 +31,55 @@ func (ct CommitmentType) Validate() bool {
 // String returns the string representation of the commitment type
 func (ct CommitmentType) String() string {
 	return string(ct)
+}
+
+// TimeOfDayBucket defines a [StartHour, EndHour) half-open hour range within a UTC day.
+// Hours are integers in [0, 24].
+// When StartHour < EndHour: normal range (e.g. {0, 12} = midnight to noon).
+// When StartHour >= EndHour: wraps midnight (e.g. {22, 6} = 10pm to 6am next day).
+type TimeOfDayBucket struct {
+	StartHour int `json:"start_hour"`
+	EndHour   int `json:"end_hour"`
+}
+
+// ContainsHour reports whether the given UTC hour (0–23) falls within this bucket.
+func (b TimeOfDayBucket) ContainsHour(hour int) bool {
+	if b.StartHour < b.EndHour {
+		return hour >= b.StartHour && hour < b.EndHour
+	}
+	// Midnight-wrapping: e.g. {22, 6} covers hours 22, 23, 0, 1, 2, 3, 4, 5
+	return hour >= b.StartHour || hour < b.EndHour
+}
+
+// TimeOfDayBuckets is a slice of TimeOfDayBucket.
+type TimeOfDayBuckets []TimeOfDayBucket
+
+// ContainsHour reports whether the given UTC hour falls within any configured bucket.
+func (bs TimeOfDayBuckets) ContainsHour(hour int) bool {
+	for _, b := range bs {
+		if b.ContainsHour(hour) {
+			return true
+		}
+	}
+	return false
+}
+
+// ToString returns a deterministic string suitable for use as a Go map key.
+// Returns "" for an empty slice. Example: "0-12", "0-2,8-14".
+func (bs TimeOfDayBuckets) ToString() string {
+	if len(bs) == 0 {
+		return ""
+	}
+	sorted := make(TimeOfDayBuckets, len(bs))
+	copy(sorted, bs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].StartHour < sorted[j].StartHour
+	})
+	parts := make([]string, len(sorted))
+	for i, b := range sorted {
+		parts[i] = fmt.Sprintf("%d-%d", b.StartHour, b.EndHour)
+	}
+	return strings.Join(parts, ",")
 }
 
 // CommitmentInfo holds information about a commitment

--- a/internal/types/commitment.go
+++ b/internal/types/commitment.go
@@ -50,8 +50,8 @@ func (b Bucket) MinuteOfDay() int {
 // When Start.MinuteOfDay() > End.MinuteOfDay(): wraps midnight (e.g. 22:00-06:00).
 // When equal: empty range — matches nothing.
 type TimeOfDayBucket struct {
-	Start Bucket `json:"start_bucket"`
-	End   Bucket `json:"end_bucket"`
+	Start Bucket `json:"start"`
+	End   Bucket `json:"end"`
 }
 
 // ContainsTime reports whether t falls within this bucket. The check uses the

--- a/internal/types/commitment_test.go
+++ b/internal/types/commitment_test.go
@@ -1,0 +1,226 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitmentType_Validate(t *testing.T) {
+	tests := []struct {
+		name string
+		ct   CommitmentType
+		want bool
+	}{
+		{"amount is valid", COMMITMENT_TYPE_AMOUNT, true},
+		{"quantity is valid", COMMITMENT_TYPE_QUANTITY, true},
+		{"unknown is invalid", CommitmentType("usage"), false},
+		{"empty is invalid", CommitmentType(""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.ct.Validate())
+		})
+	}
+}
+
+func TestCommitmentType_String(t *testing.T) {
+	assert.Equal(t, "amount", COMMITMENT_TYPE_AMOUNT.String())
+	assert.Equal(t, "quantity", COMMITMENT_TYPE_QUANTITY.String())
+	assert.Equal(t, "", CommitmentType("").String())
+}
+
+func TestBucket_MinuteOfDay(t *testing.T) {
+	tests := []struct {
+		name   string
+		bucket Bucket
+		want   int
+	}{
+		{"midnight", Bucket{Hour: 0, Minute: 0}, 0},
+		{"one minute past midnight", Bucket{Hour: 0, Minute: 1}, 1},
+		{"9 AM", Bucket{Hour: 9, Minute: 0}, 540},
+		{"5:30 PM", Bucket{Hour: 17, Minute: 30}, 1050},
+		{"11:59 PM", Bucket{Hour: 23, Minute: 59}, 1439},
+		{"end of day (24:00)", Bucket{Hour: 24, Minute: 0}, 1440},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.bucket.MinuteOfDay())
+		})
+	}
+}
+
+func TestTimeOfDayBucket_ContainsTime(t *testing.T) {
+	// Helper: build a time at a specific UTC hour/minute.
+	at := func(hour, minute int) time.Time {
+		return time.Date(2026, time.June, 2, hour, minute, 0, 0, time.UTC)
+	}
+
+	tests := []struct {
+		name   string
+		bucket TimeOfDayBucket
+		t      time.Time
+		want   bool
+	}{
+		// Normal range [09:00, 17:00)
+		{
+			name:   "09:00-17:00: contains 09:00 (inclusive start)",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{17, 0}},
+			t:      at(9, 0),
+			want:   true,
+		},
+		{
+			name:   "09:00-17:00: contains 13:00 (midpoint)",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{17, 0}},
+			t:      at(13, 0),
+			want:   true,
+		},
+		{
+			name:   "09:00-17:00: excludes 17:00 (exclusive end)",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{17, 0}},
+			t:      at(17, 0),
+			want:   false,
+		},
+		{
+			name:   "09:00-17:00: contains 16:59",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{17, 0}},
+			t:      at(16, 59),
+			want:   true,
+		},
+		{
+			name:   "09:00-17:00: excludes 08:59",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{17, 0}},
+			t:      at(8, 59),
+			want:   false,
+		},
+		// Whole-day range [00:00, 24:00)
+		{
+			name:   "00:00-24:00: contains midnight",
+			bucket: TimeOfDayBucket{Start: Bucket{0, 0}, End: Bucket{24, 0}},
+			t:      at(0, 0),
+			want:   true,
+		},
+		{
+			name:   "00:00-24:00: contains 23:59",
+			bucket: TimeOfDayBucket{Start: Bucket{0, 0}, End: Bucket{24, 0}},
+			t:      at(23, 59),
+			want:   true,
+		},
+		// Midnight-wrapping range [22:00, 06:00) covers 22:00..23:59 and 00:00..05:59
+		{
+			name:   "22:00-06:00: contains 22:00 (inclusive start)",
+			bucket: TimeOfDayBucket{Start: Bucket{22, 0}, End: Bucket{6, 0}},
+			t:      at(22, 0),
+			want:   true,
+		},
+		{
+			name:   "22:00-06:00: contains 23:59",
+			bucket: TimeOfDayBucket{Start: Bucket{22, 0}, End: Bucket{6, 0}},
+			t:      at(23, 59),
+			want:   true,
+		},
+		{
+			name:   "22:00-06:00: contains 00:00",
+			bucket: TimeOfDayBucket{Start: Bucket{22, 0}, End: Bucket{6, 0}},
+			t:      at(0, 0),
+			want:   true,
+		},
+		{
+			name:   "22:00-06:00: contains 05:59",
+			bucket: TimeOfDayBucket{Start: Bucket{22, 0}, End: Bucket{6, 0}},
+			t:      at(5, 59),
+			want:   true,
+		},
+		{
+			name:   "22:00-06:00: excludes 06:00 (exclusive end)",
+			bucket: TimeOfDayBucket{Start: Bucket{22, 0}, End: Bucket{6, 0}},
+			t:      at(6, 0),
+			want:   false,
+		},
+		{
+			name:   "22:00-06:00: excludes 12:00",
+			bucket: TimeOfDayBucket{Start: Bucket{22, 0}, End: Bucket{6, 0}},
+			t:      at(12, 0),
+			want:   false,
+		},
+		// Empty range — start == end matches nothing
+		{
+			name:   "09:00-09:00: empty range excludes 09:00",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{9, 0}},
+			t:      at(9, 0),
+			want:   false,
+		},
+		{
+			name:   "09:00-09:00: empty range excludes 12:00",
+			bucket: TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{9, 0}},
+			t:      at(12, 0),
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.bucket.ContainsTime(tt.t))
+		})
+	}
+}
+
+// ContainsTime must use the UTC hour/minute even when the input time is in a
+// different zone. A 13:00 local time in IST is 07:30 UTC, which falls outside
+// the [09:00, 17:00) UTC window.
+func TestTimeOfDayBucket_ContainsTime_UsesUTC(t *testing.T) {
+	ist, err := time.LoadLocation("Asia/Kolkata")
+	if err != nil {
+		t.Skip("Asia/Kolkata zone unavailable in test env")
+	}
+
+	bucket := TimeOfDayBucket{Start: Bucket{9, 0}, End: Bucket{17, 0}}
+
+	// 13:00 IST == 07:30 UTC → outside [09:00, 17:00) UTC
+	localAfternoon := time.Date(2026, time.June, 2, 13, 0, 0, 0, ist)
+	assert.False(t, bucket.ContainsTime(localAfternoon),
+		"13:00 IST is 07:30 UTC and should fall outside [09:00, 17:00) UTC")
+
+	// 15:00 IST == 09:30 UTC → inside [09:00, 17:00) UTC
+	localBusinessHours := time.Date(2026, time.June, 2, 15, 0, 0, 0, ist)
+	assert.True(t, bucket.ContainsTime(localBusinessHours),
+		"15:00 IST is 09:30 UTC and should fall inside [09:00, 17:00) UTC")
+}
+
+func TestTimeOfDayBuckets_ContainsTime(t *testing.T) {
+	at := func(hour, minute int) time.Time {
+		return time.Date(2026, time.June, 2, hour, minute, 0, 0, time.UTC)
+	}
+
+	// Two-window setup: business hours and late evening.
+	buckets := TimeOfDayBuckets{
+		{Start: Bucket{9, 0}, End: Bucket{17, 0}},
+		{Start: Bucket{20, 0}, End: Bucket{22, 0}},
+	}
+
+	tests := []struct {
+		name string
+		t    time.Time
+		want bool
+	}{
+		{"inside first bucket", at(10, 0), true},
+		{"inside second bucket", at(21, 0), true},
+		{"between buckets", at(18, 0), false},
+		{"before all buckets", at(8, 0), false},
+		{"after all buckets", at(23, 0), false},
+		{"on boundary of first bucket end (exclusive)", at(17, 0), false},
+		{"on boundary of first bucket start (inclusive)", at(9, 0), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, buckets.ContainsTime(tt.t))
+		})
+	}
+}
+
+// An empty TimeOfDayBuckets slice should match nothing — callers use it as a
+// sentinel meaning "no time-of-day restriction configured".
+func TestTimeOfDayBuckets_ContainsTime_EmptySlice(t *testing.T) {
+	var buckets TimeOfDayBuckets
+	assert.False(t, buckets.ContainsTime(time.Date(2026, time.June, 2, 12, 0, 0, 0, time.UTC)))
+}


### PR DESCRIPTION
## 📝 Description
Allow commitments to be limited to buckets of specific times of the day.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-of-day commitment buckets: subscription line items can include configurable UTC time-of-day windows to limit when commitments apply.

* **API**
  * Create/update requests accept commitment_time_buckets with validation (requires commitment_windowed=true); supports set/append/clear semantics and causes new line-item creation when changed.

* **Billing & Analytics**
  * Windowed billing now uses per-window timestamps and time-of-day buckets to apply or skip commitments per window.

* **Tests**
  * Added tests for bucket containment, window filtering, nil/empty behavior, and mismatch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->