### PR TITLE
ci(deploy): preprod canary + manual approval gate before production rollout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,7 +145,8 @@ jobs:
   #       "cluster":          "fp-prod-backend",
   #       "api_service":      "flexprice-api-v4",
   #       "consumer_service": "flexprice-consumer-v1",
-  #       "worker_service":   "temporal-worker"
+  #       "worker_service":   "temporal-worker",
+  #       "preprod_service":  "preprod-flexprice-api-service"
   #     },
   #     {
   #       "region":           "us-west-2",
@@ -155,6 +156,10 @@ jobs:
   #       "worker_service":   "flexprice-temporal-worker-v1"
   #     }
   #   ]
+  #
+  #   preprod_service (optional): canary ECS service in the SAME cluster/region.
+  #   Targets that define it are deployed to preprod first; production rollout
+  #   then waits for manual approval (GitHub Environment: prod-approval).
   #
   #   Trigger mapping:
   #     push to main    → production targets
@@ -166,6 +171,8 @@ jobs:
     runs-on: self-hosted
     outputs:
       targets: ${{ steps.config.outputs.targets }}
+      preprod_targets: ${{ steps.config.outputs.preprod_targets }}
+      environment: ${{ steps.config.outputs.environment }}
       dry_run: ${{ steps.config.outputs.dry_run }}
 
     steps:
@@ -191,17 +198,34 @@ jobs:
 
           echo "Environment and dry_run configured (values redacted for public logs)"
 
-          # Use delimiter format so JSON (newlines, spaces) is written correctly to GITHUB_OUTPUT
           if [ "$ENV" = "production" ]; then
-            echo "targets<<TARGETS_EOF" >> $GITHUB_OUTPUT
-            echo "$PROD_TARGETS" >> $GITHUB_OUTPUT
-            echo "TARGETS_EOF" >> $GITHUB_OUTPUT
+            TARGETS_JSON="$PROD_TARGETS"
           else
-            echo "targets<<TARGETS_EOF" >> $GITHUB_OUTPUT
-            echo "$STAGING_TARGETS" >> $GITHUB_OUTPUT
-            echo "TARGETS_EOF" >> $GITHUB_OUTPUT
+            TARGETS_JSON="$STAGING_TARGETS"
           fi
 
+          # Targets that also define a preprod_service get a canary deploy +
+          # manual approval gate before the full production rollout.
+          if [ -z "$TARGETS_JSON" ]; then
+            PREPROD_TARGETS_JSON="[]"
+          else
+            PREPROD_TARGETS_JSON=$(echo "$TARGETS_JSON" | python3 -c "
+          import json, sys
+          targets = json.load(sys.stdin)
+          print(json.dumps([t for t in targets if t.get('preprod_service')]))
+          ")
+          fi
+
+          # Use delimiter format so JSON (newlines, spaces) is written correctly to GITHUB_OUTPUT
+          echo "targets<<TARGETS_EOF" >> $GITHUB_OUTPUT
+          echo "$TARGETS_JSON" >> $GITHUB_OUTPUT
+          echo "TARGETS_EOF" >> $GITHUB_OUTPUT
+
+          echo "preprod_targets<<PREPROD_EOF" >> $GITHUB_OUTPUT
+          echo "$PREPROD_TARGETS_JSON" >> $GITHUB_OUTPUT
+          echo "PREPROD_EOF" >> $GITHUB_OUTPUT
+
+          echo "environment=$ENV" >> $GITHUB_OUTPUT
           echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
 
   # ──────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,6 +263,34 @@ jobs:
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}
 
   # ──────────────────────────────────────────────────────────────────────────
+  # Job 4: Manual approval gate (production only).
+  # Bound to the GitHub Environment `prod-approval` whose required-reviewers
+  # protection rule pauses the run here until a reviewer approves.
+  # - Runs only for production, after preprod deploys succeed.
+  # - 'skipped' preprod is also accepted so a prod config with no preprod
+  #   services still gates + deploys instead of silently doing nothing.
+  # - Dry runs bypass the gate (nothing is registered/deployed anyway).
+  # Setup runbook: docs/deployment/preprod-approval-gate.md
+  # ──────────────────────────────────────────────────────────────────────────
+  approval-gate:
+    name: Approve production rollout
+    needs: [resolve-config, deploy-preprod]
+    if: >-
+      ${{ always() &&
+          needs.resolve-config.result == 'success' &&
+          needs.resolve-config.outputs.environment == 'production' &&
+          needs.resolve-config.outputs.dry_run != 'true' &&
+          (needs.deploy-preprod.result == 'success' || needs.deploy-preprod.result == 'skipped') }}
+    runs-on: self-hosted
+    environment: prod-approval
+
+    steps:
+      - name: Production rollout approved
+        run: |
+          echo "Preprod canary validated and production rollout approved."
+          echo "Proceeding to deploy api, consumer and worker services to all production targets."
+
+  # ──────────────────────────────────────────────────────────────────────────
   # Jobs 3a–3c: Deploy API, Consumer, Worker — one job per service type,
   # each with matrix over targets (regions). Runs in parallel for faster deploys
   # and smaller, trackable steps. max-parallel limits concurrent load on runners.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -301,8 +301,16 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   deploy-api:
     name: Deploy API (${{ strategy.job-index }})
-    needs: [build, resolve-config]
-    if: ${{ always() && needs.resolve-config.result == 'success' }}
+    needs: [build, resolve-config, approval-gate]
+    # staging: deploys immediately (gate is skipped / irrelevant)
+    # production: requires the approval-gate to have been approved
+    # dry-run: bypasses the gate; composite action prints plan only
+    if: >-
+      ${{ always() &&
+          needs.resolve-config.result == 'success' &&
+          (needs.resolve-config.outputs.environment != 'production' ||
+           needs.resolve-config.outputs.dry_run == 'true' ||
+           needs.approval-gate.result == 'success') }}
     runs-on: self-hosted
     strategy:
       matrix:
@@ -329,8 +337,16 @@ jobs:
 
   deploy-consumer:
     name: Deploy Consumer (${{ strategy.job-index }})
-    needs: [build, resolve-config]
-    if: ${{ always() && needs.resolve-config.result == 'success' }}
+    needs: [build, resolve-config, approval-gate]
+    # staging: deploys immediately (gate is skipped / irrelevant)
+    # production: requires the approval-gate to have been approved
+    # dry-run: bypasses the gate; composite action prints plan only
+    if: >-
+      ${{ always() &&
+          needs.resolve-config.result == 'success' &&
+          (needs.resolve-config.outputs.environment != 'production' ||
+           needs.resolve-config.outputs.dry_run == 'true' ||
+           needs.approval-gate.result == 'success') }}
     runs-on: self-hosted
     strategy:
       matrix:
@@ -357,8 +373,16 @@ jobs:
 
   deploy-worker:
     name: Deploy Worker (${{ strategy.job-index }})
-    needs: [build, resolve-config]
-    if: ${{ always() && needs.resolve-config.result == 'success' }}
+    needs: [build, resolve-config, approval-gate]
+    # staging: deploys immediately (gate is skipped / irrelevant)
+    # production: requires the approval-gate to have been approved
+    # dry-run: bypasses the gate; composite action prints plan only
+    if: >-
+      ${{ always() &&
+          needs.resolve-config.result == 'success' &&
+          (needs.resolve-config.outputs.environment != 'production' ||
+           needs.resolve-config.outputs.dry_run == 'true' ||
+           needs.approval-gate.result == 'success') }}
     runs-on: self-hosted
     strategy:
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,6 +229,40 @@ jobs:
           echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
 
   # ──────────────────────────────────────────────────────────────────────────
+  # Job 3: Canary — deploy preprod service(s) for targets that define one.
+  # Runs BEFORE the approval gate; production rollout only proceeds after a
+  # human validates these preprod deployments and approves the gate.
+  # Skipped entirely when no target defines preprod_service (e.g. staging).
+  # ──────────────────────────────────────────────────────────────────────────
+  deploy-preprod:
+    name: Deploy Preprod (${{ strategy.job-index }})
+    needs: [build, resolve-config]
+    if: ${{ always() && needs.resolve-config.result == 'success' && needs.resolve-config.outputs.preprod_targets != '[]' }}
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.resolve-config.outputs.preprod_targets) }}
+      fail-fast: false
+      max-parallel: 3
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-cicd
+          aws-region: ${{ matrix.target.region }}
+
+      - name: Deploy ECS Preprod service
+        uses: ./.github/actions/deploy-ecs-service
+        with:
+          cluster: ${{ matrix.target.cluster }}
+          region: ${{ matrix.target.region }}
+          service_name: ${{ matrix.target.preprod_service }}
+          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          dry_run: ${{ needs.resolve-config.outputs.dry_run }}
+
+  # ──────────────────────────────────────────────────────────────────────────
   # Jobs 3a–3c: Deploy API, Consumer, Worker — one job per service type,
   # each with matrix over targets (regions). Runs in parallel for faster deploys
   # and smaller, trackable steps. max-parallel limits concurrent load on runners.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -291,7 +291,7 @@ jobs:
           echo "Proceeding to deploy api, consumer and worker services to all production targets."
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Jobs 3a–3c: Deploy API, Consumer, Worker — one job per service type,
+  # Jobs 5a–5c: Deploy API, Consumer, Worker — one job per service type,
   # each with matrix over targets (regions). Runs in parallel for faster deploys
   # and smaller, trackable steps. max-parallel limits concurrent load on runners.
   #

--- a/docs/deployment/preprod-approval-gate.md
+++ b/docs/deployment/preprod-approval-gate.md
@@ -1,0 +1,89 @@
+# Preprod canary + production approval gate — setup & operations
+
+The production deploy flow (`.github/workflows/deploy.yml`) is:
+
+    build image → deploy preprod service(s) → ⏸ manual approval → full prod rollout
+                                              (GitHub Environment: prod-approval)
+
+Staging (`develop`) is unaffected: no preprod stage, no gate.
+
+## One-time setup (repo admin)
+
+### 1. Create the `prod-approval` environment
+
+1. GitHub → repo → **Settings → Environments → New environment**.
+2. Name it exactly `prod-approval` (must match `environment:` in deploy.yml).
+3. Enable **Required reviewers** and add the people/teams allowed to approve
+   production rollouts (max 6 entries; only ONE of them needs to approve).
+4. Recommended: enable **Prevent self-review** so the merger can't approve
+   their own rollout. Optional, decide per team policy.
+5. Under **Deployment branches and tags**, choose **Selected branches and tags**
+   and add `main` — prevents the gate (and thus prod deploys) from being
+   reachable from other refs.
+
+### 2. Add `preprod_service` to the deploy targets variable
+
+GitHub → repo → **Settings → Secrets and variables → Actions → Variables** →
+edit `PROD_DEPLOY_TARGETS`:
+
+    [
+      {
+        "region": "ap-south-1",
+        "cluster": "fp-prod-backend",
+        "api_service": "flexprice-api-v4",
+        "consumer_service": "flexprice-consumer-v1",
+        "worker_service": "temporal-worker",
+        "preprod_service": "preprod-flexprice-api-service"
+      },
+      {
+        "region": "us-west-2",
+        "cluster": "prod-flexprice-v1",
+        "api_service": "prod-flexprice-v1",
+        "consumer_service": "flexprice-consumer-v1",
+        "worker_service": "flexprice-temporal-worker-v1"
+      }
+    ]
+
+`preprod_service` is optional per target and names an ECS service in the SAME
+cluster/region. Targets without it (us-west-2 today) have no preprod stage but
+still wait behind the same approval gate.
+
+The preprod ECS service must already exist (today:
+`preprod-flexprice-api-service` in `fp-prod-backend`, ap-south-1). The workflow
+reuses that service's current task definition and only swaps the image, so any
+preprod-specific config (e.g. a future distinct `OTEL_SERVICE_NAME`) lives in
+the service's task definition, not in CI.
+
+### 3. Verify with a dry run
+
+Actions → "Build, Push & Deploy to AWS ECS" → **Run workflow** →
+environment `production`, **dry_run = true**. Expected: preprod + prod jobs all
+print `[DRY RUN]` plans, and the approval gate is bypassed (dry runs don't pause).
+
+Then merge a trivial change to `main` and confirm the run pauses at
+**Approve production rollout** after the preprod deploy succeeds.
+
+## Day-to-day: approving a rollout
+
+1. Merge to `main`. The workflow builds, deploys preprod
+   (`preprod-flexprice-api-service`, Mumbai), then pauses.
+2. Validate the change on the preprod API service.
+3. Open the workflow run (Actions tab; reviewers also get a notification) →
+   **Review deployments** → check `prod-approval` → **Approve and deploy**.
+4. The api/consumer/worker services deploy to ALL production targets
+   (ap-south-1 + us-west-2).
+
+To abort: **Reject** the review. Prod jobs are skipped; preprod keeps the new
+image until the next deploy (push another commit/revert to roll preprod back).
+
+Unactioned gates auto-expire after 30 days (run fails harmlessly; nothing
+deploys).
+
+## Failure modes
+
+| Situation | Result |
+|---|---|
+| Preprod deploy fails | Gate never offered; prod jobs skipped |
+| Reviewer rejects | Prod jobs skipped |
+| Gate ignored 30 days | Run times out; prod jobs skipped |
+| `prod-approval` env missing/unprotected | Gate job runs WITHOUT pausing — prod deploys immediately (the pause lives in the environment protection rule, not the YAML). Keep the environment configured. |

--- a/docs/superpowers/plans/2026-06-11-canary-preprod-gated-deploy.md
+++ b/docs/superpowers/plans/2026-06-11-canary-preprod-gated-deploy.md
@@ -1,0 +1,485 @@
+# Canary Preprod + Gated Prod Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On `main` merges, deploy preprod ECS service(s) first, pause for manual approval (GitHub Environment), then roll out the full production deploy — per the approved spec at `docs/superpowers/specs/2026-06-11-canary-preprod-gated-deploy-design.md`.
+
+**Architecture:** Single-workflow change to `.github/workflows/deploy.yml`: `resolve-config` gains `environment` + `preprod_targets` outputs; a new `deploy-preprod` job (matrix over preprod-enabled targets) reuses the existing `deploy-ecs-service` composite action; a new `approval-gate` job bound to GitHub Environment `prod-approval` pauses the run; the three existing prod deploy jobs are gated on it for production only. Staging (`develop`) behavior is unchanged.
+
+**Tech Stack:** GitHub Actions (self-hosted runners), AWS ECS via existing composite action, python3 for JSON filtering (already used by the composite action).
+
+**Two deliberate refinements beyond the spec text** (both preserve spec intent, flag to user at review):
+1. `approval-gate` also treats `deploy-preprod.result == 'skipped'` as passable, so a production config with *zero* preprod services still gets a gate then deploys (instead of silently never deploying prod).
+2. Dry-run dispatches **bypass** the gate (`dry_run == 'true'` short-circuits both the gate job and the prod-job guards), preserving today's "validate config & print plan" UX without a human pause. Nothing is registered/deployed on dry runs anyway.
+
+---
+
+## File Structure
+
+- **Modify:** `.github/workflows/deploy.yml`
+  - `resolve-config` job: restructured config step + 2 new outputs
+  - New job `deploy-preprod` (after `resolve-config`, before the deploy jobs)
+  - New job `approval-gate`
+  - `deploy-api` / `deploy-consumer` / `deploy-worker`: `needs` + `if` changes only
+  - Comment block updates documenting `preprod_service` and the flow
+- **Create:** `docs/deployment/preprod-approval-gate.md` — one-time GitHub setup runbook (environment, reviewers, variable change, approval how-to)
+- **No change:** `.github/actions/deploy-ecs-service/action.yml`
+
+Note: `docs/superpowers/*` is gitignored — commit plan/spec files with `git add -f`. The runbook lives in `docs/deployment/` which is tracked normally.
+
+---
+
+### Task 1: `resolve-config` — emit `environment` and `preprod_targets`
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml:164-205` (the `resolve-config` job)
+
+- [ ] **Step 1: Test the preprod filter snippet locally (the "failing test" for config parsing)**
+
+Run:
+```bash
+echo '[{"region":"ap-south-1","cluster":"fp-prod-backend","api_service":"flexprice-api-v4","consumer_service":"flexprice-consumer-v1","worker_service":"temporal-worker","preprod_service":"preprod-flexprice-api-service"},{"region":"us-west-2","cluster":"prod-flexprice-v1","api_service":"prod-flexprice-v1","consumer_service":"flexprice-consumer-v1","worker_service":"flexprice-temporal-worker-v1"}]' | python3 -c "
+import json, sys
+targets = json.load(sys.stdin)
+print(json.dumps([t for t in targets if t.get('preprod_service')]))
+"
+```
+Expected: a one-element JSON array containing only the `ap-south-1` object (the one with `preprod_service`).
+
+Also verify the empty case:
+```bash
+echo '[{"region":"us-west-2","cluster":"c","api_service":"a","consumer_service":"b","worker_service":"w"}]' | python3 -c "
+import json, sys
+targets = json.load(sys.stdin)
+print(json.dumps([t for t in targets if t.get('preprod_service')]))
+"
+```
+Expected: `[]`
+
+- [ ] **Step 2: Update the `resolve-config` outputs block**
+
+Replace (current lines 167-169):
+```yaml
+    outputs:
+      targets: ${{ steps.config.outputs.targets }}
+      dry_run: ${{ steps.config.outputs.dry_run }}
+```
+With:
+```yaml
+    outputs:
+      targets: ${{ steps.config.outputs.targets }}
+      preprod_targets: ${{ steps.config.outputs.preprod_targets }}
+      environment: ${{ steps.config.outputs.environment }}
+      dry_run: ${{ steps.config.outputs.dry_run }}
+```
+
+- [ ] **Step 3: Replace the `run:` block of the "Select targets based on branch / input" step**
+
+Replace the entire `run: |` script (current lines 177-205) with:
+```bash
+          # Determine environment
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ENV="${{ github.event.inputs.environment }}"
+            # Default dry_run to false when not explicitly set
+            DRY_RUN="${{ github.event.inputs.dry_run }}"
+            if [ -z "$DRY_RUN" ]; then DRY_RUN="false"; fi
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            ENV="production"
+            DRY_RUN="false"
+          else
+            ENV="staging"
+            DRY_RUN="false"
+          fi
+
+          echo "Environment and dry_run configured (values redacted for public logs)"
+
+          if [ "$ENV" = "production" ]; then
+            TARGETS_JSON="$PROD_TARGETS"
+          else
+            TARGETS_JSON="$STAGING_TARGETS"
+          fi
+
+          # Targets that also define a preprod_service get a canary deploy +
+          # manual approval gate before the full production rollout.
+          if [ -z "$TARGETS_JSON" ]; then
+            PREPROD_TARGETS_JSON="[]"
+          else
+            PREPROD_TARGETS_JSON=$(echo "$TARGETS_JSON" | python3 -c "
+          import json, sys
+          targets = json.load(sys.stdin)
+          print(json.dumps([t for t in targets if t.get('preprod_service')]))
+          ")
+          fi
+
+          # Use delimiter format so JSON (newlines, spaces) is written correctly to GITHUB_OUTPUT
+          echo "targets<<TARGETS_EOF" >> $GITHUB_OUTPUT
+          echo "$TARGETS_JSON" >> $GITHUB_OUTPUT
+          echo "TARGETS_EOF" >> $GITHUB_OUTPUT
+
+          echo "preprod_targets<<PREPROD_EOF" >> $GITHUB_OUTPUT
+          echo "$PREPROD_TARGETS_JSON" >> $GITHUB_OUTPUT
+          echo "PREPROD_EOF" >> $GITHUB_OUTPUT
+
+          echo "environment=$ENV" >> $GITHUB_OUTPUT
+          echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
+```
+
+(Behavior-preserving restructure: the production/staging if/else now selects `TARGETS_JSON` once instead of duplicating the heredoc write. Indentation of the embedded python: GitHub Actions strips nothing — the python here-string lines must stay flush with the surrounding script indentation; python tolerates the leading whitespace because the `-c` string dedents consistently. Match the composite action's existing style at `.github/actions/deploy-ecs-service/action.yml:70-85`, which embeds python the same way.)
+
+- [ ] **Step 4: Update the comment block above `resolve-config` (lines ~132-163) to document `preprod_service`**
+
+Inside the example JSON in the comment, change the first (ap-south-1) object to include the optional field, and add one explanatory line. The comment's example becomes:
+```yaml
+  #   Format (one object per region):
+  #   [
+  #     {
+  #       "region":           "ap-south-1",
+  #       "cluster":          "fp-prod-backend",
+  #       "api_service":      "flexprice-api-v4",
+  #       "consumer_service": "flexprice-consumer-v1",
+  #       "worker_service":   "temporal-worker",
+  #       "preprod_service":  "preprod-flexprice-api-service"
+  #     },
+  #     {
+  #       "region":           "us-west-2",
+  #       "cluster":          "prod-flexprice-v1",
+  #       "api_service":      "prod-flexprice-v1",
+  #       "consumer_service": "flexprice-consumer-v1",
+  #       "worker_service":   "flexprice-temporal-worker-v1"
+  #     }
+  #   ]
+  #
+  #   preprod_service (optional): canary ECS service in the SAME cluster/region.
+  #   Targets that define it are deployed to preprod first; production rollout
+  #   then waits for manual approval (GitHub Environment: prod-approval).
+```
+
+- [ ] **Step 5: Validate YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci(deploy): resolve-config emits environment + preprod_targets"
+```
+
+---
+
+### Task 2: Add the `deploy-preprod` job
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` — insert new job between `resolve-config` and `deploy-api`
+
+- [ ] **Step 1: Insert the job**
+
+Add directly after the `resolve-config` job, before the `deploy-api` comment banner:
+```yaml
+  # ──────────────────────────────────────────────────────────────────────────
+  # Job 3: Canary — deploy preprod service(s) for targets that define one.
+  # Runs BEFORE the approval gate; production rollout only proceeds after a
+  # human validates these preprod deployments and approves the gate.
+  # Skipped entirely when no target defines preprod_service (e.g. staging).
+  # ──────────────────────────────────────────────────────────────────────────
+  deploy-preprod:
+    name: Deploy Preprod (${{ strategy.job-index }})
+    needs: [build, resolve-config]
+    if: ${{ always() && needs.resolve-config.result == 'success' && needs.resolve-config.outputs.preprod_targets != '[]' }}
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.resolve-config.outputs.preprod_targets) }}
+      fail-fast: false
+      max-parallel: 3
+
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-cicd
+          aws-region: ${{ matrix.target.region }}
+
+      - name: Deploy ECS Preprod service
+        uses: ./.github/actions/deploy-ecs-service
+        with:
+          cluster: ${{ matrix.target.cluster }}
+          region: ${{ matrix.target.region }}
+          service_name: ${{ matrix.target.preprod_service }}
+          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          dry_run: ${{ needs.resolve-config.outputs.dry_run }}
+```
+
+Notes for the implementer:
+- The `preprod_targets != '[]'` guard is REQUIRED: a matrix built from an empty array fails the job ("Matrix vector 'target' does not contain any values"), so we must skip the job instead.
+- No `actions/checkout` step — this matches the existing `deploy-api`/`deploy-consumer`/`deploy-worker` jobs, which rely on the self-hosted runner's persistent workspace for the local composite action. Do not "fix" this here; consistency with the working pattern matters more.
+- The `image:` fallback expression is copied verbatim from `deploy-api` (line 240) so dry-run dispatches (build skipped) still resolve an image string.
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci(deploy): add preprod canary deploy job"
+```
+
+---
+
+### Task 3: Add the `approval-gate` job
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` — insert new job after `deploy-preprod`
+
+- [ ] **Step 1: Insert the job**
+
+Add directly after `deploy-preprod`:
+```yaml
+  # ──────────────────────────────────────────────────────────────────────────
+  # Job 4: Manual approval gate (production only).
+  # Bound to the GitHub Environment `prod-approval` whose required-reviewers
+  # protection rule pauses the run here until a reviewer approves.
+  # - Runs only for production, after preprod deploys succeed.
+  # - 'skipped' preprod is also accepted so a prod config with no preprod
+  #   services still gates + deploys instead of silently doing nothing.
+  # - Dry runs bypass the gate (nothing is registered/deployed anyway).
+  # Setup runbook: docs/deployment/preprod-approval-gate.md
+  # ──────────────────────────────────────────────────────────────────────────
+  approval-gate:
+    name: Approve production rollout
+    needs: [resolve-config, deploy-preprod]
+    if: >-
+      ${{ always() &&
+          needs.resolve-config.result == 'success' &&
+          needs.resolve-config.outputs.environment == 'production' &&
+          needs.resolve-config.outputs.dry_run != 'true' &&
+          (needs.deploy-preprod.result == 'success' || needs.deploy-preprod.result == 'skipped') }}
+    runs-on: self-hosted
+    environment: prod-approval
+
+    steps:
+      - name: Production rollout approved
+        run: |
+          echo "Preprod canary validated and production rollout approved."
+          echo "Proceeding to deploy api, consumer and worker services to all production targets."
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci(deploy): add manual approval gate before production rollout"
+```
+
+---
+
+### Task 4: Gate `deploy-api`, `deploy-consumer`, `deploy-worker` on the approval
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml` — `needs:`/`if:` lines of the three deploy jobs (currently lines 218-219, 246-247, 274-275; shifted down by the two new jobs)
+
+- [ ] **Step 1: Update all three jobs' `needs` and `if`**
+
+In each of `deploy-api`, `deploy-consumer`, `deploy-worker`, replace:
+```yaml
+    needs: [build, resolve-config]
+    if: ${{ always() && needs.resolve-config.result == 'success' }}
+```
+With:
+```yaml
+    needs: [build, resolve-config, approval-gate]
+    # staging: deploys immediately (gate is skipped / irrelevant)
+    # production: requires the approval-gate to have been approved
+    # dry-run: bypasses the gate; composite action prints plan only
+    if: >-
+      ${{ always() &&
+          needs.resolve-config.result == 'success' &&
+          (needs.resolve-config.outputs.environment != 'production' ||
+           needs.resolve-config.outputs.dry_run == 'true' ||
+           needs.approval-gate.result == 'success') }}
+```
+All other content of the three jobs (matrix, steps, image expression) is untouched.
+
+- [ ] **Step 2: Verify the decision table by reading the final YAML**
+
+Walk each scenario against the conditions and confirm:
+
+| Scenario | deploy-preprod | approval-gate | deploy-api/consumer/worker |
+|---|---|---|---|
+| push `develop` (staging, no preprod svcs) | skipped (`[]`) | skipped (env != production) | **run** (env != production) |
+| push `main` (production) | runs | pauses → approved | **run** after approval |
+| push `main`, preprod deploy FAILS | fails | skipped (preprod not success/skipped) | **skipped** |
+| push `main`, reviewer REJECTS | runs | fails (rejected) | **skipped** |
+| dispatch production + dry_run | runs (prints plan) | skipped (dry_run) | **run** (dry_run bypass; plan only) |
+| dispatch staging (no dry_run) | skipped | skipped | **run** |
+
+- [ ] **Step 3: Validate YAML + actionlint (if available)**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml')); print('OK')"
+command -v actionlint >/dev/null && actionlint .github/workflows/deploy.yml || echo "actionlint not installed — skipped"
+```
+Expected: `OK`; actionlint reports no errors for deploy.yml (or is skipped).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy.yml
+git commit -m "ci(deploy): gate production rollout behind preprod approval"
+```
+
+---
+
+### Task 5: Write the GitHub setup runbook
+
+**Files:**
+- Create: `docs/deployment/preprod-approval-gate.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Full content:
+```markdown
+# Preprod canary + production approval gate — setup & operations
+
+The production deploy flow (`.github/workflows/deploy.yml`) is:
+
+    build image → deploy preprod service(s) → ⏸ manual approval → full prod rollout
+                                              (GitHub Environment: prod-approval)
+
+Staging (`develop`) is unaffected: no preprod stage, no gate.
+
+## One-time setup (repo admin)
+
+### 1. Create the `prod-approval` environment
+
+1. GitHub → repo → **Settings → Environments → New environment**.
+2. Name it exactly `prod-approval` (must match `environment:` in deploy.yml).
+3. Enable **Required reviewers** and add the people/teams allowed to approve
+   production rollouts (max 6 entries; only ONE of them needs to approve).
+4. Recommended: enable **Prevent self-review** so the merger can't approve
+   their own rollout. Optional, decide per team policy.
+5. Under **Deployment branches and tags**, choose **Selected branches and tags**
+   and add `main` — prevents the gate (and thus prod deploys) from being
+   reachable from other refs.
+
+### 2. Add `preprod_service` to the deploy targets variable
+
+GitHub → repo → **Settings → Secrets and variables → Actions → Variables** →
+edit `PROD_DEPLOY_TARGETS`:
+
+    [
+      {
+        "region": "ap-south-1",
+        "cluster": "fp-prod-backend",
+        "api_service": "flexprice-api-v4",
+        "consumer_service": "flexprice-consumer-v1",
+        "worker_service": "temporal-worker",
+        "preprod_service": "preprod-flexprice-api-service"
+      },
+      {
+        "region": "us-west-2",
+        "cluster": "prod-flexprice-v1",
+        "api_service": "prod-flexprice-v1",
+        "consumer_service": "flexprice-consumer-v1",
+        "worker_service": "flexprice-temporal-worker-v1"
+      }
+    ]
+
+`preprod_service` is optional per target and names an ECS service in the SAME
+cluster/region. Targets without it (us-west-2 today) have no preprod stage but
+still wait behind the same approval gate.
+
+The preprod ECS service must already exist (today:
+`preprod-flexprice-api-service` in `fp-prod-backend`, ap-south-1). The workflow
+reuses that service's current task definition and only swaps the image, so any
+preprod-specific config (e.g. a future distinct `OTEL_SERVICE_NAME`) lives in
+the service's task definition, not in CI.
+
+### 3. Verify with a dry run
+
+Actions → "Build, Push & Deploy to AWS ECS" → **Run workflow** →
+environment `production`, **dry_run = true**. Expected: preprod + prod jobs all
+print `[DRY RUN]` plans, and the approval gate is bypassed (dry runs don't pause).
+
+Then merge a trivial change to `main` and confirm the run pauses at
+**Approve production rollout** after the preprod deploy succeeds.
+
+## Day-to-day: approving a rollout
+
+1. Merge to `main`. The workflow builds, deploys preprod
+   (`preprod-flexprice-api-service`, Mumbai), then pauses.
+2. Validate the change on the preprod API service.
+3. Open the workflow run (Actions tab; reviewers also get a notification) →
+   **Review deployments** → check `prod-approval` → **Approve and deploy**.
+4. The api/consumer/worker services deploy to ALL production targets
+   (ap-south-1 + us-west-2).
+
+To abort: **Reject** the review. Prod jobs are skipped; preprod keeps the new
+image until the next deploy (push another commit/revert to roll preprod back).
+
+Unactioned gates auto-expire after 30 days (run fails harmlessly; nothing
+deploys).
+
+## Failure modes
+
+| Situation | Result |
+|---|---|
+| Preprod deploy fails | Gate never offered; prod jobs skipped |
+| Reviewer rejects | Prod jobs skipped |
+| Gate ignored 30 days | Run times out; prod jobs skipped |
+| `prod-approval` env missing/unprotected | Gate job runs WITHOUT pausing — prod deploys immediately (the pause lives in the environment protection rule, not the YAML). Keep the environment configured. |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/deployment/preprod-approval-gate.md
+git commit -m "docs(deploy): runbook for prod-approval environment setup"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Full-file review**
+
+Read the final `.github/workflows/deploy.yml` end-to-end and confirm:
+- Job order/`needs` graph: `build`, `resolve-config` → `deploy-preprod` → `approval-gate` → `deploy-api`/`deploy-consumer`/`deploy-worker`.
+- No job other than the three deploy jobs + `deploy-preprod` references `needs.build.outputs.image`.
+- `environment: prod-approval` appears exactly once (the gate job).
+- The staging path has no reference to preprod/gate other than skip conditions.
+
+- [ ] **Step 2: Re-run validators**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml')); print('OK')"
+command -v actionlint >/dev/null && actionlint .github/workflows/deploy.yml || echo "actionlint not installed — skipped"
+```
+Expected: `OK`, no actionlint errors.
+
+- [ ] **Step 3: Commit the plan file (gitignored path, force-add)**
+
+```bash
+git add -f docs/superpowers/plans/2026-06-11-canary-preprod-gated-deploy.md
+git commit -m "docs: implementation plan for canary preprod gated deploy"
+```
+
+---
+
+## Out-of-band steps (cannot be done from this repo — user action)
+
+1. Create the `prod-approval` GitHub Environment + required reviewers (runbook §1).
+2. Update the `PROD_DEPLOY_TARGETS` Actions variable (runbook §2).
+3. Dry-run verification + first real `main` merge watch (runbook §3).
+```

--- a/docs/superpowers/specs/2026-06-11-canary-preprod-gated-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-11-canary-preprod-gated-deploy-design.md
@@ -1,0 +1,169 @@
+# Canary preprod + manually-gated prod deploy
+
+**Date:** 2026-06-11
+**Status:** Approved (design)
+**Author:** ola@flexprice.io (with Claude)
+
+## Goal
+
+Introduce a canary-style preprod stage and a manual approval gate into the
+production deploy flow, so that on a `main` merge the pipeline first deploys to
+preprod ECS service(s), pauses for human validation, and only then rolls out the
+full production deploy.
+
+Today this matters for **one** preprod service — the Mumbai API
+(`preprod-flexprice-api-service` in cluster `fp-prod-backend`, region
+`ap-south-1`) — but the design is generic across regions/targets.
+
+## Current state (before)
+
+`.github/workflows/deploy.yml`:
+
+- Triggers on push to `develop`, `main`, and `v*` tags; plus `workflow_dispatch`
+  (`environment` choice, `dry_run` bool).
+- `build` job: builds the Docker image once, pushes to ECR tagged by `${github.sha}`
+  (and GHCR best-effort). Skipped on dry-run dispatches.
+- `resolve-config` job: selects `PROD_DEPLOY_TARGETS` or `STAGING_DEPLOY_TARGETS`
+  (JSON array, one object per region) based on branch/input, emits `targets` + `dry_run`.
+- `deploy-api`, `deploy-consumer`, `deploy-worker` jobs: each a matrix over
+  `targets`, each calling the reusable composite action
+  `./.github/actions/deploy-ecs-service` with the target's cluster/region/service.
+  All three run in parallel immediately after build, for **every** target.
+
+`.github/actions/deploy-ecs-service/action.yml` (composite, **unchanged** by this work):
+- Describes the ECS service → grabs its current task definition → swaps any
+  container whose image starts with the ECR prefix to the new image → registers
+  a new task-def revision → `update-service --force-new-deployment`.
+- Honors `dry_run` (prints plan only).
+
+## Decisions
+
+- **Platform:** GitHub Actions + a GitHub **Environment** for the manual gate.
+  No AWS CodePipeline. Reuses existing OIDC role (`github-cicd`), self-hosted
+  runners, ECR flow, and the `deploy-ecs-service` composite action as-is.
+- **Single workflow:** modify `deploy.yml`; do **not** add a parallel workflow.
+- **Scope of gate:** production (`main`) only. `develop`→staging stays byte-for-byte
+  unchanged: no preprod stage, no gate.
+- **Post-approval scope:** the full existing prod rollout — `api` + `consumer` +
+  `worker` across **all** prod targets (Mumbai + us-west-2).
+- **Image:** built once, reused (same SHA) across preprod and prod stages.
+
+## Target flow (after)
+
+```
+build image
+   │
+   ├─► deploy-preprod   (matrix over targets WITH a preprod_service; today: Mumbai preprod-api)
+   │        │
+   │        ▼
+   │   approval-gate    (production only; GitHub Environment `prod-approval`, required reviewers)
+   │        │  ⏸ run pauses here until a reviewer approves
+   │        ▼
+   └─► deploy-api / deploy-consumer / deploy-worker   (all targets, all regions)
+```
+
+- **main / production:** preprods deploy → workflow pauses at `approval-gate` →
+  on approval, all prod api/consumer/worker across both regions deploy.
+- **develop / staging:** `preprod_targets` is empty → `deploy-preprod` skips;
+  `approval-gate` skips (not production); prod-deploy jobs run straight through
+  exactly as today.
+
+## Changes
+
+### 1. Config: add `preprod_service` to `PROD_DEPLOY_TARGETS`
+
+Optional per-target field. The preprod service is assumed to live in the **same
+cluster and region** as its target, so no extra cluster/region fields are needed.
+
+```json
+[
+  {
+    "region": "ap-south-1",
+    "cluster": "fp-prod-backend",
+    "api_service": "flexprice-api-v4",
+    "consumer_service": "flexprice-consumer-v1",
+    "worker_service": "temporal-worker",
+    "preprod_service": "preprod-flexprice-api-service"
+  },
+  {
+    "region": "us-west-2",
+    "cluster": "prod-flexprice-v1",
+    "api_service": "prod-flexprice-v1",
+    "consumer_service": "flexprice-consumer-v1",
+    "worker_service": "flexprice-temporal-worker-v1"
+  }
+]
+```
+
+(GitHub repo-settings change, not a code change.)
+
+### 2. `resolve-config` job — new outputs
+
+In addition to `targets` and `dry_run`, emit:
+- `environment` — `production` | `staging` (already computed internally as `ENV`).
+- `preprod_targets` — the `targets` array filtered to objects with a non-empty
+  `preprod_service`. Produced with a `python3`/`jq` step. Empty array for staging.
+
+### 3. New `deploy-preprod` job
+
+- `needs: [build, resolve-config]`, `if: always() && needs.resolve-config.result == 'success'`.
+- `strategy.matrix.target: ${{ fromJson(needs.resolve-config.outputs.preprod_targets) }}`,
+  `fail-fast: false`, `max-parallel: 3`. Empty matrix → job is skipped.
+- Configures AWS creds (OIDC) for `${{ matrix.target.region }}`.
+- Calls `./.github/actions/deploy-ecs-service` with:
+  `cluster=${{ matrix.target.cluster }}`, `region=${{ matrix.target.region }}`,
+  `service_name=${{ matrix.target.preprod_service }}`, the built image (with the
+  same fallback-image expression the existing deploy jobs use), and `dry_run`.
+
+### 4. New `approval-gate` job
+
+- `needs: [resolve-config, deploy-preprod]`.
+- `if: needs.resolve-config.outputs.environment == 'production'` — so it only runs
+  for production, and (via `needs`, no `always()`) only after `deploy-preprod`
+  succeeds. If preprod fails, the gate is skipped and prod never deploys.
+- `environment: prod-approval` — the required-reviewers protection rule on this
+  GitHub Environment is what pauses the run.
+- Body is a single informational `echo` step; the gate is the environment, not the step.
+
+### 5. Gate the existing prod-deploy jobs
+
+For `deploy-api`, `deploy-consumer`, `deploy-worker`:
+- Add `approval-gate` to `needs`: `needs: [build, resolve-config, approval-gate]`.
+- Change the guard to:
+  ```yaml
+  if: >-
+    always() && needs.resolve-config.result == 'success' &&
+    ( needs.resolve-config.outputs.environment != 'production' ||
+      needs.approval-gate.result == 'success' )
+  ```
+  - **staging:** `environment != 'production'` → runs (gate skipped, irrelevant).
+  - **production:** requires `approval-gate.result == 'success'` → only runs after
+    approval; if preprod failed or approval was rejected, these skip.
+- Matrix, composite-action calls, and image expressions are otherwise unchanged.
+
+### 6. One-time GitHub repo setup (documented, not in YAML)
+
+- Create a GitHub **Environment** named `prod-approval`.
+- Add a **Required reviewers** protection rule listing the approvers.
+- (Optional) restrict the environment to the `main` branch.
+- Add `preprod_service` to the Mumbai entry of the `PROD_DEPLOY_TARGETS` variable.
+
+## Non-goals
+
+- No change to the `deploy-ecs-service` composite action.
+- No change to staging/`develop` behavior.
+- No change to how the preprod task definition is shaped (it currently mirrors
+  `web_api`; `otel_service_name` differentiation is deferred — the composite
+  action just reuses the preprod service's existing task def and swaps the image).
+- No AWS CodePipeline / CodeBuild infrastructure.
+
+## Risks / notes
+
+- The manual gate depends on the `prod-approval` Environment + reviewers being
+  configured in repo settings; without it the "pause" won't happen (the job would
+  just run through). This is the one out-of-band setup step.
+- `develop` path is protected by the `environment != 'production'` branch of the
+  guard — verify staging still deploys without interruption after the change.
+- If `preprod_service` is added to a target but that ECS service doesn't exist,
+  the composite action exits non-zero (service-not-found), failing the preprod
+  stage and correctly blocking the gate.


### PR DESCRIPTION
## 📝 Description
Adds a canary-style preprod stage and a manual approval gate to the production deploy pipeline. On a `main` merge the flow is now:

```
build image → deploy preprod service(s) → ⏸ manual approval → full prod rollout
              (today: Mumbai preprod-flexprice-api-service)   (api + consumer + worker, all regions)
```

- `resolve-config` now also emits `environment` and `preprod_targets` (targets whose config defines a `preprod_service`).
- New `deploy-preprod` job: deploys the freshly built image to each target's preprod ECS service, reusing the existing `deploy-ecs-service` composite action unchanged (same task def, image swapped).
- New `approval-gate` job: production-only, bound to GitHub Environment `prod-approval` — the required-reviewers protection rule pauses the run until someone approves.
- `deploy-api` / `deploy-consumer` / `deploy-worker` now run for production only after the gate is approved. **Staging (`develop`) behavior is unchanged**, and dry-run dispatches bypass the gate (they only print plans anyway).
- If the preprod deploy fails or the reviewer rejects, production is never touched.

Design spec and implementation plan are included under `docs/superpowers/`.

### ⚠️ Required before/at merge (repo settings — see `docs/deployment/preprod-approval-gate.md`)
1. Create GitHub Environment `prod-approval` with **Required reviewers** (without it, the gate job runs without pausing).
2. Add `"preprod_service": "preprod-flexprice-api-service"` to the `ap-south-1` entry of the `PROD_DEPLOY_TARGETS` Actions variable (until then, the preprod stage skips and the gate still applies).

---

## 🔨 Changes Made
- [x] Feature 1 (preprod canary stage + approval-gated production rollout in `deploy.yml`)
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation Update (setup/operations runbook: `docs/deployment/preprod-approval-gate.md`)

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable. (workflow change — validated by YAML parse + executing the extracted `resolve-config` script against the real prod-targets JSON; all 6 deploy scenarios walked in the plan's decision table)
- [x] All new and existing tests pass. (no Go code touched)
- [x] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Verify post-merge via Actions → "Build, Push & Deploy to AWS ECS" → Run workflow → environment `production`, `dry_run=true` (prints plans, no pause), then watch the first real `main` merge pause at "Approve production rollout"._

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments now include a preprod canary stage before full rollout
  * Added manual approval gate for production deployments; staging deploys immediately
  * Dry-run deployments bypass the approval requirement
  * Preprod deployment skipped if no canary targets configured

* **Documentation**
  * Added operational runbook for the approval workflow
  * Added deployment design specification and implementation plan

<!-- end of auto-generated comment: release notes by coderabbit.ai -->