### PR TITLE
fix(ci): drop linux/arm/v7 from release build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
           if [ "$IS_RELEASE" = "true" ]; then
-            echo "platforms=linux/amd64,linux/arm64,linux/arm/v7" >> $GITHUB_OUTPUT
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/arm64" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Problem

Release build on `main` fails:
```
ERROR: failed to solve: failed to resolve source metadata for
ghcr.io/typst/typst:v0.13.1: no match for platform in manifest: not found
```
Failing run: https://github.com/flexprice/flexprice/actions/runs/27601646748/job/81603822137

## Cause

Release builds target `linux/amd64,linux/arm64,linux/arm/v7`. The typst base image (`ghcr.io/typst/typst:v0.13.1`, used in the Dockerfile) only publishes `amd64` and `arm64` manifests — no `arm/v7`. The arm/v7 build target can't resolve typst and the whole build fails.

## Fix

Drop `linux/arm/v7` from the release platform list. Now builds `linux/amd64,linux/arm64` only — both have typst manifests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ECS deployment workflow Docker build platform configuration. Release deployments now target `linux/amd64` and `linux/arm64` architectures, with corresponding modifications to the platform matrix used in the build and push workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->