### PR TITLE
fix(wallet): Preserve end time in wallet transactions

### DIFF
--- a/internal/domain/wallet/operation.go
+++ b/internal/domain/wallet/operation.go
@@ -32,10 +32,14 @@ type WalletOperation struct {
 	// which is important for accurate billing and credit consumption.
 	InvoiceID *string `json:"invoice_id,omitempty"`
 
-	Metadata          types.Metadata          `json:"metadata,omitempty"`
-	IdempotencyKey    string                  `json:"idempotency_key,omitempty"`
-	ExpiryDate        *int                    `json:"expiry_date,omitempty"` // YYYYMMDD format
-	Priority          *int                    `json:"priority,omitempty"`    // lower number means higher priority
+	Metadata       types.Metadata `json:"metadata,omitempty"`
+	IdempotencyKey string         `json:"idempotency_key,omitempty"`
+	ExpiryDate     *int           `json:"expiry_date,omitempty"` // YYYYMMDD format (legacy/external-API path)
+	// ExpiryDateTime is the full-precision expiry timestamp. Preferred over ExpiryDate
+	// for internal callers (e.g. subscription credit grants) to avoid the YYYYMMDD truncation
+	// that strips hours/timezone and shifts the wall-clock expiry by up to ~24h.
+	ExpiryDateTime    *time.Time              `json:"expiry_date_time,omitempty"`
+	Priority          *int                    `json:"priority,omitempty"` // lower number means higher priority
 	TransactionReason types.TransactionReason `json:"transaction_reason,omitempty"`
 	// For Expiry Credits, this is the ID of the parent credit transaction
 	// so that we can use the same credits for the expiry debit transaction
@@ -86,7 +90,16 @@ func (w *WalletOperation) Validate() error {
 		return err
 	}
 
-	if w.ExpiryDate != nil {
+	if w.ExpiryDateTime != nil {
+		if w.ExpiryDateTime.Before(time.Now().UTC()) {
+			return ierr.NewError("expiry date cannot be in the past").
+				WithHint("Expiry date must be in the future").
+				WithReportableDetails(map[string]interface{}{
+					"expiry_date": w.ExpiryDateTime,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	} else if w.ExpiryDate != nil {
 		expiryTime := types.ParseYYYYMMDDToDate(w.ExpiryDate)
 		if expiryTime == nil {
 			return ierr.NewError("invalid expiry date").
@@ -108,4 +121,14 @@ func (w *WalletOperation) Validate() error {
 	}
 
 	return nil
+}
+
+// ResolvedExpiryDate returns the full-precision expiry timestamp regardless of
+// which field the caller populated. Prefers ExpiryDateTime; falls back to the
+// YYYYMMDD ExpiryDate (interpreted as midnight UTC per ParseYYYYMMDDToDate).
+func (w *WalletOperation) ResolvedExpiryDate() *time.Time {
+	if w.ExpiryDateTime != nil {
+		return w.ExpiryDateTime
+	}
+	return types.ParseYYYYMMDDToDate(w.ExpiryDate)
 }

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -201,17 +200,6 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		req.CreditsToAdd = s.getCreditsFromCurrencyAmount(req.Amount, w.TopupConversionRate)
 	}
 
-	if req.ExpiryDateUTC != nil && req.ExpiryDate == nil {
-		expiryDate := req.ExpiryDateUTC.UTC()
-		parsedDate, err := strconv.Atoi(expiryDate.Format("20060102"))
-		if err != nil {
-			return nil, ierr.WithError(err).
-				WithHint("Invalid expiry date").
-				Mark(ierr.ErrValidation)
-		}
-		req.ExpiryDate = &parsedDate
-	}
-
 	if err := req.Validate(); err != nil {
 		return nil, ierr.WithError(err).
 			WithHint("Invalid top up wallet request").
@@ -278,6 +266,7 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		ReferenceType:     referenceType,
 		ReferenceID:       referenceID,
 		ExpiryDate:        req.ExpiryDate,
+		ExpiryDateTime:    req.ExpiryDateUTC, // ExpiryDateUTC is the preferred input: a full-precision timestamp
 		IdempotencyKey:    idempotencyKey,
 		Priority:          req.Priority,
 	}
@@ -361,7 +350,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			CreditBalanceAfter:  balanceAfter,
 			Currency:            w.Currency,
 			TopupConversionRate: lo.ToPtr(w.TopupConversionRate),
-			ExpiryDate:          types.ParseYYYYMMDDToDate(req.ExpiryDate),
+			ExpiryDate:          lo.Ternary(req.ExpiryDateUTC != nil, req.ExpiryDateUTC, types.ParseYYYYMMDDToDate(req.ExpiryDate)),
 			BaseModel:           types.GetDefaultBaseModel(ctx),
 		}
 
@@ -619,7 +608,7 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 			Metadata:            req.Metadata,
 			TxStatus:            types.TransactionStatusCompleted,
 			TransactionReason:   req.TransactionReason,
-			ExpiryDate:          types.ParseYYYYMMDDToDate(req.ExpiryDate),
+			ExpiryDate:          req.ResolvedExpiryDate(),
 			Priority:            req.Priority,
 			CreditBalanceBefore: w.CreditBalance,
 			CreditBalanceAfter:  newCreditBalance,
@@ -638,9 +627,6 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 
 		if req.Type == types.TransactionTypeCredit {
 			tx.TopupConversionRate = lo.ToPtr(w.TopupConversionRate)
-			if req.ExpiryDate != nil {
-				tx.ExpiryDate = types.ParseYYYYMMDDToDate(req.ExpiryDate)
-			}
 		} else if req.Type == types.TransactionTypeDebit {
 			tx.ConversionRate = lo.ToPtr(w.ConversionRate)
 		}

--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -1083,6 +1083,9 @@ func (o InvoiceQueryOptions) applyEntityQueryOptions(_ context.Context, f *types
 	if f.InvoiceType != "" {
 		query = query.Where(invoice.InvoiceType(f.InvoiceType))
 	}
+	if f.Currency != "" {
+		query = query.Where(invoice.Currency(f.Currency))
+	}
 	if len(f.InvoiceIDs) > 0 {
 		query = query.Where(invoice.IDIn(f.InvoiceIDs...))
 	}

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -3036,17 +3036,10 @@ func (s *walletService) CheckWalletBalanceAlert(ctx context.Context, req *wallet
 		// RealTimeCreditBalance = (currency balance - pending charges) / conversion_rate
 		ongoingBalance := lo.FromPtr(balance.RealTimeCreditBalance)
 
-		// Trigger auto top-up if enabled; threshold check is handled internally by triggerAutoTopup
-		if autoTopupEnabled {
-			if err := s.triggerAutoTopup(ctx, w, ongoingBalance); err != nil {
-				s.Logger.ErrorwCtx(ctx, "failed to trigger auto top-up",
-					"error", err,
-					"wallet_id", w.ID,
-				)
-			}
-		}
-
-		// Process wallet-level balance alert if enabled
+		// Process wallet-level balance alert BEFORE triggering auto top-up so the
+		// pre-topup state (e.g. Warning) is recorded first. The nested
+		// CheckWalletBalanceAlert call that fires inside processWalletOperation
+		// during the top-up credit will then log the post-topup state (ok).
 		if walletAlertsEnabled {
 			s.Logger.InfowCtx(ctx, "wallet balance details for alert check",
 				"wallet_id", w.ID,
@@ -3074,6 +3067,18 @@ func (s *walletService) CheckWalletBalanceAlert(ctx context.Context, req *wallet
 					"error", err,
 					"wallet_id", w.ID,
 					"event_id", req.ID,
+				)
+			}
+		}
+
+		// Trigger auto top-up after alerts have been logged. The nested
+		// CheckWalletBalanceAlert that fires inside processWalletOperation during
+		// the top-up credit will record the recovered (ok) state automatically.
+		if autoTopupEnabled {
+			if err := s.triggerAutoTopup(ctx, w, ongoingBalance); err != nil {
+				s.Logger.ErrorwCtx(ctx, "failed to trigger auto top-up",
+					"error", err,
+					"wallet_id", w.ID,
 				)
 			}
 		}

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -546,18 +545,6 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		req.CreditsToAdd = s.GetCreditsFromCurrencyAmount(req.Amount, w.TopupConversionRate)
 	}
 
-	// If ExpiryDateUTC is provided, convert it to YYYYMMDD format
-	if req.ExpiryDateUTC != nil && req.ExpiryDate == nil {
-		expiryDate := req.ExpiryDateUTC.UTC()
-		parsedDate, err := strconv.Atoi(expiryDate.Format("20060102"))
-		if err != nil {
-			return nil, ierr.WithError(err).
-				WithHint("Invalid expiry date").
-				Mark(ierr.ErrValidation)
-		}
-		req.ExpiryDate = &parsedDate
-	}
-
 	// Create a credit operation
 	if err := req.Validate(); err != nil {
 		return nil, ierr.WithError(err).
@@ -635,6 +622,7 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		ReferenceType:     referenceType,
 		ReferenceID:       referenceID,
 		ExpiryDate:        req.ExpiryDate,
+		ExpiryDateTime:    req.ExpiryDateUTC, // ExpiryDateUTC is the preferred input: a full-precision timestamp
 		IdempotencyKey:    idempotencyKey,
 		Priority:          req.Priority,
 	}
@@ -740,7 +728,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			CreditBalanceAfter:  balanceAfter,
 			Currency:            w.Currency,
 			TopupConversionRate: lo.ToPtr(w.TopupConversionRate),
-			ExpiryDate:          types.ParseYYYYMMDDToDate(req.ExpiryDate),
+			ExpiryDate:          lo.Ternary(req.ExpiryDateUTC != nil, req.ExpiryDateUTC, types.ParseYYYYMMDDToDate(req.ExpiryDate)),
 			BaseModel:           types.GetDefaultBaseModel(ctx),
 		}
 
@@ -1604,7 +1592,7 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 			Metadata:            req.Metadata,
 			TxStatus:            types.TransactionStatusCompleted,
 			TransactionReason:   req.TransactionReason,
-			ExpiryDate:          types.ParseYYYYMMDDToDate(req.ExpiryDate),
+			ExpiryDate:          req.ResolvedExpiryDate(),
 			Priority:            req.Priority,
 			CreditBalanceBefore: w.CreditBalance,
 			CreditBalanceAfter:  newCreditBalance,
@@ -1625,9 +1613,6 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 		// Set transaction-specific fields based on transaction type
 		if req.Type == types.TransactionTypeCredit {
 			tx.TopupConversionRate = lo.ToPtr(w.TopupConversionRate)
-			if req.ExpiryDate != nil {
-				tx.ExpiryDate = types.ParseYYYYMMDDToDate(req.ExpiryDate)
-			}
 		} else if req.Type == types.TransactionTypeDebit {
 			tx.ConversionRate = lo.ToPtr(w.ConversionRate)
 		}
@@ -1810,6 +1795,8 @@ func (s *walletService) shouldSkipCreditExpiryDueToActiveSubscriptionOrInvoice(c
 	invoiceFilter := types.NewInvoiceFilter()
 	invoiceFilter.CustomerID = tx.CustomerID
 	invoiceFilter.InvoiceType = types.InvoiceTypeSubscription
+	invoiceFilter.Currency = tx.Currency // wallets are per-currency; an EUR invoice can't be paid by a USD wallet
+	invoiceFilter.InvoiceStatus = []types.InvoiceStatus{types.InvoiceStatusFinalized, types.InvoiceStatusDraft}
 	invoiceFilter.AmountRemainingGt = lo.ToPtr(decimal.Zero)
 	invoiceFilter.Limit = lo.ToPtr(1)
 	invoiceFilter.PeriodStartLTE = &tx.CreatedAt // period_start <= grant created_at

--- a/internal/types/invoice.go
+++ b/internal/types/invoice.go
@@ -434,6 +434,10 @@ type InvoiceFilter struct {
 	// Use this to separate recurring charges from one-time fees or credit adjustments
 	InvoiceType InvoiceType `json:"invoice_type,omitempty" form:"invoice_type"`
 
+	// currency filters invoices by their currency (ISO 4217 code, e.g. "usd", "eur").
+	// Matches on the invoices.currency column exactly.
+	Currency string `json:"currency,omitempty" form:"currency"`
+
 	// invoice_status filters by the current state of invoices in their lifecycle
 	// Multiple statuses can be specified to include invoices in any of the listed states
 	InvoiceStatus []InvoiceStatus `json:"invoice_status,omitempty" form:"invoice_status"`


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Preserve `time` along with `date` in wallet transaction for proper credit, debit and expiry handling.

---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wallet operations now accept full-precision expiry timestamps alongside the legacy date format.
  * Invoices can now be filtered by currency.

* **Refactor**
  * Enhanced expiry date handling to prioritize timestamp inputs for improved consistency across wallet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->