### PR TITLE
feature(subscription): make subscription with trial period under draf…

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1186,14 +1186,14 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		initialStatus = types.SubscriptionStatusIncomplete
 	case types.PaymentBehaviorAllowIncomplete:
 		// Allow incomplete behavior - subscription starts as incomplete (will be updated based on payment result)
-		initialStatus = types.SubscriptionStatusIncomplete
-	case types.PaymentBehaviorErrorIfIncomplete:
-		// Error if incomplete behavior - subscription starts as incomplete (will fail if payment fails)
 		if lo.FromPtr(r.TrialPeriodDays) > 0 {
 			initialStatus = types.SubscriptionStatusDraft
 		} else {
 			initialStatus = types.SubscriptionStatusIncomplete
 		}
+	case types.PaymentBehaviorErrorIfIncomplete:
+		// Error if incomplete behavior - subscription starts as incomplete (will fail if payment fails)
+		initialStatus = types.SubscriptionStatusIncomplete
 	default:
 		// Fallback to active for unknown behaviors
 		initialStatus = types.SubscriptionStatusActive

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1189,7 +1189,7 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		initialStatus = types.SubscriptionStatusIncomplete
 	case types.PaymentBehaviorErrorIfIncomplete:
 		// Error if incomplete behavior - subscription starts as incomplete (will fail if payment fails)
-		if lo.IsNotEmpty(r.TrialPeriodDays) {
+		if lo.FromPtr(r.TrialPeriodDays) > 0 {
 			initialStatus = types.SubscriptionStatusDraft
 		} else {
 			initialStatus = types.SubscriptionStatusIncomplete

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1155,7 +1155,7 @@ func (r *CreateSubscriptionRequest) validateShouldAllowProrationOnStartDate(requ
 	return nil
 }
 
-func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context, hasPaddleIntegration bool) *subscription.Subscription {
+func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscription.Subscription {
 	// Handle legacy collection method and set defaults
 	paymentBehavior := types.PaymentBehaviorDefaultActive
 	collectionMethod := types.CollectionMethodChargeAutomatically
@@ -1186,11 +1186,7 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context, hasPaddl
 		initialStatus = types.SubscriptionStatusIncomplete
 	case types.PaymentBehaviorAllowIncomplete:
 		// Allow incomplete behavior - subscription starts as incomplete (will be updated based on payment result)
-		if lo.FromPtr(r.TrialPeriodDays) > 0 && hasPaddleIntegration {
-			initialStatus = types.SubscriptionStatusDraft
-		} else {
-			initialStatus = types.SubscriptionStatusIncomplete
-		}
+		initialStatus = types.SubscriptionStatusIncomplete
 	case types.PaymentBehaviorErrorIfIncomplete:
 		// Error if incomplete behavior - subscription starts as incomplete (will fail if payment fails)
 		initialStatus = types.SubscriptionStatusIncomplete

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1189,7 +1189,12 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		initialStatus = types.SubscriptionStatusIncomplete
 	case types.PaymentBehaviorErrorIfIncomplete:
 		// Error if incomplete behavior - subscription starts as incomplete (will fail if payment fails)
-		initialStatus = types.SubscriptionStatusIncomplete
+		if lo.IsNotEmpty(r.TrialPeriodDays) {
+			initialStatus = types.SubscriptionStatusDraft
+			r.SubscriptionStatus = types.SubscriptionStatusDraft
+		} else {
+			initialStatus = types.SubscriptionStatusIncomplete
+		}
 	default:
 		// Fallback to active for unknown behaviors
 		initialStatus = types.SubscriptionStatusActive
@@ -1793,10 +1798,10 @@ type SubscriptionUpdatePeriodResponseItem struct {
 
 // AutoInvoiceThresholdBillingResult is the result of a single ProcessAutoInvoiceThresholdBilling run.
 type AutoInvoiceThresholdBillingResult struct {
-	TotalChecked  int                                    `json:"total_checked"`
-	TotalInvoiced int                                    `json:"total_invoiced"`
-	TotalSkipped  int                                    `json:"total_skipped"`
-	TotalFailed   int                                    `json:"total_failed"`
+	TotalChecked  int                                      `json:"total_checked"`
+	TotalInvoiced int                                      `json:"total_invoiced"`
+	TotalSkipped  int                                      `json:"total_skipped"`
+	TotalFailed   int                                      `json:"total_failed"`
 	Items         []*AutoInvoiceThresholdBillingResultItem `json:"items,omitempty"`
 }
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1191,7 +1191,6 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		// Error if incomplete behavior - subscription starts as incomplete (will fail if payment fails)
 		if lo.IsNotEmpty(r.TrialPeriodDays) {
 			initialStatus = types.SubscriptionStatusDraft
-			r.SubscriptionStatus = types.SubscriptionStatusDraft
 		} else {
 			initialStatus = types.SubscriptionStatusIncomplete
 		}

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1155,7 +1155,7 @@ func (r *CreateSubscriptionRequest) validateShouldAllowProrationOnStartDate(requ
 	return nil
 }
 
-func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscription.Subscription {
+func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context, hasPaddleIntegration bool) *subscription.Subscription {
 	// Handle legacy collection method and set defaults
 	paymentBehavior := types.PaymentBehaviorDefaultActive
 	collectionMethod := types.CollectionMethodChargeAutomatically
@@ -1186,7 +1186,7 @@ func (r *CreateSubscriptionRequest) ToSubscription(ctx context.Context) *subscri
 		initialStatus = types.SubscriptionStatusIncomplete
 	case types.PaymentBehaviorAllowIncomplete:
 		// Allow incomplete behavior - subscription starts as incomplete (will be updated based on payment result)
-		if lo.FromPtr(r.TrialPeriodDays) > 0 {
+		if lo.FromPtr(r.TrialPeriodDays) > 0 && hasPaddleIntegration {
 			initialStatus = types.SubscriptionStatusDraft
 		} else {
 			initialStatus = types.SubscriptionStatusIncomplete

--- a/internal/integration/paddle/sync_service.go
+++ b/internal/integration/paddle/sync_service.go
@@ -1093,6 +1093,12 @@ func (s *PaddleSyncService) ProcessSubscriptionActivatedWebhook(
 			s.logger.Infow("subscription.activated: set incomplete→active",
 				"sub_id", flexSubID, "paddle_sub_id", paddleSubID)
 		}
+	case types.SubscriptionStatusDraft:
+		if _, err := subscriptionService.ActivateDraftSubscription(ctx, flexSubID, apidto.ActivateDraftSubscriptionRequest{lo.ToPtr(time.Now())}); err != nil {
+			return fmt.Errorf("activating draft subscription: %w", err)
+		}
+		s.logger.Infow("subscription.activated",
+			"sub_id", flexSubID, "paddle_sub_id", paddleSubID)
 	default:
 		s.logger.Infow("subscription.activated: subscription not in incomplete state — no-op",
 			"sub_id", flexSubID, "status", sub.SubscriptionStatus, "paddle_sub_id", paddleSubID)

--- a/internal/integration/paddle/sync_service.go
+++ b/internal/integration/paddle/sync_service.go
@@ -1094,7 +1094,7 @@ func (s *PaddleSyncService) ProcessSubscriptionActivatedWebhook(
 				"sub_id", flexSubID, "paddle_sub_id", paddleSubID)
 		}
 	case types.SubscriptionStatusDraft:
-		startDate := time.Now()
+		startDate := time.Now().UTC()
 		if data.StartedAt != nil {
 			if parsed, parseErr := time.Parse(time.RFC3339, *data.StartedAt); parseErr == nil {
 				startDate = parsed

--- a/internal/integration/paddle/sync_service.go
+++ b/internal/integration/paddle/sync_service.go
@@ -1094,7 +1094,15 @@ func (s *PaddleSyncService) ProcessSubscriptionActivatedWebhook(
 				"sub_id", flexSubID, "paddle_sub_id", paddleSubID)
 		}
 	case types.SubscriptionStatusDraft:
-		if _, err := subscriptionService.ActivateDraftSubscription(ctx, flexSubID, apidto.ActivateDraftSubscriptionRequest{lo.ToPtr(time.Now())}); err != nil {
+		startDate := time.Now()
+		if data.StartedAt != nil {
+			if parsed, parseErr := time.Parse(time.RFC3339, *data.StartedAt); parseErr == nil {
+				startDate = parsed
+			}
+		}
+		if _, err := subscriptionService.ActivateDraftSubscription(ctx, flexSubID, apidto.ActivateDraftSubscriptionRequest{
+			StartDate: &startDate,
+		}); err != nil {
 			return fmt.Errorf("activating draft subscription: %w", err)
 		}
 		s.logger.Infow("subscription.activated",

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -536,6 +536,17 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 	sub.CurrentPeriodStart = sub.StartDate
 	sub.CurrentPeriodEnd = nextBillingDate
 
+	isTrialActivation := sub.TrialStart != nil && sub.TrialEnd != nil
+	var billingReason types.InvoiceBillingReason
+	if isTrialActivation {
+		trialDuration := sub.TrialEnd.Sub(lo.FromPtr(sub.TrialStart))
+		sub.TrialStart = lo.ToPtr(newStartDate)
+		sub.TrialEnd = lo.ToPtr(newStartDate.Add(trialDuration))
+		sub.CurrentPeriodStart = lo.FromPtr(sub.TrialStart)
+		sub.CurrentPeriodEnd = lo.FromPtr(sub.TrialEnd)
+		billingReason = types.InvoiceBillingReasonSubscriptionTrialStart
+	}
+
 	// Update line item start dates and end dates
 	for _, item := range sub.LineItems {
 		// Get price to check if it has a start date
@@ -579,6 +590,7 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 			PeriodStart:    sub.CurrentPeriodStart,
 			PeriodEnd:      sub.CurrentPeriodEnd,
 			ReferencePoint: types.ReferencePointPeriodStart,
+			BillingReason:  billingReason,
 		}, paymentParams, types.InvoiceFlowSubscriptionCreation, true) // Pass true for draft activation
 		if err != nil {
 			return err
@@ -603,7 +615,11 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 		if sub.SubscriptionStatus == types.SubscriptionStatusIncomplete || sub.SubscriptionStatus == types.SubscriptionStatusDraft {
 			if invoice == nil || invoice.PaymentStatus == types.PaymentStatusSucceeded {
 				// No invoice created or payment succeeded - activate subscription
-				targetStatus = types.SubscriptionStatusActive
+				if isTrialActivation {
+					targetStatus = types.SubscriptionStatusTrialing
+				} else {
+					targetStatus = types.SubscriptionStatusActive
+				}
 			} else {
 				// Set status based on payment_behavior
 				paymentBehavior := types.PaymentBehavior(sub.PaymentBehavior)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -533,19 +533,18 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 		return nil, err
 	}
 
-	sub.CurrentPeriodStart = sub.StartDate
-	sub.CurrentPeriodEnd = nextBillingDate
-
 	isTrialActivation := sub.TrialStart != nil && sub.TrialEnd != nil
 	var billingReason types.InvoiceBillingReason
 	if isTrialActivation {
 		trialDuration := sub.TrialEnd.Sub(lo.FromPtr(sub.TrialStart))
 		sub.TrialStart = lo.ToPtr(newStartDate)
 		sub.TrialEnd = lo.ToPtr(newStartDate.Add(trialDuration))
-		sub.CurrentPeriodStart = lo.FromPtr(sub.TrialStart)
-		sub.CurrentPeriodEnd = lo.FromPtr(sub.TrialEnd)
+		nextBillingDate = lo.FromPtr(sub.TrialEnd)
 		billingReason = types.InvoiceBillingReasonSubscriptionTrialStart
 	}
+
+	sub.CurrentPeriodStart = sub.StartDate
+	sub.CurrentPeriodEnd = nextBillingDate
 
 	// Update line item start dates and end dates
 	for _, item := range sub.LineItems {

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -101,9 +101,8 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			WithReportableDetails(map[string]interface{}{"plan_id": req.PlanID, "status": plan.Status}).
 			Mark(ierr.ErrValidation)
 	}
-	paddleInt, _ := s.IntegrationFactory.GetPaddleIntegration(ctx)
-	hasPaddleIntegration := paddleInt != nil
-	sub := req.ToSubscription(ctx, hasPaddleIntegration)
+	sub := req.ToSubscription(ctx)
+	s.overRideSubscriptionBasedOnIntegration(ctx, sub)
 
 	// Validate and filter prices
 	validPrices, err := s.ValidateAndFilterPricesForSubscription(ctx, plan.ID, types.PRICE_ENTITY_TYPE_PLAN, sub, req.Workflow)
@@ -491,6 +490,19 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		s.publishSubscriptionCreatedEvent(ctx, sub)
 	}
 	return response, nil
+}
+
+func (s *subscriptionService) overRideSubscriptionBasedOnIntegration(ctx context.Context, sub *subscription.Subscription) {
+	paddleInt, _ := s.IntegrationFactory.GetPaddleIntegration(ctx)
+	if paddleInt != nil {
+		overRideSubscriptionBasedOnPaddleIntegration(sub)
+	}
+}
+
+func overRideSubscriptionBasedOnPaddleIntegration(sub *subscription.Subscription) {
+	if sub.PaymentBehavior == types.PaymentBehaviorAllowIncomplete.String() {
+		sub.SubscriptionStatus = types.SubscriptionStatusDraft
+	}
 }
 
 func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, subID string, req dto.ActivateDraftSubscriptionRequest) (*dto.SubscriptionResponse, error) {

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -534,7 +534,7 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 		return nil, err
 	}
 
-	isTrialActivation := sub.TrialStart != nil && sub.TrialEnd != nil
+	isTrialActivation := sub.TrialStart != nil && sub.TrialEnd != nil && newStartDate.After(*sub.TrialStart) && newStartDate.Before(*sub.TrialEnd)
 	var billingReason types.InvoiceBillingReason
 	if isTrialActivation {
 		trialDuration := sub.TrialEnd.Sub(lo.FromPtr(sub.TrialStart))

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -482,6 +482,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 	isDraft := req.SubscriptionStatus == types.SubscriptionStatusDraft
 	if isDraft {
 		s.triggerHubSpotQuoteSyncWorkflow(ctx, sub.ID, customer.ID)
+		s.runPaddleSubscriptionSync(ctx, sub)
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionDraftCreated, sub.ID)
 	} else {
 		s.triggerHubSpotDealSyncWorkflow(ctx, sub.ID, customer.ID)
@@ -7313,7 +7314,7 @@ func syncTrialingStateFromCreateRequest(req *dto.CreateSubscriptionRequest, sub 
 	if sub.TrialStart == nil || sub.TrialEnd == nil {
 		return
 	}
-	if req.SubscriptionStatus == types.SubscriptionStatusDraft {
+	if req.SubscriptionStatus == types.SubscriptionStatusDraft || sub.SubscriptionStatus == types.SubscriptionStatusDraft {
 		return
 	}
 	// While trialing, "current period" is the trial, not the normal billing interval.

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -102,7 +102,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			Mark(ierr.ErrValidation)
 	}
 	sub := req.ToSubscription(ctx)
-	s.overRideSubscriptionBasedOnIntegration(ctx, sub)
+	s.overRideSubscriptionBasedOnIntegration(ctx, sub, &req)
 
 	// Validate and filter prices
 	validPrices, err := s.ValidateAndFilterPricesForSubscription(ctx, plan.ID, types.PRICE_ENTITY_TYPE_PLAN, sub, req.Workflow)
@@ -492,15 +492,15 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 	return response, nil
 }
 
-func (s *subscriptionService) overRideSubscriptionBasedOnIntegration(ctx context.Context, sub *subscription.Subscription) {
+func (s *subscriptionService) overRideSubscriptionBasedOnIntegration(ctx context.Context, sub *subscription.Subscription, req *dto.CreateSubscriptionRequest) {
 	paddleInt, _ := s.IntegrationFactory.GetPaddleIntegration(ctx)
 	if paddleInt != nil {
-		overRideSubscriptionBasedOnPaddleIntegration(sub)
+		overRideSubscriptionBasedOnPaddleIntegration(sub, req)
 	}
 }
 
-func overRideSubscriptionBasedOnPaddleIntegration(sub *subscription.Subscription) {
-	if sub.PaymentBehavior == types.PaymentBehaviorAllowIncomplete.String() {
+func overRideSubscriptionBasedOnPaddleIntegration(sub *subscription.Subscription, req *dto.CreateSubscriptionRequest) {
+	if sub.PaymentBehavior == types.PaymentBehaviorAllowIncomplete.String() && lo.FromPtr(req.TrialPeriodDays) > 0 {
 		sub.SubscriptionStatus = types.SubscriptionStatusDraft
 	}
 }

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -101,8 +101,9 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 			WithReportableDetails(map[string]interface{}{"plan_id": req.PlanID, "status": plan.Status}).
 			Mark(ierr.ErrValidation)
 	}
-
-	sub := req.ToSubscription(ctx)
+	paddleInt, _ := s.IntegrationFactory.GetPaddleIntegration(ctx)
+	hasPaddleIntegration := paddleInt != nil
+	sub := req.ToSubscription(ctx, hasPaddleIntegration)
 
 	// Validate and filter prices
 	validPrices, err := s.ValidateAndFilterPricesForSubscription(ctx, plan.ID, types.PRICE_ENTITY_TYPE_PLAN, sub, req.Workflow)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscriptions now initialize to draft only when a trial is provided; otherwise marked incomplete.
  * Draft activation preserves and realigns trial windows, recalculates trial dates, and sets correct next billing and billing reason.
  * Incoming draft-activation events are handled and trigger draft-specific activation.
  * Creating draft subscriptions now triggers external subscription synchronization.
  * Trial alignment is skipped when the request or subscription is already draft.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->