### PR TITLE
fix(analytics): true valud of computed window size in response

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -385,7 +385,7 @@ type UsageAnalyticItem struct {
 	Points               []UsageAnalyticPoint               `json:"points,omitempty"`
 	AddOnID              string                             `json:"add_on_id,omitempty"`
 	PlanID               string                             `json:"plan_id,omitempty"`
-	WindowSize           types.WindowSize                   `json:"window_size,omitempty"` // Window size for bucketed meters (only set if meter is bucketed)
+	WindowSize           types.WindowSize                   `json:"window_size,omitempty"` // Granularity of Points: max(request window_size, meter bucket_size) for bucketed meters; the request window_size otherwise
 	Group                *group.Group                       `json:"group,omitempty"`       // Group when the feature belongs to a group (object includes id)
 	// BucketSummaries is populated only when BreakdownBucket=true. Contains one
 	// entry per defined CommitmentTimeBucket plus one for out-of-bucket usage.

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -3110,14 +3110,13 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 			}
 		}
 
-		// Set window size in response:
-		// - For bucketed features: show the feature's bucket size (underlying granularity)
-		// - For non-bucketed features: show the request window size
+		// Window size reflects the granularity Points were computed at. Bucketed
+		// features cannot be subdivided below their bucket size, so points are at
+		// max(request window, bucket size); non-bucketed features use the request.
 		if analytic.MeterID != "" {
 			if meter, ok := data.Meters[analytic.MeterID]; ok {
 				if meter.HasBucketSize() {
-					// Bucketed feature: show bucket size
-					item.WindowSize = meter.Aggregation.BucketSize
+					item.WindowSize = req.WindowSize.Max(meter.Aggregation.BucketSize)
 				} else {
 					// Non-bucketed feature: show request window size
 					item.WindowSize = req.WindowSize

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1382,10 +1382,12 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 			}
 		}
 
-		// Window size: bucketed meters expose their bucket size; others use the request.
+		// Window size reflects the granularity Points were computed at. Bucketed
+		// meters cannot be subdivided below their bucket size, so points are at
+		// max(request window, bucket size); non-bucketed meters use the request.
 		if m, ok := meterMap[analytic.MeterID]; ok {
 			if m.HasBucketSize() {
-				item.WindowSize = m.Aggregation.BucketSize
+				item.WindowSize = params.WindowSize.Max(m.Aggregation.BucketSize)
 			} else {
 				item.WindowSize = params.WindowSize
 			}

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -3249,3 +3249,50 @@ func (s *MeterUsageServiceSuite) TestBucketedMeter_OmitsPointsWhenWindowSizeUnse
 	s.Empty(item.Points,
 		"points must be omitted from response when window_size is not specified")
 }
+
+// TestBucketedMeter_WindowSizeReflectsPointGranularity: for a bucketed meter the
+// response window_size must report the granularity the points were rolled up to —
+// the request window when it is coarser than the meter's bucket size — not the
+// meter's bucket size.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_WindowSizeReflectsPointGranularity() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_wsday",
+		Name:      "Bucketed SUM window-size",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_wsday", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_wsday", bucketedMeter.ID, bucketedPrice.ID)
+
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 9, 0, 0, 0, time.UTC), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeDay,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_wsday" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+	s.Equal(types.WindowSizeDay, item.WindowSize,
+		"window_size must reflect the request window the points were rolled up to, not the meter bucket size")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected window size calculation for usage analytics to accurately reflect the granularity used when computing data points.

* **Documentation**
  * Clarified how window size is derived in analytics responses.

* **Tests**
  * Added test coverage for window size accuracy in bucketed meter analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->