### PR TITLE
fix(meter-usage): Bucket breakdown flag in meter usage analytics

### DIFF
--- a/internal/api/dto/meter_usage.go
+++ b/internal/api/dto/meter_usage.go
@@ -137,6 +137,7 @@ type MeterUsageDetailedAnalyticsRequest struct {
 	Expand             []string            `json:"expand,omitempty" example:"price"`
 	IncludeChildren    bool                `json:"include_children,omitempty" example:"false"` // folds child customers' usage into the single aggregated total
 	BillingAnchor      *time.Time          `json:"billing_anchor,omitempty"`
+	BreakdownBucket    bool                `json:"breakdown_bucket,omitempty"`
 }
 
 func (r *MeterUsageDetailedAnalyticsRequest) Validate() error {
@@ -160,6 +161,7 @@ func (r *MeterUsageDetailedAnalyticsRequest) ToParams(tenantID, environmentID st
 		Expand:             r.Expand,
 		IncludeChildren:    r.IncludeChildren,
 		BillingAnchor:      r.BillingAnchor,
+		BreakdownBucket:    r.BreakdownBucket,
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional bucket-level breakdown in detailed meter usage analytics requests. Users can now enable granular analytics views to analyze usage patterns and distribution across individual buckets, providing deeper insights into consumption metrics and usage trends for better decision-making.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->