### PR TITLE
fix(meter-usage): Properties and source filters with commitment

### DIFF
--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -42,6 +42,10 @@ type MeterUsageQueryParams struct {
 	GroupByProperty string
 	// UseFinal enables FINAL for ReplacingMergeTree deduplication (use for billing queries)
 	UseFinal bool
+	// PropertyFilters restrict events whose properties match. e.g. {"model": ["gpt-4"]}
+	PropertyFilters map[string][]string
+	// Sources restricts events to those whose source is in the list.
+	Sources []string
 }
 
 // MeterUsageResult represents a single time-bucketed aggregation point

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -106,7 +106,62 @@ func (qb *MeterUsageQueryBuilder) BuildWhereClause(params *events.MeterUsageQuer
 		conditions = append(conditions, "unique_hash != ''")
 	}
 
+	// Source filter
+	if clause, addArgs := buildSourceFilterClause(params.Sources); clause != "" {
+		conditions = append(conditions, clause)
+		args = append(args, addArgs...)
+	}
+
+	// Property filters
+	if clauses, addArgs := buildPropertyFilterClauses(params.PropertyFilters); len(clauses) > 0 {
+		conditions = append(conditions, clauses...)
+		args = append(args, addArgs...)
+	}
+
 	return strings.Join(conditions, " AND "), args
+}
+
+// buildSourceFilterClause builds the "source IN (?, ?, …)" fragment.
+// Returns ("", nil) when sources is empty.
+func buildSourceFilterClause(sources []string) (string, []interface{}) {
+	if len(sources) == 0 {
+		return "", nil
+	}
+	placeholders := make([]string, len(sources))
+	args := make([]interface{}, 0, len(sources))
+	for i, src := range sources {
+		placeholders[i] = "?"
+		args = append(args, src)
+	}
+	return fmt.Sprintf("source IN (%s)", strings.Join(placeholders, ", ")), args
+}
+
+// buildPropertyFilterClauses builds JSONExtractString filter fragments. First clause
+// is "properties != ”" so the JSON extracts work; remaining clauses are per-property
+// equality (one value) or IN (multi-value). Returns (nil, nil) for empty filters.
+func buildPropertyFilterClauses(filters map[string][]string) ([]string, []interface{}) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+	clauses := []string{"properties != ''"}
+	args := make([]interface{}, 0)
+	for property, values := range filters {
+		if len(values) == 1 {
+			clauses = append(clauses, "JSONExtractString(properties, ?) = ?")
+			args = append(args, property, values[0])
+		} else if len(values) > 1 {
+			placeholders := make([]string, len(values))
+			for i := range values {
+				placeholders[i] = "?"
+			}
+			clauses = append(clauses, fmt.Sprintf("JSONExtractString(properties, ?) IN (%s)", strings.Join(placeholders, ",")))
+			args = append(args, property)
+			for _, v := range values {
+				args = append(args, v)
+			}
+		}
+	}
+	return clauses, args
 }
 
 // BuildFinalClause returns FINAL keyword and SETTINGS for ReplacingMergeTree dedup
@@ -251,34 +306,15 @@ func (qb *MeterUsageQueryBuilder) BuildDetailedWhereClause(params *events.MeterU
 	}
 
 	// Source filter
-	if len(params.Sources) > 0 {
-		placeholders := make([]string, len(params.Sources))
-		for i, src := range params.Sources {
-			placeholders[i] = "?"
-			args = append(args, src)
-		}
-		conditions = append(conditions, fmt.Sprintf("source IN (%s)", strings.Join(placeholders, ", ")))
+	if clause, addArgs := buildSourceFilterClause(params.Sources); clause != "" {
+		conditions = append(conditions, clause)
+		args = append(args, addArgs...)
 	}
 
-	// Property filters — guarded with properties != '' for tenants with empty properties
-	if len(params.PropertyFilters) > 0 {
-		conditions = append(conditions, "properties != ''")
-		for property, values := range params.PropertyFilters {
-			if len(values) == 1 {
-				conditions = append(conditions, "JSONExtractString(properties, ?) = ?")
-				args = append(args, property, values[0])
-			} else if len(values) > 1 {
-				placeholders := make([]string, len(values))
-				for i := range values {
-					placeholders[i] = "?"
-				}
-				conditions = append(conditions, fmt.Sprintf("JSONExtractString(properties, ?) IN (%s)", strings.Join(placeholders, ",")))
-				args = append(args, property)
-				for _, v := range values {
-					args = append(args, v)
-				}
-			}
-		}
+	// Property filters
+	if clauses, addArgs := buildPropertyFilterClauses(params.PropertyFilters); len(clauses) > 0 {
+		conditions = append(conditions, clauses...)
+		args = append(args, addArgs...)
 	}
 
 	return strings.Join(conditions, " AND "), args

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -143,8 +143,8 @@ func buildPropertyFilterClauses(filters map[string][]string) ([]string, []interf
 	if len(filters) == 0 {
 		return nil, nil
 	}
-	clauses := []string{"properties != ''"}
-	args := make([]interface{}, 0)
+	clauses := make([]string, 0, len(filters))
+	args := make([]interface{}, 0, len(filters))
 	for property, values := range filters {
 		if len(values) == 1 {
 			clauses = append(clauses, "JSONExtractString(properties, ?) = ?")

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1342,8 +1342,13 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 
 // getUsageValueFromDetailedResult extracts the correct scalar usage from a
 // MeterUsageDetailedResult based on aggregation type.
+//
+// For COUNT meters, buildConditionalAggregationColumns emits total_usage as a
+// literal zero — the actual count lives in the event_count column.
 func getUsageValueFromDetailedResult(r *events.MeterUsageDetailedResult, aggType types.AggregationType) decimal.Decimal {
 	switch aggType {
+	case types.AggregationCount:
+		return decimal.NewFromInt(int64(r.EventCount))
 	case types.AggregationCountUnique:
 		return decimal.NewFromInt(int64(r.CountUniqueUsage))
 	case types.AggregationMax:
@@ -2090,6 +2095,8 @@ func (s *meterUsageService) mergeBucketPointsByWindow(points []events.UsageAnaly
 // getCorrectUsageValue returns the correct usage value based on the meter's aggregation type.
 func (s *meterUsageService) getCorrectUsageValue(item *events.DetailedUsageAnalytic, aggregationType types.AggregationType) decimal.Decimal {
 	switch aggregationType {
+	case types.AggregationCount:
+		return decimal.NewFromInt(int64(item.EventCount))
 	case types.AggregationCountUnique:
 		return decimal.NewFromInt(int64(item.CountUniqueUsage))
 	case types.AggregationMax:
@@ -2104,8 +2111,11 @@ func (s *meterUsageService) getCorrectUsageValue(item *events.DetailedUsageAnaly
 }
 
 // getCorrectUsageValueForPoint returns the correct usage value for a time series point based on aggregation type.
+// COUNT meters store the per-window count in point.EventCount (same convention as the aggregate-level helper).
 func (s *meterUsageService) getCorrectUsageValueForPoint(point events.UsageAnalyticPoint, aggregationType types.AggregationType) decimal.Decimal {
 	switch aggregationType {
+	case types.AggregationCount:
+		return decimal.NewFromInt(int64(point.EventCount))
 	case types.AggregationCountUnique:
 		return decimal.NewFromInt(int64(point.CountUniqueUsage))
 	case types.AggregationMax:

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -443,6 +443,7 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			bucketedResult, err := s.queryBucketedMeterUsage(
 				ctx, m, externalCustomerIDs,
 				itemStart, itemEnd, req.BillingAnchor, req.UseFinal,
+				req.PropertyFilters, req.Sources,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query bucketed meter usage for meter %s: %w", meterID, err)
@@ -618,7 +619,8 @@ func (s *meterUsageService) queryAndAppendAnalyticsEntries(
 }
 
 // queryBucketedMeterUsage queries the meter_usage table for a single bucketed meter,
-// returning a per-bucket AggregationResult.
+// returning a per-bucket AggregationResult. propertyFilters and sources are forwarded
+// from analytics callers; pass nil for billing callers that don't use them.
 func (s *meterUsageService) queryBucketedMeterUsage(
 	ctx context.Context,
 	m *meter.Meter,
@@ -626,6 +628,8 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	periodStart, periodEnd time.Time,
 	billingAnchor *time.Time,
 	useFinal bool,
+	propertyFilters map[string][]string,
+	sources []string,
 ) (*events.AggregationResult, error) {
 	aggType := m.Aggregation.Type
 	groupBy := m.Aggregation.GroupBy
@@ -645,6 +649,8 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 		BillingAnchor:       billingAnchor,
 		GroupByProperty:     groupBy,
 		UseFinal:            useFinal,
+		PropertyFilters:     propertyFilters,
+		Sources:             sources,
 	})
 }
 
@@ -1395,6 +1401,8 @@ func (s *meterUsageService) getBucketedMeterAnalytics(
 		GroupByProperty:    m.Aggregation.GroupBy,
 		UseFinal:           params.UseFinal,
 		BillingAnchor:      params.BillingAnchor,
+		PropertyFilters:    params.PropertyFilters,
+		Sources:            params.Sources,
 	}
 
 	if len(params.ExternalCustomerIDs) > 0 {
@@ -1455,6 +1463,8 @@ func (s *meterUsageService) getEventCountForMeter(ctx context.Context, params *e
 		EndTime:            params.EndTime,
 		AggregationType:    types.AggregationCount,
 		UseFinal:           params.UseFinal,
+		PropertyFilters:    params.PropertyFilters,
+		Sources:            params.Sources,
 	}
 
 	if len(params.ExternalCustomerIDs) > 0 {
@@ -1641,6 +1651,15 @@ func subscriptionStatusPriority(sub *subscription.Subscription) int {
 func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsData) error {
 	priceService := NewPriceService(s.ServiceParams)
 
+	// Analytics filters (property_filters, sources) restrict the SQL result set
+	// to a subset of the customer's actual usage. Commitment / overage / true-up
+	// are billing concepts tied to the FULL usage in the period — applying them
+	// to a filtered subset surfaces misleading values (e.g. a filter that yields
+	// zero matching events would otherwise show the full commitment as unutilized
+	// and report it as cost). When any analytics-only filter is active, skip
+	// commitment application and report the raw filtered cost.
+	skipCommitment := len(data.Params.PropertyFilters) > 0 || len(data.Params.Sources) > 0
+
 	for _, item := range data.Analytics {
 		// Resolve meter: prefer via feature, fall back to direct MeterID lookup.
 		var m *meter.Meter
@@ -1660,9 +1679,9 @@ func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsD
 		}
 
 		if m.IsBucketedMaxMeter() || m.IsBucketedSumMeter() {
-			s.calculateBucketedCost(ctx, priceService, item, p, m, data)
+			s.calculateBucketedCost(ctx, priceService, item, p, m, data, skipCommitment)
 		} else {
-			s.calculateRegularCost(ctx, priceService, item, m, p, data)
+			s.calculateRegularCost(ctx, priceService, item, m, p, data, skipCommitment)
 		}
 	}
 
@@ -1681,10 +1700,13 @@ type meterUsageBucketedCostParams struct {
 }
 
 // calculateBucketedCost calculates cost for bucketed max/sum meters.
-func (s *meterUsageService) calculateBucketedCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, p *price.Price, m *meter.Meter, data *AnalyticsData) {
+// skipCommitment forces hasCommitment=false when set; used for analytics queries
+// with property/source filters where applying commitment over a filtered subset
+// of events would surface misleading commitment/overage/true-up amounts.
+func (s *meterUsageService) calculateBucketedCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, p *price.Price, m *meter.Meter, data *AnalyticsData, skipCommitment bool) {
 	params := &meterUsageBucketedCostParams{ctx, priceService, item, p, data, m.Aggregation.Type, m.Aggregation.BucketSize}
 	lineItem := data.SubscriptionLineItems[item.SubLineItemID]
-	hasCommitment := lineItem != nil && lineItem.HasCommitment()
+	hasCommitment := !skipCommitment && lineItem != nil && lineItem.HasCommitment()
 	isWindowed := hasCommitment && lineItem.CommitmentWindowed
 	hasTrueUp := isWindowed && lineItem.CommitmentTrueUpEnabled
 
@@ -1908,10 +1930,13 @@ func (s *meterUsageService) sumPointCosts(points []events.UsageAnalyticPoint) de
 }
 
 // calculateRegularCost calculates cost for regular (non-bucketed) meters.
-func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, m *meter.Meter, p *price.Price, data *AnalyticsData) {
+// skipCommitment forces the commitment branch to be bypassed; used for analytics
+// queries with property/source filters where applying commitment over a filtered
+// subset of events would surface misleading commitment/overage/true-up amounts.
+func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, m *meter.Meter, p *price.Price, data *AnalyticsData, skipCommitment bool) {
 	cost := priceService.CalculateCost(ctx, p, item.TotalUsage)
 
-	if item.SubLineItemID != "" {
+	if !skipCommitment && item.SubLineItemID != "" {
 		lineItem := data.SubscriptionLineItems[item.SubLineItemID]
 
 		if lineItem != nil && lineItem.HasCommitment() {

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/meter"
@@ -26,13 +27,13 @@ type MeterUsageServiceSuite struct {
 	meterUsageRepo *testutil.InMemoryMeterUsageStore
 
 	// Shared test entities
-	customer     *customer.Customer
-	meterAPI     *meter.Meter
-	priceAPI     *price.Price
-	sub          *subscription.Subscription
-	now          time.Time
-	periodStart  time.Time
-	periodEnd    time.Time
+	customer    *customer.Customer
+	meterAPI    *meter.Meter
+	priceAPI    *price.Price
+	sub         *subscription.Subscription
+	now         time.Time
+	periodStart time.Time
+	periodEnd   time.Time
 }
 
 func TestMeterUsageService(t *testing.T) {
@@ -183,8 +184,8 @@ func (s *MeterUsageServiceSuite) TestLineItemDateBounding() {
 	ctx := s.GetContext()
 
 	// Line item active Jan 1 – Jan 15 (subscription runs full month Jan 1 – Feb 1)
-	lineItemStart := s.periodStart                                          // Jan 1
-	lineItemEnd := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)          // Jan 15
+	lineItemStart := s.periodStart                              // Jan 1
+	lineItemEnd := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC) // Jan 15
 	s.createLineItem(ctx, "li_bounded", lineItemStart, lineItemEnd)
 
 	// Insert usage WITHIN the line item period (Jan 5) — should be counted
@@ -394,4 +395,651 @@ func (s *MeterUsageServiceSuite) TestZeroUsageLineItem() {
 
 	lu := result.LineItemUsages[0]
 	s.True(lu.Usage.IsZero(), "usage should be zero, got %s", lu.Usage)
+}
+
+// ---------------------------------------------------------------------------
+// PropertyFilters / Sources — verify analytics-only filters are honored across
+// standard, bucketed, and event-count code paths in meter_usage.go.
+// ---------------------------------------------------------------------------
+
+// insertMeterUsageWithProps adds a meter_usage record with arbitrary properties + source.
+func (s *MeterUsageServiceSuite) insertMeterUsageWithProps(
+	ctx context.Context, meterID, extCustID, source string, ts time.Time, qty float64,
+	props map[string]interface{},
+) {
+	s.NoError(s.meterUsageRepo.BulkInsertMeterUsage(ctx, []*events.MeterUsage{
+		{
+			Event: events.Event{
+				ID:                 types.GenerateUUID(),
+				TenantID:           types.GetTenantID(ctx),
+				EnvironmentID:      types.GetEnvironmentID(ctx),
+				ExternalCustomerID: extCustID,
+				Timestamp:          ts,
+				EventName:          "api_call",
+				Source:             source,
+				Properties:         props,
+			},
+			MeterID:  meterID,
+			QtyTotal: decimal.NewFromFloat(qty),
+		},
+	}))
+}
+
+// TestPropertyFiltersStandardMeter verifies that property_filters restrict the
+// counted events when GetSubscriptionMeterUsage is invoked with PropertyFilters.
+// Without the fix, all events are counted — the SQL builder's WHERE clause
+// silently dropped PropertyFilters on the scalar query path.
+func (s *MeterUsageServiceSuite) TestPropertyFiltersStandardMeter() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_props", s.periodStart, s.periodEnd)
+
+	// gpt-4 events: 100 + 50 = 150 (matching the filter)
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 100,
+		map[string]interface{}{"model": "gpt-4"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 10, 10, 0, 0, 0, time.UTC), 50,
+		map[string]interface{}{"model": "gpt-4"})
+	// gpt-3.5 events: 999 — must be excluded
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 12, 10, 0, 0, 0, time.UTC), 999,
+		map[string]interface{}{"model": "gpt-3.5"})
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID:  s.sub.ID,
+		StartTime:       s.periodStart,
+		EndTime:         s.periodEnd,
+		PropertyFilters: map[string][]string{"model": {"gpt-4"}},
+	})
+	s.NoError(err)
+	s.Require().Len(result.LineItemUsages, 1)
+
+	lu := result.LineItemUsages[0]
+	s.True(lu.Usage.Equal(decimal.NewFromInt(150)),
+		"only gpt-4 events should be counted, got %s", lu.Usage)
+}
+
+// TestPropertyFiltersStandardMeter_MultipleValues verifies IN-list semantics
+// (multiple values for one property key).
+func (s *MeterUsageServiceSuite) TestPropertyFiltersStandardMeter_MultipleValues() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_props_multi", s.periodStart, s.periodEnd)
+
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10,
+		map[string]interface{}{"model": "gpt-4"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20,
+		map[string]interface{}{"model": "claude-opus"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 999,
+		map[string]interface{}{"model": "gpt-3.5"})
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID:  s.sub.ID,
+		StartTime:       s.periodStart,
+		EndTime:         s.periodEnd,
+		PropertyFilters: map[string][]string{"model": {"gpt-4", "claude-opus"}},
+	})
+	s.NoError(err)
+	s.Require().Len(result.LineItemUsages, 1)
+	s.True(result.LineItemUsages[0].Usage.Equal(decimal.NewFromInt(30)),
+		"gpt-4 + claude-opus events should sum to 30, got %s", result.LineItemUsages[0].Usage)
+}
+
+// TestSourcesFilter verifies the source-list filter is honored.
+func (s *MeterUsageServiceSuite) TestSourcesFilter() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_sources", s.periodStart, s.periodEnd)
+
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "stripe",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, nil)
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "stripe",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20, nil)
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "internal",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 999, nil)
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+		Sources:        []string{"stripe"},
+	})
+	s.NoError(err)
+	s.Require().Len(result.LineItemUsages, 1)
+	s.True(result.LineItemUsages[0].Usage.Equal(decimal.NewFromInt(30)),
+		"only stripe-sourced events should be counted, got %s", result.LineItemUsages[0].Usage)
+}
+
+// TestPropertyFiltersSkipCommitment verifies that when property_filters are set,
+// commitment is NOT applied during analytics cost calculation — because the
+// filter restricts the SQL result to a subset of actual usage, and applying
+// commitment over a subset surfaces misleading true-up/overage amounts.
+func (s *MeterUsageServiceSuite) TestPropertyFiltersSkipCommitment() {
+	ctx := s.GetContext()
+
+	// Line item with a non-trivial commitment configured.
+	commitmentAmount := decimal.NewFromInt(100) // $100 commitment
+	overageFactor := decimal.NewFromFloat(1.5)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_commit",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 s.priceAPI.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 s.meterAPI.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true, // would charge full commitment if usage < commitment
+		BaseModel:               types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// Only insert a small amount of matching usage (run_id=run123, qty=10).
+	// Without the filter this would yield $0.10 in cost (below commitment),
+	// so commitment+true-up would push the charge to $100. With the filter,
+	// the SQL returns only the matching event(s); commitment must NOT apply.
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC), 10,
+		map[string]interface{}{"run_id": "run123"})
+	// Non-matching events to confirm the filter is doing its job.
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 11, 12, 0, 0, 0, time.UTC), 50,
+		map[string]interface{}{"run_id": "OTHER"})
+
+	params := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		PropertyFilters:    map[string][]string{"run_id": {"run123"}},
+	}
+	resp, err := s.svc.GetDetailedAnalytics(ctx, params)
+	s.NoError(err)
+	s.Require().NotEmpty(resp.Items)
+
+	// Find the line item analytic for our committed line item.
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_commit" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for commit line item")
+
+	// Filtered usage = 10 (only matching event); raw cost = 10 * $0.01 = $0.10.
+	// If commitment had been applied, TotalCost would be $100 (commitment+true-up).
+	expectedRawCost := decimal.NewFromFloat(0.10)
+	s.True(item.TotalCost.Equal(expectedRawCost),
+		"property-filtered analytics must NOT apply commitment; expected raw cost %s, got %s",
+		expectedRawCost, item.TotalCost)
+	s.Nil(item.CommitmentInfo,
+		"commitment_info should not be populated when filters are active")
+}
+
+// TestPropertyFilters_ExcludesNonMatchingMissingAndNilProperties verifies that
+// a single-value property filter correctly excludes every event that doesn't
+// have an exact match — covering three distinct exclusion cases in one pass:
+//  1. property is present but the value differs (run_id="OTHER")
+//  2. property key is entirely absent from the event (no run_id, only "model")
+//  3. the event's properties map is nil
+// Only the event whose property both exists AND matches the filter value should
+// contribute to the usage total.
+func (s *MeterUsageServiceSuite) TestPropertyFilters_ExcludesNonMatchingMissingAndNilProperties() {
+	ctx := s.GetContext()
+
+	// Customer with external_id "1" — matching the production payload.
+	prodCustomer := &customer.Customer{
+		ID:         "cust_prod",
+		ExternalID: "1",
+		Name:       "Prod Customer",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, prodCustomer))
+
+	prodSub := &subscription.Subscription{
+		ID:                 "sub_prod",
+		CustomerID:         prodCustomer.ID,
+		PlanID:             "plan_1",
+		Currency:           "usd",
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		CurrentPeriodStart: s.periodStart,
+		CurrentPeriodEnd:   s.periodEnd,
+		BillingAnchor:      s.periodStart,
+		StartDate:          s.periodStart,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, prodSub))
+
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_prod",
+		SubscriptionID: prodSub.ID,
+		CustomerID:     prodCustomer.ID,
+		PriceID:        s.priceAPI.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        s.meterAPI.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		EndDate:        s.periodEnd,
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// Matching event: run_id = "run123"
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, "1", "",
+		time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC), 42,
+		map[string]interface{}{"run_id": "run123"})
+	// Non-matching event: run_id = different
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, "1", "",
+		time.Date(2026, 1, 11, 12, 0, 0, 0, time.UTC), 999,
+		map[string]interface{}{"run_id": "OTHER"})
+	// Event with no run_id property at all
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, "1", "",
+		time.Date(2026, 1, 12, 12, 0, 0, 0, time.UTC), 777,
+		map[string]interface{}{"model": "gpt-4"})
+	// Event with empty properties
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, "1", "",
+		time.Date(2026, 1, 13, 12, 0, 0, 0, time.UTC), 555, nil)
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID:  prodSub.ID,
+		StartTime:       s.periodStart,
+		EndTime:         s.periodEnd,
+		PropertyFilters: map[string][]string{"run_id": {"run123"}},
+	})
+	s.NoError(err)
+	s.Require().Len(result.LineItemUsages, 1)
+
+	lu := result.LineItemUsages[0]
+	// Only the matching event (qty=42) should be counted. The other three —
+	// run_id="OTHER" (qty=999), no run_id key (qty=777), and nil properties
+	// (qty=555) — must all be excluded by the JSONExtractString filter.
+	s.True(lu.Usage.Equal(decimal.NewFromInt(42)),
+		"only the matching run_id event should be counted, got %s", lu.Usage)
+}
+
+// TestGroupByPropertyField verifies that group_by supports "properties.<field>"
+// in meter_usage analytics, mirroring feature_usage's behavior. The response
+// should contain one item per distinct property value, with usage correctly
+// aggregated within each group.
+func (s *MeterUsageServiceSuite) TestGroupByPropertyField() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_groupby_prop", s.periodStart, s.periodEnd)
+
+	// run_id "A": 10 + 20 = 30
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10,
+		map[string]interface{}{"run_id": "A", "region": "us-east"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20,
+		map[string]interface{}{"run_id": "A", "region": "us-east"})
+	// run_id "B": 5 + 50 = 55
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 5,
+		map[string]interface{}{"run_id": "B", "region": "us-west"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 50,
+		map[string]interface{}{"run_id": "B", "region": "us-west"})
+
+	params := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.run_id"},
+	}
+	resp, err := s.svc.GetDetailedAnalytics(ctx, params)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+
+	// Expect two groups: run_id=A (usage 30) and run_id=B (usage 55).
+	byRunID := make(map[string]decimal.Decimal)
+	for _, item := range resp.Items {
+		v, ok := item.Properties["run_id"]
+		if !ok {
+			continue
+		}
+		byRunID[v] = byRunID[v].Add(item.TotalUsage)
+	}
+	s.Require().Lenf(byRunID, 2, "expected 2 groups by run_id, got %d: %v", len(byRunID), byRunID)
+	s.True(byRunID["A"].Equal(decimal.NewFromInt(30)),
+		"run_id=A: expected 30, got %s", byRunID["A"])
+	s.True(byRunID["B"].Equal(decimal.NewFromInt(55)),
+		"run_id=B: expected 55, got %s", byRunID["B"])
+}
+
+// TestCountMeter_ScalarBilling sanity-checks the scalar billing path for COUNT
+// meters — that path doesn't go through the helpers I changed; it routes
+// directly via GetUsageMultiMeter which emits "COUNT(DISTINCT id) AS value".
+// Verifies my COUNT fix didn't accidentally change this.
+func (s *MeterUsageServiceSuite) TestCountMeter_ScalarBilling() {
+	ctx := s.GetContext()
+
+	cm := &meter.Meter{
+		ID:        "meter_count_scalar",
+		Name:      "Sessions",
+		EventName: "session",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationCount,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, cm))
+
+	cp := &price.Price{
+		ID: "price_count_scalar", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: cm.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, cp))
+
+	li := &subscription.SubscriptionLineItem{
+		ID: "li_count_scalar", SubscriptionID: s.sub.ID, CustomerID: s.customer.ID,
+		PriceID: cp.ID, PriceType: types.PRICE_TYPE_USAGE, MeterID: cm.ID,
+		Currency: "usd", BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart, EndDate: s.periodEnd,
+		Quantity: decimal.NewFromInt(1), BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	for i := 0; i < 3; i++ {
+		s.insertMeterUsage(ctx, cm.ID, s.customer.ExternalID,
+			time.Date(2026, 1, 5+i, 10, 0, 0, 0, time.UTC), 1)
+	}
+
+	// No analytics filters → scalar billing path (GetUsageMultiMeter).
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+	})
+	s.NoError(err)
+
+	var lu *LineItemMeterUsage
+	for _, x := range result.LineItemUsages {
+		if x.LineItem.ID == "li_count_scalar" {
+			lu = x
+			break
+		}
+	}
+	s.Require().NotNil(lu, "count line item usage should exist")
+	s.True(lu.Usage.Equal(decimal.NewFromInt(3)),
+		"scalar COUNT path: expected Usage=3 (one per event), got %s", lu.Usage)
+	s.Equal(uint64(3), lu.EventCount)
+}
+
+// TestSumMeter_AnalyticsWithGroupBy is a regression guard verifying the SUM
+// path through getCorrectUsageValue / getUsageValueFromDetailedResult is
+// unchanged by the AggregationCount addition. SUM still reads TotalUsage.
+func (s *MeterUsageServiceSuite) TestSumMeter_AnalyticsWithGroupBy() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_sum_groupby", s.periodStart, s.periodEnd)
+
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 100,
+		map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 200,
+		map[string]interface{}{"region": "us-west"})
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.region"},
+	})
+	s.NoError(err)
+	byRegion := make(map[string]decimal.Decimal)
+	for _, item := range resp.Items {
+		byRegion[item.Properties["region"]] = byRegion[item.Properties["region"]].Add(item.TotalUsage)
+	}
+	s.True(byRegion["us-east"].Equal(decimal.NewFromInt(100)),
+		"SUM us-east unchanged: expected 100, got %s", byRegion["us-east"])
+	s.True(byRegion["us-west"].Equal(decimal.NewFromInt(200)),
+		"SUM us-west unchanged: expected 200, got %s", byRegion["us-west"])
+}
+
+// TestGroupByPropertyField_CountMeter reproduces the production bug where
+// COUNT-aggregation meters returned TotalUsage=0 / TotalCost=0 in every item
+// (and the root total_cost) when group_by was a property field. Root cause:
+// the analytics SQL emits total_usage as a literal zero for COUNT meters; the
+// real count lives in event_count, but the Go helpers (getUsageValueFromDetailedResult /
+// getCorrectUsageValue) fell through to TotalUsage and returned 0. Without group_by,
+// the scalar path's COUNT aggregator emits the count directly as "value", which
+// is why the no-group-by query worked.
+func (s *MeterUsageServiceSuite) TestGroupByPropertyField_CountMeter() {
+	ctx := s.GetContext()
+
+	// COUNT-aggregation meter (mirrors the production case: COUNT(DISTINCT id)).
+	countMeter := &meter.Meter{
+		ID:        "meter_count",
+		Name:      "Sessions",
+		EventName: "session_start",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationCount,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, countMeter))
+
+	countPrice := &price.Price{
+		ID:             "price_count",
+		Amount:         decimal.NewFromInt(1), // $1 per event
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        countMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, countPrice))
+
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_count",
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        countPrice.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        countMeter.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		EndDate:        s.periodEnd,
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// 5 events across 5 distinct sessions.
+	sessions := []string{"s1", "s2", "s3", "s4", "s5"}
+	for i, sid := range sessions {
+		s.insertMeterUsageWithProps(ctx, countMeter.ID, s.customer.ExternalID, "",
+			time.Date(2026, 1, 5+i, 10, 0, 0, 0, time.UTC), 1,
+			map[string]interface{}{"session_id": sid})
+	}
+
+	params := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{countMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"meter_id", "properties.session_id"},
+	}
+	resp, err := s.svc.GetDetailedAnalytics(ctx, params)
+	s.NoError(err)
+	s.Require().Lenf(resp.Items, 5, "expected one item per session, got %d", len(resp.Items))
+
+	// Each item: TotalUsage = 1 (one event per session), TotalCost = $1.
+	totalCost := decimal.Zero
+	for _, item := range resp.Items {
+		s.True(item.TotalUsage.Equal(decimal.NewFromInt(1)),
+			"per-item TotalUsage: expected 1, got %s (session=%s)",
+			item.TotalUsage, item.Properties["session_id"])
+		s.True(item.TotalCost.Equal(decimal.NewFromInt(1)),
+			"per-item TotalCost: expected 1, got %s (session=%s)",
+			item.TotalCost, item.Properties["session_id"])
+		s.Equal(uint64(1), item.EventCount,
+			"per-item EventCount: expected 1, got %d", item.EventCount)
+		totalCost = totalCost.Add(item.TotalCost)
+	}
+	// Root TotalCost = sum of items = 5.
+	s.True(resp.TotalCost.Equal(decimal.NewFromInt(5)),
+		"root TotalCost: expected 5, got %s", resp.TotalCost)
+	s.True(totalCost.Equal(resp.TotalCost),
+		"root TotalCost should equal sum of item.TotalCost (got root=%s, sum=%s)",
+		resp.TotalCost, totalCost)
+}
+
+// TestGroupByMultipleProperties verifies multi-property group_by works
+// (properties.run_id + properties.region together produce one row per combo).
+func (s *MeterUsageServiceSuite) TestGroupByMultipleProperties() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_groupby_multi", s.periodStart, s.periodEnd)
+
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10,
+		map[string]interface{}{"run_id": "A", "region": "us-east"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 30,
+		map[string]interface{}{"run_id": "A", "region": "us-west"})
+	s.insertMeterUsageWithProps(ctx, s.meterAPI.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 7,
+		map[string]interface{}{"run_id": "B", "region": "us-east"})
+
+	params := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.run_id", "properties.region"},
+	}
+	resp, err := s.svc.GetDetailedAnalytics(ctx, params)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+
+	// Expect three distinct (run_id, region) groups: (A, us-east)=10, (A, us-west)=30, (B, us-east)=7.
+	type k struct{ run, region string }
+	byCombo := make(map[k]decimal.Decimal)
+	for _, item := range resp.Items {
+		key := k{run: item.Properties["run_id"], region: item.Properties["region"]}
+		byCombo[key] = byCombo[key].Add(item.TotalUsage)
+	}
+	s.Require().Lenf(byCombo, 3, "expected 3 (run_id, region) groups, got %d: %v", len(byCombo), byCombo)
+	s.True(byCombo[k{"A", "us-east"}].Equal(decimal.NewFromInt(10)),
+		"(A, us-east): expected 10, got %s", byCombo[k{"A", "us-east"}])
+	s.True(byCombo[k{"A", "us-west"}].Equal(decimal.NewFromInt(30)),
+		"(A, us-west): expected 30, got %s", byCombo[k{"A", "us-west"}])
+	s.True(byCombo[k{"B", "us-east"}].Equal(decimal.NewFromInt(7)),
+		"(B, us-east): expected 7, got %s", byCombo[k{"B", "us-east"}])
+}
+
+// TestPropertyFiltersBucketedMeter verifies property filters are honored on the
+// bucketed-meter path (queryBucketedMeterUsage → GetUsageForBucketedMeters).
+// This path silently dropped filters before the fix.
+func (s *MeterUsageServiceSuite) TestPropertyFiltersBucketedMeter() {
+	ctx := s.GetContext()
+
+	// Create a bucketed-sum meter (BucketSize set → bucketed code path).
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_bucketed",
+		Name:      "Bucketed SUM",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	bucketedPrice := &price.Price{
+		ID:             "price_bucketed",
+		Amount:         decimal.NewFromFloat(0.01),
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketedPrice))
+
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_bucketed",
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        bucketedPrice.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		EndDate:        s.periodEnd,
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// gpt-4 events: 10 + 20 = 30
+	s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10,
+		map[string]interface{}{"model": "gpt-4"})
+	s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 20,
+		map[string]interface{}{"model": "gpt-4"})
+	// gpt-3.5 events: 999 — must be excluded
+	s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 999,
+		map[string]interface{}{"model": "gpt-3.5"})
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID:  s.sub.ID,
+		StartTime:       s.periodStart,
+		EndTime:         s.periodEnd,
+		PropertyFilters: map[string][]string{"model": {"gpt-4"}},
+	})
+	s.NoError(err)
+
+	// Find the bucketed line item's usage entry
+	var bucketedUsage *LineItemMeterUsage
+	for _, lu := range result.LineItemUsages {
+		if lu.LineItem != nil && lu.LineItem.ID == "li_bucketed" {
+			bucketedUsage = lu
+			break
+		}
+	}
+	s.Require().NotNil(bucketedUsage, "bucketed line item usage entry should exist")
+	s.True(bucketedUsage.Usage.Equal(decimal.NewFromInt(30)),
+		"only gpt-4 events should be counted on bucketed meter, got %s", bucketedUsage.Usage)
 }

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -92,6 +92,19 @@ func matchRecord(r *events.MeterUsage, p *events.MeterUsageQueryParams) bool {
 	if p.AggregationType == types.AggregationCountUnique && r.UniqueHash == "" {
 		return false
 	}
+	if len(p.Sources) > 0 && !containsString(p.Sources, r.Source) {
+		return false
+	}
+	if len(p.PropertyFilters) > 0 {
+		for key, allowed := range p.PropertyFilters {
+			if len(allowed) == 0 {
+				continue
+			}
+			if !containsString(allowed, propertyValue(r.Properties, key)) {
+				return false
+			}
+		}
+	}
 	return true
 }
 


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Property-based filtering for meter usage queries (match JSON property values).
  * Source filtering to limit queries to specified event sources.
  * Analytics path now respects property/source filters and skips commitment/overage logic when filters are present.

* **Bug Fixes**
  * COUNT aggregation and time-series event counts corrected.
  * Group-by support for property fields improved; bucketed analytics honor filters.

* **Tests**
  * Added extensive regression and behavior tests covering filters, grouping, sources, and analytics cost handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->