### PR TITLE
feat(sub): update integration test suite

### DIFF
--- a/integration-testing-suite/go/runner.go
+++ b/integration-testing-suite/go/runner.go
@@ -55,6 +55,7 @@ type SanityRunner struct {
 	entitlementID  string
 	taxRateID      string
 	taxRateCode    string
+	taxAssociationIDs []string
 	couponID       string
 	customerID     string
 	externalCustID string

--- a/integration-testing-suite/go/steps_cleanup.go
+++ b/integration-testing-suite/go/steps_cleanup.go
@@ -161,8 +161,42 @@ func (r *SanityRunner) runCleanupSteps(ctx context.Context) {
 		})
 	}
 
-	// ── 10. Delete tax rate ──────────────────────────────────────────────
+	// ── 10. Delete tax associations, then tax rate ───────────────────────
+	// Tax rates cannot be deleted while associations still reference them.
 	if r.taxRateID != "" {
+		r.run("Cleanup: List Tax Associations", "TaxAssociations.ListTaxAssociations", false, func() error {
+			taxRateID := r.taxRateID
+			listResp, err := r.client.TaxAssociations.ListTaxAssociations(ctx, nil, nil, nil, &taxRateID)
+			if err != nil {
+				return fmt.Errorf("list tax associations: %w", err)
+			}
+			r.taxAssociationIDs = nil
+			if listResp == nil || listResp.ListTaxAssociationsResponse == nil {
+				r.lastResult().Details = "no associations found"
+				return nil
+			}
+
+			for _, assoc := range listResp.ListTaxAssociationsResponse.Items {
+				if assoc.ID != nil && *assoc.ID != "" {
+					r.taxAssociationIDs = append(r.taxAssociationIDs, *assoc.ID)
+				}
+			}
+			r.lastResult().Details = fmt.Sprintf("found %d association(s)", len(r.taxAssociationIDs))
+			return nil
+		})
+
+		for _, assocID := range r.taxAssociationIDs {
+			associationID := assocID
+			r.run("Cleanup: Delete Tax Association", "TaxAssociations.DeleteTaxAssociation", false, func() error {
+				_, err := r.client.TaxAssociations.DeleteTaxAssociation(ctx, associationID)
+				if err != nil {
+					return fmt.Errorf("delete tax association %s: %w", associationID, err)
+				}
+				r.lastResult().Details = fmt.Sprintf("association_id=%s, deleted", associationID)
+				return nil
+			})
+		}
+
 		r.run("Cleanup: Delete Tax Rate", "TaxRates.DeleteTaxRate", false, func() error {
 			_, err := r.client.TaxRates.DeleteTaxRate(ctx, r.taxRateID)
 			if err != nil {

--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -205,9 +205,7 @@ type SubModifyCouponParams struct {
 	CouponCode *string `json:"coupon_code,omitempty"`
 	// Required when action="remove". ID of the CouponAssociation to soft-delete.
 	AssociationID *string `json:"association_id,omitempty"`
-	// Optional. When to apply the change; defaults to now if omitted.
-	EffectiveDate *time.Time `json:"effective_date,omitempty"`
-	// Optional. When the coupon association starts; defaults to EffectiveDate.
+	// Optional. When the coupon association starts; defaults to now.
 	StartDate *time.Time `json:"start_date,omitempty"`
 	// Optional. When the coupon association ends.
 	EndDate *time.Time `json:"end_date,omitempty"`

--- a/internal/service/subscription_modification_coupon.go
+++ b/internal/service/subscription_modification_coupon.go
@@ -16,9 +16,6 @@ func (s *subscriptionModificationService) executeCouponModification(
 	params *dto.SubModifyCouponParams,
 ) (*dto.SubscriptionModifyResponse, error) {
 	effectiveDate := time.Now().UTC()
-	if params.EffectiveDate != nil {
-		effectiveDate = params.EffectiveDate.UTC()
-	}
 	switch params.Action {
 	case dto.SubModifyCouponActionAdd:
 		return s.executeAddCoupon(ctx, subscriptionID, params, effectiveDate)
@@ -104,11 +101,11 @@ func (s *subscriptionModificationService) executeAddCoupon(
 	}
 	if len(existing) > 0 {
 		return nil, ierr.NewError("coupon already active on this subscription for the given date range").
-			WithHint("Remove the existing coupon association before adding it again, or use a different effective_date").
+			WithHint("Remove the existing coupon association before adding it again, or use a different start_date").
 			WithReportableDetails(map[string]interface{}{
 				"coupon_id":       couponID,
 				"subscription_id": subscriptionID,
-				"effective_date":  effectiveDate,
+				"checked_at":      effectiveDate,
 			}).
 			Mark(ierr.ErrValidation)
 	}
@@ -178,12 +175,12 @@ func (s *subscriptionModificationService) executeRemoveCoupon(
 	}
 
 	if effectiveDate.Before(assoc.StartDate) {
-		return nil, ierr.NewError("effective_date cannot be before association start_date").
-			WithHint("Use an effective_date on or after the association start date").
+		return nil, ierr.NewError("cannot remove coupon association before it has started").
+			WithHint("The coupon association has not started yet; wait until after its start_date").
 			WithReportableDetails(map[string]interface{}{
 				"association_id": associationID,
 				"start_date":     assoc.StartDate,
-				"effective_date": effectiveDate,
+				"now":            effectiveDate,
 			}).
 			Mark(ierr.ErrValidation)
 	}
@@ -209,9 +206,6 @@ func (s *subscriptionModificationService) previewCouponModification(
 	params *dto.SubModifyCouponParams,
 ) (*dto.SubscriptionModifyResponse, error) {
 	effectiveDate := time.Now().UTC()
-	if params.EffectiveDate != nil {
-		effectiveDate = params.EffectiveDate.UTC()
-	}
 	switch params.Action {
 	case dto.SubModifyCouponActionAdd:
 		return s.previewAddCoupon(ctx, subscriptionID, params, effectiveDate)
@@ -333,12 +327,12 @@ func (s *subscriptionModificationService) previewRemoveCoupon(
 	}
 
 	if effectiveDate.Before(assoc.StartDate) {
-		return nil, ierr.NewError("effective_date cannot be before association start_date").
-			WithHint("Use an effective_date on or after the association start date").
+		return nil, ierr.NewError("cannot remove coupon association before it has started").
+			WithHint("The coupon association has not started yet; wait until after its start_date").
 			WithReportableDetails(map[string]interface{}{
 				"association_id": associationID,
 				"start_date":     assoc.StartDate,
-				"effective_date": effectiveDate,
+				"now":            effectiveDate,
 			}).
 			Mark(ierr.ErrValidation)
 	}

--- a/internal/service/subscription_modification_coupon_test.go
+++ b/internal/service/subscription_modification_coupon_test.go
@@ -67,7 +67,7 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 
 	cases := []tc{
 		{
-			name: "add coupon with effective_date in past",
+			name: "add coupon with start_date in past",
 			run: func() {
 				ctx := s.GetContext()
 				cust := s.createCustomer("coup-add-past")
@@ -78,9 +78,9 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionAdd,
-						CouponCode:    c.CouponCode,
-						EffectiveDate: &past,
+						Action:     dto.SubModifyCouponActionAdd,
+						CouponCode: c.CouponCode,
+						StartDate:  &past,
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -101,7 +101,7 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 			},
 		},
 		{
-			name: "add coupon with effective_date in future",
+			name: "add coupon with start_date in future",
 			run: func() {
 				ctx := s.GetContext()
 				cust := s.createCustomer("coup-add-future")
@@ -112,9 +112,9 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionAdd,
-						CouponCode:    c.CouponCode,
-						EffectiveDate: &future,
+						Action:     dto.SubModifyCouponActionAdd,
+						CouponCode: c.CouponCode,
+						StartDate:  &future,
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -135,7 +135,7 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 			},
 		},
 		{
-			name: "add coupon with nil effective_date",
+			name: "add coupon with no start_date defaults to now",
 			run: func() {
 				ctx := s.GetContext()
 				cust := s.createCustomer("coup-add-nil-date")
@@ -148,7 +148,6 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 					CouponParams: &dto.SubModifyCouponParams{
 						Action:     dto.SubModifyCouponActionAdd,
 						CouponCode: c.CouponCode,
-						// EffectiveDate is nil → should default to now
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -164,7 +163,7 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				assocs, err := s.GetStores().CouponAssociationRepo.List(ctx, filter)
 				s.Require().NoError(err)
 				s.Require().Len(assocs, 1)
-				s.True(!assocs[0].StartDate.Before(before), "StartDate should be >= now when EffectiveDate is nil")
+				s.True(!assocs[0].StartDate.Before(before), "StartDate should be >= now when no start_date is provided")
 			},
 		},
 		{
@@ -183,9 +182,8 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionAdd,
-						CouponCode:    c.CouponCode,
-						EffectiveDate: &now,
+						Action:     dto.SubModifyCouponActionAdd,
+						CouponCode: c.CouponCode,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub.ID, req)
@@ -211,74 +209,10 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 			},
 		},
 		{
-			name: "remove coupon with effective_date in past",
+			name: "remove coupon — sets end_date to now",
 			run: func() {
 				ctx := s.GetContext()
-				cust := s.createCustomer("coup-rm-past")
-				sub := s.createActiveSub(cust.ID)
-				c := s.createCoupon()
-
-				now := s.GetNow()
-				past := now.Add(-48 * time.Hour)
-				// Association starting 72h ago, currently open
-				assoc := s.createCouponAssociation(c.ID, sub.ID, now.Add(-72*time.Hour), nil)
-
-				// Remove with past effective date
-				req := dto.ExecuteSubscriptionModifyRequest{
-					Type: dto.SubscriptionModifyTypeCoupon,
-					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionRemove,
-						AssociationID: &assoc.ID,
-						EffectiveDate: &past,
-					},
-				}
-				resp, err := s.service.Execute(ctx, sub.ID, req)
-				s.Require().NoError(err)
-				s.Require().NotNil(resp)
-
-				// Verify EndDate was set to past
-				updated, err := s.GetStores().CouponAssociationRepo.Get(ctx, assoc.ID)
-				s.Require().NoError(err)
-				s.Require().NotNil(updated.EndDate)
-				s.True(updated.EndDate.Equal(past.UTC()))
-			},
-		},
-		{
-			name: "remove coupon with effective_date in future",
-			run: func() {
-				ctx := s.GetContext()
-				cust := s.createCustomer("coup-rm-future")
-				sub := s.createActiveSub(cust.ID)
-				c := s.createCoupon()
-
-				now := s.GetNow()
-				future := now.Add(48 * time.Hour)
-				assoc := s.createCouponAssociation(c.ID, sub.ID, now, nil)
-
-				req := dto.ExecuteSubscriptionModifyRequest{
-					Type: dto.SubscriptionModifyTypeCoupon,
-					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionRemove,
-						AssociationID: &assoc.ID,
-						EffectiveDate: &future,
-					},
-				}
-				resp, err := s.service.Execute(ctx, sub.ID, req)
-				s.Require().NoError(err)
-				s.Require().NotNil(resp)
-
-				// Verify EndDate was set to future
-				updated, err := s.GetStores().CouponAssociationRepo.Get(ctx, assoc.ID)
-				s.Require().NoError(err)
-				s.Require().NotNil(updated.EndDate)
-				s.True(updated.EndDate.Equal(future.UTC()))
-			},
-		},
-		{
-			name: "remove coupon with nil effective_date",
-			run: func() {
-				ctx := s.GetContext()
-				cust := s.createCustomer("coup-rm-nil-date")
+				cust := s.createCustomer("coup-rm-now")
 				sub := s.createActiveSub(cust.ID)
 				c := s.createCoupon()
 
@@ -291,7 +225,6 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 					CouponParams: &dto.SubModifyCouponParams{
 						Action:        dto.SubModifyCouponActionRemove,
 						AssociationID: &assoc.ID,
-						// EffectiveDate nil → defaults to now
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -301,7 +234,7 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				updated, err := s.GetStores().CouponAssociationRepo.Get(ctx, assoc.ID)
 				s.Require().NoError(err)
 				s.Require().NotNil(updated.EndDate)
-				s.True(!updated.EndDate.Before(before), "EndDate should be >= now when EffectiveDate is nil")
+				s.True(!updated.EndDate.Before(before), "EndDate should be set to approximately now")
 			},
 		},
 		{
@@ -362,13 +295,11 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				pastEnd := now.Add(-24 * time.Hour)
 				assoc := s.createCouponAssociation(c.ID, sub.ID, pastStart, &pastEnd)
 
-				effectiveDate := now
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
 						Action:        dto.SubModifyCouponActionRemove,
 						AssociationID: &assoc.ID,
-						EffectiveDate: &effectiveDate,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub.ID, req)
@@ -383,13 +314,11 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				sub := s.createActiveSub(cust.ID)
 				c := s.createCoupon()
 
-				future := s.GetNow().Add(24 * time.Hour)
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionAdd,
-						CouponCode:    c.CouponCode,
-						EffectiveDate: &future,
+						Action:     dto.SubModifyCouponActionAdd,
+						CouponCode: c.CouponCode,
 					},
 				}
 				resp, err := s.service.Preview(ctx, sub.ID, req)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed `effective_date` parameter from coupon modification requests; `start_date` now defaults to current time when omitted.

* **Bug Fixes**
  * Fixed cleanup process to properly delete tax associations before removing tax rates.
  * Improved coupon modification validation to support different subscription scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->