### PR TITLE
fix(kafka): use msg context in processMessage handlers

### DIFF
--- a/internal/service/costsheet_usage_tracking.go
+++ b/internal/service/costsheet_usage_tracking.go
@@ -215,8 +215,8 @@ func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) err
 		"environment_id", environmentID,
 	)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Build the context from the message so shutdown cancellation and trace values propagate.
+	ctx := types.WithForceWriter(msg.Context())
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/service/event_consumption.go
+++ b/internal/service/event_consumption.go
@@ -224,8 +224,8 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 		environmentID = event.EnvironmentID
 	}
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Build the context from the message so shutdown cancellation and trace values propagate.
+	ctx := types.WithForceWriter(msg.Context())
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/service/event_post_processing.go
+++ b/internal/service/event_post_processing.go
@@ -231,8 +231,8 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 		"environment_id", environmentID,
 	)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Build the context from the message so shutdown cancellation and trace values propagate.
+	ctx := types.WithForceWriter(msg.Context())
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -361,8 +361,8 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 
 	event.EventName = strings.TrimSpace(event.EventName)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Build the context from the message so shutdown cancellation and trace values propagate.
+	ctx := types.WithForceWriter(msg.Context())
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/service/meter_usage_tracking.go
+++ b/internal/service/meter_usage_tracking.go
@@ -224,7 +224,7 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 		return nil // non-retriable
 	}
 
-	ctx := context.Background()
+	ctx := types.WithForceWriter(msg.Context())
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 

--- a/internal/service/usage_benchmark.go
+++ b/internal/service/usage_benchmark.go
@@ -178,7 +178,7 @@ func (s *usageBenchmarkService) ProcessMessageForTest(msg *message.Message) erro
 		return nil
 	}
 
-	ctx := context.Background()
+	ctx := types.WithForceWriter(msg.Context())
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 

--- a/internal/service/wallet_balance_alert.go
+++ b/internal/service/wallet_balance_alert.go
@@ -202,8 +202,8 @@ func (s *walletBalanceAlertService) processMessage(msg *message.Message) error {
 		"published_at", event.Timestamp,
 	)
 
-	// Create context with tenant and environment IDs
-	ctx := context.Background()
+	// Build the context from the message so shutdown cancellation and trace values propagate.
+	ctx := types.WithForceWriter(msg.Context())
 	if event.TenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, event.TenantID)
 	}


### PR DESCRIPTION
Fixes #1986

## Summary
This PR migrates most Kafka consumer `processMessage` handlers in service from `context.Background()` to `msg.Context()`, while preserving writer pinning with the existing `types.WithForceWriter(...)` helper.

This restores propagation of Watermill cancellation, shutdown deadlines, and message-scoped trace/request values into downstream service calls and database access.

## 🔨 Changes Made
- [x] Refactor


- Switched Kafka handlers to build their per-message context from `msg.Context()` instead of `context.Background()`.
- Kept writer pinning applied on top of the inbound message context.
- Updated the following handlers:
  - `usage_benchmark`
  - `wallet_balance_alert`
  - `costsheet_usage_tracking`
  - `event_consumption`
  - `event_post_processing`
  - `feature_usage_tracking`
  - `meter_usage_tracking`
- Left `onboarding` unchanged because it is intentionally detached from the request/message lifecycle and already documents that behavior.
- Confirmed that handlers already using `msg.Context()` elsewhere remain unchanged.

## Why
Using `msg.Context()` allows consumers to:
- respect shutdown cancellation during in-flight processing
- propagate deadlines correctly
- preserve tracing and request metadata
- keep DB writer pinning behavior intact

## Tests and Results
`go test ./internal/service/...`
ok      github.com/flexprice/flexprice/internal/service 1.402s
ok      github.com/flexprice/flexprice/internal/service/sync/export     0.017s


## ✅ Checklist
- [x] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [x] All new and existing tests pass.
- [ ] I have updated documentation (if needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message processing context propagation across service handlers to ensure shutdown signals and trace metadata are properly carried through message-processing workflows, enhancing system reliability and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->