### PR TITLE
fix(integration): send error to paddle on webhook to trigger retry

### DIFF
--- a/internal/api/v1/webhook.go
+++ b/internal/api/v1/webhook.go
@@ -1174,6 +1174,8 @@ func (h *WebhookHandler) HandlePaddleWebhook(c *gin.Context) {
 		h.logger.Errorw("failed to handle Paddle webhook event",
 			"error", err,
 			"event_type", payload.EventType)
+		c.JSON(http.StatusInternalServerError, gin.H{})
+		handled = true
 	}
 }
 func (h *WebhookHandler) HandleWhopWebhook(c *gin.Context) {

--- a/internal/integration/paddle/sync_service.go
+++ b/internal/integration/paddle/sync_service.go
@@ -998,7 +998,6 @@ func (s *PaddleSyncService) ProcessTransactionCompletedWebhook(
 			// No mapping — this transaction may not be one we created, skip.
 			s.logger.Warnw("no FlexPrice invoice found for Paddle transaction, skipping",
 				"paddle_transaction_id", txn.ID)
-			return nil
 		}
 		return err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook handler now returns HTTP 500 when processing fails instead of incorrectly returning success.
  * Transaction webhook processing no longer swallows missing invoice mappings; it logs a warning and propagates the error so failures are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->