### PR TITLE
fix(commitment): bucket-level true-up in invoice billing + customer sweep; effective point window

### DIFF
--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -596,13 +596,24 @@ func (r *subscriptionLineItemRepository) GetDistinctCustomerIDsWithCommitmentTru
 	})
 	defer FinishSpan(span)
 
+	// True-up can be enabled either at the line-item level (commitment_true_up_enabled)
+	// or on any individual commitment time bucket (the true_up_enabled flag inside the
+	// commitment_time_buckets jsonb array). Both must surface the customer so their
+	// committed minimum is billed even with no usage in the window.
 	const query = `
 		SELECT DISTINCT customer_id
 		FROM subscription_line_items
 		WHERE tenant_id = $1
 			AND environment_id = $2
 			AND status = $3
-			AND commitment_true_up_enabled = true
+			AND (
+				commitment_true_up_enabled = true
+				OR EXISTS (
+					SELECT 1
+					FROM jsonb_array_elements(COALESCE(commitment_time_buckets, '[]'::jsonb)) AS bucket
+					WHERE (bucket->>'true_up_enabled')::boolean = true
+				)
+			)
 	`
 
 	rows, err := r.client.Reader(ctx).QueryContext(ctx, query, tenantID, envID, string(types.StatusPublished))

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1051,9 +1051,10 @@ func aggregateUsageResultsByWindow(results []events.UsageResult, aggType types.A
 
 // fillBucketedValuesForWindowedCommitment returns one value per expected bucket in the period.
 // When multiple results exist per bucket (e.g. from group_by), they are aggregated into one
-// value per window using aggType (SUM or MAX). When CommitmentTrueUpEnabled is true, fills
-// missing buckets (no usage) with zero so that windowed commitment true-up is applied to
-// every window. Otherwise returns one value per unique window in sorted order.
+// value per window using aggType (SUM or MAX). When true-up is enabled (top-level OR on
+// any commitment time bucket), fills missing buckets (no usage) with zero so that windowed
+// commitment true-up is applied to every window. Otherwise returns one value per unique
+// window in sorted order.
 // fillBucketedValuesForWindowedCommitment returns parallel slices of bucket values
 // and their corresponding window starts. The two slices are 1:1 — bucketStarts[i] is
 // the start timestamp of the window whose usage is bucketedValues[i]. Returns
@@ -1070,7 +1071,10 @@ func (s *billingService) fillBucketedValuesForWindowedCommitment(
 		return nil, nil
 	}
 	usageByWindow := aggregateUsageResultsByWindow(usageResult.Results, aggType)
-	if !item.CommitmentTrueUpEnabled {
+	// HasTrueUpEnabled() covers bucket-level true-up too: a line item whose only
+	// true-up is on a commitment time bucket must still fill empty windows so the
+	// bucket's committed minimum is billed (mirrors the analytics fill gate).
+	if !item.HasTrueUpEnabled() {
 		// Return one value per unique window in sorted order.
 		keys := make([]time.Time, 0, len(usageByWindow))
 		for t := range usageByWindow {

--- a/internal/service/billing_commitment.go
+++ b/internal/service/billing_commitment.go
@@ -467,18 +467,22 @@ func isLastPeriodOfCommitmentPeriod(periodEnd, commitmentEnd time.Time) bool {
 }
 
 // bucketIDsForPointWindow returns the ids and prices of every commitment bucket
-// that OVERLAPS the analytics display window [windowStart, windowStart+window) —
-// any intersection counts, in either direction (the bucket partially inside the
+// that OVERLAPS the display window [windowStart, windowStart+windowMin) — any
+// intersection counts, in either direction (the bucket partially inside the
 // window, or the window partially inside the bucket). The two slices are aligned
 // by index (ids[i] ↔ priceIDs[i]). Used only to annotate the rolled-up display
 // points; it never feeds bucket summaries (those use the exact per-meter-window
 // attribution, where each window sits in exactly one bucket).
 //
+// windowMin must be the point's EFFECTIVE span — max(request window, meter bucket
+// size) — because the roll-up cannot subdivide below the meter bucket, so when the
+// request window is finer than the meter bucket the displayed point still spans a
+// whole meter bucket (see effectivePointWindowMinutes).
+//
 // Overlap is computed on the minute-of-day axis. A window of a full day or more
 // touches every configured bucket. Sub-day windows and midnight-wrapping buckets
 // are each unrolled into up to two linear [lo,hi) segments and tested pairwise.
-func bucketIDsForPointWindow(buckets types.TimeOfDayBuckets, windowStart time.Time, window types.WindowSize) ([]string, []string) {
-	windowMin := window.ToMinutes()
+func bucketIDsForPointWindow(buckets types.TimeOfDayBuckets, windowStart time.Time, windowMin int) ([]string, []string) {
 	if windowMin <= 0 {
 		return nil, nil
 	}

--- a/internal/service/billing_commitment_test.go
+++ b/internal/service/billing_commitment_test.go
@@ -410,3 +410,55 @@ func TestApplyWindowCommitment_TimeBuckets_LengthMismatch(t *testing.T) {
 	_, _, err := calc.applyWindowCommitmentToLineItem(ctx, lineItem, bucketedValues, bucketStarts, p)
 	require.Error(t, err, "mismatched bucketStarts/bucketedValues must be rejected")
 }
+
+// TestFillBucketedValuesForWindowedCommitment_BucketLevelTrueUp verifies the
+// invoice-billing fill gate engages for a line item whose true-up is ONLY on a
+// commitment time bucket (no top-level CommitmentTrueUpEnabled). The fill must
+// expand to one value per expected window (zeros for empty windows) so the
+// bucket's committed minimum is billed — not collapse to just the used windows.
+func TestFillBucketedValuesForWindowedCommitment_BucketLevelTrueUp(t *testing.T) {
+	s := &billingService{}
+	overage2x := decimal.NewFromInt(2)
+	periodStart := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC) // one day → 24 hourly windows
+
+	// Usage only in a single hour.
+	usage := &events.AggregationResult{
+		Type: types.AggregationSum,
+		Results: []events.UsageResult{
+			{WindowSize: time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), Value: decimal.NewFromInt(5)},
+		},
+	}
+
+	bucketOnlyTrueUp := &subscription.SubscriptionLineItem{
+		ID:                      "li_bucket_trueup",
+		CommitmentWindowed:      true,
+		CommitmentTrueUpEnabled: false, // no top-level true-up
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
+			ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12},
+			CommitmentType: types.COMMITMENT_TYPE_AMOUNT, CommitmentValue: decimal.NewFromInt(5),
+			OverageFactor: &overage2x, TrueUpEnabled: true,
+		}},
+	}
+
+	values, starts := s.fillBucketedValuesForWindowedCommitment(
+		bucketOnlyTrueUp, usage, periodStart, periodEnd, types.WindowSizeHour, &periodStart, types.AggregationSum)
+
+	// Filled to the full 24-window grid so empty bucket windows can be trued up.
+	require.Len(t, values, 24, "bucket-level true-up must fill every window")
+	require.Len(t, starts, 24)
+
+	// Contrast: no true-up anywhere → only the used window is returned.
+	noTrueUp := &subscription.SubscriptionLineItem{
+		ID:                 "li_no_trueup",
+		CommitmentWindowed: true,
+		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
+			ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12},
+			CommitmentType: types.COMMITMENT_TYPE_AMOUNT, CommitmentValue: decimal.NewFromInt(5),
+			OverageFactor: &overage2x, TrueUpEnabled: false,
+		}},
+	}
+	values2, _ := s.fillBucketedValuesForWindowedCommitment(
+		noTrueUp, usage, periodStart, periodEnd, types.WindowSizeHour, &periodStart, types.AggregationSum)
+	require.Len(t, values2, 1, "no true-up → only windows with usage, no fill")
+}

--- a/internal/service/feature_usage_tracking.go
+++ b/internal/service/feature_usage_tracking.go
@@ -3207,8 +3207,9 @@ func (s *featureUsageTrackingService) ToGetUsageAnalyticsResponseDTO(ctx context
 				// Per-point bucket identity: every bucket the rolled-up window
 				// overlaps (informational hint only — see dto.UsageAnalyticPoint).
 				if lineItemForBucket != nil {
+					windowMin := effectivePointWindowMinutes(req.WindowSize, data.Meters[analytic.MeterID])
 					ids, priceIDs := bucketIDsForPointWindow(
-						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, req.WindowSize)
+						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, windowMin)
 					for i := range ids {
 						dtoPoint.Buckets = append(dtoPoint.Buckets, dto.PointBucket{BucketID: ids[i], PriceID: priceIDs[i]})
 					}

--- a/internal/service/meter_usage.go
+++ b/internal/service/meter_usage.go
@@ -1447,8 +1447,9 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 				// Per-point bucket identity: every bucket the rolled-up window
 				// overlaps (informational hint only — see dto.UsageAnalyticPoint).
 				if lineItemForBucket != nil {
+					windowMin := effectivePointWindowMinutes(params.WindowSize, meterMap[analytic.MeterID])
 					ids, priceIDs := bucketIDsForPointWindow(
-						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, params.WindowSize)
+						lineItemForBucket.CommitmentTimeBuckets, point.Timestamp, windowMin)
 					for i := range ids {
 						dtoPoint.Buckets = append(dtoPoint.Buckets, dto.PointBucket{BucketID: ids[i], PriceID: priceIDs[i]})
 					}
@@ -1928,6 +1929,21 @@ func (s *meterUsageService) processPointsWithBuckets(
 	p.item.Points = s.mergeBucketPointsByWindow(p.item.Points, p.aggType, p.data.Params.WindowSize, p.data.Params.BillingAnchor)
 
 	return cost
+}
+
+// effectivePointWindowMinutes returns the span (in minutes) a displayed point
+// actually covers: the request window, or the meter's bucket size when that is
+// coarser. mergeBucketPointsByWindow cannot subdivide below the meter bucket, so a
+// request window finer than the bucket leaves points at meter-bucket grain — the
+// overlap check must use that coarser span, not the (smaller) request window.
+func effectivePointWindowMinutes(requestWindow types.WindowSize, m *meter.Meter) int {
+	minutes := requestWindow.ToMinutes()
+	if m != nil && m.HasBucketSize() {
+		if bm := m.Aggregation.BucketSize.ToMinutes(); bm > minutes {
+			minutes = bm
+		}
+	}
+	return minutes
 }
 
 // captureBucketPoints snapshots the bucket-grain points (with their per-window

--- a/internal/service/sync/export/usage_analytics_export_test.go
+++ b/internal/service/sync/export/usage_analytics_export_test.go
@@ -477,3 +477,52 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 		})
 	}
 }
+
+// TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel verifies the customer
+// sweep that drives the export (so zero-event true-up customers are still billed)
+// includes a customer whose true-up is ONLY on a commitment time bucket, not just
+// the top-level commitment_true_up_enabled flag.
+func TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel(t *testing.T) {
+	ctx := context.Background()
+	ctx = types.SetTenantID(ctx, "tenant-x")
+	ctx = types.SetEnvironmentID(ctx, "env-x")
+	store := testutil.NewInMemorySubscriptionLineItemStore()
+
+	mk := func(id, customerID string, topTrueUp bool, buckets types.TimeOfDayBuckets) {
+		err := store.Create(ctx, &subscription.SubscriptionLineItem{
+			ID: id, CustomerID: customerID, SubscriptionID: "sub-" + id, PriceID: "p1",
+			EnvironmentID: "env-x", BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+			CommitmentTrueUpEnabled: topTrueUp, CommitmentTimeBuckets: buckets,
+			BaseModel: types.BaseModel{TenantID: "tenant-x", Status: types.StatusPublished},
+		})
+		if err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+
+	mk("li-top", "cust-top", true, nil)                           // top-level true-up
+	mk("li-bucket", "cust-bucket", false, types.TimeOfDayBuckets{ // bucket-only true-up
+		{ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12}, TrueUpEnabled: true},
+	})
+	mk("li-none", "cust-none", false, types.TimeOfDayBuckets{ // no true-up anywhere
+		{ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12}, TrueUpEnabled: false},
+	})
+
+	ids, err := store.GetDistinctCustomerIDsWithCommitmentTrueUp(ctx)
+	if err != nil {
+		t.Fatalf("GetDistinctCustomerIDsWithCommitmentTrueUp: %v", err)
+	}
+	set := map[string]bool{}
+	for _, id := range ids {
+		set[id] = true
+	}
+	if !set["cust-top"] {
+		t.Errorf("expected top-level true-up customer to be included")
+	}
+	if !set["cust-bucket"] {
+		t.Errorf("expected bucket-level-only true-up customer to be included")
+	}
+	if set["cust-none"] {
+		t.Errorf("customer with no true-up must NOT be included")
+	}
+}

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -302,7 +302,8 @@ func (s *InMemorySubscriptionLineItemStore) GetDistinctCustomerIDsWithCommitment
 	seen := make(map[string]struct{})
 	var customerIDs []string
 	for _, item := range items {
-		if !item.CommitmentTrueUpEnabled {
+		// HasTrueUpEnabled() covers bucket-level true-up too (mirrors the ent SQL).
+		if !item.HasTrueUpEnabled() {
 			continue
 		}
 		if _, ok := seen[item.CustomerID]; ok {


### PR DESCRIPTION
Follow-up to the per-bucket commitment fixes (previous PR merged). A critical review of where the analytics true-up gate fix (`CommitmentTrueUpEnabled` → `HasTrueUpEnabled()`, which also counts bucket-level true-up) was still missing, plus one correctness fix to the per-point bucket hint.

## 1. Invoice billing — bucket-level true-up not billed (money bug)

`fillBucketedValuesForWindowedCommitment` (billing.go) gated the empty-window fill on the **top-level** `CommitmentTrueUpEnabled` only. A line item whose true-up lives **only on a commitment time bucket** never had its empty bucket windows filled, so the bucket's committed minimum was **not charged on the invoice** — even though analytics now showed it. This fill feeds the per-bucket commitment calculator in all three billing call sites (`billing.go:788`, `billing.go:1616`, `billing_meter_usage.go:505`). The entry gates already use `HasAnyCommitment()` + `CommitmentWindowed`, so bucket-only line items reach this path — only the fill gate was wrong. Now uses `HasTrueUpEnabled()`.

## 2. Export / billing customer sweep — zero-event true-up customers dropped

`GetDistinctCustomerIDsWithCommitmentTrueUp` (ent SQL + in-memory mock) selected only `commitment_true_up_enabled = true`, so a customer whose true-up is in the `commitment_time_buckets` jsonb — and who had **no events** in the window — was skipped entirely (this sweep exists precisely so true-up customers are billed with zero usage). Added a jsonb `EXISTS` check for any bucket with `true_up_enabled = true`; the mock mirrors it via `HasTrueUpEnabled()`.

## 3. Point `buckets[]` effective window

The rolled-up display point cannot be subdivided below the meter bucket size, so when the request window is **finer** than the meter bucket the point still spans a whole meter bucket. `bucketIDsForPointWindow` now computes overlap against the **effective span = max(request window, meter bucket size)** (`effectivePointWindowMinutes`), so the `buckets[]` hint is correct in that case. Verified points are always merged to that grain before bucket assignment (cost calc runs before the response builder in both services).

### Left as-is (verified correct)
Aggregate / out-of-bucket charge paths and `shouldFillWindow`'s out-of-bucket branch use the top-level flag deliberately — out-of-bucket windows bill under the line item's own commitment, never a bucket's. `CommitmentInfo.TrueUpEnabled` still reports the line-item-level flag; per-bucket true-up is reflected in `bucket_summaries` and the (correct) `Computed*` amounts.

## Tests
- `TestFillBucketedValuesForWindowedCommitment_BucketLevelTrueUp` — billing fill expands to the full grid for bucket-only true-up, stays collapsed without true-up
- `TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel` — sweep includes top-level and bucket-only true-up customers, excludes none

Full `internal/service` + `internal/types` + export suites pass; build + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* True-up logic now correctly recognizes commitment true-up when enabled at the bucket level in addition to the subscription level.
* Fixed usage window calculations in commitment billing to properly include empty periods when bucket-level true-up applies.
* Improved accuracy of bucket attribution in usage analytics by accounting for meter bucket sizing when determining point-to-bucket relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->