### PR TITLE
fix(analytics): Filter and windowSize handling

### DIFF
--- a/internal/repository/clickhouse/feature_usage.go
+++ b/internal/repository/clickhouse/feature_usage.go
@@ -1224,6 +1224,24 @@ func (r *FeatureUsageRepository) getMaxBucketPointsForGroup(ctx context.Context,
 		queryParams = append(queryParams, group.Source)
 	}
 
+	// Propagate the request-level sources filter so the points query runs against
+	// the same row set as getMaxBucketTotals. group.Source above only narrows when
+	// `source` is in group_by (sourceInGroupBy is what decides whether outer select
+	// carries it through); when it isn't, group.Source is "" and without this clause
+	// the points query would aggregate across every source, leaving total_cost
+	// (which is computed from these points) unchanged by the filter while
+	// total_usage (from the totals query) drops correctly.
+	if len(params.Sources) > 0 {
+		placeholders := make([]string, len(params.Sources))
+		for i := range params.Sources {
+			placeholders[i] = "?"
+		}
+		innerQuery += " AND source IN (" + strings.Join(placeholders, ", ") + ")"
+		for _, source := range params.Sources {
+			queryParams = append(queryParams, source)
+		}
+	}
+
 	// Add filter for this specific group's price_id
 	if group.PriceID != "" {
 		innerQuery += " AND price_id = ?"
@@ -1653,6 +1671,20 @@ func (r *FeatureUsageRepository) getSumBucketPointsForGroup(ctx context.Context,
 		queryParams = append(queryParams, group.Source)
 	}
 
+	// Propagate the request-level sources filter. See getMaxBucketPointsForGroup
+	// for the rationale — without this, total_cost (computed from these points)
+	// stays unchanged while total_usage (from the totals query) drops correctly.
+	if len(params.Sources) > 0 {
+		placeholders := make([]string, len(params.Sources))
+		for i := range params.Sources {
+			placeholders[i] = "?"
+		}
+		innerQuery += " AND source IN (" + strings.Join(placeholders, ", ") + ")"
+		for _, source := range params.Sources {
+			queryParams = append(queryParams, source)
+		}
+	}
+
 	// Add filter for this specific group's price_id
 	if group.PriceID != "" {
 		innerQuery += " AND price_id = ?"
@@ -1894,6 +1926,20 @@ func (r *FeatureUsageRepository) getAnalyticsPoints(
 	if analytics.Source != "" {
 		query += " AND source = ?"
 		queryParams = append(queryParams, analytics.Source)
+	}
+
+	// Propagate the request-level sources filter. analytics.Source above only carries
+	// a value when source is in group_by; without this clause, per-point Cost on
+	// non-bucketed meters would aggregate across every source instead of the filtered set.
+	if len(params.Sources) > 0 {
+		placeholders := make([]string, len(params.Sources))
+		for i := range params.Sources {
+			placeholders[i] = "?"
+		}
+		query += " AND source IN (" + strings.Join(placeholders, ", ") + ")"
+		for _, source := range params.Sources {
+			queryParams = append(queryParams, source)
+		}
 	}
 
 	// Add filters for grouped properties values

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -1507,6 +1507,13 @@ func (s *featureUsageTrackingService) fetchAnalyticsData(ctx context.Context, re
 	// 6. Inject synthetic zero-usage analytics entries for committed line items
 	// that have no usage data in ClickHouse. Without this, the commitment fill
 	// logic in calculateCosts never fires for these line items.
+	//
+	// Skip injection when property_filters or sources are present: those filters
+	// restrict the SQL result by design, so "line item has no rows" is the filter
+	// working, not zero usage. Injecting full commitment cost on top would pin
+	// total_cost regardless of the filter — matching the calculateCosts skip.
+	skipSyntheticZeros := len(req.PropertyFilters) > 0 || len(req.Sources) > 0
+
 	existingLineItemIDs := make(map[string]bool, len(data.Analytics))
 	for _, item := range data.Analytics {
 		if item.SubLineItemID != "" {
@@ -1522,7 +1529,7 @@ func (s *featureUsageTrackingService) fetchAnalyticsData(ctx context.Context, re
 	var missingLineItems []missingLineItemInfo
 	for _, sub := range subscriptions {
 		for _, li := range sub.LineItems {
-			if existingLineItemIDs[li.ID] || !li.HasCommitment() || !li.IsUsage() {
+			if skipSyntheticZeros || existingLineItemIDs[li.ID] || !li.HasCommitment() || !li.IsUsage() {
 				continue
 			}
 			periodStart := li.GetPeriodStart(params.StartTime)
@@ -2075,6 +2082,13 @@ func (s *featureUsageTrackingService) CalculateCostsForAnalytics(ctx context.Con
 func (s *featureUsageTrackingService) calculateCosts(ctx context.Context, data *AnalyticsData) error {
 	priceService := NewPriceService(s.ServiceParams)
 
+	// Analytics filters (property_filters, sources) restrict the SQL result set to a
+	// subset of the customer's actual usage. Commitment / overage / true-up are billing
+	// concepts tied to the FULL period usage — applying them to a filtered subset would
+	// pin cost at the commitment floor regardless of usage and pull commitment costs from
+	// line items that fall entirely outside the filter. Report raw filtered cost instead.
+	skipCommitment := len(data.Params.PropertyFilters) > 0 || len(data.Params.Sources) > 0
+
 	for _, item := range data.Analytics {
 		// Resolve meter: prefer via feature, fall back to direct MeterID lookup.
 		// The fallback handles meter-usage analytics where no feature exists for a meter.
@@ -2097,9 +2111,9 @@ func (s *featureUsageTrackingService) calculateCosts(ctx context.Context, data *
 		}
 
 		if m.IsBucketedMaxMeter() || m.IsBucketedSumMeter() {
-			s.calculateBucketedCost(ctx, priceService, item, price, m, data)
+			s.calculateBucketedCost(ctx, priceService, item, price, m, data, skipCommitment)
 		} else {
-			s.calculateRegularCost(ctx, priceService, item, m, price, data)
+			s.calculateRegularCost(ctx, priceService, item, m, price, data, skipCommitment)
 		}
 	}
 
@@ -2118,11 +2132,14 @@ type bucketedCostParams struct {
 	bucketSize   types.WindowSize
 }
 
-// calculateBucketedCost calculates cost for bucketed max meters
-func (s *featureUsageTrackingService) calculateBucketedCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, price *price.Price, meter *meter.Meter, data *AnalyticsData) {
+// calculateBucketedCost calculates cost for bucketed max meters.
+// skipCommitment forces hasCommitment=false when set; used for analytics queries with
+// property/source filters where the SQL result is a subset of the period's true usage —
+// applying commitments to that subset would surface misleading commitment/overage values.
+func (s *featureUsageTrackingService) calculateBucketedCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, price *price.Price, meter *meter.Meter, data *AnalyticsData, skipCommitment bool) {
 	params := &bucketedCostParams{ctx, priceService, item, price, data, meter.Aggregation.Type, meter.Aggregation.BucketSize}
 	lineItem := data.SubscriptionLineItems[item.SubLineItemID]
-	hasCommitment := lineItem != nil && lineItem.HasCommitment()
+	hasCommitment := !skipCommitment && lineItem != nil && lineItem.HasCommitment()
 	isWindowed := hasCommitment && lineItem.CommitmentWindowed
 	hasTrueUp := isWindowed && lineItem.CommitmentTrueUpEnabled
 
@@ -2356,8 +2373,9 @@ func (s *featureUsageTrackingService) sumPointCosts(points []events.UsageAnalyti
 	return total
 }
 
-// calculateRegularCost calculates cost for regular meters
-func (s *featureUsageTrackingService) calculateRegularCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, meter *meter.Meter, price *price.Price, data *AnalyticsData) {
+// calculateRegularCost calculates cost for regular meters.
+// skipCommitment bypasses commitment / true-up application; see calculateBucketedCost.
+func (s *featureUsageTrackingService) calculateRegularCost(ctx context.Context, priceService PriceService, item *events.DetailedUsageAnalytic, meter *meter.Meter, price *price.Price, data *AnalyticsData, skipCommitment bool) {
 	// Set correct usage value
 	item.TotalUsage = s.getCorrectUsageValue(item, meter.Aggregation.Type)
 
@@ -2365,7 +2383,7 @@ func (s *featureUsageTrackingService) calculateRegularCost(ctx context.Context, 
 	cost := priceService.CalculateCost(ctx, price, item.TotalUsage)
 
 	// Check for line item commitment
-	if item.SubLineItemID != "" {
+	if !skipCommitment && item.SubLineItemID != "" {
 		// Find the line item
 
 		lineItem := data.SubscriptionLineItems[item.SubLineItemID]

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -434,6 +434,16 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 	}
 
 	// 11. Query bucketed meters per line item (already uses GetPeriodStart/End)
+	//
+	// When analytics filters (PropertyFilters / Sources) are active, suppress
+	// bucketed line-item entries that have no matching events — same rationale
+	// as the gates in queryAndAppendAnalyticsEntries and the step-12 loop:
+	// surfacing them would misrepresent the filtered slice (and pin commitment
+	// cost for committed items). Without filters, empty bucketed line items
+	// continue to be surfaced as zero-usage rows (preserves the contract that
+	// committed line items can have their commitment fire on no usage).
+	skipBucketedZeros := len(req.PropertyFilters) > 0 || len(req.Sources) > 0
+
 	for meterID := range bucketedMeterIDs {
 		m := result.MeterMap[meterID]
 		if m == nil {
@@ -451,6 +461,10 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query bucketed meter usage for meter %s: %w", meterID, err)
+			}
+
+			if skipBucketedZeros && (bucketedResult == nil || len(bucketedResult.Results) == 0) {
+				continue
 			}
 
 			usage := &LineItemMeterUsage{
@@ -492,34 +506,45 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 		}
 	}
 
-	// 12. Zero-usage entries for line items that had no data
-	processedLineItemIDs := make(map[string]bool, len(result.LineItemUsages))
-	for _, lu := range result.LineItemUsages {
-		if lu.LineItem != nil {
-			processedLineItemIDs[lu.LineItem.ID] = true
-		}
-	}
+	// 12. Zero-usage entries for line items that had no data.
+	// Skip when analytics filters (PropertyFilters / Sources) are active: those
+	// filters restrict the SQL result by design, so "line item has no rows" means
+	// the filter excluded them — not that there was zero usage. Surfacing a
+	// zero-usage row for every filtered-out line item would misrepresent the
+	// filtered slice and (for committed line items) pin commitment cost regardless
+	// of the filter. Mirrors the skipSyntheticZeros gate in
+	// featureUsageTrackingService.fetchAnalyticsData.
+	skipSyntheticZeros := len(req.PropertyFilters) > 0 || len(req.Sources) > 0
 
-	for _, item := range lineItems {
-		if item.PriceType != types.PRICE_TYPE_USAGE || item.MeterID == "" {
-			continue
-		}
-		if meterIDSet != nil {
-			if _, ok := meterIDSet[item.MeterID]; !ok {
-				continue
+	if !skipSyntheticZeros {
+		processedLineItemIDs := make(map[string]bool, len(result.LineItemUsages))
+		for _, lu := range result.LineItemUsages {
+			if lu.LineItem != nil {
+				processedLineItemIDs[lu.LineItem.ID] = true
 			}
 		}
-		if processedLineItemIDs[item.ID] {
-			continue
+
+		for _, item := range lineItems {
+			if item.PriceType != types.PRICE_TYPE_USAGE || item.MeterID == "" {
+				continue
+			}
+			if meterIDSet != nil {
+				if _, ok := meterIDSet[item.MeterID]; !ok {
+					continue
+				}
+			}
+			if processedLineItemIDs[item.ID] {
+				continue
+			}
+			result.LineItemUsages = append(result.LineItemUsages, &LineItemMeterUsage{
+				LineItem:    item,
+				MeterID:     item.MeterID,
+				Meter:       result.MeterMap[item.MeterID],
+				Price:       result.PriceMap[item.PriceID],
+				PeriodStart: item.GetPeriodStart(usageStartTime),
+				PeriodEnd:   item.GetPeriodEnd(usageEndTime),
+			})
 		}
-		result.LineItemUsages = append(result.LineItemUsages, &LineItemMeterUsage{
-			LineItem:    item,
-			MeterID:     item.MeterID,
-			Meter:       result.MeterMap[item.MeterID],
-			Price:       result.PriceMap[item.PriceID],
-			PeriodStart: item.GetPeriodStart(usageStartTime),
-			PeriodEnd:   item.GetPeriodEnd(usageEndTime),
-		})
 	}
 
 	return result, nil
@@ -585,9 +610,18 @@ func (s *meterUsageService) queryAndAppendAnalyticsEntries(
 		resultsByMeter[dr.MeterID] = append(resultsByMeter[dr.MeterID], dr)
 	}
 
+	// When analytics filters are active, suppress the zero-usage entry for line
+	// items whose analytics query returned no rows — that's the filter excluding
+	// them, not zero usage. Surfacing a zero-usage row would misrepresent the
+	// filtered slice. Mirrors the step-12 skipSyntheticZeros gate.
+	skipSyntheticZeros := len(req.PropertyFilters) > 0 || len(req.Sources) > 0
+
 	for _, liw := range lis {
 		drs := resultsByMeter[liw.MeterID]
 		if len(drs) == 0 {
+			if skipSyntheticZeros {
+				continue
+			}
 			// No data — zero-usage entry; step 12 commitment check uses LineItem.HasCommitment().
 			result.LineItemUsages = append(result.LineItemUsages, &LineItemMeterUsage{
 				LineItem:    liw.Item,
@@ -1378,16 +1412,20 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 			}
 		}
 
-		for _, point := range analytic.Points {
-			item.Points = append(item.Points, dto.UsageAnalyticPoint{
-				Timestamp:                        point.Timestamp,
-				Usage:                            point.Usage,
-				Cost:                             point.Cost,
-				EventCount:                       point.EventCount,
-				ComputedCommitmentUtilizedAmount: point.ComputedCommitmentUtilizedAmount,
-				ComputedOverageAmount:            point.ComputedOverageAmount,
-				ComputedTrueUpAmount:             point.ComputedTrueUpAmount,
-			})
+		// Points are computed internally for bucketed cost calc regardless of request;
+		// only expose them when the caller asked for a window_size (mirrors feature_usage).
+		if params.WindowSize != "" {
+			for _, point := range analytic.Points {
+				item.Points = append(item.Points, dto.UsageAnalyticPoint{
+					Timestamp:                        point.Timestamp,
+					Usage:                            point.Usage,
+					Cost:                             point.Cost,
+					EventCount:                       point.EventCount,
+					ComputedCommitmentUtilizedAmount: point.ComputedCommitmentUtilizedAmount,
+					ComputedOverageAmount:            point.ComputedOverageAmount,
+					ComputedTrueUpAmount:             point.ComputedTrueUpAmount,
+				})
+			}
 		}
 
 		response.Items = append(response.Items, item)
@@ -1829,7 +1867,7 @@ func (s *meterUsageService) processPointsWithBuckets(
 		cost = s.fillMissingWindowsAndRecalculate(p, lineItem)
 	}
 
-	p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType)
+	p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType, p.data.Params.WindowSize, p.data.Params.BillingAnchor)
 
 	if isWindowed && !needsWindowedFill {
 		cost = s.sumPointCosts(p.item.Points)
@@ -1964,7 +2002,7 @@ func (s *meterUsageService) fillZeroUsageWindows(p *meterUsageBucketedCostParams
 	for _, t := range expectedStarts {
 		bucketPoints = append(bucketPoints, s.createFillPoint(p, lineItem, t, billingAnchor, commitmentCalc))
 	}
-	p.item.Points = s.mergeBucketPointsByWindow(bucketPoints, p.aggType)
+	p.item.Points = s.mergeBucketPointsByWindow(bucketPoints, p.aggType, p.data.Params.WindowSize, p.data.Params.BillingAnchor)
 
 	return totalCost
 }
@@ -2102,7 +2140,13 @@ func (s *meterUsageService) applyLineItemCommitment(
 }
 
 // mergeBucketPointsByWindow merges bucket-level points into request-window-level points.
-func (s *meterUsageService) mergeBucketPointsByWindow(points []events.UsageAnalyticPoint, aggregationType types.AggregationType) []events.UsageAnalyticPoint {
+// Each input point's WindowStart is the bucket start (at the meter's bucket_size). To emit
+// points at the requested window_size, WindowStart is truncated to that window before grouping
+// — so when request window > bucket size (e.g. DAY request, MINUTE bucket), many bucket points
+// collapse into one response point per request window. When request window <= bucket size, the
+// truncation is a no-op and points stay at bucket grain (we cannot subdivide a bucket).
+// requestWindowSize == "" disables roll-up entirely.
+func (s *meterUsageService) mergeBucketPointsByWindow(points []events.UsageAnalyticPoint, aggregationType types.AggregationType, requestWindowSize types.WindowSize, billingAnchor *time.Time) []events.UsageAnalyticPoint {
 	if len(points) == 0 {
 		return points
 	}
@@ -2113,7 +2157,11 @@ func (s *meterUsageService) mergeBucketPointsByWindow(points []events.UsageAnaly
 
 	windowGroups := make(map[time.Time][]events.UsageAnalyticPoint)
 	for _, point := range points {
-		windowGroups[point.WindowStart] = append(windowGroups[point.WindowStart], point)
+		key := point.WindowStart
+		if requestWindowSize != "" {
+			key = truncateToBucketStart(point.WindowStart, requestWindowSize, billingAnchor)
+		}
+		windowGroups[key] = append(windowGroups[key], point)
 	}
 
 	mergedPoints := make([]events.UsageAnalyticPoint, 0, len(windowGroups))

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -2755,3 +2755,245 @@ func (s *MeterUsageServiceSuite) TestMeterUsage_CancelledSubInsideWindow_Attribu
 	s.True(activeUsage.Equal(decimal.NewFromInt(150)),
 		"active sub should own both events (100 + 50); got %s", activeUsage)
 }
+
+// ---------------------------------------------------------------------------
+// skipSyntheticZeros — suppress zero-usage line-item injection under filters.
+//
+// When PropertyFilters or Sources are present, the SQL result is a deliberate
+// subset of the customer's usage. The zero-fill loop in GetSubscriptionMeterUsage
+// must not fabricate entries for line items whose events filtered out — those
+// would misrepresent the filtered slice and (for committed line items) pin
+// commitment cost regardless of filter. Baseline (no filter) zero-fill is
+// covered by TestZeroUsageLineItem.
+// ---------------------------------------------------------------------------
+
+// setupBucketedMeterForSkipZeros creates a bucketed SUM meter (HOUR bucket) +
+// price + line item bound to the suite's subscription. Returns the line item ID.
+func (s *MeterUsageServiceSuite) setupBucketedMeterForSkipZeros(ctx context.Context, idSuffix string) string {
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_bkt_" + idSuffix,
+		Name:      "Bucketed SUM " + idSuffix,
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_bkt_"+idSuffix, bucketedMeter.ID, decimal.NewFromInt(1))
+	li := s.createLineItemForMeter(ctx, "li_bkt_"+idSuffix, bucketedMeter.ID, bucketedPrice.ID)
+	return li.ID
+}
+
+// TestSkipSyntheticZeros_PropertyFiltersSuppressZeroFill: a bucketed-meter
+// line item whose only event fails the property filter must not appear in the
+// result. Bucketed meters take the step-11 path (which unconditionally appended
+// an entry per line item before the gate) — that's the production scenario
+// where this bug actually surfaces.
+func (s *MeterUsageServiceSuite) TestSkipSyntheticZeros_PropertyFiltersSuppressZeroFill() {
+	ctx := s.GetContext()
+
+	liID := s.setupBucketedMeterForSkipZeros(ctx, "pf")
+	s.insertMeterUsageWithProps(ctx, "mtr_bkt_pf", s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 100,
+		map[string]interface{}{"model": "claude-opus"})
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID:  s.sub.ID,
+		StartTime:       s.periodStart,
+		EndTime:         s.periodEnd,
+		PropertyFilters: map[string][]string{"model": {"gpt-4"}},
+	})
+	s.NoError(err)
+	for _, lu := range result.LineItemUsages {
+		if lu.LineItem != nil && lu.LineItem.ID == liID {
+			s.Failf("zero-fill leak",
+				"bucketed line item with no filter-matching events must not surface under PropertyFilters; got entry %+v", lu)
+		}
+	}
+}
+
+// TestSkipSyntheticZeros_SourcesFilterSuppressesZeroFill: same as the property
+// filter case but for Sources. Same step-11 bucketed path.
+func (s *MeterUsageServiceSuite) TestSkipSyntheticZeros_SourcesFilterSuppressesZeroFill() {
+	ctx := s.GetContext()
+
+	liID := s.setupBucketedMeterForSkipZeros(ctx, "src")
+	s.insertMeterUsageWithProps(ctx, "mtr_bkt_src", s.customer.ExternalID, "internal",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 100, nil)
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+		Sources:        []string{"stripe"},
+	})
+	s.NoError(err)
+	for _, lu := range result.LineItemUsages {
+		if lu.LineItem != nil && lu.LineItem.ID == liID {
+			s.Failf("zero-fill leak",
+				"bucketed line item with no source-matching events must not surface under Sources; got entry %+v", lu)
+		}
+	}
+}
+
+// TestSkipSyntheticZeros_NoFilter_BucketedLineItemStillZeroFilled is the
+// counterpart regression guard: with NO filters, the bucketed step-11 path
+// must still append an entry for line items with no usage (Usage=0). This
+// preserves the existing contract that committed line items can have their
+// commitment fire on empty usage.
+func (s *MeterUsageServiceSuite) TestSkipSyntheticZeros_NoFilter_BucketedLineItemStillZeroFilled() {
+	ctx := s.GetContext()
+
+	liID := s.setupBucketedMeterForSkipZeros(ctx, "nofilter")
+	// No usage inserted at all.
+
+	result, err := s.svc.GetSubscriptionMeterUsage(ctx, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID: s.sub.ID,
+		StartTime:      s.periodStart,
+		EndTime:        s.periodEnd,
+		// no filters
+	})
+	s.NoError(err)
+
+	var found *LineItemMeterUsage
+	for _, lu := range result.LineItemUsages {
+		if lu.LineItem != nil && lu.LineItem.ID == liID {
+			found = lu
+			break
+		}
+	}
+	s.Require().NotNil(found, "without filters, bucketed line item with no usage must still appear (zero-usage entry)")
+	s.True(found.Usage.IsZero(), "zero-fill entry should have usage=0, got %s", found.Usage)
+}
+
+// ---------------------------------------------------------------------------
+// Bucketed-meter window roll-up
+//
+// Bucketed meters query meter_usage at the meter's bucket_size (e.g. HOUR) so
+// bucketed cost math has the values it needs. The response must surface points
+// at the caller's request window_size — bucket points are rolled up by
+// mergeBucketPointsByWindow before the response is built. When the caller
+// omits window_size, the response points are suppressed entirely (matches
+// feature_usage's response shape).
+// ---------------------------------------------------------------------------
+
+// TestBucketedMeter_RollsUpPointsToRequestWindow: HOUR-bucketed meter with
+// events spanning multiple hours on two days; request window=DAY. The response
+// must collapse the hourly internal buckets to one point per day.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_RollsUpPointsToRequestWindow() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_rollup",
+		Name:      "Bucketed SUM (HOUR)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_rollup", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_rollup", bucketedMeter.ID, bucketedPrice.ID)
+
+	// Four events: three on Jan 5 at hours 9/10/14, one on Jan 6 at hour 9.
+	// Without rollup these surface as 4 hourly points; with rollup → 2 daily points.
+	for _, ev := range []struct {
+		t   time.Time
+		qty float64
+	}{
+		{time.Date(2026, 1, 5, 9, 0, 0, 0, time.UTC), 10},
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 20},
+		{time.Date(2026, 1, 5, 14, 0, 0, 0, time.UTC), 30},
+		{time.Date(2026, 1, 6, 9, 0, 0, 0, time.UTC), 5},
+	} {
+		s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, ev.t, ev.qty)
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeDay,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_rollup" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+
+	s.Require().Len(item.Points, 2,
+		"expected 2 daily points (Jan 5 + Jan 6); got %d", len(item.Points))
+
+	byDay := map[string]decimal.Decimal{}
+	for _, pt := range item.Points {
+		byDay[pt.Timestamp.UTC().Format("2006-01-02")] = pt.Usage
+	}
+	s.True(byDay["2026-01-05"].Equal(decimal.NewFromInt(60)),
+		"Jan 5 rolled-up usage: expected 60 (10+20+30); got %s", byDay["2026-01-05"])
+	s.True(byDay["2026-01-06"].Equal(decimal.NewFromInt(5)),
+		"Jan 6 rolled-up usage: expected 5; got %s", byDay["2026-01-06"])
+}
+
+// TestBucketedMeter_OmitsPointsWhenWindowSizeUnset: when window_size is absent
+// from the request, response Points must be empty even though bucketed cost
+// calc still runs internally (TotalUsage is still populated). Mirrors
+// feature_usage's response shape.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_OmitsPointsWhenWindowSizeUnset() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_nows",
+		Name:      "Bucketed SUM no window",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_nows", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_nows", bucketedMeter.ID, bucketedPrice.ID)
+
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 9, 0, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 20)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		// no WindowSize
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_nows" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+
+	s.True(item.TotalUsage.Equal(decimal.NewFromInt(30)),
+		"total usage must still be computed: expected 30; got %s", item.TotalUsage)
+	s.Empty(item.Points,
+		"points must be omitted from response when window_size is not specified")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent source filtering in feature usage analytics queries to apply filters uniformly across all query types.
  * Commitment logic now correctly skips when property or source filters are applied, preventing incorrect cost calculations.
  * Bucketed meter data now properly aggregates to the requested time window instead of remaining at bucket granularity.
  * Zero-usage line items are now suppressed when analytics filters are active.

* **Tests**
  * Added regression tests for synthetic zero-fill suppression under filter conditions.
  * Added regression tests for bucketed meter window aggregation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->