### PR TITLE
fix(price-sync): empty string instead of nil parent price id

### DIFF
--- a/internal/repository/ent/plan_price_sync.go
+++ b/internal/repository/ent/plan_price_sync.go
@@ -422,7 +422,7 @@ func (r *planPriceSyncRepository) ListPlanLineItemsToCreate(
 					AND sp.entity_id = s.id
 					AND (
 						sp.parent_price_id = p.id
-						OR (p.parent_price_id IS NOT NULL AND sp.parent_price_id = p.parent_price_id)
+						OR (NULLIF(p.parent_price_id, '') IS NOT NULL AND sp.parent_price_id = p.parent_price_id)
 					)
 			)
 			AND NOT EXISTS (

--- a/internal/repository/ent/plan_price_sync_v2.go
+++ b/internal/repository/ent/plan_price_sync_v2.go
@@ -131,7 +131,7 @@ func (r *planPriceSyncRepository) ListPlanLineItemsToCreateV2(
 			        AND sp.status = '%s'
 			        AND sp.entity_type = '%s' AND sp.entity_id = s.id
 			        AND ( sp.parent_price_id = p.id
-			           OR (p.parent_price_id IS NOT NULL AND sp.parent_price_id = p.parent_price_id) )
+			           OR (NULLIF(p.parent_price_id, '') IS NOT NULL AND sp.parent_price_id = p.parent_price_id) )
 			  )
 			  AND NOT EXISTS (
 			      SELECT 1 FROM subscription_line_items li

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -91,7 +91,6 @@ func (r *priceRepository) Create(ctx context.Context, p *domainPrice.Price) erro
 		SetCreatedBy(p.CreatedBy).
 		SetUpdatedBy(p.UpdatedBy).
 		SetEnvironmentID(p.EnvironmentID).
-		SetNillableParentPriceID(lo.ToPtr(p.ParentPriceID)).
 		SetEntityType(p.EntityType).
 		SetEntityID(p.EntityID).
 		SetNillablePriceUnitID(p.PriceUnitID).
@@ -102,6 +101,9 @@ func (r *priceRepository) Create(ctx context.Context, p *domainPrice.Price) erro
 
 	if p.GroupID != "" {
 		priceBuilder = priceBuilder.SetGroupID(p.GroupID)
+	}
+	if p.ParentPriceID != "" {
+		priceBuilder = priceBuilder.SetNillableParentPriceID(lo.EmptyableToPtr(p.ParentPriceID))
 	}
 
 	price, err := priceBuilder.Save(ctx)
@@ -454,7 +456,6 @@ func (r *priceRepository) CreateBulk(ctx context.Context, prices []*domainPrice.
 			SetDisplayAmount(p.DisplayAmount).
 			SetEntityID(p.EntityID).
 			SetEntityType(p.EntityType).
-			SetNillableParentPriceID(lo.ToPtr(p.ParentPriceID)).
 			SetType(p.Type).
 			SetBillingPeriod(p.BillingPeriod).
 			SetBillingPeriodCount(p.BillingPeriodCount).
@@ -476,6 +477,9 @@ func (r *priceRepository) CreateBulk(ctx context.Context, prices []*domainPrice.
 			SetStatus(string(p.Status))
 		if p.MinQuantity != nil {
 			builders[i] = builders[i].SetMinQuantity(*p.MinQuantity)
+		}
+		if p.ParentPriceID != "" {
+			builders[i] = builders[i].SetNillableParentPriceID(lo.EmptyableToPtr(p.ParentPriceID))
 		}
 		builders[i] = builders[i].
 			SetCreatedAt(p.CreatedAt).


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of empty parent price IDs during plan price sync and price creation so empty values are treated as null, preventing mismatches and improving accuracy of derived subscription price pairing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->