### PR TITLE
fix(ci): run loglint via make lint-ci so warnings don't fail the gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,5 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Build loglint
-        run: cd tools/loglint && go mod download && go build -o ../bin/loglint ./main.go
-
       - name: Run loglint
-        run: go vet -vettool=./tools/bin/loglint ./internal/...
+        run: make lint-ci


### PR DESCRIPTION
## Problem

After #1957 fixed the Go 1.25 toolchain mismatch, loglint successfully typechecks the codebase and now emits its rule diagnostics. But the Release PR ([#1955](https://github.com/flexprice/flexprice/pull/1955)) **Run Loglint** check still fails — this time purely on **LL008 warnings** (`dev-checkpoint log — delete or demote to Debug`).

Root cause: the CI step ran raw \`go vet -vettool=./tools/bin/loglint ./internal/...\`, which exits non-zero on **any** emitted diagnostic. But per [internal/logger/README.md](internal/logger/README.md), LL008 (and LL007) are **warnings** — the documented CI gate is \`make lint-ci\`, which filters \`warning:\` lines and fails only on real violations:

\`\`\`make
lint-ci: build-loglint
	@out=$(go vet -vettool=./tools/bin/loglint ./internal/... 2>&1 | grep -v "^#" | grep -v "warning:"); \
	if [ -n "$out" ]; then echo "$out"; exit 1; fi
\`\`\`

The workflow simply wasn't using that target.

## Fix

- \`.github/workflows/test.yml\`: \`Run loglint\` step now runs \`make lint-ci\` instead of raw \`go vet\`.
- Removed the now-redundant \`Build loglint\` step — \`lint-ci\` depends on \`build-loglint\`, which runs the identical build command.

## Verification

\`make lint-ci\` → **exit 0**. The only remaining diagnostics are LL008 warnings, which the gate is designed to ignore. No real (error-level) LL00x violations exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration efficiency by streamlining the linting workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->