### PR TITLE
feat: add support for CLF (Unidad de Fomento) currency

### DIFF
--- a/internal/types/currency.go
+++ b/internal/types/currency.go
@@ -28,6 +28,7 @@ var CURRENCY_CONFIG = map[string]CurrencyConfig{
 	"brl": {Symbol: "R$", Precision: 2},
 	"chf": {Symbol: "CHF", Precision: 2},
 	"clp": {Symbol: "CLP$", Precision: 0},
+	"clf": {Symbol: "CLF", Precision: 4},
 	"cny": {Symbol: "CN¥", Precision: 2},
 	"czk": {Symbol: "CZK", Precision: 2},
 	"dkk": {Symbol: "DKK", Precision: 2},

--- a/internal/types/currency_rounding_test.go
+++ b/internal/types/currency_rounding_test.go
@@ -302,6 +302,7 @@ func TestCurrencyRounding_PrecisionConfig(t *testing.T) {
 		expectedPrecisions := map[string]int32{
 			"usd": 2, "eur": 2, "gbp": 2, "aud": 2, "cad": 2,
 			"jpy": 0, "krw": 0, "vnd": 0, "clp": 0,
+			"clf": 4, "kwd": 3,
 			"inr": 2, "idr": 2, "sgd": 2, "thb": 2, "myr": 2,
 			"php": 2, "hkd": 2, "nzd": 2, "brl": 2, "chf": 2,
 			"cny": 2, "czk": 2, "dkk": 2, "huf": 2, "ils": 2,


### PR DESCRIPTION
Fixes #1941 


## 📝 Description
This PR introduces support for the **CLF (Unidad de Fomento)** currency code in the backend configuration and validation. CLF is an inflation-indexed currency unit widely used in Chile for B2B contracts and invoicing. 

*Note: The corresponding frontend changes will be submitted in a separate PR in the `flexprice-front` repository.*

---

## 🔨 Changes Made
- [x] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the CLF currency code, including its configured decimal precision for exchange rates and calculations.  
* **Tests**
  * Updated currency rounding precision expectations to cover the newly added CLF precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->