### PR TITLE
feat(integration): delink api to remove provider entity mapping

### DIFF
--- a/internal/api/dto/integration.go
+++ b/internal/api/dto/integration.go
@@ -85,8 +85,8 @@ func (r *LinkIntegrationMappingRequest) Validate() error {
 
 type DelinkIntegrationMappingRequest struct {
 	EntityType   types.IntegrationEntityType `json:"entity_type" validate:"required"`
-	EntityID     string                      `json:"entity_id" validate:"required,max=255"`
-	ProviderType string                      `json:"provider_type" validate:"required,max=50"`
+	EntityID     string                      `json:"entity_id" validate:"required"`
+	ProviderType string                      `json:"provider_type" validate:"required"`
 }
 
 type DelinkIntegrationMappingResponse struct {

--- a/internal/api/dto/integration.go
+++ b/internal/api/dto/integration.go
@@ -83,6 +83,30 @@ func (r *LinkIntegrationMappingRequest) Validate() error {
 	return nil
 }
 
+type DelinkIntegrationMappingRequest struct {
+	EntityType   types.IntegrationEntityType `json:"entity_type" validate:"required"`
+	EntityID     string                      `json:"entity_id" validate:"required,max=255"`
+	ProviderType string                      `json:"provider_type" validate:"required,max=50"`
+}
+
+type DelinkIntegrationMappingResponse struct {
+	Success  bool `json:"success"`
+	Archived int  `json:"archived"`
+}
+
+func (r *DelinkIntegrationMappingRequest) Validate() error {
+	if err := validator.ValidateRequest(r); err != nil {
+		return err
+	}
+	if err := r.EntityType.Validate(); err != nil {
+		return err
+	}
+	if err := types.SecretProvider(r.ProviderType).Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 type IntegrationConfigEntry struct {
 	Provider      types.SecretProvider `json:"provider"`
 	BaseConfig    *types.SyncConfig    `json:"base_config"`

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -530,6 +530,7 @@ func NewRouter(
 		integrations := v1Private.Group("/integrations")
 		{
 			integrations.POST("/link", handlers.Integration.Link)
+			integrations.POST("/delink", handlers.Integration.Delink)
 			integrations.POST("/sync", handlers.Integration.Sync)
 			integrations.GET("/mappings", handlers.Integration.GetMappings)
 			integrations.GET("/config", handlers.Integration.GetConfig)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -530,7 +530,7 @@ func NewRouter(
 		integrations := v1Private.Group("/integrations")
 		{
 			integrations.POST("/link", handlers.Integration.Link)
-			integrations.POST("/delink", handlers.Integration.Delink)
+			integrations.DELETE("/link", handlers.Integration.Delink)
 			integrations.POST("/sync", handlers.Integration.Sync)
 			integrations.GET("/mappings", handlers.Integration.GetMappings)
 			integrations.GET("/config", handlers.Integration.GetConfig)

--- a/internal/api/v1/integration.go
+++ b/internal/api/v1/integration.go
@@ -98,15 +98,11 @@ func (h *IntegrationHandler) Link(c *gin.Context) {
 // @Failure 400 {object} ierr.ErrorResponse
 // @Failure 404 {object} ierr.ErrorResponse
 // @Failure 500 {object} ierr.ErrorResponse
-// @Router /integrations/delink [post]
+// @Router /integrations/link [delete]
 func (h *IntegrationHandler) Delink(c *gin.Context) {
 	var req dto.DelinkIntegrationMappingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.Error(ierr.WithError(err).WithHint("Invalid request body").Mark(ierr.ErrValidation))
-		return
-	}
-	if err := req.Validate(); err != nil {
-		c.Error(err)
 		return
 	}
 	resp, err := h.mappingService.DelinkIntegrationMapping(c.Request.Context(), req)

--- a/internal/api/v1/integration.go
+++ b/internal/api/v1/integration.go
@@ -86,6 +86,37 @@ func (h *IntegrationHandler) Link(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// @Summary Delink integration mapping
+// @ID delinkIntegrationMapping
+// @Description Soft-delete (archive) the mapping between a FlexPrice entity and a provider entity.
+// @Tags Integrations
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param request body dto.DelinkIntegrationMappingRequest true "Delink mapping request"
+// @Success 200 {object} dto.DelinkIntegrationMappingResponse
+// @Failure 400 {object} ierr.ErrorResponse
+// @Failure 404 {object} ierr.ErrorResponse
+// @Failure 500 {object} ierr.ErrorResponse
+// @Router /integrations/delink [post]
+func (h *IntegrationHandler) Delink(c *gin.Context) {
+	var req dto.DelinkIntegrationMappingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(ierr.WithError(err).WithHint("Invalid request body").Mark(ierr.ErrValidation))
+		return
+	}
+	if err := req.Validate(); err != nil {
+		c.Error(err)
+		return
+	}
+	resp, err := h.mappingService.DelinkIntegrationMapping(c.Request.Context(), req)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
 // @Summary Get entity integration mappings
 // @ID getEntityIntegrationMappings
 // @Description Get integration mappings for a specific entity by entity type and entity ID.

--- a/internal/integration/mapping_adapter.go
+++ b/internal/integration/mapping_adapter.go
@@ -112,6 +112,12 @@ func (a *entityIntegrationMappingAdapter) LinkIntegrationMapping(ctx context.Con
 		Mark(ierr.ErrValidation)
 }
 
+func (a *entityIntegrationMappingAdapter) DelinkIntegrationMapping(ctx context.Context, req apidto.DelinkIntegrationMappingRequest) (*apidto.DelinkIntegrationMappingResponse, error) {
+	return nil, ierr.NewError("DelinkIntegrationMapping not supported via integration factory adapter").
+		WithHint("Use the service layer directly for this operation").
+		Mark(ierr.ErrValidation)
+}
+
 // toMappingResponse converts a domain mapping to a DTO response.
 func toMappingResponse(m *entityintegrationmapping.EntityIntegrationMapping) *apidto.EntityIntegrationMappingResponse {
 	return &apidto.EntityIntegrationMappingResponse{

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	invoice_domain "github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/integration/paddle"
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -118,7 +119,37 @@ func (s *inMemoryMappingService) LinkIntegrationMapping(ctx context.Context, req
 }
 
 func (s *inMemoryMappingService) DelinkIntegrationMapping(ctx context.Context, req apidto.DelinkIntegrationMappingRequest) (*apidto.DelinkIntegrationMappingResponse, error) {
-	return nil, nil
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	filter := &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityID:      req.EntityID,
+		EntityType:    req.EntityType,
+		ProviderTypes: []string{req.ProviderType},
+	}
+	mappings, err := s.repo.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(mappings) == 0 {
+		return nil, ierr.NewError("no entity integration mapping found to delink").
+			WithHint("No active mapping exists for the given entity and provider").
+			Mark(ierr.ErrNotFound)
+	}
+
+	for _, mapping := range mappings {
+		if err := s.repo.Delete(ctx, mapping); err != nil {
+			return nil, err
+		}
+	}
+
+	return &apidto.DelinkIntegrationMappingResponse{
+		Success:  true,
+		Archived: len(mappings),
+	}, nil
 }
 
 func toTestMappingResponse(m *entityintegrationmapping.EntityIntegrationMapping) *apidto.EntityIntegrationMappingResponse {
@@ -409,6 +440,56 @@ func TestEnsureCustomerSynced_AlreadyMapped(t *testing.T) {
 
 	// The critical assertion: CreateCustomer must NOT have been called.
 	assert.False(t, mockClient.createCustomerCalled, "CreateCustomer must NOT be called when customer is already mapped")
+}
+
+// TestDelinkIntegrationMapping_ArchivesExistingMappings verifies that delinking an
+// entity→provider mapping removes every matching mapping and reports the archived count.
+func TestDelinkIntegrationMapping_ArchivesExistingMappings(t *testing.T) {
+	ctx := buildTestContext()
+
+	mappingStore := testutil.NewInMemoryEntityIntegrationMappingStore()
+	svc := newTestMappingService(mappingStore)
+
+	const customerID = "cust_to_delink"
+
+	// Seed a mapping for the customer → Paddle.
+	seedMapping(ctx, t, mappingStore, customerID, types.IntegrationEntityTypeCustomer, "ctm_existing", nil)
+
+	resp, err := svc.DelinkIntegrationMapping(ctx, apidto.DelinkIntegrationMappingRequest{
+		EntityType:   types.IntegrationEntityTypeCustomer,
+		EntityID:     customerID,
+		ProviderType: string(types.SecretProviderPaddle),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Success)
+	assert.Equal(t, 1, resp.Archived)
+
+	// The mapping must no longer be returned by a published-only query.
+	remaining, err := mappingStore.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityID:      customerID,
+		EntityType:    types.IntegrationEntityTypeCustomer,
+		ProviderTypes: []string{string(types.SecretProviderPaddle)},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "delinked mapping should not remain active")
+}
+
+// TestDelinkIntegrationMapping_NotFound verifies that delinking when no mapping exists
+// returns a not-found error rather than a success with zero archived.
+func TestDelinkIntegrationMapping_NotFound(t *testing.T) {
+	ctx := buildTestContext()
+
+	mappingStore := testutil.NewInMemoryEntityIntegrationMappingStore()
+	svc := newTestMappingService(mappingStore)
+
+	_, err := svc.DelinkIntegrationMapping(ctx, apidto.DelinkIntegrationMappingRequest{
+		EntityType:   types.IntegrationEntityTypeCustomer,
+		EntityID:     "cust_missing",
+		ProviderType: string(types.SecretProviderPaddle),
+	})
+	require.Error(t, err)
+	assert.True(t, ierr.IsNotFound(err), "expected a not-found error")
 }
 
 // TestEnsureSubscriptionSynced_AlreadyMapped verifies that when a subscription→Paddle mapping

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -117,6 +117,10 @@ func (s *inMemoryMappingService) LinkIntegrationMapping(ctx context.Context, req
 	return nil, nil
 }
 
+func (s *inMemoryMappingService) DelinkIntegrationMapping(ctx context.Context, req apidto.DelinkIntegrationMappingRequest) (*apidto.DelinkIntegrationMappingResponse, error) {
+	return nil, nil
+}
+
 func toTestMappingResponse(m *entityintegrationmapping.EntityIntegrationMapping) *apidto.EntityIntegrationMappingResponse {
 	return &apidto.EntityIntegrationMappingResponse{
 		ID:               m.ID,

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -71,6 +71,7 @@ type EntityIntegrationMappingService interface {
 	UpdateEntityIntegrationMapping(ctx context.Context, id string, req dto.UpdateEntityIntegrationMappingRequest) (*dto.EntityIntegrationMappingResponse, error)
 	DeleteEntityIntegrationMapping(ctx context.Context, id string) error
 	LinkIntegrationMapping(ctx context.Context, req dto.LinkIntegrationMappingRequest) (*dto.LinkIntegrationMappingResponse, error)
+	DelinkIntegrationMapping(ctx context.Context, req dto.DelinkIntegrationMappingRequest) (*dto.DelinkIntegrationMappingResponse, error)
 }
 
 // RevenueAnalyticsService defines the interface for revenue analytics operations

--- a/internal/service/entityintegrationmapping.go
+++ b/internal/service/entityintegrationmapping.go
@@ -268,6 +268,47 @@ func (s *entityIntegrationMappingService) LinkIntegrationMapping(ctx context.Con
 	}, nil
 }
 
+func (s *entityIntegrationMappingService) DelinkIntegrationMapping(ctx context.Context, req dto.DelinkIntegrationMappingRequest) (*dto.DelinkIntegrationMappingResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	filter := &types.EntityIntegrationMappingFilter{
+		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
+		EntityID:    req.EntityID,
+		EntityType:  req.EntityType,
+		ProviderTypes: []string{
+			req.ProviderType,
+		},
+	}
+	mappings, err := s.EntityIntegrationMappingRepo.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(mappings) == 0 {
+		return nil, ierr.NewError("no entity integration mapping found to delink").
+			WithHint("No active mapping exists for the given entity and provider").
+			WithReportableDetails(map[string]any{
+				"entity_id":     req.EntityID,
+				"entity_type":   req.EntityType,
+				"provider_type": req.ProviderType,
+			}).
+			Mark(ierr.ErrNotFound)
+	}
+
+	for _, mapping := range mappings {
+		if err := s.EntityIntegrationMappingRepo.Delete(ctx, mapping); err != nil {
+			return nil, err
+		}
+	}
+
+	return &dto.DelinkIntegrationMappingResponse{
+		Success:  true,
+		Archived: len(mappings),
+	}, nil
+}
+
 func (s *entityIntegrationMappingService) upsertEntityMapping(ctx context.Context, req dto.LinkIntegrationMappingRequest) (*entityintegrationmapping.EntityIntegrationMapping, error) {
 	filter := &types.EntityIntegrationMappingFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),

--- a/internal/service/entityintegrationmapping.go
+++ b/internal/service/entityintegrationmapping.go
@@ -297,10 +297,15 @@ func (s *entityIntegrationMappingService) DelinkIntegrationMapping(ctx context.C
 			Mark(ierr.ErrNotFound)
 	}
 
-	for _, mapping := range mappings {
-		if err := s.EntityIntegrationMappingRepo.Delete(ctx, mapping); err != nil {
-			return nil, err
+	if err := s.DB.WithTx(ctx, func(txCtx context.Context) error {
+		for _, mapping := range mappings {
+			if err := s.EntityIntegrationMappingRepo.Delete(txCtx, mapping); err != nil {
+				return err
+			}
 		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return &dto.DelinkIntegrationMappingResponse{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to delink (archive) integration mappings via a new authenticated API endpoint.
  * Returns a confirmation response including the number of mappings archived.

* **Bug Fixes**
  * Ensures delinking returns a clear “not found” error when no matching mappings exist.

* **Tests**
  * Added unit tests covering successful archiving/removal and the not-found scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->