### PR TITLE
chore(ci): push develop tag and enable multi-arch builds on develop branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,18 +83,22 @@ jobs:
           # legacy output used by deploy jobs
           echo "tag=${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
+          IS_DEVELOP="${{ github.ref_name == 'develop' }}"
+
           {
             echo "ghcr_tags<<TAGS_EOF"
             echo "${GHCR_IMAGE}:${GITHUB_SHA}"
             if [ "$IS_RELEASE" = "true" ]; then
               echo "${GHCR_IMAGE}:${GITHUB_REF_NAME}"
               echo "${GHCR_IMAGE}:latest"
+            elif [ "$IS_DEVELOP" = "true" ]; then
+              echo "${GHCR_IMAGE}:develop"
             fi
             echo "TAGS_EOF"
           } >> $GITHUB_OUTPUT
 
-          if [ "$IS_RELEASE" = "true" ]; then
-            echo "platforms=linux/amd64,linux/arm64,linux/arm/v7" >> $GITHUB_OUTPUT
+          if [ "$IS_RELEASE" = "true" ] || [ "$IS_DEVELOP" = "true" ]; then
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/arm64" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
On every push to `develop`:
- GHCR gets `ghcr.io/flexprice/flexprice:develop` tag (mutable pointer) in addition to SHA tag
- Build platforms expanded to `linux/amd64,linux/arm64` (was arm64-only)

Release builds (v* tags) unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD Docker tagging to add an additional `develop` tag alongside the commit-specific tag.
  * Refined multi-architecture build behavior: builds include both `linux/amd64` and `linux/arm64` for release tags and the `develop` branch; otherwise it uses `linux/arm64` only.
  * Removed support for the `linux/arm/v7` build target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->