### PR TITLE
feat(subscription): add support for backdated sub cancellation

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -559,6 +559,10 @@ type CancelSubscriptionRequest struct {
 	// Reason for cancellation (for audit and business intelligence)
 	Reason string `json:"reason,omitempty"`
 
+	// CancelAt is the exact date/time when the subscription should be cancelled.
+	// Required for cancellation_type "scheduled_date"; optional for "immediate" (past dates only — backdated cancellation).
+	// For "scheduled_date", accepts both future dates (deferred cancellation) and past dates (backdated cancellation).
+	// For "immediate", accepts past/current dates only; use "scheduled_date" for future dates.
 	CancelAt *time.Time `json:"cancel_at,omitempty"`
 
 	//SuppressWebhook is an internal flag to suppress webhook events during cancellation.
@@ -621,16 +625,7 @@ func (r *CancelSubscriptionRequest) Validate() error {
 	if r.CancellationType == types.CancellationTypeScheduledDate {
 		if r.CancelAt == nil {
 			return ierr.NewError("cancel_at is required for scheduled_date").
-				WithHint("Provide a date strictly after the current period start in cancel_at").
-				Mark(ierr.ErrValidation)
-		}
-		now := time.Now().UTC()
-		if !r.CancelAt.After(now) {
-			return ierr.NewError("cancel_at must be a future date for scheduled_date cancellation").
-				WithHint("Provide a date strictly in the future for cancel_at").
-				WithReportableDetails(map[string]interface{}{
-					"cancel_at": r.CancelAt.UTC().Format(time.RFC3339),
-				}).
+				WithHint("Provide a cancel_at date (past for backdated cancellation, future for scheduled cancellation)").
 				Mark(ierr.ErrValidation)
 		}
 	}

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -120,13 +120,13 @@ func TestCancelSubscriptionRequest_Validate_BackdatedImmediate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "scheduled_date_past_cancel_at_still_rejected",
+			name: "scheduled_date_past_cancel_at_is_valid",
 			req: CancelSubscriptionRequest{
 				CancellationType:  types.CancellationTypeScheduledDate,
 				ProrationBehavior: types.ProrationBehaviorNone,
 				CancelAt:          &past,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "scheduled_date_future_cancel_at_is_valid",

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -1872,7 +1872,7 @@ func (s *subscriptionService) CancelSubscription(
 	}
 
 	// Step 3b: Guard against double-scheduling
-	// Both end_of_period and scheduled_date schedule a future cancellation via cancel_at.
+	// Both end_of_period and scheduled_date use cancel_at to set the cancellation date.
 	// Reject if one is already in place to prevent silent overwrites.
 	if req.CancellationType == types.CancellationTypeScheduledDate ||
 		req.CancellationType == types.CancellationTypeEndOfPeriod {
@@ -5340,7 +5340,7 @@ func (s *subscriptionService) determineEffectiveDate(
 	case types.CancellationTypeScheduledDate:
 		if customDate == nil {
 			return time.Time{}, ierr.NewError("cancel_at is required for scheduled_date").
-				WithHint("Provide a future date in cancel_at").
+				WithHint("Provide a cancel_at date (past for backdated cancellation, future for scheduled cancellation)").
 				Mark(ierr.ErrValidation)
 		}
 		return customDate.UTC(), nil

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -4125,18 +4125,27 @@ func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
 		s.T().Logf("✅ scheduled_date: missing cancel_at rejected")
 	})
 
-	s.Run("validation rejects past cancel_at", func() {
+	s.Run("backdated past cancel_at is accepted", func() {
 		sub := newActiveSub("sub_sched_past_date")
 		pastDate := s.testData.now.Add(-24 * time.Hour)
 
-		_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		resp, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
 			CancellationType: types.CancellationTypeScheduledDate,
 			CancelAt:         &pastDate,
+			Reason:           "backdated_cancel",
 		})
-		s.Error(err)
-		s.True(ierr.IsValidation(err), "expected validation error")
-		s.Contains(err.Error(), "future")
-		s.T().Logf("✅ scheduled_date: past cancel_at rejected")
+		s.NoError(err)
+		s.True(resp.EffectiveDate.Equal(pastDate), "effective date should match cancel_at")
+
+		updated, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+		s.NoError(err)
+		s.NotNil(updated.CancelAt)
+		s.WithinDuration(pastDate, *updated.CancelAt, time.Second)
+		s.NotNil(updated.EndDate, "end_date must be set to the backdated cancellation date")
+		s.WithinDuration(pastDate, *updated.EndDate, time.Second)
+		s.True(updated.CancelAtPeriodEnd, "cancel_at_period_end must be true")
+		s.Equal(types.SubscriptionStatusActive, updated.SubscriptionStatus, "status stays active until schedule fires")
+		s.T().Logf("✅ scheduled_date: past cancel_at accepted for backdated cancellation")
 	})
 
 	s.Run("errors if subscription is already scheduled to cancel via end_of_period", func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified cancellation guidance and error hints so requests clearly state when a cancellation date is required or optional for each cancellation type.

* **Bug Fixes**
  * Scheduled-date cancellations with a past cancellation date (backdated) are now accepted and treated as the effective cancellation date; validation no longer rejects backdated scheduled cancellations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->