### PR TITLE
feat(tax): prevent deletion of tax rates with active associations

### DIFF
--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -926,6 +926,7 @@ func (s *subscriptionService) handleTaxRateLinking(ctx context.Context, sub *sub
 		filter.EntityType = types.TaxRateEntityTypeCustomer
 		filter.EntityID = sub.CustomerID
 		filter.AutoApply = lo.ToPtr(true)
+		filter.Status = lo.ToPtr(types.StatusPublished)
 		tenantTaxAssociations, err := taxService.ListTaxAssociations(ctx, filter)
 		if err != nil {
 			return err

--- a/internal/service/tax.go
+++ b/internal/service/tax.go
@@ -283,6 +283,29 @@ func (s *taxService) DeleteTaxRate(ctx context.Context, id string) error {
 		return err
 	}
 
+	// Block delete when the tax rate has any active association
+	taxAssociationFilter := types.NewTaxAssociationFilter()
+	taxAssociationFilter.TaxRateIDs = []string{id}
+	taxAssociationFilter.Status = lo.ToPtr(types.StatusPublished)
+	taxAssociationFilter.Limit = lo.ToPtr(1)
+	taxAssociations, err := s.TaxAssociationRepo.List(ctx, taxAssociationFilter)
+	if err != nil {
+		s.Logger.ErrorwCtx(ctx, "failed to get tax associations for tax rate",
+			"error", err,
+			"tax_rate_id", id,
+		)
+		return err
+	}
+
+	if len(taxAssociations) > 0 {
+		s.Logger.WarnwCtx(ctx, "tax rate has active associations, cannot delete",
+			"tax_rate_id", id,
+		)
+		return ierr.NewError("tax rate has active associations, cannot delete").
+			WithHint("This tax rate has active associations. Please remove all associations before deleting it.").
+			Mark(ierr.ErrValidation)
+	}
+
 	// Call the repository's Delete method which handles archiving
 	if err := s.TaxRateRepo.Delete(ctx, taxRate); err != nil {
 		s.Logger.ErrorwCtx(ctx, "failed to delete tax rate",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tax rates with active published associations can no longer be deleted, preventing data inconsistency.
  * Auto-applied customer tax associations now respect publication status, ensuring only published associations are applied when no manual overrides are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->