### PR TITLE
feat(integration-suite): support skipping TLS verification per target

### DIFF
--- a/integration-testing-suite/go/http_client.go
+++ b/integration-testing-suite/go/http_client.go
@@ -3,12 +3,26 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 )
+
+// newHTTPClient builds an HTTP client. When insecure is true, TLS certificate
+// verification is disabled — useful for environments whose cert does not cover
+// the host (e.g. preprod). Never enable this against production.
+func newHTTPClient(insecure bool) *http.Client {
+	c := &http.Client{Timeout: 30 * time.Second}
+	if insecure {
+		c.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // opt-in via insecure flag
+		}
+	}
+	return c
+}
 
 // RawClient provides thin HTTP helpers for API resources that are not
 // exposed by the generated Speakeasy Go SDK.
@@ -19,14 +33,13 @@ type RawClient struct {
 }
 
 // NewRawClient creates a RawClient. baseURL should include the scheme and
-// path prefix, e.g. "https://us.api.flexprice.io/v1".
-func NewRawClient(baseURL, apiKey string) *RawClient {
+// path prefix, e.g. "https://us.api.flexprice.io/v1". httpClient is the
+// underlying client to use (e.g. one with TLS verification disabled).
+func NewRawClient(baseURL, apiKey string, httpClient *http.Client) *RawClient {
 	return &RawClient{
 		baseURL: baseURL,
 		apiKey:  apiKey,
-		http: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		http:    httpClient,
 	}
 }
 

--- a/integration-testing-suite/go/main.go
+++ b/integration-testing-suite/go/main.go
@@ -86,20 +86,27 @@ func main() {
 // its aggregate outcome.
 func runTarget(t Target) targetOutcome {
 	serverURL := t.serverURL()
+	insecure := t.skipTLSVerify()
 
 	fmt.Printf("API Host: %s\n", t.host())
 	fmt.Printf("API Key:  %s\n", t.maskedKey())
+	if insecure {
+		fmt.Printf("TLS:      INSECURE (certificate verification disabled)\n")
+	}
 	fmt.Printf("Started:  %s\n", time.Now().Format(time.RFC3339))
 
 	// ── Initialize SDK client ───────────────────────────────────────────
 
+	httpClient := newHTTPClient(insecure)
+
 	client := flexprice.New(
 		flexprice.WithServerURL(serverURL),
 		flexprice.WithSecurity(t.APIKey),
+		flexprice.WithClient(httpClient),
 	)
 
 	// Also keep a raw HTTP client as fallback for any edge cases.
-	raw := NewRawClient(serverURL, t.APIKey)
+	raw := NewRawClient(serverURL, t.APIKey, httpClient)
 
 	// ── Run orchestrated sanity test ────────────────────────────────────
 

--- a/integration-testing-suite/go/targets.example.json
+++ b/integration-testing-suite/go/targets.example.json
@@ -5,6 +5,12 @@
     "api_key": "sk_replace_me"
   },
   {
+    "name": "preprod",
+    "api_host": "https://api-preprod.cloud.flexprice.io/v1",
+    "api_key": "sk_replace_me",
+    "insecure": true
+  },
+  {
     "name": "tirdad-prod",
     "api_host": "https://api.tirdad.ai/v1",
     "api_key": "sk_replace_me"

--- a/integration-testing-suite/go/targets.go
+++ b/integration-testing-suite/go/targets.go
@@ -18,6 +18,25 @@ type Target struct {
 	APIHost string `json:"api_host"`
 	// APIKey is the secret API key for this target.
 	APIKey string `json:"api_key"`
+	// Insecure skips TLS certificate verification for this target. Use only
+	// for environments whose cert does not cover the host (e.g. preprod).
+	// Can also be forced for all targets via FLEXPRICE_INSECURE_SKIP_VERIFY.
+	Insecure bool `json:"insecure"`
+}
+
+// skipTLSVerify reports whether TLS verification should be skipped for this
+// target, honouring both the per-target flag and the global env override.
+func (t Target) skipTLSVerify() bool {
+	return t.Insecure || envTruthy("FLEXPRICE_INSECURE_SKIP_VERIFY")
+}
+
+// envTruthy reports whether an env var is set to a truthy value.
+func envTruthy(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	}
+	return false
 }
 
 // host returns the scheme-stripped host (and path) for this target, applying


### PR DESCRIPTION
## What

Some environments (e.g. **preprod**) serve a TLS certificate that does not cover their hostname:

```
tls: failed to verify certificate: x509: certificate is valid for
flexprice.io, api.cloud.flexprice.io, api-dev.cloud.flexprice.io, *.flexprice.io,
not api-preprod.cloud.flexprice.io
```

This adds an **opt-in** insecure mode that disables TLS certificate verification, wired into both the SDK client (via `WithClient`) and the raw HTTP fallback client.

Builds on the multi-target support merged in #1959.

## How to use

Per-target in the targets JSON:
```json
{
  "name": "preprod",
  "api_host": "https://api-preprod.cloud.flexprice.io/v1",
  "api_key": "sk_...",
  "insecure": true
}
```

Or globally for all targets:
```bash
FLEXPRICE_INSECURE_SKIP_VERIFY=1 go run .
```

When active, a clear warning is printed:
```
TLS:      INSECURE (certificate verification disabled)
```

## Changes

- **`http_client.go`** — `newHTTPClient(insecure)` helper; `NewRawClient` now takes the client
- **`targets.go`** — `insecure` field on `Target` + `FLEXPRICE_INSECURE_SKIP_VERIFY` env override
- **`main.go`** — builds the client once, wires it into the SDK + raw client, prints the warning
- **`targets.example.json`** — documents the flag

## Testing

- `go build ./...` and `go vet ./...` — clean
- Ran against `api-preprod.cloud.flexprice.io` with `insecure: true`: request now reaches the server (returns `401` on a dummy key) instead of failing the x509 cert check. ✅

> ⚠️ This disables cert verification — use only for preprod/staging where the cert gap exists, never against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration test suite now supports flexible TLS certificate verification control—configure per-target or globally via environment variable for testing against non-production environments
  * Added preprod target configuration example with insecure TLS option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->