### PR TITLE
feat(tenant-onboarding): add status field to environment 

### DIFF
--- a/scripts/internal/add_tenant_environment.go
+++ b/scripts/internal/add_tenant_environment.go
@@ -1,0 +1,124 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/environment"
+	"github.com/flexprice/flexprice/internal/domain/tenant"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
+	"github.com/flexprice/flexprice/internal/repository"
+	"github.com/flexprice/flexprice/internal/sentry"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+type addEnvironmentScript struct {
+	log             *logger.Logger
+	tenantRepo      tenant.Repository
+	environmentRepo environment.Repository
+}
+
+func newAddEnvironmentScript() (*addEnvironmentScript, error) {
+	cfg, err := config.NewConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create logger: %w", err)
+	}
+
+	entClient, err := postgres.NewEntClients(cfg, log)
+	if err != nil {
+		log.Fatalf("Failed to connect to postgres: %v", err)
+	}
+
+	client := postgres.NewClient(entClient, log, sentry.NewSentryService(cfg, log))
+	repoParams := repository.RepositoryParams{
+		EntClient: client,
+		Logger:    log,
+	}
+
+	return &addEnvironmentScript{
+		log:             log,
+		tenantRepo:      repository.NewTenantRepository(repoParams),
+		environmentRepo: repository.NewEnvironmentRepository(repoParams),
+	}, nil
+}
+
+func parseEnvironmentType(value string) (types.EnvironmentType, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case string(types.EnvironmentDevelopment):
+		return types.EnvironmentDevelopment, nil
+	case string(types.EnvironmentProduction):
+		return types.EnvironmentProduction, nil
+	default:
+		return "", fmt.Errorf("invalid environment type %q, allowed values: development, production", value)
+	}
+}
+
+func (s *addEnvironmentScript) createEnvironment(ctx context.Context, tenantID, name string, envType types.EnvironmentType) (*environment.Environment, error) {
+	env := &environment.Environment{
+		ID:   types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENVIRONMENT),
+		Name: name,
+		Type: envType,
+		BaseModel: types.BaseModel{
+			TenantID:  tenantID,
+			CreatedBy: types.DefaultUserID,
+			UpdatedBy: types.DefaultUserID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Status:    types.StatusPublished,
+		},
+	}
+
+	if err := s.environmentRepo.Create(ctx, env); err != nil {
+		return nil, fmt.Errorf("failed to create environment: %w", err)
+	}
+
+	return env, nil
+}
+
+func AddEnvironmentToTenant() error {
+	tenantID := strings.TrimSpace(os.Getenv("TENANT_ID"))
+	environmentName := strings.TrimSpace(os.Getenv("ENVIRONMENT_NAME"))
+	environmentTypeRaw := strings.TrimSpace(os.Getenv("ENVIRONMENT_TYPE"))
+
+	if tenantID == "" || environmentName == "" || environmentTypeRaw == "" {
+		return fmt.Errorf("TENANT_ID, ENVIRONMENT_NAME and ENVIRONMENT_TYPE are required")
+	}
+
+	environmentType, err := parseEnvironmentType(environmentTypeRaw)
+	if err != nil {
+		return err
+	}
+
+	script, err := newAddEnvironmentScript()
+	if err != nil {
+		return fmt.Errorf("failed to initialize script: %w", err)
+	}
+
+	ctx := context.Background()
+
+	_, err = script.tenantRepo.GetByID(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("failed to get tenant %s: %w", tenantID, err)
+	}
+
+	env, err := script.createEnvironment(ctx, tenantID, environmentName, environmentType)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully created environment %s for tenant %s\n", env.Name, tenantID)
+	fmt.Printf("Environment ID: %s\n", env.ID)
+	fmt.Printf("Environment Type: %s\n", env.Type)
+
+	return nil
+}

--- a/scripts/internal/add_tenant_environment.go
+++ b/scripts/internal/add_tenant_environment.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/domain/environment"
 	"github.com/flexprice/flexprice/internal/domain/tenant"
@@ -43,6 +44,7 @@ func newAddEnvironmentScript() (*addEnvironmentScript, error) {
 	repoParams := repository.RepositoryParams{
 		EntClient: client,
 		Logger:    log,
+		Cache:     cache.GetInMemoryCache(),
 	}
 
 	return &addEnvironmentScript{

--- a/scripts/internal/tenant_onboarding.go
+++ b/scripts/internal/tenant_onboarding.go
@@ -142,6 +142,7 @@ func (s *onboardingScript) createEnvironment(ctx context.Context, name string, e
 			CreatedBy: types.DefaultUserID,
 			UpdatedBy: types.DefaultUserID,
 			CreatedAt: time.Now(),
+			Status:    types.StatusPublished,
 			UpdatedAt: time.Now(),
 		},
 	}
@@ -189,12 +190,12 @@ func OnboardNewTenant() error {
 	// Create default environments (development, staging, production)
 	envTypes := []types.EnvironmentType{
 		types.EnvironmentDevelopment,
-		types.EnvironmentProduction,
+		// types.EnvironmentProduction,
 	}
 
 	envNameMap := map[types.EnvironmentType]string{
 		types.EnvironmentDevelopment: "Sandbox",
-		types.EnvironmentProduction:  "Production",
+		// types.EnvironmentProduction:  "Production",
 	}
 
 	for _, envType := range envTypes {

--- a/scripts/main.go
+++ b/scripts/main.go
@@ -84,6 +84,11 @@ var commands = []Command{
 		Run:         internal.AddNewUserToTenant,
 	},
 	{
+		Name:        "add-environment",
+		Description: "Add an environment to an existing tenant",
+		Run:         internal.AddEnvironmentToTenant,
+	},
+	{
 		Name:        "migrate-invoice-sequences",
 		Description: "Migrate invoice sequences to include environment isolation",
 		Run:         internal.MigrateInvoiceSequences,
@@ -187,6 +192,8 @@ func main() {
 		startDate          string
 		billingCycle       string
 		customerCount      string
+		environmentName    string
+		environmentType    string
 		addonID            string
 		workerCount        string
 		effectiveDate      string
@@ -205,6 +212,8 @@ func main() {
 	flag.StringVar(&userID, "user-id", "", "User ID for operations")
 	flag.StringVar(&password, "user-password", "", "password for setting up new user")
 	flag.StringVar(&environmentID, "environment-id", "", "Environment ID for operations")
+	flag.StringVar(&environmentName, "environment-name", "", "Environment name for add-environment command")
+	flag.StringVar(&environmentType, "environment-type", "", "Environment type for add-environment (development or production)")
 	flag.StringVar(&filePath, "file-path", "", "File path for operations")
 	flag.StringVar(&planID, "plan-id", "", "Plan ID for operations")
 	flag.StringVar(&meterID, "meter-id", "", "Meter ID (for setup-dummy-billing-customer)")
@@ -262,6 +271,12 @@ func main() {
 	}
 	if environmentID != "" {
 		os.Setenv("ENVIRONMENT_ID", environmentID)
+	}
+	if environmentName != "" {
+		os.Setenv("ENVIRONMENT_NAME", environmentName)
+	}
+	if environmentType != "" {
+		os.Setenv("ENVIRONMENT_TYPE", environmentType)
 	}
 	if filePath != "" {
 		os.Setenv("FILE_PATH", filePath)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "add environment" CLI to create development or production environments for a tenant (validates inputs and prints success details).
  * Tenant onboarding now provisions only the development environment by default (production is no longer auto-created).

* **Bug Fixes**
  * Newly created environments are set to a Published status by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->