### PR TITLE
fix(meter-usage): Group by in bucketed SUM and MAX meters

### DIFF
--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -40,6 +40,11 @@ type MeterUsageQueryParams struct {
 	BillingAnchor       *time.Time
 	// GroupByProperty is the JSON property key for group-by aggregation (e.g. for bucketed MAX meters)
 	GroupByProperty string
+	// GroupByProperties is the ordered list of JSON property keys for bucketed multi-key
+	// group-by aggregation. When non-empty, takes precedence over GroupByProperty.
+	// In the result, UsageResult.GroupKey carries the values joined by \x1f in the
+	// same order as this slice.
+	GroupByProperties []string
 	// UseFinal enables FINAL for ReplacingMergeTree deduplication (use for billing queries)
 	UseFinal bool
 	// PropertyFilters restrict events whose properties match. e.g. {"model": ["gpt-4"]}

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -309,7 +309,7 @@ func (r *MeterUsageRepository) GetUsageForBucketedMeters(ctx context.Context, pa
 	result.Type = params.AggregationType
 	result.MeterID = params.MeterID
 
-	hasGroupBy := params.GroupByProperty != "" && validMeterUsageGroupByPattern.MatchString(params.GroupByProperty)
+	hasGroupBy := len(bucketedInnerGroupKeys(params)) > 0
 
 	for rows.Next() {
 		var total decimal.Decimal

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -36,16 +36,26 @@ func bucketedInnerGroupKeys(params *events.MeterUsageQueryParams) []string {
 	return out
 }
 
-// bucketedOuterGroupKeys returns the key list that appears in the outer CTE
-// GROUP BY and in the result GroupKey. User-supplied keys take precedence; the
-// meter-config single key is the fallback (billing/event paths).
+// bucketedOuterGroupKeys returns the de-duplicated key list that appears in the
+// outer CTE GROUP BY and in the result GroupKey. User-supplied keys take
+// precedence; the meter-config single key is the fallback (billing/event paths).
+// Dedup mirrors bucketedInnerGroupKeys so the stacked-mode check
+// (len(innerKeys) == len(outerKeys)) and bucketedGroupByExpr both see a clean
+// key list — duplicate entries in GroupByProperties would otherwise inflate the
+// outer length and trigger the wrong CTE form.
 func bucketedOuterGroupKeys(params *events.MeterUsageQueryParams) []string {
 	if len(params.GroupByProperties) > 0 {
+		seen := make(map[string]struct{}, len(params.GroupByProperties))
 		out := make([]string, 0, len(params.GroupByProperties))
 		for _, k := range params.GroupByProperties {
-			if k != "" && validMeterUsageGroupByPattern.MatchString(k) {
-				out = append(out, k)
+			if k == "" || !validMeterUsageGroupByPattern.MatchString(k) {
+				continue
 			}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			out = append(out, k)
 		}
 		if len(out) > 0 {
 			return out

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -12,6 +12,68 @@ import (
 // validMeterUsageGroupByPattern matches safe property names (alphanumeric, underscores, dots).
 var validMeterUsageGroupByPattern = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
 
+// bucketedInnerGroupKeys returns the de-duplicated key list used by the inner
+// CTE's GROUP BY. It unions the meter-config key (GroupByProperty) and the
+// analytics keys (GroupByProperties) so the inner MAX is taken per
+// (bucket × all keys).
+func bucketedInnerGroupKeys(params *events.MeterUsageQueryParams) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, 1+len(params.GroupByProperties))
+	if params.GroupByProperty != "" && validMeterUsageGroupByPattern.MatchString(params.GroupByProperty) {
+		seen[params.GroupByProperty] = struct{}{}
+		out = append(out, params.GroupByProperty)
+	}
+	for _, k := range params.GroupByProperties {
+		if k == "" || !validMeterUsageGroupByPattern.MatchString(k) {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
+}
+
+// bucketedOuterGroupKeys returns the key list that appears in the outer CTE
+// GROUP BY and in the result GroupKey. User-supplied keys take precedence; the
+// meter-config single key is the fallback (billing/event paths).
+func bucketedOuterGroupKeys(params *events.MeterUsageQueryParams) []string {
+	if len(params.GroupByProperties) > 0 {
+		out := make([]string, 0, len(params.GroupByProperties))
+		for _, k := range params.GroupByProperties {
+			if k != "" && validMeterUsageGroupByPattern.MatchString(k) {
+				out = append(out, k)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	if params.GroupByProperty != "" && validMeterUsageGroupByPattern.MatchString(params.GroupByProperty) {
+		return []string{params.GroupByProperty}
+	}
+	return nil
+}
+
+// bucketedGroupByExpr returns the SQL expression that evaluates to the group key
+// for a row: a single JSONExtractString for one key, or a concat with \x1f
+// (ASCII Unit Separator) delimiters for multiple keys.
+func bucketedGroupByExpr(keys []string) string {
+	if len(keys) == 1 {
+		return fmt.Sprintf("JSONExtractString(properties, '%s')", keys[0])
+	}
+	parts := make([]string, 0, 2*len(keys)-1)
+	for i, k := range keys {
+		if i > 0 {
+			parts = append(parts, "'\\x1f'")
+		}
+		parts = append(parts, fmt.Sprintf("JSONExtractString(properties, '%s')", k))
+	}
+	return fmt.Sprintf("concat(%s)", strings.Join(parts, ", "))
+}
+
 // MeterUsageQueryBuilder constructs SQL queries for the meter_usage table.
 // It encapsulates WHERE clause construction, FINAL handling, and window grouping
 // so that aggregators only need to specify their aggregation expression.
@@ -202,30 +264,80 @@ func (qb *MeterUsageQueryBuilder) BuildBucketedQuery(params *events.MeterUsageQu
 		tableRef = "meter_usage " + finalClause
 	}
 
-	// With GroupBy: 3-level aggregation
-	if params.GroupByProperty != "" && validMeterUsageGroupByPattern.MatchString(params.GroupByProperty) {
-		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", params.GroupByProperty)
+	// With GroupBy: aggregation per group per bucket.
+	// Two shapes depending on whether keys come from one source or two:
+	//
+	//   Single-source (innerKeys == outerKeys): one set of keys (either
+	//   meter-config GroupByProperty or analytics GroupByProperties). Existing
+	//   2-CTE form: per_group → outer SELECT.
+	//
+	//   Stacked (innerKeys ⊃ outerKeys): both meter-config and analytics keys
+	//   present. Inner CTE groups by all keys (so MAX is per finest tuple);
+	//   middle CTE collapses the meter-key dimension via SUM per (bucket,
+	//   outer-key); outer SELECT exposes per-(bucket, outer-key) rows.
+	//   Mirrors feature_usage's getMaxBucketAnalytics semantic.
+	//
+	// Result rows carry outer-key values concatenated by \x1f in slice order;
+	// downstream code splits on \x1f to recover individual values.
+	innerKeys := bucketedInnerGroupKeys(params)
+	outerKeys := bucketedOuterGroupKeys(params)
+	if len(innerKeys) > 0 {
+		if len(innerKeys) == len(outerKeys) {
+			// Single-source — existing 2-CTE form.
+			groupByExpr := bucketedGroupByExpr(outerKeys)
+			query := fmt.Sprintf(`
+				WITH per_group AS (
+					SELECT
+						%s as bucket_start,
+						%s as group_key,
+						%s(qty_total) as group_value
+					FROM %s
+					WHERE %s
+					GROUP BY bucket_start, group_key
+				)
+				SELECT
+					(SELECT sum(group_value) FROM per_group) as total,
+					bucket_start as timestamp,
+					group_value as value,
+					group_key
+				FROM per_group
+				ORDER BY bucket_start, group_key
+				%s
+			`, bucketWindow, groupByExpr, aggFunc, tableRef, where, settings)
+			return query, args
+		}
 
+		// Stacked — 3-CTE form.
+		innerExpr := bucketedGroupByExpr(innerKeys)
+		outerExpr := bucketedGroupByExpr(outerKeys)
 		query := fmt.Sprintf(`
-			WITH per_group AS (
+			WITH per_inner AS (
 				SELECT
 					%s as bucket_start,
-					%s as group_key,
-					%s(qty_total) as group_value
+					%s as inner_key,
+					%s as outer_key,
+					%s(qty_total) as inner_value
 				FROM %s
 				WHERE %s
-				GROUP BY bucket_start, group_key
+				GROUP BY bucket_start, inner_key, outer_key
+			),
+			per_outer AS (
+				SELECT
+					bucket_start,
+					outer_key,
+					sum(inner_value) as group_value
+				FROM per_inner
+				GROUP BY bucket_start, outer_key
 			)
 			SELECT
-				(SELECT sum(group_value) FROM per_group) as total,
+				(SELECT sum(group_value) FROM per_outer) as total,
 				bucket_start as timestamp,
 				group_value as value,
-				group_key
-			FROM per_group
-			ORDER BY bucket_start, group_key
+				outer_key as group_key
+			FROM per_outer
+			ORDER BY bucket_start, outer_key
 			%s
-		`, bucketWindow, groupByExpr, aggFunc, tableRef, where, settings)
-
+		`, bucketWindow, innerExpr, outerExpr, aggFunc, tableRef, where, settings)
 		return query, args
 	}
 

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -249,6 +249,20 @@ func (qb *MeterUsageQueryBuilder) BuildBucketedQuery(params *events.MeterUsageQu
 	where, args := qb.BuildWhereClause(params)
 	finalClause, settings := qb.BuildFinalClause(params.UseFinal)
 
+	// Every bucketed query gets the 90GB per-query memory cap.
+	// without it, a worst-case bucketed scan could exhaust ClickHouse server
+	// memory. Splice into the existing SETTINGS clause when present (from
+	// useFinal), otherwise emit a fresh SETTINGS clause.
+	const maxMemSetting = "max_memory_usage = 96636764160"
+	switch {
+	case settings == "":
+		settings = "SETTINGS " + maxMemSetting
+	case strings.HasPrefix(settings, "SETTINGS"):
+		settings = settings + ", " + maxMemSetting
+	default:
+		settings = settings + " SETTINGS " + maxMemSetting
+	}
+
 	// Determine aggregation function based on type (default MAX for backward compat)
 	aggFunc := "MAX"
 	bucketTableName := "bucket_maxes"

--- a/internal/repository/clickhouse/meter_usage_test.go
+++ b/internal/repository/clickhouse/meter_usage_test.go
@@ -267,3 +267,58 @@ func (s *MeterUsageQuerySuite) TestWindowSize_DayIgnoresBillingAnchor() {
 	result := formatWindowSizeWithBillingAnchor(types.WindowSizeDay, &anchor)
 	assert.Equal(s.T(), "toStartOfDay(timestamp)", result)
 }
+
+// TestBuildBucketedQuery_EnforcesMemoryCap verifies the 90GB ClickHouse
+// per-query memory cap (see CLAUDE.md) is present in every bucketed query
+// shape — no-group, single-source GroupBy, stacked GroupBy — combined with
+// and without FINAL. Without the cap, an expensive bucketed scan could
+// exhaust ClickHouse server memory.
+func (s *MeterUsageQuerySuite) TestBuildBucketedQuery_EnforcesMemoryCap() {
+	base := &events.MeterUsageQueryParams{
+		TenantID:        "t1",
+		EnvironmentID:   "e1",
+		MeterID:         "m1",
+		StartTime:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:         time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		AggregationType: types.AggregationSum,
+		WindowSize:      types.WindowSizeHour,
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(p *events.MeterUsageQueryParams)
+	}{
+		{"no group, no FINAL", func(p *events.MeterUsageQueryParams) {}},
+		{"single-source group, no FINAL", func(p *events.MeterUsageQueryParams) {
+			p.AggregationType = types.AggregationMax
+			p.GroupByProperty = "user_id"
+		}},
+		{"stacked group, no FINAL", func(p *events.MeterUsageQueryParams) {
+			p.AggregationType = types.AggregationMax
+			p.GroupByProperty = "user_id"
+			p.GroupByProperties = []string{"region"}
+		}},
+		{"no group, with FINAL", func(p *events.MeterUsageQueryParams) {
+			p.UseFinal = true
+		}},
+		{"single-source group, with FINAL", func(p *events.MeterUsageQueryParams) {
+			p.AggregationType = types.AggregationMax
+			p.GroupByProperty = "user_id"
+			p.UseFinal = true
+		}},
+		{"stacked group, with FINAL", func(p *events.MeterUsageQueryParams) {
+			p.AggregationType = types.AggregationMax
+			p.GroupByProperty = "user_id"
+			p.GroupByProperties = []string{"region"}
+			p.UseFinal = true
+		}},
+	}
+
+	for _, tc := range cases {
+		p := *base
+		tc.mutate(&p)
+		q, _ := s.qb.BuildBucketedQuery(&p)
+		assert.Contains(s.T(), q, "max_memory_usage = 96636764160",
+			"case %s: bucketed query must include 90GB memory cap; got: %s", tc.name, q)
+	}
+}

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -320,7 +321,28 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 		}
 	}
 
-	// 9. Split bucketed vs standard meters
+	// 9. Split bucketed vs standard meters.
+	//
+	// Both MAX-bucketed and SUM-bucketed meters stay on the bucketed path
+	// regardless of whether user req.GroupBy is set. The bucketed path threads
+	// user group_by through bucketedUserGroupBy and queryBucketedMeterUsage so
+	// per-group rows are returned, and step 11 fans them out into per-group
+	// LineItemMeterUsage entries. When a MAX-bucketed meter also has a
+	// meter-config GroupBy, the query builder stacks both: inner MAX is per
+	// (bucket × meter-key × user-keys), outer SUM collapses the meter-key
+	// dimension (mirrors feature_usage's getMaxBucketAnalytics).
+	hasExtraGroupBy := false
+	for _, g := range req.GroupBy {
+		if g != "" && g != "meter_id" {
+			hasExtraGroupBy = true
+			break
+		}
+	}
+
+	// Extract the user-supplied property keys (stripped of "properties." prefix)
+	// for the bucketed path. nil for billing callers.
+	bucketedUserGroupBy := extractBucketedUserGroupBy(req.GroupBy)
+
 	bucketedMeterIDs := make(map[string]bool)
 	for meterID, m := range result.MeterMap {
 		if m.IsBucketedMaxMeter() || m.IsBucketedSumMeter() {
@@ -368,13 +390,6 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			// If yes, split the batch: commitment line items query with meter_id only
 			// (clean aggregate for applyLineItemCommitment), non-commitment items query
 			// with the full group_by (per-group breakdown in the response).
-			hasExtraGroupBy := false
-			for _, g := range req.GroupBy {
-				if g != "" && g != "meter_id" {
-					hasExtraGroupBy = true
-					break
-				}
-			}
 
 			var commitmentLIs, nonCommitmentLIs []*lineItemWithMeter
 			if hasExtraGroupBy {
@@ -457,6 +472,17 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			continue
 		}
 		items := meterToLineItems[meterID]
+
+		// User-supplied group_by applies to both MAX-bucketed and SUM-bucketed.
+		// For MAX-bucketed with meter-config GroupBy, the query builder stacks
+		// both keys (inner MAX per all-keys, outer SUM collapses meter-key);
+		// only the user keys appear in result GroupKey. For SUM-bucketed, the
+		// query simply groups by user keys (SUM is associative).
+		var userKeys []string
+		if (m.IsBucketedMaxMeter() || m.IsBucketedSumMeter()) && len(bucketedUserGroupBy) > 0 {
+			userKeys = bucketedUserGroupBy
+		}
+
 		for _, item := range items {
 			itemStart := item.GetPeriodStart(usageStartTime)
 			itemEnd := item.GetPeriodEnd(usageEndTime)
@@ -465,12 +491,20 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 				ctx, m, externalCustomerIDs,
 				itemStart, itemEnd, req.BillingAnchor, req.UseFinal,
 				req.PropertyFilters, req.Sources,
+				userKeys,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query bucketed meter usage for meter %s: %w", meterID, err)
 			}
 
 			if skipBucketedZeros && (bucketedResult == nil || len(bucketedResult.Results) == 0) {
+				continue
+			}
+
+			// Fan out per group when user group_by is in effect: each (item, group)
+			// becomes its own LineItemMeterUsage with per-group sub-result + Properties.
+			if len(userKeys) > 0 && bucketedResult != nil && len(bucketedResult.Results) > 0 {
+				appendBucketedGroupFanOut(result, m, item, itemStart, itemEnd, bucketedResult, userKeys)
 				continue
 			}
 
@@ -663,9 +697,121 @@ func (s *meterUsageService) queryAndAppendAnalyticsEntries(
 	return nil
 }
 
+// appendBucketedGroupFanOut splits a bucketed query result into per-group
+// LineItemMeterUsage entries. Used only when analytics req.GroupBy is in effect
+// for a MAX-bucketed meter. Each distinct GroupKey becomes one entry carrying:
+//   - a per-group sub-result (Value = SUM of that group's bucket MAXes) so
+//     calculateBucketedMeterCost applies tier pricing on the right slice
+//   - a synthesized MeterUsageDetailedResult with Properties parsed from the
+//     concat-encoded GroupKey, so downstream analytics merge sees a uniform
+//     shape across standard, SUM-routed, and bucketed-with-group_by paths
+//   - per-bucket Points scoped to the group
+func appendBucketedGroupFanOut(
+	result *SubscriptionMeterUsage,
+	m *meter.Meter,
+	item *subscription.SubscriptionLineItem,
+	itemStart, itemEnd time.Time,
+	bucketedResult *events.AggregationResult,
+	userKeys []string,
+) {
+	type groupAgg struct {
+		rows  []events.UsageResult
+		total decimal.Decimal
+	}
+	byGroup := make(map[string]*groupAgg)
+	order := make([]string, 0)
+	for _, r := range bucketedResult.Results {
+		g, ok := byGroup[r.GroupKey]
+		if !ok {
+			g = &groupAgg{}
+			byGroup[r.GroupKey] = g
+			order = append(order, r.GroupKey)
+		}
+		g.rows = append(g.rows, r)
+		g.total = g.total.Add(r.Value)
+	}
+
+	for _, gk := range order {
+		g := byGroup[gk]
+
+		props := make(map[string]string, len(userKeys))
+		parts := strings.Split(gk, "\x1f")
+		for i, key := range userKeys {
+			if i < len(parts) {
+				props[key] = parts[i]
+			}
+		}
+
+		subResult := &events.AggregationResult{
+			Type:      bucketedResult.Type,
+			MeterID:   bucketedResult.MeterID,
+			EventName: bucketedResult.EventName,
+			Value:     g.total,
+			Results:   g.rows,
+		}
+
+		points := make([]events.MeterUsageDetailedPoint, 0, len(g.rows))
+		for _, r := range g.rows {
+			p := events.MeterUsageDetailedPoint{WindowStart: r.WindowSize}
+			if m.IsBucketedMaxMeter() {
+				p.MaxUsage = r.Value
+				p.TotalUsage = r.Value
+			} else {
+				p.TotalUsage = r.Value
+			}
+			points = append(points, p)
+		}
+
+		analyticsResult := &events.MeterUsageDetailedResult{
+			MeterID:    m.ID,
+			Properties: props,
+			TotalUsage: g.total,
+			Points:     points,
+		}
+
+		result.LineItemUsages = append(result.LineItemUsages, &LineItemMeterUsage{
+			LineItem:        item,
+			MeterID:         m.ID,
+			Meter:           m,
+			Price:           result.PriceMap[item.PriceID],
+			PeriodStart:     itemStart,
+			PeriodEnd:       itemEnd,
+			Usage:           g.total,
+			Points:          points,
+			BucketedResult:  subResult,
+			AnalyticsResult: analyticsResult,
+		})
+	}
+}
+
+// extractBucketedUserGroupBy filters and normalizes the analytics req.GroupBy
+// for use by the bucketed query path. It drops "meter_id" (always in req.GroupBy
+// for non-empty cases) and any entry that isn't a "properties.<key>" reference,
+// then strips the "properties." prefix. The returned slice preserves caller
+// order, which is how response Properties keys are reconstructed downstream.
+func extractBucketedUserGroupBy(groupBy []string) []string {
+	const propPrefix = "properties."
+	out := make([]string, 0, len(groupBy))
+	for _, g := range groupBy {
+		if g == "" || g == "meter_id" {
+			continue
+		}
+		if len(g) <= len(propPrefix) || g[:len(propPrefix)] != propPrefix {
+			continue
+		}
+		out = append(out, g[len(propPrefix):])
+	}
+	return out
+}
+
 // queryBucketedMeterUsage queries the meter_usage table for a single bucketed meter,
 // returning a per-bucket AggregationResult. propertyFilters and sources are forwarded
 // from analytics callers; pass nil for billing callers that don't use them.
+// userGroupByKeys (already stripped of "properties." prefix) is forwarded only by
+// the analytics path on MAX-bucketed meters. When the meter also has a meter-config
+// GroupBy, both flow to the query builder and the inner CTE groups by all keys; the
+// outer CTE collapses the meter-key dimension via SUM so result rows are keyed by
+// the user keys (mirrors feature_usage's getMaxBucketAnalytics).
 func (s *meterUsageService) queryBucketedMeterUsage(
 	ctx context.Context,
 	m *meter.Meter,
@@ -675,12 +821,14 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	useFinal bool,
 	propertyFilters map[string][]string,
 	sources []string,
+	userGroupByKeys []string,
 ) (*events.AggregationResult, error) {
 	aggType := m.Aggregation.Type
-	groupBy := m.Aggregation.GroupBy
+	meterConfigKey := m.Aggregation.GroupBy
+	userKeys := userGroupByKeys
 	if m.IsBucketedSumMeter() {
 		aggType = types.AggregationSum
-		groupBy = ""
+		meterConfigKey = "" // SUM-bucketed can't have meter-config GroupBy (validated)
 	}
 	return s.repo.GetUsageForBucketedMeters(ctx, &events.MeterUsageQueryParams{
 		TenantID:            types.GetTenantID(ctx),
@@ -692,7 +840,8 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 		AggregationType:     aggType,
 		WindowSize:          m.Aggregation.BucketSize,
 		BillingAnchor:       billingAnchor,
-		GroupByProperty:     groupBy,
+		GroupByProperty:     meterConfigKey, // legacy single-key: meter-config (inner-only when stacked)
+		GroupByProperties:   userKeys,       // analytics keys: outer keys when set
 		UseFinal:            useFinal,
 		PropertyFilters:     propertyFilters,
 		Sources:             sources,
@@ -800,6 +949,13 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 			Sources:         params.Sources,
 		})
 		if err != nil {
+			// Validation errors are caller-fixable (e.g. conflicting group_by on a
+			// bucketed meter) and apply identically to every subscription in the
+			// loop — propagate so the user sees them. Other errors are likely
+			// transient or per-sub; log and skip to keep partial results usable.
+			if ierr.IsValidation(err) {
+				return nil, err
+			}
 			s.logger.Info(ctx, "failed to get subscription meter usage, skipping",
 				"error", err,
 				"subscription_id", sub.ID,

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -134,6 +135,11 @@ type lineItemWithMeter struct {
 	Item    *subscription.SubscriptionLineItem
 	MeterID string
 }
+
+// validBucketedUserGroupByKey matches safe property names (alphanumeric, underscores, dots).
+// Mirrors clickhouse.validMeterUsageGroupByPattern; redeclared here so the service
+// layer can validate without importing the repository package.
+var validBucketedUserGroupByKey = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
 
 // ---------------------------------------------------------------------------
 // Simple passthrough methods
@@ -340,8 +346,13 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 	}
 
 	// Extract the user-supplied property keys (stripped of "properties." prefix)
-	// for the bucketed path. nil for billing callers.
-	bucketedUserGroupBy := extractBucketedUserGroupBy(req.GroupBy)
+	// for the bucketed path. nil for billing callers. Strict validation: any
+	// non-properties / invalid-property entry → ErrValidation (mirrors
+	// feature_usage's policy; see validateBucketedUserGroupBy doc for rationale).
+	bucketedUserGroupBy, err := validateBucketedUserGroupBy(req.GroupBy)
+	if err != nil {
+		return nil, err
+	}
 
 	bucketedMeterIDs := make(map[string]bool)
 	for meterID, m := range result.MeterMap {
@@ -784,24 +795,49 @@ func appendBucketedGroupFanOut(
 	}
 }
 
-// extractBucketedUserGroupBy filters and normalizes the analytics req.GroupBy
-// for use by the bucketed query path. It drops "meter_id" (always in req.GroupBy
-// for non-empty cases) and any entry that isn't a "properties.<key>" reference,
-// then strips the "properties." prefix. The returned slice preserves caller
-// order, which is how response Properties keys are reconstructed downstream.
-func extractBucketedUserGroupBy(groupBy []string) []string {
+// validateBucketedUserGroupBy validates the analytics req.GroupBy for the
+// bucketed query path and returns the property keys (stripped of "properties.")
+// in caller order. Validation matches feature_usage's strict policy:
+//
+//   - "meter_id" and empty string are skipped (no-op).
+//   - "properties.<key>" with <key> matching validBucketedUserGroupByKey is
+//     accepted and added to the output.
+//   - Anything else (bare identifiers like "source"/"feature_id", or
+//     "properties.<key>" where <key> is empty or contains unsafe characters)
+//     is rejected with ErrValidation. Silent stripping would leave the caller
+//     thinking they got a per-group breakdown when they didn't, and routing
+//     to the standard analytics path would corrupt MAX-bucketed totals
+//     (MAX(qty over period) ≠ SUM(MAX per bucket)).
+//
+// The returned slice ordering is how response Properties keys are
+// reconstructed downstream when the bucketed result fans out per group.
+func validateBucketedUserGroupBy(groupBy []string) ([]string, error) {
 	const propPrefix = "properties."
 	out := make([]string, 0, len(groupBy))
 	for _, g := range groupBy {
 		if g == "" || g == "meter_id" {
 			continue
 		}
-		if len(g) <= len(propPrefix) || g[:len(propPrefix)] != propPrefix {
-			continue
+		if !strings.HasPrefix(g, propPrefix) {
+			return nil, ierr.NewError("unsupported group_by value for bucketed meter").
+				WithHint("Valid group_by values are 'meter_id' or 'properties.<field_name>'").
+				WithReportableDetails(map[string]interface{}{
+					"group_by": g,
+				}).
+				Mark(ierr.ErrValidation)
 		}
-		out = append(out, g[len(propPrefix):])
+		stripped := strings.TrimPrefix(g, propPrefix)
+		if !validBucketedUserGroupByKey.MatchString(stripped) {
+			return nil, ierr.NewError("invalid group_by property name").
+				WithHint("Property names must contain only letters, digits, underscores, or dots").
+				WithReportableDetails(map[string]interface{}{
+					"group_by": g,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		out = append(out, stripped)
 	}
-	return out
+	return out, nil
 }
 
 // queryBucketedMeterUsage queries the meter_usage table for a single bucketed meter,

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -3249,3 +3249,257 @@ func (s *MeterUsageServiceSuite) TestBucketedMeter_OmitsPointsWhenWindowSizeUnse
 	s.Empty(item.Points,
 		"points must be omitted from response when window_size is not specified")
 }
+
+// ---------------------------------------------------------------------------
+// SUM-bucketed analytics routing — when req.GroupBy carries user-supplied
+// dimensions (e.g. properties.session_id), SUM-bucketed meters take the
+// standard analytics path instead of the bucketed path, because the bucketed
+// query builder only supports a single meter-config group key and would
+// silently drop the request-level group_by otherwise. SUM-of-bucket-sums =
+// SUM, so this is mathematically equivalent for total_usage.
+// ---------------------------------------------------------------------------
+
+// TestSumBucketedMeter_GroupByPropertyBreaksOutItems: SUM-bucketed meter,
+// events with three distinct session_id values, group_by=[properties.session_id]
+// → response must contain three items (one per session_id) with each item's
+// total_usage matching the sum of its events. Before the routing fix this
+// returned ONE collapsed item because BuildBucketedQuery ignored req.GroupBy.
+func (s *MeterUsageServiceSuite) TestSumBucketedMeter_GroupByPropertyBreaksOutItems() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_sum_bkt_grp",
+		Name:      "Bucketed SUM with group-by",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_sum_bkt_grp", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_sum_bkt_grp", bucketedMeter.ID, bucketedPrice.ID)
+
+	// session A: 3 events @ 10 = 30
+	// session B: 2 events @ 10 = 20
+	// session C: 1 event  @ 10 = 10
+	for _, ev := range []struct {
+		t       time.Time
+		session string
+	}{
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), "A"},
+		{time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), "A"},
+		{time.Date(2026, 1, 5, 12, 0, 0, 0, time.UTC), "A"},
+		{time.Date(2026, 1, 5, 13, 0, 0, 0, time.UTC), "B"},
+		{time.Date(2026, 1, 5, 14, 0, 0, 0, time.UTC), "B"},
+		{time.Date(2026, 1, 5, 15, 0, 0, 0, time.UTC), "C"},
+	} {
+		s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+			ev.t, 10, map[string]interface{}{"session_id": ev.session})
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.session_id"},
+	})
+	s.NoError(err)
+
+	usageBySession := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		if item.MeterID != bucketedMeter.ID {
+			continue
+		}
+		session := item.Properties["session_id"]
+		usageBySession[session] = item.TotalUsage
+	}
+
+	s.Require().Len(usageBySession, 3,
+		"expected three items (one per session_id); got %d (items=%v)", len(usageBySession), usageBySession)
+	s.True(usageBySession["A"].Equal(decimal.NewFromInt(30)),
+		"session A usage: expected 30, got %s", usageBySession["A"])
+	s.True(usageBySession["B"].Equal(decimal.NewFromInt(20)),
+		"session B usage: expected 20, got %s", usageBySession["B"])
+	s.True(usageBySession["C"].Equal(decimal.NewFromInt(10)),
+		"session C usage: expected 10, got %s", usageBySession["C"])
+}
+
+// ---------------------------------------------------------------------------
+// MAX-bucketed analytics group_by — MAX-bucketed semantic is
+// "MAX per bucket per group, then SUM the maxes". The bucketed query path is
+// extended to accept user-supplied group_by; results fan out one item per
+// group tuple, each carrying its own per-bucket points + total. Multi-key
+// group_by is supported via in-query concat.
+// ---------------------------------------------------------------------------
+
+// TestMaxBucketedMeter_GroupByPropertiesBreaksOutItems: MAX-bucketed meter
+// with no meter-config GroupBy, group_by=[properties.session_id, properties.region]
+// → response must contain one item per (session_id, region) tuple. Each
+// item's total_usage must equal SUM(MAX-per-bucket within that tuple).
+func (s *MeterUsageServiceSuite) TestMaxBucketedMeter_GroupByPropertiesBreaksOutItems() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_max_bkt_grp",
+		Name:      "Bucketed MAX with multi group-by",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationMax,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_max_bkt_grp", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_max_bkt_grp", bucketedMeter.ID, bucketedPrice.ID)
+
+	// Events grouped by (session, region) across multiple hourly buckets:
+	//
+	// (A, us) hour 10: qty 5, 15, 25  → bucket MAX = 25
+	// (A, us) hour 11: qty 10, 20     → bucket MAX = 20
+	//   → tuple total = 25 + 20 = 45
+	// (A, eu) hour 10: qty 30         → bucket MAX = 30
+	//   → tuple total = 30
+	// (B, us) hour 10: qty 50         → bucket MAX = 50
+	//   → tuple total = 50
+	for _, ev := range []struct {
+		t       time.Time
+		qty     float64
+		session string
+		region  string
+	}{
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 5, "A", "us"},
+		{time.Date(2026, 1, 5, 10, 5, 0, 0, time.UTC), 15, "A", "us"},
+		{time.Date(2026, 1, 5, 10, 30, 0, 0, time.UTC), 25, "A", "us"},
+		{time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 10, "A", "us"},
+		{time.Date(2026, 1, 5, 11, 30, 0, 0, time.UTC), 20, "A", "us"},
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 30, "A", "eu"},
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 50, "B", "us"},
+	} {
+		s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+			ev.t, ev.qty, map[string]interface{}{"session_id": ev.session, "region": ev.region})
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.session_id", "properties.region"},
+	})
+	s.NoError(err)
+
+	type key struct{ session, region string }
+	usage := map[key]decimal.Decimal{}
+	for _, item := range resp.Items {
+		if item.MeterID != bucketedMeter.ID {
+			continue
+		}
+		k := key{item.Properties["session_id"], item.Properties["region"]}
+		usage[k] = item.TotalUsage
+	}
+
+	s.Require().Len(usage, 3,
+		"expected three items (one per (session, region) tuple); got %d (items=%v)", len(usage), usage)
+	s.True(usage[key{"A", "us"}].Equal(decimal.NewFromInt(45)),
+		"(A, us) usage: expected 45 (25+20), got %s", usage[key{"A", "us"}])
+	s.True(usage[key{"A", "eu"}].Equal(decimal.NewFromInt(30)),
+		"(A, eu) usage: expected 30, got %s", usage[key{"A", "eu"}])
+	s.True(usage[key{"B", "us"}].Equal(decimal.NewFromInt(50)),
+		"(B, us) usage: expected 50, got %s", usage[key{"B", "us"}])
+}
+
+// TestMaxBucketedMeter_StackedGroupByWithMeterConfig: when a MAX-bucketed
+// meter has a meter-config Aggregation.GroupBy AND the analytics caller
+// passes req.GroupBy, both dimensions stack — matches feature_usage's
+// getMaxBucketAnalytics semantic. The per-user-key total is:
+//
+//	SUM over buckets of ( SUM over meter-key values of MAX_per_(bucket, meter-key) )
+//
+// Equivalent to: MAX is taken per (bucket, meter-key, user-keys), and the
+// meter-key dimension is collapsed via SUM before per-bucket roll-up.
+func (s *MeterUsageServiceSuite) TestMaxBucketedMeter_StackedGroupByWithMeterConfig() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_max_bkt_stack",
+		Name:      "Bucketed MAX with meter-config GroupBy and analytics group_by",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationMax,
+			BucketSize: types.WindowSizeHour,
+			GroupBy:    "user_id", // meter-config key (pricing semantic)
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_max_bkt_stack", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_max_bkt_stack", bucketedMeter.ID, bucketedPrice.ID)
+
+	// Events laid out so the stacked MAX-SUM math is explicit:
+	//
+	// Inner MAX per (bucket, user_id, region):
+	//   (h10, u1, us) max(5, 15)   = 15
+	//   (h10, u2, us) max(20, 80)  = 80
+	//   (h11, u1, us) max(30)      = 30
+	//   (h10, u1, eu) max(50)      = 50
+	//
+	// Per-(bucket, region) sum over user_id:
+	//   (h10, us) 15 + 80 = 95
+	//   (h11, us) 30
+	//   (h10, eu) 50
+	//
+	// Per-region totals:
+	//   us: 95 + 30 = 125
+	//   eu: 50
+	for _, ev := range []struct {
+		t      time.Time
+		qty    float64
+		user   string
+		region string
+	}{
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 5, "u1", "us"},
+		{time.Date(2026, 1, 5, 10, 5, 0, 0, time.UTC), 15, "u1", "us"},
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 20, "u2", "us"},
+		{time.Date(2026, 1, 5, 10, 5, 0, 0, time.UTC), 80, "u2", "us"},
+		{time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 30, "u1", "us"},
+		{time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 50, "u1", "eu"},
+	} {
+		s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+			ev.t, ev.qty, map[string]interface{}{"user_id": ev.user, "region": ev.region})
+	}
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"properties.region"},
+	})
+	s.NoError(err,
+		"expected stacked group_by to succeed (meter-config GroupBy collapsed via outer SUM)")
+
+	usageByRegion := map[string]decimal.Decimal{}
+	for _, item := range resp.Items {
+		if item.MeterID != bucketedMeter.ID {
+			continue
+		}
+		usageByRegion[item.Properties["region"]] = item.TotalUsage
+	}
+
+	s.Require().Len(usageByRegion, 2,
+		"expected two items (one per region); got %d (items=%v)", len(usageByRegion), usageByRegion)
+	s.True(usageByRegion["us"].Equal(decimal.NewFromInt(125)),
+		"region=us total: expected 125 (95+30), got %s", usageByRegion["us"])
+	s.True(usageByRegion["eu"].Equal(decimal.NewFromInt(50)),
+		"region=eu total: expected 50, got %s", usageByRegion["eu"])
+}

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
@@ -3502,4 +3503,68 @@ func (s *MeterUsageServiceSuite) TestMaxBucketedMeter_StackedGroupByWithMeterCon
 		"region=us total: expected 125 (95+30), got %s", usageByRegion["us"])
 	s.True(usageByRegion["eu"].Equal(decimal.NewFromInt(50)),
 		"region=eu total: expected 50, got %s", usageByRegion["eu"])
+}
+
+// TestBucketedMeter_RejectsUnsupportedGroupBy: any req.GroupBy entry that
+// isn't "meter_id" or a valid "properties.<key>" is a caller error on the
+// bucketed path — mirrors feature_usage's strict policy. Specifically:
+//
+//   - "source" and other non-properties dimensions → reject (bucketed
+//     SQL doesn't break these out today)
+//   - "properties.<key>" where the stripped key fails the safe-pattern
+//     regex → reject (would otherwise be silently dropped, leaving the
+//     caller's request unfulfilled)
+//
+// All cases must surface ErrValidation; silently stripping leaves the
+// caller thinking they got per-group analytics when they didn't.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_RejectsUnsupportedGroupBy() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_bkt_reject",
+		Name:      "Bucketed SUM for invalid group_by test",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_bkt_reject", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_bkt_reject", bucketedMeter.ID, bucketedPrice.ID)
+
+	s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10,
+		map[string]interface{}{"session_id": "A"})
+
+	// Note: "feature_id" is rewritten to "meter_id" by GetDetailedAnalytics, so it
+	// isn't a rejected case — meter_id is a no-op for the bucketed path.
+	cases := []struct {
+		name    string
+		groupBy []string
+	}{
+		{"non-properties dimension", []string{"source"}},
+		{"unknown bare identifier", []string{"arbitrary"}},
+		{"properties prefix with empty key", []string{"properties."}},
+		{"properties prefix with invalid chars", []string{"properties.bad-key!@#"}},
+		{"mix: one valid + one invalid", []string{"properties.session_id", "source"}},
+	}
+
+	for _, tc := range cases {
+		_, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+			TenantID:           types.GetTenantID(ctx),
+			EnvironmentID:      types.GetEnvironmentID(ctx),
+			ExternalCustomerID: s.customer.ExternalID,
+			MeterIDs:           []string{bucketedMeter.ID},
+			StartTime:          s.periodStart,
+			EndTime:            s.periodEnd,
+			GroupBy:            tc.groupBy,
+		})
+		s.Error(err, "case %s: expected validation error for group_by=%v, got nil", tc.name, tc.groupBy)
+		if err != nil {
+			s.True(ierr.IsValidation(err),
+				"case %s: expected ErrValidation, got %T: %s", tc.name, err, err)
+		}
+	}
 }

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -450,7 +450,32 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 		return aggregateScalar(recs, types.AggregationMax)
 	}
 
-	hasGroupBy := params.GroupByProperty != ""
+	// Inner GROUP BY uses union of meter-config key + analytics keys (so MAX is per
+	// finest tuple). Outer GROUP BY uses analytics keys when set, else meter-config.
+	// When inner ⊃ outer, the meter-key dimension is collapsed via SUM per
+	// (bucket, outer-key) — matches BuildBucketedQuery's stacked CTE.
+	innerKeys := []string{}
+	seen := map[string]struct{}{}
+	if params.GroupByProperty != "" {
+		seen[params.GroupByProperty] = struct{}{}
+		innerKeys = append(innerKeys, params.GroupByProperty)
+	}
+	for _, k := range params.GroupByProperties {
+		if k == "" {
+			continue
+		}
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		innerKeys = append(innerKeys, k)
+	}
+	outerKeys := append([]string(nil), params.GroupByProperties...)
+	if len(outerKeys) == 0 && params.GroupByProperty != "" {
+		outerKeys = []string{params.GroupByProperty}
+	}
+	hasGroupBy := len(innerKeys) > 0
+	stacked := len(innerKeys) > len(outerKeys)
 
 	// Bucket records by window first.
 	byBucket := make(map[time.Time][]*events.MeterUsage)
@@ -468,13 +493,38 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 
 	if hasGroupBy {
 		for bucket, recs := range byBucket {
-			byGroup := make(map[string][]*events.MeterUsage)
+			// Inner: aggregate per (bucket, all-inner-key tuple).
+			byInner := make(map[string][]*events.MeterUsage)
 			for _, r := range recs {
-				gk := propertyValue(r.Properties, params.GroupByProperty)
-				byGroup[gk] = append(byGroup[gk], r)
+				parts := make([]string, len(innerKeys))
+				for i, k := range innerKeys {
+					parts[i] = propertyValue(r.Properties, k)
+				}
+				ik := strings.Join(parts, "\x1f")
+				byInner[ik] = append(byInner[ik], r)
 			}
-			for gk, grecs := range byGroup {
-				entries = append(entries, entry{bucket: bucket, group: gk, value: aggFn(grecs)})
+			if !stacked {
+				for ik, grecs := range byInner {
+					entries = append(entries, entry{bucket: bucket, group: ik, value: aggFn(grecs)})
+				}
+				continue
+			}
+			// Stacked: per (bucket, outer-key tuple), sum the inner aggregates that
+			// share that outer tuple. Outer key is a prefix or subset of inner key,
+			// but we re-derive it from the first record in each inner partition so
+			// the in-memory store doesn't need to know the layout.
+			byOuter := make(map[string]decimal.Decimal)
+			for _, grecs := range byInner {
+				inner := aggFn(grecs)
+				outerParts := make([]string, len(outerKeys))
+				for i, k := range outerKeys {
+					outerParts[i] = propertyValue(grecs[0].Properties, k)
+				}
+				ok := strings.Join(outerParts, "\x1f")
+				byOuter[ok] = byOuter[ok].Add(inner)
+			}
+			for ok, v := range byOuter {
+				entries = append(entries, entry{bucket: bucket, group: ok, value: v})
 			}
 		}
 		sort.Slice(entries, func(i, j int) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-property grouping for meter-usage queries (ordered property tuples); request-level multi-property grouping overrides single-property config.
  * Bucketed SUM/MAX meters emit per-property-combination results and support stacked grouping when config and request keys differ.

* **Bug Fixes**
  * Validation now rejects unsupported/malformed group-by entries; bucketed queries include a per-query memory cap.

* **Tests**
  * Added regression tests for multi-property/stacked grouping, validation, and memory-cap enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->