### PR TITLE
perf(ci): cross-compile Go natively instead of QEMU emulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:experimental
 # Build stage
-FROM golang:1.25-alpine3.22 AS builder
+# Pin the builder to the runner's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested $TARGETARCH. Avoids QEMU emulation of
+# the Go toolchain, which is 10-20x slower on multi-arch builds.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS builder
 WORKDIR /app
 
 RUN apk add --no-cache git
@@ -11,12 +14,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 COPY . .
 
+# TARGETARCH is provided automatically by buildx (e.g. amd64, arm64)
+ARG TARGETARCH
 ENV CGO_ENABLED=0 \
     GOOS=linux
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -ldflags="-w -s" -trimpath -o server cmd/server/main.go && \
-    go build -ldflags="-w -s" -trimpath -o migrate cmd/migrate/main.go
+    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o server cmd/server/main.go && \
+    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o migrate cmd/migrate/main.go
 
 # Typst stage
 FROM ghcr.io/typst/typst:v0.13.1 AS typst


### PR DESCRIPTION
## Problem

develop multi-arch builds stall ~1h on the build step.
Example: https://github.com/flexprice/flexprice/actions/runs/27603537474/job/81609940104

## Cause

develop/release now build `linux/amd64,linux/arm64`. The self-hosted runner is single-arch, so the non-native arch is emulated via QEMU. The Go builder stage compiles two binaries (server + migrate) — under emulation that's 10-20x slower.

## Fix

Pin the builder stage to `$BUILDPLATFORM` (runner-native) and cross-compile to `$TARGETARCH` via `GOARCH`. CGO is already disabled (`CGO_ENABLED=0`), so Go cross-compiles cleanly with zero emulation. typst + final alpine stages still resolve per-arch but do no compilation.

## Verified

Local `docker buildx build --platform linux/amd64,linux/arm64` completes both arches fast — no QEMU stall on the Go compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to enable efficient cross-compilation for multiple target architectures using native platform builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->