### PR TITLE
Fix/helm extraenv and otel traces

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
+++ b/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
@@ -23,6 +23,9 @@ FlexPrice app release.
 - `extraEnv` rendered invalid YAML when non-empty — `{{- toYaml . }}` left-chomped
   the preceding newline and glued the first env var onto the previous line. Now
   uses `{{ toYaml . | trim }}`.
+- Chart-managed (dev) Secret now renders the shared `logging-otel-auth-value` key
+  when `otel.traces.enabled` (not only `logging.otel.enabled`), so a traces-only
+  config doesn't fail pods with a missing secret key (`CreateContainerConfigError`).
 
 ## [1.0.0] - 2026-05-11
 

--- a/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
+++ b/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
@@ -9,6 +9,21 @@ Chart versions are independent of the application (`appVersion`) version —
 `Chart.yaml#version` bumps on every chart change, `appVersion` follows the
 FlexPrice app release.
 
+## [1.1.0] - 2026-06-11
+
+### Added
+- Native OpenTelemetry **trace** export (`otel.traces.*`) for shipping APM/RED
+  metrics (request rate, error rate, latency) to any OTLP backend (SigNoz,
+  Tempo, Datadog). Mirrors the existing `logging.otel` (logs) wiring; the traces
+  auth value reuses the `logging-otel-auth-value` secret key.
+- `logging.environment` to set the OTel resource `deployment.environment`
+  (rendered as the `FLEXPRICE_LOGGING_ENVIRONMENT` env var).
+
+### Fixed
+- `extraEnv` rendered invalid YAML when non-empty — `{{- toYaml . }}` left-chomped
+  the preceding newline and glued the first env var onto the previous line. Now
+  uses `{{ toYaml . | trim }}`.
+
 ## [1.0.0] - 2026-05-11
 
 Initial GA release of the FlexPrice Helm chart. Production-ready packaging

--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -589,6 +589,6 @@ All service addresses are resolved via named templates above so this block stays
 {{- end }}
 {{- /* ---- Extra env vars (passthrough) ---- */}}
 {{- with .Values.extraEnv }}
-{{- toYaml . }}
+{{ toYaml . | trim }}
 {{- end }}
 {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -531,6 +531,10 @@ All service addresses are resolved via named templates above so this block stays
 {{- /* ---- Logging extended ---- */}}
 - name: FLEXPRICE_LOGGING_FORMAT
   value: {{ .Values.logging.format | default "json" | quote }}
+{{- if .Values.logging.environment }}
+- name: FLEXPRICE_LOGGING_ENVIRONMENT
+  value: {{ .Values.logging.environment | quote }}
+{{- end }}
 {{- if .Values.logging.otel.enabled }}
 - name: FLEXPRICE_LOGGING_OTEL_ENABLED
   value: "true"
@@ -545,6 +549,34 @@ All service addresses are resolved via named templates above so this block stays
     secretKeyRef:
       name: {{ include "flexprice.secretName" . }}
       key: logging-otel-auth-value
+{{- end }}
+{{- /* ---- OpenTelemetry traces (APM/RED metrics) ---- */}}
+{{- if .Values.otel.enabled }}
+- name: FLEXPRICE_OTEL_ENABLED
+  value: "true"
+{{- if .Values.otel.serviceName }}
+- name: FLEXPRICE_OTEL_SERVICE_NAME
+  value: {{ .Values.otel.serviceName | quote }}
+{{- end }}
+{{- if .Values.otel.traces.enabled }}
+- name: FLEXPRICE_OTEL_TRACES_ENABLED
+  value: "true"
+- name: FLEXPRICE_OTEL_TRACES_ENDPOINT
+  value: {{ .Values.otel.traces.endpoint | quote }}
+{{- if .Values.otel.traces.authHeader }}
+- name: FLEXPRICE_OTEL_TRACES_AUTH_HEADER
+  value: {{ .Values.otel.traces.authHeader | quote }}
+- name: FLEXPRICE_OTEL_TRACES_AUTH_VALUE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "flexprice.secretName" . }}
+      key: logging-otel-auth-value
+{{- end }}
+{{- if .Values.otel.traces.sampleRate }}
+- name: FLEXPRICE_OTEL_TRACES_SAMPLE_RATE
+  value: {{ .Values.otel.traces.sampleRate | quote }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- /* ---- App URLs ---- */}}
 {{- if .Values.app.customerPortalUrl }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/secret.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/secret.yaml
@@ -42,7 +42,12 @@ stringData:
   {{- if and .Values.webhook.enabled .Values.webhook.svixConfig.enabled .Values.webhook.svixConfig.authToken }}
   svix-auth-token: {{ .Values.webhook.svixConfig.authToken | quote }}
   {{- end }}
-  {{- if and .Values.logging.otel.enabled .Values.logging.otel.authValue }}
+  {{- /* Shared OTLP ingestion key — used by BOTH the logs exporter
+         (logging.otel) and the traces exporter (otel.traces). Render it
+         whenever EITHER is enabled, so a traces-only config doesn't reference
+         a missing key (CreateContainerConfigError). The dev plaintext value
+         lives under logging.otel.authValue (canonical home for this shared key). */}}
+  {{- if and (or .Values.logging.otel.enabled .Values.otel.traces.enabled) .Values.logging.otel.authValue }}
   logging-otel-auth-value: {{ .Values.logging.otel.authValue | quote }}
   {{- end }}
 {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -909,7 +909,7 @@ webhook:
 #   pyroscope-basic-auth-password  required if pyroscope.basicAuthUser is set
 #   email-resend-api-key           required if email.enabled=true
 #   svix-auth-token                required if webhook.svixConfig.enabled=true
-#   logging-otel-auth-value        required if logging.otel.enabled=true
+#   logging-otel-auth-value        required if logging.otel.enabled=true OR otel.traces.enabled=true
 #   redis-password                 required if redisConfig.password is set
 #
 # ── Dev fallback ──────────────────────────────────────────────────────────────

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -652,12 +652,26 @@ temporalConfig:
 logging:
   level: "info"    # "debug", "info", "warn", "error"
   format: "json"   # "json" or "text"
-  otel:
+  environment: ""  # OTel resource deployment.environment (e.g. "staging-gcp", "production"); empty → unset
+  otel:            # OTLP LOG export
     enabled: false
     endpoint: ""           # e.g. "ingest.in2.signoz.cloud:443"
     insecure: false        # set true for non-TLS endpoints
     authHeader: ""         # e.g. "signoz-ingestion-key"
     authValue: ""          # Set via secret in production
+
+# OpenTelemetry TRACES export (distinct from logging.otel, which is logs).
+# Traces drive the APM/RED metrics (request rate, error rate, latency) in SigNoz.
+# The traces auth value is read from the existingSecret key `logging-otel-auth-value`
+# (the shared SigNoz ingestion key — same one logging.otel uses above).
+otel:
+  enabled: false
+  serviceName: ""     # empty → app falls back to FLEXPRICE_DEPLOYMENT_MODE per component (api/consumer/temporal_worker)
+  traces:
+    enabled: false
+    endpoint: ""        # e.g. "ingest.in2.signoz.cloud:443"
+    authHeader: ""      # e.g. "signoz-ingestion-key"
+    sampleRate: ""      # empty → app default (1.0 = 100%); e.g. "0.2" to sample 20%
 
 # Sentry configuration
 sentry:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable logging environment variable.
  * Introduced native OpenTelemetry traces configuration (enable, endpoint, auth sourcing from shared secret, optional sample rate).

* **Bug Fixes**
  * Fixed extra environment rendering to avoid invalid YAML from leading/trailing whitespace.
  * Ensured traces-only deployments receive the required auth value.

* **Chores**
  * Chart version bumped to 1.1.0 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->