### PR TITLE
feat(logging): add support for role tag to sentry context

### DIFF
--- a/internal/rest/middleware/sentry.go
+++ b/internal/rest/middleware/sentry.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/config"
@@ -45,6 +46,12 @@ func SentryTenantContextMiddleware(c *gin.Context) {
 	if userID := types.GetUserID(ctx); userID != "" {
 		hub.Scope().SetTag("user_id", userID)
 		hub.Scope().SetUser(sentry.User{ID: userID})
+	}
+	roles := types.GetRoles(ctx)
+	if len(roles) > 0 {
+		hub.Scope().SetTag("roles", strings.Join(roles, ","))
+	} else {
+		hub.Scope().SetTag("roles", "full_access")
 	}
 	c.Next()
 }

--- a/internal/rest/middleware/sentry.go
+++ b/internal/rest/middleware/sentry.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/config"
@@ -47,11 +46,8 @@ func SentryTenantContextMiddleware(c *gin.Context) {
 		hub.Scope().SetTag("user_id", userID)
 		hub.Scope().SetUser(sentry.User{ID: userID})
 	}
-	roles := types.GetRoles(ctx)
-	if len(roles) > 0 {
-		hub.Scope().SetTag("roles", strings.Join(roles, ","))
-	} else {
-		hub.Scope().SetTag("roles", "full_access")
+	for _, role := range types.GetRoles(ctx) {
+		hub.Scope().SetTag(role, "true")
 	}
 	c.Next()
 }

--- a/internal/rest/middleware/sentry.go
+++ b/internal/rest/middleware/sentry.go
@@ -46,7 +46,11 @@ func SentryTenantContextMiddleware(c *gin.Context) {
 		hub.Scope().SetTag("user_id", userID)
 		hub.Scope().SetUser(sentry.User{ID: userID})
 	}
-	for _, role := range types.GetRoles(ctx) {
+	roles := types.GetRoles(ctx)
+	if len(roles) == 0 {
+		hub.Scope().SetTag("full_access", "true")
+	}
+	for _, role := range roles {
 		hub.Scope().SetTag(role, "true")
 	}
 	c.Next()

--- a/internal/rest/middleware/sentry.go
+++ b/internal/rest/middleware/sentry.go
@@ -48,10 +48,10 @@ func SentryTenantContextMiddleware(c *gin.Context) {
 	}
 	roles := types.GetRoles(ctx)
 	if len(roles) == 0 {
-		hub.Scope().SetTag("full_access", "true")
+		hub.Scope().SetTag("role_super_admin", "true")
 	}
 	for _, role := range roles {
-		hub.Scope().SetTag(role, "true")
+		hub.Scope().SetTag("role_"+role, "true")
 	}
 	c.Next()
 }


### PR DESCRIPTION
Filterable — SetTag indexes the value so you can search/alert on it in Sentry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic reporting: error tracking now adds role-based tags for any request-scoped roles. If no roles are present, a default "role_super_admin" tag is applied. Tenant, environment, and user tagging behavior remain unchanged, improving context in logs for faster debugging and incident investigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->