### PR TITLE
feature(subscription): publish subscription.cancelled system event on…

### DIFF
--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -916,7 +916,7 @@ func (m *mockSubscriptionService) CascadeCancelToInheritedSubscriptions(ctx cont
 func (m *mockSubscriptionService) ExternalCustomerIDsForSubscription(ctx context.Context, sub *subscription.Subscription) ([]string, error) {
 	return nil, nil
 }
-func (m *mockSubscriptionService) PublishSubscriptionEvent(ctx context.Context, eventName types.WebhookEventName, subscriptionID string) {
+func (m *mockSubscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription) {
 }
 
 // --- ProcessSubscriptionActivatedWebhook tests ---

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -916,6 +916,8 @@ func (m *mockSubscriptionService) CascadeCancelToInheritedSubscriptions(ctx cont
 func (m *mockSubscriptionService) ExternalCustomerIDsForSubscription(ctx context.Context, sub *subscription.Subscription) ([]string, error) {
 	return nil, nil
 }
+func (m *mockSubscriptionService) PublishSubscriptionEvent(ctx context.Context, eventName types.WebhookEventName, subscriptionID string) {
+}
 
 // --- ProcessSubscriptionActivatedWebhook tests ---
 

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -166,9 +166,9 @@ type SubscriptionService interface {
 	// CascadeCancelToInheritedSubscriptions mirrors the parent's cancellation fields onto INHERITED child subscriptions (no-op if not a parent). Used by Temporal update-billing-period cancellation and aligned with CancelSubscription / cron processing.
 	CascadeCancelToInheritedSubscriptions(ctx context.Context, parentSub *subscription.Subscription) error
 
-	// PublishSubscriptionEvent publishes a webhook event for a subscription.
+	// PublishCancellationEvents publishes a update and cancel webhook event for a subscription and its inherited subs.
 	// Used by Temporal activities and other callers that need to fire subscription lifecycle events.
-	PublishSubscriptionEvent(ctx context.Context, eventName types.WebhookEventName, subscriptionID string)
+	PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription)
 
 	// ExternalCustomerIDsForSubscription returns distinct non-empty external customer IDs
 	// for the subscription owner plus all active/trialing/draft inherited children.

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -166,6 +166,10 @@ type SubscriptionService interface {
 	// CascadeCancelToInheritedSubscriptions mirrors the parent's cancellation fields onto INHERITED child subscriptions (no-op if not a parent). Used by Temporal update-billing-period cancellation and aligned with CancelSubscription / cron processing.
 	CascadeCancelToInheritedSubscriptions(ctx context.Context, parentSub *subscription.Subscription) error
 
+	// PublishSubscriptionEvent publishes a webhook event for a subscription.
+	// Used by Temporal activities and other callers that need to fire subscription lifecycle events.
+	PublishSubscriptionEvent(ctx context.Context, eventName types.WebhookEventName, subscriptionID string)
+
 	// ExternalCustomerIDsForSubscription returns distinct non-empty external customer IDs
 	// for the subscription owner plus all active/trialing/draft inherited children.
 	ExternalCustomerIDsForSubscription(ctx context.Context, sub *subscription.Subscription) ([]string, error)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -5510,15 +5510,8 @@ func (s *subscriptionService) publishCancellationEvents(
 ) {
 	// Publish standard subscription events
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
-	children, err := s.getInheritedSubscriptions(ctx, sub.ID)
-	if err != nil {
-		return
-	}
 	if cancellationType == types.CancellationTypeImmediate {
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
-		for _, child := range children {
-			s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, child.ID)
-		}
 	}
 	s.Logger.Debugw("subscription cancellation events published",
 		"subscription_id", sub.ID)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -3135,6 +3135,8 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 		}
 
 		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled {
+			s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
+
 			if err := s.CascadeCancelToInheritedSubscriptions(ctx, sub); err != nil {
 				return err
 			}
@@ -3374,6 +3376,9 @@ func (s *subscriptionService) CascadeCancelToInheritedSubscriptions(ctx context.
 			return ierr.WithError(err).
 				WithHintf("Failed to cascade cancel to inherited subscription %s", child.ID).
 				Mark(ierr.ErrInternal)
+		}
+		if parentSub.SubscriptionStatus == types.SubscriptionStatusCancelled {
+			s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, child.ID)
 		}
 	}
 	return nil
@@ -4135,6 +4140,10 @@ func (s *subscriptionService) publishSystemEvent(ctx context.Context, eventName 
 	if err := s.WebhookPublisher.PublishWebhook(ctx, webhookEvent); err != nil {
 		s.Logger.ErrorfCtx(ctx, "failed to publish %s event: %v", webhookEvent.EventName, err)
 	}
+}
+
+func (s *subscriptionService) PublishSubscriptionEvent(ctx context.Context, eventName types.WebhookEventName, subscriptionID string) {
+	s.publishSystemEvent(ctx, eventName, subscriptionID)
 }
 
 // ProcessSubscriptionRenewalDueAlert processes subscriptions that are due for renewal in 24 hours
@@ -5500,7 +5509,7 @@ func (s *subscriptionService) publishCancellationEvents(
 ) {
 	// Publish standard subscription events
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
-	if cancellationType != types.CancellationTypeScheduledDate {
+	if cancellationType == types.CancellationTypeImmediate {
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
 	}
 

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -3018,6 +3018,7 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 		return s.SubRepo.Update(ctx, sub)
 	}
 
+	isSubscriptionCancelled := false
 	// Use db's WithTx for atomic operations
 	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
 		// Process all periods except the last one (which becomes the new current period)
@@ -3135,8 +3136,7 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 		}
 
 		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled {
-			s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
-
+			isSubscriptionCancelled = true
 			if err := s.CascadeCancelToInheritedSubscriptions(ctx, sub); err != nil {
 				return err
 			}
@@ -3169,6 +3169,10 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 			"subscription_id", sub.ID,
 			"error", err)
 		return err
+	}
+
+	if isSubscriptionCancelled {
+		s.publishCancellationEvents(ctx, sub, "")
 	}
 
 	return nil
@@ -3376,9 +3380,6 @@ func (s *subscriptionService) CascadeCancelToInheritedSubscriptions(ctx context.
 			return ierr.WithError(err).
 				WithHintf("Failed to cascade cancel to inherited subscription %s", child.ID).
 				Mark(ierr.ErrInternal)
-		}
-		if parentSub.SubscriptionStatus == types.SubscriptionStatusCancelled {
-			s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, child.ID)
 		}
 	}
 	return nil
@@ -4142,8 +4143,8 @@ func (s *subscriptionService) publishSystemEvent(ctx context.Context, eventName 
 	}
 }
 
-func (s *subscriptionService) PublishSubscriptionEvent(ctx context.Context, eventName types.WebhookEventName, subscriptionID string) {
-	s.publishSystemEvent(ctx, eventName, subscriptionID)
+func (s *subscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription) {
+	s.publishCancellationEvents(ctx, sub, "")
 }
 
 // ProcessSubscriptionRenewalDueAlert processes subscriptions that are due for renewal in 24 hours
@@ -5509,10 +5510,16 @@ func (s *subscriptionService) publishCancellationEvents(
 ) {
 	// Publish standard subscription events
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
+	children, err := s.getInheritedSubscriptions(ctx, sub.ID)
+	if err != nil {
+		return
+	}
 	if cancellationType == types.CancellationTypeImmediate {
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
+		for _, child := range children {
+			s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, child.ID)
+		}
 	}
-
 	s.Logger.Debugw("subscription cancellation events published",
 		"subscription_id", sub.ID)
 }

--- a/internal/service/subscription_change.go
+++ b/internal/service/subscription_change.go
@@ -719,6 +719,7 @@ func (s *subscriptionChangeService) executeChange(
 		Reason:                    "subscription_change",
 		ProrationBehavior:         req.ProrationBehavior,
 		SkipProrationWalletCredit: true, // we always skip the wallet credit refund since we will apply it as adjustment to the new subscription 1st invoice
+		SuppressWebhook:           true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/subscription_change.go
+++ b/internal/service/subscription_change.go
@@ -719,7 +719,6 @@ func (s *subscriptionChangeService) executeChange(
 		Reason:                    "subscription_change",
 		ProrationBehavior:         req.ProrationBehavior,
 		SkipProrationWalletCredit: true, // we always skip the wallet credit refund since we will apply it as adjustment to the new subscription 1st invoice
-		SuppressWebhook:           true,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -304,14 +304,13 @@ func (s *BillingActivities) CheckCancellationActivity(
 	if shouldCancel {
 		sub.SubscriptionStatus = types.SubscriptionStatusCancelled
 		sub.CancelledAt = cancelledAt
+		subscriptionService := service.NewSubscriptionService(s.serviceParams)
 
 		err := s.serviceParams.DB.WithTx(ctx, func(ctx context.Context) error {
 			// Update subscription
 			if err := s.serviceParams.SubRepo.Update(ctx, sub); err != nil {
 				return err
 			}
-
-			subscriptionService := service.NewSubscriptionService(s.serviceParams)
 
 			// Update the cancellation schedule status to executed
 			if err := subscriptionService.MarkCancellationScheduleAsExecuted(ctx, sub.ID); err != nil {
@@ -335,8 +334,7 @@ func (s *BillingActivities) CheckCancellationActivity(
 			return nil, err
 		}
 
-		subscriptionSvc := service.NewSubscriptionService(s.serviceParams)
-		subscriptionSvc.PublishCancellationEvents(ctx, sub)
+		subscriptionService.PublishCancellationEvents(ctx, sub)
 
 		s.logger.Infow("subscription cancelled successfully",
 			"subscription_id", sub.ID,

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -335,6 +335,9 @@ func (s *BillingActivities) CheckCancellationActivity(
 			return nil, err
 		}
 
+		subscriptionSvc := service.NewSubscriptionService(s.serviceParams)
+		subscriptionSvc.PublishSubscriptionEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
+
 		s.logger.Infow("subscription cancelled successfully",
 			"subscription_id", sub.ID,
 			"cancelled_at", *cancelledAt)

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -336,7 +336,7 @@ func (s *BillingActivities) CheckCancellationActivity(
 		}
 
 		subscriptionSvc := service.NewSubscriptionService(s.serviceParams)
-		subscriptionSvc.PublishSubscriptionEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
+		subscriptionSvc.PublishCancellationEvents(ctx, sub)
 
 		s.logger.Infow("subscription cancelled successfully",
 			"subscription_id", sub.ID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a service entry to publish subscription cancellation events for downstream webhooks and system handlers.

* **Bug Fixes**
  * Emit cancellation events only for immediate cancellations.
  * Ensure cancellation events are dispatched only after the database transaction completes successfully.

* **Tests**
  * Updated test doubles to cover publishing of cancellation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->