### PR TITLE
feat(observability): add request_id in all consumers and make ctx mandatory for all processMessage in event handlers

### DIFF
--- a/internal/integration/events/handler.go
+++ b/internal/integration/events/handler.go
@@ -145,11 +145,11 @@ func (h *handler) processIntegrationError(err error, event *types.WebhookEvent, 
 
 // processMessage unmarshals types.WebhookEvent (same envelope as customer webhooks).
 // It dispatches to event-specific processors; unknown events are ACKed and ignored.
-func (h *handler) processMessage(msg *message.Message) error {
-	ctx := msg.Context()
+func (h *handler) processMessage(ctx context.Context, msg *message.Message) error {
+
 	var event types.WebhookEvent
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		h.deps.Logger.Error(context.Background(), "integration_events: failed to unmarshal WebhookEvent, dropping message",
+		h.deps.Logger.Error(ctx, "integration_events: failed to unmarshal WebhookEvent, dropping message",
 			"message_uuid", msg.UUID,
 			"error", err,
 		)
@@ -165,7 +165,7 @@ func (h *handler) processMessage(msg *message.Message) error {
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, event.EnvironmentID)
 	ctx = context.WithValue(ctx, types.CtxUserID, event.UserID)
 
-	h.deps.Logger.Debug(context.Background(), "integration_events: consumed webhook-shaped system event",
+	h.deps.Logger.Debug(ctx, "integration_events: consumed webhook-shaped system event",
 		"message_uuid", msg.UUID,
 		"event_name", event.EventName,
 		"tenant_id", event.TenantID,

--- a/internal/integration/events/handler_test.go
+++ b/internal/integration/events/handler_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestProcessMessage_IgnoresUnknownEvent(t *testing.T) {
 	b, _ := json.Marshal(ev)
 	msg := message.NewMessage("msg-1", b)
 
-	if err := h.processMessage(msg); err != nil {
+	if err := h.processMessage(context.Background(), msg); err != nil {
 		t.Fatalf("expected nil error for unknown event, got %v", err)
 	}
 }
@@ -58,7 +59,7 @@ func TestProcessMessage_CustomerCreatedDispatchError(t *testing.T) {
 	b, _ := json.Marshal(ev)
 	msg := message.NewMessage("msg-2", b)
 
-	if err := h.processMessage(msg); err == nil {
+	if err := h.processMessage(context.Background(), msg); err == nil {
 		t.Fatalf("expected error when temporal service is unavailable")
 	}
 }

--- a/internal/pubsub/router/router.go
+++ b/internal/pubsub/router/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/tracing"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 // Router manages all message routing
@@ -119,7 +120,7 @@ func (r *Router) AddNoPublishHandler(
 	handlerName string,
 	topicName string,
 	subscriber message.Subscriber,
-	handlerFunc func(msg *message.Message) error,
+	handlerFunc func(ctx context.Context, msg *message.Message) error,
 	middlewares ...message.HandlerMiddleware,
 ) {
 	handler := r.router.AddNoPublisherHandler(
@@ -127,12 +128,13 @@ func (r *Router) AddNoPublishHandler(
 		topicName,
 		subscriber,
 		func(msg *message.Message) error {
-			err := handlerFunc(msg)
+			ctx := context.WithValue(context.Background(), types.CtxRequestID, types.GenerateUUID())
+			err := handlerFunc(ctx, msg)
 			if err != nil {
 				// No request span on this watermill callback — CaptureException
 				// synthesizes a span so the failure still reaches SigNoz.
-				r.tracing.CaptureException(context.Background(), err)
-				r.logger.Error(context.Background(), "handler failed",
+				r.tracing.CaptureException(ctx, err)
+				r.logger.Error(ctx, "handler failed",
 					"error", err,
 					"correlation_id", middleware.MessageCorrelationID(msg),
 					"message_uuid", msg.UUID,

--- a/internal/service/costsheet_usage_tracking.go
+++ b/internal/service/costsheet_usage_tracking.go
@@ -202,21 +202,13 @@ func (s *costsheetUsageTrackingService) RegisterHandlerLazy(router *pubsubRouter
 }
 
 // Process a single event message for cost sheet usage tracking
-func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) error {
+func (s *costsheetUsageTrackingService) processMessage(ctx context.Context, msg *message.Message) error {
+
 	// Extract tenant ID from message metadata
 	partitionKey := msg.Metadata.Get("partition_key")
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
-	s.Logger.Debug(context.Background(), "processing event from message queue in cost sheet usage tracking service",
-		"message_uuid", msg.UUID,
-		"partition_key", partitionKey,
-		"tenant_id", tenantID,
-		"environment_id", environmentID,
-	)
-
-	// Create a background context with tenant ID
-	ctx := context.Background()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}
@@ -225,10 +217,17 @@ func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) err
 		ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 	}
 
+	s.Logger.Debug(ctx, "processing event from message queue in cost sheet usage tracking service",
+		"message_uuid", msg.UUID,
+		"partition_key", partitionKey,
+		"tenant_id", tenantID,
+		"environment_id", environmentID,
+	)
+
 	// Unmarshal the event
 	var event events.Event
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal event for cost sheet usage tracking",
+		s.Logger.Error(ctx, "failed to unmarshal event for cost sheet usage tracking",
 			"error", err,
 			"message_uuid", msg.UUID,
 		)
@@ -237,7 +236,7 @@ func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) err
 
 	// validate tenant id
 	if event.TenantID != tenantID {
-		s.Logger.Info(context.Background(), "invalid tenant id",
+		s.Logger.Info(ctx, "invalid tenant id",
 			"expected", tenantID,
 			"actual", event.TenantID,
 			"message_uuid", msg.UUID,
@@ -247,7 +246,7 @@ func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) err
 
 	// Process the event
 	if err := s.processEvent(ctx, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to process event for cost sheet usage tracking",
+		s.Logger.Error(ctx, "failed to process event for cost sheet usage tracking",
 			"error", err,
 			"event_id", event.ID,
 			"event_name", event.EventName,
@@ -255,7 +254,7 @@ func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) err
 		return err // Return error for retry
 	}
 
-	s.Logger.Info(context.Background(), "event for cost sheet usage tracking processed successfully",
+	s.Logger.Info(ctx, "event for cost sheet usage tracking processed successfully",
 		"event_id", event.ID,
 		"event_name", event.EventName,
 	)

--- a/internal/service/event_consumption.go
+++ b/internal/service/event_consumption.go
@@ -186,13 +186,13 @@ func (s *eventConsumptionService) RegisterHandlerReplay(
 }
 
 // processMessage processes a single event message from Kafka
-func (s *eventConsumptionService) processMessage(msg *message.Message) error {
+func (s *eventConsumptionService) processMessage(ctx context.Context, msg *message.Message) error {
 
 	partitionKey := msg.Metadata.Get("partition_key")
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
-	s.Logger.Debug(context.Background(), "processing event from message queue in event consumption service",
+	s.Logger.Debug(ctx, "processing event from message queue in event consumption service",
 		"message_uuid", msg.UUID,
 		"partition_key", partitionKey,
 		"tenant_id", tenantID,
@@ -202,11 +202,11 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 	// Unmarshal the event
 	var event events.Event
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal event",
+		s.Logger.Error(ctx, "failed to unmarshal event",
 			"error", err,
 			"payload", string(msg.Payload),
 		)
-		s.tracingService.CaptureException(context.Background(), err)
+		s.tracingService.CaptureException(ctx, err)
 
 		// Return error for non-retriable parse errors
 		// Watermill's poison queue middleware will handle moving it to DLQ
@@ -224,8 +224,6 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 		environmentID = event.EnvironmentID
 	}
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}
@@ -234,7 +232,7 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 		ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 	}
 
-	s.Logger.Debug(context.Background(), "processing event in event consumption service",
+	s.Logger.Debug(ctx, "processing event in event consumption service",
 		"event_id", event.ID,
 		"event_name", event.EventName,
 		"tenant_id", event.TenantID,
@@ -246,7 +244,7 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 	// Prepare events to insert
 	eventsToInsert := []*events.Event{&event}
 
-	s.Logger.Debug(context.Background(), "creating billing event",
+	s.Logger.Debug(ctx, "creating billing event",
 		"tenant_id", s.Config.Billing.TenantID,
 		"environment_id", s.Config.Billing.EnvironmentID,
 		"external_customer_id", event.ExternalCustomerID,
@@ -271,7 +269,7 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 			"system",
 			s.Config.Billing.EnvironmentID,
 		)
-		s.Logger.Debug(context.Background(), "appending billing event",
+		s.Logger.Debug(ctx, "appending billing event",
 			"tenant_id", s.Config.Billing.TenantID,
 			"environment_id", s.Config.Billing.EnvironmentID,
 			"external_customer_id", event.ExternalCustomerID,
@@ -281,13 +279,13 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 	}
 
 	// Insert events into ClickHouse
-	s.Logger.Debug(context.Background(), "inserting events into ClickHouse",
+	s.Logger.Debug(ctx, "inserting events into ClickHouse",
 		"event_id", event.ID,
 		"events_to_insert_count", len(eventsToInsert),
 	)
 
 	if err := s.eventRepo.BulkInsertEvents(ctx, eventsToInsert); err != nil {
-		s.Logger.Error(context.Background(), "failed to insert events",
+		s.Logger.Error(ctx, "failed to insert events",
 			"error", err,
 			"event_id", event.ID,
 			"event_name", event.EventName,
@@ -303,7 +301,7 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 	// Only for the tenants that are forced to v1
 	if s.Config.FeatureFlag.ForceV1ForTenant != "" && event.TenantID == s.Config.FeatureFlag.ForceV1ForTenant {
 		if err := s.eventPostProcessingSvc.PublishEvent(ctx, &event, false); err != nil {
-			s.Logger.Error(context.Background(), "failed to publish event to post-processing service",
+			s.Logger.Error(ctx, "failed to publish event to post-processing service",
 				"error", err,
 				"event_id", event.ID,
 				"event_name", event.EventName,
@@ -316,7 +314,7 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 		}
 	}
 
-	s.Logger.Debug(context.Background(), "successfully processed event",
+	s.Logger.Debug(ctx, "successfully processed event",
 		"event_id", event.ID,
 		"event_name", event.EventName,
 		"lag_ms", time.Since(event.Timestamp).Milliseconds(),

--- a/internal/service/event_post_processing.go
+++ b/internal/service/event_post_processing.go
@@ -210,29 +210,21 @@ func (s *eventPostProcessingService) RegisterHandler(router *pubsubRouter.Router
 }
 
 // Process a single event message
-func (s *eventPostProcessingService) processMessage(msg *message.Message) error {
+func (s *eventPostProcessingService) processMessage(ctx context.Context, msg *message.Message) error {
+
 	// Extract tenant ID from message metadata
 	partitionKey := msg.Metadata.Get("partition_key")
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
 	if s.Config.FeatureFlag.ForceV1ForTenant != "" && tenantID != s.Config.FeatureFlag.ForceV1ForTenant {
-		s.Logger.Debug(context.Background(), "skipping event post-processing for tenant as its not a part of v1 pipeline",
+		s.Logger.Debug(ctx, "skipping event post-processing for tenant as its not a part of v1 pipeline",
 			"tenant_id", tenantID,
 			"force_v1_for_tenant", s.Config.FeatureFlag.ForceV1ForTenant,
 		)
 		return nil
 	}
 
-	s.Logger.Debug(context.Background(), "processing event from message queue in event post processing service",
-		"message_uuid", msg.UUID,
-		"partition_key", partitionKey,
-		"tenant_id", tenantID,
-		"environment_id", environmentID,
-	)
-
-	// Create a background context with tenant ID
-	ctx := context.Background()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}
@@ -241,10 +233,17 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 		ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 	}
 
+	s.Logger.Debug(ctx, "processing event from message queue in event post processing service",
+		"message_uuid", msg.UUID,
+		"partition_key", partitionKey,
+		"tenant_id", tenantID,
+		"environment_id", environmentID,
+	)
+
 	// Unmarshal the event
 	var event events.Event
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal event for post-processing",
+		s.Logger.Error(ctx, "failed to unmarshal event for post-processing",
 			"error", err,
 			"message_uuid", msg.UUID,
 		)
@@ -263,14 +262,14 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 			ExternalCustomerID: event.ExternalCustomerID,
 		})
 		if err != nil {
-			s.Logger.Error(context.Background(), "failed to update event with ingested_at",
+			s.Logger.Error(ctx, "failed to update event with ingested_at",
 				"error", err,
 			)
 			return err
 		}
 
 		if len(events) == 0 {
-			s.Logger.Info(context.Background(), "event not found",
+			s.Logger.Info(ctx, "event not found",
 				"event_id", event.ID,
 				"external_customer_id", event.ExternalCustomerID,
 			)
@@ -284,7 +283,7 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 
 	// validate tenant id
 	if foundEvent.TenantID != tenantID {
-		s.Logger.Info(context.Background(), "invalid tenant id",
+		s.Logger.Info(ctx, "invalid tenant id",
 			"expected", tenantID,
 			"actual", event.TenantID,
 			"message_uuid", msg.UUID,
@@ -294,7 +293,7 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 
 	// Process the event
 	if err := s.processEvent(ctx, foundEvent); err != nil {
-		s.Logger.Error(context.Background(), "failed to process event",
+		s.Logger.Error(ctx, "failed to process event",
 			"error", err,
 			"event_id", foundEvent.ID,
 			"event_name", foundEvent.EventName,
@@ -302,7 +301,7 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 		return err // Return error for retry
 	}
 
-	s.Logger.Info(context.Background(), "event processed successfully",
+	s.Logger.Info(ctx, "event processed successfully",
 		"event_id", foundEvent.ID,
 		"event_name", foundEvent.EventName,
 	)

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -318,13 +318,14 @@ func (s *featureUsageTrackingService) RegisterHandlerReplay(router *pubsubRouter
 }
 
 // Process a single event message for feature usage tracking
-func (s *featureUsageTrackingService) processMessage(msg *message.Message) error {
+func (s *featureUsageTrackingService) processMessage(ctx context.Context, msg *message.Message) error {
+
 	// Extract tenant ID from message metadata
 	partitionKey := msg.Metadata.Get("partition_key")
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
-	s.Logger.Debug(context.Background(), "processing event from message queue in feature usage tracking service",
+	s.Logger.Debug(ctx, "processing event from message queue in feature usage tracking service",
 		"message_uuid", msg.UUID,
 		"partition_key", partitionKey,
 		"tenant_id", tenantID,
@@ -334,7 +335,7 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 	// Unmarshal the event
 	var event events.Event
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal event for feature usage tracking",
+		s.Logger.Error(ctx, "failed to unmarshal event for feature usage tracking",
 			"error", err,
 			"message_uuid", msg.UUID,
 		)
@@ -343,7 +344,7 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 
 	// validate tenant id (todo commenting for now)
 	// if event.TenantID != tenantID {
-	// 	s.Logger.Error(context.Background(), "invalid tenant id",
+	// 	s.Logger.Error(ctx, "invalid tenant id",
 	// 		"expected", tenantID,
 	// 		"actual", event.TenantID,
 	// 		"message_uuid", msg.UUID,
@@ -361,18 +362,8 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 
 	event.EventName = strings.TrimSpace(event.EventName)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
-	if tenantID != "" {
-		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
-	}
-
-	if environmentID != "" {
-		ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
-	}
-
 	if tenantID == "" {
-		s.Logger.Info(context.Background(), "tenant id is required for feature usage tracking: event_id", event.ID,
+		s.Logger.Info(ctx, "tenant id is required for feature usage tracking: event_id", event.ID,
 			"event_name", event.EventName,
 			"message_uuid", msg.UUID,
 		)
@@ -380,16 +371,19 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 	}
 
 	if environmentID == "" {
-		s.Logger.Info(context.Background(), "environment id is required for feature usage tracking: event_id", event.ID,
+		s.Logger.Info(ctx, "environment id is required for feature usage tracking: event_id", event.ID,
 			"event_name", event.EventName,
 			"message_uuid", msg.UUID,
 		)
 		return nil // Don't retry on invalid environment id
 	}
 
+	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
+
 	// Process the event
 	if err := s.processEvent(ctx, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to process event for feature usage tracking",
+		s.Logger.Error(ctx, "failed to process event for feature usage tracking",
 			"error", err,
 			"event_id", event.ID,
 			"event_name", event.EventName,
@@ -397,7 +391,7 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 		return err // Return error for retry
 	}
 
-	s.Logger.Info(context.Background(), "event for feature usage tracking processed successfully",
+	s.Logger.Info(ctx, "event for feature usage tracking processed successfully",
 		"event_id", event.ID,
 		"event_name", event.EventName,
 		"tenant_id", tenantID,

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -193,13 +193,14 @@ func (s *meterUsageTrackingService) RegisterHandlerLazy(router *pubsubRouter.Rou
 }
 
 // processMessage unmarshals the Kafka message and delegates to processEvent
-func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
+func (s *meterUsageTrackingService) processMessage(ctx context.Context, msg *message.Message) error {
+
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
 	var event events.Event
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal event for meter usage tracking",
+		s.Logger.Error(ctx, "failed to unmarshal event for meter usage tracking",
 			"error", err,
 			"message_uuid", msg.UUID,
 		)
@@ -216,7 +217,7 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 	event.EventName = strings.TrimSpace(event.EventName)
 
 	if tenantID == "" || environmentID == "" {
-		s.Logger.Info(context.Background(), "tenant_id and environment_id are required for meter usage tracking",
+		s.Logger.Info(ctx, "tenant_id and environment_id are required for meter usage tracking",
 			"event_id", event.ID,
 			"tenant_id", tenantID,
 			"environment_id", environmentID,
@@ -224,12 +225,11 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 		return nil // non-retriable
 	}
 
-	ctx := context.Background()
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 
 	if err := s.processEvent(ctx, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to process event for meter usage tracking",
+		s.Logger.Error(ctx, "failed to process event for meter usage tracking",
 			"error", err,
 			"event_id", event.ID,
 		)

--- a/internal/service/onboarding.go
+++ b/internal/service/onboarding.go
@@ -232,22 +232,21 @@ func (s *onboardingService) RegisterHandler(router *pubsubRouter.Router, cfg *co
 }
 
 // processMessage processes a single onboarding event message
-func (s *onboardingService) processMessage(msg *message.Message) error {
-	// We don't need the message context anymore since we're using a background context
-	// Just log the message UUID for tracing
-	s.Logger.Debug(context.Background(), "received onboarding event message", "message_uuid", msg.UUID)
+func (s *onboardingService) processMessage(ctx context.Context, msg *message.Message) error {
+
+	s.Logger.Debug(ctx, "received onboarding event message", "message_uuid", msg.UUID)
 
 	// Unmarshal the message
 	var eventMsg types.OnboardingEventsMessage
 	if err := eventMsg.Unmarshal(msg.Payload); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal onboarding event message",
+		s.Logger.Error(ctx, "failed to unmarshal onboarding event message",
 			"error", err,
 			"message_uuid", msg.UUID,
 		)
 		return nil // Don't retry on unmarshal errors
 	}
 
-	s.Logger.Info(context.Background(), "processing onboarding events",
+	s.Logger.Info(ctx, "processing onboarding events",
 		"customer_id", eventMsg.CustomerID,
 		"feature_id", eventMsg.FeatureID,
 		"subscription_id", eventMsg.SubscriptionID,
@@ -259,9 +258,7 @@ func (s *onboardingService) processMessage(msg *message.Message) error {
 
 	// Create a new background context instead of using the message context
 	// This prevents the event generation from being cancelled when the HTTP request completes
-	bgCtx := context.Background()
-
-	// Copy tenant ID from original context to background context
+	bgCtx := context.WithValue(context.Background(), types.CtxRequestID, types.GenerateUUID())
 	bgCtx = context.WithValue(bgCtx, types.CtxTenantID, eventMsg.TenantID)
 	bgCtx = context.WithValue(bgCtx, types.CtxEnvironmentID, eventMsg.EnvironmentID)
 	bgCtx = context.WithValue(bgCtx, types.CtxUserID, eventMsg.UserID)

--- a/internal/service/raw_event_consumption.go
+++ b/internal/service/raw_event_consumption.go
@@ -151,23 +151,24 @@ func (s *rawEventConsumptionService) loadIngestionFilter(ctx context.Context) (e
 }
 
 // processMessage processes a batch of raw events from Kafka
-func (s *rawEventConsumptionService) processMessage(msg *message.Message) error {
-	s.Logger.Debug(context.Background(), "processing raw event batch from message queue",
+func (s *rawEventConsumptionService) processMessage(ctx context.Context, msg *message.Message) error {
+
+	s.Logger.Debug(ctx, "processing raw event batch from message queue",
 		"message_uuid", msg.UUID,
 	)
 
 	// Unmarshal the batch first so we have tenant/environment IDs.
 	var batch RawEventBatch
 	if err := json.Unmarshal(msg.Payload, &batch); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal raw event batch",
+		s.Logger.Error(ctx, "failed to unmarshal raw event batch",
 			"error", err,
 			"payload", string(msg.Payload),
 		)
-		s.tracingService.CaptureException(context.Background(), err)
+		s.tracingService.CaptureException(ctx, err)
 		return fmt.Errorf("non-retriable unmarshal error: %w", err)
 	}
 
-	s.Logger.Info(context.Background(), "processing raw event batch",
+	s.Logger.Info(ctx, "processing raw event batch",
 		"batch_size", len(batch.Data),
 		"message_uuid", msg.UUID,
 	)
@@ -184,7 +185,10 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		environmentID = s.Config.Billing.EnvironmentID
 	}
 
-	s.Logger.Debug(context.Background(), "using tenant and environment context",
+	ctx = types.SetTenantID(ctx, tenantID)
+	ctx = types.SetEnvironmentID(ctx, environmentID)
+
+	s.Logger.Debug(ctx, "using tenant and environment context",
 		"tenant_id", tenantID,
 		"environment_id", environmentID,
 		"source", func() string {
@@ -195,16 +199,11 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		}(),
 	)
 
-	// Build a context from the message's own context so cancellation/tracing propagates,
-	// then attach tenant and environment IDs so the settings repo can scope its query.
-	ctx := types.SetTenantID(msg.Context(), tenantID)
-	ctx = types.SetEnvironmentID(ctx, environmentID)
-
 	// Fetch the ingestion filter once per batch (one DB read per Kafka message).
 	// On a real settings-store error (not ErrNotFound) we fail the batch so Kafka retries it.
 	filterEnabled, allowlist, err := s.loadIngestionFilter(ctx)
 	if err != nil {
-		s.Logger.Error(context.Background(), "failed to load ingestion filter, failing batch for retry",
+		s.Logger.Error(ctx, "failed to load ingestion filter, failing batch for retry",
 			"tenant_id", tenantID,
 			"environment_id", environmentID,
 			"error", err,
@@ -229,7 +228,7 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		if err != nil {
 			// Transformation error
 			errorCount++
-			s.Logger.Info(context.Background(), "transformation error - event skipped",
+			s.Logger.Info(ctx, "transformation error - event skipped",
 				"batch_position", i+1,
 				"error", err.Error(),
 			)
@@ -239,7 +238,7 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		if transformedEvent == nil {
 			// Event failed validation and was dropped
 			skipCount++
-			s.Logger.Debug(context.Background(), "validation failed - event dropped",
+			s.Logger.Debug(ctx, "validation failed - event dropped",
 				"batch_position", i+1,
 			)
 			continue
@@ -250,7 +249,7 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		if filterEnabled {
 			if _, ok := allowlist[transformedEvent.ExternalCustomerID]; !ok {
 				skipCount++
-				s.Logger.Debug(context.Background(), "event filtered by ingestion allowlist - skipped",
+				s.Logger.Debug(ctx, "event filtered by ingestion allowlist - skipped",
 					"batch_position", i+1,
 				)
 				continue
@@ -260,7 +259,7 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		// Publish the transformed event to events topic
 		if err := s.publishTransformedEvent(ctx, transformedEvent); err != nil {
 			errorCount++
-			s.Logger.Error(context.Background(), "failed to publish transformed event",
+			s.Logger.Error(ctx, "failed to publish transformed event",
 				"event_id", transformedEvent.ID,
 				"event_name", transformedEvent.EventName,
 				"external_customer_id", transformedEvent.ExternalCustomerID,
@@ -272,14 +271,14 @@ func (s *rawEventConsumptionService) processMessage(msg *message.Message) error 
 		}
 
 		successCount++
-		s.Logger.Debug(context.Background(), "successfully transformed and published event",
+		s.Logger.Debug(ctx, "successfully transformed and published event",
 			"event_id", transformedEvent.ID,
 			"event_name", transformedEvent.EventName,
 			"batch_position", i+1,
 		)
 	}
 
-	s.Logger.Info(context.Background(), "completed raw event batch processing",
+	s.Logger.Info(ctx, "completed raw event batch processing",
 		"batch_size", len(batch.Data),
 		"success_count", successCount,
 		"skip_count", skipCount,

--- a/internal/service/raw_event_consumption_test.go
+++ b/internal/service/raw_event_consumption_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -194,7 +195,7 @@ func (s *RawEventConsumptionSuite) TestProcessMessage_FilterBehavior() {
 				Data:          data,
 			}
 
-			err := s.svc.processMessage(buildBatchMsg(batch))
+			err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 
 			if tc.wantErr {
 				s.Error(err)
@@ -233,7 +234,7 @@ func (s *RawEventConsumptionSuite) TestInvalidBentoEvent_SkippedBeforeFilterChec
 		},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
+	err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 	s.NoError(err)
 	s.Equal([]string{"org_001"}, s.publishedExternalIDs())
 }
@@ -242,7 +243,7 @@ func (s *RawEventConsumptionSuite) TestInvalidBentoEvent_SkippedBeforeFilterChec
 // returns an immediate non-retriable error (no retries would help).
 func (s *RawEventConsumptionSuite) TestMalformedBatchPayload_ReturnsNonRetriableError() {
 	msg := message.NewMessage("test-uuid", []byte("not-json"))
-	err := s.svc.processMessage(msg)
+	err := s.svc.processMessage(context.Background(), msg)
 	s.Error(err)
 	s.Contains(err.Error(), "non-retriable unmarshal error")
 }
@@ -272,7 +273,7 @@ func (s *RawEventConsumptionSuite) TestSettingsRepoError_FailsBatchForRetry() {
 		Data:          []json.RawMessage{json.RawMessage(validBentoPayload("org_001", "evt_001"))},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
+	err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 	s.Error(err, "corrupt setting value should fail the batch for retry")
 	s.Equal(0, len(s.outputPubSub.GetMessages(testOutputTopic)),
 		"no events should be forwarded when filter config is unreadable")
@@ -293,7 +294,7 @@ func (s *RawEventConsumptionSuite) TestTenantFallbackFromConfig() {
 		},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
+	err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 	s.NoError(err)
 	s.Equal([]string{"org_001"}, s.publishedExternalIDs())
 }

--- a/internal/service/usage_benchmark.go
+++ b/internal/service/usage_benchmark.go
@@ -159,26 +159,26 @@ func (s *usageBenchmarkService) RegisterHandler(router *pubsubRouter.Router, cfg
 }
 
 // processMessage is the internal watermill handler delegate.
-func (s *usageBenchmarkService) processMessage(msg *message.Message) error {
-	return s.ProcessMessageForTest(msg)
+func (s *usageBenchmarkService) processMessage(ctx context.Context, msg *message.Message) error {
+	return s.ProcessMessageForTest(ctx, msg)
 }
 
 // ProcessMessageForTest is exported so unit tests can call it directly.
 // Dispatches by event Kind; empty Kind is treated as subscription for back-compat
 // with events already in flight when this code rolled out.
-func (s *usageBenchmarkService) ProcessMessageForTest(msg *message.Message) error {
+func (s *usageBenchmarkService) ProcessMessageForTest(ctx context.Context, msg *message.Message) error {
+
 	tenantID := msg.Metadata.Get("tenant_id")
 	environmentID := msg.Metadata.Get("environment_id")
 
 	var evt events.UsageBenchmarkEvent
 	if err := json.Unmarshal(msg.Payload, &evt); err != nil {
 		if s.Logger != nil {
-			s.Logger.Error(context.Background(), "usage benchmark: failed to unmarshal event", "error", err)
+			s.Logger.Error(ctx, "usage benchmark: failed to unmarshal event", "error", err)
 		}
 		return nil
 	}
 
-	ctx := context.Background()
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 

--- a/internal/service/usage_benchmark_analytics_test.go
+++ b/internal/service/usage_benchmark_analytics_test.go
@@ -200,7 +200,7 @@ func TestUsageBenchmark_DispatchByKind(t *testing.T) {
 		msg.Metadata.Set("tenant_id", evt.TenantID)
 		msg.Metadata.Set("environment_id", evt.EnvironmentID)
 
-		require.NoError(t, svc.ProcessMessageForTest(msg))
+		require.NoError(t, svc.ProcessMessageForTest(context.Background(), msg))
 		require.Equal(t, 1, stub.calls, "subscription benchRepo.Insert should be called for empty Kind")
 	})
 
@@ -220,7 +220,7 @@ func TestUsageBenchmark_DispatchByKind(t *testing.T) {
 		require.NoError(t, err)
 		msg := message.NewMessage("test-2", payload)
 
-		require.NoError(t, svc.ProcessMessageForTest(msg))
+		require.NoError(t, svc.ProcessMessageForTest(context.Background(), msg))
 		require.Equal(t, 1, stub.calls)
 	})
 
@@ -251,7 +251,7 @@ func TestUsageBenchmark_DispatchByKind(t *testing.T) {
 		require.NoError(t, err)
 		msg := message.NewMessage("test-3", payload)
 
-		require.NoError(t, svc.ProcessMessageForTest(msg))
+		require.NoError(t, svc.ProcessMessageForTest(context.Background(), msg))
 		// Both pipelines return nil → no records → BulkInsert NOT called.
 		require.Equal(t, 0, stubAnalytics.calls)
 	})

--- a/internal/service/wallet_balance_alert.go
+++ b/internal/service/wallet_balance_alert.go
@@ -183,17 +183,26 @@ func (s *walletBalanceAlertService) RegisterHandler(router *pubsubRouter.Router,
 }
 
 // processMessage processes a single Kafka message for wallet balance alerts
-func (s *walletBalanceAlertService) processMessage(msg *message.Message) error {
+func (s *walletBalanceAlertService) processMessage(ctx context.Context, msg *message.Message) error {
+
 	var event wallet.WalletBalanceAlertEvent
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		s.Logger.Error(context.Background(), "failed to unmarshal wallet balance alert event",
+		s.Logger.Error(ctx, "failed to unmarshal wallet balance alert event",
 			"error", err,
 			"message_uuid", msg.UUID,
 			"payload_size", len(msg.Payload),
 		)
 		return nil
 	}
-	s.Logger.Info(context.Background(), "processing wallet balance alert message",
+
+	if event.TenantID != "" {
+		ctx = context.WithValue(ctx, types.CtxTenantID, event.TenantID)
+	}
+	if event.EnvironmentID != "" {
+		ctx = context.WithValue(ctx, types.CtxEnvironmentID, event.EnvironmentID)
+	}
+
+	s.Logger.Info(ctx, "processing wallet balance alert message",
 		"message_uuid", msg.UUID,
 		"tenant_id", event.TenantID,
 		"environment_id", event.EnvironmentID,
@@ -202,19 +211,10 @@ func (s *walletBalanceAlertService) processMessage(msg *message.Message) error {
 		"published_at", event.Timestamp,
 	)
 
-	// Create context with tenant and environment IDs
-	ctx := context.Background()
-	if event.TenantID != "" {
-		ctx = context.WithValue(ctx, types.CtxTenantID, event.TenantID)
-	}
-	if event.EnvironmentID != "" {
-		ctx = context.WithValue(ctx, types.CtxEnvironmentID, event.EnvironmentID)
-	}
-
 	// Process the event
 	if err := s.processEvent(ctx, event); err != nil {
 		// Return error to trigger retry with backoff
-		s.Logger.Error(context.Background(), "failed to process wallet balance alert event",
+		s.Logger.Error(ctx, "failed to process wallet balance alert event",
 			"error", err,
 			"event_id", event.ID,
 			"customer_id", event.CustomerID,

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -184,17 +184,11 @@ func (h *handler) absorbDeliveryError(ctx context.Context, transport string, err
 
 // processMessage processes a single webhook message from the system_events topic:
 // 1) unmarshal and verify, 2) call deliverSvix/deliverNative to send to Svix or native HTTP.
-func (h *handler) processMessage(msg *message.Message) error {
-	ctx := msg.Context()
-
-	h.logger.Debug(context.Background(), "context",
-		"tenant_id", types.GetTenantID(ctx),
-		"event_name", types.GetRequestID(ctx),
-	)
+func (h *handler) processMessage(ctx context.Context, msg *message.Message) error {
 
 	var event types.WebhookEvent
 	if err := json.Unmarshal(msg.Payload, &event); err != nil {
-		h.logger.Error(context.Background(), "failed to unmarshal webhook event",
+		h.logger.Error(ctx, "failed to unmarshal webhook event",
 			"error", err,
 			"message_uuid", msg.UUID,
 		)
@@ -203,7 +197,7 @@ func (h *handler) processMessage(msg *message.Message) error {
 		// system_event ID because the publisher sets it from event.ID.
 		if h.systemEventRepo != nil && msg.UUID != "" {
 			if dbErr := h.systemEventRepo.OnFailed(ctx, msg.UUID, "unmarshal failed: "+err.Error()); dbErr != nil {
-				h.logger.Info(context.Background(), "failed to persist webhook failure_reason on unmarshal error",
+				h.logger.Info(ctx, "failed to persist webhook failure_reason on unmarshal error",
 					"error", dbErr,
 					"message_uuid", msg.UUID,
 				)
@@ -216,7 +210,7 @@ func (h *handler) processMessage(msg *message.Message) error {
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, event.EnvironmentID)
 	ctx = context.WithValue(ctx, types.CtxUserID, event.UserID)
 
-	h.logger.Debug(context.Background(), "consumed webhook from topic and delivering",
+	h.logger.Debug(ctx, "consumed webhook from topic and delivering",
 		"topic", h.config.Topic,
 		"message_uuid", msg.UUID,
 		"event_name", event.EventName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Propagated request-scoped context across message handling to provide consistent logging, tracing, and richer diagnostic info during processing.
* **Tests**
  * Updated tests to use the new context-aware message processing entry points to keep behavior unchanged while verifying the new context propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->