### PR TITLE
refactor(subscription): rename TrialEndAction

### DIFF
--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -62,33 +62,33 @@ func (r *SubModifyQuantityChangeRequest) Validate() error {
 type TrialEndAction string
 
 const (
-	// TrialEndActionEndNow ends the trial immediately and begins conversion.
-	TrialEndActionEndNow TrialEndAction = "end_now"
-	// TrialEndActionModifyDate changes the trial end date to a new value.
-	TrialEndActionModifyDate TrialEndAction = "modify_date"
+	// TrialEndActionImmediate ends the trial immediately and begins conversion.
+	TrialEndActionImmediate TrialEndAction = "immediate"
+	// TrialEndActionScheduledDate changes the trial end date to a new value.
+	TrialEndActionScheduledDate TrialEndAction = "scheduled_date"
 )
 
 // SubModifyTrialEndRequest is the payload for modifying a subscription's trial period end.
 type SubModifyTrialEndRequest struct {
-	// Action is "end_now" or "modify_date".
+	// Action is "immediate" or "scheduled_date".
 	Action TrialEndAction `json:"action" binding:"required"`
-	// NewTrialEnd is the new trial end date. Required when action is "modify_date".
+	// NewTrialEnd is the new trial end date. Required when action is "scheduled_date".
 	NewTrialEnd *time.Time `json:"new_trial_end,omitempty"`
 }
 
 func (r *SubModifyTrialEndRequest) Validate() error {
 	switch r.Action {
-	case TrialEndActionEndNow:
+	case TrialEndActionImmediate:
 		// no extra fields needed
-	case TrialEndActionModifyDate:
+	case TrialEndActionScheduledDate:
 		if r.NewTrialEnd == nil {
-			return ierr.NewError("new_trial_end is required when action is 'modify_date'").
+			return ierr.NewError("new_trial_end is required when action is 'scheduled_date'").
 				WithHint("Provide a new_trial_end date to extend or reduce the trial").
 				Mark(ierr.ErrValidation)
 		}
 	default:
 		return ierr.NewError("unknown trial end action: " + string(r.Action)).
-			WithHint("Valid values: end_now, modify_date").
+			WithHint("Valid values: immediate, scheduled_date").
 			Mark(ierr.ErrValidation)
 	}
 	return nil

--- a/internal/service/subscription_modification_test.go
+++ b/internal/service/subscription_modification_test.go
@@ -1356,7 +1356,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_RejectsNonTrialingSu
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action: dto.TrialEndActionEndNow,
+			Action: dto.TrialEndActionImmediate,
 		},
 	}
 	_, err := s.service.Execute(ctx, sub.ID, req)
@@ -1372,7 +1372,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewRejectsNonTri
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action: dto.TrialEndActionEndNow,
+			Action: dto.TrialEndActionImmediate,
 		},
 	}
 	_, err := s.service.Preview(ctx, sub.ID, req)
@@ -1393,7 +1393,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ValidationMissingPar
 	s.Contains(err.Error(), "trial_end_params is required")
 }
 
-func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRequiresDate() {
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ScheduledDateRequiresDate() {
 	ctx := s.GetContext()
 	cust := s.createCustomer("ext-trial-004")
 	sub := s.createTrialingSub(cust.ID)
@@ -1401,7 +1401,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRequiresDa
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action: dto.TrialEndActionModifyDate,
+			Action: dto.TrialEndActionScheduledDate,
 		},
 	}
 	_, err := s.service.Execute(ctx, sub.ID, req)
@@ -1409,7 +1409,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRequiresDa
 	s.Contains(err.Error(), "new_trial_end is required")
 }
 
-func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRejectsPast() {
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ScheduledDateRejectsPast() {
 	ctx := s.GetContext()
 	cust := s.createCustomer("ext-trial-005")
 	sub := s.createTrialingSub(cust.ID)
@@ -1418,7 +1418,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRejectsPas
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action:      dto.TrialEndActionModifyDate,
+			Action:      dto.TrialEndActionScheduledDate,
 			NewTrialEnd: &pastDate,
 		},
 	}
@@ -1427,7 +1427,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateRejectsPas
 	s.Contains(err.Error(), "new_trial_end must be in the future")
 }
 
-func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateExtend() {
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ScheduledDateExtend() {
 	ctx := s.GetContext()
 	cust := s.createCustomer("ext-trial-006")
 	sub := s.createTrialingSub(cust.ID)
@@ -1437,7 +1437,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateExtend() {
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action:      dto.TrialEndActionModifyDate,
+			Action:      dto.TrialEndActionScheduledDate,
 			NewTrialEnd: &newEnd,
 		},
 	}
@@ -1458,7 +1458,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateExtend() {
 	s.Equal(dto.ChangedSubscriptionActionUpdated, resp.ChangedResources.Subscriptions[0].Action)
 }
 
-func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateReduce() {
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ScheduledDateReduce() {
 	ctx := s.GetContext()
 	cust := s.createCustomer("ext-trial-007")
 	sub := s.createTrialingSub(cust.ID)
@@ -1468,7 +1468,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateReduce() {
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action:      dto.TrialEndActionModifyDate,
+			Action:      dto.TrialEndActionScheduledDate,
 			NewTrialEnd: &newEnd,
 		},
 	}
@@ -1483,7 +1483,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_ModifyDateReduce() {
 	s.True(updated.CurrentPeriodEnd.Equal(newEnd))
 }
 
-func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewModifyDate() {
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewScheduledDate() {
 	ctx := s.GetContext()
 	cust := s.createCustomer("ext-trial-008")
 	sub := s.createTrialingSub(cust.ID)
@@ -1493,7 +1493,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewModifyDate() 
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action:      dto.TrialEndActionModifyDate,
+			Action:      dto.TrialEndActionScheduledDate,
 			NewTrialEnd: &newEnd,
 		},
 	}
@@ -1510,7 +1510,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewModifyDate() 
 	s.Equal(dto.ChangedSubscriptionActionUpdated, resp.ChangedResources.Subscriptions[0].Action)
 }
 
-func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewEndNow() {
+func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewImmediate() {
 	ctx := s.GetContext()
 	cust := s.createCustomer("ext-trial-009")
 	sub := s.createTrialingSub(cust.ID)
@@ -1519,7 +1519,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_PreviewEndNow() {
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action: dto.TrialEndActionEndNow,
+			Action: dto.TrialEndActionImmediate,
 		},
 	}
 	resp, err := s.service.Preview(ctx, sub.ID, req)
@@ -1563,7 +1563,7 @@ func (s *SubscriptionModificationServiceSuite) TestTrialEnd_RejectsInheritedSub(
 	req := dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeTrialEnd,
 		TrialEndParams: &dto.SubModifyTrialEndRequest{
-			Action: dto.TrialEndActionEndNow,
+			Action: dto.TrialEndActionImmediate,
 		},
 	}
 	_, err := s.service.Execute(ctx, sub.ID, req)

--- a/internal/service/subscription_modification_trial_end.go
+++ b/internal/service/subscription_modification_trial_end.go
@@ -11,7 +11,7 @@ import (
 	"github.com/samber/lo"
 )
 
-// validateTrialEndRequest validates the subscription state and, for modify_date actions,
+// validateTrialEndRequest validates the subscription state and, for scheduled_date actions,
 // the new trial end date. Combines subscription-level and date-level checks in one pass.
 func (s *subscriptionModificationService) validateTrialEndRequest(
 	sub *subscription.Subscription,
@@ -37,13 +37,13 @@ func (s *subscriptionModificationService) validateTrialEndRequest(
 			Mark(ierr.ErrValidation)
 	}
 
-	// Date-specific validation only applies to modify_date action.
-	if params.Action == dto.TrialEndActionModifyDate {
+	// Date-specific validation only applies to scheduled_date action.
+	if params.Action == dto.TrialEndActionScheduledDate {
 		newTrialEnd := params.NewTrialEnd.UTC()
 		now := time.Now().UTC()
 		if !newTrialEnd.After(now) {
 			return ierr.NewError("new_trial_end must be in the future").
-				WithHint("To end the trial immediately, use action 'end_now'").
+				WithHint("To end the trial immediately, use action 'immediate'").
 				WithReportableDetails(map[string]interface{}{"new_trial_end": newTrialEnd, "now": now}).
 				Mark(ierr.ErrValidation)
 		}
@@ -80,9 +80,9 @@ func (s *subscriptionModificationService) executeTrialEnd(
 	}
 
 	switch params.Action {
-	case dto.TrialEndActionEndNow:
+	case dto.TrialEndActionImmediate:
 		return s.executeTrialEndNow(ctx, sub)
-	case dto.TrialEndActionModifyDate:
+	case dto.TrialEndActionScheduledDate:
 		return s.executeTrialEndModifyDate(ctx, sub, params.NewTrialEnd.UTC())
 	default:
 		return nil, ierr.NewError("unknown trial end action: " + string(params.Action)).
@@ -192,7 +192,7 @@ func (s *subscriptionModificationService) previewTrialEnd(
 
 	status := types.SubscriptionStatusIncomplete
 	endDate := time.Now().UTC()
-	if params.Action == dto.TrialEndActionModifyDate {
+	if params.Action == dto.TrialEndActionScheduledDate {
 		status = types.SubscriptionStatusTrialing
 		endDate = params.NewTrialEnd.UTC()
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trial-end modification actions have been updated: `immediate` (replaces `end_now`) and `scheduled_date` (replaces `modify_date`) provide clearer operation semantics
  * Improved validation: the `new_trial_end` date field is now required only when the `scheduled_date` action is used, enabling more flexible subscription trial management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->