### PR TITLE
feature(subscription): allow trial subscription end date modif and subs cancellation

### DIFF
--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -58,6 +58,42 @@ func (r *SubModifyQuantityChangeRequest) Validate() error {
 	return nil
 }
 
+// TrialEndAction specifies how to modify the trial period.
+type TrialEndAction string
+
+const (
+	// TrialEndActionEndNow ends the trial immediately and begins conversion.
+	TrialEndActionEndNow TrialEndAction = "end_now"
+	// TrialEndActionModifyDate changes the trial end date to a new value.
+	TrialEndActionModifyDate TrialEndAction = "modify_date"
+)
+
+// SubModifyTrialEndRequest is the payload for modifying a subscription's trial period end.
+type SubModifyTrialEndRequest struct {
+	// Action is "end_now" or "modify_date".
+	Action TrialEndAction `json:"action" binding:"required"`
+	// NewTrialEnd is the new trial end date. Required when action is "modify_date".
+	NewTrialEnd *time.Time `json:"new_trial_end,omitempty"`
+}
+
+func (r *SubModifyTrialEndRequest) Validate() error {
+	switch r.Action {
+	case TrialEndActionEndNow:
+		// no extra fields needed
+	case TrialEndActionModifyDate:
+		if r.NewTrialEnd == nil {
+			return ierr.NewError("new_trial_end is required when action is 'modify_date'").
+				WithHint("Provide a new_trial_end date to extend or reduce the trial").
+				Mark(ierr.ErrValidation)
+		}
+	default:
+		return ierr.NewError("unknown trial end action: " + string(r.Action)).
+			WithHint("Valid values: end_now, modify_date").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
 // SubscriptionModifyType identifies the kind of modification.
 type SubscriptionModifyType string
 
@@ -65,6 +101,7 @@ const (
 	SubscriptionModifyTypeInheritance      SubscriptionModifyType = "inheritance"
 	SubscriptionModifyTypeQuantityChange   SubscriptionModifyType = "quantity_change"
 	SubscriptionModifyTypeGroupedInvoicing SubscriptionModifyType = "grouped_invoicing"
+	SubscriptionModifyTypeTrialEnd         SubscriptionModifyType = "trial_end"
 )
 
 // GroupedInvoicingAction identifies whether children are being added to or removed from grouped invoicing.
@@ -104,12 +141,13 @@ func (r *SubModifyGroupedInvoicingParams) Validate() error {
 
 // ExecuteSubscriptionModifyRequest is the unified body for
 // POST /subscriptions/:id/modify/execute and /modify/preview.
-// Exactly one of InheritanceParams or QuantityChangeParams must be set.
+// Exactly one of the *Params fields must be set, matching the type.
 type ExecuteSubscriptionModifyRequest struct {
 	Type                   SubscriptionModifyType           `json:"type" binding:"required"`
 	InheritanceParams      *SubModifyInheritanceRequest     `json:"inheritance_params,omitempty"`
 	QuantityChangeParams   *SubModifyQuantityChangeRequest  `json:"quantity_change_params,omitempty"`
 	GroupedInvoicingParams *SubModifyGroupedInvoicingParams `json:"grouped_invoicing_params,omitempty"`
+	TrialEndParams         *SubModifyTrialEndRequest        `json:"trial_end_params,omitempty"`
 }
 
 func (r *ExecuteSubscriptionModifyRequest) Validate() error {
@@ -132,9 +170,15 @@ func (r *ExecuteSubscriptionModifyRequest) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 		return r.GroupedInvoicingParams.Validate()
+	case SubscriptionModifyTypeTrialEnd:
+		if r.TrialEndParams == nil {
+			return ierr.NewError("trial_end_params is required for type 'trial_end'").
+				Mark(ierr.ErrValidation)
+		}
+		return r.TrialEndParams.Validate()
 	default:
 		return ierr.NewError("unknown modification type: " + string(r.Type)).
-			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing").
+			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end").
 			Mark(ierr.ErrValidation)
 	}
 }

--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -239,9 +239,11 @@ type ChangedLineItem struct {
 
 // ChangedSubscription describes a subscription that was created or updated.
 type ChangedSubscription struct {
-	ID     string                    `json:"id"`
-	Action ChangedSubscriptionAction `json:"action"`
-	Status types.SubscriptionStatus  `json:"status"`
+	ID               string                    `json:"id"`
+	Action           ChangedSubscriptionAction `json:"action"`
+	Status           types.SubscriptionStatus  `json:"status"`
+	TrialEnd         *time.Time                `json:"trial_end,omitempty"`
+	CurrentPeriodEnd *time.Time                `json:"current_period_end,omitempty"`
 }
 
 // ChangedInvoice describes a proration invoice or wallet credit from a modification.

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/connection"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
-	invoice_domain "github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	invoice_domain "github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/integration/paddle"
 	"github.com/flexprice/flexprice/internal/interfaces"
@@ -334,7 +334,7 @@ func seedCustomer(ctx context.Context, t *testing.T, store *testutil.InMemoryCus
 		Name:           "Test Customer",
 		AddressCountry: "US",
 		EnvironmentID:  types.GetEnvironmentID(ctx),
-		BaseModel: types.GetDefaultBaseModel(ctx),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
 	}
 	require.NoError(t, store.Create(ctx, c))
 }
@@ -815,6 +815,9 @@ func (m *mockSubscriptionService) UpdateBillingPeriods(ctx context.Context) (*ap
 	return nil, nil
 }
 func (m *mockSubscriptionService) ProcessTrialEndDue(ctx context.Context) (*apidto.SubscriptionUpdatePeriodResponse, error) {
+	return nil, nil
+}
+func (m *mockSubscriptionService) ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) (*apidto.InvoiceResponse, error) {
 	return nil, nil
 }
 func (m *mockSubscriptionService) PauseSubscription(ctx context.Context, subscriptionID string, req *apidto.PauseSubscriptionRequest) (*apidto.PauseSubscriptionResponse, error) {

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -92,7 +92,7 @@ type SubscriptionService interface {
 	GetUsageBySubscription(ctx context.Context, req *dto.GetUsageBySubscriptionRequest) (*dto.GetUsageBySubscriptionResponse, error)
 	UpdateBillingPeriods(ctx context.Context) (*dto.SubscriptionUpdatePeriodResponse, error)
 	ProcessTrialEndDue(ctx context.Context) (*dto.SubscriptionUpdatePeriodResponse, error)
-	ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) error
+	ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) (*dto.InvoiceResponse, error)
 
 	// Pause-related methods
 	PauseSubscription(ctx context.Context, subscriptionID string, req *dto.PauseSubscriptionRequest) (*dto.PauseSubscriptionResponse, error)

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -2,6 +2,7 @@ package interfaces
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addonassociation"
@@ -91,6 +92,7 @@ type SubscriptionService interface {
 	GetUsageBySubscription(ctx context.Context, req *dto.GetUsageBySubscriptionRequest) (*dto.GetUsageBySubscriptionResponse, error)
 	UpdateBillingPeriods(ctx context.Context) (*dto.SubscriptionUpdatePeriodResponse, error)
 	ProcessTrialEndDue(ctx context.Context) (*dto.SubscriptionUpdatePeriodResponse, error)
+	ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) error
 
 	// Pause-related methods
 	PauseSubscription(ctx context.Context, subscriptionID string, req *dto.PauseSubscriptionRequest) (*dto.PauseSubscriptionResponse, error)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1883,11 +1883,15 @@ func (s *subscriptionService) CancelSubscription(
 	var prorationDetails []dto.ProrationDetail
 	totalCreditAmount := decimal.Zero
 
+	// Trialing subscriptions have not been charged yet, so generating a
+	// non-zero invoice on cancellation is incorrect — skip invoice creation.
+	isTrialing := subscription.SubscriptionStatus == types.SubscriptionStatusTrialing
+
 	// Step 5: Execute in transaction
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 
 		// Step 6: Calculate proration using unified function
-		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations {
+		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations && isTrialing {
 			prorationService := NewProrationService(s.ServiceParams)
 			prorationResult, err := prorationService.CalculateSubscriptionCancellationProration(
 				ctx, subscription, lineItems, req.CancellationType, effectiveDate, req.Reason, req.ProrationBehavior)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1891,7 +1891,8 @@ func (s *subscriptionService) CancelSubscription(
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 
 		// Step 6: Calculate proration using unified function
-		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations && isTrialing {
+		// Trialing subscriptions have not been charged yet, so proration is not applicable.
+		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations && !isTrialing {
 			prorationService := NewProrationService(s.ServiceParams)
 			prorationResult, err := prorationService.CalculateSubscriptionCancellationProration(
 				ctx, subscription, lineItems, req.CancellationType, effectiveDate, req.Reason, req.ProrationBehavior)

--- a/internal/service/subscription_modification.go
+++ b/internal/service/subscription_modification.go
@@ -53,9 +53,11 @@ func (s *subscriptionModificationService) Execute(ctx context.Context, subscript
 		return s.executeQuantityChange(ctx, subscriptionID, req.QuantityChangeParams)
 	case dto.SubscriptionModifyTypeGroupedInvoicing:
 		return s.executeGroupedInvoicingMembership(ctx, req.GroupedInvoicingParams)
+	case dto.SubscriptionModifyTypeTrialEnd:
+		return s.executeTrialEnd(ctx, subscriptionID, req.TrialEndParams)
 	default:
 		return nil, ierr.NewError("unknown modification type: " + string(req.Type)).
-			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing").
+			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end").
 			Mark(ierr.ErrValidation)
 	}
 }
@@ -73,9 +75,11 @@ func (s *subscriptionModificationService) Preview(ctx context.Context, subscript
 		return s.previewQuantityChange(ctx, subscriptionID, req.QuantityChangeParams)
 	case dto.SubscriptionModifyTypeGroupedInvoicing:
 		return s.previewGroupedInvoicingMembership(ctx, req.GroupedInvoicingParams)
+	case dto.SubscriptionModifyTypeTrialEnd:
+		return s.previewTrialEnd(ctx, subscriptionID, req.TrialEndParams)
 	default:
 		return nil, ierr.NewError("unknown modification type: " + string(req.Type)).
-			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing").
+			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end").
 			Mark(ierr.ErrValidation)
 	}
 }

--- a/internal/service/subscription_modification_test.go
+++ b/internal/service/subscription_modification_test.go
@@ -1315,3 +1315,258 @@ func (s *SubscriptionModificationServiceSuite) TestExecute_UnknownTypeRejected()
 	})
 	s.Require().Error(err)
 }
+
+// ─────────────────────────────────────────────
+// Sub-feature: Trial End Modification
+// ─────────────────────────────────────────────
+
+func (s *SubscriptionModificationServiceSuite) createTrialingSub(customerID string) *subscription.Subscription {
+	ctx := s.GetContext()
+	now := s.GetNow()
+	p := s.createPlan()
+	trialStart := now
+	trialEnd := now.AddDate(0, 0, 14)
+	sub := &subscription.Subscription{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		CustomerID:         customerID,
+		PlanID:             p.ID,
+		Currency:           "USD",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		BillingAnchor:      now,
+		SubscriptionStatus: types.SubscriptionStatusTrialing,
+		SubscriptionType:   types.SubscriptionTypeStandalone,
+		CurrentPeriodStart: trialStart,
+		CurrentPeriodEnd:   trialEnd,
+		StartDate:          now,
+		TrialStart:         &trialStart,
+		TrialEnd:           &trialEnd,
+	}
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Create(ctx, sub))
+	return sub
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_RejectsNonTrialingSub() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-001")
+	sub := s.createActiveSub(cust.ID)
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action: dto.TrialEndActionEndNow,
+		},
+	}
+	_, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not in trialing status")
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewRejectsNonTrialing() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-002")
+	sub := s.createActiveSub(cust.ID)
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action: dto.TrialEndActionEndNow,
+		},
+	}
+	_, err := s.service.Preview(ctx, sub.ID, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not in trialing status")
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ValidationMissingParams() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-003")
+	sub := s.createTrialingSub(cust.ID)
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+	}
+	_, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "trial_end_params is required")
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRequiresDate() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-004")
+	sub := s.createTrialingSub(cust.ID)
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action: dto.TrialEndActionModifyDate,
+		},
+	}
+	_, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "new_trial_end is required")
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRejectsPast() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-005")
+	sub := s.createTrialingSub(cust.ID)
+
+	pastDate := time.Now().UTC().Add(-24 * time.Hour)
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action:      dto.TrialEndActionModifyDate,
+			NewTrialEnd: &pastDate,
+		},
+	}
+	_, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "new_trial_end must be in the future")
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateExtend() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-006")
+	sub := s.createTrialingSub(cust.ID)
+	originalTrialEnd := *sub.TrialEnd
+
+	newEnd := originalTrialEnd.AddDate(0, 0, 7)
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action:      dto.TrialEndActionModifyDate,
+			NewTrialEnd: &newEnd,
+		},
+	}
+	resp, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// Verify subscription was updated
+	updated, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.Equal(types.SubscriptionStatusTrialing, updated.SubscriptionStatus)
+	s.True(updated.TrialEnd.Equal(newEnd))
+	s.True(updated.CurrentPeriodEnd.Equal(newEnd))
+
+	// Verify changed resources
+	s.Require().Len(resp.ChangedResources.Subscriptions, 1)
+	s.Equal(sub.ID, resp.ChangedResources.Subscriptions[0].ID)
+	s.Equal(dto.ChangedSubscriptionActionUpdated, resp.ChangedResources.Subscriptions[0].Action)
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateReduce() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-007")
+	sub := s.createTrialingSub(cust.ID)
+
+	// Reduce by 7 days but still in the future
+	newEnd := time.Now().UTC().Add(24 * time.Hour)
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action:      dto.TrialEndActionModifyDate,
+			NewTrialEnd: &newEnd,
+		},
+	}
+	resp, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	updated, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.Equal(types.SubscriptionStatusTrialing, updated.SubscriptionStatus)
+	s.True(updated.TrialEnd.Equal(newEnd))
+	s.True(updated.CurrentPeriodEnd.Equal(newEnd))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewModifyDate() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-008")
+	sub := s.createTrialingSub(cust.ID)
+	originalTrialEnd := *sub.TrialEnd
+
+	newEnd := originalTrialEnd.AddDate(0, 0, 7)
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action:      dto.TrialEndActionModifyDate,
+			NewTrialEnd: &newEnd,
+		},
+	}
+	resp, err := s.service.Preview(ctx, sub.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// Preview should NOT mutate the subscription
+	unchanged, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.True(unchanged.TrialEnd.Equal(originalTrialEnd))
+
+	s.Require().Len(resp.ChangedResources.Subscriptions, 1)
+	s.Equal(dto.ChangedSubscriptionActionUpdated, resp.ChangedResources.Subscriptions[0].Action)
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewEndNow() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-009")
+	sub := s.createTrialingSub(cust.ID)
+	originalTrialEnd := *sub.TrialEnd
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action: dto.TrialEndActionEndNow,
+		},
+	}
+	resp, err := s.service.Preview(ctx, sub.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// Preview should NOT mutate the subscription
+	unchanged, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.True(unchanged.TrialEnd.Equal(originalTrialEnd))
+	s.Equal(types.SubscriptionStatusTrialing, unchanged.SubscriptionStatus)
+}
+
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_RejectsInheritedSub() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("ext-trial-010")
+	now := s.GetNow()
+	p := s.createPlan()
+	trialStart := now
+	trialEnd := now.AddDate(0, 0, 14)
+	sub := &subscription.Subscription{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		CustomerID:         cust.ID,
+		PlanID:             p.ID,
+		Currency:           "USD",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		BillingAnchor:      now,
+		SubscriptionStatus: types.SubscriptionStatusTrialing,
+		SubscriptionType:   types.SubscriptionTypeInherited,
+		CurrentPeriodStart: trialStart,
+		CurrentPeriodEnd:   trialEnd,
+		StartDate:          now,
+		TrialStart:         &trialStart,
+		TrialEnd:           &trialEnd,
+	}
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Create(ctx, sub))
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeTrialEnd,
+		TrialEndParams: &dto.SubModifyTrialEndRequest{
+			Action: dto.TrialEndActionEndNow,
+		},
+	}
+	_, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "inherited subscription")
+}

--- a/internal/service/subscription_modification_trial_end.go
+++ b/internal/service/subscription_modification_trial_end.go
@@ -113,9 +113,11 @@ func (s *subscriptionModificationService) executeTrialEndNow(
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
 
 	changedSubs := []dto.ChangedSubscription{{
-		ID:     sub.ID,
-		Action: dto.ChangedSubscriptionActionUpdated,
-		Status: types.SubscriptionStatusIncomplete,
+		ID:               sub.ID,
+		Action:           dto.ChangedSubscriptionActionUpdated,
+		Status:           types.SubscriptionStatusIncomplete,
+		TrialEnd:         lo.ToPtr(now),
+		CurrentPeriodEnd: lo.ToPtr(now),
 	}}
 
 	return &dto.SubscriptionModifyResponse{
@@ -150,9 +152,11 @@ func (s *subscriptionModificationService) executeTrialEndModifyDate(
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
 
 	changedSubs := []dto.ChangedSubscription{{
-		ID:     sub.ID,
-		Action: dto.ChangedSubscriptionActionUpdated,
-		Status: sub.SubscriptionStatus,
+		ID:               sub.ID,
+		Action:           dto.ChangedSubscriptionActionUpdated,
+		Status:           sub.SubscriptionStatus,
+		TrialEnd:         lo.ToPtr(newTrialEnd),
+		CurrentPeriodEnd: lo.ToPtr(newTrialEnd),
 	}}
 
 	return &dto.SubscriptionModifyResponse{
@@ -182,17 +186,22 @@ func (s *subscriptionModificationService) previewTrialEnd(
 		return nil, err
 	}
 
+	status := types.SubscriptionStatusIncomplete
+	endDate := time.Now().UTC()
 	if params.Action == dto.TrialEndActionModifyDate {
-		newTrialEnd := params.NewTrialEnd.UTC()
-		if err := s.validateModifyDate(newTrialEnd, sub, subscriptionID); err != nil {
+		status = types.SubscriptionStatusTrialing
+		endDate = params.NewTrialEnd.UTC()
+		if err := s.validateModifyDate(endDate, sub, subscriptionID); err != nil {
 			return nil, err
 		}
 	}
 
 	changedSubs := []dto.ChangedSubscription{{
-		ID:     sub.ID,
-		Action: dto.ChangedSubscriptionActionUpdated,
-		Status: sub.SubscriptionStatus,
+		ID:               sub.ID,
+		Action:           dto.ChangedSubscriptionActionUpdated,
+		Status:           status,
+		TrialEnd:         lo.ToPtr(endDate),
+		CurrentPeriodEnd: lo.ToPtr(endDate),
 	}}
 
 	// For inherited children, show them as preview-updated too.
@@ -203,21 +212,16 @@ func (s *subscriptionModificationService) previewTrialEnd(
 		}
 		for _, child := range children {
 			changedSubs = append(changedSubs, dto.ChangedSubscription{
-				ID:     child.ID,
-				Action: dto.ChangedSubscriptionActionUpdated,
-				Status: child.SubscriptionStatus,
+				ID:               child.ID,
+				Action:           dto.ChangedSubscriptionActionUpdated,
+				Status:           status,
+				TrialEnd:         lo.ToPtr(endDate),
+				CurrentPeriodEnd: lo.ToPtr(endDate),
 			})
 		}
 	}
 
-	subSvc := NewSubscriptionService(sp)
-	subResp, err := subSvc.GetSubscription(ctx, subscriptionID)
-	if err != nil {
-		return nil, err
-	}
-
 	return &dto.SubscriptionModifyResponse{
-		Subscription: subResp,
 		ChangedResources: dto.ChangedResources{
 			Subscriptions: changedSubs,
 		},

--- a/internal/service/subscription_modification_trial_end.go
+++ b/internal/service/subscription_modification_trial_end.go
@@ -1,0 +1,248 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+)
+
+func (s *subscriptionModificationService) validateTrialEndSubscription(sub *subscription.Subscription, subscriptionID string) error {
+	if sub.SubscriptionStatus != types.SubscriptionStatusTrialing {
+		return ierr.NewError("subscription is not in trialing status").
+			WithHint("Only trialing subscriptions can have their trial period modified").
+			WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID, "status": sub.SubscriptionStatus}).
+			Mark(ierr.ErrValidation)
+	}
+	if sub.TrialStart == nil || sub.TrialEnd == nil {
+		return ierr.NewError("subscription is missing trial bounds").
+			WithHint("Subscription must have both trial_start and trial_end set").
+			WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID}).
+			Mark(ierr.ErrValidation)
+	}
+	if sub.SubscriptionType == types.SubscriptionTypeInherited {
+		return ierr.NewError("cannot modify trial on inherited subscription").
+			WithHint("Modify the parent subscription's trial instead").
+			WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID}).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+func (s *subscriptionModificationService) validateModifyDate(newTrialEnd time.Time, sub *subscription.Subscription, subscriptionID string) error {
+	now := time.Now().UTC()
+	if !newTrialEnd.After(now) {
+		return ierr.NewError("new_trial_end must be in the future").
+			WithHint("To end the trial immediately, use action 'end_now'").
+			WithReportableDetails(map[string]interface{}{"new_trial_end": newTrialEnd, "now": now}).
+			Mark(ierr.ErrValidation)
+	}
+	if !newTrialEnd.After(lo.FromPtr(sub.TrialStart)) {
+		return ierr.NewError("new_trial_end must be after trial start").
+			WithReportableDetails(map[string]interface{}{
+				"new_trial_end": newTrialEnd,
+				"trial_start":   lo.FromPtr(sub.TrialStart),
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	if sub.EndDate != nil && newTrialEnd.After(lo.FromPtr(sub.EndDate)) {
+		return ierr.NewError("new_trial_end cannot be after the subscription end date").
+			WithReportableDetails(map[string]interface{}{
+				"new_trial_end":         newTrialEnd,
+				"subscription_end_date": lo.FromPtr(sub.EndDate),
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────
+// Execute: trial end
+// ─────────────────────────────────────────────
+
+func (s *subscriptionModificationService) executeTrialEnd(
+	ctx context.Context,
+	subscriptionID string,
+	params *dto.SubModifyTrialEndRequest,
+) (*dto.SubscriptionModifyResponse, error) {
+	sp := s.serviceParams
+
+	sub, err := sp.SubRepo.Get(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.validateTrialEndSubscription(sub, subscriptionID); err != nil {
+		return nil, err
+	}
+
+	switch params.Action {
+	case dto.TrialEndActionEndNow:
+		return s.executeTrialEndNow(ctx, sub)
+	case dto.TrialEndActionModifyDate:
+		newTrialEnd := params.NewTrialEnd.UTC()
+		if err := s.validateModifyDate(newTrialEnd, sub, subscriptionID); err != nil {
+			return nil, err
+		}
+		return s.executeTrialEndModifyDate(ctx, sub, newTrialEnd)
+	default:
+		return nil, ierr.NewError("unknown trial end action: " + string(params.Action)).
+			Mark(ierr.ErrValidation)
+	}
+}
+
+// executeTrialEndNow ends the trial immediately by delegating to the existing
+// processSubscriptionTrialEnd logic (now exposed via ProcessSingleSubscriptionTrialEnd).
+func (s *subscriptionModificationService) executeTrialEndNow(
+	ctx context.Context,
+	sub *subscription.Subscription,
+) (*dto.SubscriptionModifyResponse, error) {
+	sp := s.serviceParams
+
+	subSvc := NewSubscriptionService(sp)
+	now := time.Now().UTC()
+	sub.TrialEnd = lo.ToPtr(now)
+	if err := subSvc.ProcessSingleSubscriptionTrialEnd(ctx, sub, now); err != nil {
+		return nil, err
+	}
+
+	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
+
+	changedSubs := []dto.ChangedSubscription{{
+		ID:     sub.ID,
+		Action: dto.ChangedSubscriptionActionUpdated,
+		Status: types.SubscriptionStatusIncomplete,
+	}}
+
+	return &dto.SubscriptionModifyResponse{
+		ChangedResources: dto.ChangedResources{
+			Subscriptions: changedSubs,
+		},
+	}, nil
+}
+
+// executeTrialEndModifyDate extends or reduces the trial end date.
+func (s *subscriptionModificationService) executeTrialEndModifyDate(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	newTrialEnd time.Time,
+) (*dto.SubscriptionModifyResponse, error) {
+	sp := s.serviceParams
+
+	sub.TrialEnd = lo.ToPtr(newTrialEnd)
+	// During trialing, CurrentPeriodEnd is aligned with TrialEnd.
+	sub.CurrentPeriodEnd = newTrialEnd
+
+	err := sp.DB.WithTx(ctx, func(txCtx context.Context) error {
+		if err := sp.SubRepo.Update(txCtx, sub); err != nil {
+			return err
+		}
+		return s.cascadeTrialEndModifyToInherited(txCtx, sub, newTrialEnd)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
+
+	changedSubs := []dto.ChangedSubscription{{
+		ID:     sub.ID,
+		Action: dto.ChangedSubscriptionActionUpdated,
+		Status: sub.SubscriptionStatus,
+	}}
+
+	return &dto.SubscriptionModifyResponse{
+		ChangedResources: dto.ChangedResources{
+			Subscriptions: changedSubs,
+		},
+	}, nil
+}
+
+// ─────────────────────────────────────────────
+// Preview: trial end
+// ─────────────────────────────────────────────
+
+func (s *subscriptionModificationService) previewTrialEnd(
+	ctx context.Context,
+	subscriptionID string,
+	params *dto.SubModifyTrialEndRequest,
+) (*dto.SubscriptionModifyResponse, error) {
+	sp := s.serviceParams
+
+	sub, err := sp.SubRepo.Get(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.validateTrialEndSubscription(sub, subscriptionID); err != nil {
+		return nil, err
+	}
+
+	if params.Action == dto.TrialEndActionModifyDate {
+		newTrialEnd := params.NewTrialEnd.UTC()
+		if err := s.validateModifyDate(newTrialEnd, sub, subscriptionID); err != nil {
+			return nil, err
+		}
+	}
+
+	changedSubs := []dto.ChangedSubscription{{
+		ID:     sub.ID,
+		Action: dto.ChangedSubscriptionActionUpdated,
+		Status: sub.SubscriptionStatus,
+	}}
+
+	// For inherited children, show them as preview-updated too.
+	if sub.SubscriptionType == types.SubscriptionTypeParent {
+		children, err := s.getInheritedSubscriptions(ctx, sub.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			changedSubs = append(changedSubs, dto.ChangedSubscription{
+				ID:     child.ID,
+				Action: dto.ChangedSubscriptionActionUpdated,
+				Status: child.SubscriptionStatus,
+			})
+		}
+	}
+
+	subSvc := NewSubscriptionService(sp)
+	subResp, err := subSvc.GetSubscription(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.SubscriptionModifyResponse{
+		Subscription: subResp,
+		ChangedResources: dto.ChangedResources{
+			Subscriptions: changedSubs,
+		},
+	}, nil
+}
+
+// ─────────────────────────────────────────────
+// Cascade helpers
+// ─────────────────────────────────────────────
+
+// cascadeTrialEndModifyToInherited propagates the updated trial end date to inherited children.
+func (s *subscriptionModificationService) cascadeTrialEndModifyToInherited(ctx context.Context, parentSub *subscription.Subscription, newTrialEnd time.Time) error {
+	if parentSub.SubscriptionType != types.SubscriptionTypeParent {
+		return nil
+	}
+	children, err := s.getInheritedSubscriptions(ctx, parentSub.ID)
+	if err != nil {
+		return err
+	}
+	for _, child := range children {
+		child.TrialEnd = lo.ToPtr(newTrialEnd)
+		child.CurrentPeriodEnd = newTrialEnd
+		if err := s.serviceParams.SubRepo.Update(ctx, child); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/service/subscription_modification_trial_end.go
+++ b/internal/service/subscription_modification_trial_end.go
@@ -11,7 +11,13 @@ import (
 	"github.com/samber/lo"
 )
 
-func (s *subscriptionModificationService) validateTrialEndSubscription(sub *subscription.Subscription, subscriptionID string) error {
+// validateTrialEndRequest validates the subscription state and, for modify_date actions,
+// the new trial end date. Combines subscription-level and date-level checks in one pass.
+func (s *subscriptionModificationService) validateTrialEndRequest(
+	sub *subscription.Subscription,
+	subscriptionID string,
+	params *dto.SubModifyTrialEndRequest,
+) error {
 	if sub.SubscriptionStatus != types.SubscriptionStatusTrialing {
 		return ierr.NewError("subscription is not in trialing status").
 			WithHint("Only trialing subscriptions can have their trial period modified").
@@ -30,32 +36,25 @@ func (s *subscriptionModificationService) validateTrialEndSubscription(sub *subs
 			WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID}).
 			Mark(ierr.ErrValidation)
 	}
-	return nil
-}
 
-func (s *subscriptionModificationService) validateModifyDate(newTrialEnd time.Time, sub *subscription.Subscription, subscriptionID string) error {
-	now := time.Now().UTC()
-	if !newTrialEnd.After(now) {
-		return ierr.NewError("new_trial_end must be in the future").
-			WithHint("To end the trial immediately, use action 'end_now'").
-			WithReportableDetails(map[string]interface{}{"new_trial_end": newTrialEnd, "now": now}).
-			Mark(ierr.ErrValidation)
-	}
-	if !newTrialEnd.After(lo.FromPtr(sub.TrialStart)) {
-		return ierr.NewError("new_trial_end must be after trial start").
-			WithReportableDetails(map[string]interface{}{
-				"new_trial_end": newTrialEnd,
-				"trial_start":   lo.FromPtr(sub.TrialStart),
-			}).
-			Mark(ierr.ErrValidation)
-	}
-	if sub.EndDate != nil && newTrialEnd.After(lo.FromPtr(sub.EndDate)) {
-		return ierr.NewError("new_trial_end cannot be after the subscription end date").
-			WithReportableDetails(map[string]interface{}{
-				"new_trial_end":         newTrialEnd,
-				"subscription_end_date": lo.FromPtr(sub.EndDate),
-			}).
-			Mark(ierr.ErrValidation)
+	// Date-specific validation only applies to modify_date action.
+	if params.Action == dto.TrialEndActionModifyDate {
+		newTrialEnd := params.NewTrialEnd.UTC()
+		now := time.Now().UTC()
+		if !newTrialEnd.After(now) {
+			return ierr.NewError("new_trial_end must be in the future").
+				WithHint("To end the trial immediately, use action 'end_now'").
+				WithReportableDetails(map[string]interface{}{"new_trial_end": newTrialEnd, "now": now}).
+				Mark(ierr.ErrValidation)
+		}
+		if sub.EndDate != nil && newTrialEnd.After(lo.FromPtr(sub.EndDate)) {
+			return ierr.NewError("new_trial_end cannot be after the subscription end date").
+				WithReportableDetails(map[string]interface{}{
+					"new_trial_end":         newTrialEnd,
+					"subscription_end_date": lo.FromPtr(sub.EndDate),
+				}).
+				Mark(ierr.ErrValidation)
+		}
 	}
 	return nil
 }
@@ -76,7 +75,7 @@ func (s *subscriptionModificationService) executeTrialEnd(
 		return nil, err
 	}
 
-	if err := s.validateTrialEndSubscription(sub, subscriptionID); err != nil {
+	if err := s.validateTrialEndRequest(sub, subscriptionID, params); err != nil {
 		return nil, err
 	}
 
@@ -84,11 +83,7 @@ func (s *subscriptionModificationService) executeTrialEnd(
 	case dto.TrialEndActionEndNow:
 		return s.executeTrialEndNow(ctx, sub)
 	case dto.TrialEndActionModifyDate:
-		newTrialEnd := params.NewTrialEnd.UTC()
-		if err := s.validateModifyDate(newTrialEnd, sub, subscriptionID); err != nil {
-			return nil, err
-		}
-		return s.executeTrialEndModifyDate(ctx, sub, newTrialEnd)
+		return s.executeTrialEndModifyDate(ctx, sub, params.NewTrialEnd.UTC())
 	default:
 		return nil, ierr.NewError("unknown trial end action: " + string(params.Action)).
 			Mark(ierr.ErrValidation)
@@ -106,7 +101,8 @@ func (s *subscriptionModificationService) executeTrialEndNow(
 	subSvc := NewSubscriptionService(sp)
 	now := time.Now().UTC()
 	sub.TrialEnd = lo.ToPtr(now)
-	if err := subSvc.ProcessSingleSubscriptionTrialEnd(ctx, sub, now); err != nil {
+	invRes, err := subSvc.ProcessSingleSubscriptionTrialEnd(ctx, sub, now)
+	if err != nil {
 		return nil, err
 	}
 
@@ -120,9 +116,17 @@ func (s *subscriptionModificationService) executeTrialEndNow(
 		CurrentPeriodEnd: lo.ToPtr(now),
 	}}
 
+	changedInvoice := []dto.ChangedInvoice{
+		{
+			ID:      invRes.ID,
+			Action:  dto.ChangedInvoiceActionCreated,
+			Invoice: invRes,
+		},
+	}
 	return &dto.SubscriptionModifyResponse{
 		ChangedResources: dto.ChangedResources{
 			Subscriptions: changedSubs,
+			Invoices:      changedInvoice,
 		},
 	}, nil
 }
@@ -182,7 +186,7 @@ func (s *subscriptionModificationService) previewTrialEnd(
 		return nil, err
 	}
 
-	if err := s.validateTrialEndSubscription(sub, subscriptionID); err != nil {
+	if err := s.validateTrialEndRequest(sub, subscriptionID, params); err != nil {
 		return nil, err
 	}
 
@@ -191,9 +195,6 @@ func (s *subscriptionModificationService) previewTrialEnd(
 	if params.Action == dto.TrialEndActionModifyDate {
 		status = types.SubscriptionStatusTrialing
 		endDate = params.NewTrialEnd.UTC()
-		if err := s.validateModifyDate(endDate, sub, subscriptionID); err != nil {
-			return nil, err
-		}
 	}
 
 	changedSubs := []dto.ChangedSubscription{{

--- a/internal/service/subscription_trial.go
+++ b/internal/service/subscription_trial.go
@@ -109,7 +109,7 @@ func (s *subscriptionService) ProcessTrialEndDue(ctx context.Context) (*dto.Subs
 				PeriodEnd:      trialingSubscription.CurrentPeriodEnd,
 			}
 
-			err := s.processSubscriptionTrialEnd(subCtx, trialingSubscription, invoiceService, now)
+			_, err := s.processSubscriptionTrialEnd(subCtx, trialingSubscription, invoiceService, now)
 			if err != nil {
 				s.Logger.ErrorwCtx(subCtx, "failed to process trial end for subscription",
 					"subscription_id", trialingSubscription.ID,
@@ -143,28 +143,28 @@ func derivePerSubscriptionCtx(parentCtx context.Context, sub *subscription.Subsc
 // ProcessSingleSubscriptionTrialEnd is the public entry point for ending a single subscription's
 // trial on demand (e.g. from the modification API). It delegates to the private batch-oriented
 // processSubscriptionTrialEnd with now = time.Now().
-func (s *subscriptionService) ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) error {
+func (s *subscriptionService) ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) (*dto.InvoiceResponse, error) {
 	invService := NewInvoiceService(s.ServiceParams)
 	return s.processSubscriptionTrialEnd(ctx, sub, invService, now)
 }
 
-func (s *subscriptionService) processSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, invoiceService InvoiceService, now time.Time) error {
+func (s *subscriptionService) processSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, invoiceService InvoiceService, now time.Time) (*dto.InvoiceResponse, error) {
 	if sub.SubscriptionType == types.SubscriptionTypeInherited {
-		return nil
+		return nil, nil
 	}
 	if sub.SubscriptionStatus == types.SubscriptionStatusPaused {
-		return nil
+		return nil, nil
 	}
 	if sub.SubscriptionStatus != types.SubscriptionStatusTrialing {
-		return nil
+		return nil, nil
 	}
 	if sub.TrialStart == nil || sub.TrialEnd == nil {
 		s.Logger.WarnwCtx(ctx, "trialing subscription missing trial bounds, skipping",
 			"subscription_id", sub.ID)
-		return nil
+		return nil, nil
 	}
 	if sub.TrialEnd.After(now) {
-		return nil
+		return nil, nil
 	}
 
 	// Billing really starts at trial end. Anchor there so the first paid period isn't short-changed
@@ -173,7 +173,7 @@ func (s *subscriptionService) processSubscriptionTrialEnd(ctx context.Context, s
 	sub.BillingAnchor = firstPeriodStart
 	firstPeriodEnd, err := types.NextBillingDate(firstPeriodStart, sub.BillingAnchor, sub.BillingPeriodCount, sub.BillingPeriod, sub.EndDate)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Out of trialing, first real period on the books. If this job double-fires, we bail earlier because
@@ -207,7 +207,7 @@ func (s *subscriptionService) processSubscriptionTrialEnd(ctx context.Context, s
 		return errInv
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.Logger.InfowCtx(ctx, "subscription period advanced and moved to incomplete after trial end",
@@ -218,12 +218,12 @@ func (s *subscriptionService) processSubscriptionTrialEnd(ctx context.Context, s
 	// Runs after commit: webhooks and credit grants must not fire if the tx above rolled back.
 	if trialEndInvoice == nil {
 		if err := s.completeTrialConversionToActive(ctx, sub); err != nil {
-			return err
+			return nil, err
 		}
 		s.Logger.InfowCtx(ctx, "subscription activated after zero-amount trial end",
 			"subscription_id", sub.ID)
 	}
-	return nil
+	return trialEndInvoice, nil
 }
 
 // cascadeTrialEndToInherited propagates the trial-end state (incomplete + advanced period) to all

--- a/internal/service/subscription_trial.go
+++ b/internal/service/subscription_trial.go
@@ -140,6 +140,14 @@ func derivePerSubscriptionCtx(parentCtx context.Context, sub *subscription.Subsc
 	return ctx
 }
 
+// ProcessSingleSubscriptionTrialEnd is the public entry point for ending a single subscription's
+// trial on demand (e.g. from the modification API). It delegates to the private batch-oriented
+// processSubscriptionTrialEnd with now = time.Now().
+func (s *subscriptionService) ProcessSingleSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, now time.Time) error {
+	invService := NewInvoiceService(s.ServiceParams)
+	return s.processSubscriptionTrialEnd(ctx, sub, invService, now)
+}
+
 func (s *subscriptionService) processSubscriptionTrialEnd(ctx context.Context, sub *subscription.Subscription, invoiceService InvoiceService, now time.Time) error {
 	if sub.SubscriptionType == types.SubscriptionTypeInherited {
 		return nil
@@ -229,6 +237,7 @@ func (s *subscriptionService) cascadeTrialEndToInherited(ctx context.Context, pa
 		return err
 	}
 	for _, child := range children {
+		child.TrialEnd = parentSub.TrialEnd
 		child.SubscriptionStatus = types.SubscriptionStatusIncomplete
 		child.BillingAnchor = parentSub.BillingAnchor
 		child.CurrentPeriodStart = parentSub.CurrentPeriodStart


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial-end modifications: end now or set a new future trial end date
  * Subscription events now include trial-end and current-period-end timestamps

* **Behavior Changes**
  * Cancelling a trialing subscription no longer creates proration adjustments

* **Bug Fixes / Validation**
  * Stronger validation and errors for trial-end changes, including inherited-subscription checks

* **Tests**
  * Added comprehensive tests covering trial-end execute/preview flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->