### PR TITLE
feat(subscription): add backdated sub cancellation

### DIFF
--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	domainCreditGrantApplication "github.com/flexprice/flexprice/internal/domain/creditgrantapplication"
 	"github.com/flexprice/flexprice/internal/errors"
-	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/validator"
 	"github.com/samber/lo"
@@ -450,23 +449,8 @@ func (r *CancelFutureSubscriptionGrantsRequest) Validate() error {
 		return err
 	}
 
-	// EffectiveDate is optional - if not provided, it defaults to now in the implementation
-	// Only validate if it's provided
-	if r.EffectiveDate != nil && !r.EffectiveDate.IsZero() {
-		// Allow dates that are at or within 1 minute of the current time
-		// This accounts for timing differences between date calculation and validation,
-		now := time.Now().UTC()
-		tolerance := 1 * time.Minute
-		if r.EffectiveDate.Before(now.Add(-tolerance)) {
-			return errors.NewError("effective_date must be at or after the current time (within tolerance)").
-				WithHint("Please provide a valid effective date that is not too far in the past").
-				WithReportableDetails(map[string]interface{}{
-					"effective_date": r.EffectiveDate,
-					"current_time":   now,
-				}).
-				Mark(ierr.ErrValidation)
-		}
-	}
+	// EffectiveDate is optional; when omitted, DeleteCreditGrant defaults to now.
+	// Past dates are valid (e.g. backdated immediate subscription cancellation).
 
 	return nil
 }

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -603,13 +603,25 @@ func (r *CancelSubscriptionRequest) Validate() error {
 	if r.CancellationType == types.CancellationTypeScheduledDate {
 		if r.CancelAt == nil {
 			return ierr.NewError("cancel_at is required for scheduled_date").
-				WithHint("Provide a future date in cancel_at").
+				WithHint("Provide a date strictly after the current period start in cancel_at").
 				Mark(ierr.ErrValidation)
 		}
 		now := time.Now().UTC()
 		if !r.CancelAt.After(now) {
 			return ierr.NewError("cancel_at must be a future date for scheduled_date cancellation").
 				WithHint("Provide a date strictly in the future for cancel_at").
+				WithReportableDetails(map[string]interface{}{
+					"cancel_at": r.CancelAt.UTC().Format(time.RFC3339),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	if r.CancellationType == types.CancellationTypeImmediate && r.CancelAt != nil {
+		now := time.Now().UTC()
+		if r.CancelAt.After(now) {
+			return ierr.NewError("cancel_at cannot be a future date for immediate cancellation").
+				WithHint("Use cancellation_type 'scheduled_date' to schedule a future cancellation").
 				WithReportableDetails(map[string]interface{}{
 					"cancel_at": r.CancelAt.UTC().Format(time.RFC3339),
 				}).

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -83,6 +83,75 @@ func TestCreateSubscriptionRequestValidate_BillingAnchorOnOrAfterStartDate(t *te
 	})
 }
 
+func TestCancelSubscriptionRequest_Validate_BackdatedImmediate(t *testing.T) {
+	now := time.Now().UTC()
+	past := now.Add(-5 * 24 * time.Hour)
+	future := now.Add(5 * 24 * time.Hour)
+
+	tests := []struct {
+		name    string
+		req     CancelSubscriptionRequest
+		wantErr bool
+	}{
+		{
+			name: "immediate_no_cancel_at_is_valid",
+			req: CancelSubscriptionRequest{
+				CancellationType:  types.CancellationTypeImmediate,
+				ProrationBehavior: types.ProrationBehaviorNone,
+			},
+			wantErr: false,
+		},
+		{
+			name: "immediate_past_cancel_at_is_valid",
+			req: CancelSubscriptionRequest{
+				CancellationType:  types.CancellationTypeImmediate,
+				ProrationBehavior: types.ProrationBehaviorNone,
+				CancelAt:          &past,
+			},
+			wantErr: false,
+		},
+		{
+			name: "immediate_future_cancel_at_is_rejected",
+			req: CancelSubscriptionRequest{
+				CancellationType:  types.CancellationTypeImmediate,
+				ProrationBehavior: types.ProrationBehaviorNone,
+				CancelAt:          &future,
+			},
+			wantErr: true,
+		},
+		{
+			name: "scheduled_date_past_cancel_at_still_rejected",
+			req: CancelSubscriptionRequest{
+				CancellationType:  types.CancellationTypeScheduledDate,
+				ProrationBehavior: types.ProrationBehaviorNone,
+				CancelAt:          &past,
+			},
+			wantErr: true,
+		},
+		{
+			name: "scheduled_date_future_cancel_at_is_valid",
+			req: CancelSubscriptionRequest{
+				CancellationType:  types.CancellationTypeScheduledDate,
+				ProrationBehavior: types.ProrationBehaviorNone,
+				CancelAt:          &future,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.req.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestCreateSubscriptionRequestValidate_AutoInvoiceThreshold(t *testing.T) {
 	t.Run("nil passes", func(t *testing.T) {
 		req := baseCreateSubscriptionRequest()

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1847,6 +1847,19 @@ func (s *subscriptionService) CancelSubscription(
 			Mark(ierr.ErrValidation)
 	}
 
+	// Backdated immediate cancellation: cancel_at must be after current period start
+	if req.CancellationType == types.CancellationTypeImmediate && req.CancelAt != nil {
+		if !req.CancelAt.After(subscription.CurrentPeriodStart) {
+			return nil, ierr.NewError("cancel_at must be after current period start").
+				WithHint("Backdated cancellation is not allowed at or before the current period start").
+				WithReportableDetails(map[string]interface{}{
+					"cancel_at":            req.CancelAt.UTC().Format(time.RFC3339),
+					"current_period_start": subscription.CurrentPeriodStart.UTC().Format(time.RFC3339),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
 	// Reject proration for subscriptions with mixed billing periods
 	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations && subscription.HasMixedBillingPeriods() {
 		return nil, ierr.NewError("proration is not supported for subscriptions with mixed billing periods").
@@ -5316,6 +5329,9 @@ func (s *subscriptionService) determineEffectiveDate(
 
 	switch cancellationType {
 	case types.CancellationTypeImmediate:
+		if customDate != nil && customDate.Before(now) {
+			return customDate.UTC(), nil
+		}
 		return now, nil
 
 	case types.CancellationTypeEndOfPeriod:

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -3939,6 +3939,89 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 			})
 		}
 	})
+
+	s.Run("TestBackdatedImmediateCancellation", func() {
+		periodStart := s.testData.now.Add(-7 * 24 * time.Hour)
+		periodEnd := s.testData.now.Add(23 * 24 * time.Hour)
+		backdateSub := &subscription.Subscription{
+			ID:                 "sub_backdate_test",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: periodStart,
+			CurrentPeriodEnd:   periodEnd,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+			LineItems:          []*subscription.SubscriptionLineItem{},
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(s.GetContext(), backdateSub, backdateSub.LineItems))
+
+		// Valid backdated cancellation — 3 days into the current period
+		validBackdate := periodStart.Add(3 * 24 * time.Hour)
+		resp, err := s.service.CancelSubscription(s.GetContext(), backdateSub.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:  types.CancellationTypeImmediate,
+			ProrationBehavior: types.ProrationBehaviorNone,
+			CancelAt:          &validBackdate,
+			Reason:            "test_backdated",
+		})
+		s.NoError(err)
+		s.Equal(types.SubscriptionStatusCancelled, resp.Status)
+		s.True(resp.EffectiveDate.Equal(validBackdate), "effective date should match cancel_at")
+
+		// Verify persisted state
+		updated, err := s.GetStores().SubscriptionRepo.Get(s.GetContext(), backdateSub.ID)
+		s.NoError(err)
+		s.Equal(types.SubscriptionStatusCancelled, updated.SubscriptionStatus)
+		s.NotNil(updated.EndDate)
+		s.True(updated.EndDate.Equal(validBackdate), "EndDate should equal cancel_at")
+		s.NotNil(updated.CancelAt)
+		s.True(updated.CancelAt.Equal(validBackdate), "CancelAt should equal cancel_at")
+
+		s.T().Logf("✅ Backdated immediate cancellation completed successfully")
+	})
+
+	s.Run("TestBackdatedCancellationAtPeriodStartRejected", func() {
+		periodStart := s.testData.now.Add(-7 * 24 * time.Hour)
+		periodEnd := s.testData.now.Add(23 * 24 * time.Hour)
+		subAtBoundary := &subscription.Subscription{
+			ID:                 "sub_boundary_test",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: periodStart,
+			CurrentPeriodEnd:   periodEnd,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+			LineItems:          []*subscription.SubscriptionLineItem{},
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(s.GetContext(), subAtBoundary, subAtBoundary.LineItems))
+
+		// cancel_at == current_period_start → rejected
+		atStart := periodStart
+		_, err := s.service.CancelSubscription(s.GetContext(), subAtBoundary.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:  types.CancellationTypeImmediate,
+			ProrationBehavior: types.ProrationBehaviorNone,
+			CancelAt:          &atStart,
+		})
+		s.Error(err, "cancel_at == current_period_start should be rejected")
+
+		// cancel_at before current_period_start → rejected
+		beforeStart := periodStart.Add(-1 * time.Hour)
+		_, err = s.service.CancelSubscription(s.GetContext(), subAtBoundary.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:  types.CancellationTypeImmediate,
+			ProrationBehavior: types.ProrationBehaviorNone,
+			CancelAt:          &beforeStart,
+		})
+		s.Error(err, "cancel_at before current_period_start should be rejected")
+
+		s.T().Logf("✅ Backdated cancellation boundary rejection completed successfully")
+	})
 }
 
 func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cancellation validation: immediate cancellations now reject future cancel-at dates and accept backdated cancel-at dates that fall within the current billing period; cancellations equal to or before the period start are rejected.
  * Clarified error messaging to guide using scheduled-date for future cancellations.
  * Allowed past effective dates for credit grant cancellations (no longer rejected).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flexprice/flexprice/pull/1912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->