### PR TITLE
refactor(meter-usage): Unify queries and test cases

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -662,6 +662,7 @@ func registerRouterHandlers(
 		walletBalanceAlertSvc.RegisterHandler(router, cfg)
 		rawEventConsumptionSvc.RegisterHandler(router, cfg)
 		meterUsageTrackingSvc.RegisterHandler(router, cfg)
+		meterUsageTrackingSvc.RegisterHandlerLazy(router, cfg)
 		usageBenchmarkSvc.RegisterHandler(router, cfg)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type Configuration struct {
 	FeatureUsageTrackingLazy   FeatureUsageTrackingLazyConfig   `mapstructure:"feature_usage_tracking_lazy" validate:"required"`
 	FeatureUsageTrackingReplay FeatureUsageTrackingReplayConfig `mapstructure:"feature_usage_tracking_replay" validate:"required"`
 	MeterUsageTracking         MeterUsageTrackingConfig         `mapstructure:"meter_usage_tracking" validate:"required"`
+	MeterUsageTrackingLazy     MeterUsageTrackingLazyConfig     `mapstructure:"meter_usage_tracking_lazy" validate:"required"`
 	UsageBenchmark             UsageBenchmarkConfig             `mapstructure:"usage_benchmark" validate:"omitempty"`
 	EnvAccess                  EnvAccessConfig                  `mapstructure:"env_access" json:"env_access" validate:"omitempty"`
 	FeatureFlag                FeatureFlagConfig                `mapstructure:"feature_flag" validate:"required"`
@@ -331,6 +332,18 @@ type MeterUsageTrackingConfig struct {
 	Topic         string `mapstructure:"topic" default:"events"`
 	RateLimit     int64  `mapstructure:"rate_limit" default:"1"`
 	ConsumerGroup string `mapstructure:"consumer_group" default:"v1_meter_usage_tracking_service"`
+}
+
+// MeterUsageTrackingLazyConfig configures the lazy consumer for tenants that
+// the central publisher routes to the events_lazy topic (see Kafka.TopicLazy
+// and Kafka.RouteTenantsOnLazyMode). Mirrors MeterUsageTrackingConfig but
+// reads from a separate topic with its own consumer group so lazy traffic is
+// isolated from the normal stream.
+type MeterUsageTrackingLazyConfig struct {
+	Enabled       bool   `mapstructure:"enabled" default:"true"`
+	Topic         string `mapstructure:"topic" default:"events_lazy"`
+	RateLimit     int64  `mapstructure:"rate_limit" default:"1"`
+	ConsumerGroup string `mapstructure:"consumer_group" default:"v1_meter_usage_tracking_service_lazy"`
 }
 
 // UsageBenchmarkConfig configures the usage benchmarking consumer

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -233,6 +233,12 @@ meter_usage_tracking:
   rate_limit: 1
   consumer_group: "v1_meter_usage_tracking_service"
 
+meter_usage_tracking_lazy:
+  enabled: true
+  topic: "events_lazy"
+  rate_limit: 1
+  consumer_group: "v1_meter_usage_tracking_service_lazy"
+
 usage_benchmark:
   enabled: false
   topic: "staging_benchmarking"

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -414,7 +414,7 @@ func (r *MeterUsageRepository) GetDetailedAnalytics(ctx context.Context, params 
 	if len(groupByResult.Aliases) > 0 {
 		selectColumns = append(selectColumns, groupByResult.Aliases...)
 	}
-	aggColumns := buildConditionalAggregationColumns(params.AggregationTypes)
+	aggColumns := buildMeterUsageAggregationColumns(params.AggregationTypes)
 	selectColumns = append(selectColumns, aggColumns...)
 	if !sourceInGroupBy {
 		selectColumns = append(selectColumns, "groupUniqArray(source) AS sources")
@@ -588,12 +588,75 @@ func getMeterUsageAggExprs(agg MeterUsageAggregator) (aggExpr string, countExpr 
 	case *MeterUsageAvgAggregator:
 		aggExpr = "AVG(qty_total)"
 	case *MeterUsageLatestAggregator:
-		aggExpr = fmt.Sprintf("argMax(qty_total, timestamp)")
+		aggExpr = "argMax(qty_total, timestamp)"
 	default:
 		aggExpr = "SUM(qty_total)"
 	}
 
 	return aggExpr, countExpr
+}
+
+// buildMeterUsageAggregationColumns builds SQL aggregation columns for meter_usage
+// analytics queries.
+//
+// Unlike feature_usage's buildConditionalAggregationColumns (where total_usage
+// only holds a real value when SUM is in the aggregation set), here total_usage
+// always holds the PRIMARY aggregation result regardless of type — COUNT meters
+// get total_usage = COUNT(DISTINCT id), MAX meters get total_usage = MAX(qty_total),
+// etc. Priority order matches frequency (SUM → COUNT → COUNT_UNIQUE → MAX → LATEST).
+//
+// This keeps the Go-side simple: r.TotalUsage and p.TotalUsage carry the
+// aggregation-aware value with no further routing needed. The per-type columns
+// (max_usage, latest_usage, count_unique_usage) remain so multi-aggregation
+// queries still get all values in a single round-trip; for single-aggregation
+// queries (the common case) total_usage and the matching per-type column will
+// hold the same value, which is harmless.
+func buildMeterUsageAggregationColumns(aggTypes []types.AggregationType) []string {
+	aggSet := make(map[types.AggregationType]bool, len(aggTypes))
+	for _, aggType := range aggTypes {
+		aggSet[aggType] = true
+	}
+
+	var primaryExpr string
+	switch {
+	case aggSet[types.AggregationSum]:
+		primaryExpr = "SUM(qty_total)"
+	case aggSet[types.AggregationCount]:
+		primaryExpr = "COUNT(DISTINCT id)"
+	case aggSet[types.AggregationCountUnique]:
+		primaryExpr = "COUNT(DISTINCT unique_hash)"
+	case aggSet[types.AggregationMax]:
+		primaryExpr = "MAX(qty_total)"
+	case aggSet[types.AggregationLatest]:
+		primaryExpr = "argMax(qty_total, timestamp)"
+	default:
+		primaryExpr = "toDecimal128(0, 9)"
+	}
+
+	columns := []string{primaryExpr + " AS total_usage"}
+
+	if aggSet[types.AggregationMax] {
+		columns = append(columns, "MAX(qty_total) AS max_usage")
+	} else {
+		columns = append(columns, "toDecimal128(0, 9) AS max_usage")
+	}
+
+	if aggSet[types.AggregationLatest] {
+		columns = append(columns, "argMax(qty_total, timestamp) AS latest_usage")
+	} else {
+		columns = append(columns, "toDecimal128(0, 9) AS latest_usage")
+	}
+
+	if aggSet[types.AggregationCountUnique] {
+		columns = append(columns, "COUNT(DISTINCT unique_hash) AS count_unique_usage")
+	} else {
+		columns = append(columns, "toUInt64(0) AS count_unique_usage")
+	}
+
+	// event_count is the total distinct event count for every query.
+	columns = append(columns, "COUNT(DISTINCT id) AS event_count")
+
+	return columns
 }
 
 // GetMeterUsageForExport retrieves meter usage data for export in batches.

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -603,7 +603,7 @@ func getMeterUsageAggExprs(agg MeterUsageAggregator) (aggExpr string, countExpr 
 // only holds a real value when SUM is in the aggregation set), here total_usage
 // always holds the PRIMARY aggregation result regardless of type — COUNT meters
 // get total_usage = COUNT(DISTINCT id), MAX meters get total_usage = MAX(qty_total),
-// etc. Priority order matches frequency (SUM → COUNT → COUNT_UNIQUE → MAX → LATEST).
+// etc. Priority order matches frequency (SUM → COUNT → COUNT_UNIQUE → MAX → AVG → LATEST).
 //
 // This keeps the Go-side simple: r.TotalUsage and p.TotalUsage carry the
 // aggregation-aware value with no further routing needed. The per-type columns
@@ -627,6 +627,8 @@ func buildMeterUsageAggregationColumns(aggTypes []types.AggregationType) []strin
 		primaryExpr = "COUNT(DISTINCT unique_hash)"
 	case aggSet[types.AggregationMax]:
 		primaryExpr = "MAX(qty_total)"
+	case aggSet[types.AggregationAvg]:
+		primaryExpr = "AVG(qty_total)"
 	case aggSet[types.AggregationLatest]:
 		primaryExpr = "argMax(qty_total, timestamp)"
 	default:

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -377,7 +377,7 @@ func (qb *MeterUsageQueryBuilder) BuildDetailedPointsQuery(
 		return "", nil
 	}
 
-	aggColumns := buildConditionalAggregationColumns(params.AggregationTypes)
+	aggColumns := buildMeterUsageAggregationColumns(params.AggregationTypes)
 	finalClause, settings := qb.BuildFinalClause(params.UseFinal)
 
 	// Start with the base WHERE from the detailed params

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1049,13 +1049,11 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 	}
 
 	// Split meters
-	var bucketedMaxMeterIDs, bucketedSumMeterIDs, standardMeterIDs []string
+	var bucketedMeterIDs, standardMeterIDs []string
 	for _, m := range meters {
 		switch {
-		case m.IsBucketedMaxMeter():
-			bucketedMaxMeterIDs = append(bucketedMaxMeterIDs, m.ID)
-		case m.IsBucketedSumMeter():
-			bucketedSumMeterIDs = append(bucketedSumMeterIDs, m.ID)
+		case m.IsBucketedMaxMeter(), m.IsBucketedSumMeter():
+			bucketedMeterIDs = append(bucketedMeterIDs, m.ID)
 		default:
 			standardMeterIDs = append(standardMeterIDs, m.ID)
 		}
@@ -1063,7 +1061,7 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 
 	var allResults []*events.MeterUsageDetailedResult
 
-	for _, meterID := range bucketedMaxMeterIDs {
+	for _, meterID := range bucketedMeterIDs {
 		results, err := s.getBucketedMeterAnalytics(ctx, params, meterMap[meterID])
 		if err != nil {
 			return nil, err
@@ -1071,27 +1069,52 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 		allResults = append(allResults, results...)
 	}
 
-	for _, meterID := range bucketedSumMeterIDs {
-		results, err := s.getBucketedMeterAnalytics(ctx, params, meterMap[meterID])
-		if err != nil {
-			return nil, err
+	// Standard (non-bucketed) meters: one repo call per aggregation type.
+	// Mirrors the subscription path, which already splits by AggType via
+	// dateRangeGroup (see queryAndAppendAnalyticsEntries). N is small in
+	// practice — most requests touch 1-2 aggregation types — and keeping the
+	// two paths consistent is worth more than collapsing this loop.
+	// Without splitting, buildMeterUsageAggregationColumns would emit a
+	// single primary total_usage expression chosen by priority order, which
+	// is wrong for every non-winning meter in a mixed-type request.
+	var standardTargets []string
+	if len(standardMeterIDs) > 0 {
+		standardTargets = standardMeterIDs
+	} else if len(params.MeterIDs) == 0 {
+		// Catch-all: enumerate every standard meter we already fetched.
+		for _, m := range meters {
+			if !m.IsBucketedMaxMeter() && !m.IsBucketedSumMeter() {
+				standardTargets = append(standardTargets, m.ID)
+			}
 		}
-		allResults = append(allResults, results...)
 	}
 
-	if len(standardMeterIDs) > 0 || len(params.MeterIDs) == 0 {
-		standardParams := *params
-		if len(standardMeterIDs) > 0 {
-			standardParams.MeterIDs = standardMeterIDs
+	if len(standardTargets) > 0 {
+		byAggType := make(map[types.AggregationType][]string)
+		for _, mid := range standardTargets {
+			m := meterMap[mid]
+			if m == nil {
+				continue
+			}
+			byAggType[m.Aggregation.Type] = append(byAggType[m.Aggregation.Type], mid)
 		}
-		if len(standardParams.MeterIDs) > 1 && !lo.Contains(standardParams.GroupBy, "meter_id") {
-			standardParams.GroupBy = append([]string{"meter_id"}, standardParams.GroupBy...)
+
+		for aggType, meterIDs := range byAggType {
+			subParams := *params
+			subParams.MeterIDs = meterIDs
+			subParams.AggregationTypes = []types.AggregationType{aggType}
+			// Always group by meter_id so the repo populates result.MeterID even
+			// when the subquery has a single meter — the converter keys analytics
+			// by MeterID downstream.
+			if !lo.Contains(subParams.GroupBy, "meter_id") {
+				subParams.GroupBy = append([]string{"meter_id"}, subParams.GroupBy...)
+			}
+			results, err := s.repo.GetDetailedAnalytics(ctx, &subParams)
+			if err != nil {
+				return nil, err
+			}
+			allResults = append(allResults, results...)
 		}
-		results, err := s.repo.GetDetailedAnalytics(ctx, &standardParams)
-		if err != nil {
-			return nil, err
-		}
-		allResults = append(allResults, results...)
 	}
 
 	// Build minimal AnalyticsData (no subscription context)

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -607,7 +607,7 @@ func (s *meterUsageService) queryAndAppendAnalyticsEntries(
 				Price:           result.PriceMap[liw.Item.PriceID],
 				PeriodStart:     group.Start,
 				PeriodEnd:       group.End,
-				Usage:           getUsageValueFromDetailedResult(dr, group.AggType),
+				Usage:           dr.TotalUsage,
 				EventCount:      dr.EventCount,
 				Points:          dr.Points,
 				AnalyticsResult: dr,
@@ -884,7 +884,9 @@ func (s *meterUsageService) mergeSubscriptionUsagesToAnalyticsData(
 				analytic.SubscriptionID = lu.LineItem.SubscriptionID
 			}
 
-			// Convert time-series points
+			// Convert time-series points. p.TotalUsage is the primary aggregation
+			// value (see buildMeterUsageAggregationColumns), so it works for every
+			// meter type without per-aggregation routing.
 			if len(lu.Points) > 0 {
 				analytic.Points = make([]events.UsageAnalyticPoint, 0, len(lu.Points))
 				for _, p := range lu.Points {
@@ -1142,7 +1144,9 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 		}
 	}
 
-	// Convert results to analytics
+	// Convert results to analytics. r.TotalUsage / p.TotalUsage hold the primary
+	// aggregation value courtesy of buildMeterUsageAggregationColumns, so no
+	// per-aggregation routing is needed here.
 	for _, r := range allResults {
 		analytic := &events.DetailedUsageAnalytic{
 			MeterID:          r.MeterID,
@@ -1356,29 +1360,6 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-// getUsageValueFromDetailedResult extracts the correct scalar usage from a
-// MeterUsageDetailedResult based on aggregation type.
-//
-// For COUNT meters, buildConditionalAggregationColumns emits total_usage as a
-// literal zero — the actual count lives in the event_count column.
-func getUsageValueFromDetailedResult(r *events.MeterUsageDetailedResult, aggType types.AggregationType) decimal.Decimal {
-	switch aggType {
-	case types.AggregationCount:
-		return decimal.NewFromInt(int64(r.EventCount))
-	case types.AggregationCountUnique:
-		return decimal.NewFromInt(int64(r.CountUniqueUsage))
-	case types.AggregationMax:
-		if !r.TotalUsage.IsZero() {
-			return r.TotalUsage
-		}
-		return r.MaxUsage
-	case types.AggregationLatest:
-		return r.LatestUsage
-	default:
-		return r.TotalUsage
-	}
-}
 
 // fetchMeters fetches meter configurations for the requested meter IDs.
 func (s *meterUsageService) fetchMeters(ctx context.Context, params *events.MeterUsageDetailedAnalyticsParams) ([]*meter.Meter, error) {
@@ -1783,7 +1764,10 @@ func (s *meterUsageService) processSingleBucket(
 	lineItem *subscription.SubscriptionLineItem,
 	hasCommitment, isWindowed, hasTrueUp bool,
 ) decimal.Decimal {
-	totalUsage := s.getSingleBucketUsage(p.item, p.aggType)
+	// p.item.TotalUsage is the primary aggregation value (see
+	// buildMeterUsageAggregationColumns) — bucketed-max meters also write it from
+	// bucketedResult.Value at construction, so reading it works uniformly.
+	totalUsage := p.item.TotalUsage
 
 	if totalUsage.IsPositive() {
 		bucketedValues := []decimal.Decimal{totalUsage}
@@ -1809,7 +1793,7 @@ func (s *meterUsageService) processSingleBucket(
 func (s *meterUsageService) extractBucketValues(points []events.UsageAnalyticPoint, aggType types.AggregationType) []decimal.Decimal {
 	values := make([]decimal.Decimal, len(points))
 	for i, pt := range points {
-		values[i] = s.getCorrectUsageValueForPoint(pt, aggType)
+		values[i] = pt.Usage
 	}
 	return values
 }
@@ -1818,7 +1802,7 @@ func (s *meterUsageService) extractBucketValues(points []events.UsageAnalyticPoi
 func (s *meterUsageService) calculatePointCosts(p *meterUsageBucketedCostParams, lineItem *subscription.SubscriptionLineItem, isWindowed bool) {
 	if !isWindowed {
 		for i := range p.item.Points {
-			usage := s.getCorrectUsageValueForPoint(p.item.Points[i], p.aggType)
+			usage := p.item.Points[i].Usage
 			p.item.Points[i].Cost = p.priceService.CalculateCost(p.ctx, p.price, usage)
 		}
 		return
@@ -1826,7 +1810,7 @@ func (s *meterUsageService) calculatePointCosts(p *meterUsageBucketedCostParams,
 
 	commitmentCalc := newCommitmentCalculator(s.logger, p.priceService)
 	for i := range p.item.Points {
-		usage := s.getCorrectUsageValueForPoint(p.item.Points[i], p.aggType)
+		usage := p.item.Points[i].Usage
 		pointCost, info, err := commitmentCalc.applyWindowCommitmentToLineItem(p.ctx, lineItem, []decimal.Decimal{usage}, p.price)
 		if err != nil {
 			s.logger.Warnw("failed to apply window commitment to point", "error", err, "point_index", i, "line_item_id", lineItem.ID)
@@ -1859,7 +1843,7 @@ func (s *meterUsageService) fillMissingWindowsAndRecalculate(p *meterUsageBucket
 
 	for _, t := range expectedStarts {
 		if existing, ok := pointsByBucket[t]; ok {
-			filled = append(filled, s.getCorrectUsageValueForPoint(existing, p.aggType))
+			filled = append(filled, existing.Usage)
 			filledPoints = append(filledPoints, existing)
 		} else {
 			filled = append(filled, decimal.Zero)
@@ -1934,14 +1918,6 @@ func (s *meterUsageService) getBillingAnchorFromData(data *AnalyticsData, subscr
 	return nil
 }
 
-// getSingleBucketUsage returns the usage value for single-bucket calculation.
-func (s *meterUsageService) getSingleBucketUsage(item *events.DetailedUsageAnalytic, aggType types.AggregationType) decimal.Decimal {
-	if aggType == types.AggregationMax {
-		return item.MaxUsage
-	}
-	return s.getCorrectUsageValue(item, aggType)
-}
-
 // sumPointCosts sums the cost of all points.
 func (s *meterUsageService) sumPointCosts(points []events.UsageAnalyticPoint) decimal.Decimal {
 	total := decimal.Zero
@@ -1966,7 +1942,7 @@ func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceServi
 				if len(item.Points) > 0 {
 					bucketedValues := make([]decimal.Decimal, len(item.Points))
 					for i, point := range item.Points {
-						bucketedValues[i] = s.getCorrectUsageValueForPoint(point, m.Aggregation.Type)
+						bucketedValues[i] = point.Usage
 					}
 					cost = s.applyLineItemCommitment(ctx, priceService, item, lineItem, p, bucketedValues, decimal.Zero)
 				} else {
@@ -1982,7 +1958,7 @@ func (s *meterUsageService) calculateRegularCost(ctx context.Context, priceServi
 	item.Currency = p.Currency
 
 	for i := range item.Points {
-		pointUsage := s.getCorrectUsageValueForPoint(item.Points[i], m.Aggregation.Type)
+		pointUsage := item.Points[i].Usage
 		pointCost := priceService.CalculateCost(ctx, p, pointUsage)
 		item.Points[i].Cost = pointCost
 	}
@@ -2107,43 +2083,6 @@ func (s *meterUsageService) mergeBucketPointsByWindow(points []events.UsageAnaly
 	})
 
 	return mergedPoints
-}
-
-// getCorrectUsageValue returns the correct usage value based on the meter's aggregation type.
-func (s *meterUsageService) getCorrectUsageValue(item *events.DetailedUsageAnalytic, aggregationType types.AggregationType) decimal.Decimal {
-	switch aggregationType {
-	case types.AggregationCount:
-		return decimal.NewFromInt(int64(item.EventCount))
-	case types.AggregationCountUnique:
-		return decimal.NewFromInt(int64(item.CountUniqueUsage))
-	case types.AggregationMax:
-		return item.MaxUsage
-	case types.AggregationLatest:
-		return item.LatestUsage
-	case types.AggregationSum, types.AggregationSumWithMultiplier, types.AggregationAvg, types.AggregationWeightedSum:
-		return item.TotalUsage
-	default:
-		return item.TotalUsage
-	}
-}
-
-// getCorrectUsageValueForPoint returns the correct usage value for a time series point based on aggregation type.
-// COUNT meters store the per-window count in point.EventCount (same convention as the aggregate-level helper).
-func (s *meterUsageService) getCorrectUsageValueForPoint(point events.UsageAnalyticPoint, aggregationType types.AggregationType) decimal.Decimal {
-	switch aggregationType {
-	case types.AggregationCount:
-		return decimal.NewFromInt(int64(point.EventCount))
-	case types.AggregationCountUnique:
-		return decimal.NewFromInt(int64(point.CountUniqueUsage))
-	case types.AggregationMax:
-		return point.MaxUsage
-	case types.AggregationLatest:
-		return point.LatestUsage
-	case types.AggregationSum, types.AggregationSumWithMultiplier, types.AggregationAvg, types.AggregationWeightedSum:
-		return point.Usage
-	default:
-		return point.Usage
-	}
 }
 
 // ensure meterUsageService implements MeterUsageService

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -1690,6 +1690,94 @@ func (s *MeterUsageServiceSuite) TestMultiMeter_MaxAndLatest_NoSubscription() {
 		"LATEST meter total: expected 7 (would be 200 under priority-collapse bug), got %s", byMeter[mLatest.ID])
 }
 
+// TestMultiMeter_MixedAggregations_GroupByAndFilter exercises the no-sub
+// fallback with the full combination: three meters with distinct aggregation
+// types (SUM, MAX, COUNT), a user-supplied group_by on a property field, and
+// a property filter. Each meter gets its own subquery (per the split-by-agg
+// pattern); each subquery applies the filter and groups by (meter_id, region).
+// The converter then produces one item per (meter, region) with the correct
+// per-meter primary aggregation in TotalUsage.
+func (s *MeterUsageServiceSuite) TestMultiMeter_MixedAggregations_GroupByAndFilter() {
+	ctx := s.GetContext()
+	mSum := s.createMeterWithAggregation(ctx, "mtr_full_sum", "ev_sum", types.AggregationSum)
+	mMax := s.createMeterWithAggregation(ctx, "mtr_full_max", "ev_max", types.AggregationMax)
+	mCnt := s.createMeterWithAggregation(ctx, "mtr_full_cnt", "ev_cnt", types.AggregationCount)
+
+	// us-east + cloud=aws — should pass filter.
+	props := func(region, cloud string) map[string]interface{} {
+		return map[string]interface{}{"region": region, "cloud": cloud}
+	}
+
+	// SUM meter: us-east+aws → 10+20=30; us-west+aws → 50; us-east+gcp → filtered out.
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", props("us-east", "aws"))
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20, "", props("us-east", "aws"))
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 50, "", props("us-west", "aws"))
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 999, "", props("us-east", "gcp"))
+
+	// MAX meter: us-east+aws → max(7,15)=15; us-west+aws → 99; us-east+gcp → filtered.
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 7, "", props("us-east", "aws"))
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 15, "", props("us-east", "aws"))
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 99, "", props("us-west", "aws"))
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 8888, "", props("us-east", "gcp"))
+
+	// COUNT meter: us-east+aws → 3 distinct ids; us-west+aws → 1; us-east+gcp → filtered.
+	for i := 0; i < 3; i++ {
+		s.insertMeterUsageFull(ctx, mCnt.ID, "unknown_cust", "", "ev_cnt",
+			time.Date(2026, 1, 5, 10, i, 0, 0, time.UTC), 1, "", props("us-east", "aws"))
+	}
+	s.insertMeterUsageFull(ctx, mCnt.ID, "unknown_cust", "", "ev_cnt",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 1, "", props("us-west", "aws"))
+	s.insertMeterUsageFull(ctx, mCnt.ID, "unknown_cust", "", "ev_cnt",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 1, "", props("us-east", "gcp"))
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{mSum.ID, mMax.ID, mCnt.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.region"},
+		PropertyFilters:    map[string][]string{"cloud": {"aws"}},
+	})
+	s.NoError(err)
+
+	// Key by (meter, region) → expected primary value.
+	type k struct{ meter, region string }
+	got := map[k]decimal.Decimal{}
+	for _, item := range resp.Items {
+		got[k{item.MeterID, item.Properties["region"]}] = item.TotalUsage
+	}
+
+	s.True(got[k{mSum.ID, "us-east"}].Equal(decimal.NewFromInt(30)),
+		"SUM us-east: expected 30, got %s", got[k{mSum.ID, "us-east"}])
+	s.True(got[k{mSum.ID, "us-west"}].Equal(decimal.NewFromInt(50)),
+		"SUM us-west: expected 50, got %s", got[k{mSum.ID, "us-west"}])
+	s.True(got[k{mMax.ID, "us-east"}].Equal(decimal.NewFromInt(15)),
+		"MAX us-east: expected 15, got %s", got[k{mMax.ID, "us-east"}])
+	s.True(got[k{mMax.ID, "us-west"}].Equal(decimal.NewFromInt(99)),
+		"MAX us-west: expected 99, got %s", got[k{mMax.ID, "us-west"}])
+	s.True(got[k{mCnt.ID, "us-east"}].Equal(decimal.NewFromInt(3)),
+		"COUNT us-east: expected 3, got %s", got[k{mCnt.ID, "us-east"}])
+	s.True(got[k{mCnt.ID, "us-west"}].Equal(decimal.NewFromInt(1)),
+		"COUNT us-west: expected 1, got %s", got[k{mCnt.ID, "us-west"}])
+
+	// gcp rows must be filtered out — no (meter, "gcp") keys should exist
+	// AND no value should equal the gcp-only payload (999, 8888).
+	for kk, v := range got {
+		s.False(v.Equal(decimal.NewFromInt(999)), "SUM gcp leaked: %v=%s", kk, v)
+		s.False(v.Equal(decimal.NewFromInt(8888)), "MAX gcp leaked: %v=%s", kk, v)
+	}
+}
+
 // TestAvgMeter_NoSubscriptionAnalytics: pre-fix AVG was missing from the
 // primary switch in buildMeterUsageAggregationColumns and from the in-memory
 // primaryAggregationValue, so AVG meters returned total_usage = 0. After fix,

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
@@ -678,6 +679,7 @@ func (s *MeterUsageServiceSuite) TestPropertyFiltersSkipCommitment() {
 //  1. property is present but the value differs (run_id="OTHER")
 //  2. property key is entirely absent from the event (no run_id, only "model")
 //  3. the event's properties map is nil
+//
 // Only the event whose property both exists AND matches the filter value should
 // contribute to the usage total.
 func (s *MeterUsageServiceSuite) TestPropertyFilters_ExcludesNonMatchingMissingAndNilProperties() {
@@ -1918,4 +1920,62 @@ func (s *MeterUsageServiceSuite) TestCountMeter_LineItemDateBounding() {
 		"COUNT with date bounding: expected 4 in-bounds events, got %s", lu.Usage)
 	s.Equal(uint64(4), lu.EventCount,
 		"COUNT EventCount: expected 4, got %d", lu.EventCount)
+}
+
+// TestGroupByFeatureID_RewritesToMeterID: the API contract (dto/events.go)
+// documents group_by=[feature_id], but meter_usage has no feature_id column.
+// The service rewrites feature_id → meter_id at entry (features are 1:1 with
+// meters), and the converter populates FeatureID on each item via the
+// meter→feature lookup. This test pins both: the query no longer errors out,
+// AND callers still get FeatureID in the response.
+func (s *MeterUsageServiceSuite) TestGroupByFeatureID_RewritesToMeterID() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_feat_groupby", s.periodStart, s.periodEnd)
+
+	// Feature pointing at the existing s.meterAPI.
+	feat := &feature.Feature{
+		ID: "feat_api", Name: "API Feature", MeterID: s.meterAPI.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, feat))
+
+	s.insertMeterUsage(ctx, s.meterAPI.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 25)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"feature_id"}, // public contract — must not error
+	})
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1, "expected one item for the single meter")
+	s.Equal(feat.ID, resp.Items[0].FeatureID,
+		"FeatureID should be populated from meter→feature lookup")
+	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(25)),
+		"TotalUsage: expected 25, got %s", resp.Items[0].TotalUsage)
+}
+
+// TestGroupByFeatureIDAndMeterID_Deduplicates: passing both feature_id and
+// meter_id in GroupBy shouldn't produce [meter_id, meter_id] after rewrite.
+func (s *MeterUsageServiceSuite) TestGroupByFeatureIDAndMeterID_Deduplicates() {
+	ctx := s.GetContext()
+	s.createLineItem(ctx, "li_feat_dedup", s.periodStart, s.periodEnd)
+
+	s.insertMeterUsage(ctx, s.meterAPI.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 42)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"feature_id", "meter_id"},
+	})
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(42)))
 }

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/events"
-	"github.com/flexprice/flexprice/internal/domain/feature"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -426,6 +426,92 @@ func (s *MeterUsageServiceSuite) insertMeterUsageWithProps(
 	}))
 }
 
+// insertMeterUsageFull is the most flexible inserter: lets the test specify
+// unique_hash (needed for COUNT_UNIQUE) and event_name.
+func (s *MeterUsageServiceSuite) insertMeterUsageFull(
+	ctx context.Context, meterID, extCustID, source, eventName string,
+	ts time.Time, qty float64, uniqueHash string, props map[string]interface{},
+) {
+	s.NoError(s.meterUsageRepo.BulkInsertMeterUsage(ctx, []*events.MeterUsage{
+		{
+			Event: events.Event{
+				ID:                 types.GenerateUUID(),
+				TenantID:           types.GetTenantID(ctx),
+				EnvironmentID:      types.GetEnvironmentID(ctx),
+				ExternalCustomerID: extCustID,
+				Timestamp:          ts,
+				EventName:          eventName,
+				Source:             source,
+				Properties:         props,
+			},
+			MeterID:    meterID,
+			QtyTotal:   decimal.NewFromFloat(qty),
+			UniqueHash: uniqueHash,
+		},
+	}))
+}
+
+// createMeterWithAggregation creates a custom meter with the given aggregation type.
+func (s *MeterUsageServiceSuite) createMeterWithAggregation(
+	ctx context.Context, id, eventName string, aggType types.AggregationType,
+) *meter.Meter {
+	m := &meter.Meter{
+		ID:        id,
+		Name:      id,
+		EventName: eventName,
+		Aggregation: meter.Aggregation{
+			Type: aggType,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+	return m
+}
+
+// createPriceForMeter creates a per-unit USD price for the given meter.
+func (s *MeterUsageServiceSuite) createPriceForMeter(
+	ctx context.Context, id, meterID string, amount decimal.Decimal,
+) *price.Price {
+	p := &price.Price{
+		ID:             id,
+		Amount:         amount,
+		Currency:       "usd",
+		EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:       "plan_1",
+		BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+		Type:           types.PRICE_TYPE_USAGE,
+		MeterID:        meterID,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	return p
+}
+
+// createLineItemForMeter creates a line item bound to a specific meter + price.
+func (s *MeterUsageServiceSuite) createLineItemForMeter(
+	ctx context.Context, id, meterID, priceID string,
+) *subscription.SubscriptionLineItem {
+	li := &subscription.SubscriptionLineItem{
+		ID:             id,
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        priceID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        meterID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		EndDate:        s.periodEnd,
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+	return li
+}
+
 // TestPropertyFiltersStandardMeter verifies that property_filters restrict the
 // counted events when GetSubscriptionMeterUsage is invoked with PropertyFilters.
 // Without the fix, all events are counted — the SQL builder's WHERE clause
@@ -722,6 +808,55 @@ func (s *MeterUsageServiceSuite) TestGroupByPropertyField() {
 		"run_id=A: expected 30, got %s", byRunID["A"])
 	s.True(byRunID["B"].Equal(decimal.NewFromInt(55)),
 		"run_id=B: expected 55, got %s", byRunID["B"])
+}
+
+// TestCountMeter_NoSubscriptionAnalytics verifies the COUNT-meter fix for the
+// no-subscription analytics path (getDetailedAnalyticsWithoutSubscriptionContext).
+// Triggered when no external_customer_id is supplied (or the customer has no
+// subscriptions), this path goes through the "Convert results to analytics"
+// loop in meter_usage.go (around line 1138) which copies r.TotalUsage directly.
+// For COUNT meters that field is literal zero in the analytics SQL — without
+// substituting EventCount, every item would report TotalUsage=0 (and per-point
+// Usage=0). The subscription path was fixed earlier via getUsageValueFromDetailedResult;
+// this test pins the parity fix for the no-subscription branch.
+func (s *MeterUsageServiceSuite) TestCountMeter_NoSubscriptionAnalytics() {
+	ctx := s.GetContext()
+
+	cm := &meter.Meter{
+		ID:        "meter_count_nosub",
+		Name:      "Sessions",
+		EventName: "session_start",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationCount,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, cm))
+
+	// 3 events for an external_customer_id that has NO Flexprice customer
+	// record — forces resolveCustomerAndSubscriptions to return empty, and
+	// GetDetailedAnalytics falls through to the no-subscription path.
+	for i := 0; i < 3; i++ {
+		s.insertMeterUsage(ctx, cm.ID, "unknown_customer",
+			time.Date(2026, 1, 5+i, 10, 0, 0, 0, time.UTC), 1)
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_customer", // no customer record → no-sub path
+		MeterIDs:           []string{cm.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+	s.Require().Lenf(resp.Items, 1, "expected one item for the count meter, got %d", len(resp.Items))
+
+	item := resp.Items[0]
+	s.True(item.TotalUsage.Equal(decimal.NewFromInt(3)),
+		"no-sub COUNT path: expected TotalUsage=3 (was 0 before fix), got %s", item.TotalUsage)
+	s.Equal(uint64(3), item.EventCount,
+		"no-sub COUNT path: expected EventCount=3, got %d", item.EventCount)
 }
 
 // TestCountMeter_ScalarBilling sanity-checks the scalar billing path for COUNT
@@ -1045,60 +1180,572 @@ func (s *MeterUsageServiceSuite) TestPropertyFiltersBucketedMeter() {
 		"only gpt-4 events should be counted on bucketed meter, got %s", bucketedUsage.Usage)
 }
 
-// TestGroupByFeatureID_RewritesToMeterID: the API contract (dto/events.go)
-// documents group_by=[feature_id], but meter_usage has no feature_id column.
-// The service rewrites feature_id → meter_id at entry (features are 1:1 with
-// meters), and the converter populates FeatureID on each item via the
-// meter→feature lookup. This test pins both: the query no longer errors out,
-// AND callers still get FeatureID in the response.
-func (s *MeterUsageServiceSuite) TestGroupByFeatureID_RewritesToMeterID() {
+// ---------------------------------------------------------------------------
+// Aggregation-type matrix
+//
+// Verifies that buildMeterUsageAggregationColumns puts the correct value in
+// total_usage for every aggregation type, across both the subscription
+// analytics path (queryAndAppendAnalyticsEntries) and the no-subscription
+// analytics path (getDetailedAnalyticsWithoutSubscriptionContext), plus the
+// scalar billing path (GetUsageMultiMeter) where applicable.
+// ---------------------------------------------------------------------------
+
+// --- MAX ---
+
+func (s *MeterUsageServiceSuite) TestMaxMeter_AnalyticsWithGroupBy() {
 	ctx := s.GetContext()
-	s.createLineItem(ctx, "li_feat_groupby", s.periodStart, s.periodEnd)
+	m := s.createMeterWithAggregation(ctx, "mtr_max_grp", "ev_max", types.AggregationMax)
+	p := s.createPriceForMeter(ctx, "pr_max_grp", m.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_max_grp", m.ID, p.ID)
 
-	// Feature pointing at the existing s.meterAPI.
-	feat := &feature.Feature{
-		ID: "feat_api", Name: "API Feature", MeterID: s.meterAPI.ID,
-		BaseModel: types.GetDefaultBaseModel(ctx),
-	}
-	s.NoError(s.GetStores().FeatureRepo.Create(ctx, feat))
-
-	s.insertMeterUsage(ctx, s.meterAPI.ID, s.customer.ExternalID,
-		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 25)
+	// us-east: 10, 50, 20 → MAX = 50;  us-west: 5, 30 → MAX = 30
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 50, "", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 20, "", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 5, "", map[string]interface{}{"region": "us-west"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 9, 10, 0, 0, 0, time.UTC), 30, "", map[string]interface{}{"region": "us-west"})
 
 	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
 		TenantID:           types.GetTenantID(ctx),
 		EnvironmentID:      types.GetEnvironmentID(ctx),
 		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
 		StartTime:          s.periodStart,
 		EndTime:            s.periodEnd,
-		GroupBy:            []string{"feature_id"}, // public contract — must not error
+		GroupBy:            []string{"properties.region"},
 	})
 	s.NoError(err)
-	s.Require().Len(resp.Items, 1, "expected one item for the single meter")
-	s.Equal(feat.ID, resp.Items[0].FeatureID,
-		"FeatureID should be populated from meter→feature lookup")
-	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(25)),
-		"TotalUsage: expected 25, got %s", resp.Items[0].TotalUsage)
+	byRegion := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		byRegion[item.Properties["region"]] = item.TotalUsage
+	}
+	s.True(byRegion["us-east"].Equal(decimal.NewFromInt(50)), "MAX us-east: expected 50, got %s", byRegion["us-east"])
+	s.True(byRegion["us-west"].Equal(decimal.NewFromInt(30)), "MAX us-west: expected 30, got %s", byRegion["us-west"])
 }
 
-// TestGroupByFeatureIDAndMeterID_Deduplicates: passing both feature_id and
-// meter_id in GroupBy shouldn't produce [meter_id, meter_id] after rewrite.
-func (s *MeterUsageServiceSuite) TestGroupByFeatureIDAndMeterID_Deduplicates() {
+func (s *MeterUsageServiceSuite) TestMaxMeter_NoSubscriptionAnalytics() {
 	ctx := s.GetContext()
-	s.createLineItem(ctx, "li_feat_dedup", s.periodStart, s.periodEnd)
+	m := s.createMeterWithAggregation(ctx, "mtr_max_nosub", "ev_max", types.AggregationMax)
 
-	s.insertMeterUsage(ctx, s.meterAPI.ID, s.customer.ExternalID,
-		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 42)
+	// External customer with no Flexprice record → no-sub path.
+	for _, q := range []float64{10, 50, 20} {
+		s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_max",
+			time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC).Add(time.Duration(q)*time.Hour), q, "", nil)
+	}
 
 	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
 		TenantID:           types.GetTenantID(ctx),
 		EnvironmentID:      types.GetEnvironmentID(ctx),
-		ExternalCustomerID: s.customer.ExternalID,
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{m.ID},
 		StartTime:          s.periodStart,
 		EndTime:            s.periodEnd,
-		GroupBy:            []string{"feature_id", "meter_id"},
 	})
 	s.NoError(err)
 	s.Require().Len(resp.Items, 1)
-	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(42)))
+	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(50)),
+		"no-sub MAX: expected 50, got %s", resp.Items[0].TotalUsage)
+}
+
+func (s *MeterUsageServiceSuite) TestMaxMeter_ScalarBilling() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_max_scalar", "ev_max", types.AggregationMax)
+	p := s.createPriceForMeter(ctx, "pr_max_scalar", m.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_max_scalar", m.ID, p.ID)
+
+	for _, q := range []float64{10, 50, 20} {
+		s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+			time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC).Add(time.Duration(q)*time.Hour), q, "", nil)
+	}
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+	})
+	s.NoError(err)
+
+	var lu *LineItemMeterUsage
+	for _, x := range result.LineItemUsages {
+		if x.LineItem.ID == "li_max_scalar" {
+			lu = x
+			break
+		}
+	}
+	s.Require().NotNil(lu)
+	s.True(lu.Usage.Equal(decimal.NewFromInt(50)), "scalar MAX: expected 50, got %s", lu.Usage)
+}
+
+// --- LATEST ---
+
+func (s *MeterUsageServiceSuite) TestLatestMeter_AnalyticsWithGroupBy() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_latest_grp", "ev_latest", types.AggregationLatest)
+	p := s.createPriceForMeter(ctx, "pr_latest_grp", m.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_latest_grp", m.ID, p.ID)
+
+	// us-east: 10 @ Jan5, 99 @ Jan10  → LATEST = 99
+	// us-west: 7 @ Jan8, 3 @ Jan12   → LATEST = 3
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_latest",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_latest",
+		time.Date(2026, 1, 10, 10, 0, 0, 0, time.UTC), 99, "", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_latest",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 7, "", map[string]interface{}{"region": "us-west"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_latest",
+		time.Date(2026, 1, 12, 10, 0, 0, 0, time.UTC), 3, "", map[string]interface{}{"region": "us-west"})
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.region"},
+	})
+	s.NoError(err)
+	byRegion := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		byRegion[item.Properties["region"]] = item.TotalUsage
+	}
+	s.True(byRegion["us-east"].Equal(decimal.NewFromInt(99)), "LATEST us-east: expected 99, got %s", byRegion["us-east"])
+	s.True(byRegion["us-west"].Equal(decimal.NewFromInt(3)), "LATEST us-west: expected 3, got %s", byRegion["us-west"])
+}
+
+func (s *MeterUsageServiceSuite) TestLatestMeter_NoSubscriptionAnalytics() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_latest_nosub", "ev_latest", types.AggregationLatest)
+
+	s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_latest",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", nil)
+	s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_latest",
+		time.Date(2026, 1, 12, 10, 0, 0, 0, time.UTC), 77, "", nil)
+	s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_latest",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 22, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(77)),
+		"no-sub LATEST: expected 77 (Jan 12), got %s", resp.Items[0].TotalUsage)
+}
+
+// --- COUNT_UNIQUE ---
+
+func (s *MeterUsageServiceSuite) TestCountUniqueMeter_AnalyticsWithGroupBy() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_unique_grp", "ev_unique", types.AggregationCountUnique)
+	p := s.createPriceForMeter(ctx, "pr_unique_grp", m.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_unique_grp", m.ID, p.ID)
+
+	// us-east: unique_hash ∈ {u1, u2, u1} → 2 distinct
+	// us-west: unique_hash ∈ {u3}         → 1 distinct
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_unique",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 1, "u1", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_unique",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 1, "u2", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_unique",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 1, "u1", map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_unique",
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC), 1, "u3", map[string]interface{}{"region": "us-west"})
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.region"},
+	})
+	s.NoError(err)
+	byRegion := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		byRegion[item.Properties["region"]] = item.TotalUsage
+	}
+	s.True(byRegion["us-east"].Equal(decimal.NewFromInt(2)),
+		"COUNT_UNIQUE us-east: expected 2, got %s", byRegion["us-east"])
+	s.True(byRegion["us-west"].Equal(decimal.NewFromInt(1)),
+		"COUNT_UNIQUE us-west: expected 1, got %s", byRegion["us-west"])
+}
+
+func (s *MeterUsageServiceSuite) TestCountUniqueMeter_NoSubscriptionAnalytics() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_unique_nosub", "ev_unique", types.AggregationCountUnique)
+
+	// 3 events, 2 distinct unique_hash values.
+	s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_unique",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 1, "u1", nil)
+	s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_unique",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 1, "u2", nil)
+	s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_unique",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 1, "u1", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(2)),
+		"no-sub COUNT_UNIQUE: expected 2, got %s", resp.Items[0].TotalUsage)
+}
+
+// ---------------------------------------------------------------------------
+// Windowed analytics — per-window points carry the aggregation-aware Usage.
+// ---------------------------------------------------------------------------
+
+// TestWindowedAnalytics_CountMeter exercises BuildDetailedPointsQuery for a
+// COUNT meter with WindowSize=DAY. Each per-window point.Usage should equal
+// the count of events in that window — not zero.
+func (s *MeterUsageServiceSuite) TestWindowedAnalytics_CountMeter() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_count_win", "ev_cnt", types.AggregationCount)
+	p := s.createPriceForMeter(ctx, "pr_count_win", m.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_count_win", m.ID, p.ID)
+
+	// 2 events on Jan 5, 3 events on Jan 6, 1 event on Jan 7.
+	for i := 0; i < 2; i++ {
+		s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_cnt",
+			time.Date(2026, 1, 5, 10+i, 0, 0, 0, time.UTC), 1, "", nil)
+	}
+	for i := 0; i < 3; i++ {
+		s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_cnt",
+			time.Date(2026, 1, 6, 10+i, 0, 0, 0, time.UTC), 1, "", nil)
+	}
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_cnt",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 1, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeDay,
+	})
+	s.NoError(err)
+	s.Require().Lenf(resp.Items, 1, "expected one item, got %d", len(resp.Items))
+	item := resp.Items[0]
+
+	// Aggregate TotalUsage = 2 + 3 + 1 = 6 distinct events.
+	s.True(item.TotalUsage.Equal(decimal.NewFromInt(6)),
+		"windowed COUNT total: expected 6, got %s", item.TotalUsage)
+
+	// Per-window points: each carries its day's count in Usage.
+	byDay := map[string]decimal.Decimal{}
+	for _, pt := range item.Points {
+		byDay[pt.Timestamp.UTC().Format("2006-01-02")] = pt.Usage
+	}
+	s.True(byDay["2026-01-05"].Equal(decimal.NewFromInt(2)),
+		"per-window COUNT Jan 5: expected 2, got %s", byDay["2026-01-05"])
+	s.True(byDay["2026-01-06"].Equal(decimal.NewFromInt(3)),
+		"per-window COUNT Jan 6: expected 3, got %s", byDay["2026-01-06"])
+	s.True(byDay["2026-01-07"].Equal(decimal.NewFromInt(1)),
+		"per-window COUNT Jan 7: expected 1, got %s", byDay["2026-01-07"])
+}
+
+// TestWindowedAnalytics_MaxMeter same as above but for MAX — verifies per-window
+// Usage carries the per-window MAX value via total_usage.
+func (s *MeterUsageServiceSuite) TestWindowedAnalytics_MaxMeter() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_max_win", "ev_max", types.AggregationMax)
+	p := s.createPriceForMeter(ctx, "pr_max_win", m.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_max_win", m.ID, p.ID)
+
+	// Jan 5: qty 10, 50 → MAX 50
+	// Jan 6: qty 20    → MAX 20
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", nil)
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 50, "", nil)
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeDay,
+	})
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	item := resp.Items[0]
+
+	// Aggregate MAX across all events = 50.
+	s.True(item.TotalUsage.Equal(decimal.NewFromInt(50)),
+		"windowed MAX total: expected 50, got %s", item.TotalUsage)
+
+	byDay := map[string]decimal.Decimal{}
+	for _, pt := range item.Points {
+		byDay[pt.Timestamp.UTC().Format("2006-01-02")] = pt.Usage
+	}
+	s.True(byDay["2026-01-05"].Equal(decimal.NewFromInt(50)),
+		"per-window MAX Jan 5: expected 50, got %s", byDay["2026-01-05"])
+	s.True(byDay["2026-01-06"].Equal(decimal.NewFromInt(20)),
+		"per-window MAX Jan 6: expected 20, got %s", byDay["2026-01-06"])
+}
+
+// ---------------------------------------------------------------------------
+// Commitment + non-SUM aggregation
+//
+// Before the primary-aggregation SQL fix, COUNT/MAX meters returned TotalUsage=0
+// in analytics, which made commitment + overage / true-up surface bogus values.
+// These tests pin the correct commitment behavior across aggregation types.
+// ---------------------------------------------------------------------------
+
+// TestCommitmentNonWindowed_CountMeter: $10 commitment, true-up enabled, COUNT
+// meter at $1/event. With 3 events the usage cost ($3) is below commitment
+// ($10) and true-up would charge full commitment — but the analytics path
+// SKIPS commitment when filters/groupings are set. With no filters and going
+// through GetSubscriptionMeterUsage (billing), the commitment logic runs at
+// the billing layer, not in analytics. Here we verify analytics returns the
+// raw filtered cost when filters skip commitment, AND verify the analytic's
+// EventCount / TotalUsage match expectations for COUNT.
+func (s *MeterUsageServiceSuite) TestCommitmentNonWindowed_CountMeter() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_cnt_commit", "ev_cnt", types.AggregationCount)
+	p := s.createPriceForMeter(ctx, "pr_cnt_commit", m.ID, decimal.NewFromInt(1))
+
+	commitmentAmount := decimal.NewFromInt(10)
+	overageFactor := decimal.NewFromFloat(1.5)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_cnt_commit",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 p.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 m.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		BaseModel:               types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// 15 events @ $1 = $15 → above $10 commitment, expect overage.
+	for i := 0; i < 15; i++ {
+		s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_cnt",
+			time.Date(2026, 1, 5, 10, i, 0, 0, time.UTC), 1, "", nil)
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_cnt_commit" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+
+	// Without filters the commitment path runs: cost = $10 commitment +
+	// ($15-$10)*1.5 = $10 + $7.5 = $17.5.
+	s.True(item.TotalUsage.Equal(decimal.NewFromInt(15)),
+		"COUNT total usage: expected 15 events, got %s", item.TotalUsage)
+	s.True(item.TotalCost.Equal(decimal.NewFromFloat(17.5)),
+		"commitment + overage: expected 17.5, got %s", item.TotalCost)
+	s.Require().NotNil(item.CommitmentInfo)
+	s.True(item.CommitmentInfo.ComputedCommitmentUtilizedAmount.Equal(decimal.NewFromInt(10)),
+		"commitment utilized: expected 10, got %s",
+		item.CommitmentInfo.ComputedCommitmentUtilizedAmount)
+}
+
+// ---------------------------------------------------------------------------
+// Multi-meter analytics query — exercises the no-subscription path with
+// mixed aggregation types in a single call (passes a single AggregationTypes
+// slice containing both SUM and COUNT).
+// ---------------------------------------------------------------------------
+
+func (s *MeterUsageServiceSuite) TestMultiMeter_MixedAggregations_NoSubscription() {
+	ctx := s.GetContext()
+	mSum := s.createMeterWithAggregation(ctx, "mtr_mix_sum", "ev_sum", types.AggregationSum)
+	mCnt := s.createMeterWithAggregation(ctx, "mtr_mix_cnt", "ev_cnt", types.AggregationCount)
+
+	// SUM meter: 3 events qty 10 + 20 + 30 = 60.
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", nil)
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20, "", nil)
+	s.insertMeterUsageFull(ctx, mSum.ID, "unknown_cust", "", "ev_sum",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 30, "", nil)
+	// COUNT meter: 4 distinct events.
+	for i := 0; i < 4; i++ {
+		s.insertMeterUsageFull(ctx, mCnt.ID, "unknown_cust", "", "ev_cnt",
+			time.Date(2026, 1, 5, 10, i, 0, 0, time.UTC), 1, "", nil)
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{mSum.ID, mCnt.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	byMeter := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		byMeter[item.MeterID] = item.TotalUsage
+	}
+	// With mixed aggregations, the SUM in the priority order populates total_usage
+	// for any row that GROUPs together SUM rows; COUNT rows still report their
+	// distinct-event count via the same column thanks to the priority fallback.
+	// Concretely: SUM meter → 60; COUNT meter → 4 distinct events.
+	s.True(byMeter[mSum.ID].Equal(decimal.NewFromInt(60)),
+		"multi-meter SUM total: expected 60, got %s", byMeter[mSum.ID])
+	s.True(byMeter[mCnt.ID].Equal(decimal.NewFromInt(4)),
+		"multi-meter COUNT total: expected 4, got %s", byMeter[mCnt.ID])
+}
+
+// ---------------------------------------------------------------------------
+// Time-bounding sanity for non-SUM aggregations — make sure the basic
+// effective-period bounding (already tested for SUM) also works for MAX/COUNT.
+// ---------------------------------------------------------------------------
+
+func (s *MeterUsageServiceSuite) TestMaxMeter_LineItemDateBounding() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_max_bound", "ev_max", types.AggregationMax)
+	p := s.createPriceForMeter(ctx, "pr_max_bound", m.ID, decimal.NewFromInt(1))
+
+	// Line item active Jan 1 – Jan 15.
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_max_bound",
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        p.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        m.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		EndDate:        time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// In-bounds events with MAX 50.
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", nil)
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 10, 10, 0, 0, 0, time.UTC), 50, "", nil)
+	// Out-of-bounds with qty 999 — must be excluded.
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_max",
+		time.Date(2026, 1, 20, 10, 0, 0, 0, time.UTC), 999, "", nil)
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+	})
+	s.NoError(err)
+
+	var lu *LineItemMeterUsage
+	for _, x := range result.LineItemUsages {
+		if x.LineItem.ID == "li_max_bound" {
+			lu = x
+			break
+		}
+	}
+	s.Require().NotNil(lu)
+	s.True(lu.Usage.Equal(decimal.NewFromInt(50)),
+		"MAX with date bounding: expected 50 (Jan 20 event excluded), got %s", lu.Usage)
+}
+
+func (s *MeterUsageServiceSuite) TestCountMeter_LineItemDateBounding() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_cnt_bound", "ev_cnt", types.AggregationCount)
+	p := s.createPriceForMeter(ctx, "pr_cnt_bound", m.ID, decimal.NewFromInt(1))
+
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_cnt_bound",
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        p.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        m.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		EndDate:        time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// 4 in-bounds, 2 out-of-bounds.
+	for _, t := range []time.Time{
+		time.Date(2026, 1, 3, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 8, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 14, 10, 0, 0, 0, time.UTC),
+	} {
+		s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_cnt", t, 1, "", nil)
+	}
+	for _, t := range []time.Time{
+		time.Date(2026, 1, 20, 10, 0, 0, 0, time.UTC),
+		time.Date(2026, 1, 25, 10, 0, 0, 0, time.UTC),
+	} {
+		s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "", "ev_cnt", t, 1, "", nil)
+	}
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+	})
+	s.NoError(err)
+
+	var lu *LineItemMeterUsage
+	for _, x := range result.LineItemUsages {
+		if x.LineItem.ID == "li_cnt_bound" {
+			lu = x
+			break
+		}
+	}
+	s.Require().NotNil(lu)
+	s.True(lu.Usage.Equal(decimal.NewFromInt(4)),
+		"COUNT with date bounding: expected 4 in-bounds events, got %s", lu.Usage)
+	s.Equal(uint64(4), lu.EventCount,
+		"COUNT EventCount: expected 4, got %d", lu.EventCount)
 }

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -1515,14 +1515,17 @@ func (s *MeterUsageServiceSuite) TestWindowedAnalytics_MaxMeter() {
 // These tests pin the correct commitment behavior across aggregation types.
 // ---------------------------------------------------------------------------
 
-// TestCommitmentNonWindowed_CountMeter: $10 commitment, true-up enabled, COUNT
-// meter at $1/event. With 3 events the usage cost ($3) is below commitment
-// ($10) and true-up would charge full commitment — but the analytics path
-// SKIPS commitment when filters/groupings are set. With no filters and going
-// through GetSubscriptionMeterUsage (billing), the commitment logic runs at
-// the billing layer, not in analytics. Here we verify analytics returns the
-// raw filtered cost when filters skip commitment, AND verify the analytic's
-// EventCount / TotalUsage match expectations for COUNT.
+// TestCommitmentNonWindowed_CountMeter exercises the billing path through
+// GetSubscriptionMeterUsage with a COUNT meter at $1/event, a $10 commitment,
+// and true-up enabled. 15 events ingested with no property/source filters so
+// the commitment runs normally: $10 utilized + $5 overage × 1.5 overage factor
+// → TotalCost = $17.50. Asserts:
+//   - EventCount == 15 and TotalUsage == 15 (COUNT semantics for COUNT meter)
+//   - TotalCost == 17.5 (commitment applied with overage)
+//   - CommitmentInfo populated (commitment recorded on the response)
+//
+// This pins the COUNT-meter contract end-to-end: the primary aggregation
+// expression in total_usage feeds commitment computation correctly.
 func (s *MeterUsageServiceSuite) TestCommitmentNonWindowed_CountMeter() {
 	ctx := s.GetContext()
 	m := s.createMeterWithAggregation(ctx, "mtr_cnt_commit", "ev_cnt", types.AggregationCount)
@@ -1633,6 +1636,86 @@ func (s *MeterUsageServiceSuite) TestMultiMeter_MixedAggregations_NoSubscription
 		"multi-meter SUM total: expected 60, got %s", byMeter[mSum.ID])
 	s.True(byMeter[mCnt.ID].Equal(decimal.NewFromInt(4)),
 		"multi-meter COUNT total: expected 4, got %s", byMeter[mCnt.ID])
+}
+
+// ---------------------------------------------------------------------------
+// Mixed-aggregation regression — MAX + LATEST. Pre-fix, the fallback path
+// sent both meters through one repo call with AggregationTypes=[MAX,LATEST].
+// buildMeterUsageAggregationColumns prefers MAX, so total_usage came back as
+// MAX(qty_total) for every row — wrong for the LATEST meter (which should
+// report argMax(qty_total, timestamp)). With the split fix each meter gets
+// its own primary expression, so values are correct.
+// ---------------------------------------------------------------------------
+
+func (s *MeterUsageServiceSuite) TestMultiMeter_MaxAndLatest_NoSubscription() {
+	ctx := s.GetContext()
+	mMax := s.createMeterWithAggregation(ctx, "mtr_mix_max", "ev_max", types.AggregationMax)
+	mLatest := s.createMeterWithAggregation(ctx, "mtr_mix_latest", "ev_latest", types.AggregationLatest)
+
+	// MAX meter: 3 events qty 5, 30, 12 → MAX=30.
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 5, "", nil)
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 30, "", nil)
+	s.insertMeterUsageFull(ctx, mMax.ID, "unknown_cust", "", "ev_max",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 12, "", nil)
+
+	// LATEST meter: 3 events qty 100, 200, 7 at increasing timestamps → LATEST=7.
+	// Critically, MAX of this set is 200, so a MAX-poisoned total_usage would
+	// be 200 — clearly distinguishable from the correct LATEST=7.
+	s.insertMeterUsageFull(ctx, mLatest.ID, "unknown_cust", "", "ev_latest",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 100, "", nil)
+	s.insertMeterUsageFull(ctx, mLatest.ID, "unknown_cust", "", "ev_latest",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 200, "", nil)
+	s.insertMeterUsageFull(ctx, mLatest.ID, "unknown_cust", "", "ev_latest",
+		time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC), 7, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{mMax.ID, mLatest.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	byMeter := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		byMeter[item.MeterID] = item.TotalUsage
+	}
+	s.True(byMeter[mMax.ID].Equal(decimal.NewFromInt(30)),
+		"MAX meter total: expected 30, got %s", byMeter[mMax.ID])
+	s.True(byMeter[mLatest.ID].Equal(decimal.NewFromInt(7)),
+		"LATEST meter total: expected 7 (would be 200 under priority-collapse bug), got %s", byMeter[mLatest.ID])
+}
+
+// TestAvgMeter_NoSubscriptionAnalytics: pre-fix AVG was missing from the
+// primary switch in buildMeterUsageAggregationColumns and from the in-memory
+// primaryAggregationValue, so AVG meters returned total_usage = 0. After fix,
+// AVG meters compute AVG(qty_total) and the in-memory store mirrors that.
+func (s *MeterUsageServiceSuite) TestAvgMeter_NoSubscriptionAnalytics() {
+	ctx := s.GetContext()
+	m := s.createMeterWithAggregation(ctx, "mtr_avg", "ev_avg", types.AggregationAvg)
+
+	// 4 events qty 10, 20, 30, 40 → AVG = 25.
+	for i, q := range []int64{10, 20, 30, 40} {
+		s.insertMeterUsageFull(ctx, m.ID, "unknown_cust", "", "ev_avg",
+			time.Date(2026, 1, 5, 10, i, 0, 0, time.UTC), float64(q), "", nil)
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: "unknown_cust",
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+	s.Len(resp.Items, 1)
+	s.True(resp.Items[0].TotalUsage.Equal(decimal.NewFromInt(25)),
+		"AVG meter total: expected 25, got %s", resp.Items[0].TotalUsage)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -58,11 +58,16 @@ type MeterUsageTrackingService interface {
 
 	// RegisterHandler registers the consumer handler with the router
 	RegisterHandler(router *pubsubRouter.Router, cfg *config.Configuration)
+
+	// RegisterHandlerLazy registers a dedicated consumer for the events_lazy
+	// topic (lazy-mode tenants — see kafka.RouteTenantsOnLazyMode).
+	RegisterHandlerLazy(router *pubsubRouter.Router, cfg *config.Configuration)
 }
 
 type meterUsageTrackingService struct {
 	ServiceParams
 	pubSub              pubsub.PubSub
+	lazyPubSub          pubsub.PubSub
 	meterUsageRepo      events.MeterUsageRepository
 	expressionEvaluator expression.Evaluator
 	// meterListCache is a dedicated in-memory cache for meter lists keyed by
@@ -95,6 +100,17 @@ func NewMeterUsageTrackingService(
 		return nil
 	}
 	svc.pubSub = ps
+
+	lazyPS, err := kafka.NewPubSubFromConfig(
+		params.Config,
+		params.Logger,
+		params.Config.MeterUsageTrackingLazy.ConsumerGroup,
+	)
+	if err != nil {
+		params.Logger.Fatalw("failed to create lazy pubsub for meter usage tracking", "error", err)
+		return nil
+	}
+	svc.lazyPubSub = lazyPS
 
 	return svc
 }
@@ -146,6 +162,33 @@ func (s *meterUsageTrackingService) RegisterHandler(router *pubsubRouter.Router,
 	s.Logger.Infow("registered meter usage tracking handler",
 		"topic", cfg.MeterUsageTracking.Topic,
 		"rate_limit", cfg.MeterUsageTracking.RateLimit,
+	)
+}
+
+// RegisterHandlerLazy registers a separate consumer for the events_lazy topic.
+// Same processMessage logic as RegisterHandler; the split lets lazy-mode tenant
+// traffic flow through its own topic + consumer group so it can't starve or
+// be starved by the normal stream. Mirrors the pattern in
+// FeatureUsageTrackingService and CostSheetUsageTrackingService.
+func (s *meterUsageTrackingService) RegisterHandlerLazy(router *pubsubRouter.Router, cfg *config.Configuration) {
+	if !cfg.MeterUsageTrackingLazy.Enabled {
+		s.Logger.Infow("meter usage tracking lazy handler disabled by configuration")
+		return
+	}
+
+	throttle := middleware.NewThrottle(cfg.MeterUsageTrackingLazy.RateLimit, time.Second)
+
+	router.AddNoPublishHandler(
+		"meter_usage_tracking_lazy_handler",
+		cfg.MeterUsageTrackingLazy.Topic,
+		s.lazyPubSub,
+		s.processMessage,
+		throttle.Middleware,
+	)
+
+	s.Logger.Infow("registered meter usage tracking lazy handler",
+		"topic", cfg.MeterUsageTrackingLazy.Topic,
+		"rate_limit", cfg.MeterUsageTrackingLazy.RateLimit,
 	)
 }
 

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -597,15 +597,17 @@ func (s *InMemoryMeterUsageStore) GetDetailedAnalytics(_ context.Context, params
 
 	results := make([]*events.MeterUsageDetailedResult, 0, len(byKey))
 	for _, g := range byKey {
+		eventCount := uint64(distinctIDCount(g.records))
+		countUnique := uint64(distinctUniqueHashCount(g.records))
 		res := &events.MeterUsageDetailedResult{
 			MeterID:          g.meterID,
 			Source:           g.source,
 			Properties:       g.properties,
-			TotalUsage:       aggregateScalar(g.records, types.AggregationSum),
+			TotalUsage:       primaryAggregationValue(g.records, params.AggregationTypes, eventCount, countUnique),
 			MaxUsage:         aggregateScalar(g.records, types.AggregationMax),
 			LatestUsage:      aggregateScalar(g.records, types.AggregationLatest),
-			CountUniqueUsage: uint64(distinctUniqueHashCount(g.records)),
-			EventCount:       uint64(distinctIDCount(g.records)),
+			CountUniqueUsage: countUnique,
+			EventCount:       eventCount,
 		}
 
 		// When source isn't a group dimension, ClickHouse returns groupUniqArray(source)
@@ -624,7 +626,7 @@ func (s *InMemoryMeterUsageStore) GetDetailedAnalytics(_ context.Context, params
 		}
 
 		if params.WindowSize != "" {
-			res.Points = computeDetailedPoints(g.records, params.WindowSize, params.BillingAnchor)
+			res.Points = computeDetailedPoints(g.records, params.WindowSize, params.BillingAnchor, params.AggregationTypes)
 		}
 
 		results = append(results, res)
@@ -644,23 +646,50 @@ func (s *InMemoryMeterUsageStore) GetDetailedAnalytics(_ context.Context, params
 	return results, nil
 }
 
-// computeDetailedPoints buckets a group's records by WindowSize and computes
-// all five aggregations per bucket (mirroring buildConditionalAggregationColumns).
-func computeDetailedPoints(records []*events.MeterUsage, ws types.WindowSize, anchor *time.Time) []events.MeterUsageDetailedPoint {
+// computeDetailedPoints buckets a group's records by WindowSize and mirrors
+// buildMeterUsageAggregationColumns: total_usage holds the primary aggregation
+// result, per-type columns retain their independent values.
+func computeDetailedPoints(records []*events.MeterUsage, ws types.WindowSize, anchor *time.Time, aggTypes []types.AggregationType) []events.MeterUsageDetailedPoint {
 	buckets := bucketRecords(records, ws, anchor)
 	points := make([]events.MeterUsageDetailedPoint, 0, len(buckets))
 	for _, b := range buckets {
+		eventCount := uint64(distinctIDCount(b.records))
+		countUnique := uint64(distinctUniqueHashCount(b.records))
 		points = append(points, events.MeterUsageDetailedPoint{
 			WindowStart:      b.start,
-			TotalUsage:       aggregateScalar(b.records, types.AggregationSum),
+			TotalUsage:       primaryAggregationValue(b.records, aggTypes, eventCount, countUnique),
 			MaxUsage:         aggregateScalar(b.records, types.AggregationMax),
 			LatestUsage:      aggregateScalar(b.records, types.AggregationLatest),
-			CountUniqueUsage: uint64(distinctUniqueHashCount(b.records)),
-			EventCount:       uint64(distinctIDCount(b.records)),
+			CountUniqueUsage: countUnique,
+			EventCount:       eventCount,
 		})
 	}
 	sort.Slice(points, func(i, j int) bool { return points[i].WindowStart.Before(points[j].WindowStart) })
 	return points
+}
+
+// primaryAggregationValue returns the value that buildMeterUsageAggregationColumns
+// would put in total_usage for these records and requested aggregation types.
+// Priority matches the repo function: SUM → COUNT → COUNT_UNIQUE → MAX → LATEST.
+func primaryAggregationValue(records []*events.MeterUsage, aggTypes []types.AggregationType, eventCount, countUnique uint64) decimal.Decimal {
+	aggSet := make(map[types.AggregationType]bool, len(aggTypes))
+	for _, t := range aggTypes {
+		aggSet[t] = true
+	}
+	switch {
+	case aggSet[types.AggregationSum]:
+		return aggregateScalar(records, types.AggregationSum)
+	case aggSet[types.AggregationCount]:
+		return decimal.NewFromInt(int64(eventCount))
+	case aggSet[types.AggregationCountUnique]:
+		return decimal.NewFromInt(int64(countUnique))
+	case aggSet[types.AggregationMax]:
+		return aggregateScalar(records, types.AggregationMax)
+	case aggSet[types.AggregationLatest]:
+		return aggregateScalar(records, types.AggregationLatest)
+	default:
+		return decimal.Zero
+	}
 }
 
 func propertiesString(p map[string]string) string {

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -670,7 +670,7 @@ func computeDetailedPoints(records []*events.MeterUsage, ws types.WindowSize, an
 
 // primaryAggregationValue returns the value that buildMeterUsageAggregationColumns
 // would put in total_usage for these records and requested aggregation types.
-// Priority matches the repo function: SUM → COUNT → COUNT_UNIQUE → MAX → LATEST.
+// Priority matches the repo function: SUM → COUNT → COUNT_UNIQUE → MAX → AVG → LATEST.
 func primaryAggregationValue(records []*events.MeterUsage, aggTypes []types.AggregationType, eventCount, countUnique uint64) decimal.Decimal {
 	aggSet := make(map[types.AggregationType]bool, len(aggTypes))
 	for _, t := range aggTypes {
@@ -685,6 +685,8 @@ func primaryAggregationValue(records []*events.MeterUsage, aggTypes []types.Aggr
 		return decimal.NewFromInt(int64(countUnique))
 	case aggSet[types.AggregationMax]:
 		return aggregateScalar(records, types.AggregationMax)
+	case aggSet[types.AggregationAvg]:
+		return aggregateScalar(records, types.AggregationAvg)
 	case aggSet[types.AggregationLatest]:
 		return aggregateScalar(records, types.AggregationLatest)
 	default:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detailed analytics now consistently compute per-meter totals, per-point usage and event counts across aggregation types, fixing mixed-meter, windowed, commitment and date-bounding edge cases.

* **New Features**
  * Added configurable "lazy" meter-usage consumer with separate topic/consumer-group and lazy registration.

* **Refactor**
  * Unified primary usage/count exposure and defaulting for missing aggregations; simplified latest-aggregation handling.

* **Tests**
  * Added extensive regression, windowing, commitment and multi-meter coverage (including COUNT/COUNT_UNIQUE/MAX/LATEST/AVG).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->