### PR TITLE
fix(commitment): correct per-bucket analytics — summaries, true-up, and fill scoping

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -413,16 +413,21 @@ type UsageAnalyticPoint struct {
 	ComputedOverageAmount            decimal.Decimal `json:"computed_overage_amount,omitempty" swaggertype:"string"`
 	ComputedTrueUpAmount             decimal.Decimal `json:"computed_true_up_amount,omitempty" swaggertype:"string"`
 
-	// Bucket identity (only populated when BreakdownBucket=true and the line item
-	// has CommitmentTimeBuckets). A rolled-up window can overlap more than one
-	// bucket — and only partially — so these are arrays of every bucket the window
-	// touches, aligned by index (BucketIDs[i] ↔ BucketPriceIDs[i]). Empty when the
-	// window touches no bucket. These are an informational HINT only: a point's
-	// single cost/computed_* totals mix all overlapped buckets and out-of-bucket
-	// time and CANNOT be split per bucket — read bucket_summaries for exact
-	// per-bucket cost.
-	BucketIDs      []string `json:"bucket_ids,omitempty"`
-	BucketPriceIDs []string `json:"bucket_price_ids,omitempty"`
+	// Buckets lists every commitment bucket this (possibly rolled-up) window
+	// overlaps — only populated when BreakdownBucket=true and the line item has
+	// CommitmentTimeBuckets. A coarse window can overlap more than one bucket, and
+	// only partially, so this is a list. Empty when the window touches no bucket.
+	// It is an informational HINT only: the point's single cost/computed_* totals
+	// mix all overlapped buckets and out-of-bucket time and CANNOT be split per
+	// bucket — read bucket_summaries for exact per-bucket cost.
+	Buckets []PointBucket `json:"buckets,omitempty"`
+}
+
+// PointBucket identifies one commitment bucket a usage point overlaps, with that
+// bucket's own price.
+type PointBucket struct {
+	BucketID string `json:"bucket_id"`
+	PriceID  string `json:"price_id"`
 }
 
 // BucketSummary holds per-bucket aggregated usage and commitment math for

--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -414,9 +414,15 @@ type UsageAnalyticPoint struct {
 	ComputedTrueUpAmount             decimal.Decimal `json:"computed_true_up_amount,omitempty" swaggertype:"string"`
 
 	// Bucket identity (only populated when BreakdownBucket=true and the line item
-	// has CommitmentTimeBuckets). Empty strings indicate out-of-bucket windows.
-	BucketID string `json:"bucket_id,omitempty"`
-	PriceID  string `json:"bucket_price_id,omitempty"`
+	// has CommitmentTimeBuckets). A rolled-up window can overlap more than one
+	// bucket — and only partially — so these are arrays of every bucket the window
+	// touches, aligned by index (BucketIDs[i] ↔ BucketPriceIDs[i]). Empty when the
+	// window touches no bucket. These are an informational HINT only: a point's
+	// single cost/computed_* totals mix all overlapped buckets and out-of-bucket
+	// time and CANNOT be split per bucket — read bucket_summaries for exact
+	// per-bucket cost.
+	BucketIDs      []string `json:"bucket_ids,omitempty"`
+	BucketPriceIDs []string `json:"bucket_price_ids,omitempty"`
 }
 
 // BucketSummary holds per-bucket aggregated usage and commitment math for

--- a/internal/domain/events/models.go
+++ b/internal/domain/events/models.go
@@ -67,6 +67,13 @@ type DetailedUsageAnalytic struct {
 	CommitmentInfo  *types.CommitmentInfo // Stores commitment info if applicable
 	Points          []UsageAnalyticPoint
 
+	// BucketPoints holds the bucket-grain (meter BucketSize) points BEFORE they are
+	// rolled up to the requested window in Points. Each carries its BucketID from the
+	// commitment pass. It is populated only for line items with commitment time
+	// buckets, so per-bucket summaries can be built at the grain where bucket
+	// attribution is exact — independent of how coarse the requested window_size is.
+	BucketPoints []UsageAnalyticPoint
+
 	// All aggregation values - we fetch all and use the appropriate one based on meter type
 	MaxUsage         decimal.Decimal `swaggertype:"string"` // MAX(qty_total * sign)
 	LatestUsage      decimal.Decimal `swaggertype:"string"` // argMax(qty_total, timestamp)
@@ -80,6 +87,11 @@ type UsageAnalyticPoint struct {
 	Usage       decimal.Decimal `swaggertype:"string"`
 	Cost        decimal.Decimal `swaggertype:"string"`
 	EventCount  uint64          // Number of events in this time window
+
+	// BucketID is the commitment time bucket this window's start falls in (empty
+	// when out-of-bucket). Stamped during the windowed-commitment pass at bucket
+	// grain; used to build per-bucket summaries before the request-window roll-up.
+	BucketID string
 
 	// Commitment breakdown (for windowed commitments)
 	ComputedCommitmentUtilizedAmount decimal.Decimal `swaggertype:"string"` // Amount of commitment utilized

--- a/internal/service/billing_commitment.go
+++ b/internal/service/billing_commitment.go
@@ -466,40 +466,69 @@ func isLastPeriodOfCommitmentPeriod(periodEnd, commitmentEnd time.Time) bool {
 	return !periodEnd.Before(commitmentEnd)
 }
 
-// bucketIDForPointWindow returns (bucketID, bucketPriceID, ok) for the commitment
-// bucket that FULLY contains the analytics window [windowStart, windowStart+window).
-// A window that straddles a bucket boundary (possible when the requested window
-// size is coarser than the buckets) is left unattributed so per-point breakdown
-// and bucket summaries don't misreport. Used by analytics breakdown only.
+// bucketIDsForPointWindow returns the ids and prices of every commitment bucket
+// that OVERLAPS the analytics display window [windowStart, windowStart+window) —
+// any intersection counts, in either direction (the bucket partially inside the
+// window, or the window partially inside the bucket). The two slices are aligned
+// by index (ids[i] ↔ priceIDs[i]). Used only to annotate the rolled-up display
+// points; it never feeds bucket summaries (those use the exact per-meter-window
+// attribution, where each window sits in exactly one bucket).
 //
-// The check compares the window's UTC start/end against the bucket's bounds on
-// the minute-of-day axis. When the bucket wraps midnight (end <= start) — or the
-// window starts in the bucket's post-midnight part — the times are unwrapped by
-// one day so a plain end-to-end comparison works.
-func bucketIDForPointWindow(buckets types.TimeOfDayBuckets, windowStart time.Time, window types.WindowSize) (string, string, bool) {
+// Overlap is computed on the minute-of-day axis. A window of a full day or more
+// touches every configured bucket. Sub-day windows and midnight-wrapping buckets
+// are each unrolled into up to two linear [lo,hi) segments and tested pairwise.
+func bucketIDsForPointWindow(buckets types.TimeOfDayBuckets, windowStart time.Time, window types.WindowSize) ([]string, []string) {
 	windowMin := window.ToMinutes()
-	if windowMin <= 0 || windowMin > 1440 {
-		// Unknown or multi-day window sizes can never sit inside a single
-		// time-of-day bucket.
-		return "", "", false
+	if windowMin <= 0 {
+		return nil, nil
 	}
-	idx, ok := buckets.BucketIndexAt([]time.Time{windowStart}, 0)
-	if !ok {
-		return "", "", false
+
+	var ids, priceIDs []string
+	// A window spanning a full day (or more) covers every minute-of-day, so it
+	// overlaps every bucket.
+	if windowMin >= 1440 {
+		for _, b := range buckets {
+			ids = append(ids, b.ID)
+			priceIDs = append(priceIDs, b.PriceID)
+		}
+		return ids, priceIDs
 	}
-	b := buckets[idx]
 
 	utc := windowStart.UTC()
-	winStart := utc.Hour()*60 + utc.Minute()
-	bucketStart, bucketEnd := b.Start.MinuteOfDay(), b.End.MinuteOfDay()
-	if bucketEnd <= bucketStart {
-		bucketEnd += 1440 // bucket wraps midnight, e.g. [22:00, 06:00)
+	winSegs := todSegments(utc.Hour()*60+utc.Minute(), windowMin)
+	for _, b := range buckets {
+		bStart := b.Start.MinuteOfDay()
+		bEnd := b.End.MinuteOfDay()
+		dur := bEnd - bStart
+		if dur <= 0 {
+			dur = 1440 - bStart + bEnd // bucket wraps midnight, e.g. [22:00, 06:00)
+		}
+		if segmentsOverlap(winSegs, todSegments(bStart, dur)) {
+			ids = append(ids, b.ID)
+			priceIDs = append(priceIDs, b.PriceID)
+		}
 	}
-	if winStart < bucketStart {
-		winStart += 1440 // window starts in the bucket's post-midnight part
+	return ids, priceIDs
+}
+
+// todSegments unrolls a time-of-day interval [start, start+length) into up to two
+// linear [lo,hi) segments within [0,1440), splitting it when it wraps past midnight.
+func todSegments(start, length int) [][2]int {
+	end := start + length
+	if end <= 1440 {
+		return [][2]int{{start, end}}
 	}
-	if winStart+windowMin > bucketEnd {
-		return "", "", false
+	return [][2]int{{start, 1440}, {0, end - 1440}}
+}
+
+// segmentsOverlap reports whether any [lo,hi) segment in a intersects any in b.
+func segmentsOverlap(a, b [][2]int) bool {
+	for _, s := range a {
+		for _, t := range b {
+			if s[0] < t[1] && t[0] < s[1] {
+				return true
+			}
+		}
 	}
-	return b.ID, b.PriceID, true
+	return false
 }

--- a/internal/service/billing_commitment.go
+++ b/internal/service/billing_commitment.go
@@ -209,6 +209,9 @@ type commitmentParts struct {
 	utilized decimal.Decimal
 	overage  decimal.Decimal
 	trueUp   decimal.Decimal
+	// bucketID is the commitment time bucket this window was billed under (empty
+	// for out-of-bucket windows). Per-window identity — NOT summed by add().
+	bucketID string
 }
 
 func (p *commitmentParts) add(o commitmentParts) {
@@ -272,6 +275,7 @@ func (c *commitmentCalculator) applyWindowCommitmentPerBucket(
 
 		if idx, ok := buckets.BucketIndexAt(windowStarts, i); ok {
 			parts, err = c.chargeWindowAtBucket(ctx, buckets[idx], v, pricesMap)
+			parts.bucketID = buckets[idx].ID
 		} else {
 			parts, err = c.chargeWindowAtLineItem(ctx, lineItem, lineItemPrice, v)
 		}

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -2195,6 +2195,12 @@ func (s *featureUsageTrackingService) processPointsWithBuckets(
 		cost = s.fillMissingWindowsAndRecalculate(p, lineItem)
 	}
 
+	// Snapshot the bucket-grain points (with their BucketID) before the roll-up so
+	// per-bucket summaries can be built at bucket grain regardless of request window.
+	if lineItem != nil && lineItem.HasCommitmentTimeBuckets() {
+		p.item.BucketPoints = p.item.Points
+	}
+
 	// Merge bucket-level points to request window level
 	p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType)
 
@@ -2272,6 +2278,11 @@ func (s *featureUsageTrackingService) calculatePointCosts(p *bucketedCostParams,
 			p.item.Points[i].ComputedOverageAmount = info.ComputedOverageAmount
 			p.item.Points[i].ComputedTrueUpAmount = info.ComputedTrueUpAmount
 		}
+		// Stamp the bucket this window's start falls in, so per-bucket summaries can
+		// be built at bucket grain (before the request-window roll-up).
+		if idx, ok := lineItem.CommitmentTimeBuckets.BucketIndexAt([]time.Time{p.item.Points[i].Timestamp}, 0); ok {
+			p.item.Points[i].BucketID = lineItem.CommitmentTimeBuckets[idx].ID
+		}
 	}
 }
 
@@ -2328,6 +2339,11 @@ func (s *featureUsageTrackingService) fillZeroUsageWindows(p *bucketedCostParams
 	for _, t := range expectedStarts {
 		bucketPoints = append(bucketPoints, s.createFillPoint(p, lineItem, t, billingAnchor, commitmentCalc))
 	}
+	// Snapshot bucket-grain points (with BucketID) before the roll-up so per-bucket
+	// summaries are exact even when the request window is coarser than the buckets.
+	if lineItem.HasCommitmentTimeBuckets() {
+		p.item.BucketPoints = bucketPoints
+	}
 	p.item.Points = s.mergeBucketPointsByWindow(bucketPoints, p.aggType)
 
 	return totalCost
@@ -2356,6 +2372,11 @@ func (s *featureUsageTrackingService) createFillPoint(
 		pt.ComputedCommitmentUtilizedAmount = info.ComputedCommitmentUtilizedAmount
 		pt.ComputedOverageAmount = info.ComputedOverageAmount
 		pt.ComputedTrueUpAmount = info.ComputedTrueUpAmount
+	}
+	// Stamp the bucket this filled window falls in (empty for out-of-bucket fills),
+	// so per-bucket summaries built from the bucket-grain points attribute correctly.
+	if idx, ok := lineItem.CommitmentTimeBuckets.BucketIndexAt([]time.Time{timestamp}, 0); ok {
+		pt.BucketID = lineItem.CommitmentTimeBuckets[idx].ID
 	}
 	return pt
 }
@@ -3194,10 +3215,20 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 				item.Points = append(item.Points, dtoPoint)
 			}
 
-			// Bucket-level summaries (Task 19).
+			// Bucket-level summaries (Task 19). Build them from the bucket-grain
+			// points (analytic.BucketPoints), which carry each window's BucketID —
+			// NOT from item.Points, which were rolled up to the request window. When
+			// the request window is coarser than the buckets, a rolled-up point
+			// straddles bucket boundaries and loses attribution, so summarising from
+			// item.Points would report zero. BucketPoints is empty only in the
+			// degenerate no-timestamp aggregate path; fall back to item.Points there.
 			if lineItemForBucket != nil {
 				priceService := NewPriceService(s.ServiceParams)
-				item.BucketSummaries = buildBucketSummaries(ctx, priceService, item.Points, lineItemForBucket, data)
+				summaryPoints := item.Points
+				if len(analytic.BucketPoints) > 0 {
+					summaryPoints = bucketGrainDTOPoints(analytic.BucketPoints)
+				}
+				item.BucketSummaries = buildBucketSummaries(ctx, priceService, summaryPoints, lineItemForBucket, data)
 			}
 		}
 

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -2150,7 +2150,10 @@ func (s *featureUsageTrackingService) calculateBucketedCost(ctx context.Context,
 	lineItem := data.SubscriptionLineItems[item.SubLineItemID]
 	hasCommitment := !skipCommitment && lineItem != nil && lineItem.HasAnyCommitment()
 	isWindowed := hasCommitment && lineItem.CommitmentWindowed
-	hasTrueUp := isWindowed && lineItem.CommitmentTrueUpEnabled
+	// Use HasTrueUpEnabled() (top-level OR any bucket) — a bucket-level-only true-up
+	// must still engage the window fill, otherwise empty windows inside a true-up
+	// bucket are never charged the committed minimum. Mirrors meter_usage.
+	hasTrueUp := isWindowed && lineItem.HasTrueUpEnabled()
 
 	var cost decimal.Decimal
 

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -2970,17 +2970,18 @@ func (s *featureUsageTrackingService) TriggerReprocessEventsWorkflowInternal(ctx
 
 // buildBucketSummaries constructs per-bucket rollup rows by summing the per-point
 // commitment fields the caller already stamped (BucketID + Computed* per point).
-// Because commitment is applied per window/point, the summary is a straight sum of
-// those per-point values — it matches the per-window billing exactly. One summary
-// is produced per CommitmentTimeBucket, plus one aggregate for out-of-bucket
-// points (BucketID == "", priced at the line item's own price + commitment).
+// It takes the BUCKET-GRAIN points (one per meter window, each fully inside a
+// single bucket) — NOT the rolled-up display points, whose windows can straddle
+// bucket boundaries. Because commitment is applied per window, the summary is a
+// straight sum of those per-window values — it matches per-window billing exactly.
+// One summary is produced per CommitmentTimeBucket.
 //
 // It is a package-level helper so both the feature-usage and meter-usage
 // analytics paths produce identical bucket summaries.
 func buildBucketSummaries(
 	ctx context.Context,
 	priceService PriceService,
-	points []dto.UsageAnalyticPoint,
+	points []events.UsageAnalyticPoint,
 	lineItem *subscription.SubscriptionLineItem,
 	data *AnalyticsData,
 ) []dto.BucketSummary {
@@ -3016,7 +3017,7 @@ type bucketPointRollup struct {
 func rollupBucketPoints(
 	ctx context.Context,
 	priceService PriceService,
-	points []dto.UsageAnalyticPoint,
+	points []events.UsageAnalyticPoint,
 	bucketID string,
 	p *price.Price,
 ) bucketPointRollup {
@@ -3204,31 +3205,23 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 					ComputedOverageAmount:            point.ComputedOverageAmount,
 					ComputedTrueUpAmount:             point.ComputedTrueUpAmount,
 				}
-				// Per-point bucket identity (only when the point's whole window
-				// fits inside a single bucket).
+				// Per-point bucket identity: every bucket the rolled-up window
+				// overlaps (informational hint only — see dto.UsageAnalyticPoint).
 				if lineItemForBucket != nil {
-					if id, priceID, ok := bucketIDForPointWindow(lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, req.WindowSize); ok {
-						dtoPoint.BucketID = id
-						dtoPoint.PriceID = priceID
-					}
+					dtoPoint.BucketIDs, dtoPoint.BucketPriceIDs = bucketIDsForPointWindow(
+						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, req.WindowSize)
 				}
 				item.Points = append(item.Points, dtoPoint)
 			}
 
-			// Bucket-level summaries (Task 19). Build them from the bucket-grain
-			// points (analytic.BucketPoints), which carry each window's BucketID —
-			// NOT from item.Points, which were rolled up to the request window. When
-			// the request window is coarser than the buckets, a rolled-up point
-			// straddles bucket boundaries and loses attribution, so summarising from
-			// item.Points would report zero. BucketPoints is empty only in the
-			// degenerate no-timestamp aggregate path; fall back to item.Points there.
+			// Bucket-level summaries (Task 19). Always built from the bucket-grain
+			// points (analytic.BucketPoints) — one per meter window, each fully
+			// inside a single bucket — so attribution is exact regardless of the
+			// request window grain. Never from item.Points, whose rolled-up windows
+			// can straddle bucket boundaries.
 			if lineItemForBucket != nil {
 				priceService := NewPriceService(s.ServiceParams)
-				summaryPoints := item.Points
-				if len(analytic.BucketPoints) > 0 {
-					summaryPoints = bucketGrainDTOPoints(analytic.BucketPoints)
-				}
-				item.BucketSummaries = buildBucketSummaries(ctx, priceService, summaryPoints, lineItemForBucket, data)
+				item.BucketSummaries = buildBucketSummaries(ctx, priceService, analytic.BucketPoints, lineItemForBucket, data)
 			}
 		}
 

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -3208,8 +3208,11 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 				// Per-point bucket identity: every bucket the rolled-up window
 				// overlaps (informational hint only — see dto.UsageAnalyticPoint).
 				if lineItemForBucket != nil {
-					dtoPoint.BucketIDs, dtoPoint.BucketPriceIDs = bucketIDsForPointWindow(
+					ids, priceIDs := bucketIDsForPointWindow(
 						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, req.WindowSize)
+					for i := range ids {
+						dtoPoint.Buckets = append(dtoPoint.Buckets, dto.PointBucket{BucketID: ids[i], PriceID: priceIDs[i]})
+					}
 				}
 				item.Points = append(item.Points, dtoPoint)
 			}

--- a/internal/service/feature_usage_tracking_bucket_test.go
+++ b/internal/service/feature_usage_tracking_bucket_test.go
@@ -77,12 +77,14 @@ func (f *flatRatePriceService) GetByLookupKey(_ context.Context, _ string) (*dto
 	panic("not implemented")
 }
 
-// buildHourlyPoints returns a slice of 24 dto.UsageAnalyticPoints at hourly boundaries
-// starting at baseDate. Each point carries 10 units of usage and no bucket attribution.
-func buildHourlyPoints(baseDate time.Time) []dto.UsageAnalyticPoint {
-	pts := make([]dto.UsageAnalyticPoint, 24)
+// buildHourlyPoints returns 24 bucket-grain (domain) points at hourly boundaries
+// starting at baseDate. Each carries 10 units of usage and no bucket attribution.
+// buildBucketSummaries consumes the domain points (exact single attribution), not
+// the display DTO points.
+func buildHourlyPoints(baseDate time.Time) []eventsDomain.UsageAnalyticPoint {
+	pts := make([]eventsDomain.UsageAnalyticPoint, 24)
 	for i := 0; i < 24; i++ {
-		pts[i] = dto.UsageAnalyticPoint{
+		pts[i] = eventsDomain.UsageAnalyticPoint{
 			Timestamp: baseDate.Add(time.Duration(i) * time.Hour),
 			Usage:     decimal.NewFromInt(10),
 		}
@@ -126,23 +128,20 @@ func TestAnalytics_PerPointBucketAttribution(t *testing.T) {
 	baseDate := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
 	points := buildHourlyPoints(baseDate)
 
-	// Stamp the points with bucket attribution.
+	// Stamp the bucket-grain points with their (single) bucket attribution.
 	for i := range points {
 		if idx, ok := lineItem.CommitmentTimeBuckets.BucketIndexAt([]time.Time{points[i].Timestamp}, 0); ok {
 			points[i].BucketID = lineItem.CommitmentTimeBuckets[idx].ID
-			points[i].PriceID = lineItem.CommitmentTimeBuckets[idx].PriceID
 		}
 	}
 
 	// Assert: hours 0-8 and 17-23 are out-of-bucket (empty BucketID).
 	for i := 0; i < 9; i++ {
 		assert.Empty(t, points[i].BucketID, "hour %d should be out-of-bucket", i)
-		assert.Empty(t, points[i].PriceID, "hour %d should have no bucket PriceID", i)
 	}
 	// Assert: hours 9-16 are in-bucket.
 	for i := 9; i < 17; i++ {
 		assert.Equal(t, bucketID, points[i].BucketID, "hour %d should be in-bucket", i)
-		assert.Equal(t, bucketPriceID, points[i].PriceID, "hour %d should have bucket PriceID", i)
 	}
 	// Assert: hours 17-23 are out-of-bucket again.
 	for i := 17; i < 24; i++ {
@@ -213,7 +212,6 @@ func TestAnalytics_BucketSummaries_WithAmountCommitment(t *testing.T) {
 	for i := range points {
 		if idx, ok := lineItem.CommitmentTimeBuckets.BucketIndexAt([]time.Time{points[i].Timestamp}, 0); ok {
 			points[i].BucketID = lineItem.CommitmentTimeBuckets[idx].ID
-			points[i].PriceID = lineItem.CommitmentTimeBuckets[idx].PriceID
 			points[i].ComputedCommitmentUtilizedAmount = decimal.NewFromInt(5)
 			points[i].ComputedOverageAmount = decimal.NewFromInt(15)
 		}
@@ -458,7 +456,10 @@ func TestFeatureUsage_CoarseRequestWindow_BucketSummariesNonZero(t *testing.T) {
 	require.NotEmpty(t, item.BucketPoints, "bucket-grain points must be captured for summary building")
 	require.Equal(t, "bkt_fu_cw", item.BucketPoints[0].BucketID, "bucket-grain point must carry its BucketID")
 
-	summaries := buildBucketSummaries(ctx, priceSvc, bucketGrainDTOPoints(item.BucketPoints), lineItem, data)
+	// Summaries are built directly from the bucket-grain points (exact per-window
+	// attribution), so they stay correct even though the request window (HOUR) is
+	// coarser than the MINUTE bucket.
+	summaries := buildBucketSummaries(ctx, priceSvc, item.BucketPoints, lineItem, data)
 	require.Len(t, summaries, 1, "expected one summary per configured bucket")
 	bs := summaries[0]
 	assert.Equal(t, "bkt_fu_cw", bs.BucketID)
@@ -468,32 +469,4 @@ func TestFeatureUsage_CoarseRequestWindow_BucketSummariesNonZero(t *testing.T) {
 		"bucket utilized should be $5, got %s", bs.ComputedUtilized)
 	assert.True(t, bs.ComputedOverage.Equal(decimal.NewFromInt(30)),
 		"bucket overage should be $30 (($20-$5)×2), got %s", bs.ComputedOverage)
-
-	// Contrast: building summaries from the rolled-up HOUR points (the old path)
-	// loses attribution and reports zero — exactly the bug this fix avoids.
-	oldSummaries := buildBucketSummaries(ctx, priceSvc, hourPointsWithLegacyAttribution(item.Points, lineItem), lineItem, data)
-	require.Len(t, oldSummaries, 1)
-	assert.True(t, oldSummaries[0].TotalUsage.IsZero(),
-		"rolled-up HOUR points cannot attribute to a sub-hour bucket; got %s", oldSummaries[0].TotalUsage)
-}
-
-// hourPointsWithLegacyAttribution rebuilds the pre-fix DTO points: rolled-up
-// points whose BucketID is derived via bucketIDForPointWindow (full-containment).
-func hourPointsWithLegacyAttribution(points []eventsDomain.UsageAnalyticPoint, lineItem *subscriptionDomain.SubscriptionLineItem) []dto.UsageAnalyticPoint {
-	out := make([]dto.UsageAnalyticPoint, len(points))
-	for i, p := range points {
-		out[i] = dto.UsageAnalyticPoint{
-			Timestamp:                        p.Timestamp,
-			Usage:                            p.Usage,
-			Cost:                             p.Cost,
-			ComputedCommitmentUtilizedAmount: p.ComputedCommitmentUtilizedAmount,
-			ComputedOverageAmount:            p.ComputedOverageAmount,
-			ComputedTrueUpAmount:             p.ComputedTrueUpAmount,
-		}
-		if id, priceID, ok := bucketIDForPointWindow(lineItem.CommitmentTimeBuckets, p.Timestamp, types.WindowSizeHour); ok {
-			out[i].BucketID = id
-			out[i].PriceID = priceID
-		}
-	}
-	return out
 }

--- a/internal/service/feature_usage_tracking_bucket_test.go
+++ b/internal/service/feature_usage_tracking_bucket_test.go
@@ -7,8 +7,11 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	eventsDomain "github.com/flexprice/flexprice/internal/domain/events"
+	meterDomain "github.com/flexprice/flexprice/internal/domain/meter"
 	priceDomain "github.com/flexprice/flexprice/internal/domain/price"
 	subscriptionDomain "github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -272,4 +275,99 @@ func TestAnalytics_BreakdownBucketFlag_NoLineItem(t *testing.T) {
 	summaries := buildBucketSummaries(ctx, &flatRatePriceService{}, points, lineItem, data)
 	// No defined buckets => no summaries (out-of-bucket usage is not summarized).
 	require.Empty(t, summaries, "expect no summaries when no buckets defined")
+}
+
+// TestFeatureUsage_ZeroUsage_BucketTrueUp reproduces the production report where
+// an addon line item with a per-bucket true-up commitment but NO top-level
+// commitment returned total_cost 0 / true_up 0 through the FEATURE-USAGE path.
+//
+// The gate that engages the zero-usage window fill used the top-level
+// CommitmentTrueUpEnabled flag only, so a bucket-level-only true-up never fired —
+// the calculation fell through to applyLineItemCommitment(nil,nil), yielding the
+// empty is_windowed commitment info the customer saw.
+//
+// Setup mirrors the report: MINUTE bucketed SUM meter, line item scoped to a
+// single day, one bucket [11:00,11:30) with $3 amount commitment + true-up ON, no
+// usage. 30 empty minute windows × $3 true-up = $90.
+func TestFeatureUsage_ZeroUsage_BucketTrueUp(t *testing.T) {
+	ctx := testutil.SetupContext()
+	log := logger.NewNoopLogger()
+	priceStore := testutil.NewInMemoryPriceStore()
+	params := ServiceParams{
+		Logger:        log,
+		DB:            testutil.NewMockPostgresClient(log),
+		PriceRepo:     priceStore,
+		MeterRepo:     testutil.NewInMemoryMeterStore(),
+		PlanRepo:      testutil.NewInMemoryPlanStore(),
+		PriceUnitRepo: testutil.NewInMemoryPriceUnitStore(),
+		AddonRepo:     testutil.NewInMemoryAddonStore(),
+		SubRepo:       testutil.NewInMemorySubscriptionStore(),
+	}
+	svc := &featureUsageTrackingService{ServiceParams: params}
+	priceSvc := NewPriceService(params)
+
+	bucketPrice := &priceDomain.Price{
+		ID: "price_fu_bkt", Amount: decimal.NewFromInt(1), Currency: "usd",
+		Type: types.PRICE_TYPE_USAGE, BillingModel: types.BILLING_MODEL_FLAT_FEE,
+	}
+	require.NoError(t, priceStore.Create(ctx, bucketPrice))
+
+	linePrice := &priceDomain.Price{
+		ID: "price_fu_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		Type: types.PRICE_TYPE_USAGE, BillingModel: types.BILLING_MODEL_FLAT_FEE,
+	}
+	require.NoError(t, priceStore.Create(ctx, linePrice))
+
+	dayStart := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	dayEnd := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+	overage := decimal.NewFromInt(2)
+	lineItem := &subscriptionDomain.SubscriptionLineItem{
+		ID:                 "li_fu_zero_tu",
+		SubscriptionID:     "sub_fu",
+		PriceID:            linePrice.ID,
+		PriceType:          types.PRICE_TYPE_USAGE,
+		MeterID:            "meter_fu",
+		StartDate:          dayStart,
+		EndDate:            dayEnd,
+		CommitmentWindowed: true, // buckets only; no top-level commitment / true-up
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
+			ID: "bkt_fu", Start: types.Bucket{Hour: 11, Minute: 0}, End: types.Bucket{Hour: 11, Minute: 30},
+			PriceID: bucketPrice.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+			CommitmentValue: decimal.NewFromInt(3), OverageFactor: &overage, TrueUpEnabled: true,
+		}},
+	}
+
+	bucketedMeter := &meterDomain.Meter{
+		ID: "meter_fu",
+		Aggregation: meterDomain.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeMinute,
+		},
+	}
+
+	item := &eventsDomain.DetailedUsageAnalytic{
+		MeterID:         "meter_fu",
+		PriceID:         linePrice.ID,
+		SubLineItemID:   "li_fu_zero_tu",
+		SubscriptionID:  "sub_fu",
+		AggregationType: types.AggregationSum,
+		// zero usage, no points
+	}
+
+	data := &AnalyticsData{
+		SubscriptionLineItems: map[string]*subscriptionDomain.SubscriptionLineItem{"li_fu_zero_tu": lineItem},
+		SubscriptionsMap: map[string]*subscriptionDomain.Subscription{
+			"sub_fu": {ID: "sub_fu", BillingAnchor: dayStart},
+		},
+		Prices: map[string]*priceDomain.Price{linePrice.ID: linePrice},
+		Params: &eventsDomain.UsageAnalyticsParams{StartTime: dayStart, EndTime: dayEnd},
+	}
+
+	svc.calculateBucketedCost(ctx, priceSvc, item, linePrice, bucketedMeter, data, false)
+
+	require.NotNil(t, item.CommitmentInfo, "windowed commitment must record commitment info")
+	assert.True(t, item.CommitmentInfo.ComputedTrueUpAmount.Equal(decimal.NewFromInt(90)),
+		"expected true-up $90 (30 empty minute windows × $3); got %s", item.CommitmentInfo.ComputedTrueUpAmount)
+	assert.True(t, item.TotalCost.Equal(decimal.NewFromInt(90)),
+		"expected total cost $90 from bucket true-up; got %s", item.TotalCost)
 }

--- a/internal/service/feature_usage_tracking_bucket_test.go
+++ b/internal/service/feature_usage_tracking_bucket_test.go
@@ -371,3 +371,129 @@ func TestFeatureUsage_ZeroUsage_BucketTrueUp(t *testing.T) {
 	assert.True(t, item.TotalCost.Equal(decimal.NewFromInt(90)),
 		"expected total cost $90 from bucket true-up; got %s", item.TotalCost)
 }
+
+// TestFeatureUsage_CoarseRequestWindow_BucketSummariesNonZero verifies the ported
+// coarse-window summary fix on the feature-usage path: with a MINUTE-bucketed
+// meter and a HOUR request window (coarser than the buckets), per-bucket summaries
+// must still reflect the bucket's usage/commitment instead of rolling up to zero.
+func TestFeatureUsage_CoarseRequestWindow_BucketSummariesNonZero(t *testing.T) {
+	ctx := testutil.SetupContext()
+	log := logger.NewNoopLogger()
+	priceStore := testutil.NewInMemoryPriceStore()
+	params := ServiceParams{
+		Logger:        log,
+		DB:            testutil.NewMockPostgresClient(log),
+		PriceRepo:     priceStore,
+		MeterRepo:     testutil.NewInMemoryMeterStore(),
+		PlanRepo:      testutil.NewInMemoryPlanStore(),
+		PriceUnitRepo: testutil.NewInMemoryPriceUnitStore(),
+		AddonRepo:     testutil.NewInMemoryAddonStore(),
+		SubRepo:       testutil.NewInMemorySubscriptionStore(),
+	}
+	svc := &featureUsageTrackingService{ServiceParams: params}
+	priceSvc := NewPriceService(params)
+
+	bucketPrice := &priceDomain.Price{
+		ID: "price_fu_cw_bkt", Amount: decimal.NewFromInt(2), Currency: "usd",
+		Type: types.PRICE_TYPE_USAGE, BillingModel: types.BILLING_MODEL_FLAT_FEE,
+	}
+	require.NoError(t, priceStore.Create(ctx, bucketPrice))
+	linePrice := &priceDomain.Price{
+		ID: "price_fu_cw_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		Type: types.PRICE_TYPE_USAGE, BillingModel: types.BILLING_MODEL_FLAT_FEE,
+	}
+	require.NoError(t, priceStore.Create(ctx, linePrice))
+
+	dayStart := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	dayEnd := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+	overage := decimal.NewFromInt(2)
+	lineItem := &subscriptionDomain.SubscriptionLineItem{
+		ID:                 "li_fu_cw",
+		SubscriptionID:     "sub_fu_cw",
+		PriceID:            linePrice.ID,
+		PriceType:          types.PRICE_TYPE_USAGE,
+		MeterID:            "meter_fu_cw",
+		StartDate:          dayStart,
+		EndDate:            dayEnd,
+		CommitmentWindowed: true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
+			ID: "bkt_fu_cw", Start: types.Bucket{Hour: 11, Minute: 0}, End: types.Bucket{Hour: 11, Minute: 30},
+			PriceID: bucketPrice.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+			CommitmentValue: decimal.NewFromInt(5), OverageFactor: &overage, TrueUpEnabled: false,
+		}},
+	}
+	bucketedMeter := &meterDomain.Meter{
+		ID:          "meter_fu_cw",
+		Aggregation: meterDomain.Aggregation{Type: types.AggregationSum, BucketSize: types.WindowSizeMinute},
+	}
+
+	// One in-bucket minute point at 11:15 with 10 units (bucket grain).
+	item := &eventsDomain.DetailedUsageAnalytic{
+		MeterID:         "meter_fu_cw",
+		PriceID:         linePrice.ID,
+		SubLineItemID:   "li_fu_cw",
+		SubscriptionID:  "sub_fu_cw",
+		AggregationType: types.AggregationSum,
+		Points: []eventsDomain.UsageAnalyticPoint{{
+			Timestamp:   time.Date(2026, 1, 5, 11, 15, 0, 0, time.UTC),
+			WindowStart: time.Date(2026, 1, 5, 11, 15, 0, 0, time.UTC),
+			Usage:       decimal.NewFromInt(10),
+		}},
+	}
+
+	data := &AnalyticsData{
+		SubscriptionLineItems: map[string]*subscriptionDomain.SubscriptionLineItem{"li_fu_cw": lineItem},
+		SubscriptionsMap: map[string]*subscriptionDomain.Subscription{
+			"sub_fu_cw": {ID: "sub_fu_cw", BillingAnchor: dayStart},
+		},
+		Prices: map[string]*priceDomain.Price{linePrice.ID: linePrice, bucketPrice.ID: bucketPrice},
+		// HOUR request window — coarser than the MINUTE bucket.
+		Params: &eventsDomain.UsageAnalyticsParams{StartTime: dayStart, EndTime: dayEnd, WindowSize: types.WindowSizeHour},
+	}
+
+	svc.calculateBucketedCost(ctx, priceSvc, item, linePrice, bucketedMeter, data, false)
+
+	// The fix: bucket-grain points are captured (with BucketID) before the HOUR
+	// roll-up, and summaries are built from them.
+	require.NotEmpty(t, item.BucketPoints, "bucket-grain points must be captured for summary building")
+	require.Equal(t, "bkt_fu_cw", item.BucketPoints[0].BucketID, "bucket-grain point must carry its BucketID")
+
+	summaries := buildBucketSummaries(ctx, priceSvc, bucketGrainDTOPoints(item.BucketPoints), lineItem, data)
+	require.Len(t, summaries, 1, "expected one summary per configured bucket")
+	bs := summaries[0]
+	assert.Equal(t, "bkt_fu_cw", bs.BucketID)
+	assert.True(t, bs.TotalUsage.Equal(decimal.NewFromInt(10)),
+		"bucket usage should be 10 even with HOUR request window, got %s", bs.TotalUsage)
+	assert.True(t, bs.ComputedUtilized.Equal(decimal.NewFromInt(5)),
+		"bucket utilized should be $5, got %s", bs.ComputedUtilized)
+	assert.True(t, bs.ComputedOverage.Equal(decimal.NewFromInt(30)),
+		"bucket overage should be $30 (($20-$5)×2), got %s", bs.ComputedOverage)
+
+	// Contrast: building summaries from the rolled-up HOUR points (the old path)
+	// loses attribution and reports zero — exactly the bug this fix avoids.
+	oldSummaries := buildBucketSummaries(ctx, priceSvc, hourPointsWithLegacyAttribution(item.Points, lineItem), lineItem, data)
+	require.Len(t, oldSummaries, 1)
+	assert.True(t, oldSummaries[0].TotalUsage.IsZero(),
+		"rolled-up HOUR points cannot attribute to a sub-hour bucket; got %s", oldSummaries[0].TotalUsage)
+}
+
+// hourPointsWithLegacyAttribution rebuilds the pre-fix DTO points: rolled-up
+// points whose BucketID is derived via bucketIDForPointWindow (full-containment).
+func hourPointsWithLegacyAttribution(points []eventsDomain.UsageAnalyticPoint, lineItem *subscriptionDomain.SubscriptionLineItem) []dto.UsageAnalyticPoint {
+	out := make([]dto.UsageAnalyticPoint, len(points))
+	for i, p := range points {
+		out[i] = dto.UsageAnalyticPoint{
+			Timestamp:                        p.Timestamp,
+			Usage:                            p.Usage,
+			Cost:                             p.Cost,
+			ComputedCommitmentUtilizedAmount: p.ComputedCommitmentUtilizedAmount,
+			ComputedOverageAmount:            p.ComputedOverageAmount,
+			ComputedTrueUpAmount:             p.ComputedTrueUpAmount,
+		}
+		if id, priceID, ok := bucketIDForPointWindow(lineItem.CommitmentTimeBuckets, p.Timestamp, types.WindowSizeHour); ok {
+			out[i].BucketID = id
+			out[i].PriceID = priceID
+		}
+	}
+	return out
+}

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1445,8 +1445,11 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 				// Per-point bucket identity: every bucket the rolled-up window
 				// overlaps (informational hint only — see dto.UsageAnalyticPoint).
 				if lineItemForBucket != nil {
-					dtoPoint.BucketIDs, dtoPoint.BucketPriceIDs = bucketIDsForPointWindow(
+					ids, priceIDs := bucketIDsForPointWindow(
 						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, params.WindowSize)
+					for i := range ids {
+						dtoPoint.Buckets = append(dtoPoint.Buckets, dto.PointBucket{BucketID: ids[i], PriceID: priceIDs[i]})
+					}
 				}
 				item.Points = append(item.Points, dtoPoint)
 			}

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1442,31 +1442,23 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 					ComputedOverageAmount:            point.ComputedOverageAmount,
 					ComputedTrueUpAmount:             point.ComputedTrueUpAmount,
 				}
-				// Per-point bucket identity (only when the point's whole window
-				// fits inside a single bucket).
+				// Per-point bucket identity: every bucket the rolled-up window
+				// overlaps (informational hint only — see dto.UsageAnalyticPoint).
 				if lineItemForBucket != nil {
-					if id, priceID, ok := bucketIDForPointWindow(lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, params.WindowSize); ok {
-						dtoPoint.BucketID = id
-						dtoPoint.PriceID = priceID
-					}
+					dtoPoint.BucketIDs, dtoPoint.BucketPriceIDs = bucketIDsForPointWindow(
+						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, params.WindowSize)
 				}
 				item.Points = append(item.Points, dtoPoint)
 			}
 
-			// Bucket-level summaries. Build them from the bucket-grain points
-			// (analytic.BucketPoints) where each window carries its BucketID — NOT
-			// from item.Points, which have been rolled up to the requested window.
-			// When the request window is coarser than the buckets, a rolled-up point
-			// straddles bucket boundaries and loses attribution, so summarising from
-			// item.Points would report zero. BucketPoints is empty only in the
-			// degenerate no-timestamp aggregate path; fall back to item.Points there.
+			// Bucket-level summaries. Always built from the bucket-grain points
+			// (analytic.BucketPoints) — one per meter window, each fully inside a
+			// single bucket — so attribution is exact regardless of the request
+			// window grain. Never from item.Points, whose rolled-up windows can
+			// straddle bucket boundaries.
 			if lineItemForBucket != nil {
 				priceService := NewPriceService(s.ServiceParams)
-				summaryPoints := item.Points
-				if len(analytic.BucketPoints) > 0 {
-					summaryPoints = bucketGrainDTOPoints(analytic.BucketPoints)
-				}
-				item.BucketSummaries = buildBucketSummaries(ctx, priceService, summaryPoints, lineItemForBucket, data)
+				item.BucketSummaries = buildBucketSummaries(ctx, priceService, analytic.BucketPoints, lineItemForBucket, data)
 			}
 		}
 
@@ -1942,25 +1934,6 @@ func (s *meterUsageService) captureBucketPoints(item *events.DetailedUsageAnalyt
 	if lineItem != nil && lineItem.HasCommitmentTimeBuckets() {
 		item.BucketPoints = item.Points
 	}
-}
-
-// bucketGrainDTOPoints projects bucket-grain analytic points to the minimal DTO
-// points buildBucketSummaries consumes — usage, per-window BucketID, and the
-// commitment breakdown. Used so summaries are rolled up at bucket grain.
-func bucketGrainDTOPoints(points []events.UsageAnalyticPoint) []dto.UsageAnalyticPoint {
-	out := make([]dto.UsageAnalyticPoint, len(points))
-	for i, p := range points {
-		out[i] = dto.UsageAnalyticPoint{
-			Timestamp:                        p.Timestamp,
-			Usage:                            p.Usage,
-			Cost:                             p.Cost,
-			BucketID:                         p.BucketID,
-			ComputedCommitmentUtilizedAmount: p.ComputedCommitmentUtilizedAmount,
-			ComputedOverageAmount:            p.ComputedOverageAmount,
-			ComputedTrueUpAmount:             p.ComputedTrueUpAmount,
-		}
-	}
-	return out
 }
 
 // processSingleBucket handles the case where there are no time-series points.

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1453,10 +1453,20 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 				item.Points = append(item.Points, dtoPoint)
 			}
 
-			// Bucket-level summaries.
+			// Bucket-level summaries. Build them from the bucket-grain points
+			// (analytic.BucketPoints) where each window carries its BucketID — NOT
+			// from item.Points, which have been rolled up to the requested window.
+			// When the request window is coarser than the buckets, a rolled-up point
+			// straddles bucket boundaries and loses attribution, so summarising from
+			// item.Points would report zero. BucketPoints is empty only in the
+			// degenerate no-timestamp aggregate path; fall back to item.Points there.
 			if lineItemForBucket != nil {
 				priceService := NewPriceService(s.ServiceParams)
-				item.BucketSummaries = buildBucketSummaries(ctx, priceService, item.Points, lineItemForBucket, data)
+				summaryPoints := item.Points
+				if len(analytic.BucketPoints) > 0 {
+					summaryPoints = bucketGrainDTOPoints(analytic.BucketPoints)
+				}
+				item.BucketSummaries = buildBucketSummaries(ctx, priceService, summaryPoints, lineItemForBucket, data)
 			}
 		}
 
@@ -1912,9 +1922,40 @@ func (s *meterUsageService) processPointsWithBuckets(
 		s.stampPointCosts(p.ctx, p.priceService, p.item, p.price)
 	}
 
+	s.captureBucketPoints(p.item, lineItem)
 	p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType, p.data.Params.WindowSize, p.data.Params.BillingAnchor)
 
 	return cost
+}
+
+// captureBucketPoints snapshots the bucket-grain points (with their per-window
+// BucketID) before mergeBucketPointsByWindow rolls them up to the requested window.
+// Only meaningful for line items with commitment time buckets — that's where the
+// per-bucket summaries are built. The snapshot is the same backing slice; merge
+// returns a new slice and does not mutate it.
+func (s *meterUsageService) captureBucketPoints(item *events.DetailedUsageAnalytic, lineItem *subscription.SubscriptionLineItem) {
+	if lineItem != nil && lineItem.HasCommitmentTimeBuckets() {
+		item.BucketPoints = item.Points
+	}
+}
+
+// bucketGrainDTOPoints projects bucket-grain analytic points to the minimal DTO
+// points buildBucketSummaries consumes — usage, per-window BucketID, and the
+// commitment breakdown. Used so summaries are rolled up at bucket grain.
+func bucketGrainDTOPoints(points []events.UsageAnalyticPoint) []dto.UsageAnalyticPoint {
+	out := make([]dto.UsageAnalyticPoint, len(points))
+	for i, p := range points {
+		out[i] = dto.UsageAnalyticPoint{
+			Timestamp:                        p.Timestamp,
+			Usage:                            p.Usage,
+			Cost:                             p.Cost,
+			BucketID:                         p.BucketID,
+			ComputedCommitmentUtilizedAmount: p.ComputedCommitmentUtilizedAmount,
+			ComputedOverageAmount:            p.ComputedOverageAmount,
+			ComputedTrueUpAmount:             p.ComputedTrueUpAmount,
+		}
+	}
+	return out
 }
 
 // processSingleBucket handles the case where there are no time-series points.
@@ -1949,6 +1990,7 @@ func (s *meterUsageService) processSingleBucket(
 
 	if needsWindowedFill && p.bucketSize != "" {
 		cost := s.fillWindowsAndApplyCommitment(p, lineItem)
+		s.captureBucketPoints(p.item, lineItem)
 		p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType, p.data.Params.WindowSize, p.data.Params.BillingAnchor)
 		return cost
 	}
@@ -2004,6 +2046,7 @@ func (s *meterUsageService) applyWindowCommitmentToPoints(
 		points[i].ComputedCommitmentUtilizedAmount = perWindow[i].utilized
 		points[i].ComputedOverageAmount = perWindow[i].overage
 		points[i].ComputedTrueUpAmount = perWindow[i].trueUp
+		points[i].BucketID = perWindow[i].bucketID
 	}
 	p.item.Points = points
 	p.item.CommitmentInfo = info

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1854,17 +1854,22 @@ type meterUsageBucketedCostParams struct {
 }
 
 // shouldFillWindow reports whether an EMPTY window starting at t needs a
-// synthetic zero-usage fill point. Filling only matters where commitment math
-// can produce a charge for an empty window: any window when the line item
-// carries its own (top-level) commitment, or windows inside a commitment time
-// bucket otherwise. Empty windows outside both bill $0 regardless, so filling
-// them would only add noise points.
+// synthetic zero-usage fill point. Fill only where commitment math can charge an
+// empty window — anywhere else the window bills $0 and a fill is pure noise:
+//
+//   - Inside a bucket, the bucket's own commitment governs the window (it
+//     overrides the line item), so an empty in-bucket window is charged only when
+//     that bucket has true-up.
+//   - Outside every bucket, only the line item's own commitment can charge an
+//     empty window, and only when it has true-up. A bucket-level-only true-up
+//     (no top-level commitment) therefore fills its bucket windows but NOT the
+//     out-of-bucket remainder — which previously produced 1440 all-zero
+//     points/day for a MINUTE meter.
 func shouldFillWindow(lineItem *subscription.SubscriptionLineItem, t time.Time) bool {
-	if lineItem.HasTrueUpEnabled() {
-		return true
+	if idx, ok := lineItem.CommitmentTimeBuckets.BucketIndexAt([]time.Time{t}, 0); ok {
+		return lineItem.CommitmentTimeBuckets[idx].TrueUpEnabled
 	}
-	_, ok := lineItem.CommitmentTimeBuckets.BucketIndexAt([]time.Time{t}, 0)
-	return ok
+	return lineItem.CommitmentTrueUpEnabled && lineItem.HasCommitment()
 }
 
 // calculateBucketedCost calculates cost for bucketed max/sum meters.

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -42,6 +42,15 @@ func TestMeterUsageService(t *testing.T) {
 	suite.Run(t, new(MeterUsageServiceSuite))
 }
 
+// pointBucketIDs extracts the bucket ids from a point's Buckets list.
+func pointBucketIDs(buckets []dto.PointBucket) []string {
+	ids := make([]string, len(buckets))
+	for i, b := range buckets {
+		ids[i] = b.BucketID
+	}
+	return ids
+}
+
 func (s *MeterUsageServiceSuite) SetupTest() {
 	s.BaseServiceTestSuite.SetupTest()
 
@@ -2212,9 +2221,10 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_PerBucket_BreakdownAndSumm
 	// Per-point bucket identity: the 10:00 window overlaps the bucket.
 	var inBucketPoints int
 	for _, pt := range item.Points {
-		if slices.Contains(pt.BucketIDs, "bkt_morning") {
+		if slices.Contains(pointBucketIDs(pt.Buckets), "bkt_morning") {
 			inBucketPoints++
-			s.Contains(pt.BucketPriceIDs, bucketPrice.ID, "in-bucket point must carry the bucket price id")
+			s.Contains(pt.Buckets, dto.PointBucket{BucketID: "bkt_morning", PriceID: bucketPrice.ID},
+				"in-bucket point must carry the bucket id + price")
 		}
 	}
 	s.Positive(inBucketPoints, "expected at least one point stamped with the bucket id")
@@ -2689,9 +2699,10 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_MultipleBucketsPerPoint_Co
 		if pt.Cost.GreaterThan(decimal.Zero) {
 			dayPoints++
 			s.True(pt.Cost.Equal(decimal.NewFromInt(101)), "the day point should sum to $101; got %s", pt.Cost)
-			// The DAY window overlaps BOTH buckets → bucket_ids lists both (array).
-			s.Contains(pt.BucketIDs, "bkt_a", "day point overlaps bucket A")
-			s.Contains(pt.BucketIDs, "bkt_b", "day point overlaps bucket B")
+			// The DAY window overlaps BOTH buckets → buckets lists both.
+			ids := pointBucketIDs(pt.Buckets)
+			s.Contains(ids, "bkt_a", "day point overlaps bucket A")
+			s.Contains(ids, "bkt_b", "day point overlaps bucket B")
 		}
 	}
 	s.Equal(1, dayPoints, "DAY window should collapse the three hours into one point")
@@ -2787,7 +2798,7 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_MultiplePointsPerBucket_Co
 	// Three in-bucket hourly points, each attributed to the bucket.
 	inBucket := 0
 	for _, pt := range item.Points {
-		if slices.Contains(pt.BucketIDs, "bkt_one") {
+		if slices.Contains(pointBucketIDs(pt.Buckets), "bkt_one") {
 			inBucket++
 		}
 	}
@@ -2879,7 +2890,8 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_BucketTrueUp_NoOutOfBucket
 	// Only the 30 in-bucket windows are emitted — no out-of-bucket all-zero noise.
 	s.Equal(30, len(item.Points), "expected exactly 30 in-bucket points, got %d", len(item.Points))
 	for _, pt := range item.Points {
-		s.Equal([]string{"bkt_noise"}, pt.BucketIDs, "every emitted point must be in-bucket; found out-of-bucket fill at %s", pt.Timestamp)
+		s.Equal([]dto.PointBucket{{BucketID: "bkt_noise", PriceID: bucketPrice.ID}}, pt.Buckets,
+			"every emitted point must be in-bucket; found out-of-bucket fill at %s", pt.Timestamp)
 	}
 }
 
@@ -2963,7 +2975,8 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_BucketPartiallyOverlapsDis
 	// though its single cost mixes in- and out-of-bucket — so per-bucket cost must
 	// come from bucket_summaries, never from this point.
 	s.Require().Len(item.Points, 1)
-	s.Equal([]string{"bkt_po"}, item.Points[0].BucketIDs, "the HOUR point overlaps the bucket → bucket_ids lists it")
+	s.Equal([]dto.PointBucket{{BucketID: "bkt_po", PriceID: bucketPrice.ID}}, item.Points[0].Buckets,
+		"the HOUR point overlaps the bucket → buckets lists it")
 
 	// Yet the SUMMARY is exact — built from minute-grain attribution, not the point.
 	s.Require().Len(item.BucketSummaries, 1)
@@ -3087,7 +3100,7 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_Bucket_SlabPricing_Overage
 	// Per-point: the 10:00 point bills $13 with $8 overage at no premium.
 	var inBucketPoint *dto.UsageAnalyticPoint
 	for i := range item.Points {
-		if slices.Contains(item.Points[i].BucketIDs, "bkt_slab") && item.Points[i].Usage.Equal(decimal.NewFromInt(8)) {
+		if slices.Contains(pointBucketIDs(item.Points[i].Buckets), "bkt_slab") && item.Points[i].Usage.Equal(decimal.NewFromInt(8)) {
 			inBucketPoint = &item.Points[i]
 			break
 		}

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -2208,12 +2209,12 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_PerBucket_BreakdownAndSumm
 	s.True(item.TotalCost.Equal(decimal.NewFromInt(50)),
 		"expected $50 (in-bucket $35 via bucket price + out-of-bucket $15); got %s", item.TotalCost)
 
-	// Per-point bucket identity: the 10:00 window must be stamped with the bucket.
+	// Per-point bucket identity: the 10:00 window overlaps the bucket.
 	var inBucketPoints int
 	for _, pt := range item.Points {
-		if pt.BucketID == "bkt_morning" {
+		if slices.Contains(pt.BucketIDs, "bkt_morning") {
 			inBucketPoints++
-			s.Equal(bucketPrice.ID, pt.PriceID, "in-bucket point must carry the bucket price id")
+			s.Contains(pt.BucketPriceIDs, bucketPrice.ID, "in-bucket point must carry the bucket price id")
 		}
 	}
 	s.Positive(inBucketPoints, "expected at least one point stamped with the bucket id")
@@ -2688,6 +2689,9 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_MultipleBucketsPerPoint_Co
 		if pt.Cost.GreaterThan(decimal.Zero) {
 			dayPoints++
 			s.True(pt.Cost.Equal(decimal.NewFromInt(101)), "the day point should sum to $101; got %s", pt.Cost)
+			// The DAY window overlaps BOTH buckets → bucket_ids lists both (array).
+			s.Contains(pt.BucketIDs, "bkt_a", "day point overlaps bucket A")
+			s.Contains(pt.BucketIDs, "bkt_b", "day point overlaps bucket B")
 		}
 	}
 	s.Equal(1, dayPoints, "DAY window should collapse the three hours into one point")
@@ -2783,7 +2787,7 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_MultiplePointsPerBucket_Co
 	// Three in-bucket hourly points, each attributed to the bucket.
 	inBucket := 0
 	for _, pt := range item.Points {
-		if pt.BucketID == "bkt_one" {
+		if slices.Contains(pt.BucketIDs, "bkt_one") {
 			inBucket++
 		}
 	}
@@ -2875,8 +2879,99 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_BucketTrueUp_NoOutOfBucket
 	// Only the 30 in-bucket windows are emitted — no out-of-bucket all-zero noise.
 	s.Equal(30, len(item.Points), "expected exactly 30 in-bucket points, got %d", len(item.Points))
 	for _, pt := range item.Points {
-		s.Equal("bkt_noise", pt.BucketID, "every emitted point must be in-bucket; found out-of-bucket fill at %s", pt.Timestamp)
+		s.Equal([]string{"bkt_noise"}, pt.BucketIDs, "every emitted point must be in-bucket; found out-of-bucket fill at %s", pt.Timestamp)
 	}
+}
+
+// TestWindowCommitment_BucketPartiallyOverlapsDisplayWindow_SummaryCorrect proves
+// the bucket SUMMARY stays exact even when a bucket only PARTIALLY overlaps a
+// rolled-up display window (so the display point carries no single bucket_id).
+// Summaries are computed from the meter-grain points (each minute is fully inside
+// exactly one bucket), NOT from the rolled-up display points — so partial overlap
+// at the display grain cannot under- or over-count the bucket.
+//
+//	MINUTE meter; bucket [12:00,12:45) $2/u, commit $5/window, 2x, no true-up.
+//	usage 12:30 → 10u (in bucket); 12:50 → 10u (out of bucket, same HOUR).
+//	request window HOUR → one display point [12:00,13:00) mixing both.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_BucketPartiallyOverlapsDisplayWindow_SummaryCorrect() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID: "meter_partial_overlap", Name: "Minute SUM (partial overlap)", EventName: "api_call",
+		Aggregation: meter.Aggregation{Type: types.AggregationSum, BucketSize: types.WindowSizeMinute},
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	linePrice := &price.Price{
+		ID: "price_po_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, linePrice))
+	bucketPrice := &price.Price{
+		ID: "price_po_bkt", Amount: decimal.NewFromInt(2), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPrice))
+
+	overage := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID: "li_partial_overlap", SubscriptionID: s.sub.ID, CustomerID: s.customer.ID,
+		PriceID: linePrice.ID, PriceType: types.PRICE_TYPE_USAGE, MeterID: bucketedMeter.ID,
+		Currency: "usd", BillingPeriod: types.BILLING_PERIOD_MONTHLY, InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate: s.periodStart, EndDate: s.periodEnd, Quantity: decimal.NewFromInt(1),
+		CommitmentWindowed: true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{ID: "bkt_po", Start: types.Bucket{Hour: 12, Minute: 0}, End: types.Bucket{Hour: 12, Minute: 45},
+				PriceID: bucketPrice.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(5), OverageFactor: &overage},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 12, 30, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 12, 50, 0, 0, time.UTC), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID: types.GetTenantID(ctx), EnvironmentID: types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID, MeterIDs: []string{bucketedMeter.ID},
+		StartTime: s.periodStart, EndTime: s.periodEnd, WindowSize: types.WindowSizeHour, BreakdownBucket: true,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_partial_overlap" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+
+	// 12:30 in-bucket $35 + 12:50 out-of-bucket $10 = $45.
+	s.True(item.TotalCost.Equal(decimal.NewFromInt(45)), "expected $45; got %s", item.TotalCost)
+
+	// The single HOUR display point mixes in- and out-of-bucket minutes. With the
+	// overlap rule it now LISTS the bucket it partially overlaps (bucket_ids), even
+	// though its single cost mixes in- and out-of-bucket — so per-bucket cost must
+	// come from bucket_summaries, never from this point.
+	s.Require().Len(item.Points, 1)
+	s.Equal([]string{"bkt_po"}, item.Points[0].BucketIDs, "the HOUR point overlaps the bucket → bucket_ids lists it")
+
+	// Yet the SUMMARY is exact — built from minute-grain attribution, not the point.
+	s.Require().Len(item.BucketSummaries, 1)
+	bs := item.BucketSummaries[0]
+	s.True(bs.TotalUsage.Equal(decimal.NewFromInt(10)), "summary must count only the in-bucket 12:30 usage; got %s", bs.TotalUsage)
+	s.True(bs.BaseCharge.Equal(decimal.NewFromInt(20)), "summary base $20 (10×$2); got %s", bs.BaseCharge)
+	s.True(bs.ComputedUtilized.Equal(decimal.NewFromInt(5)), "utilized $5; got %s", bs.ComputedUtilized)
+	s.True(bs.ComputedOverage.Equal(decimal.NewFromInt(30)), "overage $30; got %s", bs.ComputedOverage)
 }
 
 // TestWindowCommitment_Bucket_SlabPricing_OverageFactorOne verifies a bucket
@@ -2992,7 +3087,7 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_Bucket_SlabPricing_Overage
 	// Per-point: the 10:00 point bills $13 with $8 overage at no premium.
 	var inBucketPoint *dto.UsageAnalyticPoint
 	for i := range item.Points {
-		if item.Points[i].BucketID == "bkt_slab" && item.Points[i].Usage.Equal(decimal.NewFromInt(8)) {
+		if slices.Contains(item.Points[i].BucketIDs, "bkt_slab") && item.Points[i].Usage.Equal(decimal.NewFromInt(8)) {
 			inBucketPoint = &item.Points[i]
 			break
 		}

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -2594,6 +2594,291 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_ZeroUsage_BucketTrueUp() {
 		"expected total cost $90 from true-up alone; got %s", item.TotalCost)
 }
 
+// TestWindowCommitment_MultipleBucketsPerPoint_Cost verifies cost when a single
+// rolled-up display point spans MULTIPLE buckets: the request window (DAY) is
+// coarser than the buckets, so one DAY point contains hours from bucket A, bucket
+// B, and out-of-bucket time. Cost is computed per meter window (HOUR) and summed —
+// each hour attributed to its own bucket (or the line item) independently.
+//
+//	bucket A [09:00,11:00): $2/u, commit $5/window, 2x        09:00 10u → $5+($15×2)=$35
+//	bucket B [14:00,16:00): $3/u, commit $4/window, 2x        14:00 10u → $4+($26×2)=$56
+//	line item: $1/u, no commitment (out-of-bucket base)       20:00 10u → $10
+//
+// Total = $101, returned as ONE day point.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_MultipleBucketsPerPoint_Cost() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID: "meter_multi_per_point", Name: "Hourly SUM (multi-bucket/point)", EventName: "api_call",
+		Aggregation: meter.Aggregation{Type: types.AggregationSum, BucketSize: types.WindowSizeHour},
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	linePrice := &price.Price{
+		ID: "price_mpp_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, linePrice))
+	bucketPriceA := &price.Price{
+		ID: "price_mpp_a", Amount: decimal.NewFromInt(2), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPriceA))
+	bucketPriceB := &price.Price{
+		ID: "price_mpp_b", Amount: decimal.NewFromInt(3), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPriceB))
+
+	overage := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID: "li_multi_per_point", SubscriptionID: s.sub.ID, CustomerID: s.customer.ID,
+		PriceID: linePrice.ID, PriceType: types.PRICE_TYPE_USAGE, MeterID: bucketedMeter.ID,
+		Currency: "usd", BillingPeriod: types.BILLING_PERIOD_MONTHLY, InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate: s.periodStart, EndDate: s.periodEnd, Quantity: decimal.NewFromInt(1),
+		CommitmentWindowed: true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{ID: "bkt_a", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 11},
+				PriceID: bucketPriceA.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(5), OverageFactor: &overage},
+			{ID: "bkt_b", Start: types.Bucket{Hour: 14}, End: types.Bucket{Hour: 16},
+				PriceID: bucketPriceB.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(4), OverageFactor: &overage},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 9, 0, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 14, 0, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 20, 0, 0, 0, time.UTC), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID: types.GetTenantID(ctx), EnvironmentID: types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID, MeterIDs: []string{bucketedMeter.ID},
+		StartTime: s.periodStart, EndTime: s.periodEnd, WindowSize: types.WindowSizeDay, BreakdownBucket: true,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_multi_per_point" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+	// $35 (A) + $56 (B) + $10 (out-of-bucket) = $101.
+	s.True(item.TotalCost.Equal(decimal.NewFromInt(101)),
+		"expected $101 (A $35 + B $56 + out $10); got %s", item.TotalCost)
+
+	// One DAY point carries the summed cost of all three meter-hour windows.
+	dayPoints := 0
+	for _, pt := range item.Points {
+		if pt.Cost.GreaterThan(decimal.Zero) {
+			dayPoints++
+			s.True(pt.Cost.Equal(decimal.NewFromInt(101)), "the day point should sum to $101; got %s", pt.Cost)
+		}
+	}
+	s.Equal(1, dayPoints, "DAY window should collapse the three hours into one point")
+
+	// Per-bucket summaries stay correct at bucket grain.
+	byBucket := map[string]dto.BucketSummary{}
+	for _, bs := range item.BucketSummaries {
+		byBucket[bs.BucketID] = bs
+	}
+	s.Require().Len(item.BucketSummaries, 2)
+	s.True(byBucket["bkt_a"].TotalUsage.Equal(decimal.NewFromInt(10)))
+	s.True(byBucket["bkt_a"].ComputedOverage.Equal(decimal.NewFromInt(30)), "A overage ($15×2); got %s", byBucket["bkt_a"].ComputedOverage)
+	s.True(byBucket["bkt_b"].TotalUsage.Equal(decimal.NewFromInt(10)))
+	s.True(byBucket["bkt_b"].ComputedOverage.Equal(decimal.NewFromInt(52)), "B overage ($26×2); got %s", byBucket["bkt_b"].ComputedOverage)
+}
+
+// TestWindowCommitment_MultiplePointsPerBucket_Cost verifies cost when a single
+// bucket spans MULTIPLE meter windows: bucket [09:00,12:00) over an HOUR meter is
+// three windows (09,10,11). Each window applies the bucket's commitment
+// independently and the costs sum.
+//
+//	09:00 10u → 10×$2=$20 → $5+($15×2)=$35
+//	10:00  4u →  4×$2=$8  → $5+($3×2)=$11
+//	11:00 10u → 10×$2=$20 → $5+($15×2)=$35
+//
+// Total = $81 (utilized $15, overage $66, true-up $0).
+func (s *MeterUsageServiceSuite) TestWindowCommitment_MultiplePointsPerBucket_Cost() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID: "meter_multi_per_bucket", Name: "Hourly SUM (multi-point/bucket)", EventName: "api_call",
+		Aggregation: meter.Aggregation{Type: types.AggregationSum, BucketSize: types.WindowSizeHour},
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	linePrice := &price.Price{
+		ID: "price_mpb_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, linePrice))
+	bucketPrice := &price.Price{
+		ID: "price_mpb_bkt", Amount: decimal.NewFromInt(2), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPrice))
+
+	overage := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID: "li_multi_per_bucket", SubscriptionID: s.sub.ID, CustomerID: s.customer.ID,
+		PriceID: linePrice.ID, PriceType: types.PRICE_TYPE_USAGE, MeterID: bucketedMeter.ID,
+		Currency: "usd", BillingPeriod: types.BILLING_PERIOD_MONTHLY, InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate: s.periodStart, EndDate: s.periodEnd, Quantity: decimal.NewFromInt(1),
+		CommitmentWindowed: true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{ID: "bkt_one", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12},
+				PriceID: bucketPrice.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(5), OverageFactor: &overage},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 9, 0, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 4)
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID, time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 10)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID: types.GetTenantID(ctx), EnvironmentID: types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID, MeterIDs: []string{bucketedMeter.ID},
+		StartTime: s.periodStart, EndTime: s.periodEnd, WindowSize: types.WindowSizeHour, BreakdownBucket: true,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_multi_per_bucket" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+	// $35 + $11 + $35 = $81.
+	s.True(item.TotalCost.Equal(decimal.NewFromInt(81)),
+		"expected $81 (windows $35 + $11 + $35); got %s", item.TotalCost)
+
+	// Three in-bucket hourly points, each attributed to the bucket.
+	inBucket := 0
+	for _, pt := range item.Points {
+		if pt.BucketID == "bkt_one" {
+			inBucket++
+		}
+	}
+	s.Equal(3, inBucket, "expected 3 in-bucket hourly points")
+
+	s.Require().Len(item.BucketSummaries, 1)
+	bs := item.BucketSummaries[0]
+	s.True(bs.TotalUsage.Equal(decimal.NewFromInt(24)), "bucket usage 10+4+10=24; got %s", bs.TotalUsage)
+	s.True(bs.ComputedUtilized.Equal(decimal.NewFromInt(15)), "utilized $5×3; got %s", bs.ComputedUtilized)
+	s.True(bs.ComputedOverage.Equal(decimal.NewFromInt(66)), "overage $30+$6+$30; got %s", bs.ComputedOverage)
+}
+
+// TestWindowCommitment_BucketTrueUp_NoOutOfBucketFillPoints verifies that when the
+// ONLY true-up is bucket-level (no top-level line-item commitment), empty windows
+// OUTSIDE every bucket are not synthesized as all-zero fill points — only windows
+// inside a true-up bucket are filled. Cost is unaffected (out-of-bucket empty
+// windows bill $0) but the response no longer carries 1440 noise points/day.
+//
+// MINUTE meter, bucket [11:00,11:30) amount commit $3 + true-up, zero usage, line
+// item scoped to one day. Expect exactly 30 in-bucket points, no out-of-bucket noise.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_BucketTrueUp_NoOutOfBucketFillPoints() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID: "meter_no_noise", Name: "Minute SUM (no out-of-bucket fill)", EventName: "api_call",
+		Aggregation: meter.Aggregation{Type: types.AggregationSum, BucketSize: types.WindowSizeMinute},
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	linePrice := &price.Price{
+		ID: "price_noise_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, linePrice))
+	bucketPrice := &price.Price{
+		ID: "price_noise_bkt", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPrice))
+
+	overage := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID: "li_no_noise", SubscriptionID: s.sub.ID, CustomerID: s.customer.ID,
+		PriceID: linePrice.ID, PriceType: types.PRICE_TYPE_USAGE, MeterID: bucketedMeter.ID,
+		Currency: "usd", BillingPeriod: types.BILLING_PERIOD_MONTHLY, InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate: time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+		EndDate:   time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC),
+		Quantity:  decimal.NewFromInt(1),
+		// Bucket-level true-up only; no top-level commitment.
+		CommitmentWindowed: true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{ID: "bkt_noise", Start: types.Bucket{Hour: 11, Minute: 0}, End: types.Bucket{Hour: 11, Minute: 30},
+				PriceID: bucketPrice.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(3), OverageFactor: &overage, TrueUpEnabled: true},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// No usage. Request MINUTE windows so points are exposed at bucket grain.
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID: types.GetTenantID(ctx), EnvironmentID: types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID, MeterIDs: []string{bucketedMeter.ID},
+		StartTime:  time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC),
+		WindowSize: types.WindowSizeMinute, BreakdownBucket: true,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_no_noise" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item)
+
+	// Cost is the 30 bucket minutes trued up to $3 = $90 (unchanged by the fill scoping).
+	s.True(item.TotalCost.Equal(decimal.NewFromInt(90)), "expected $90; got %s", item.TotalCost)
+
+	// Only the 30 in-bucket windows are emitted — no out-of-bucket all-zero noise.
+	s.Equal(30, len(item.Points), "expected exactly 30 in-bucket points, got %d", len(item.Points))
+	for _, pt := range item.Points {
+		s.Equal("bkt_noise", pt.BucketID, "every emitted point must be in-bucket; found out-of-bucket fill at %s", pt.Timestamp)
+	}
+}
+
 // TestWindowCommitment_Bucket_SlabPricing_OverageFactorOne verifies a bucket
 // whose price is TIERED/SLAB and whose overage factor is exactly 1.0 (allowed
 // for buckets): usage beyond the commitment bills at the slab rate with no

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -2228,6 +2228,133 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_PerBucket_BreakdownAndSumm
 	s.True(bucketSummary.ComputedOverage.GreaterThan(decimal.Zero), "bucket overage should be positive, got %s", bucketSummary.ComputedOverage)
 }
 
+// TestWindowCommitment_CoarseRequestWindow_BucketSummariesNonZero reproduces the
+// production report where a customer's per-bucket commitment looked "not applied":
+// the meter buckets at MINUTE grain (forced by a sub-hour bucket like [11:00,11:30)),
+// but analytics is requested with window_size=HOUR — coarser than the bucket.
+//
+// The per-minute commitment IS applied to TotalCost (billing is correct), but the
+// bucket summaries must ALSO reflect it. Before the fix, mergeBucketPointsByWindow
+// collapsed the minute points into one hourly point and dropped bucket identity, so
+// bucketIDForPointWindow could never fit a 60-min window inside the 30-min bucket and
+// every summary rolled up to zero.
+//
+// Setup: MINUTE SUM meter; one bucket [11:00,12:00)→ use [11:00,11:30) (sub-hour),
+// bucket price $2/u, $5 amount commitment, 2x overage. Single event 11:15 → 10u.
+//
+//	in-bucket: 10u × $2 = $20 base → $5 + ($15×2) = $35
+//
+// TotalCost = $35 AND the bucket summary must report usage 10 / utilized $5 / overage $30.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_CoarseRequestWindow_BucketSummariesNonZero() {
+	ctx := s.GetContext()
+
+	// Minute-grained bucketed SUM meter — the bucket below is sub-hour so it only
+	// aligns to a 1-minute meter window.
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_coarse_win",
+		Name:      "Minute Bucketed SUM (coarse request)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeMinute,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	linePrice := &price.Price{
+		ID: "price_coarse_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, linePrice))
+
+	bucketPrice := &price.Price{
+		ID: "price_coarse_bucket", Amount: decimal.NewFromInt(2), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPrice))
+
+	overageFactor := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                 "li_coarse_win",
+		SubscriptionID:     s.sub.ID,
+		CustomerID:         s.customer.ID,
+		PriceID:            linePrice.ID,
+		PriceType:          types.PRICE_TYPE_USAGE,
+		MeterID:            bucketedMeter.ID,
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		StartDate:          s.periodStart,
+		EndDate:            s.periodEnd,
+		Quantity:           decimal.NewFromInt(1),
+		CommitmentWindowed: true, // required for buckets; no top-level commitment
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{
+				ID:              "bkt_sub_hour",
+				Start:           types.Bucket{Hour: 11, Minute: 0},
+				End:             types.Bucket{Hour: 11, Minute: 30},
+				PriceID:         bucketPrice.ID,
+				CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(5),
+				OverageFactor:   &overageFactor,
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// Single event at 11:15 UTC (inside the [11:00,11:30) bucket), 10 units.
+	s.insertMeterUsage(ctx, bucketedMeter.ID, s.customer.ExternalID,
+		time.Date(2026, 1, 5, 11, 15, 0, 0, time.UTC), 10)
+
+	// Request HOUR windows — COARSER than the minute bucket.
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeHour,
+		BreakdownBucket:    true,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_coarse_win" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for coarse-window line item")
+
+	// Commitment IS applied to the cost regardless of request grain.
+	s.True(item.TotalCost.Equal(decimal.NewFromInt(35)),
+		"expected $35 (10u × $2 = $20 → $5 + $15×2); got %s", item.TotalCost)
+
+	// The bug: with a coarser request window the bucket summary must STILL reflect
+	// the per-bucket usage and commitment — not roll up to zero.
+	s.Require().Len(item.BucketSummaries, 1, "expected one summary per configured bucket")
+	bs := item.BucketSummaries[0]
+	s.Equal("bkt_sub_hour", bs.BucketID)
+	s.True(bs.TotalUsage.Equal(decimal.NewFromInt(10)),
+		"bucket usage should be 10 even with HOUR request window, got %s", bs.TotalUsage)
+	s.True(bs.BaseCharge.Equal(decimal.NewFromInt(20)),
+		"bucket base charge should be $20 (10u × $2), got %s", bs.BaseCharge)
+	s.True(bs.ComputedUtilized.Equal(decimal.NewFromInt(5)),
+		"bucket utilized should be $5, got %s", bs.ComputedUtilized)
+	s.True(bs.ComputedOverage.Equal(decimal.NewFromInt(30)),
+		"bucket overage should be $30 ($15×2), got %s", bs.ComputedOverage)
+}
+
 // TestWindowCommitment_MultipleBuckets_WithTrueUp verifies two commitment
 // buckets with bucket-level true-up: empty windows inside each bucket are
 // filled and trued up to that bucket's commitment, even though the line item's

--- a/internal/service/meter_usage_test.go
+++ b/internal/service/meter_usage_test.go
@@ -2492,6 +2492,108 @@ func (s *MeterUsageServiceSuite) TestWindowCommitment_MultipleBuckets_WithTrueUp
 			Add(item.CommitmentInfo.ComputedTrueUpAmount)))
 }
 
+// TestWindowCommitment_ZeroUsage_BucketTrueUp reproduces the production report
+// where an addon line item with a per-bucket true-up commitment but NO usage in
+// the period returns total_cost 0 and computed_true_up_amount 0. With zero usage
+// the item routes through processSingleBucket, which must still fill the empty
+// windows inside the bucket and charge each one up to the committed minimum.
+//
+// Setup: MINUTE bucketed SUM meter; line item scoped to a single day; one bucket
+// [11:00,11:30) with $1/u price, $3 amount commitment, true-up ON, no top-level
+// commitment. No events at all. No window_size on the request (mirrors the report).
+//
+//	30 empty minute windows × $3 true-up = $90.
+func (s *MeterUsageServiceSuite) TestWindowCommitment_ZeroUsage_BucketTrueUp() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "meter_zero_tu",
+		Name:      "Minute SUM (zero-usage bucket true-up)",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeMinute,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+
+	linePrice := &price.Price{
+		ID: "price_zero_tu_line", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN, EntityID: "plan_1",
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, linePrice))
+
+	bucketPrice := &price.Price{
+		ID: "price_zero_tu_bucket", Amount: decimal.NewFromInt(1), Currency: "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION, EntityID: s.sub.ID,
+		BillingModel: types.BILLING_MODEL_FLAT_FEE, Type: types.PRICE_TYPE_USAGE,
+		MeterID: bucketedMeter.ID, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, bucketPrice))
+
+	overage := decimal.NewFromInt(2)
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_zero_tu",
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        linePrice.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        bucketedMeter.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		// Single day so the fill grid is 1440 minute windows.
+		StartDate:          time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+		EndDate:            time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC),
+		Quantity:           decimal.NewFromInt(1),
+		CommitmentWindowed: true, // buckets only; no top-level commitment / true-up
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{
+			{
+				ID: "bkt_tu", Start: types.Bucket{Hour: 11, Minute: 0}, End: types.Bucket{Hour: 11, Minute: 30},
+				PriceID: bucketPrice.ID, CommitmentType: types.COMMITMENT_TYPE_AMOUNT,
+				CommitmentValue: decimal.NewFromInt(3), OverageFactor: &overage, TrueUpEnabled: true,
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// NO usage events at all.
+
+	// No window_size — mirrors the production request.
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC),
+		EndTime:            time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC),
+		BreakdownBucket:    true,
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_zero_tu" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected analytic for zero-usage true-up line item")
+
+	// 30 empty minute windows inside [11:00,11:30), each trued up to $3 = $90.
+	s.Require().NotNil(item.CommitmentInfo, "windowed commitment must record commitment info")
+	s.True(item.CommitmentInfo.ComputedTrueUpAmount.Equal(decimal.NewFromInt(90)),
+		"expected true-up $90 (30 empty windows × $3); got %s", item.CommitmentInfo.ComputedTrueUpAmount)
+	s.True(item.TotalCost.Equal(decimal.NewFromInt(90)),
+		"expected total cost $90 from true-up alone; got %s", item.TotalCost)
+}
+
 // TestWindowCommitment_Bucket_SlabPricing_OverageFactorOne verifies a bucket
 // whose price is TIERED/SLAB and whose overage factor is exactly 1.0 (allowed
 // for buckets): usage beyond the commitment bills at the slab rate with no


### PR DESCRIPTION
Follow-up fixes to the per-bucket commitment feature (previous PR merged), all from customer-reported analytics issues. Each fix has a test that reproduces the bug before and passes after.

## What was wrong & fixed

**1. Coarse-window bucket summaries rolled up to zero** (`8ec22330`, meter usage)
When the requested `window_size` is coarser than the meter's buckets (e.g. a MINUTE-bucketed meter queried at `HOUR`), per-bucket commitment was billed correctly into `total_cost`, but `mergeBucketPointsByWindow` collapsed the bucket-grain points into the request window and dropped per-window bucket identity. `buildBucketSummaries` then ran on rolled-up points where `bucketIDForPointWindow` can't fit a coarse window inside a finer bucket, so every summary reported **0** — looking like the commitment wasn't applied.
Fix: carry each window's `BucketID` through the commitment pass, stamp it on the bucket-grain points, snapshot them (`DetailedUsageAnalytic.BucketPoints`) before the roll-up, and build summaries from that snapshot. The time-series `points` array still rolls up to the requested window.

**2. Bucket-level true-up ignored on the feature-usage path** (`28e70e20`)
A line item whose true-up lived only on a commitment time bucket (no top-level `CommitmentTrueUpEnabled`) never charged the committed minimum for empty windows: `calculateBucketedCost` gated the window fill on the top-level flag alone, so the committed minimum was skipped and the response returned `total_cost 0` with an empty `is_windowed` commitment info. Now uses `HasTrueUpEnabled()` (top-level OR any bucket), matching meter usage.

**3. Coarse-window summaries on the feature-usage path** (`d7a227e0`)
Ported fix #1 to feature usage (stamp `BucketID`, snapshot `BucketPoints`, build summaries from the snapshot). Only the pure `bucketGrainDTOPoints` projection is shared — no commitment logic is shared between the two services.

**4. Out-of-bucket empty windows no longer filled with all-zero points** (`456d21f3`, meter usage)
`shouldFillWindow` returned true for **every** window whenever any true-up existed, so a bucket-only true-up emitted a synthetic zero-usage point for every out-of-bucket window — **1440 noise points/day** for a MINUTE meter. Now scoped to windows that can actually be charged (inside a true-up bucket, or outside any bucket only when the line item has a top-level commitment with true-up). **Cost is unchanged** — out-of-bucket empty windows without a line-item commitment already billed $0.

## Tests added

- `TestWindowCommitment_CoarseRequestWindow_BucketSummariesNonZero` — summaries non-zero with coarse window
- `TestWindowCommitment_ZeroUsage_BucketTrueUp` / `TestFeatureUsage_ZeroUsage_BucketTrueUp` — bucket-level true-up fires on zero usage
- `TestFeatureUsage_CoarseRequestWindow_BucketSummariesNonZero` — feature-usage parity (asserts the legacy rolled-up path would report zero)
- `TestWindowCommitment_MultipleBucketsPerPoint_Cost` ($101) / `TestWindowCommitment_MultiplePointsPerBucket_Cost` ($81) — cost correctness across bucket/point topologies
- `TestWindowCommitment_BucketTrueUp_NoOutOfBucketFillPoints` — exactly the in-bucket points, no out-of-bucket noise

Full `internal/service` + `internal/types` suites pass; build clean; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * Updated detailed analytics point bucket identity: points now expose a `buckets` array (bucket/price pairs) to reflect partial overlaps across multiple commitment buckets.
  * Bucket summaries are now built from bucket-grain attribution so they match the underlying commitment-time granularity.
* **Bug Fixes**
  * Improved commitment and true-up attribution for coarser request windows, including correct zero-usage in-bucket true-up behavior.
* **Tests**
  * Added regression tests covering coarse-window bucket summaries and zero-usage bucket true-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->