### PR TITLE
fix(ci): build loglint with Go 1.25 to match go.mod toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.0'
           cache: true
 
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.0'
+          go-version: '1.25.0'
           cache: true
 
       - name: Install dependencies

--- a/tools/loglint/go.mod
+++ b/tools/loglint/go.mod
@@ -1,6 +1,6 @@
 module github.com/flexprice/flexprice/tools/loglint
 
-go 1.24.0
+go 1.25.0
 
 require golang.org/x/tools v0.41.0
 


### PR DESCRIPTION
## Problem

The **Run Loglint** check on the Release PR ([#1955](https://github.com/flexprice/flexprice/pull/1955)) fails on every internal package with:

\`\`\`
loglint: <file>.go:1:1: package requires newer Go version go1.25 (application built with go1.24)
\`\`\`

These are **not** logger-API rule violations. The main module declares \`go 1.25.0\`, but the loglint analyzer binary is built from \`tools/loglint/go.mod\` (pinned to \`go 1.24.0\`). Its embedded \`go/types\` only understands up to Go 1.24, so it refuses to typecheck the 1.25 packages — failing before any LL00x rule can run. \`make test\` survives only because the \`go\` command auto-fetches the 1.25 toolchain.

## Fix

- \`tools/loglint/go.mod\`: \`go 1.24.0\` → \`go 1.25.0\` (analyzer typechecks the codebase)
- \`.github/workflows/test.yml\`: both jobs' \`setup-go\` \`1.24.0\` → \`1.25.0\`

## Verification

Built loglint with Go 1.25 and ran \`make lint-ci\` → **exit 0**. The only findings are 153 **LL008 warnings** (dev-checkpoint Info messages), which \`lint-ci\` already filters out. No CI-failing rule violations exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.24.0 to 1.25.0 across build and test systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->