### PR TITLE
feat(schedule): pick db lookup reference window as schedule job time

### DIFF
--- a/internal/api/cron/subscription.go
+++ b/internal/api/cron/subscription.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/service"
@@ -86,7 +87,7 @@ func (h *SubscriptionHandler) ProcessAutoCancellationSubscriptions(c *gin.Contex
 func (h *SubscriptionHandler) ProcessSubscriptionRenewalDueAlerts(c *gin.Context) {
 	h.logger.Infow("starting subscription renewal due alerts cron job")
 
-	if err := h.subscriptionService.ProcessSubscriptionRenewalDueAlert(c.Request.Context()); err != nil {
+	if err := h.subscriptionService.ProcessSubscriptionRenewalDueAlert(c.Request.Context(), time.Now()); err != nil {
 		h.logger.Errorw("failed to process subscription renewal due alerts",
 			"error", err)
 		c.Error(err)

--- a/internal/domain/subscription/repository.go
+++ b/internal/domain/subscription/repository.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/types"
 )
@@ -27,7 +28,7 @@ type Repository interface {
 	GetWithPauses(ctx context.Context, id string) (*Subscription, []*SubscriptionPause, error)
 
 	// Renewal due alert methods
-	ListSubscriptionsDueForRenewal(ctx context.Context) ([]*Subscription, error)
+	ListSubscriptionsDueForRenewal(ctx context.Context, now time.Time) ([]*Subscription, error)
 
 	// Dashboard methods
 	GetRecentSubscriptionsByPlan(ctx context.Context) ([]types.SubscriptionPlanCount, error)

--- a/internal/domain/subscription/repository.go
+++ b/internal/domain/subscription/repository.go
@@ -28,7 +28,7 @@ type Repository interface {
 	GetWithPauses(ctx context.Context, id string) (*Subscription, []*SubscriptionPause, error)
 
 	// Renewal due alert methods
-	ListSubscriptionsDueForRenewal(ctx context.Context, now time.Time) ([]*Subscription, error)
+	ListSubscriptionsDueForRenewal(ctx context.Context, referenceTime time.Time) ([]*Subscription, error)
 
 	// Dashboard methods
 	GetRecentSubscriptionsByPlan(ctx context.Context) ([]types.SubscriptionPlanCount, error)

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -862,7 +862,7 @@ func (m *mockSubscriptionService) ListSubscriptionLineItems(ctx context.Context,
 func (m *mockSubscriptionService) ProcessAutoCancellationSubscriptions(ctx context.Context) error {
 	return nil
 }
-func (m *mockSubscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context) error {
+func (m *mockSubscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context, _ time.Time) error {
 	return nil
 }
 func (m *mockSubscriptionService) ProcessAutoInvoiceThresholdBilling(ctx context.Context) (*apidto.AutoInvoiceThresholdBillingResult, error) {

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -117,7 +117,7 @@ type SubscriptionService interface {
 	// Auto-cancellation methods
 	ProcessAutoCancellationSubscriptions(ctx context.Context) error
 	// Renewal due alert methods
-	ProcessSubscriptionRenewalDueAlert(ctx context.Context, now time.Time) error
+	ProcessSubscriptionRenewalDueAlert(ctx context.Context, referenceTime time.Time) error
 
 	// ProcessAutoInvoiceThresholdBilling checks subscriptions with subscription-level auto_invoice_threshold
 	// set and runs auto invoice threshold billing (mid-period invoices when usage crosses that threshold).

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -117,7 +117,7 @@ type SubscriptionService interface {
 	// Auto-cancellation methods
 	ProcessAutoCancellationSubscriptions(ctx context.Context) error
 	// Renewal due alert methods
-	ProcessSubscriptionRenewalDueAlert(ctx context.Context) error
+	ProcessSubscriptionRenewalDueAlert(ctx context.Context, now time.Time) error
 
 	// ProcessAutoInvoiceThresholdBilling checks subscriptions with subscription-level auto_invoice_threshold
 	// set and runs auto invoice threshold billing (mid-period invoices when usage crosses that threshold).

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -348,14 +348,14 @@ func (r *subscriptionRepository) List(ctx context.Context, filter *types.Subscri
 }
 
 // ListActiveSubscriptionsDueForRenewal retrieves all active subscriptions that are due for renewal in 24 hours
-func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context) ([]*domainSub.Subscription, error) {
-	now := time.Now().UTC()
+func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context, now time.Time) ([]*domainSub.Subscription, error) {
+	now = now.UTC()
 	targetTime := now.Add(24 * time.Hour)
 
-	// Half-open window [targetTime-29m, targetTime) is slightly under 2x the
-	// 15-minute schedule interval, giving one guaranteed hit with a buffer
-	// for scheduling jitter while avoiding triple-sends.
-	windowStart := targetTime.Add(-29 * time.Minute)
+	// Half-open window [targetTime-15m, targetTime) matches the 15-minute
+	// schedule interval exactly. The workflow passes its scheduled start
+	// time, so each run covers a non-overlapping 15-minute slice.
+	windowStart := targetTime.Add(-15 * time.Minute)
 
 	subs, err := r.client.Reader(ctx).Subscription.Query().
 		Where(

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -348,9 +348,9 @@ func (r *subscriptionRepository) List(ctx context.Context, filter *types.Subscri
 }
 
 // ListActiveSubscriptionsDueForRenewal retrieves all active subscriptions that are due for renewal in 24 hours
-func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context, now time.Time) ([]*domainSub.Subscription, error) {
-	now = now.UTC()
-	targetTime := now.Add(24 * time.Hour)
+func (r *subscriptionRepository) ListSubscriptionsDueForRenewal(ctx context.Context, referenceTime time.Time) ([]*domainSub.Subscription, error) {
+	referenceTime = referenceTime.UTC()
+	targetTime := referenceTime.Add(24 * time.Hour)
 
 	// Half-open window [targetTime-15m, targetTime) matches the 15-minute
 	// schedule interval exactly. The workflow passes its scheduled start

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4150,8 +4150,8 @@ func (s *subscriptionService) PublishCancellationEvents(ctx context.Context, sub
 }
 
 // ProcessSubscriptionRenewalDueAlert processes subscriptions that are due for renewal in 24 hours
-func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context, now time.Time) error {
-	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx, now)
+func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context, referenceTime time.Time) error {
+	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx, referenceTime)
 	if err != nil {
 		s.Logger.ErrorwCtx(ctx, "failed to list subscriptions due for renewal", "error", err)
 		return err

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -4150,8 +4150,8 @@ func (s *subscriptionService) PublishCancellationEvents(ctx context.Context, sub
 }
 
 // ProcessSubscriptionRenewalDueAlert processes subscriptions that are due for renewal in 24 hours
-func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context) error {
-	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx)
+func (s *subscriptionService) ProcessSubscriptionRenewalDueAlert(ctx context.Context, now time.Time) error {
+	subscriptions, err := s.SubRepo.ListSubscriptionsDueForRenewal(ctx, now)
 	if err != nil {
 		s.Logger.ErrorwCtx(ctx, "failed to list subscriptions due for renewal", "error", err)
 		return err

--- a/internal/temporal/activities/cron/subscription_activities.go
+++ b/internal/temporal/activities/cron/subscription_activities.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/service"
@@ -65,10 +66,13 @@ func (a *SubscriptionCronActivities) ProcessTrialEndDueActivity(ctx context.Cont
 }
 
 // ProcessRenewalDueAlertsActivity runs the same work as POST /v1/cron/subscriptions/renewal-due-alerts.
-func (a *SubscriptionCronActivities) ProcessRenewalDueAlertsActivity(ctx context.Context) (*cronModels.SubscriptionRenewalDueAlertsWorkflowResult, error) {
+func (a *SubscriptionCronActivities) ProcessRenewalDueAlertsActivity(ctx context.Context, runTime time.Time) (*cronModels.SubscriptionRenewalDueAlertsWorkflowResult, error) {
 	log := activity.GetLogger(ctx)
 	log.Info("Processing subscription renewal-due alerts (cron activity)")
-	if err := a.subscriptionService.ProcessSubscriptionRenewalDueAlert(ctx); err != nil {
+	if runTime.IsZero() {
+		runTime = time.Now()
+	}
+	if err := a.subscriptionService.ProcessSubscriptionRenewalDueAlert(ctx, runTime); err != nil {
 		return nil, err
 	}
 	return &cronModels.SubscriptionRenewalDueAlertsWorkflowResult{}, nil

--- a/internal/temporal/workflows/cron/subscription_renewal_due_alerts_workflow.go
+++ b/internal/temporal/workflows/cron/subscription_renewal_due_alerts_workflow.go
@@ -12,6 +12,8 @@ const (
 	ActivityProcessRenewalDueAlerts = "ProcessRenewalDueAlertsActivity"
 )
 
+var temporalScheduledStartTimeKey = temporal.NewSearchAttributeKeyTime("TemporalScheduledStartTime")
+
 // SubscriptionRenewalDueAlertsWorkflow sends renewal-due webhooks; same as POST /v1/cron/subscriptions/renewal-due-alerts.
 func SubscriptionRenewalDueAlertsWorkflow(ctx workflow.Context, _ cronModels.SubscriptionRenewalDueAlertsWorkflowInput) (*cronModels.SubscriptionRenewalDueAlertsWorkflowResult, error) {
 	log := workflow.GetLogger(ctx)
@@ -28,8 +30,17 @@ func SubscriptionRenewalDueAlertsWorkflow(ctx workflow.Context, _ cronModels.Sub
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 
+	var runTime time.Time
+	scheduledTime, ok := workflow.GetTypedSearchAttributes(ctx).GetTime(temporalScheduledStartTimeKey)
+	if ok && !scheduledTime.IsZero() {
+		runTime = scheduledTime
+	} else {
+		runTime = workflow.Now(ctx)
+	}
+	log.Info("Using reference time for renewal-due alerts", "run_time", runTime)
+
 	var result cronModels.SubscriptionRenewalDueAlertsWorkflowResult
-	if err := workflow.ExecuteActivity(ctx, ActivityProcessRenewalDueAlerts).Get(ctx, &result); err != nil {
+	if err := workflow.ExecuteActivity(ctx, ActivityProcessRenewalDueAlerts, runTime).Get(ctx, &result); err != nil {
 		log.Error("SubscriptionRenewalDueAlertsWorkflow activity failed", "error", err)
 		return nil, err
 	}

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -474,7 +474,7 @@ func (s *InMemorySubscriptionStore) GetWithPauses(ctx context.Context, id string
 }
 
 // ListSubscriptionsDueForRenewal retrieves all active subscriptions that are due for renewal in 24 hours
-func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context) ([]*subscription.Subscription, error) {
+func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, now time.Time) ([]*subscription.Subscription, error) {
 	// Create a filter for active subscriptions
 	filter := &types.SubscriptionFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),
@@ -482,7 +482,7 @@ func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.C
 			types.SubscriptionStatusActive,
 		},
 		TimeRangeFilter: &types.TimeRangeFilter{
-			EndTime: lo.ToPtr(time.Now().UTC().Add(24 * time.Hour)),
+			EndTime: lo.ToPtr(now.UTC().Add(24 * time.Hour)),
 		},
 	}
 

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -474,19 +474,26 @@ func (s *InMemorySubscriptionStore) GetWithPauses(ctx context.Context, id string
 }
 
 // ListSubscriptionsDueForRenewal retrieves all active subscriptions that are due for renewal in 24 hours
-func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, now time.Time) ([]*subscription.Subscription, error) {
-	// Create a filter for active subscriptions
+func (s *InMemorySubscriptionStore) ListSubscriptionsDueForRenewal(ctx context.Context, referenceTime time.Time) ([]*subscription.Subscription, error) {
+	referenceTime = referenceTime.UTC()
+	targetTime := referenceTime.Add(24 * time.Hour)
+	windowStart := targetTime.Add(-15 * time.Minute)
+
 	filter := &types.SubscriptionFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),
 		SubscriptionStatus: []types.SubscriptionStatus{
 			types.SubscriptionStatusActive,
 		},
-		TimeRangeFilter: &types.TimeRangeFilter{
-			EndTime: lo.ToPtr(now.UTC().Add(24 * time.Hour)),
-		},
 	}
 
-	return s.ListAll(ctx, filter)
+	allSubs, err := s.ListAll(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Filter(allSubs, func(sub *subscription.Subscription, _ int) bool {
+		return !sub.CurrentPeriodEnd.Before(windowStart) && sub.CurrentPeriodEnd.Before(targetTime) && !sub.CancelAtPeriodEnd
+	}), nil
 }
 
 // GetRecentSubscriptionsByPlan returns subscription counts grouped by plan for last 7 days


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Subscription renewal alert flow now uses an explicit reference time across services and workflows for better timing control and testability.
  * The renewal-due window calculation was adjusted (narrower pre-renewal window), which may slightly change when renewal alerts are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->