### PR TITLE
feat(observability): OTel-native error & exception reporting to SigNoz

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -93,12 +93,16 @@ func NewRouter(
 		middleware.LoggingMiddleware(logger), // Use our standard logger for HTTP logging
 		middleware.CORSMiddleware,
 	)
-	// Tracing middleware fans out into otelgin (SigNoz / OTLP) and sentrygin
-	// (panic recovery + Sentry scope binding). Each handler is added separately
-	// because gin's Use signature is variadic and the slice may be empty.
+	// Tracing middleware creates the otelgin span per request (SigNoz / OTLP).
+	// Each handler is added separately because gin's Use signature is variadic
+	// and the slice may be empty.
 	for _, h := range middleware.TracingMiddleware(cfg) {
 		router.Use(h)
 	}
+	// OtelRecoveryMiddleware runs inside the otelgin span so it can record a
+	// panic as an exception span event before re-panicking to gin's outer
+	// recovery (registered above) for the 500 response + log.
+	router.Use(middleware.OtelRecoveryMiddleware())
 	// SpanEnrichmentMiddleware runs after otelgin (span created) and before handlers.
 	// Post-phase executes before otelgin's post-phase (LIFO), so it can set span
 	// status / record errors before the span is ended and exported.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,22 +126,22 @@ type SupabaseConfig struct {
 }
 
 type KafkaConfig struct {
-	Brokers                []string             `mapstructure:"brokers" validate:"required"`
-	ConsumerGroup          string               `mapstructure:"consumer_group" validate:"required"`
-	Topic                  string               `mapstructure:"topic" validate:"required"`
-	TopicLazy              string               `mapstructure:"topic_lazy" validate:"required"`
-	TopicDLQ               string               `mapstructure:"topic_dlq" default:""`
-	TLS                    bool                 `mapstructure:"tls"` // set to true if using 9094 port else can set to false
-	UseSASL                bool                 `mapstructure:"use_sasl"`
-	SASLMechanism          sarama.SASLMechanism `mapstructure:"sasl_mechanism"`
-	SASLUser               string               `mapstructure:"sasl_user"`
-	SASLPassword           string               `mapstructure:"sasl_password"`
+	Brokers       []string             `mapstructure:"brokers" validate:"required"`
+	ConsumerGroup string               `mapstructure:"consumer_group" validate:"required"`
+	Topic         string               `mapstructure:"topic" validate:"required"`
+	TopicLazy     string               `mapstructure:"topic_lazy" validate:"required"`
+	TopicDLQ      string               `mapstructure:"topic_dlq" default:""`
+	TLS           bool                 `mapstructure:"tls"` // set to true if using 9094 port else can set to false
+	UseSASL       bool                 `mapstructure:"use_sasl"`
+	SASLMechanism sarama.SASLMechanism `mapstructure:"sasl_mechanism"`
+	SASLUser      string               `mapstructure:"sasl_user"`
+	SASLPassword  string               `mapstructure:"sasl_password"`
 	// SASLOAuthScopes is consulted only when SASLMechanism is OAUTHBEARER.
 	// Empty defaults to ["https://www.googleapis.com/auth/cloud-platform"],
 	// which is what GCP Managed Kafka requires.
-	SASLOAuthScopes        []string             `mapstructure:"sasl_oauth_scopes"`
-	ClientID               string               `mapstructure:"client_id" validate:"required"`
-	RouteTenantsOnLazyMode []string             `mapstructure:"route_tenants_on_lazy_mode" validate:"omitempty"`
+	SASLOAuthScopes        []string `mapstructure:"sasl_oauth_scopes"`
+	ClientID               string   `mapstructure:"client_id" validate:"required"`
+	RouteTenantsOnLazyMode []string `mapstructure:"route_tenants_on_lazy_mode" validate:"omitempty"`
 }
 
 type ClickHouseConfig struct {
@@ -206,8 +206,11 @@ type APIKeyDetails struct {
 	IsActive bool   `mapstructure:"is_active" json:"is_active" default:"true"` // whether this key is active
 }
 
+// SentryConfig is retained only for transitional rollback. Error/exception
+// capture is now OTel-native (see internal/tracing.CaptureException and
+// internal/spanerr); Sentry is no longer the sink and defaults to disabled.
 type SentryConfig struct {
-	Enabled     bool    `mapstructure:"enabled"`
+	Enabled     bool    `mapstructure:"enabled" default:"false"`
 	DSN         string  `mapstructure:"dsn"`
 	Environment string  `mapstructure:"environment"`
 	SampleRate  float64 `mapstructure:"sample_rate" default:"1.0"`
@@ -240,9 +243,13 @@ type OtelTracesConfig struct {
 	Protocol            string            `mapstructure:"protocol" validate:"omitempty"` // overrides otel.protocol when non-empty
 	AuthHeader          string            `mapstructure:"auth_header" validate:"omitempty"`
 	AuthValue           string            `mapstructure:"auth_value" validate:"omitempty"`
-	Headers             map[string]string `mapstructure:"headers" validate:"omitempty"` // overrides otel.headers when non-empty
-	SampleRate          float64           `mapstructure:"sample_rate" default:"1.0"`    // 0.0 - 1.0
+	Headers             map[string]string `mapstructure:"headers" validate:"omitempty"`          // overrides otel.headers when non-empty
+	SampleRate          float64           `mapstructure:"sample_rate" default:"1.0"`             // 0.0 - 1.0
 	StorageSpansEnabled bool              `mapstructure:"storage_spans_enabled" default:"false"` // enable per-query DB/cache/ClickHouse child spans (can be noisy)
+	// CaptureExceptions records errors (CaptureException calls, error-level logs,
+	// recovered panics) as OTel "exception" span events for SigNoz's Exceptions
+	// tab. Keep sample_rate at 1.0 so error-bearing traces are not sampled away.
+	CaptureExceptions bool `mapstructure:"capture_exceptions" default:"true"`
 }
 
 // OtelLogsConfig configures OTLP log export. See OtelTracesConfig for the
@@ -618,20 +625,20 @@ type CustomerPortalConfig struct {
 
 // RedisConfig holds configuration for Redis
 type RedisConfig struct {
-	Host        string        `mapstructure:"host" default:"localhost"`
-	Port        int           `mapstructure:"port" default:"6379"`
-	Password    string        `mapstructure:"password" default:""`
-	DB          int           `mapstructure:"db" default:"0"`
-	UseTLS      bool          `mapstructure:"use_tls" default:"false"`
-	PoolSize    int           `mapstructure:"pool_size" default:"10"`
-	Timeout     time.Duration `mapstructure:"timeout" default:"5s"`
-	KeyPrefix   string        `mapstructure:"key_prefix" default:"flexprice"`
+	Host      string        `mapstructure:"host" default:"localhost"`
+	Port      int           `mapstructure:"port" default:"6379"`
+	Password  string        `mapstructure:"password" default:""`
+	DB        int           `mapstructure:"db" default:"0"`
+	UseTLS    bool          `mapstructure:"use_tls" default:"false"`
+	PoolSize  int           `mapstructure:"pool_size" default:"10"`
+	Timeout   time.Duration `mapstructure:"timeout" default:"5s"`
+	KeyPrefix string        `mapstructure:"key_prefix" default:"flexprice"`
 	// ClusterMode: true → *redis.ClusterClient (Redis Cluster, ElastiCache
 	// cluster-mode enabled). false → standalone *redis.Client. Default is
 	// true to preserve the pre-1.1 hardcoded behaviour; flip to false for
 	// single-node Redis. Baked default lives in config.yaml; env override:
 	// FLEXPRICE_REDIS_CLUSTER_MODE.
-	ClusterMode bool          `mapstructure:"cluster_mode"`
+	ClusterMode bool `mapstructure:"cluster_mode"`
 }
 
 func NewConfig() (*Configuration, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -685,6 +685,11 @@ func NewConfig() (*Configuration, error) {
 	_ = v.BindEnv("otel.traces.auth_value", "FLEXPRICE_OTEL_TRACES_AUTH_VALUE")
 	_ = v.BindEnv("otel.traces.sample_rate", "FLEXPRICE_OTEL_TRACES_SAMPLE_RATE")
 	_ = v.BindEnv("otel.traces.storage_spans_enabled", "FLEXPRICE_OTEL_TRACES_STORAGE_SPANS_ENABLED")
+	_ = v.BindEnv("otel.traces.capture_exceptions", "FLEXPRICE_OTEL_TRACES_CAPTURE_EXCEPTIONS")
+	// Exception capture is on by default. Struct `default:` tags aren't applied at
+	// runtime here (defaults live in config.yaml), so guarantee default-on via
+	// SetDefault for deploys whose config.yaml predates this key. Env/yaml override.
+	v.SetDefault("otel.traces.capture_exceptions", true)
 	_ = v.BindEnv("otel.logs.enabled", "FLEXPRICE_OTEL_LOGS_ENABLED")
 	_ = v.BindEnv("otel.logs.endpoint", "FLEXPRICE_OTEL_LOGS_ENDPOINT")
 	_ = v.BindEnv("otel.logs.protocol", "FLEXPRICE_OTEL_LOGS_PROTOCOL")

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -58,8 +58,12 @@ postgres:
   conn_max_lifetime_minutes: 60
   auto_migrate: false
 
+# Sentry is decommissioned: error/exception capture is now OTel-native and lands
+# in SigNoz's Exceptions tab (see otel.traces.capture_exceptions below). These
+# keys are retained, default-off, only for transitional rollback and will be
+# removed in a follow-up.
 sentry:
-  enabled: true
+  enabled: false
   dsn: "" # Set via FLEXPRICE_SENTRY_DSN env var
   environment: "development" # Override via FLEXPRICE_SENTRY_ENVIRONMENT
   sample_rate: 1.0 # Adjust sampling rate as needed (0.0 to 1.0)
@@ -97,6 +101,9 @@ otel:
     auth_header: "signoz-ingestion-key"  # Set auth_value via FLEXPRICE_OTEL_TRACES_AUTH_VALUE
     auth_value: ""
     sample_rate: 1.0
+    # Record errors/panics as OTel "exception" span events (SigNoz Exceptions tab).
+    # Replaces Sentry. Keep sample_rate at 1.0 so error traces aren't sampled away.
+    capture_exceptions: true
 
   logs:
     enabled: false

--- a/internal/ee/service/credit_grants.go
+++ b/internal/ee/service/credit_grants.go
@@ -388,7 +388,7 @@ func (s *creditGrantService) applyCreditGrantToWallet(ctx context.Context, grant
 
 func (s *creditGrantService) handleCreditGrantFailure(ctx context.Context, cga *domainCreditGrantApplication.CreditGrantApplication, err error, hint string) error {
 	s.Logger.Error(ctx, "Credit grant application failed", "cga_id", cga.ID, "grant_id", cga.CreditGrantID, "hint", hint, "error", err)
-	s.TracingSvc.CaptureException(err)
+	s.TracingSvc.CaptureException(ctx, err)
 	cga.ApplicationStatus = types.ApplicationStatusFailed
 	cga.FailureReason = lo.ToPtr(fmt.Sprintf("%s: %s", hint, err.Error()))
 	if updateErr := s.CreditGrantApplicationRepo.Update(ctx, cga); updateErr != nil {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/spanerr"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/fluent/fluent-logger-golang/fluent"
 	"go.opentelemetry.io/contrib/bridges/otelzap"
@@ -41,6 +42,10 @@ type Logger struct {
 	fluentdLogger   *fluent.Fluent
 	otelLogProvider *sdklog.LoggerProvider
 	serviceName     string
+	// captureExceptions enables auto-recording error-level logs as OTel
+	// exception span events (SigNoz Exceptions tab). Mirrors
+	// otel.traces.capture_exceptions; see logErrorToSpan.
+	captureExceptions bool
 	// ctxBound is true once WithContext has wrapped the core with otelCtxCore.
 	// Guards against repeated WithContext calls accumulating nested wrappers,
 	// which would append multiple _span_ctx fields on every Write.
@@ -213,10 +218,11 @@ func NewLogger(cfg *config.Configuration) (*Logger, error) {
 	}
 
 	return &Logger{
-		SugaredLogger:   sugar,
-		fluentdLogger:   fluentdLogger,
-		otelLogProvider: otelLogProvider,
-		serviceName:     string(cfg.Deployment.Mode),
+		SugaredLogger:     sugar,
+		fluentdLogger:     fluentdLogger,
+		otelLogProvider:   otelLogProvider,
+		serviceName:       string(cfg.Deployment.Mode),
+		captureExceptions: cfg.Otel.Enabled && cfg.Otel.Traces.Enabled && cfg.Otel.Traces.CaptureExceptions,
 	}, nil
 }
 
@@ -413,11 +419,12 @@ func (l *Logger) WithContext(ctx context.Context) *Logger {
 	}
 
 	return &Logger{
-		SugaredLogger:   newSugared,
-		fluentdLogger:   l.fluentdLogger,
-		otelLogProvider: l.otelLogProvider,
-		serviceName:     l.serviceName,
-		ctxBound:        ctxBound,
+		SugaredLogger:     newSugared,
+		fluentdLogger:     l.fluentdLogger,
+		otelLogProvider:   l.otelLogProvider,
+		serviceName:       l.serviceName,
+		captureExceptions: l.captureExceptions,
+		ctxBound:          ctxBound,
 	}
 }
 
@@ -455,11 +462,54 @@ func (l *Logger) Warn(ctx context.Context, msg string, fields ...any) {
 	lc.sendToFluentd("warning", msg, lc.keysAndValuesToMap(fields...))
 }
 
-// Error logs at error level with auto-bound context fields.
+// Error logs at error level with auto-bound context fields. When OTel exception
+// capture is enabled and ctx carries a recording span, the error is also
+// recorded as an "exception" span event so it appears in SigNoz's Exceptions tab
+// (Sentry-parity auto-capture, near-zero call-site churn).
 func (l *Logger) Error(ctx context.Context, msg string, fields ...any) {
 	lc := l.WithContext(ctx)
 	lc.SugaredLogger.Errorw(msg, fields...)
 	lc.sendToFluentd("error", msg, lc.keysAndValuesToMap(fields...))
+	l.logErrorToSpan(ctx, msg, fields...)
+}
+
+// logErrorToSpan records an error-level log as an OTel exception span event.
+// It derives exception.type / exception.message from the structured "error" and
+// "error_type" fields the codebase already emits via logger.Err(err); the field
+// value may be a raw error or its string form (both call styles exist). No-op
+// when capture is disabled or ctx has no recording span (spanerr handles the
+// latter) — spanless errors reach the Exceptions tab via CaptureException.
+func (l *Logger) logErrorToSpan(ctx context.Context, msg string, fields ...any) {
+	if !l.captureExceptions || ctx == nil {
+		return
+	}
+	errType, message := "", ""
+	for i := 0; i+1 < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "error":
+			switch v := fields[i+1].(type) {
+			case error:
+				message = v.Error()
+				if errType == "" {
+					errType = fmt.Sprintf("%T", v)
+				}
+			case string:
+				message = v
+			}
+		case "error_type":
+			if v, ok := fields[i+1].(string); ok && v != "" {
+				errType = v
+			}
+		}
+	}
+	if message == "" {
+		message = msg
+	}
+	spanerr.RecordException(ctx, errType, message)
 }
 
 // Fatal logs at fatal level then calls os.Exit(1). Use only in cmd/.

--- a/internal/pubsub/router/router.go
+++ b/internal/pubsub/router/router.go
@@ -129,7 +129,9 @@ func (r *Router) AddNoPublishHandler(
 		func(msg *message.Message) error {
 			err := handlerFunc(msg)
 			if err != nil {
-				r.tracing.CaptureException(err)
+				// No request span on this watermill callback — CaptureException
+				// synthesizes a span so the failure still reaches SigNoz.
+				r.tracing.CaptureException(context.Background(), err)
 				r.logger.Error(context.Background(), "handler failed",
 					"error", err,
 					"correlation_id", middleware.MessageCorrelationID(msg),

--- a/internal/rest/middleware/tracing.go
+++ b/internal/rest/middleware/tracing.go
@@ -1,21 +1,19 @@
 package middleware
 
 import (
-	"time"
-
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/spanerr"
 	"github.com/flexprice/flexprice/internal/types"
-	"github.com/getsentry/sentry-go"
-	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// TracingMiddleware is the combined HTTP tracing + error capture middleware.
-// It uses otelgin to create a span per request (exported to SigNoz / any OTLP
-// backend) and sentrygin for panic recovery + scope binding into Sentry Issues.
+// TracingMiddleware is the HTTP tracing middleware. It uses otelgin to create a
+// span per request (exported to SigNoz / any OTLP backend). Panic recovery is
+// handled separately by OtelRecoveryMiddleware (records the panic as an
+// exception span event) plus gin's own recovery as the outermost safety net.
 func TracingMiddleware(cfg *config.Configuration) []gin.HandlerFunc {
 	handlers := []gin.HandlerFunc{}
 
@@ -23,24 +21,33 @@ func TracingMiddleware(cfg *config.Configuration) []gin.HandlerFunc {
 		handlers = append(handlers, otelgin.Middleware(cfg.Otel.ResolveServiceName(cfg)))
 	}
 
-	if cfg.Sentry.Enabled {
-		handlers = append(handlers, sentrygin.New(sentrygin.Options{
-			Repanic:         true,
-			WaitForDelivery: false,
-			Timeout:         2 * time.Second,
-		}))
-	}
-
 	return handlers
+}
+
+// OtelRecoveryMiddleware records a panicking request as an OTel "exception" span
+// event (with the unwinding stacktrace) on the active span before re-panicking
+// so gin's outer recovery middleware writes the 500 and logs it. Mount it AFTER
+// TracingMiddleware so otelgin's span is present in the request context when the
+// panic unwinds through this deferred handler.
+func OtelRecoveryMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if r := recover(); r != nil {
+				spanerr.RecordPanic(c.Request.Context(), r)
+				panic(r) // re-panic: gin's outer Recovery writes 500 + logs
+			}
+		}()
+		c.Next()
+	}
 }
 
 // Gin context keys used to propagate OTel trace context from SpanEnrichmentMiddleware
 // to LoggingMiddleware. otelgin's deferred context-restore fires between the two
 // post-phases, so we stash the span IDs and the pre-restore request context here.
 const (
-	ginKeyTraceID  = "_otel_trace_id"
-	ginKeySpanID   = "_otel_span_id"
-	ginKeySpanCtx  = "_otel_span_ctx" // full context.Context with active span
+	ginKeyTraceID = "_otel_trace_id"
+	ginKeySpanID  = "_otel_span_id"
+	ginKeySpanCtx = "_otel_span_ctx" // full context.Context with active span
 )
 
 // SpanEnrichmentMiddleware runs after otelgin (which creates the span) and
@@ -73,6 +80,11 @@ func SpanEnrichmentMiddleware() gin.HandlerFunc {
 			}
 		}
 
+		// Seed a per-request exception dedup scope so an error that is both
+		// logged (auto-capture) and explicitly captured within this request
+		// produces a single exception span event rather than two.
+		c.Request = c.Request.WithContext(spanerr.WithDedup(ctx))
+
 		c.Next()
 
 		// Post-request: the span is still in c.Request.Context() here because
@@ -102,8 +114,8 @@ func SpanEnrichmentMiddleware() gin.HandlerFunc {
 	}
 }
 
-// TenantContextMiddleware enriches the active OTel span and Sentry scope with
-// tenant_id, environment_id, and user_id. Mount this after AuthenticateMiddleware
+// TenantContextMiddleware enriches the active OTel span with tenant_id,
+// environment_id, and user_id. Mount this after AuthenticateMiddleware
 // and EnvAccessMiddleware so the request context already has these set.
 func TenantContextMiddleware(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -129,20 +141,6 @@ func TenantContextMiddleware(c *gin.Context) {
 		}
 		if len(attrs) > 0 {
 			span.SetAttributes(attrs...)
-		}
-	}
-
-	// Attach to Sentry scope (visible in Sentry Issues)
-	if hub := sentrygin.GetHubFromContext(c); hub != nil {
-		if tenantID != "" {
-			hub.Scope().SetTag("tenant_id", tenantID)
-		}
-		if environmentID != "" {
-			hub.Scope().SetTag("environment_id", environmentID)
-		}
-		if userID != "" {
-			hub.Scope().SetTag("user_id", userID)
-			hub.Scope().SetUser(sentry.User{ID: userID})
 		}
 	}
 

--- a/internal/service/creditgrant.go
+++ b/internal/service/creditgrant.go
@@ -736,8 +736,9 @@ func (s *creditGrantService) handleCreditGrantFailure(
 		"hint", hint,
 		"error", err)
 
-	// Send to tracing/Sentry early
-	s.TracingSvc.CaptureException(err)
+	// Record the exception (SigNoz Exceptions tab) early. Deduped against the
+	// log.Error auto-capture above within the activity's dedup scope.
+	s.TracingSvc.CaptureException(ctx, err)
 
 	// Prepare status update with readable error message
 	cga.ApplicationStatus = types.ApplicationStatusFailed

--- a/internal/service/event.go
+++ b/internal/service/event.go
@@ -310,12 +310,12 @@ func (s *eventService) BulkGetUsageByMeter(ctx context.Context, req []*dto.GetUs
 						"processing_time_ms", processingDuration.Milliseconds(),
 					)
 
-					// Capture the error in Sentry if enabled
+					// Record the exception (SigNoz Exceptions tab) if observability is enabled
 					if sentrySvc != nil && sentrySvc.IsEnabled() {
-						sentrySvc.CaptureException(err)
+						sentrySvc.CaptureException(ctx, err)
 
 						// Add breadcrumb about the failure
-						sentrySvc.AddBreadcrumb("meter_error", fmt.Sprintf("Failed to get usage for meter %s", meterID), map[string]interface{}{
+						sentrySvc.AddBreadcrumb(ctx, "meter_error", fmt.Sprintf("Failed to get usage for meter %s", meterID), map[string]interface{}{
 							"meter_id": meterID,
 							"price_id": r.PriceID,
 							"error":    err.Error(),
@@ -436,8 +436,8 @@ func (s *eventService) BulkGetUsageByMeterSync(ctx context.Context, req []*dto.G
 			)
 
 			if sentrySvc != nil && sentrySvc.IsEnabled() {
-				sentrySvc.CaptureException(err)
-				sentrySvc.AddBreadcrumb("meter_error", fmt.Sprintf("Failed to get usage for meter %s", meterID), map[string]interface{}{
+				sentrySvc.CaptureException(ctx, err)
+				sentrySvc.AddBreadcrumb(ctx, "meter_error", fmt.Sprintf("Failed to get usage for meter %s", meterID), map[string]interface{}{
 					"meter_id": meterID,
 					"price_id": r.PriceID,
 					"error":    err.Error(),

--- a/internal/service/event_consumption.go
+++ b/internal/service/event_consumption.go
@@ -206,7 +206,7 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 			"error", err,
 			"payload", string(msg.Payload),
 		)
-		s.tracingService.CaptureException(err)
+		s.tracingService.CaptureException(context.Background(), err)
 
 		// Return error for non-retriable parse errors
 		// Watermill's poison queue middleware will handle moving it to DLQ
@@ -340,7 +340,7 @@ func (s *eventConsumptionService) ProcessRawEvent(ctx context.Context, payload [
 			"error", err,
 			"payload", string(payload),
 		)
-		s.tracingService.CaptureException(err)
+		s.tracingService.CaptureException(ctx, err)
 		return fmt.Errorf("failed to unmarshal event: %w", err)
 	}
 

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -163,7 +163,7 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 			"error", err,
 			"payload", string(msg.Payload),
 		)
-		s.tracingService.CaptureException(err)
+		s.tracingService.CaptureException(context.Background(), err)
 		return fmt.Errorf("non-retriable unmarshal error: %w", err)
 	}
 

--- a/internal/spanerr/spanerr.go
+++ b/internal/spanerr/spanerr.go
@@ -1,0 +1,135 @@
+// Package spanerr records Go errors and panics as OpenTelemetry "exception"
+// span events so they surface in SigNoz's Exceptions tab.
+//
+// SigNoz (like any OTLP backend) builds its Exceptions view from span events
+// named "exception" carrying the semantic-convention attributes exception.type,
+// exception.message and exception.stacktrace. The OTel SDK's span.RecordError
+// emits exactly such an event, but (a) it does not capture a stacktrace unless
+// asked and (b) it derives exception.type from the Go dynamic type, which loses
+// the richer error_type our structured logging already produces. This package
+// emits the event directly so we control all three attributes and always attach
+// a stacktrace.
+//
+// It is a leaf package: it depends only on the OTel API (not on internal/logger
+// or internal/tracing), so both of those packages can import it without an
+// import cycle.
+package spanerr
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// OTel semantic-convention names for exception span events. Hard-coded as string
+// literals (rather than pulled from a semconv/vX.Y.Z package) so a semconv
+// version bump can never silently change what SigNoz reads.
+const (
+	exceptionEventName    = "exception"
+	attrExceptionType     = "exception.type"
+	attrExceptionMessage  = "exception.message"
+	attrExceptionStack    = "exception.stacktrace"
+	attrExceptionEscaped  = "exception.escaped"
+	defaultExceptionType  = "error"
+	defaultPanicException = "panic"
+)
+
+// dedupCtxKey marks a context that carries a per-scope dedup set.
+type dedupCtxKey struct{}
+
+// WithDedup returns a context carrying a fresh fingerprint set scoped to the
+// current unit of work (an HTTP request, a Temporal activity, a pubsub handler).
+// While that context is in effect, Record/RecordException will record any given
+// (type, message) pair at most once — so a handler that both logs an error and
+// explicitly captures it does not produce two identical exception events.
+//
+// When a context has no dedup set (the common case for ad-hoc/background work),
+// recording proceeds without deduplication. Seeding is therefore an optimization,
+// never a correctness requirement.
+func WithDedup(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Value(dedupCtxKey{}).(*sync.Map); ok {
+		return ctx // already seeded; don't reset the set mid-scope
+	}
+	return context.WithValue(ctx, dedupCtxKey{}, &sync.Map{})
+}
+
+// markSeen reports whether (errType, message) should be recorded now. It returns
+// true the first time a fingerprint is seen within a dedup scope and false on
+// repeats. With no dedup set in ctx it always returns true.
+func markSeen(ctx context.Context, errType, message string) bool {
+	set, ok := ctx.Value(dedupCtxKey{}).(*sync.Map)
+	if !ok {
+		return true
+	}
+	_, loaded := set.LoadOrStore(errType+"\x00"+message, struct{}{})
+	return !loaded
+}
+
+// Record records err as an exception event on the active span in ctx and flips
+// the span status to Error. It is a no-op (returning false) when ctx carries no
+// recording span — callers that need the error captured even without a span
+// should use tracing.Service.CaptureException, which synthesizes one.
+func Record(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	return RecordException(ctx, fmt.Sprintf("%T", err), err.Error())
+}
+
+// RecordException records an exception event from an already-extracted type and
+// message. internal/logger uses this for auto-capture, where the error has often
+// already been reduced to its structured "error"/"error_type" fields.
+func RecordException(ctx context.Context, errType, message string) bool {
+	span := trace.SpanFromContext(ctx)
+	if span == nil || !span.SpanContext().IsValid() || !span.IsRecording() {
+		return false
+	}
+	if errType == "" {
+		errType = defaultExceptionType
+	}
+	if !markSeen(ctx, errType, message) {
+		return false
+	}
+	span.AddEvent(exceptionEventName, trace.WithAttributes(
+		attribute.String(attrExceptionType, errType),
+		attribute.String(attrExceptionMessage, message),
+		attribute.String(attrExceptionStack, currentStack()),
+	))
+	span.SetStatus(codes.Error, message)
+	return true
+}
+
+// RecordPanic records a recovered panic value as an exception event with the
+// unwinding stacktrace and marks it escaped. Intended for recovery middleware.
+func RecordPanic(ctx context.Context, recovered any) bool {
+	span := trace.SpanFromContext(ctx)
+	if span == nil || !span.SpanContext().IsValid() || !span.IsRecording() {
+		return false
+	}
+	message := fmt.Sprintf("%v", recovered)
+	span.AddEvent(exceptionEventName, trace.WithAttributes(
+		attribute.String(attrExceptionType, defaultPanicException),
+		attribute.String(attrExceptionMessage, message),
+		attribute.String(attrExceptionStack, string(debug.Stack())),
+		attribute.Bool(attrExceptionEscaped, true),
+	))
+	span.SetStatus(codes.Error, message)
+	return true
+}
+
+// currentStack captures the calling goroutine's stack. Equivalent in spirit to
+// trace.WithStackTrace(true) on RecordError, but lets us emit the event directly.
+func currentStack() string {
+	buf := make([]byte, 8192)
+	n := runtime.Stack(buf, false)
+	return string(buf[:n])
+}

--- a/internal/spanerr/spanerr_test.go
+++ b/internal/spanerr/spanerr_test.go
@@ -1,0 +1,140 @@
+package spanerr
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// newRecordingSpan returns a context carrying a live recording span plus the
+// recorder that will hold the span once it ends.
+func newRecordingSpan(t *testing.T) (context.Context, trace.Span, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	ctx, span := tp.Tracer("test").Start(context.Background(), "op")
+	return ctx, span, sr
+}
+
+func attrMap(t *testing.T, sr *tracetest.SpanRecorder) (events int, byKey map[string]string) {
+	t.Helper()
+	ended := sr.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("expected 1 ended span, got %d", len(ended))
+	}
+	byKey = map[string]string{}
+	for _, ev := range ended[0].Events() {
+		if ev.Name != exceptionEventName {
+			continue
+		}
+		events++
+		for _, a := range ev.Attributes {
+			byKey[string(a.Key)] = a.Value.Emit() // Emit renders any type (incl. bool) as a string
+		}
+	}
+	return events, byKey
+}
+
+func TestRecord_AddsExceptionEvent(t *testing.T) {
+	ctx, span, sr := newRecordingSpan(t)
+
+	if !Record(ctx, errors.New("boom")) {
+		t.Fatal("Record returned false on a recording span")
+	}
+	span.End()
+
+	n, attrs := attrMap(t, sr)
+	if n != 1 {
+		t.Fatalf("expected 1 exception event, got %d", n)
+	}
+	if attrs[attrExceptionMessage] != "boom" {
+		t.Errorf("exception.message = %q, want %q", attrs[attrExceptionMessage], "boom")
+	}
+	if attrs[attrExceptionType] != "*errors.errorString" {
+		t.Errorf("exception.type = %q, want %q", attrs[attrExceptionType], "*errors.errorString")
+	}
+	if attrs[attrExceptionStack] == "" {
+		t.Error("exception.stacktrace is empty; expected a captured stack")
+	}
+}
+
+func TestRecordException_DefaultsType(t *testing.T) {
+	ctx, span, sr := newRecordingSpan(t)
+	RecordException(ctx, "", "msg only")
+	span.End()
+
+	_, attrs := attrMap(t, sr)
+	if attrs[attrExceptionType] != defaultExceptionType {
+		t.Errorf("exception.type = %q, want default %q", attrs[attrExceptionType], defaultExceptionType)
+	}
+}
+
+func TestRecord_DedupWithinScope(t *testing.T) {
+	ctx, span, sr := newRecordingSpan(t)
+	ctx = WithDedup(ctx)
+
+	err := errors.New("dup")
+	Record(ctx, err)
+	Record(ctx, err) // same fingerprint, same scope -> suppressed
+	Record(ctx, errors.New("other"))
+	span.End()
+
+	n, _ := attrMap(t, sr)
+	if n != 2 {
+		t.Fatalf("expected 2 exception events after dedup, got %d", n)
+	}
+}
+
+func TestRecord_NoDedupWithoutScope(t *testing.T) {
+	ctx, span, sr := newRecordingSpan(t)
+
+	err := errors.New("dup")
+	Record(ctx, err)
+	Record(ctx, err) // no dedup scope -> both recorded
+	span.End()
+
+	n, _ := attrMap(t, sr)
+	if n != 2 {
+		t.Fatalf("expected 2 exception events without dedup scope, got %d", n)
+	}
+}
+
+func TestRecord_NoSpanIsNoop(t *testing.T) {
+	if Record(context.Background(), errors.New("x")) {
+		t.Error("Record returned true with no span in context")
+	}
+}
+
+func TestRecord_NilError(t *testing.T) {
+	ctx, span, sr := newRecordingSpan(t)
+	if Record(ctx, nil) {
+		t.Error("Record returned true for a nil error")
+	}
+	span.End()
+	if n, _ := attrMap(t, sr); n != 0 {
+		t.Errorf("expected 0 exception events for nil error, got %d", n)
+	}
+}
+
+func TestRecordPanic_MarksEscaped(t *testing.T) {
+	ctx, span, sr := newRecordingSpan(t)
+	if !RecordPanic(ctx, "kaboom") {
+		t.Fatal("RecordPanic returned false on a recording span")
+	}
+	span.End()
+
+	n, attrs := attrMap(t, sr)
+	if n != 1 {
+		t.Fatalf("expected 1 exception event, got %d", n)
+	}
+	if attrs[attrExceptionType] != defaultPanicException {
+		t.Errorf("exception.type = %q, want %q", attrs[attrExceptionType], defaultPanicException)
+	}
+	if attrs[attrExceptionEscaped] != "true" {
+		t.Errorf("exception.escaped = %q, want \"true\"", attrs[attrExceptionEscaped])
+	}
+}

--- a/internal/svix/client.go
+++ b/internal/svix/client.go
@@ -161,7 +161,7 @@ func (c *Client) SendMessage(ctx context.Context, applicationID string, eventTyp
 		if err.Error() == "application not found" {
 			return "", nil
 		}
-		c.captureException(err)
+		c.captureException(ctx, err)
 		return "", fmt.Errorf("failed to send message: %w", err)
 	}
 	if out == nil {
@@ -181,8 +181,8 @@ func (c *Client) startSpan(ctx context.Context, operation string, params map[str
 	return &tracing.SpanFinisher{Span: span}, ctx
 }
 
-func (c *Client) captureException(err error) {
+func (c *Client) captureException(ctx context.Context, err error) {
 	if c.sentry != nil {
-		c.sentry.CaptureException(err)
+		c.sentry.CaptureException(ctx, err)
 	}
 }

--- a/internal/temporal/interceptor/tracing_interceptor.go
+++ b/internal/temporal/interceptor/tracing_interceptor.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/flexprice/flexprice/internal/spanerr"
 	"github.com/flexprice/flexprice/internal/tracing"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/workflow"
 )
 
-// TracingInterceptor adds OTel spans around activity executions and forwards
-// workflow / activity errors to Sentry via the shared tracing.Service.
+// TracingInterceptor adds OTel spans around activity executions and records
+// workflow / activity failures as OTel exception events (SigNoz Exceptions tab)
+// via the shared tracing.Service.
 //
 // For Temporal-native span/trace propagation across workflow boundaries, the
 // recommended upstream package is github.com/temporalio/sdk-contrib/opentelemetry.
@@ -63,16 +65,17 @@ func (w *workflowInboundInterceptor) ExecuteWorkflow(ctx workflow.Context, in *i
 	result, err := w.Next.ExecuteWorkflow(ctx, in)
 
 	if err != nil {
-		logger.Error("Workflow execution failed, capturing in Sentry",
+		logger.Error("Workflow execution failed, recording exception",
 			"workflow_type", workflowInfo.WorkflowType.Name,
 			"workflow_id", workflowInfo.WorkflowExecution.ID,
 			"run_id", workflowInfo.WorkflowExecution.RunID,
 			"error", err,
 		)
 		// Guard against replay: replayed workflows re-run deterministically and
-		// would emit duplicate Sentry events for the same failure.
-		if w.tracing.IsSentryEnabled() && !workflow.IsReplaying(ctx) {
-			w.tracing.CaptureException(fmt.Errorf("temporal workflow failed: %s (ID: %s) - %w",
+		// would emit duplicate exception events for the same failure. No OTel span
+		// exists for workflows here, so CaptureException synthesizes one.
+		if !workflow.IsReplaying(ctx) {
+			w.tracing.CaptureException(context.Background(), fmt.Errorf("temporal workflow failed: %s (ID: %s) - %w",
 				workflowInfo.WorkflowType.Name,
 				workflowInfo.WorkflowExecution.ID,
 				err,
@@ -93,6 +96,12 @@ type activityInboundInterceptor struct {
 func (a *activityInboundInterceptor) ExecuteActivity(ctx context.Context, in *interceptor.ExecuteActivityInput) (interface{}, error) {
 	activityInfo := activity.GetInfo(ctx)
 
+	// Seed a per-activity exception dedup scope BEFORE creating the span so the
+	// span's context (and thus SetStatusError below) shares the same scope as the
+	// inner activity code's auto-capture — an error that is both logged and
+	// recorded via span status then produces a single exception event.
+	ctx = spanerr.WithDedup(ctx)
+
 	span, spanCtx := a.tracing.StartMonitoringSpan(ctx, fmt.Sprintf("temporal.activity.%s", activityInfo.ActivityType.Name), map[string]interface{}{
 		"activity_type": activityInfo.ActivityType.Name,
 		"activity_id":   activityInfo.ActivityID,
@@ -105,6 +114,9 @@ func (a *activityInboundInterceptor) ExecuteActivity(ctx context.Context, in *in
 
 	result, err := a.Next.ExecuteActivity(spanCtx, in)
 
+	// On failure, SetStatusError records the error as an exception event (with
+	// stacktrace) on the activity span — which is exactly what SigNoz's
+	// Exceptions tab reads. No separate CaptureException is needed here.
 	if span != nil {
 		if err != nil {
 			span.SetStatusError(err)
@@ -112,10 +124,6 @@ func (a *activityInboundInterceptor) ExecuteActivity(ctx context.Context, in *in
 			span.SetStatusOK()
 		}
 		span.Finish()
-	}
-
-	if err != nil && a.tracing.IsSentryEnabled() {
-		a.tracing.CaptureException(fmt.Errorf("temporal activity failed: %s - %w", activityInfo.ActivityType.Name, err))
 	}
 
 	return result, err

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,9 +1,12 @@
 // Package tracing provides OpenTelemetry-based distributed tracing for Flexprice.
 //
 // Tracing is OTel-native: spans are exported via OTLP (gRPC or HTTP) to any
-// compatible backend (SigNoz, Grafana Tempo, Datadog, etc.). Sentry is kept
-// only for error capture (CaptureException) — it no longer receives traces
-// or transactions.
+// compatible backend (SigNoz, Grafana Tempo, Datadog, etc.). Error and
+// exception capture is also OTel-native — CaptureException records an
+// "exception" span event (see internal/spanerr) which surfaces in SigNoz's
+// Exceptions tab. Sentry init/flush hooks remain behind the (now default-off)
+// Sentry config purely for transitional rollback; they are no longer the sink
+// for CaptureException and will be removed in a follow-up.
 //
 // The Service exposes the same span helpers the codebase historically used
 // (StartRepositorySpan, StartDBSpan, StartClickHouseSpan, etc.) and returns a
@@ -20,6 +23,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/spanerr"
 	"github.com/getsentry/sentry-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -329,25 +333,54 @@ func (s *Service) Flush(timeout uint) bool {
 	return true
 }
 
-// CaptureException reports an error to Sentry Issues.
-func (s *Service) CaptureException(err error) {
-	if s == nil || !s.sentryEnabled || err == nil {
+// CaptureException records err as an OTel "exception" span event so it surfaces
+// in SigNoz's Exceptions tab. If ctx carries a recording span, the event is
+// attached to it. Otherwise a short-lived "error.capture" span is synthesized so
+// the error is captured even outside any active trace (background goroutines,
+// some consumers). Sentry is no longer the sink — see package docs.
+func (s *Service) CaptureException(ctx context.Context, err error) {
+	if s == nil || err == nil {
 		return
 	}
-	sentry.CaptureException(err)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Active span present: record directly onto it (with per-scope dedup).
+	if sp := trace.SpanFromContext(ctx); sp.SpanContext().IsValid() && sp.IsRecording() {
+		spanerr.Record(ctx, err)
+		return
+	}
+
+	// No active span. Synthesize one so the exception still reaches SigNoz.
+	// Requires tracing to be enabled; otherwise there is nowhere to export it.
+	if !s.tracingEnabled {
+		return
+	}
+	_, sp := s.tracer.Start(ctx, "error.capture")
+	defer sp.End()
+	sp.RecordError(err, trace.WithStackTrace(true))
+	sp.SetStatus(codes.Error, err.Error())
 }
 
-// AddBreadcrumb attaches a Sentry breadcrumb to the current scope.
-func (s *Service) AddBreadcrumb(category, message string, data map[string]interface{}) {
-	if s == nil || !s.sentryEnabled {
+// AddBreadcrumb attaches a contextual breadcrumb as an OTel span event on the
+// active span. Breadcrumbs show up in the Span Details timeline in SigNoz,
+// alongside any exception events, giving the same "what led up to this" trail
+// Sentry breadcrumbs provided. No-op when ctx has no recording span.
+func (s *Service) AddBreadcrumb(ctx context.Context, category, message string, data map[string]interface{}) {
+	if s == nil || ctx == nil {
 		return
 	}
-	sentry.AddBreadcrumb(&sentry.Breadcrumb{
-		Category: category,
-		Message:  message,
-		Level:    sentry.LevelInfo,
-		Data:     data,
-	})
+	sp := trace.SpanFromContext(ctx)
+	if !sp.SpanContext().IsValid() || !sp.IsRecording() {
+		return
+	}
+	attrs := make([]attribute.KeyValue, 0, len(data)+1)
+	attrs = append(attrs, attribute.String("breadcrumb.message", message))
+	for k, v := range data {
+		attrs = append(attrs, toAttr("breadcrumb.data."+k, v))
+	}
+	sp.AddEvent("breadcrumb."+category, trace.WithAttributes(attrs...))
 }
 
 // ---------------------------------------------------------------------------
@@ -386,12 +419,18 @@ func (s *Span) SetTag(key, value string) {
 	s.span.SetAttributes(attribute.String(key, value))
 }
 
-// SetStatusError marks the span as failed and records the error.
+// SetStatusError marks the span as failed and records the error as an exception
+// event with a stacktrace (so it lands in SigNoz's Exceptions tab). Routes
+// through spanerr for a stacktrace and per-scope dedup; falls back to the raw
+// OTel RecordError if the span isn't reachable via context.
 func (s *Span) SetStatusError(err error) {
 	if s == nil || s.span == nil || err == nil {
 		return
 	}
-	s.span.RecordError(err)
+	if s.ctx != nil && spanerr.Record(s.ctx, err) {
+		return
+	}
+	s.span.RecordError(err, trace.WithStackTrace(true))
 	s.span.SetStatus(codes.Error, err.Error())
 }
 
@@ -497,7 +536,9 @@ func (s *Service) StartTransaction(ctx context.Context, name string) (*Span, con
 	if s == nil || !s.tracingEnabled {
 		return nil, ctx
 	}
-	newCtx, sp := s.tracer.Start(ctx, name, trace.WithSpanKind(trace.SpanKindServer))
+	// Seed a dedup scope on the transaction so an error that is both logged
+	// (auto-capture) and explicitly captured within it yields one exception event.
+	newCtx, sp := s.tracer.Start(spanerr.WithDedup(ctx), name, trace.WithSpanKind(trace.SpanKindServer))
 	return &Span{span: sp, ctx: newCtx}, newCtx
 }
 
@@ -589,7 +630,7 @@ func rootSpan(ctx context.Context) trace.Span {
 }
 
 func (s *Service) StartSvixSpan(ctx context.Context, operation string, params map[string]interface{}) (*Span, context.Context) {
-	if !s.cfg.Sentry.Enabled {
+	if s == nil || !s.tracingEnabled {
 		return nil, ctx
 	}
 

--- a/internal/webhook/payload/alert.go
+++ b/internal/webhook/payload/alert.go
@@ -32,7 +32,7 @@ func (b *AlertPayloadBuilder) BuildPayload(ctx context.Context, eventType types.
 		if err != nil {
 			// Log error but don't fail the webhook if customer fetch fails
 			// Customer is optional in the payload
-			b.services.Tracing.CaptureException(err)
+			b.services.Tracing.CaptureException(ctx, err)
 			customer = nil
 		} else {
 			customer = customerData

--- a/internal/webhook/payload/communication.go
+++ b/internal/webhook/payload/communication.go
@@ -51,7 +51,7 @@ func (b *CommunicationPayloadBuilder) BuildPayload(ctx context.Context, eventTyp
 	// inject the invoice pdf url into the invoice response
 	pdfUrl, err := b.services.InvoiceService.GetInvoicePDFUrl(ctx, invoiceID, false)
 	if err != nil {
-		b.services.Tracing.CaptureException(err)
+		b.services.Tracing.CaptureException(ctx, err)
 	}
 	invoice.InvoicePDFURL = lo.ToPtr(pdfUrl)
 

--- a/internal/webhook/payload/invoice.go
+++ b/internal/webhook/payload/invoice.go
@@ -62,7 +62,7 @@ func (b *InvoicePayloadBuilder) BuildPayload(ctx context.Context, eventType type
 	// inject the invoice pdf url into the invoice response
 	pdfUrl, err := b.services.InvoiceService.GetInvoicePDFUrl(ctx, invoiceID, false)
 	if err != nil {
-		b.services.Tracing.CaptureException(err)
+		b.services.Tracing.CaptureException(ctx, err)
 
 	}
 	invoice.InvoicePDFURL = lo.ToPtr(pdfUrl)

--- a/internal/webhook/payload/wallet.go
+++ b/internal/webhook/payload/wallet.go
@@ -54,7 +54,7 @@ func (b WalletPayloadBuilder) BuildPayload(ctx context.Context, eventType types.
 		if err != nil {
 			// Log error but don't fail the webhook if customer fetch fails
 			// Customer is optional in the payload
-			b.services.Tracing.CaptureException(err)
+			b.services.Tracing.CaptureException(ctx, err)
 			customerData = nil
 		} else {
 			customerData = customer


### PR DESCRIPTION
## Summary

Migrates error & exception capture from **Sentry** to **OTel-native `exception` span events**, so errors surface in **SigNoz's Exceptions tab** (per https://signoz.io/docs/userguide/exceptions/). Sentry is **gated off** but kept in-tree for rollback — deleting the deps/config is a deliberate follow-up.

Traces and logs were already OTLP-native to SigNoz; the only remaining Sentry-only path was explicit error capture. This closes that gap.

## What changed

- **New `internal/spanerr` leaf package** — emits `exception` span events (`exception.type` / `exception.message` / `exception.stacktrace`, the attributes SigNoz reads) with best-effort per-span dedup and an always-captured stacktrace (which `RecordError` omits by default).
- **`tracing.CaptureException(ctx, err)`** — now takes `ctx`; records onto the active span, or **synthesizes** a short-lived `error.capture` span when there's none (background goroutines, consumers). `AddBreadcrumb(ctx, …)` → span events.
- **Logger auto-capture** — `log.Error(ctx, …)` records an exception event when ctx carries a recording span. Gated by `otel.traces.capture_exceptions` (default `true`).
- **Panics** — new `OtelRecoveryMiddleware` records the panic (with stacktrace) then re-panics to gin's outer recovery. Replaces `sentrygin`.
- **Dedup scopes** seeded in the HTTP request (`SpanEnrichmentMiddleware`), `StartTransaction`, and the Temporal activity interceptor so a logged-and-captured error yields one event.
- ~10 capture sites threaded `ctx`; Temporal activity capture dropped (its `SetStatusError` already records, now with a stacktrace).
- `sentry.enabled` default flipped to `false`.

## Not in this PR (follow-up)

Deleting `getsentry/sentry-go` deps, `SentryConfig`, and `initSentry`/Sentry-`Flush` — once SigNoz exceptions are validated in prod.

## Testing

- `go build ./internal/... ./cmd/...` ✅ · `go vet ./internal/...` ✅
- New `internal/spanerr` unit tests (event emission, dedup, panic, no-span no-op) ✅
- Local end-to-end validation against an OTLP collector (see PR comments).

## Rollout note

Keep traces `sample_rate: 1.0` so error-bearing traces aren't sampled away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrate error/exception handling to OpenTelemetry-native capture; panics now emit OTel exception events and per-request dedup scopes reduce duplicates.
* **Configuration**
  * OTel exception capture enabled by default; legacy error backend disabled by default and retained only for rollback.
* **Bug Fixes**
  * Improved context propagation so exception events attach to active requests and background flows; reduced duplicate recordings.
* **Tests**
  * Added unit tests for exception recording, panic capture, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->