### PR TITLE
feat(events-debugger): add attributed-to-customer step to track meter_usage pipeline

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -478,6 +478,7 @@ type DebugTracker struct {
 	MeterMatching              *MeterMatchingResult              `json:"meter_matching"`
 	PriceLookup                *PriceLookupResult                `json:"price_lookup"`
 	SubscriptionLineItemLookup *SubscriptionLineItemLookupResult `json:"subscription_line_item_lookup"`
+	AttributedToCustomer       *AttributedToCustomerResult       `json:"attributed_to_customer,omitempty"`
 	FailurePoint               *types.FailurePoint               `json:"failure_point"`
 }
 
@@ -527,6 +528,18 @@ type MatchedSubscriptionLineItem struct {
 	IsActiveForEvent     bool                               `json:"is_active_for_event"`
 	TimestampWithinRange bool                               `json:"timestamp_within_range"`
 	SubscriptionLineItem *subscription.SubscriptionLineItem `json:"subscription_line_item,omitempty"`
+}
+
+type AttributedToCustomerResult struct {
+	Status     types.DebugTrackerStatus `json:"status"`
+	MeterUsage *MeterUsageAttribution   `json:"meter_usage,omitempty"`
+	Error      *ierr.ErrorResponse      `json:"error,omitempty"`
+}
+
+type MeterUsageAttribution struct {
+	MeterID            string `json:"meter_id"`
+	ExternalCustomerID string `json:"external_customer_id"`
+	QtyTotal           string `json:"qty_total"`
 }
 
 // ReprocessEventsRequest represents the request to reprocess events

--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -142,4 +142,7 @@ type MeterUsageRepository interface {
 
 	// GetMeterUsageForExport retrieves meter usage data for export in batches
 	GetMeterUsageForExport(ctx context.Context, startTime, endTime time.Time, batchSize int, offset int) ([]*MeterUsage, error)
+
+	// GetByEventID returns the meter_usage record for a single event, or nil if not yet processed.
+	GetByEventID(ctx context.Context, tenantID, environmentID, eventID string) (*MeterUsage, error)
 }

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -705,7 +705,7 @@ func (r *MeterUsageRepository) GetByEventID(ctx context.Context, tenantID, envir
 			meter_id,
 			qty_total,
 			unique_hash
-		FROM meter_usage FINAL
+		FROM meter_usage
 		WHERE tenant_id = ?
 		  AND environment_id = ?
 		  AND id = ?

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -688,3 +688,63 @@ func (r *MeterUsageRepository) GetMeterUsageForExport(ctx context.Context, start
 
 	return results, nil
 }
+
+// GetByEventID returns the meter_usage record for a single event, or nil if not yet processed.
+func (r *MeterUsageRepository) GetByEventID(ctx context.Context, tenantID, environmentID, eventID string) (*events.MeterUsage, error) {
+	query := `
+		SELECT
+			id,
+			tenant_id,
+			environment_id,
+			external_customer_id,
+			event_name,
+			source,
+			timestamp,
+			ingested_at,
+			properties,
+			meter_id,
+			qty_total,
+			unique_hash
+		FROM meter_usage FINAL
+		WHERE tenant_id = ?
+		  AND environment_id = ?
+		  AND id = ?
+		LIMIT 1
+		SETTINGS max_memory_usage = 96636764160
+	`
+
+	var usage events.MeterUsage
+	var propertiesJSON string
+
+	err := r.store.GetConn().QueryRow(ctx, query, tenantID, environmentID, eventID).Scan(
+		&usage.ID,
+		&usage.TenantID,
+		&usage.EnvironmentID,
+		&usage.ExternalCustomerID,
+		&usage.EventName,
+		&usage.Source,
+		&usage.Timestamp,
+		&usage.IngestedAt,
+		&propertiesJSON,
+		&usage.MeterID,
+		&usage.QtyTotal,
+		&usage.UniqueHash,
+	)
+	if err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return nil, nil
+		}
+		return nil, ierr.WithError(err).
+			WithHint("Failed to query meter_usage by event ID").
+			Mark(ierr.ErrDatabase)
+	}
+
+	if propertiesJSON != "" {
+		if err := json.Unmarshal([]byte(propertiesJSON), &usage.Properties); err != nil {
+			r.logger.Warnw("failed to parse properties JSON", "event_id", usage.ID, "error", err)
+			usage.Properties = make(map[string]interface{})
+		}
+	}
+
+	return &usage, nil
+}

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -319,10 +319,6 @@ func (s *featureUsageTrackingService) RegisterHandlerReplay(router *pubsubRouter
 
 // Process a single event message for feature usage tracking
 func (s *featureUsageTrackingService) processMessage(msg *message.Message) error {
-	s.Logger.Debugw("processing event from message queue in feature usage tracking service",
-		"message_uuid", msg.UUID,
-	)
-	return nil
 	// Extract tenant ID from message metadata
 	partitionKey := msg.Metadata.Get("partition_key")
 	tenantID := msg.Metadata.Get("tenant_id")

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -319,6 +319,10 @@ func (s *featureUsageTrackingService) RegisterHandlerReplay(router *pubsubRouter
 
 // Process a single event message for feature usage tracking
 func (s *featureUsageTrackingService) processMessage(msg *message.Message) error {
+	s.Logger.Debugw("processing event from message queue in feature usage tracking service",
+		"message_uuid", msg.UUID,
+	)
+	return nil
 	// Extract tenant ID from message metadata
 	partitionKey := msg.Metadata.Get("partition_key")
 	tenantID := msg.Metadata.Get("tenant_id")
@@ -3588,11 +3592,15 @@ func (s *featureUsageTrackingService) DebugEvent(ctx context.Context, eventID st
 }
 
 func (s *featureUsageTrackingService) runDebugTracker(ctx context.Context, event *events.Event) *dto.DebugTracker {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
 	tracker := &dto.DebugTracker{
 		CustomerLookup:             &dto.CustomerLookupResult{Status: types.DebugTrackerStatusUnprocessed},
 		MeterMatching:              &dto.MeterMatchingResult{Status: types.DebugTrackerStatusUnprocessed},
 		PriceLookup:                &dto.PriceLookupResult{Status: types.DebugTrackerStatusUnprocessed},
 		SubscriptionLineItemLookup: &dto.SubscriptionLineItemLookupResult{Status: types.DebugTrackerStatusUnprocessed},
+		// AttributedToCustomer is only populated when the meter_usage feature flag is enabled.
+		// It is initialised lazily in Step 5 below; left nil otherwise (omitted from JSON).
 	}
 
 	// Step 1: Customer Lookup
@@ -3869,6 +3877,47 @@ func (s *featureUsageTrackingService) runDebugTracker(ctx context.Context, event
 
 	// At least one active line item found
 	tracker.SubscriptionLineItemLookup.Status = types.DebugTrackerStatusFound
+
+	// Step 5: Attributed to Customer — only applicable when the meter_usage pipeline is
+	// enabled for this tenant. When disabled, attribution flows through feature_usage
+	// (already checked by the caller before invoking runDebugTracker), so we omit the
+	// step entirely by leaving AttributedToCustomer nil.
+	if s.Config.FeatureFlag.IsMeterUsageEnabledForAnalytics(tenantID) {
+		tracker.AttributedToCustomer = &dto.AttributedToCustomerResult{Status: types.DebugTrackerStatusUnprocessed}
+		meterUsage, err := s.MeterUsageRepo.GetByEventID(ctx, tenantID, environmentID, event.ID)
+		if err != nil {
+			tracker.AttributedToCustomer.Status = types.DebugTrackerStatusError
+			status, code := ierr.ResolveError(err)
+			errorResp := &ierr.ErrorResponse{
+				Code:           code,
+				Message:        err.Error(),
+				HTTPStatusCode: status,
+			}
+			tracker.AttributedToCustomer.Error = errorResp
+			tracker.FailurePoint = &types.FailurePoint{
+				FailurePointType: types.FailurePointTypeAttributedToCustomer,
+				Error:            errorResp,
+			}
+			return tracker
+		}
+
+		if meterUsage == nil {
+			// Event hasn't reached meter_usage yet — still moving through the pipeline.
+			// Not a hard failure; the consumer may not have processed it yet.
+			tracker.AttributedToCustomer.Status = types.DebugTrackerStatusProcessing
+			return tracker
+		}
+
+		tracker.AttributedToCustomer.Status = types.DebugTrackerStatusAttributed
+		tracker.AttributedToCustomer.MeterUsage = &dto.MeterUsageAttribution{
+			MeterID:            meterUsage.MeterID,
+			ExternalCustomerID: meterUsage.ExternalCustomerID,
+			QtyTotal:           meterUsage.QtyTotal.String(),
+		}
+	} else {
+		// meter_usage pipeline not enabled — omit this step entirely.
+		tracker.AttributedToCustomer = nil
+	}
 
 	// No failure point if we got here
 	tracker.FailurePoint = nil

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -713,5 +713,26 @@ func (s *InMemoryMeterUsageStore) GetMeterUsageForExport(ctx context.Context, st
 	return filtered[offset:end], nil
 }
 
+// GetByEventID returns the meter_usage record for a single event, or nil if not found.
+func (s *InMemoryMeterUsageStore) GetByEventID(_ context.Context, tenantID, environmentID, eventID string) (*events.MeterUsage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, r := range s.records {
+		if r.TenantID == tenantID && r.EnvironmentID == environmentID && r.ID == eventID {
+			// Return minimal copy with only the fields needed for debug response
+			return &events.MeterUsage{
+				Event: events.Event{
+					ID:                 eventID,
+					ExternalCustomerID: r.ExternalCustomerID,
+				},
+				MeterID:  r.MeterID,
+				QtyTotal: r.QtyTotal,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
 // Ensure interface compliance
 var _ events.MeterUsageRepository = (*InMemoryMeterUsageStore)(nil)

--- a/internal/types/event.go
+++ b/internal/types/event.go
@@ -9,6 +9,7 @@ const (
 	FailurePointTypeMeterLookup                FailurePointType = "meter_lookup"
 	FailurePointTypePriceLookup                FailurePointType = "price_lookup"
 	FailurePointTypeSubscriptionLineItemLookup FailurePointType = "subscription_line_item_lookup"
+	FailurePointTypeAttributedToCustomer       FailurePointType = "attributed_to_customer"
 )
 
 type FailurePoint struct {
@@ -23,6 +24,8 @@ const (
 	DebugTrackerStatusNotFound    DebugTrackerStatus = "not_found"
 	DebugTrackerStatusFound       DebugTrackerStatus = "found"
 	DebugTrackerStatusError       DebugTrackerStatus = "error"
+	DebugTrackerStatusProcessing  DebugTrackerStatus = "processing"
+	DebugTrackerStatusAttributed  DebugTrackerStatus = "attributed"
 )
 
 type EventProcessingStatusType string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug tracking now includes an optional attribution section showing status (processing, attributed, error) and meter-usage attribution details (meter ID, external customer ID, total quantity).
  * Backend can look up meter-usage by event ID to populate attribution info in debug output.

* **Chores**
  * Added new enum/state values and a failure-point to represent meter-usage attribution states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->