### PR TITLE
feat(subscription): implement auto-invoice threshold alert webhook

### DIFF
--- a/internal/types/sync_config.go
+++ b/internal/types/sync_config.go
@@ -189,7 +189,7 @@ func ProviderBaseSyncConfig(provider SecretProvider) *SyncConfig {
 	case SecretProviderPaddle:
 		return &SyncConfig{
 			Customer:     &EntitySyncConfig{Inbound: true, Outbound: true},
-			Invoice:      &EntitySyncConfig{Inbound: false, Outbound: true},
+			Invoice:      &EntitySyncConfig{Inbound: true, Outbound: true},
 			Payment:      off,
 			Plan:         off,
 			Subscription: off,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled bidirectional invoice synchronization for Paddle provider. Paddle invoices can now sync both inbound and outbound, resolving the previous limitation where only outbound sync was active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->