### PR TITLE
fix(user): compensate-delete auth on InviteUser to avoid orphaned auth (#1634)

### DIFF
--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -283,6 +283,35 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 		return nil, nil, err
 	}
 	if err := s.userRepo.Create(ctx, newUser); err != nil {
+		// Flexprice path: Consider deleting the provisioned auth record in case of user creation failure to avoid orphaned records, depending on your consistency requirements.
+		if inviteResp.AuthRecord != nil {
+			if rollBackErr := s.authRepo.DeleteAuth(ctx, inviteResp.AuthRecord.UserID); rollBackErr != nil {
+				if s.logger != nil {
+					s.logger.Warnw("failed to roll back auth record after user create failure",
+						"user_id", inviteResp.AuthRecord.UserID,
+						"email", req.Email,
+						"rollback_error", rollBackErr,
+						"create_error", err,
+					)
+				}
+			} else {
+				if s.logger != nil {
+					s.logger.Infow("rolled back auth record after user create failure",
+						"user_id", inviteResp.AuthRecord.UserID,
+						"email", req.Email,
+					)
+				}
+			}
+		} else if inviteResp.AuthRecord == nil && s.logger != nil && s.cfg != nil && s.cfg.Auth.Provider == types.AuthProviderSupabase {
+			// TODO: Handle Supabase partial-failure recovery.
+			// Supabase path: If Supabase user creation succeeds but local user creation fails,
+			// an orphaned Supabase user may remain and require manual remediation.
+			s.logger.Warnw("user create failed after remote auth provisioning; manual remediation may be required",
+				"email", req.Email,
+				"provider", s.cfg.Auth.Provider,
+				"create_error", err,
+			)
+		}
 		return nil, nil, err
 	}
 	return newUser, &password, nil

--- a/internal/service/user_test.go
+++ b/internal/service/user_test.go
@@ -2,12 +2,15 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/config"
+	domainAuth "github.com/flexprice/flexprice/internal/domain/auth"
 	"github.com/flexprice/flexprice/internal/domain/tenant"
 	"github.com/flexprice/flexprice/internal/domain/user"
+	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
@@ -20,6 +23,24 @@ type UserServiceSuite struct {
 	userService *userService
 	userRepo    *testutil.InMemoryUserStore
 	tenantRepo  *testutil.InMemoryTenantStore
+}
+
+// failingUserRepo returns an error for Create to simulate DB failure.
+type failingUserRepo struct {
+	*testutil.InMemoryUserStore
+	createErr error
+}
+
+func (r *failingUserRepo) Create(ctx context.Context, u *user.User) error {
+	return r.createErr
+}
+
+// authRepoSpy records create/delete calls.
+type authRepoSpy struct {
+	createdAuth   *domainAuth.Auth
+	deletedUserID string
+	createCalls   int
+	deleteCalls   int
 }
 
 func TestUserService(t *testing.T) {
@@ -226,4 +247,77 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 			}
 		})
 	}
+}
+
+func (r *authRepoSpy) CreateAuth(ctx context.Context, a *domainAuth.Auth) error {
+	r.createdAuth = a
+	r.createCalls++
+	return nil
+}
+
+func (r *authRepoSpy) GetAuthByUserID(ctx context.Context, userID string) (*domainAuth.Auth, error) {
+	if r.createdAuth != nil && r.createdAuth.UserID == userID {
+		return r.createdAuth, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (r *authRepoSpy) UpdateAuth(ctx context.Context, a *domainAuth.Auth) error {
+	return nil
+}
+
+func (r *authRepoSpy) DeleteAuth(ctx context.Context, userID string) error {
+	r.deletedUserID = userID
+	r.deleteCalls++
+	return nil
+}
+
+func (s *UserServiceSuite) TestInviteUser_CompensatingDeleteOnUserCreateFailure() {
+	ctx := testutil.SetupContext()
+	// set tenant and actor
+	ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
+	ctx = context.WithValue(ctx, types.CtxUserID, "test-actor")
+
+	// prepare tenant repo with default tenant
+	tenantRepo := testutil.NewInMemoryTenantStore()
+	_ = tenantRepo.Create(ctx, &tenant.Tenant{ID: types.DefaultTenantID, Name: "Test Tenant"})
+
+	// prepare settings service expected by InviteUser
+	settingsSvc := &settingsService{
+		ServiceParams: ServiceParams{
+			SettingsRepo: testutil.NewInMemorySettingsStore(),
+		},
+	}
+
+	// auth spy and failing user repo
+	authSpy := &authRepoSpy{}
+	userRepo := &failingUserRepo{
+		InMemoryUserStore: testutil.NewInMemoryUserStore(),
+		createErr:         errors.New("forced user create failure"),
+	}
+
+	svc := &userService{
+		userRepo:        userRepo,
+		tenantRepo:      tenantRepo,
+		authRepo:        authSpy,
+		cfg:             &config.Configuration{Auth: config.AuthConfig{Provider: types.AuthProviderFlexprice}},
+		rbacService:     nil,
+		supabaseAuth:    nil,
+		settingsService: settingsSvc,
+		logger:          logger.NewNoopLogger(),
+	}
+
+	// Call InviteUser which should attempt CreateAuth then fail on userRepo.Create,
+	// and then call DeleteAuth as compensation.
+	resp, pw, err := svc.InviteUser(ctx, &dto.CreateUserRequest{Type: types.UserTypeUser, Email: "rollback@example.com"}, "test-actor")
+
+	s.Error(err)
+	s.Nil(resp)
+	s.Nil(pw)
+
+	// Validate that CreateAuth was called once and DeleteAuth was called once
+	s.Equal(1, authSpy.createCalls, "expected CreateAuth to be called once")
+	s.Equal(1, authSpy.deleteCalls, "expected DeleteAuth to be called once")
+	s.NotNil(authSpy.createdAuth, "created auth should be recorded")
+	s.Equal(authSpy.createdAuth.UserID, authSpy.deletedUserID, "deleted user id should match created auth user id")
 }


### PR DESCRIPTION
Fixes #1634

## 📝 Description
Fix a partial-failure window in InviteUser where the auth record (Flexprice provider) could be created but the application user row failed to persist, leaving an orphaned auth record that blocks re-registration. Adds a compensating DeleteAuth when the user insert fails and surfaces a distinct warning for Supabase (remote) partial failures.

---

## 🔨 Changes Made
- [x] Bug Fix: Added compensating delete + logging to InviteUser.
Tests: Added a regression test that simulates `userRepo.Create` failure and asserts DeleteAuth was invoked.
Files changed:
`user.go`
`user_test.go`

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.

---

## 📷 Screenshots / Demo (if applicable)
- [x] New test pass.

### Logs
go test ./internal/service -run TestUserService -v
=== RUN   TestUserService
=== RUN   TestUserService/TestCreateUser_TableDriven
=== RUN   TestUserService/TestCreateUser_TableDriven/type_user_without_supabase_returns_error
=== RUN   TestUserService/TestCreateUser_TableDriven/type_service_account_without_rbac_returns_error
=== RUN   TestUserService/TestCreateUser_TableDriven/invalid_user_type_returns_error
=== RUN   TestUserService/TestGetUserInfo
=== RUN   TestUserService/TestGetUserInfo/user_found
=== RUN   TestUserService/TestGetUserInfo/user_not_found
=== RUN   TestUserService/TestInviteUser_CompensatingDeleteOnUserCreateFailure
--- PASS: TestUserService (0.05s)
    --- PASS: TestUserService/TestCreateUser_TableDriven (0.00s)
        --- PASS: TestUserService/TestCreateUser_TableDriven/type_user_without_supabase_returns_error (0.00s)
        --- PASS: TestUserService/TestCreateUser_TableDriven/type_service_account_without_rbac_returns_error (0.00s)
        --- PASS: TestUserService/TestCreateUser_TableDriven/invalid_user_type_returns_error (0.00s)
    --- PASS: TestUserService/TestGetUserInfo (0.00s)
        --- PASS: TestUserService/TestGetUserInfo/user_found (0.00s)
        --- PASS: TestUserService/TestGetUserInfo/user_not_found (0.00s)
    --- PASS: TestUserService/TestInviteUser_CompensatingDeleteOnUserCreateFailure (0.05s)
PASS
ok      github.com/flexprice/flexprice/internal/service 0.071s



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User invitations now automatically clean up provisioned authentication records when user creation fails. Added handling for edge cases, including logging for potential orphaned authentication records.

* **Tests**
  * Added comprehensive test coverage for authentication cleanup and error recovery behavior during user invitation failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->