### PR TITLE
feat(kafka): support SASL/OAUTHBEARER for GCP Managed Kafka (develop)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	go.uber.org/fx v1.23.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.48.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.8.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -76,6 +77,7 @@ require (
 require (
 	ariga.io/atlas v0.19.1-0.20240203083654-5948b60a8e43 // indirect
 	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/ClickHouse/ch-go v0.66.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,12 @@ ariga.io/atlas v0.19.1-0.20240203083654-5948b60a8e43/go.mod h1:uj3pm+hUTVN/X5yfd
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.112.1 h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
+cloud.google.com/go/compute v1.24.0 h1:phWcR2eWzRJaL/kOiJwfFsPs4BaKq1j6vnpZrc1YlVg=
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 entgo.io/ent v0.14.1 h1:fUERL506Pqr92EPHJqr8EYxbPioflJo6PudkrEA8a/s=
 entgo.io/ent v0.14.1/go.mod h1:MH6XLG0KXpkcDQhKiHfANZSzR55TJyPL5IGNpI8wpco=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -575,6 +581,8 @@ golang.org/x/net v0.0.0-20220725212005-46097bf591d3/go.mod h1:AaygXjzTFtRAg2ttMY
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,10 @@ type KafkaConfig struct {
 	SASLMechanism          sarama.SASLMechanism `mapstructure:"sasl_mechanism"`
 	SASLUser               string               `mapstructure:"sasl_user"`
 	SASLPassword           string               `mapstructure:"sasl_password"`
+	// SASLOAuthScopes is consulted only when SASLMechanism is OAUTHBEARER.
+	// Empty defaults to ["https://www.googleapis.com/auth/cloud-platform"],
+	// which is what GCP Managed Kafka requires.
+	SASLOAuthScopes        []string             `mapstructure:"sasl_oauth_scopes"`
 	ClientID               string               `mapstructure:"client_id" validate:"required"`
 	RouteTenantsOnLazyMode []string             `mapstructure:"route_tenants_on_lazy_mode" validate:"omitempty"`
 }

--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
@@ -49,14 +50,27 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 
 	// sasl configs
 	saramaConfig.Net.SASL.Mechanism = cfg.Kafka.SASLMechanism
-	saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
-	saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 
-	// Configure SCRAM client generator for SCRAM mechanisms
-	if cfg.Kafka.SASLMechanism == sarama.SASLTypeSCRAMSHA256 || cfg.Kafka.SASLMechanism == sarama.SASLTypeSCRAMSHA512 {
+	switch cfg.Kafka.SASLMechanism {
+	case sarama.SASLTypeOAuth:
+		// OAUTHBEARER (e.g. GCP Managed Kafka). Token comes from Application
+		// Default Credentials — Workload Identity on GKE, gcloud locally.
+		// User/Password are not used.
+		provider, err := newGCPTokenProvider(context.Background(), cfg.Kafka.SASLOAuthScopes)
+		if err != nil {
+			panic(err)
+		}
+		saramaConfig.Net.SASL.TokenProvider = provider
+	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512:
+		saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
+		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 		saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 			return &XDGSCRAMClient{HashGeneratorFcn: getHashGenerator(cfg.Kafka.SASLMechanism)}
 		}
+	default:
+		// PLAIN and any other mechanism that uses user+password.
+		saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
+		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 	}
 
 	return saramaConfig

--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/sha512"
+	"fmt"
 	"hash"
 
 	"crypto/tls"
@@ -58,7 +59,7 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 		// User/Password are not used.
 		provider, err := newGCPTokenProvider(context.Background(), cfg.Kafka.SASLOAuthScopes)
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", cfg.Kafka.SASLOAuthScopes, err))
 		}
 		saramaConfig.Net.SASL.TokenProvider = provider
 	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512:

--- a/internal/kafka/oauth.go
+++ b/internal/kafka/oauth.go
@@ -1,0 +1,41 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// gcpTokenProvider implements sarama.AccessTokenProvider for SASL/OAUTHBEARER
+// against GCP Managed Kafka. It pulls credentials from Application Default
+// Credentials, which resolves to:
+//   - the GKE metadata server when running with Workload Identity, or
+//   - gcloud user credentials when running locally.
+//
+// oauth2.ReuseTokenSource caches the token until expiry, so we don't hit the
+// metadata server on every broker connect.
+type gcpTokenProvider struct {
+	src oauth2.TokenSource
+}
+
+func newGCPTokenProvider(ctx context.Context, scopes []string) (*gcpTokenProvider, error) {
+	if len(scopes) == 0 {
+		scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
+	}
+	src, err := google.DefaultTokenSource(ctx, scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("kafka oauthbearer: resolve GCP default token source: %w", err)
+	}
+	return &gcpTokenProvider{src: oauth2.ReuseTokenSource(nil, src)}, nil
+}
+
+func (p *gcpTokenProvider) Token() (*sarama.AccessToken, error) {
+	tok, err := p.src.Token()
+	if err != nil {
+		return nil, fmt.Errorf("kafka oauthbearer: fetch GCP access token: %w", err)
+	}
+	return &sarama.AccessToken{Token: tok.AccessToken}, nil
+}


### PR DESCRIPTION
## Summary

Develop-targeted version of #1882 (which targets `main`), for staging-environment testing before the change lands on `main`.

Adds `OAUTHBEARER` as a supported value for `kafkaConfig.saslMechanism`, so the Go client can authenticate to **GCP Managed Kafka** (and any other broker that speaks OAUTHBEARER with Google-issued tokens).

The token source is `golang.org/x/oauth2/google.DefaultTokenSource`, wrapped in `oauth2.ReuseTokenSource` so the metadata server is hit at most once per token TTL, not on every broker connect. ADC resolution picks up:

- **GKE Workload Identity** at runtime in-cluster
- `gcloud auth application-default login` locally

No service-account key files required or supported.

## Backwards compatibility

**Existing SCRAM, PLAIN, and no-SASL deployments require zero config changes and produce a byte-identical `sarama.Config`.**

The change to [`internal/kafka/base.go`](https://github.com/flexprice/flexprice/blob/feat/kafka-gmk-oauthbearer-develop/internal/kafka/base.go) refactors the existing flat assignments into a `switch` on `cfg.Kafka.SASLMechanism`:

| `UseSASL` | `SASLMechanism` | Before | After |
|---|---|---|---|
| `false` | (anything) | early return | early return — **identical** |
| `true` | `SCRAM-SHA-256/512` | sets Mechanism, User, Password, SCRAM generator | `case SCRAM*` sets exactly the same four fields — **identical** |
| `true` | `PLAIN` (or any other user/pw mechanism) | sets Mechanism, User, Password | `default` sets the same three — **identical** |
| `true` | `OAUTHBEARER` (new) | would have crashed mid-handshake | sets Mechanism + `TokenProvider`, skips user/pw |

The new optional `KafkaConfig.SASLOAuthScopes []string` defaults to `nil`; the provider falls back to `["https://www.googleapis.com/auth/cloud-platform"]` (what GMK requires) when empty. Existing values files don't need to set it.

## Diff scope (vs `develop`)

- `internal/kafka/oauth.go` (new) — 41 lines, GCP token provider
- `internal/kafka/base.go` — added `switch` for OAUTHBEARER case
- `internal/config/config.go` — added optional `SASLOAuthScopes`
- `go.mod`, `go.sum` — only two additions: `golang.org/x/oauth2` (direct) and `cloud.google.com/go/compute/metadata` (transitive)

**No `go` directive change** — kept at `1.24.0`, matches `Dockerfile.ecs` and `Dockerfile.local` (`golang:1.24-alpine3.20`). No Dockerfile updates needed.

## Operator usage

```yaml
kafkaConfig:
  useSASL: true
  saslMechanism: OAUTHBEARER
  # saslUser / saslPassword unused — leave empty
  # sasl_oauth_scopes optional; defaults to cloud-platform
```

For the Helm chart, the matching change is a one-line gate around the `FLEXPRICE_KAFKA_SASL_USER` / `FLEXPRICE_KAFKA_SASL_PASSWORD` env-var block in `_helpers.tpl` (skip emitting them when `saslMechanism == "OAUTHBEARER"`). That edit lands in the separate EE chart repo. Without it, the chart emits empty user/password env vars — harmless because the OAUTHBEARER branch in `base.go` ignores them, but worth cleaning up.

## Why now

Surfaced during the May 2026 GCP staging bring-up (`flexprice/infrastructure#11`, "Blocker 1 — Managed Kafka"). GMK requires SASL/OAUTHBEARER with GCP IAM tokens, but the Go client had no OAUTHBEARER path, so we fell back to in-cluster Redpanda for staging. This PR closes that gap; once it ships and the matching helm gate lands, we can rip Redpanda out and point staging back at GMK.

## Notes for reviewers

- **`panic` in `GetSaramaConfig` for the token-source resolution error path** — done deliberately because the function signature doesn't return `error` and changing it would cascade through `producer.go` / `consumer.go` (violating the backwards-compat goal above). Panic only fires when an operator has explicitly opted into OAUTHBEARER **and** ADC fails — a fatal config error on the same severity as a missing required env var, so crashing at boot is correct.
- `go mod tidy` doesn't run cleanly on `develop` today (broken `github.com/flexprice/flexprice-go/v2/models/types` import in `api/custom/go/`). Not introduced here; just flagging.
- Paired with #1882 against `main` — once merged here and tested in staging-GCP, that PR is the version to merge to `main`.

## Test plan

- [x] `go build ./internal/kafka/... ./internal/config/...` passes
- [x] `go vet ./internal/kafka/... ./internal/config/...` passes
- [x] No `go` toolchain change; Dockerfile unchanged
- [ ] Staging deploy with `saslMechanism: OAUTHBEARER` against GMK from inside GKE (Workload Identity bound)
- [ ] Regression: smoke-test SCRAM and PLAIN paths to confirm no behavior change
- [ ] Unit test for `gcpTokenProvider.Token()` using a fake `oauth2.TokenSource`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SASL/OAUTHBEARER authentication for Kafka using Google Cloud credentials.
  * Kafka SASL authentication supports configurable OAuth scopes for token generation.

* **Chores**
  * Updated Go module dependencies (internal dependency updates to support OAuth token integration).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->