### PR TITLE
refactor(commitment): scope billing window-fill to true-up-able windows; table-driven tests

### DIFF
--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -1091,15 +1091,24 @@ func (s *billingService) fillBucketedValuesForWindowedCommitment(
 	if len(expectedStarts) == 0 {
 		return nil, nil
 	}
+	// Always bill every window that has real usage. For EMPTY windows, only fill the
+	// ones that can actually true-up: inside a true-up bucket, or out-of-bucket only
+	// when the line item's own commitment has true-up (shouldFillWindow). Empty
+	// windows that cannot charge bill $0 regardless, so filling them would just
+	// inflate the calculation — and for partial bucket configs would synthesize
+	// out-of-bucket windows that shouldn't be billed at all.
 	bucketedValues := make([]decimal.Decimal, 0, len(expectedStarts))
+	bucketStarts := make([]time.Time, 0, len(expectedStarts))
 	for _, t := range expectedStarts {
 		if v, ok := usageByWindow[t]; ok {
 			bucketedValues = append(bucketedValues, v)
-		} else {
+			bucketStarts = append(bucketStarts, t)
+		} else if shouldFillWindow(item, t) {
 			bucketedValues = append(bucketedValues, decimal.Zero)
+			bucketStarts = append(bucketStarts, t)
 		}
 	}
-	return bucketedValues, expectedStarts
+	return bucketedValues, bucketStarts
 }
 
 func (s *billingService) CalculateFeatureUsageCharges(

--- a/internal/service/billing_commitment_test.go
+++ b/internal/service/billing_commitment_test.go
@@ -343,8 +343,9 @@ func TestApplyWindowCommitment_PerBucket_PriceOverrideFromWindowSize(t *testing.
 	lineItem := &subscription.SubscriptionLineItem{
 		ID:                 "li_override_ws",
 		CommitmentWindowed: true,
-		// True-up at the line-item level only makes the fill path generate the
-		// full hourly grid; with no line-item commitment nothing is trued up.
+		// Top-level true-up flag with NO top-level commitment: nothing can be trued
+		// up, so the fill emits only the windows with real usage (the bucket here
+		// has no true-up either). The override still applies per usage window.
 		CommitmentTrueUpEnabled: true,
 		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
 			ID: "bkt_morning", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12},
@@ -366,11 +367,12 @@ func TestApplyWindowCommitment_PerBucket_PriceOverrideFromWindowSize(t *testing.
 		},
 	}
 
-	// Drive the grid from the window size input (HOUR).
+	// Drive the grid from the window size input (HOUR). Only the three windows with
+	// real usage are emitted — no empty window here can true-up.
 	bs := &billingService{}
 	windowValues, windowStarts := bs.fillBucketedValuesForWindowedCommitment(
 		lineItem, usageResult, periodStart, periodEnd, types.WindowSizeHour, nil, types.AggregationSum)
-	require.Len(t, windowStarts, 24, "HOUR window size over a day must yield 24 windows")
+	require.Len(t, windowStarts, 3, "only the windows with real usage are emitted")
 
 	total, info, err := calc.applyWindowCommitmentToLineItem(ctx, lineItem, windowValues, windowStarts, lineItemPrice)
 	require.NoError(t, err)
@@ -411,54 +413,82 @@ func TestApplyWindowCommitment_TimeBuckets_LengthMismatch(t *testing.T) {
 	require.Error(t, err, "mismatched bucketStarts/bucketedValues must be rejected")
 }
 
-// TestFillBucketedValuesForWindowedCommitment_BucketLevelTrueUp verifies the
-// invoice-billing fill gate engages for a line item whose true-up is ONLY on a
-// commitment time bucket (no top-level CommitmentTrueUpEnabled). The fill must
-// expand to one value per expected window (zeros for empty windows) so the
-// bucket's committed minimum is billed — not collapse to just the used windows.
-func TestFillBucketedValuesForWindowedCommitment_BucketLevelTrueUp(t *testing.T) {
-	s := &billingService{}
+// TestFillBucketedValuesForWindowedCommitment verifies which windows the
+// invoice-billing fill emits: every window with real usage, plus EMPTY windows
+// only where commitment can actually true-up (inside a true-up bucket, or
+// out-of-bucket only when the line item's own commitment has true-up). Empty
+// windows that cannot charge are not synthesized.
+//
+// All cases use a 24-hour period (24 hourly windows), bucket [09:00,12:00), and a
+// single usage event at 10:00 (in-bucket).
+func TestFillBucketedValuesForWindowedCommitment(t *testing.T) {
 	overage2x := decimal.NewFromInt(2)
 	periodStart := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
-	periodEnd := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC) // one day → 24 hourly windows
+	periodEnd := time.Date(2026, 1, 6, 0, 0, 0, 0, time.UTC)
+	hourTrueUpCommit := decimal.NewFromInt(10)
 
-	// Usage only in a single hour.
 	usage := &events.AggregationResult{
 		Type: types.AggregationSum,
 		Results: []events.UsageResult{
 			{WindowSize: time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), Value: decimal.NewFromInt(5)},
 		},
 	}
-
-	bucketOnlyTrueUp := &subscription.SubscriptionLineItem{
-		ID:                      "li_bucket_trueup",
-		CommitmentWindowed:      true,
-		CommitmentTrueUpEnabled: false, // no top-level true-up
-		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
+	bucket := func(trueUp bool) types.TimeOfDayBuckets {
+		return types.TimeOfDayBuckets{{
 			ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12},
 			CommitmentType: types.COMMITMENT_TYPE_AMOUNT, CommitmentValue: decimal.NewFromInt(5),
-			OverageFactor: &overage2x, TrueUpEnabled: true,
-		}},
+			OverageFactor: &overage2x, TrueUpEnabled: trueUp,
+		}}
 	}
 
-	values, starts := s.fillBucketedValuesForWindowedCommitment(
-		bucketOnlyTrueUp, usage, periodStart, periodEnd, types.WindowSizeHour, &periodStart, types.AggregationSum)
-
-	// Filled to the full 24-window grid so empty bucket windows can be trued up.
-	require.Len(t, values, 24, "bucket-level true-up must fill every window")
-	require.Len(t, starts, 24)
-
-	// Contrast: no true-up anywhere → only the used window is returned.
-	noTrueUp := &subscription.SubscriptionLineItem{
-		ID:                 "li_no_trueup",
-		CommitmentWindowed: true,
-		CommitmentTimeBuckets: types.TimeOfDayBuckets{{
-			ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12},
-			CommitmentType: types.COMMITMENT_TYPE_AMOUNT, CommitmentValue: decimal.NewFromInt(5),
-			OverageFactor: &overage2x, TrueUpEnabled: false,
-		}},
+	tests := []struct {
+		name      string
+		item      *subscription.SubscriptionLineItem
+		wantHours []int // expected window start hours, in order
+	}{
+		{
+			// Only in-bucket windows are filled: 09 (empty), 10 (usage), 11 (empty).
+			// Out-of-bucket empties bill $0 and must NOT be synthesized.
+			name: "bucket-only true-up fills only in-bucket windows",
+			item: &subscription.SubscriptionLineItem{
+				ID: "li_bucket_trueup", CommitmentWindowed: true, CommitmentTrueUpEnabled: false,
+				CommitmentTimeBuckets: bucket(true),
+			},
+			wantHours: []int{9, 10, 11},
+		},
+		{
+			// Top-level commitment + true-up commits 24/7 → every empty window fills.
+			name: "top-level true-up fills every window",
+			item: &subscription.SubscriptionLineItem{
+				ID: "li_top_trueup", CommitmentWindowed: true,
+				CommitmentType: types.COMMITMENT_TYPE_AMOUNT, CommitmentAmount: &hourTrueUpCommit,
+				CommitmentOverageFactor: &overage2x, CommitmentTrueUpEnabled: true,
+			},
+			wantHours: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23},
+		},
+		{
+			// No true-up anywhere → early return, only the used window.
+			name: "no true-up returns only used windows",
+			item: &subscription.SubscriptionLineItem{
+				ID: "li_no_trueup", CommitmentWindowed: true, CommitmentTimeBuckets: bucket(false),
+			},
+			wantHours: []int{10},
+		},
 	}
-	values2, _ := s.fillBucketedValuesForWindowedCommitment(
-		noTrueUp, usage, periodStart, periodEnd, types.WindowSizeHour, &periodStart, types.AggregationSum)
-	require.Len(t, values2, 1, "no true-up → only windows with usage, no fill")
+
+	s := &billingService{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			values, starts := s.fillBucketedValuesForWindowedCommitment(
+				tc.item, usage, periodStart, periodEnd, types.WindowSizeHour, &periodStart, types.AggregationSum)
+
+			require.Len(t, values, len(tc.wantHours))
+			require.Len(t, starts, len(tc.wantHours))
+			gotHours := make([]int, len(starts))
+			for i, st := range starts {
+				gotHours[i] = st.Hour()
+			}
+			require.Equal(t, tc.wantHours, gotHours, "filled window hours")
+		})
+	}
 }

--- a/internal/service/sync/export/usage_analytics_export_test.go
+++ b/internal/service/sync/export/usage_analytics_export_test.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -480,49 +481,64 @@ func TestUsageAnalyticsExporter_PrepareData(t *testing.T) {
 
 // TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel verifies the customer
 // sweep that drives the export (so zero-event true-up customers are still billed)
-// includes a customer whose true-up is ONLY on a commitment time bucket, not just
-// the top-level commitment_true_up_enabled flag.
+// keys off true-up enabled at EITHER the line-item level or on any commitment time
+// bucket — not just the top-level commitment_true_up_enabled flag.
 func TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel(t *testing.T) {
-	ctx := context.Background()
-	ctx = types.SetTenantID(ctx, "tenant-x")
-	ctx = types.SetEnvironmentID(ctx, "env-x")
-	store := testutil.NewInMemorySubscriptionLineItemStore()
+	tests := []struct {
+		name        string
+		topTrueUp   bool
+		buckets     types.TimeOfDayBuckets
+		wantInclude bool
+	}{
+		{
+			name:        "top-level true-up is included",
+			topTrueUp:   true,
+			wantInclude: true,
+		},
+		{
+			name:      "bucket-level-only true-up is included",
+			topTrueUp: false,
+			buckets: types.TimeOfDayBuckets{
+				{ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12}, TrueUpEnabled: true},
+			},
+			wantInclude: true,
+		},
+		{
+			name:      "no true-up anywhere is excluded",
+			topTrueUp: false,
+			buckets: types.TimeOfDayBuckets{
+				{ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12}, TrueUpEnabled: false},
+			},
+			wantInclude: false,
+		},
+	}
 
-	mk := func(id, customerID string, topTrueUp bool, buckets types.TimeOfDayBuckets) {
-		err := store.Create(ctx, &subscription.SubscriptionLineItem{
-			ID: id, CustomerID: customerID, SubscriptionID: "sub-" + id, PriceID: "p1",
-			EnvironmentID: "env-x", BillingPeriod: types.BILLING_PERIOD_MONTHLY,
-			CommitmentTrueUpEnabled: topTrueUp, CommitmentTimeBuckets: buckets,
-			BaseModel: types.BaseModel{TenantID: "tenant-x", Status: types.StatusPublished},
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx = types.SetTenantID(ctx, "tenant-x")
+			ctx = types.SetEnvironmentID(ctx, "env-x")
+			store := testutil.NewInMemorySubscriptionLineItemStore()
+
+			err := store.Create(ctx, &subscription.SubscriptionLineItem{
+				ID: "li-1", CustomerID: "cust-1", SubscriptionID: "sub-1", PriceID: "p1",
+				EnvironmentID: "env-x", BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+				CommitmentTrueUpEnabled: tc.topTrueUp, CommitmentTimeBuckets: tc.buckets,
+				BaseModel: types.BaseModel{TenantID: "tenant-x", Status: types.StatusPublished},
+			})
+			if err != nil {
+				t.Fatalf("create line item: %v", err)
+			}
+
+			ids, err := store.GetDistinctCustomerIDsWithCommitmentTrueUp(ctx)
+			if err != nil {
+				t.Fatalf("GetDistinctCustomerIDsWithCommitmentTrueUp: %v", err)
+			}
+
+			included := slices.Contains(ids, "cust-1")
+			if included != tc.wantInclude {
+				t.Errorf("customer included = %v, want %v (ids=%v)", included, tc.wantInclude, ids)
+			}
 		})
-		if err != nil {
-			t.Fatalf("create %s: %v", id, err)
-		}
-	}
-
-	mk("li-top", "cust-top", true, nil)                           // top-level true-up
-	mk("li-bucket", "cust-bucket", false, types.TimeOfDayBuckets{ // bucket-only true-up
-		{ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12}, TrueUpEnabled: true},
-	})
-	mk("li-none", "cust-none", false, types.TimeOfDayBuckets{ // no true-up anywhere
-		{ID: "b1", Start: types.Bucket{Hour: 9}, End: types.Bucket{Hour: 12}, TrueUpEnabled: false},
-	})
-
-	ids, err := store.GetDistinctCustomerIDsWithCommitmentTrueUp(ctx)
-	if err != nil {
-		t.Fatalf("GetDistinctCustomerIDsWithCommitmentTrueUp: %v", err)
-	}
-	set := map[string]bool{}
-	for _, id := range ids {
-		set[id] = true
-	}
-	if !set["cust-top"] {
-		t.Errorf("expected top-level true-up customer to be included")
-	}
-	if !set["cust-bucket"] {
-		t.Errorf("expected bucket-level-only true-up customer to be included")
-	}
-	if set["cust-none"] {
-		t.Errorf("customer with no true-up must NOT be included")
 	}
 }


### PR DESCRIPTION
Review follow-ups to the per-bucket commitment work (previous PR merged).

## 1. Scope the invoice-billing window-fill (functional)

`fillBucketedValuesForWindowedCommitment` filled **every** window in the period with synthetic zeros whenever any true-up existed. For partial bucket configs this synthesized out-of-bucket windows that bill `$0` — wasteful and conceptually wrong. It now uses the same `shouldFillWindow` gate as `meter_usage`:

- always keep windows with **real usage**;
- fill an **empty** window only when it can actually true-up — inside a true-up bucket, or out-of-bucket only when the line item's own commitment has true-up.

The billed **total is unchanged** (skipped windows would each have charged `$0`), but the grid is no longer inflated — e.g. a bucket-only true-up over a MINUTE meter for a month now fills only its bucket windows instead of ~43k. The returned `starts` slice is filtered in lockstep with the values.

## 2. Table-driven tests

- `TestFillBucketedValuesForWindowedCommitment` — `t.Run` per case: bucket-only true-up (fills only the 3 in-bucket windows), top-level true-up (fills all 24), no true-up (only the 1 used window); each asserts the exact filled window hours.
- `TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel` — `t.Run` per case (top-level / bucket-only / none), each with its own expected inclusion and an isolated store.

### Regression caught & fixed
`TestApplyWindowCommitment_PerBucket_PriceOverrideFromWindowSize` used a degenerate config (top-level true-up flag with **no** top-level commitment) purely to force the old 24-window grid. Nothing there can true-up, so it now emits the 3 real-usage windows; the override total/overage/utilized assertions ($530 / $400 / $130) are unchanged.

Full `internal/service` + `internal/types` + export suites pass; build + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty usage periods in windowed commitment true-ups. Empty windows are now only included when applicable, resulting in more accurate billing calculations and reducing unnecessary zero-filled entries in commitment adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->