### PR TITLE
refactor(costsheet): gate cost analytics on meter usage and disable usage consumer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	go.uber.org/fx v1.23.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.48.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/time v0.8.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -76,6 +77,7 @@ require (
 require (
 	ariga.io/atlas v0.19.1-0.20240203083654-5948b60a8e43 // indirect
 	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/ClickHouse/ch-go v0.66.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,12 @@ ariga.io/atlas v0.19.1-0.20240203083654-5948b60a8e43/go.mod h1:uj3pm+hUTVN/X5yfd
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.112.1 h1:uJSeirPke5UNZHIb4SxfZklVSiWWVqW4oXlETwZziwM=
+cloud.google.com/go/compute v1.24.0 h1:phWcR2eWzRJaL/kOiJwfFsPs4BaKq1j6vnpZrc1YlVg=
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 entgo.io/ent v0.14.1 h1:fUERL506Pqr92EPHJqr8EYxbPioflJo6PudkrEA8a/s=
 entgo.io/ent v0.14.1/go.mod h1:MH6XLG0KXpkcDQhKiHfANZSzR55TJyPL5IGNpI8wpco=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -575,6 +581,8 @@ golang.org/x/net v0.0.0-20220725212005-46097bf591d3/go.mod h1:AaygXjzTFtRAg2ttMY
 golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
 golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,10 @@ type KafkaConfig struct {
 	SASLMechanism          sarama.SASLMechanism `mapstructure:"sasl_mechanism"`
 	SASLUser               string               `mapstructure:"sasl_user"`
 	SASLPassword           string               `mapstructure:"sasl_password"`
+	// SASLOAuthScopes is consulted only when SASLMechanism is OAUTHBEARER.
+	// Empty defaults to ["https://www.googleapis.com/auth/cloud-platform"],
+	// which is what GCP Managed Kafka requires.
+	SASLOAuthScopes        []string             `mapstructure:"sasl_oauth_scopes"`
 	ClientID               string               `mapstructure:"client_id" validate:"required"`
 	RouteTenantsOnLazyMode []string             `mapstructure:"route_tenants_on_lazy_mode" validate:"omitempty"`
 }

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -240,13 +240,13 @@ usage_benchmark:
   consumer_group: "v1_usage_benchmark_service"
 
 costsheet_usage_tracking:
-  enabled: true
+  enabled: false
   topic: "events"
   rate_limit: 1
   consumer_group: "v1_costsheet_usage_tracking_service"
 
 costsheet_usage_tracking_lazy:
-  enabled: true
+  enabled: false
   topic: "events_lazy"
   rate_limit: 1
   consumer_group: "v1_costsheet_usage_tracking_service_lazy"

--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/sha512"
 	"hash"
@@ -49,14 +50,27 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 
 	// sasl configs
 	saramaConfig.Net.SASL.Mechanism = cfg.Kafka.SASLMechanism
-	saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
-	saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 
-	// Configure SCRAM client generator for SCRAM mechanisms
-	if cfg.Kafka.SASLMechanism == sarama.SASLTypeSCRAMSHA256 || cfg.Kafka.SASLMechanism == sarama.SASLTypeSCRAMSHA512 {
+	switch cfg.Kafka.SASLMechanism {
+	case sarama.SASLTypeOAuth:
+		// OAUTHBEARER (e.g. GCP Managed Kafka). Token comes from Application
+		// Default Credentials — Workload Identity on GKE, gcloud locally.
+		// User/Password are not used.
+		provider, err := newGCPTokenProvider(context.Background(), cfg.Kafka.SASLOAuthScopes)
+		if err != nil {
+			panic(err)
+		}
+		saramaConfig.Net.SASL.TokenProvider = provider
+	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512:
+		saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
+		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 		saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 			return &XDGSCRAMClient{HashGeneratorFcn: getHashGenerator(cfg.Kafka.SASLMechanism)}
 		}
+	default:
+		// PLAIN and any other mechanism that uses user+password.
+		saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
+		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 	}
 
 	return saramaConfig

--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/sha512"
+	"fmt"
 	"hash"
 
 	"crypto/tls"
@@ -58,7 +59,7 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 		// User/Password are not used.
 		provider, err := newGCPTokenProvider(context.Background(), cfg.Kafka.SASLOAuthScopes)
 		if err != nil {
-			panic(err)
+			panic(fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", cfg.Kafka.SASLOAuthScopes, err))
 		}
 		saramaConfig.Net.SASL.TokenProvider = provider
 	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512:

--- a/internal/kafka/oauth.go
+++ b/internal/kafka/oauth.go
@@ -1,0 +1,41 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// gcpTokenProvider implements sarama.AccessTokenProvider for SASL/OAUTHBEARER
+// against GCP Managed Kafka. It pulls credentials from Application Default
+// Credentials, which resolves to:
+//   - the GKE metadata server when running with Workload Identity, or
+//   - gcloud user credentials when running locally.
+//
+// oauth2.ReuseTokenSource caches the token until expiry, so we don't hit the
+// metadata server on every broker connect.
+type gcpTokenProvider struct {
+	src oauth2.TokenSource
+}
+
+func newGCPTokenProvider(ctx context.Context, scopes []string) (*gcpTokenProvider, error) {
+	if len(scopes) == 0 {
+		scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
+	}
+	src, err := google.DefaultTokenSource(ctx, scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("kafka oauthbearer: resolve GCP default token source: %w", err)
+	}
+	return &gcpTokenProvider{src: oauth2.ReuseTokenSource(nil, src)}, nil
+}
+
+func (p *gcpTokenProvider) Token() (*sarama.AccessToken, error) {
+	tok, err := p.src.Token()
+	if err != nil {
+		return nil, fmt.Errorf("kafka oauthbearer: fetch GCP access token: %w", err)
+	}
+	return &sarama.AccessToken{Token: tok.AccessToken}, nil
+}

--- a/internal/service/costsheet_usage_tracking.go
+++ b/internal/service/costsheet_usage_tracking.go
@@ -44,6 +44,9 @@ type CostSheetUsageTrackingService interface {
 	// Get Analytics
 	GetCostSheetUsageAnalytics(ctx context.Context, req *dto.GetCostAnalyticsRequest) (*dto.GetCostAnalyticsResponse, error)
 
+	// Get Analytics computed from meter usage (replaces the costsheet_usage read path)
+	GetCostAnalyticsFromMeterUsage(ctx context.Context, req *dto.GetCostAnalyticsRequest) (*dto.GetCostAnalyticsResponse, error)
+
 	// Reprocess cost sheet usage
 	ReprocessEvents(ctx context.Context, params *events.ReprocessEventsParams) error
 }
@@ -1424,4 +1427,222 @@ func (s *costsheetUsageTrackingService) getActiveCostsheetWithCache(ctx context.
 	}
 
 	return costSheet, nil
+}
+
+// GetCostAnalyticsFromMeterUsage computes cost analytics by combining the
+// active costsheet's prices with raw quantities pulled from the meter_usage
+// pipeline. It replaces the previous read path against the costsheet_usage
+// ClickHouse table (which was populated by a Kafka consumer that has now been
+// disabled).
+//
+// Behavior:
+//   - Resolves the active costsheet for the tenant (cached, 5m TTL).
+//   - Collects the meters referenced by the costsheet's usage-based prices.
+//   - Calls MeterUsageService.GetDetailedAnalytics scoped to those meters to
+//     get aggregated quantities per (meter, source, properties).
+//   - Multiplies each quantity by its costsheet price using PriceService.
+func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
+	ctx context.Context,
+	req *dto.GetCostAnalyticsRequest,
+) (*dto.GetCostAnalyticsResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	// STEP1: Resolve active costsheet (cached).
+	costSheet, err := s.getActiveCostsheetWithCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if costSheet == nil {
+		return nil, ierr.NewError("no active costsheet found").
+			WithHint("Please activate a costsheet for this tenant").
+			Mark(ierr.ErrNotFound)
+	}
+
+	// STEP2: Optional customer lookup.
+	var cust *customer.Customer
+	if req.ExternalCustomerID != "" {
+		cust, err = s.CustomerRepo.GetByLookupKey(ctx, req.ExternalCustomerID)
+		if err != nil {
+			return nil, err
+		}
+		if cust == nil {
+			return nil, ierr.NewError("customer not found").
+				WithHint("No customer found with the provided external_customer_id").
+				WithReportableDetails(map[string]interface{}{
+					"external_customer_id": req.ExternalCustomerID,
+				}).
+				Mark(ierr.ErrNotFound)
+		}
+	}
+
+	// STEP3: Walk the costsheet's prices to get meter IDs and a meter->price
+	// map. Costsheet prices are scoped via PRICE_ENTITY_TYPE_COSTSHEET, which
+	// is distinct from subscription prices — i.e. these are the cost rates,
+	// not the customer-facing rates.
+	meterToPrice := make(map[string]*price.Price)
+	meterIDs := make([]string, 0)
+	for _, p := range costSheet.Prices {
+		if p == nil || p.Price == nil || !p.IsUsage() {
+			continue
+		}
+		if p.MeterID == "" {
+			continue
+		}
+		if _, seen := meterToPrice[p.MeterID]; seen {
+			continue
+		}
+		meterToPrice[p.MeterID] = p.Price
+		meterIDs = append(meterIDs, p.MeterID)
+	}
+
+	if len(meterIDs) == 0 {
+		// No usage-based pricing in the costsheet — return an empty response.
+		return s.emptyCostAnalyticsResponse(req, costSheet, cust), nil
+	}
+
+	// STEP4: Resolve meter metadata in bulk so we know how to interpret the
+	// usage value (regular vs bucketed) when calling PriceService.
+	meterFilter := types.NewNoLimitMeterFilter()
+	meterFilter.MeterIDs = meterIDs
+	meters, err := s.MeterRepo.List(ctx, meterFilter)
+	if err != nil {
+		return nil, err
+	}
+	meterMap := make(map[string]*meter.Meter, len(meters))
+	for _, m := range meters {
+		meterMap[m.ID] = m
+	}
+
+	// STEP5: Query raw meter usage (no subscription context). This goes
+	// through MeterUsageService so we get analytics-shaped results that we can
+	// then re-cost using costsheet prices.
+	meterUsageService := NewMeterUsageService(s.ServiceParams)
+	analyticsParams := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:      types.GetTenantID(ctx),
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		MeterIDs:      meterIDs,
+		FeatureIDs:    req.FeatureIDs,
+		StartTime:     req.StartTime,
+		EndTime:       req.EndTime,
+		// Group by meter_id so we get one row per meter (matches how the old
+		// costsheet_usage path keyed its results).
+		GroupBy: []string{"meter_id"},
+	}
+	if cust != nil {
+		analyticsParams.ExternalCustomerID = cust.ExternalID
+	}
+
+	usageResp, err := meterUsageService.GetDetailedAnalytics(ctx, analyticsParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// STEP6: Re-cost each item using the costsheet price for its meter.
+	priceService := NewPriceService(s.ServiceParams)
+	response := &dto.GetCostAnalyticsResponse{
+		CostsheetID:   costSheet.ID,
+		StartTime:     req.StartTime,
+		EndTime:       req.EndTime,
+		TotalCost:     decimal.Zero,
+		TotalQuantity: decimal.Zero,
+		TotalEvents:   0,
+		CostAnalytics: make([]dto.CostAnalyticItem, 0, len(usageResp.Items)),
+	}
+	if cust != nil {
+		response.CustomerID = cust.ID
+		response.ExternalCustomerID = cust.ExternalID
+	}
+
+	for _, item := range usageResp.Items {
+		csPrice, ok := meterToPrice[item.MeterID]
+		if !ok {
+			// Meter is present in usage results but not in the costsheet —
+			// skip; nothing to cost it against.
+			continue
+		}
+		m := meterMap[item.MeterID]
+
+		// Compute the cost using PriceService. Bucketed meters need
+		// CalculateBucketedCost (single-bucket fallback when there are no
+		// time-series points); standard meters use CalculateCost on the
+		// total usage.
+		var totalCost decimal.Decimal
+		if m != nil && (m.IsBucketedMaxMeter() || m.IsBucketedSumMeter()) {
+			if len(item.Points) > 0 {
+				bucketed := make([]decimal.Decimal, len(item.Points))
+				for i, pt := range item.Points {
+					bucketed[i] = pt.Usage
+				}
+				totalCost = priceService.CalculateBucketedCost(ctx, csPrice, bucketed)
+			} else if item.TotalUsage.IsPositive() {
+				totalCost = priceService.CalculateBucketedCost(ctx, csPrice, []decimal.Decimal{item.TotalUsage})
+			}
+		} else {
+			totalCost = priceService.CalculateCost(ctx, csPrice, item.TotalUsage)
+		}
+
+		costItem := dto.CostAnalyticItem{
+			MeterID:       item.MeterID,
+			MeterName:     item.EventName,
+			Source:        item.Source,
+			Properties:    item.Properties,
+			TotalCost:     totalCost,
+			TotalQuantity: item.TotalUsage,
+			TotalEvents:   int64(item.EventCount),
+			Currency:      csPrice.Currency,
+			PriceID:       csPrice.ID,
+			CostsheetID:   costSheet.ID,
+		}
+		if cust != nil {
+			costItem.CustomerID = cust.ID
+			costItem.ExternalCustomerID = cust.ExternalID
+		}
+		if len(item.Points) > 0 {
+			costItem.CostByPeriod = make([]dto.CostPoint, 0, len(item.Points))
+			for _, pt := range item.Points {
+				pointCost := priceService.CalculateCost(ctx, csPrice, pt.Usage)
+				costItem.CostByPeriod = append(costItem.CostByPeriod, dto.CostPoint{
+					Timestamp:  pt.Timestamp,
+					Cost:       pointCost,
+					Quantity:   pt.Usage,
+					EventCount: int64(pt.EventCount),
+				})
+			}
+		}
+
+		response.CostAnalytics = append(response.CostAnalytics, costItem)
+		response.TotalCost = response.TotalCost.Add(totalCost)
+		response.TotalQuantity = response.TotalQuantity.Add(item.TotalUsage)
+		response.TotalEvents += int64(item.EventCount)
+		if response.Currency == "" && csPrice.Currency != "" {
+			response.Currency = csPrice.Currency
+		}
+	}
+
+	return response, nil
+}
+
+// emptyCostAnalyticsResponse returns a zero-valued cost response — used when
+// the active costsheet has no usage-based prices, so there's nothing to cost.
+func (s *costsheetUsageTrackingService) emptyCostAnalyticsResponse(
+	req *dto.GetCostAnalyticsRequest,
+	costSheet *dto.CostsheetResponse,
+	cust *customer.Customer,
+) *dto.GetCostAnalyticsResponse {
+	resp := &dto.GetCostAnalyticsResponse{
+		CostsheetID:   costSheet.ID,
+		StartTime:     req.StartTime,
+		EndTime:       req.EndTime,
+		TotalCost:     decimal.Zero,
+		TotalQuantity: decimal.Zero,
+		TotalEvents:   0,
+		CostAnalytics: []dto.CostAnalyticItem{},
+	}
+	if cust != nil {
+		resp.CustomerID = cust.ID
+		resp.ExternalCustomerID = cust.ExternalID
+	}
+	return resp
 }

--- a/internal/service/revenue_analytics.go
+++ b/internal/service/revenue_analytics.go
@@ -39,9 +39,15 @@ func (s *revenueAnalyticsService) GetDetailedCostAnalytics(
 			Mark(ierr.ErrValidation)
 	}
 
-	// 1. Fetch cost analytics using the costsheet usage tracking service
+	// 1. Fetch cost analytics. Behind a feature flag we now compute cost from
+	// the meter_usage table instead of the legacy costsheet_usage table.
 	var costAnalytics *dto.GetCostAnalyticsResponse
-	costAnalytics, err := s.costsheetUsageTrackingService.GetCostSheetUsageAnalytics(ctx, req)
+	var err error
+	if s.Config.FeatureFlag.IsMeterUsageEnabledForAnalytics(types.GetTenantID(ctx)) {
+		costAnalytics, err = s.costsheetUsageTrackingService.GetCostAnalyticsFromMeterUsage(ctx, req)
+	} else {
+		costAnalytics, err = s.costsheetUsageTrackingService.GetCostSheetUsageAnalytics(ctx, req)
+	}
 	if err != nil {
 		s.Logger.Warnw("failed to fetch cost analytics", "error", err)
 		costAnalytics = nil


### PR DESCRIPTION
## Summary

- Disables the `costsheet_usage` Kafka consumer pipeline via config only (`costsheet_usage_tracking[_lazy].enabled: false`). `RegisterHandler` / `RegisterHandlerLazy` already early-return when the flag is off, so no code paths are removed.
- Behind the existing `IsMeterUsageEnabledForAnalytics` feature flag, `revenueAnalyticsService.GetDetailedCostAnalytics` (V1 `/costs/analytics`) now sources cost from a new meter_usage-backed computation instead of the legacy `costsheet_usage` table read. This mirrors how the revenue side of the same handler already branches on the same flag.
- The new method `GetCostAnalyticsFromMeterUsage` lives on `CostSheetUsageTrackingService` (alongside the existing `GetCostSheetUsageAnalytics`) and reuses the existing `getActiveCostsheetWithCache` helper. It walks the active costsheet's usage-based prices, pulls quantities via `MeterUsageService.GetDetailedAnalytics` scoped to those meters, then re-costs each item with `PriceService.CalculateCost` / `CalculateBucketedCost`.
- `/costs/analytics-v2` is intentionally untouched and continues to call `GetCostSheetUsageAnalytics` directly.

## Diff scope

```
internal/config/config.yaml                  |   4 +-
internal/service/costsheet_usage_tracking.go | 221 +++++++++++++++++++++++++++
internal/service/revenue_analytics.go        |  10 +-
3 files changed, 231 insertions(+), 4 deletions(-)
```

## Test plan

- [x] `go build ./internal/... ./cmd/...` passes
- [x] `go test ./internal/service/... ./internal/api/dto/...` passes
- [ ] Smoke-test V1 `/costs/analytics` with the feature flag enabled for a tenant that has an active costsheet
- [ ] Smoke-test V1 `/costs/analytics` with the feature flag disabled (legacy path)
- [ ] Confirm `costsheet_usage_tracking` and `costsheet_usage_tracking_lazy` handlers do not register on consumer startup

## Rollout

The Kafka consumer is disabled at the same time as the new read path is gated on the existing meter-usage flag. Tenants where the flag is currently `false` (i.e. still using the costsheet_usage table) will see no costs once the consumer is off; flip the flag for those tenants before merging (or invert the rollout order).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to calculate cost analytics from meter usage with feature-flag controlled rollout

* **Chores**
  * Disabled costsheet usage tracking configurations by default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->