### PR TITLE
fix(redis,config): cluster-mode toggle, structured cache logging, cli…

### DIFF
--- a/internal/cache/init.go
+++ b/internal/cache/init.go
@@ -24,7 +24,7 @@ func Initialize(config *config.Configuration, log *logger.Logger) Cache {
 
 	switch CacheType(config.Cache.Type) {
 	case CacheTypeRedis:
-		InitializeRedisCache()
+		InitializeRedisCache(config, log)
 		cache = GetRedisCache()
 	case CacheTypeInMemory:
 		fallthrough

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -21,10 +21,12 @@ const (
 	ScanCount = 100
 )
 
-// RedisCache implements the Cache interface using Redis
+// RedisCache implements the Cache interface using Redis.
+// The client is a UniversalClient so it works for both standalone and cluster deployments.
 type RedisCache struct {
-	client *redis.ClusterClient
+	client redis.UniversalClient
 	config *config.Configuration
+	log    *logger.Logger
 }
 
 // Redis cache instance
@@ -33,35 +35,44 @@ var redisCache *RedisCache
 // NewRedisCache creates a new Redis cache
 func NewRedisCache() *RedisCache {
 	if redisCache == nil {
-		InitializeRedisCache()
+		cfg, err := config.NewConfig()
+		if err != nil {
+			logger.GetLogger().Errorw("Failed to initialize Redis cache", "error", err)
+			return nil
+		}
+		InitializeRedisCache(cfg, logger.GetLogger())
 	}
 	return redisCache
 }
 
-// InitializeRedisCache initializes the global Redis cache instance
-func InitializeRedisCache() {
-	config, err := config.NewConfig()
-	if err != nil {
-		fmt.Println("Failed to initialize Redis cache", "error", err)
+// InitializeRedisCache initializes the global Redis cache instance using the
+// provided configuration and logger. Dependencies are explicit; callers should
+// pass through the values wired by Initialize rather than relying on globals.
+func InitializeRedisCache(cfg *config.Configuration, log *logger.Logger) {
+	if redisCache != nil {
 		return
 	}
-	if redisCache == nil {
-		redisClient, err := redisClient.NewClient(config, logger.GetLogger())
-		if err != nil {
-			fmt.Println("Failed to create Redis client", "error", err)
-			return
-		}
-		redisCache = &RedisCache{
-			client: redisClient.GetClient(),
-			config: config,
-		}
+	client, err := redisClient.NewClient(cfg, log)
+	if err != nil {
+		log.Errorw("Failed to create Redis client", "error", err)
+		return
+	}
+	redisCache = &RedisCache{
+		client: client.GetClient(),
+		config: cfg,
+		log:    log,
 	}
 }
 
 // GetRedisCache returns the global Redis cache instance
 func GetRedisCache() *RedisCache {
 	if redisCache == nil {
-		InitializeRedisCache()
+		cfg, err := config.NewConfig()
+		if err != nil {
+			logger.GetLogger().Errorw("Failed to initialize Redis cache", "error", err)
+			return nil
+		}
+		InitializeRedisCache(cfg, logger.GetLogger())
 	}
 	return redisCache
 }
@@ -78,7 +89,7 @@ func (c *RedisCache) GetRedisKey(key string) string {
 func (c *RedisCache) Get(ctx context.Context, key string) (interface{}, bool) {
 
 	if !c.config.Cache.Enabled {
-		fmt.Println("Cache is disabled")
+		c.log.Debugw("Cache is disabled")
 		return nil, false
 	}
 
@@ -90,7 +101,7 @@ func (c *RedisCache) Get(ctx context.Context, key string) (interface{}, bool) {
 			// Key does not exist
 			return nil, false
 		}
-		fmt.Print("Redis GET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis GET error", "key", redisKey, "error", err)
 		return nil, false
 	}
 
@@ -101,7 +112,7 @@ func (c *RedisCache) Get(ctx context.Context, key string) (interface{}, bool) {
 func (c *RedisCache) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) {
 
 	if !c.config.Cache.Enabled {
-		fmt.Println("Cache is disabled")
+		c.log.Debugw("Cache is disabled")
 		return
 	}
 	// Use default expiration if none specified
@@ -121,14 +132,14 @@ func (c *RedisCache) Set(ctx context.Context, key string, value interface{}, exp
 		// Marshal non-string values to JSON
 		jsonBytes, err := json.Marshal(value)
 		if err != nil {
-			fmt.Println("Failed to marshal cache value", "key", redisKey, "error", err)
+			c.log.Errorw("Failed to marshal cache value", "key", redisKey, "error", err)
 			return
 		}
 		strValue = string(jsonBytes)
 	}
 
 	if err := c.client.Set(ctx, redisKey, strValue, expiration).Err(); err != nil {
-		fmt.Println("Redis SET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis SET error", "key", redisKey, "error", err)
 	}
 }
 
@@ -138,7 +149,7 @@ func (c *RedisCache) Delete(ctx context.Context, key string) {
 	redisKey := c.GetRedisKey(key)
 	err := c.delete(ctx, redisKey)
 	if err != nil {
-		fmt.Println("Redis DELETE failed, retrying...", "key", redisKey, "error", err)
+		c.log.Warnw("Redis DELETE failed, retrying...", "key", redisKey, "error", err)
 
 		// Create a new context with timeout for the retry
 		retryCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -149,7 +160,7 @@ func (c *RedisCache) Delete(ctx context.Context, key string) {
 
 		// Retry once
 		if retryErr := c.delete(retryCtx, redisKey); retryErr != nil {
-			fmt.Println("Redis DELETE retry failed", "key", redisKey, "error", retryErr)
+			c.log.Errorw("Redis DELETE retry failed", "key", redisKey, "error", retryErr)
 		}
 	}
 }
@@ -217,7 +228,7 @@ func (c *RedisCache) DeleteByPrefix(ctx context.Context, prefix string) {
 // Flush removes all items from the cache
 func (c *RedisCache) Flush(ctx context.Context) {
 	if err := c.client.FlushDB(ctx).Err(); err != nil {
-		fmt.Println("Redis FLUSHDB error", "error", err)
+		c.log.Errorw("Redis FLUSHDB error", "error", err)
 	}
 }
 
@@ -230,7 +241,7 @@ func (c *RedisCache) ForceCacheGet(ctx context.Context, key string) (interface{}
 			// Key does not exist
 			return nil, false
 		}
-		fmt.Println("Redis GET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis GET error", "key", redisKey, "error", err)
 		return nil, false
 	}
 
@@ -245,13 +256,13 @@ func (c *RedisCache) ForceCacheGetWithTTL(ctx context.Context, key string) (inte
 		if errors.Is(err, redis.Nil) {
 			return nil, 0, false
 		}
-		fmt.Println("Redis GET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis GET error", "key", redisKey, "error", err)
 		return nil, 0, false
 	}
 
 	ttl, err := c.client.TTL(ctx, redisKey).Result()
 	if err != nil {
-		fmt.Println("Redis TTL error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis TTL error", "key", redisKey, "error", err)
 		// Still return the value even if TTL lookup fails
 		return value, 0, true
 	}
@@ -278,13 +289,13 @@ func (c *RedisCache) ForceCacheSet(ctx context.Context, key string, value interf
 		// Marshal non-string values to JSON
 		jsonBytes, err := json.Marshal(value)
 		if err != nil {
-			fmt.Println("Failed to marshal cache value", "key", redisKey, "error", err)
+			c.log.Errorw("Failed to marshal cache value", "key", redisKey, "error", err)
 			return
 		}
 		strValue = string(jsonBytes)
 	}
 
 	if err := c.client.Set(ctx, redisKey, strValue, expiration).Err(); err != nil {
-		fmt.Println("Redis SET error", "key", redisKey, "error", err)
+		c.log.Errorw("Redis SET error", "key", redisKey, "error", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -476,14 +476,20 @@ type CustomerPortalConfig struct {
 
 // RedisConfig holds configuration for Redis
 type RedisConfig struct {
-	Host      string        `mapstructure:"host" default:"localhost"`
-	Port      int           `mapstructure:"port" default:"6379"`
-	Password  string        `mapstructure:"password" default:""`
-	DB        int           `mapstructure:"db" default:"0"`
-	UseTLS    bool          `mapstructure:"use_tls" default:"false"`
-	PoolSize  int           `mapstructure:"pool_size" default:"10"`
-	Timeout   time.Duration `mapstructure:"timeout" default:"5s"`
-	KeyPrefix string        `mapstructure:"key_prefix" default:"flexprice"`
+	Host        string        `mapstructure:"host" default:"localhost"`
+	Port        int           `mapstructure:"port" default:"6379"`
+	Password    string        `mapstructure:"password" default:""`
+	DB          int           `mapstructure:"db" default:"0"`
+	UseTLS      bool          `mapstructure:"use_tls" default:"false"`
+	PoolSize    int           `mapstructure:"pool_size" default:"10"`
+	Timeout     time.Duration `mapstructure:"timeout" default:"5s"`
+	KeyPrefix   string        `mapstructure:"key_prefix" default:"flexprice"`
+	// ClusterMode: true → *redis.ClusterClient (Redis Cluster, ElastiCache
+	// cluster-mode enabled). false → standalone *redis.Client. Default is
+	// true to preserve the pre-1.1 hardcoded behaviour; flip to false for
+	// single-node Redis. Baked default lives in config.yaml; env override:
+	// FLEXPRICE_REDIS_CLUSTER_MODE.
+	ClusterMode bool          `mapstructure:"cluster_mode"`
 }
 
 func NewConfig() (*Configuration, error) {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -316,6 +316,10 @@ redis:
   pool_size: 10 # Maximum number of connections in the pool
   timeout: 5s # Timeout for Redis operations
   key_prefix: "flexprice:local"
+  # cluster_mode preserves the pre-existing hardcoded behaviour (the client
+  # was always *redis.ClusterClient). Set to false when targeting a single-node
+  # Redis (in-cluster bitnami/redis chart, single-node ElastiCache).
+  cluster_mode: true
 
 # Raw events reprocessing configuration
 raw_events_reprocessing:

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -10,46 +10,54 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// Client wraps Redis client functionality
+// Client wraps a Redis client. The underlying *redis.UniversalClient transparently
+// targets a standalone node or a Redis Cluster based on RedisConfig.ClusterMode.
 type Client struct {
-	rdb *redis.ClusterClient
+	rdb redis.UniversalClient
 	log *logger.Logger
 }
 
-// NewClient creates a new Redis client
+// NewClient creates a new Redis client. Set RedisConfig.ClusterMode=true for
+// Redis Cluster (e.g. AWS ElastiCache cluster mode enabled); leave false for
+// standalone Redis (single ElastiCache node, in-cluster redis, Redis sentinel
+// via the universal client's failover path).
 func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error) {
-
-	// Test connection
 	ctx, cancel := context.WithTimeout(context.Background(), config.Redis.Timeout)
 	defer cancel()
 
-	// Create cluster client
-	clusterOpts := &redis.ClusterOptions{
-		Addrs:        []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)},
-		Password:     config.Redis.Password,
-		ReadTimeout:  config.Redis.Timeout,
-		WriteTimeout: config.Redis.Timeout,
-		PoolSize:     config.Redis.PoolSize,
-	}
-
+	var tlsConfig *tls.Config
 	if config.Redis.UseTLS {
-		clusterOpts.TLSConfig = &tls.Config{
+		tlsConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true, // Required for AWS ElastiCache wildcard certificates
 		}
 	}
 
-	rdb := redis.NewClusterClient(clusterOpts)
+	opts := &redis.UniversalOptions{
+		Addrs:        []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)},
+		Password:     config.Redis.Password,
+		DB:           config.Redis.DB,
+		ReadTimeout:  config.Redis.Timeout,
+		WriteTimeout: config.Redis.Timeout,
+		PoolSize:     config.Redis.PoolSize,
+		TLSConfig:    tlsConfig,
+	}
+
+	var rdb redis.UniversalClient
+	if config.Redis.ClusterMode {
+		rdb = redis.NewClusterClient(opts.Cluster())
+	} else {
+		// UniversalOptions.Simple() routes to a standalone *redis.Client; DB index applies.
+		rdb = redis.NewClient(opts.Simple())
+	}
 
 	result, err := rdb.Ping(ctx).Result()
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create redis client: %w", err)
 	}
 
-	log.Infow("PING result", "result", result)
-
-	log.Infow("Connected to Redis Cluster successfully", "addr", clusterOpts.Addrs)
+	log.Infow("PING result", "result", result, "cluster_mode", config.Redis.ClusterMode)
+	log.Infow("Connected to Redis successfully", "addr", opts.Addrs, "cluster_mode", config.Redis.ClusterMode)
 
 	return &Client{
 		rdb: rdb,
@@ -57,8 +65,10 @@ func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error
 	}, nil
 }
 
-// GetClient returns the underlying Redis client
-func (c *Client) GetClient() *redis.ClusterClient {
+// GetClient returns the underlying Redis client. Callers should depend on
+// redis.UniversalClient (or redis.Cmdable) rather than the concrete type so
+// they work for both cluster and standalone deployments.
+func (c *Client) GetClient() redis.UniversalClient {
 	return c.rdb
 }
 


### PR DESCRIPTION
…ckhouse env bindings

Three unrelated fixes that all need to land before the FlexPrice helm chart can be released, batched into one PR so the chart can rely on them being available together.

1) Redis client topology branching
   The Redis client unconditionally created *redis.ClusterClient
   regardless of deployment topology, breaking against single-node
   Redis (e.g. AWS ElastiCache cluster-mode-disabled) where MOVED
   redirects never arrive and the client times out on slot routing.

   Switch to redis.UniversalClient, branch on a new RedisConfig.ClusterMode
   field exposed as FLEXPRICE_REDIS_CLUSTER_MODE. Default in
   config.yaml is `cluster_mode: true` so existing production installs
   that silently relied on the hardcoded ClusterClient keep working.
   Operators on single-node Redis flip it to false explicitly.

   internal/redis/client.go      — branch UniversalClient on ClusterMode
   internal/cache/redis.go       — store client as UniversalClient
   internal/config/config.go     — RedisConfig.ClusterMode bool
   internal/config/config.yaml   — bake cluster_mode: true default

2) Structured logging in cache.RedisCache
   Add a `log *logger.Logger` field, populated from logger.GetLogger()
   in InitializeRedisCache, and replace 12 fmt.Print* call sites with
   c.log.Errorw / Warnw / Debugw for consistency with internal/redis/client.go.
   The single fmt.Errorf in TrySetNX stays — it returns an error, not a log.

   internal/cache/redis.go

3) ClickHouse explicit env bindings
   Viper's AutomaticEnv() doesn't reliably map nested keys with
   underscores (e.g. clickhouse.password ←→ FLEXPRICE_CLICKHOUSE_PASSWORD)
   in all environments. Explicitly bind the four hot-path ClickHouse
   keys so the chart's FLEXPRICE_CLICKHOUSE_* env vars are guaranteed
   to be picked up.

   internal/config/config.go     — v.BindEnv for password/username/address/database

Companion helm changes land in a follow-up PR. Helm chart's redisExtended.clusterMode default matches the new cluster_mode default.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redis cache now supports flexible configuration for both standalone and cluster deployment modes, providing better alignment with diverse infrastructure requirements.

* **Chores**
  * Refactored internal cache initialization system to improve dependency injection and configuration handling.
  * Upgraded cache operation logging to use structured logging for enhanced visibility and debugging capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->