### PR TITLE
fix(wallet): return 409 on duplicate idempotency key instead of 500

### DIFF
--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -363,9 +363,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 		}
 
 		if err := s.WalletRepo.CreateTransaction(ctx, tx); err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to create wallet transaction").
-				Mark(ierr.ErrInternal)
+			return err
 		}
 
 		if autoCompleteEnabled {

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -408,6 +408,17 @@ func (r *walletRepository) CreateTransaction(ctx context.Context, tx *walletdoma
 		Save(ctx)
 
 	if err != nil {
+		if ent.IsConstraintError(err) {
+			return ierr.WithError(err).
+				WithHint("A wallet transaction with this idempotency key already exists").
+				WithReportableDetails(map[string]interface{}{
+					"wallet_id":       tx.WalletID,
+					"type":            tx.Type,
+					"amount":          tx.Amount,
+					"idempotency_key": tx.IdempotencyKey,
+				}).
+				Mark(ierr.ErrAlreadyExists)
+		}
 		return ierr.WithError(err).
 			WithHint("Failed to create wallet transaction").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/service/wallet.go
+++ b/internal/service/wallet.go
@@ -746,9 +746,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 
 		// Create the transaction
 		if err := s.WalletRepo.CreateTransaction(ctx, tx); err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to create wallet transaction").
-				Mark(ierr.ErrInternal)
+			return err
 		}
 
 		// If auto-complete is enabled, update wallet balance immediately


### PR DESCRIPTION
## Summary

- `CreateTransaction` in the wallet repository now detects `ent.ConstraintError` (duplicate unique index hit on `idx_tenant_environment_idempotency_key`) and marks the error as `ErrAlreadyExists` → HTTP 409 Conflict, instead of the generic `ErrDatabase` → HTTP 500
- Two callsites in `handlePurchasedCreditInvoicedTransaction` (OSS + EE) were re-wrapping the repo error with `ErrInternal`, which masked the 409 mark; they now pass the error through unchanged — consistent with `processWalletOperation` (the path where the original error was observed)

## Root Cause

The constraint `idx_tenant_environment_idempotency_key` is a partial unique index on `(tenant_id, environment_id, idempotency_key)` for published wallet transactions. A retried top-up with the same idempotency key hits this constraint and produces an `ent.ConstraintError`, but every insert error was blanket-marked `ErrDatabase` → 500. A duplicate idempotent request is a client conflict (409), not a server fault.

## Test Plan

- [x] `go build ./internal/... ./cmd/...` succeeds
- [x] `go vet` clean on all changed packages
- [x] All 77 wallet service tests pass
- Follows the same `ent.IsConstraintError` → `ErrAlreadyExists` pattern used in 20+ other repositories (plan, coupon, feature, entitlement, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for wallet transaction creation to better detect and report duplicate transaction attempts, providing more specific error responses for conflicts instead of generic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->