### PR TITLE
feat(analytics-benchmark): mirror /events/analytics through both pipelines

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,6 +138,7 @@ func main() {
 			repository.NewCostSheetUsageRepository,
 			repository.NewMeterUsageRepository,
 			repository.NewUsageBenchmarkRepository,
+			repository.NewAnalyticsBenchmarkRepository,
 			repository.NewMeterRepository,
 			repository.NewUserRepository,
 			repository.NewAuthRepository,
@@ -366,9 +367,10 @@ func provideHandlers(
 	meterUsageService service.MeterUsageService,
 	geminiPricingService service.GeminiPricingService,
 	webhookService *webhook.WebhookService,
+	usageBenchmarkService service.UsageBenchmarkService,
 ) api.Handlers {
 	return api.Handlers{
-		Events:                   v1.NewEventsHandler(eventService, eventPostProcessingService, featureUsageTrackingService, rawEventsReprocessingService, rawEventConsumptionService, meterUsageService, cfg, logger),
+		Events:                   v1.NewEventsHandler(eventService, eventPostProcessingService, featureUsageTrackingService, rawEventsReprocessingService, rawEventConsumptionService, meterUsageService, usageBenchmarkService, cfg, logger),
 		Meter:                    v1.NewMeterHandler(meterService, logger),
 		Auth:                     v1.NewAuthHandler(cfg, authService, logger),
 		User:                     v1.NewUserHandler(userService, logger),

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -474,7 +474,7 @@ func (h *EventsHandler) publishAnalyticsBenchmark(ctx context.Context, req *dto.
 		return
 	}
 	if err := h.usageBenchmarkService.PublishAnalyticsEvent(ctx, req); err != nil {
-		h.log.WarnwCtx(ctx, "analytics benchmark: failed to publish event",
+		h.log.Info(ctx, "analytics benchmark: failed to publish event",
 			"tenant_id", types.GetTenantID(ctx),
 			"error", err,
 		)

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -474,7 +474,7 @@ func (h *EventsHandler) publishAnalyticsBenchmark(ctx context.Context, req *dto.
 		return
 	}
 	if err := h.usageBenchmarkService.PublishAnalyticsEvent(ctx, req); err != nil {
-		h.log.Warnw("analytics benchmark: failed to publish event",
+		h.log.WarnwCtx(ctx, "analytics benchmark: failed to publish event",
 			"tenant_id", types.GetTenantID(ctx),
 			"error", err,
 		)

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -25,11 +26,12 @@ type EventsHandler struct {
 	rawEventsReprocessingService service.RawEventsReprocessingService
 	rawEventConsumptionService   service.RawEventConsumptionService
 	meterUsageService            service.MeterUsageService
+	usageBenchmarkService        service.UsageBenchmarkService
 	config                       *config.Configuration
 	log                          *logger.Logger
 }
 
-func NewEventsHandler(eventService service.EventService, eventPostProcessingService service.EventPostProcessingService, featureUsageTrackingService service.FeatureUsageTrackingService, rawEventsReprocessingService service.RawEventsReprocessingService, rawEventConsumptionService service.RawEventConsumptionService, meterUsageService service.MeterUsageService, config *config.Configuration, log *logger.Logger) *EventsHandler {
+func NewEventsHandler(eventService service.EventService, eventPostProcessingService service.EventPostProcessingService, featureUsageTrackingService service.FeatureUsageTrackingService, rawEventsReprocessingService service.RawEventsReprocessingService, rawEventConsumptionService service.RawEventConsumptionService, meterUsageService service.MeterUsageService, usageBenchmarkService service.UsageBenchmarkService, config *config.Configuration, log *logger.Logger) *EventsHandler {
 	return &EventsHandler{
 		eventService:                 eventService,
 		eventPostProcessingService:   eventPostProcessingService,
@@ -37,6 +39,7 @@ func NewEventsHandler(eventService service.EventService, eventPostProcessingServ
 		rawEventsReprocessingService: rawEventsReprocessingService,
 		rawEventConsumptionService:   rawEventConsumptionService,
 		meterUsageService:            meterUsageService,
+		usageBenchmarkService:        usageBenchmarkService,
 		config:                       config,
 		log:                          log,
 	}
@@ -423,6 +426,8 @@ func (h *EventsHandler) GetUsageAnalytics(c *gin.Context) {
 		return
 	}
 
+	h.publishAnalyticsBenchmark(ctx, &req)
+
 	c.JSON(http.StatusOK, response)
 }
 
@@ -453,7 +458,27 @@ func (h *EventsHandler) GetUsageAnalyticsV2(c *gin.Context) {
 		return
 	}
 
+	h.publishAnalyticsBenchmark(ctx, &req)
+
 	c.JSON(http.StatusOK, response)
+}
+
+// publishAnalyticsBenchmark fires a benchmark trigger to Kafka after the live
+// analytics response is produced. Strict fire-and-forget: gated on the per-tenant
+// feature flag, never blocks or fails the live response, errors are logged only.
+func (h *EventsHandler) publishAnalyticsBenchmark(ctx context.Context, req *dto.GetUsageAnalyticsRequest) {
+	if h.usageBenchmarkService == nil || h.config == nil {
+		return
+	}
+	if !h.config.FeatureFlag.IsUsageBenchmarkEnabled(types.GetTenantID(ctx)) {
+		return
+	}
+	if err := h.usageBenchmarkService.PublishAnalyticsEvent(ctx, req); err != nil {
+		h.log.Warnw("analytics benchmark: failed to publish event",
+			"tenant_id", types.GetTenantID(ctx),
+			"error", err,
+		)
+	}
 }
 
 func parseStartAndEndTime(startTimeStr, endTimeStr string) (time.Time, time.Time, error) {

--- a/internal/domain/events/analytics_benchmark.go
+++ b/internal/domain/events/analytics_benchmark.go
@@ -1,0 +1,64 @@
+package events
+
+import (
+	"context"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// AnalyticsBenchmarkMatchStatus is the join-side discriminator for analytics benchmark rows.
+type AnalyticsBenchmarkMatchStatus string
+
+const (
+	AnalyticsBenchmarkMatchMatched     AnalyticsBenchmarkMatchStatus = "matched"
+	AnalyticsBenchmarkMatchFeatureOnly AnalyticsBenchmarkMatchStatus = "feature_only"
+	AnalyticsBenchmarkMatchMeterOnly   AnalyticsBenchmarkMatchStatus = "meter_only"
+)
+
+// AnalyticsBenchmarkRecord is one row in the analytics_benchmark ClickHouse table.
+// One row per (feature_id, group_key) per trigger event.
+type AnalyticsBenchmarkRecord struct {
+	TenantID      string    `ch:"tenant_id"`
+	EnvironmentID string    `ch:"environment_id"`
+	EventID       string    `ch:"event_id"`
+	StartTime     time.Time `ch:"start_time"`
+	EndTime       time.Time `ch:"end_time"`
+
+	// Parsed request fields
+	ExternalCustomerID  string   `ch:"external_customer_id"`
+	ExternalCustomerIDs []string `ch:"external_customer_ids"`
+	FeatureIDs          []string `ch:"feature_ids"`
+	Sources             []string `ch:"sources"`
+	GroupBy             []string `ch:"group_by"`
+	WindowSize          string   `ch:"window_size"`
+	Expand              []string `ch:"expand"`
+	IncludeChildren     uint8    `ch:"include_children"`
+	HasPropertyFilters  uint8    `ch:"has_property_filters"`
+	RequestJSON         string   `ch:"request_json"`
+
+	// Per-item row
+	FeatureID   string                        `ch:"feature_id"`
+	GroupKey    string                        `ch:"group_key"`
+	MatchStatus AnalyticsBenchmarkMatchStatus `ch:"match_status"`
+
+	FeatureTotalUsage decimal.Decimal `ch:"feature_total_usage"`
+	MeterTotalUsage   decimal.Decimal `ch:"meter_total_usage"`
+	UsageDiff         decimal.Decimal `ch:"usage_diff"`
+
+	FeatureTotalCost decimal.Decimal `ch:"feature_total_cost"`
+	MeterTotalCost   decimal.Decimal `ch:"meter_total_cost"`
+	CostDiff         decimal.Decimal `ch:"cost_diff"`
+
+	FeatureEventCount uint64 `ch:"feature_event_count"`
+	MeterEventCount   uint64 `ch:"meter_event_count"`
+
+	Currency  string    `ch:"currency"`
+	CreatedAt time.Time `ch:"created_at"`
+}
+
+// AnalyticsBenchmarkRepository persists analytics benchmark comparison rows.
+type AnalyticsBenchmarkRepository interface {
+	// BulkInsert writes all rows from a single trigger event in one batched statement.
+	BulkInsert(ctx context.Context, records []*AnalyticsBenchmarkRecord) error
+}

--- a/internal/domain/events/usage_benchmark.go
+++ b/internal/domain/events/usage_benchmark.go
@@ -2,18 +2,40 @@ package events
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/shopspring/decimal"
 )
 
-// UsageBenchmarkEvent is the thin Kafka payload published by the wallet service.
+// UsageBenchmarkKind discriminates between benchmark event variants.
+type UsageBenchmarkKind string
+
+const (
+	// UsageBenchmarkKindSubscription is the original subscription pipeline benchmark.
+	// Empty Kind is also treated as subscription for backwards compat with in-flight events.
+	UsageBenchmarkKindSubscription UsageBenchmarkKind = "subscription"
+	// UsageBenchmarkKindAnalytics compares the feature-usage vs meter-usage analytics pipelines.
+	UsageBenchmarkKindAnalytics UsageBenchmarkKind = "analytics"
+)
+
+// UsageBenchmarkEvent is the thin Kafka payload published for benchmarking.
+// Subscription and analytics variants share the topic; consumer dispatches on Kind.
 type UsageBenchmarkEvent struct {
-	SubscriptionID string    `json:"subscription_id"`
-	StartTime      time.Time `json:"start_time"`
-	EndTime        time.Time `json:"end_time"`
-	TenantID       string    `json:"tenant_id"`
-	EnvironmentID  string    `json:"environment_id"`
+	// Kind discriminates the event variant. Empty == "subscription" for back-compat.
+	Kind UsageBenchmarkKind `json:"kind,omitempty"`
+	// TenantID and EnvironmentID are always populated.
+	TenantID      string `json:"tenant_id"`
+	EnvironmentID string `json:"environment_id"`
+
+	// Subscription-kind fields.
+	SubscriptionID string    `json:"subscription_id,omitempty"`
+	StartTime      time.Time `json:"start_time,omitempty"`
+	EndTime        time.Time `json:"end_time,omitempty"`
+
+	// Analytics-kind fields. AnalyticsRequest carries the raw dto.GetUsageAnalyticsRequest
+	// as JSON to avoid an import cycle (events <- dto would cycle through service).
+	AnalyticsRequest json.RawMessage `json:"analytics_request,omitempty"`
 }
 
 // UsageBenchmarkRecord is one row in the usage_benchmark ClickHouse table.

--- a/internal/repository/clickhouse/analytics_benchmark.go
+++ b/internal/repository/clickhouse/analytics_benchmark.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"time"
 
-	"github.com/flexprice/flexprice/internal/clickhouse"
+	"github.com/ClickHouse/clickhouse-go/v2"
+	ich "github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 )
 
 type AnalyticsBenchmarkRepository struct {
-	store  *clickhouse.ClickHouseStore
+	store  *ich.ClickHouseStore
 	logger *logger.Logger
 }
 
-func NewAnalyticsBenchmarkRepository(store *clickhouse.ClickHouseStore, logger *logger.Logger) events.AnalyticsBenchmarkRepository {
+func NewAnalyticsBenchmarkRepository(store *ich.ClickHouseStore, logger *logger.Logger) events.AnalyticsBenchmarkRepository {
 	return &AnalyticsBenchmarkRepository{store: store, logger: logger}
 }
 
@@ -23,6 +24,11 @@ func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records [
 	if len(records) == 0 {
 		return nil
 	}
+
+	// Attach settings to context
+	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_memory_usage": 90000000000,
+	}))
 
 	stmt, err := r.store.GetConn().PrepareBatch(ctx, `
 		INSERT INTO analytics_benchmark (
@@ -43,6 +49,9 @@ func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records [
 			WithHint("Failed to prepare analytics_benchmark insert").
 			Mark(ierr.ErrDatabase)
 	}
+
+	rowsInserted := 0
+	var firstInserted *events.AnalyticsBenchmarkRecord
 
 	now := time.Now().UTC()
 	for _, record := range records {
@@ -108,6 +117,15 @@ func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records [
 				WithHint("Failed to append analytics_benchmark row").
 				Mark(ierr.ErrDatabase)
 		}
+
+		rowsInserted++
+		if firstInserted == nil {
+			firstInserted = record
+		}
+	}
+
+	if rowsInserted == 0 || firstInserted == nil {
+		return nil
 	}
 
 	if err := stmt.Send(); err != nil {
@@ -118,8 +136,8 @@ func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records [
 
 	r.logger.Debugw("inserted analytics_benchmark batch",
 		"rows", len(records),
-		"event_id", records[0].EventID,
-		"tenant_id", records[0].TenantID,
+		"event_id", firstInserted.EventID,
+		"tenant_id", firstInserted.TenantID,
 	)
 
 	return nil

--- a/internal/repository/clickhouse/analytics_benchmark.go
+++ b/internal/repository/clickhouse/analytics_benchmark.go
@@ -134,7 +134,7 @@ func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records [
 			Mark(ierr.ErrDatabase)
 	}
 
-	r.logger.Debugw("inserted analytics_benchmark batch",
+	r.logger.DebugwCtx(ctx, "inserted analytics_benchmark batch",
 		"rows", len(records),
 		"event_id", firstInserted.EventID,
 		"tenant_id", firstInserted.TenantID,

--- a/internal/repository/clickhouse/analytics_benchmark.go
+++ b/internal/repository/clickhouse/analytics_benchmark.go
@@ -1,0 +1,126 @@
+package clickhouse
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/clickhouse"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+type AnalyticsBenchmarkRepository struct {
+	store  *clickhouse.ClickHouseStore
+	logger *logger.Logger
+}
+
+func NewAnalyticsBenchmarkRepository(store *clickhouse.ClickHouseStore, logger *logger.Logger) events.AnalyticsBenchmarkRepository {
+	return &AnalyticsBenchmarkRepository{store: store, logger: logger}
+}
+
+func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records []*events.AnalyticsBenchmarkRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	stmt, err := r.store.GetConn().PrepareBatch(ctx, `
+		INSERT INTO analytics_benchmark (
+			tenant_id, environment_id, event_id,
+			start_time, end_time,
+			external_customer_id, external_customer_ids,
+			feature_ids, sources, group_by, window_size, expand,
+			include_children, has_property_filters, request_json,
+			feature_id, group_key, match_status,
+			feature_total_usage, meter_total_usage, usage_diff,
+			feature_total_cost, meter_total_cost, cost_diff,
+			feature_event_count, meter_event_count,
+			currency, created_at
+		)
+	`)
+	if err != nil {
+		return ierr.WithError(err).
+			WithHint("Failed to prepare analytics_benchmark insert").
+			Mark(ierr.ErrDatabase)
+	}
+
+	now := time.Now().UTC()
+	for _, record := range records {
+		if record == nil {
+			continue
+		}
+		if record.CreatedAt.IsZero() {
+			record.CreatedAt = now
+		}
+		// ClickHouse Array columns reject nil — coerce to empty slices.
+		extCustIDs := record.ExternalCustomerIDs
+		if extCustIDs == nil {
+			extCustIDs = []string{}
+		}
+		featureIDs := record.FeatureIDs
+		if featureIDs == nil {
+			featureIDs = []string{}
+		}
+		sources := record.Sources
+		if sources == nil {
+			sources = []string{}
+		}
+		groupBy := record.GroupBy
+		if groupBy == nil {
+			groupBy = []string{}
+		}
+		expand := record.Expand
+		if expand == nil {
+			expand = []string{}
+		}
+
+		if err := stmt.Append(
+			record.TenantID,
+			record.EnvironmentID,
+			record.EventID,
+			record.StartTime,
+			record.EndTime,
+			record.ExternalCustomerID,
+			extCustIDs,
+			featureIDs,
+			sources,
+			groupBy,
+			record.WindowSize,
+			expand,
+			record.IncludeChildren,
+			record.HasPropertyFilters,
+			record.RequestJSON,
+			record.FeatureID,
+			record.GroupKey,
+			string(record.MatchStatus),
+			record.FeatureTotalUsage,
+			record.MeterTotalUsage,
+			record.UsageDiff,
+			record.FeatureTotalCost,
+			record.MeterTotalCost,
+			record.CostDiff,
+			record.FeatureEventCount,
+			record.MeterEventCount,
+			record.Currency,
+			record.CreatedAt,
+		); err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to append analytics_benchmark row").
+				Mark(ierr.ErrDatabase)
+		}
+	}
+
+	if err := stmt.Send(); err != nil {
+		return ierr.WithError(err).
+			WithHint("Failed to send analytics_benchmark insert").
+			Mark(ierr.ErrDatabase)
+	}
+
+	r.logger.Debugw("inserted analytics_benchmark batch",
+		"rows", len(records),
+		"event_id", records[0].EventID,
+		"tenant_id", records[0].TenantID,
+	)
+
+	return nil
+}

--- a/internal/repository/clickhouse/analytics_benchmark.go
+++ b/internal/repository/clickhouse/analytics_benchmark.go
@@ -134,7 +134,7 @@ func (r *AnalyticsBenchmarkRepository) BulkInsert(ctx context.Context, records [
 			Mark(ierr.ErrDatabase)
 	}
 
-	r.logger.DebugwCtx(ctx, "inserted analytics_benchmark batch",
+	r.logger.Debug(ctx, "inserted analytics_benchmark batch",
 		"rows", len(records),
 		"event_id", firstInserted.EventID,
 		"tenant_id", firstInserted.TenantID,

--- a/internal/repository/factory.go
+++ b/internal/repository/factory.go
@@ -259,6 +259,10 @@ func NewUsageBenchmarkRepository(p RepositoryParams) events.UsageBenchmarkReposi
 	return clickhouseRepo.NewUsageBenchmarkRepository(p.ClickHouseDB, p.Logger)
 }
 
+func NewAnalyticsBenchmarkRepository(p RepositoryParams) events.AnalyticsBenchmarkRepository {
+	return clickhouseRepo.NewAnalyticsBenchmarkRepository(p.ClickHouseDB, p.Logger)
+}
+
 func NewWorkflowExecutionRepository(p RepositoryParams) workflowexecution.Repository {
 	return entRepo.NewWorkflowExecutionRepository(p.EntClient, p.Logger, p.Cache)
 }

--- a/internal/service/usage_benchmark.go
+++ b/internal/service/usage_benchmark.go
@@ -18,10 +18,16 @@ import (
 )
 
 // UsageBenchmarkService publishes benchmark trigger events and consumes them
-// to compare GetFeatureUsageBySubscription against the meter_usage pipeline.
+// to compare two analytics pipelines. Two event kinds share the topic:
+//   - "subscription": GetFeatureUsageBySubscription vs GetMeterUsageBySubscription
+//   - "analytics":    featureUsageTracking GetDetailedUsageAnalytics vs meterUsage GetDetailedAnalytics
 type UsageBenchmarkService interface {
 	// PublishEvent sends a thin benchmark trigger to Kafka. Non-blocking best-effort.
 	PublishEvent(ctx context.Context, event *events.UsageBenchmarkEvent) error
+
+	// PublishAnalyticsEvent sends the analytics-kind benchmark trigger carrying the raw request.
+	// Fire-and-forget: callers should not propagate errors to the live response.
+	PublishAnalyticsEvent(ctx context.Context, req *dto.GetUsageAnalyticsRequest) error
 
 	// RegisterHandler wires the consumer into the router.
 	RegisterHandler(router *pubsubRouter.Router, cfg *config.Configuration)
@@ -29,38 +35,49 @@ type UsageBenchmarkService interface {
 
 type usageBenchmarkService struct {
 	ServiceParams
-	pubSub    pubsub.PubSub
-	benchRepo events.UsageBenchmarkRepository
+	pubSub             pubsub.PubSub
+	benchRepo          events.UsageBenchmarkRepository
+	analyticsBenchRepo events.AnalyticsBenchmarkRepository
+
+	// Injected analytics services for the analytics-kind benchmark path.
+	// Optional — if nil, the analytics dispatch silently no-ops. NewUsageBenchmarkService
+	// wires them; the wallet path uses a partial constructor that leaves them nil.
+	featureUsageTrackingService FeatureUsageTrackingService
+	meterUsageService           MeterUsageService
 }
 
-// NewUsageBenchmarkService is the production constructor wired by FX. It uses
-// the FX-singleton UsageBenchmarkPubSub from ServiceParams instead of opening
-// its own Kafka client — the previous behavior leaked a producer + consumer on
-// every call (publishBenchmarkEvent in walletService re-invokes this constructor
-// per billing iteration).
+// NewUsageBenchmarkService is the production constructor wired by FX.
 func NewUsageBenchmarkService(
 	params ServiceParams,
 	benchRepo events.UsageBenchmarkRepository,
+	analyticsBenchRepo events.AnalyticsBenchmarkRepository,
+	featureUsageTrackingService FeatureUsageTrackingService,
+	meterUsageService MeterUsageService,
 ) UsageBenchmarkService {
 	return &usageBenchmarkService{
-		ServiceParams: params,
-		benchRepo:     benchRepo,
-		pubSub:        params.UsageBenchmarkPubSub.PubSub,
+		ServiceParams:               params,
+		benchRepo:                   benchRepo,
+		analyticsBenchRepo:          analyticsBenchRepo,
+		pubSub:                      params.UsageBenchmarkPubSub.PubSub,
+		featureUsageTrackingService: featureUsageTrackingService,
+		meterUsageService:           meterUsageService,
 	}
 }
 
 // NewUsageBenchmarkServiceForTest builds a minimal service using injected deps (test only).
 func NewUsageBenchmarkServiceForTest(
 	benchRepo events.UsageBenchmarkRepository,
+	analyticsBenchRepo events.AnalyticsBenchmarkRepository,
 	ps pubsub.PubSub,
 ) *usageBenchmarkService {
 	return &usageBenchmarkService{
-		pubSub:    ps,
-		benchRepo: benchRepo,
+		pubSub:             ps,
+		benchRepo:          benchRepo,
+		analyticsBenchRepo: analyticsBenchRepo,
 	}
 }
 
-// PublishEvent marshals and publishes a UsageBenchmarkEvent.
+// PublishEvent marshals and publishes a UsageBenchmarkEvent (any kind).
 func (s *usageBenchmarkService) PublishEvent(ctx context.Context, event *events.UsageBenchmarkEvent) error {
 	if s.pubSub == nil {
 		return nil
@@ -75,7 +92,13 @@ func (s *usageBenchmarkService) PublishEvent(ctx context.Context, event *events.
 		return fmt.Errorf("usage benchmark: failed to marshal event: %w", err)
 	}
 
-	msg := message.NewMessage(fmt.Sprintf("bench-%s-%d", event.SubscriptionID, time.Now().UnixNano()), payload)
+	// Use SubscriptionID in the watermill UUID when present so subscription-kind
+	// events remain debuggable; analytics-kind events fall back to a timestamp suffix.
+	msgID := fmt.Sprintf("bench-%s-%d", event.SubscriptionID, time.Now().UnixNano())
+	if event.Kind == events.UsageBenchmarkKindAnalytics {
+		msgID = fmt.Sprintf("bench-analytics-%d", time.Now().UnixNano())
+	}
+	msg := message.NewMessage(msgID, payload)
 	msg.Metadata.Set("tenant_id", event.TenantID)
 	msg.Metadata.Set("environment_id", event.EnvironmentID)
 
@@ -84,6 +107,32 @@ func (s *usageBenchmarkService) PublishEvent(ctx context.Context, event *events.
 		return fmt.Errorf("usage benchmark: failed to publish to %s: %w", topic, err)
 	}
 	return nil
+}
+
+// PublishAnalyticsEvent wraps a request into an analytics-kind event and publishes it.
+// Fire-and-forget contract: callers (HTTP handlers) must not block or fail on errors.
+func (s *usageBenchmarkService) PublishAnalyticsEvent(ctx context.Context, req *dto.GetUsageAnalyticsRequest) error {
+	if req == nil {
+		return nil
+	}
+	if s.pubSub == nil || s.Config == nil {
+		return nil
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("usage benchmark: failed to marshal analytics request: %w", err)
+	}
+
+	evt := &events.UsageBenchmarkEvent{
+		Kind:             events.UsageBenchmarkKindAnalytics,
+		TenantID:         types.GetTenantID(ctx),
+		EnvironmentID:    types.GetEnvironmentID(ctx),
+		StartTime:        req.StartTime,
+		EndTime:          req.EndTime,
+		AnalyticsRequest: raw,
+	}
+	return s.PublishEvent(ctx, evt)
 }
 
 // RegisterHandler wires the benchmark consumer into the watermill router.
@@ -115,6 +164,8 @@ func (s *usageBenchmarkService) processMessage(msg *message.Message) error {
 }
 
 // ProcessMessageForTest is exported so unit tests can call it directly.
+// Dispatches by event Kind; empty Kind is treated as subscription for back-compat
+// with events already in flight when this code rolled out.
 func (s *usageBenchmarkService) ProcessMessageForTest(msg *message.Message) error {
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
@@ -131,8 +182,22 @@ func (s *usageBenchmarkService) ProcessMessageForTest(msg *message.Message) erro
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 
-	featureAmt, featureCurrency := s.callFeatureUsagePipeline(ctx, &evt)
-	meterAmt, meterCurrency := s.callMeterUsagePipeline(ctx, &evt)
+	switch evt.Kind {
+	case events.UsageBenchmarkKindAnalytics:
+		return s.processAnalyticsMessage(ctx, msg, &evt)
+	default:
+		// Empty Kind == subscription (back-compat).
+		return s.processSubscriptionMessage(ctx, msg, &evt)
+	}
+}
+
+// processSubscriptionMessage holds the original subscription-pipeline benchmark logic.
+func (s *usageBenchmarkService) processSubscriptionMessage(ctx context.Context, _ *message.Message, evt *events.UsageBenchmarkEvent) error {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	featureAmt, featureCurrency := s.callFeatureUsagePipeline(ctx, evt)
+	meterAmt, meterCurrency := s.callMeterUsagePipeline(ctx, evt)
 
 	// Prefer feature pipeline's currency (source of truth); fall back to meter
 	// pipeline's currency if the feature call returned no result.
@@ -206,9 +271,7 @@ func (s *usageBenchmarkService) callFeatureUsagePipeline(ctx context.Context, ev
 }
 
 // callMeterUsagePipeline calls GetMeterUsageBySubscription. Returns (0, "") on
-// error so the benchmark insert still succeeds with a recorded diff. The
-// shared subscription service is constructed per call to avoid holding stale
-// references; this matches the feature-pipeline path.
+// error so the benchmark insert still succeeds with a recorded diff.
 func (s *usageBenchmarkService) callMeterUsagePipeline(ctx context.Context, evt *events.UsageBenchmarkEvent) (decimal.Decimal, string) {
 	if s.MeterUsageRepo == nil {
 		return decimal.Zero, ""

--- a/internal/service/usage_benchmark_analytics.go
+++ b/internal/service/usage_benchmark_analytics.go
@@ -20,13 +20,13 @@ import (
 func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg *message.Message, evt *events.UsageBenchmarkEvent) error {
 	if s.analyticsBenchRepo == nil {
 		if s.Logger != nil {
-			s.Logger.Warnw("usage benchmark: analytics repo not wired, skipping analytics event")
+			s.Logger.WarnwCtx(ctx, "usage benchmark: analytics repo not wired, skipping analytics event")
 		}
 		return nil
 	}
 	if len(evt.AnalyticsRequest) == 0 {
 		if s.Logger != nil {
-			s.Logger.Warnw("usage benchmark: analytics event missing request body, skipping")
+			s.Logger.WarnwCtx(ctx, "usage benchmark: analytics event missing request body, skipping")
 		}
 		return nil
 	}
@@ -34,7 +34,7 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 	var req dto.GetUsageAnalyticsRequest
 	if err := json.Unmarshal(evt.AnalyticsRequest, &req); err != nil {
 		if s.Logger != nil {
-			s.Logger.Errorw("usage benchmark: failed to unmarshal analytics request", "error", err)
+			s.Logger.ErrorwCtx(ctx, "usage benchmark: failed to unmarshal analytics request", "error", err)
 		}
 		return nil
 	}
@@ -43,13 +43,13 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 	meterResp, meterErr := s.callAnalyticsMeterPipeline(ctx, &req)
 
 	if featureErr != nil && s.Logger != nil {
-		s.Logger.Warnw("usage benchmark: analytics feature pipeline failed",
+		s.Logger.WarnwCtx(ctx, "usage benchmark: analytics feature pipeline failed",
 			"tenant_id", evt.TenantID,
 			"error", featureErr,
 		)
 	}
 	if meterErr != nil && s.Logger != nil {
-		s.Logger.Warnw("usage benchmark: analytics meter pipeline failed",
+		s.Logger.WarnwCtx(ctx, "usage benchmark: analytics meter pipeline failed",
 			"tenant_id", evt.TenantID,
 			"error", meterErr,
 		)
@@ -113,7 +113,7 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 
 	if err := s.analyticsBenchRepo.BulkInsert(ctx, records); err != nil {
 		if s.Logger != nil {
-			s.Logger.Errorw("usage benchmark: failed to bulk insert analytics rows",
+			s.Logger.ErrorwCtx(ctx, "usage benchmark: failed to bulk insert analytics rows",
 				"event_id", eventID,
 				"rows", len(records),
 				"error", err,

--- a/internal/service/usage_benchmark_analytics.go
+++ b/internal/service/usage_benchmark_analytics.go
@@ -1,0 +1,309 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// processAnalyticsMessage handles analytics-kind benchmark events. It replays the
+// captured request through both pipelines, joins the per-(feature_id, group_key)
+// items, and writes one row per joined item to analytics_benchmark.
+func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg *message.Message, evt *events.UsageBenchmarkEvent) error {
+	if s.analyticsBenchRepo == nil {
+		if s.Logger != nil {
+			s.Logger.Warnw("usage benchmark: analytics repo not wired, skipping analytics event")
+		}
+		return nil
+	}
+	if len(evt.AnalyticsRequest) == 0 {
+		if s.Logger != nil {
+			s.Logger.Warnw("usage benchmark: analytics event missing request body, skipping")
+		}
+		return nil
+	}
+
+	var req dto.GetUsageAnalyticsRequest
+	if err := json.Unmarshal(evt.AnalyticsRequest, &req); err != nil {
+		if s.Logger != nil {
+			s.Logger.Errorw("usage benchmark: failed to unmarshal analytics request", "error", err)
+		}
+		return nil
+	}
+
+	featureResp, featureErr := s.callAnalyticsFeaturePipeline(ctx, &req)
+	meterResp, meterErr := s.callAnalyticsMeterPipeline(ctx, &req)
+
+	if featureErr != nil && s.Logger != nil {
+		s.Logger.Warnw("usage benchmark: analytics feature pipeline failed",
+			"tenant_id", evt.TenantID,
+			"error", featureErr,
+		)
+	}
+	if meterErr != nil && s.Logger != nil {
+		s.Logger.Warnw("usage benchmark: analytics meter pipeline failed",
+			"tenant_id", evt.TenantID,
+			"error", meterErr,
+		)
+	}
+
+	featureItems := []dto.UsageAnalyticItem{}
+	meterItems := []dto.UsageAnalyticItem{}
+	currency := ""
+	if featureResp != nil {
+		featureItems = featureResp.Items
+		currency = featureResp.Currency
+	}
+	if meterResp != nil {
+		meterItems = meterResp.Items
+		if currency == "" {
+			currency = meterResp.Currency
+		}
+	}
+
+	records := joinAnalyticsResults(featureItems, meterItems)
+	if len(records) == 0 {
+		// Nothing to write — still no-op ack.
+		return nil
+	}
+
+	eventID := msg.UUID
+	if eventID == "" {
+		eventID = types.GenerateUUID()
+	}
+
+	parsed := extractRequestFields(&req, evt.AnalyticsRequest)
+	now := time.Now().UTC()
+	startTime := evt.StartTime
+	if startTime.IsZero() {
+		startTime = req.StartTime
+	}
+	endTime := evt.EndTime
+	if endTime.IsZero() {
+		endTime = req.EndTime
+	}
+
+	for _, r := range records {
+		r.TenantID = evt.TenantID
+		r.EnvironmentID = evt.EnvironmentID
+		r.EventID = eventID
+		r.StartTime = startTime
+		r.EndTime = endTime
+		r.ExternalCustomerID = parsed.ExternalCustomerID
+		r.ExternalCustomerIDs = parsed.ExternalCustomerIDs
+		r.FeatureIDs = parsed.FeatureIDs
+		r.Sources = parsed.Sources
+		r.GroupBy = parsed.GroupBy
+		r.WindowSize = parsed.WindowSize
+		r.Expand = parsed.Expand
+		r.IncludeChildren = parsed.IncludeChildren
+		r.HasPropertyFilters = parsed.HasPropertyFilters
+		r.RequestJSON = parsed.RequestJSON
+		r.Currency = currency
+		r.CreatedAt = now
+	}
+
+	if err := s.analyticsBenchRepo.BulkInsert(ctx, records); err != nil {
+		if s.Logger != nil {
+			s.Logger.Errorw("usage benchmark: failed to bulk insert analytics rows",
+				"event_id", eventID,
+				"rows", len(records),
+				"error", err,
+			)
+		}
+		// Ack anyway — benchmark data is non-critical.
+	}
+	return nil
+}
+
+// callAnalyticsFeaturePipeline invokes the feature-usage tracking analytics service.
+func (s *usageBenchmarkService) callAnalyticsFeaturePipeline(ctx context.Context, req *dto.GetUsageAnalyticsRequest) (*dto.GetUsageAnalyticsResponse, error) {
+	if s.featureUsageTrackingService == nil {
+		return nil, nil
+	}
+	// Pass-by-value copy: the live handler hands the same request to its target
+	// service, so callers may mutate downstream — keep our copy isolated.
+	reqCopy := *req
+	return s.featureUsageTrackingService.GetDetailedUsageAnalytics(ctx, &reqCopy)
+}
+
+// callAnalyticsMeterPipeline invokes the meter-usage analytics service mirroring the handler params.
+func (s *usageBenchmarkService) callAnalyticsMeterPipeline(ctx context.Context, req *dto.GetUsageAnalyticsRequest) (*dto.GetUsageAnalyticsResponse, error) {
+	if s.meterUsageService == nil {
+		return nil, nil
+	}
+	params := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:            types.GetTenantID(ctx),
+		EnvironmentID:       types.GetEnvironmentID(ctx),
+		ExternalCustomerID:  req.ExternalCustomerID,
+		ExternalCustomerIDs: req.ExternalCustomerIDs,
+		FeatureIDs:          req.FeatureIDs,
+		StartTime:           req.StartTime,
+		EndTime:             req.EndTime,
+		GroupBy:             req.GroupBy,
+		PropertyFilters:     req.PropertyFilters,
+		Sources:             req.Sources,
+		WindowSize:          req.WindowSize,
+		Expand:              req.Expand,
+		IncludeChildren:     req.IncludeChildren,
+	}
+	return s.meterUsageService.GetDetailedAnalytics(ctx, params)
+}
+
+// canonicalGroupKey produces a deterministic group-key string for an analytics
+// item by walking Source/Sources + Properties in sorted-key order so feature and
+// meter results can be joined regardless of map iteration order.
+func canonicalGroupKey(item *dto.UsageAnalyticItem) string {
+	if item == nil {
+		return ""
+	}
+	parts := make([]string, 0, 1+len(item.Properties))
+
+	// Source first. Prefer the singular Source (set when grouping by source);
+	// otherwise fall back to a sorted join of Sources so the key stays stable
+	// when the result type carries the multi-source variant.
+	if item.Source != "" {
+		parts = append(parts, "source="+item.Source)
+	} else if len(item.Sources) > 0 {
+		sortedSources := make([]string, len(item.Sources))
+		copy(sortedSources, item.Sources)
+		sort.Strings(sortedSources)
+		parts = append(parts, "sources="+strings.Join(sortedSources, ","))
+	}
+
+	if len(item.Properties) > 0 {
+		keys := make([]string, 0, len(item.Properties))
+		for k := range item.Properties {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			parts = append(parts, "properties."+k+"="+item.Properties[k])
+		}
+	}
+
+	return strings.Join(parts, "|")
+}
+
+// joinAnalyticsResults outer-joins two pipelines' items by (feature_id, group_key)
+// and emits one AnalyticsBenchmarkRecord per joined item. Tenant/env/event_id/
+// request fields are filled by the caller.
+func joinAnalyticsResults(featureItems, meterItems []dto.UsageAnalyticItem) []*events.AnalyticsBenchmarkRecord {
+	type joinKey struct {
+		featureID string
+		groupKey  string
+	}
+
+	featureMap := make(map[joinKey]*dto.UsageAnalyticItem, len(featureItems))
+	for i := range featureItems {
+		k := joinKey{featureID: featureItems[i].FeatureID, groupKey: canonicalGroupKey(&featureItems[i])}
+		featureMap[k] = &featureItems[i]
+	}
+	meterMap := make(map[joinKey]*dto.UsageAnalyticItem, len(meterItems))
+	for i := range meterItems {
+		k := joinKey{featureID: meterItems[i].FeatureID, groupKey: canonicalGroupKey(&meterItems[i])}
+		meterMap[k] = &meterItems[i]
+	}
+
+	// Sort keys for deterministic insert order so multiple test runs / replays
+	// produce the same ClickHouse ordering for a given event_id.
+	seen := make(map[joinKey]struct{}, len(featureMap)+len(meterMap))
+	keys := make([]joinKey, 0, len(featureMap)+len(meterMap))
+	for k := range featureMap {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	for k := range meterMap {
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].featureID != keys[j].featureID {
+			return keys[i].featureID < keys[j].featureID
+		}
+		return keys[i].groupKey < keys[j].groupKey
+	})
+
+	records := make([]*events.AnalyticsBenchmarkRecord, 0, len(keys))
+	for _, k := range keys {
+		fItem, fOk := featureMap[k]
+		mItem, mOk := meterMap[k]
+
+		rec := &events.AnalyticsBenchmarkRecord{
+			FeatureID: k.featureID,
+			GroupKey:  k.groupKey,
+		}
+		switch {
+		case fOk && mOk:
+			rec.MatchStatus = events.AnalyticsBenchmarkMatchMatched
+			rec.FeatureTotalUsage = fItem.TotalUsage
+			rec.FeatureTotalCost = fItem.TotalCost
+			rec.FeatureEventCount = fItem.EventCount
+			rec.MeterTotalUsage = mItem.TotalUsage
+			rec.MeterTotalCost = mItem.TotalCost
+			rec.MeterEventCount = mItem.EventCount
+		case fOk:
+			rec.MatchStatus = events.AnalyticsBenchmarkMatchFeatureOnly
+			rec.FeatureTotalUsage = fItem.TotalUsage
+			rec.FeatureTotalCost = fItem.TotalCost
+			rec.FeatureEventCount = fItem.EventCount
+		case mOk:
+			rec.MatchStatus = events.AnalyticsBenchmarkMatchMeterOnly
+			rec.MeterTotalUsage = mItem.TotalUsage
+			rec.MeterTotalCost = mItem.TotalCost
+			rec.MeterEventCount = mItem.EventCount
+		}
+		rec.UsageDiff = rec.FeatureTotalUsage.Sub(rec.MeterTotalUsage)
+		rec.CostDiff = rec.FeatureTotalCost.Sub(rec.MeterTotalCost)
+		records = append(records, rec)
+	}
+	return records
+}
+
+// parsedRequestFields holds the fields we promote from GetUsageAnalyticsRequest
+// to dedicated ClickHouse columns for SQL filtering.
+type parsedRequestFields struct {
+	ExternalCustomerID  string
+	ExternalCustomerIDs []string
+	FeatureIDs          []string
+	Sources             []string
+	GroupBy             []string
+	WindowSize          string
+	Expand              []string
+	IncludeChildren     uint8
+	HasPropertyFilters  uint8
+	RequestJSON         string
+}
+
+func extractRequestFields(req *dto.GetUsageAnalyticsRequest, raw json.RawMessage) parsedRequestFields {
+	p := parsedRequestFields{
+		ExternalCustomerID:  req.ExternalCustomerID,
+		ExternalCustomerIDs: req.ExternalCustomerIDs,
+		FeatureIDs:          req.FeatureIDs,
+		Sources:             req.Sources,
+		GroupBy:             req.GroupBy,
+		WindowSize:          string(req.WindowSize),
+		Expand:              req.Expand,
+	}
+	if req.IncludeChildren {
+		p.IncludeChildren = 1
+	}
+	if len(req.PropertyFilters) > 0 {
+		p.HasPropertyFilters = 1
+	}
+	if len(raw) > 0 {
+		p.RequestJSON = string(raw)
+	}
+	return p
+}

--- a/internal/service/usage_benchmark_analytics.go
+++ b/internal/service/usage_benchmark_analytics.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -38,7 +39,7 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 		return nil
 	}
 
-	featureResp, featureErr := s.callAnalyticsFeaturePipeline(ctx, &req)
+	featureResp, featureErr := s.callAnalyticsFeaturePipeline(ctx, req)
 	meterResp, meterErr := s.callAnalyticsMeterPipeline(ctx, &req)
 
 	if featureErr != nil && s.Logger != nil {
@@ -124,13 +125,13 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 }
 
 // callAnalyticsFeaturePipeline invokes the feature-usage tracking analytics service.
-func (s *usageBenchmarkService) callAnalyticsFeaturePipeline(ctx context.Context, req *dto.GetUsageAnalyticsRequest) (*dto.GetUsageAnalyticsResponse, error) {
+func (s *usageBenchmarkService) callAnalyticsFeaturePipeline(ctx context.Context, req dto.GetUsageAnalyticsRequest) (*dto.GetUsageAnalyticsResponse, error) {
 	if s.featureUsageTrackingService == nil {
 		return nil, nil
 	}
 	// Pass-by-value copy: the live handler hands the same request to its target
 	// service, so callers may mutate downstream — keep our copy isolated.
-	reqCopy := *req
+	reqCopy := req
 	return s.featureUsageTrackingService.GetDetailedUsageAnalytics(ctx, &reqCopy)
 }
 
@@ -169,13 +170,19 @@ func canonicalGroupKey(item *dto.UsageAnalyticItem) string {
 	// Source first. Prefer the singular Source (set when grouping by source);
 	// otherwise fall back to a sorted join of Sources so the key stays stable
 	// when the result type carries the multi-source variant.
+	// User-derived strings are percent-encoded so the '=', '|' and ',' delimiters
+	// can't appear in payload values and collide with structural separators.
 	if item.Source != "" {
-		parts = append(parts, "source="+item.Source)
+		parts = append(parts, "source="+url.QueryEscape(item.Source))
 	} else if len(item.Sources) > 0 {
 		sortedSources := make([]string, len(item.Sources))
 		copy(sortedSources, item.Sources)
 		sort.Strings(sortedSources)
-		parts = append(parts, "sources="+strings.Join(sortedSources, ","))
+		encoded := make([]string, len(sortedSources))
+		for i, s := range sortedSources {
+			encoded[i] = url.QueryEscape(s)
+		}
+		parts = append(parts, "sources="+strings.Join(encoded, ","))
 	}
 
 	if len(item.Properties) > 0 {
@@ -185,7 +192,7 @@ func canonicalGroupKey(item *dto.UsageAnalyticItem) string {
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			parts = append(parts, "properties."+k+"="+item.Properties[k])
+			parts = append(parts, "properties."+url.QueryEscape(k)+"="+url.QueryEscape(item.Properties[k]))
 		}
 	}
 

--- a/internal/service/usage_benchmark_analytics.go
+++ b/internal/service/usage_benchmark_analytics.go
@@ -20,13 +20,13 @@ import (
 func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg *message.Message, evt *events.UsageBenchmarkEvent) error {
 	if s.analyticsBenchRepo == nil {
 		if s.Logger != nil {
-			s.Logger.WarnwCtx(ctx, "usage benchmark: analytics repo not wired, skipping analytics event")
+			s.Logger.Info(ctx, "usage benchmark: analytics repo not wired, skipping analytics event")
 		}
 		return nil
 	}
 	if len(evt.AnalyticsRequest) == 0 {
 		if s.Logger != nil {
-			s.Logger.WarnwCtx(ctx, "usage benchmark: analytics event missing request body, skipping")
+			s.Logger.Info(ctx, "usage benchmark: analytics event missing request body, skipping")
 		}
 		return nil
 	}
@@ -34,7 +34,7 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 	var req dto.GetUsageAnalyticsRequest
 	if err := json.Unmarshal(evt.AnalyticsRequest, &req); err != nil {
 		if s.Logger != nil {
-			s.Logger.ErrorwCtx(ctx, "usage benchmark: failed to unmarshal analytics request", "error", err)
+			s.Logger.Error(ctx, "usage benchmark: failed to unmarshal analytics request", "error", err)
 		}
 		return nil
 	}
@@ -43,13 +43,13 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 	meterResp, meterErr := s.callAnalyticsMeterPipeline(ctx, &req)
 
 	if featureErr != nil && s.Logger != nil {
-		s.Logger.WarnwCtx(ctx, "usage benchmark: analytics feature pipeline failed",
+		s.Logger.Info(ctx, "usage benchmark: analytics feature pipeline failed",
 			"tenant_id", evt.TenantID,
 			"error", featureErr,
 		)
 	}
 	if meterErr != nil && s.Logger != nil {
-		s.Logger.WarnwCtx(ctx, "usage benchmark: analytics meter pipeline failed",
+		s.Logger.Info(ctx, "usage benchmark: analytics meter pipeline failed",
 			"tenant_id", evt.TenantID,
 			"error", meterErr,
 		)
@@ -113,7 +113,7 @@ func (s *usageBenchmarkService) processAnalyticsMessage(ctx context.Context, msg
 
 	if err := s.analyticsBenchRepo.BulkInsert(ctx, records); err != nil {
 		if s.Logger != nil {
-			s.Logger.ErrorwCtx(ctx, "usage benchmark: failed to bulk insert analytics rows",
+			s.Logger.Error(ctx, "usage benchmark: failed to bulk insert analytics rows",
 				"event_id", eventID,
 				"rows", len(records),
 				"error", err,

--- a/internal/service/usage_benchmark_analytics_test.go
+++ b/internal/service/usage_benchmark_analytics_test.go
@@ -1,0 +1,280 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUsageBenchmark_CanonicalGroupKey verifies the group key is stable across
+// map iteration orders for the same Source+Properties combination.
+func TestUsageBenchmark_CanonicalGroupKey(t *testing.T) {
+	cases := []struct {
+		name string
+		item dto.UsageAnalyticItem
+		want string
+	}{
+		{
+			name: "empty item",
+			item: dto.UsageAnalyticItem{},
+			want: "",
+		},
+		{
+			name: "source only",
+			item: dto.UsageAnalyticItem{Source: "stripe"},
+			want: "source=stripe",
+		},
+		{
+			name: "sources slice sorted",
+			item: dto.UsageAnalyticItem{Sources: []string{"stripe", "api", "import"}},
+			want: "sources=api,import,stripe",
+		},
+		{
+			name: "properties sorted",
+			item: dto.UsageAnalyticItem{
+				Source: "api",
+				Properties: map[string]string{
+					"region": "us-east-1",
+					"model":  "gpt-4",
+				},
+			},
+			want: "source=api|properties.model=gpt-4|properties.region=us-east-1",
+		},
+		{
+			name: "properties only no source",
+			item: dto.UsageAnalyticItem{
+				Properties: map[string]string{"x": "1"},
+			},
+			want: "properties.x=1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := canonicalGroupKey(&tc.item)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("stable across iterations", func(t *testing.T) {
+		item := dto.UsageAnalyticItem{
+			Source: "api",
+			Properties: map[string]string{
+				"a": "1", "b": "2", "c": "3", "d": "4", "e": "5",
+			},
+		}
+		first := canonicalGroupKey(&item)
+		for i := 0; i < 100; i++ {
+			require.Equal(t, first, canonicalGroupKey(&item))
+		}
+	})
+}
+
+// TestUsageBenchmark_JoinAnalyticsResults verifies outer-join semantics: items
+// only in feature side → feature_only; only in meter → meter_only; in both → matched.
+func TestUsageBenchmark_JoinAnalyticsResults(t *testing.T) {
+	feature := []dto.UsageAnalyticItem{
+		{
+			FeatureID:  "feat_1",
+			Source:     "api",
+			TotalUsage: decimal.NewFromInt(100),
+			TotalCost:  decimal.NewFromInt(10),
+			EventCount: 5,
+		},
+		{
+			FeatureID:  "feat_2",
+			Source:     "stripe",
+			TotalUsage: decimal.NewFromInt(50),
+			TotalCost:  decimal.NewFromInt(5),
+			EventCount: 2,
+		},
+	}
+	meter := []dto.UsageAnalyticItem{
+		{
+			FeatureID:  "feat_1",
+			Source:     "api",
+			TotalUsage: decimal.NewFromInt(99),
+			TotalCost:  decimal.NewFromInt(10),
+			EventCount: 5,
+		},
+		{
+			FeatureID:  "feat_3",
+			Source:     "import",
+			TotalUsage: decimal.NewFromInt(7),
+			TotalCost:  decimal.NewFromInt(1),
+			EventCount: 1,
+		},
+	}
+
+	records := joinAnalyticsResults(feature, meter)
+	require.Len(t, records, 3)
+
+	byKey := make(map[string]*events.AnalyticsBenchmarkRecord, len(records))
+	for _, r := range records {
+		byKey[r.FeatureID+"|"+r.GroupKey] = r
+	}
+
+	matched := byKey["feat_1|source=api"]
+	require.NotNil(t, matched)
+	require.Equal(t, events.AnalyticsBenchmarkMatchMatched, matched.MatchStatus)
+	require.True(t, matched.FeatureTotalUsage.Equal(decimal.NewFromInt(100)))
+	require.True(t, matched.MeterTotalUsage.Equal(decimal.NewFromInt(99)))
+	require.True(t, matched.UsageDiff.Equal(decimal.NewFromInt(1)))
+	require.Equal(t, uint64(5), matched.FeatureEventCount)
+	require.Equal(t, uint64(5), matched.MeterEventCount)
+
+	featureOnly := byKey["feat_2|source=stripe"]
+	require.NotNil(t, featureOnly)
+	require.Equal(t, events.AnalyticsBenchmarkMatchFeatureOnly, featureOnly.MatchStatus)
+	require.True(t, featureOnly.FeatureTotalUsage.Equal(decimal.NewFromInt(50)))
+	require.True(t, featureOnly.MeterTotalUsage.IsZero())
+	require.True(t, featureOnly.UsageDiff.Equal(decimal.NewFromInt(50)))
+	require.Equal(t, uint64(2), featureOnly.FeatureEventCount)
+	require.Equal(t, uint64(0), featureOnly.MeterEventCount)
+
+	meterOnly := byKey["feat_3|source=import"]
+	require.NotNil(t, meterOnly)
+	require.Equal(t, events.AnalyticsBenchmarkMatchMeterOnly, meterOnly.MatchStatus)
+	require.True(t, meterOnly.FeatureTotalUsage.IsZero())
+	require.True(t, meterOnly.MeterTotalUsage.Equal(decimal.NewFromInt(7)))
+	require.True(t, meterOnly.UsageDiff.Equal(decimal.NewFromInt(-7)))
+	require.Equal(t, uint64(0), meterOnly.FeatureEventCount)
+	require.Equal(t, uint64(1), meterOnly.MeterEventCount)
+}
+
+// TestUsageBenchmark_ExtractRequestFields verifies request fields promote correctly.
+func TestUsageBenchmark_ExtractRequestFields(t *testing.T) {
+	req := &dto.GetUsageAnalyticsRequest{
+		ExternalCustomerID:  "cust_1",
+		ExternalCustomerIDs: []string{"cust_2", "cust_3"},
+		FeatureIDs:          []string{"feat_a"},
+		Sources:             []string{"stripe"},
+		GroupBy:             []string{"source", "feature_id"},
+		WindowSize:          "HOUR",
+		Expand:              []string{"price", "meter"},
+		PropertyFilters:     map[string][]string{"model": {"gpt-4"}},
+		IncludeChildren:     true,
+	}
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	got := extractRequestFields(req, raw)
+	require.Equal(t, "cust_1", got.ExternalCustomerID)
+	require.Equal(t, []string{"cust_2", "cust_3"}, got.ExternalCustomerIDs)
+	require.Equal(t, []string{"feat_a"}, got.FeatureIDs)
+	require.Equal(t, []string{"stripe"}, got.Sources)
+	require.Equal(t, []string{"source", "feature_id"}, got.GroupBy)
+	require.Equal(t, "HOUR", got.WindowSize)
+	require.Equal(t, []string{"price", "meter"}, got.Expand)
+	require.Equal(t, uint8(1), got.IncludeChildren)
+	require.Equal(t, uint8(1), got.HasPropertyFilters)
+	require.NotEmpty(t, got.RequestJSON)
+}
+
+// TestUsageBenchmark_DispatchByKind verifies the ProcessMessageForTest dispatcher
+// routes subscription-kind and empty-kind events to the subscription path, and
+// analytics-kind events to the analytics path. We use a stub repo to detect which
+// codepath was hit without invoking real pipelines.
+func TestUsageBenchmark_DispatchByKind(t *testing.T) {
+	t.Run("empty kind treated as subscription", func(t *testing.T) {
+		stub := &stubSubscriptionBenchRepo{}
+		svc := &usageBenchmarkService{benchRepo: stub}
+
+		evt := events.UsageBenchmarkEvent{
+			SubscriptionID: "sub_1",
+			StartTime:      time.Now().Add(-time.Hour),
+			EndTime:        time.Now(),
+			TenantID:       "tenant_1",
+			EnvironmentID:  "env_1",
+		}
+		payload, err := json.Marshal(evt)
+		require.NoError(t, err)
+		msg := message.NewMessage("test-1", payload)
+		msg.Metadata.Set("tenant_id", evt.TenantID)
+		msg.Metadata.Set("environment_id", evt.EnvironmentID)
+
+		require.NoError(t, svc.ProcessMessageForTest(msg))
+		require.Equal(t, 1, stub.calls, "subscription benchRepo.Insert should be called for empty Kind")
+	})
+
+	t.Run("explicit subscription kind", func(t *testing.T) {
+		stub := &stubSubscriptionBenchRepo{}
+		svc := &usageBenchmarkService{benchRepo: stub}
+
+		evt := events.UsageBenchmarkEvent{
+			Kind:           events.UsageBenchmarkKindSubscription,
+			SubscriptionID: "sub_2",
+			StartTime:      time.Now().Add(-time.Hour),
+			EndTime:        time.Now(),
+			TenantID:       "tenant_1",
+			EnvironmentID:  "env_1",
+		}
+		payload, err := json.Marshal(evt)
+		require.NoError(t, err)
+		msg := message.NewMessage("test-2", payload)
+
+		require.NoError(t, svc.ProcessMessageForTest(msg))
+		require.Equal(t, 1, stub.calls)
+	})
+
+	t.Run("analytics kind routes to analytics path", func(t *testing.T) {
+		stubAnalytics := &stubAnalyticsBenchRepo{}
+		svc := &usageBenchmarkService{
+			analyticsBenchRepo: stubAnalytics,
+			// no featureUsageTrackingService / meterUsageService → both sides return empty
+		}
+
+		req := dto.GetUsageAnalyticsRequest{
+			ExternalCustomerID: "cust_1",
+			StartTime:          time.Now().Add(-time.Hour),
+			EndTime:            time.Now(),
+		}
+		raw, err := json.Marshal(&req)
+		require.NoError(t, err)
+
+		evt := events.UsageBenchmarkEvent{
+			Kind:             events.UsageBenchmarkKindAnalytics,
+			TenantID:         "tenant_1",
+			EnvironmentID:    "env_1",
+			StartTime:        req.StartTime,
+			EndTime:          req.EndTime,
+			AnalyticsRequest: raw,
+		}
+		payload, err := json.Marshal(evt)
+		require.NoError(t, err)
+		msg := message.NewMessage("test-3", payload)
+
+		require.NoError(t, svc.ProcessMessageForTest(msg))
+		// Both pipelines return nil → no records → BulkInsert NOT called.
+		require.Equal(t, 0, stubAnalytics.calls)
+	})
+}
+
+// --- test stubs ---
+
+type stubSubscriptionBenchRepo struct {
+	calls int
+}
+
+func (s *stubSubscriptionBenchRepo) Insert(_ context.Context, _ *events.UsageBenchmarkRecord) error {
+	s.calls++
+	return nil
+}
+
+type stubAnalyticsBenchRepo struct {
+	calls int
+	rows  int
+}
+
+func (s *stubAnalyticsBenchRepo) BulkInsert(_ context.Context, records []*events.AnalyticsBenchmarkRecord) error {
+	s.calls++
+	s.rows += len(records)
+	return nil
+}

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -3555,7 +3555,7 @@ func (s *walletService) getWalletRealtimeBalanceFromCache(ctx context.Context, w
 // publishBenchmarkEvent publishes a usage benchmark event to Kafka.
 // Fire-and-forget: errors are logged but never returned to the caller.
 func (s *walletService) publishBenchmarkEvent(ctx context.Context, subscriptionID string, startTime, endTime time.Time) {
-	benchSvc := NewUsageBenchmarkService(s.ServiceParams, nil)
+	benchSvc := NewUsageBenchmarkService(s.ServiceParams, nil, nil, nil, nil)
 	evt := &events.UsageBenchmarkEvent{
 		SubscriptionID: subscriptionID,
 		StartTime:      startTime,

--- a/migrations/clickhouse/000009_create_analytics_benchmark_table.down.sql
+++ b/migrations/clickhouse/000009_create_analytics_benchmark_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS flexprice.analytics_benchmark;

--- a/migrations/clickhouse/000009_create_analytics_benchmark_table.down.sql
+++ b/migrations/clickhouse/000009_create_analytics_benchmark_table.down.sql
@@ -1,1 +1,0 @@
-DROP TABLE IF EXISTS flexprice.analytics_benchmark;

--- a/migrations/clickhouse/000009_create_analytics_benchmark_table.up.sql
+++ b/migrations/clickhouse/000009_create_analytics_benchmark_table.up.sql
@@ -38,6 +38,6 @@ CREATE TABLE IF NOT EXISTS flexprice.analytics_benchmark
     created_at             DateTime64(3)           NOT NULL DEFAULT now64(3)  CODEC(Delta, ZSTD(1))
 )
 ENGINE = MergeTree()
-PARTITION BY toYYYYMM(start_time)
+PARTITION BY toYYYYMMDD(created_at)
 ORDER BY (tenant_id, environment_id, event_id, feature_id, group_key)
 SETTINGS index_granularity = 8192;

--- a/migrations/clickhouse/000009_create_analytics_benchmark_table.up.sql
+++ b/migrations/clickhouse/000009_create_analytics_benchmark_table.up.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS flexprice.analytics_benchmark
+(
+    tenant_id              LowCardinality(String)  NOT NULL,
+    environment_id         LowCardinality(String)  NOT NULL,
+    event_id               String                  NOT NULL CODEC(ZSTD(1)),
+    start_time             DateTime64(3)           NOT NULL CODEC(Delta, ZSTD(1)),
+    end_time               DateTime64(3)           NOT NULL CODEC(Delta, ZSTD(1)),
+
+    -- parsed request fields (for SQL filtering)
+    external_customer_id   String                  NOT NULL DEFAULT '',
+    external_customer_ids  Array(String)           NOT NULL DEFAULT [],
+    feature_ids            Array(String)           NOT NULL DEFAULT [],
+    sources                Array(String)           NOT NULL DEFAULT [],
+    group_by               Array(String)           NOT NULL DEFAULT [],
+    window_size            LowCardinality(String)  NOT NULL DEFAULT '',
+    expand                 Array(String)           NOT NULL DEFAULT [],
+    include_children       UInt8                   NOT NULL DEFAULT 0,
+    has_property_filters   UInt8                   NOT NULL DEFAULT 0,
+    request_json           String                  NOT NULL DEFAULT ''  CODEC(ZSTD(3)),
+
+    -- per-item row
+    feature_id             String                  NOT NULL DEFAULT '',
+    group_key              String                  NOT NULL DEFAULT '',
+    match_status           LowCardinality(String)  NOT NULL,
+
+    feature_total_usage    Decimal(25, 15)         NOT NULL DEFAULT 0,
+    meter_total_usage      Decimal(25, 15)         NOT NULL DEFAULT 0,
+    usage_diff             Decimal(25, 15)         NOT NULL DEFAULT 0,
+
+    feature_total_cost     Decimal(25, 15)         NOT NULL DEFAULT 0,
+    meter_total_cost       Decimal(25, 15)         NOT NULL DEFAULT 0,
+    cost_diff              Decimal(25, 15)         NOT NULL DEFAULT 0,
+
+    feature_event_count    UInt64                  NOT NULL DEFAULT 0,
+    meter_event_count      UInt64                  NOT NULL DEFAULT 0,
+
+    currency               LowCardinality(String)  NOT NULL DEFAULT '',
+    created_at             DateTime64(3)           NOT NULL DEFAULT now64(3)  CODEC(Delta, ZSTD(1))
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(start_time)
+ORDER BY (tenant_id, environment_id, event_id, feature_id, group_key)
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
Capture each /events/analytics request, replay it through the feature-usage and meter-usage pipelines asynchronously, and write per-(feature_id, group_key) diffs to a new analytics_benchmark ClickHouse table. Reuses the existing UsageBenchmark Kafka topic + consumer group; events are discriminated by a new Kind field so subscription-pipeline benchmarks continue to flow. Gated per-tenant on the existing IsUsageBenchmarkEnabled flag.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieval of usage analytics can now emit analytics-benchmark events (feature-flag gated) and route them for end-to-end analytics replay and storage; analytics vs subscription variants supported.

* **Database**
  * Added ClickHouse table and migration to persist analytics benchmark records.

* **Tests**
  * Added unit tests for routing by benchmark kind, deterministic join logic, request-field promotion, and processing behaviors.

* **Behavior**
  * Benchmark publishing is fire-and-forget and non-blocking; publish failures are logged without affecting responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->