### PR TITLE
fix(clickhouse): align events schema with production (out-of-band drift)

### DIFF
--- a/migrations/clickhouse/000010_align_events_with_prod_schema.down.sql
+++ b/migrations/clickhouse/000010_align_events_with_prod_schema.down.sql
@@ -1,0 +1,4 @@
+-- 000010 down — remove the projection added by the up migration on a fresh env.
+-- Does NOT revert column codecs/types (no safe automatic reversal on populated
+-- tables). On a fresh CREATE-only env, dropping the projection is sufficient.
+ALTER TABLE flexprice.events DROP PROJECTION IF EXISTS proj_by_customer_event;

--- a/migrations/clickhouse/000010_align_events_with_prod_schema.up.sql
+++ b/migrations/clickhouse/000010_align_events_with_prod_schema.up.sql
@@ -55,27 +55,32 @@ SETTINGS index_granularity = 16384,
     max_bytes_to_merge_at_max_space_in_pool = 5368709120,
     deduplicate_merge_projection_mode = 'rebuild';
 
--- ── Existing env reconciliation (e.g. staging on the 000001 schema) ───────────
--- The statements below bring an EXISTING 000001-era `events` table in line with
--- production. They are HEAVY on large tables (column re-encode + projection
--- materialize rewrite every part) and are therefore NOT auto-applied here —
--- run them deliberately, in a maintenance window, only on envs that still carry
--- the old schema. Left commented so golang-migrate does not execute them.
+-- ── Existing env reconciliation (envs already on the 000001 schema) ───────────
+-- These ALTERs bring an EXISTING events table in line with production. They are
+-- idempotent (IF EXISTS / IF NOT EXISTS, and MODIFY COLUMN to the target type is
+-- a no-op when already that type), so on a FRESH env the CREATE above already
+-- built the final schema and every ALTER below no-ops.
 --
--- ALTER TABLE flexprice.events MODIFY COLUMN event_name LowCardinality(String) CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN source LowCardinality(String) DEFAULT '' CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN customer_id String DEFAULT '' CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN id String CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN tenant_id String CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN external_customer_id String CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN environment_id String CODEC(ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN timestamp DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN ingested_at DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
--- ALTER TABLE flexprice.events MODIFY COLUMN properties String CODEC(ZSTD(6));
--- ALTER TABLE flexprice.events DROP INDEX IF EXISTS external_customer_id_idx;
--- ALTER TABLE flexprice.events DROP INDEX IF EXISTS event_name_idx;
--- ALTER TABLE flexprice.events DROP INDEX IF EXISTS source_idx;
--- ALTER TABLE flexprice.events ADD PROJECTION IF NOT EXISTS proj_by_customer_event
---   (SELECT * ORDER BY tenant_id, environment_id, external_customer_id, event_name, timestamp, id);
--- ALTER TABLE flexprice.events MATERIALIZE PROJECTION proj_by_customer_event;
--- ALTER TABLE flexprice.events MODIFY SETTING parts_to_delay_insert = 2000, parts_to_throw_insert = 4000, deduplicate_merge_projection_mode = 'rebuild';
+-- ⚠️ HEAVY ON LARGE EXISTING TABLES. `MODIFY COLUMN` (codec/LowCardinality change)
+-- and `MATERIALIZE PROJECTION` rewrite every data part in the BACKGROUND. CH
+-- accepts the statements quickly (mutation is async — see system.mutations), but
+-- the actual rewrite of a multi-hundred-GiB events table takes hours of disk I/O.
+-- Schedule the deploy that ships this migration into a low-traffic window and
+-- watch `SELECT * FROM system.mutations WHERE is_done = 0` until it drains.
+ALTER TABLE flexprice.events MODIFY COLUMN event_name LowCardinality(String) CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN source LowCardinality(String) DEFAULT '' CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN customer_id String DEFAULT '' CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN id String CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN tenant_id String CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN external_customer_id String CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN environment_id String CODEC(ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN timestamp DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN ingested_at DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
+ALTER TABLE flexprice.events MODIFY COLUMN properties String CODEC(ZSTD(6));
+ALTER TABLE flexprice.events DROP INDEX IF EXISTS external_customer_id_idx;
+ALTER TABLE flexprice.events DROP INDEX IF EXISTS event_name_idx;
+ALTER TABLE flexprice.events DROP INDEX IF EXISTS source_idx;
+ALTER TABLE flexprice.events ADD PROJECTION IF NOT EXISTS proj_by_customer_event
+  (SELECT * ORDER BY tenant_id, environment_id, external_customer_id, event_name, timestamp, id);
+ALTER TABLE flexprice.events MATERIALIZE PROJECTION proj_by_customer_event;
+ALTER TABLE flexprice.events MODIFY SETTING parts_to_delay_insert = 2000, parts_to_throw_insert = 4000, deduplicate_merge_projection_mode = 'rebuild';

--- a/migrations/clickhouse/000010_align_events_with_prod_schema.up.sql
+++ b/migrations/clickhouse/000010_align_events_with_prod_schema.up.sql
@@ -1,0 +1,81 @@
+-- 000010_align_events_with_prod_schema
+--
+-- WHY: The production ClickHouse `flexprice.events` table has drifted out-of-band
+-- from migration 000001. Production carries column-level CODECs, LowCardinality
+-- typing on event_name/source, a `proj_by_customer_event` PROJECTION, and has
+-- DROPPED the three secondary indexes that 000001 created — none of which were
+-- ever committed to this repo. The existing staging CH still matches 000001.
+--
+-- This was surfaced by the prod->staging CH migration rehearsal (2026-06-17):
+-- a `clickhouse-backup restore --data` ATTACH of production parts into a
+-- 000001-built `events` table FAILS, because ATTACH requires byte-identical
+-- column types, codecs and projections. The AWS->GCP cutover restores prod
+-- parts into the new GCP CH, so the GCP `events` schema MUST match production.
+--
+-- This migration makes the repo the source of truth for the *production*
+-- `events` schema so a fresh deploy (e.g. the new GCP CH) is ATTACH-compatible
+-- with production backups.
+--
+-- ── Fresh deploy (new env, e.g. GCP CH): CREATE matches prod exactly ──────────
+CREATE TABLE IF NOT EXISTS flexprice.events
+(
+    `id` String CODEC(ZSTD(3)),
+    `tenant_id` String CODEC(ZSTD(3)),
+    `external_customer_id` String CODEC(ZSTD(3)),
+    `environment_id` String CODEC(ZSTD(3)),
+    `event_name` LowCardinality(String) CODEC(ZSTD(3)),
+    `customer_id` String DEFAULT '' CODEC(ZSTD(3)),
+    `source` LowCardinality(String) DEFAULT '' CODEC(ZSTD(3)),
+    `timestamp` DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3)),
+    `ingested_at` DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3)),
+    `properties` String CODEC(ZSTD(6)),
+    CONSTRAINT check_event_name CHECK event_name != '',
+    CONSTRAINT check_tenant_id CHECK tenant_id != '',
+    CONSTRAINT check_event_id CHECK id != '',
+    CONSTRAINT check_environment_id CHECK environment_id != '',
+    PROJECTION proj_by_customer_event
+    (
+        SELECT *
+        ORDER BY
+            tenant_id,
+            environment_id,
+            external_customer_id,
+            event_name,
+            timestamp,
+            id
+    )
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMMDD(timestamp)
+PRIMARY KEY (tenant_id, environment_id)
+ORDER BY (tenant_id, environment_id, timestamp, id)
+SETTINGS index_granularity = 16384,
+    parts_to_delay_insert = 2000,
+    parts_to_throw_insert = 4000,
+    max_bytes_to_merge_at_max_space_in_pool = 5368709120,
+    deduplicate_merge_projection_mode = 'rebuild';
+
+-- ── Existing env reconciliation (e.g. staging on the 000001 schema) ───────────
+-- The statements below bring an EXISTING 000001-era `events` table in line with
+-- production. They are HEAVY on large tables (column re-encode + projection
+-- materialize rewrite every part) and are therefore NOT auto-applied here —
+-- run them deliberately, in a maintenance window, only on envs that still carry
+-- the old schema. Left commented so golang-migrate does not execute them.
+--
+-- ALTER TABLE flexprice.events MODIFY COLUMN event_name LowCardinality(String) CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN source LowCardinality(String) DEFAULT '' CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN customer_id String DEFAULT '' CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN id String CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN tenant_id String CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN external_customer_id String CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN environment_id String CODEC(ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN timestamp DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN ingested_at DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
+-- ALTER TABLE flexprice.events MODIFY COLUMN properties String CODEC(ZSTD(6));
+-- ALTER TABLE flexprice.events DROP INDEX IF EXISTS external_customer_id_idx;
+-- ALTER TABLE flexprice.events DROP INDEX IF EXISTS event_name_idx;
+-- ALTER TABLE flexprice.events DROP INDEX IF EXISTS source_idx;
+-- ALTER TABLE flexprice.events ADD PROJECTION IF NOT EXISTS proj_by_customer_event
+--   (SELECT * ORDER BY tenant_id, environment_id, external_customer_id, event_name, timestamp, id);
+-- ALTER TABLE flexprice.events MATERIALIZE PROJECTION proj_by_customer_event;
+-- ALTER TABLE flexprice.events MODIFY SETTING parts_to_delay_insert = 2000, parts_to_throw_insert = 4000, deduplicate_merge_projection_mode = 'rebuild';

--- a/migrations/clickhouse/000010_align_events_with_prod_schema.up.sql
+++ b/migrations/clickhouse/000010_align_events_with_prod_schema.up.sql
@@ -6,67 +6,36 @@
 -- DROPPED the three secondary indexes that 000001 created — none of which were
 -- ever committed to this repo. The existing staging CH still matches 000001.
 --
--- This was surfaced by the prod->staging CH migration rehearsal (2026-06-17):
--- a `clickhouse-backup restore --data` ATTACH of production parts into a
+-- Surfaced by the prod->staging CH migration rehearsal (2026-06-17): a
+-- `clickhouse-backup restore --data` ATTACH of production parts into a
 -- 000001-built `events` table FAILS, because ATTACH requires byte-identical
--- column types, codecs and projections. The AWS->GCP cutover restores prod
--- parts into the new GCP CH, so the GCP `events` schema MUST match production.
+-- column types, codecs and projections. The AWS->GCP cutover restores prod parts
+-- into the new GCP CH, so the GCP `events` schema MUST match production.
 --
--- This migration makes the repo the source of truth for the *production*
--- `events` schema so a fresh deploy (e.g. the new GCP CH) is ATTACH-compatible
--- with production backups.
+-- HOW: 000001 already created `flexprice.events` (every env, including a fresh
+-- GCP CH, runs 000001 before 000010). So this migration does NOT re-create the
+-- table — it ALTERs the existing 000001-era table into the production schema.
+-- Idempotent (IF EXISTS / IF NOT EXISTS, MODIFY COLUMN to target type is a no-op
+-- when already applied), so re-running is safe and a table already at the prod
+-- schema is left unchanged.
 --
--- ── Fresh deploy (new env, e.g. GCP CH): CREATE matches prod exactly ──────────
-CREATE TABLE IF NOT EXISTS flexprice.events
-(
-    `id` String CODEC(ZSTD(3)),
-    `tenant_id` String CODEC(ZSTD(3)),
-    `external_customer_id` String CODEC(ZSTD(3)),
-    `environment_id` String CODEC(ZSTD(3)),
-    `event_name` LowCardinality(String) CODEC(ZSTD(3)),
-    `customer_id` String DEFAULT '' CODEC(ZSTD(3)),
-    `source` LowCardinality(String) DEFAULT '' CODEC(ZSTD(3)),
-    `timestamp` DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3)),
-    `ingested_at` DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3)),
-    `properties` String CODEC(ZSTD(6)),
-    CONSTRAINT check_event_name CHECK event_name != '',
-    CONSTRAINT check_tenant_id CHECK tenant_id != '',
-    CONSTRAINT check_event_id CHECK id != '',
-    CONSTRAINT check_environment_id CHECK environment_id != '',
-    PROJECTION proj_by_customer_event
-    (
-        SELECT *
-        ORDER BY
-            tenant_id,
-            environment_id,
-            external_customer_id,
-            event_name,
-            timestamp,
-            id
-    )
-)
-ENGINE = ReplacingMergeTree(ingested_at)
-PARTITION BY toYYYYMMDD(timestamp)
-PRIMARY KEY (tenant_id, environment_id)
-ORDER BY (tenant_id, environment_id, timestamp, id)
-SETTINGS index_granularity = 16384,
-    parts_to_delay_insert = 2000,
-    parts_to_throw_insert = 4000,
-    max_bytes_to_merge_at_max_space_in_pool = 5368709120,
-    deduplicate_merge_projection_mode = 'rebuild';
-
--- ── Existing env reconciliation (envs already on the 000001 schema) ───────────
--- These ALTERs bring an EXISTING events table in line with production. They are
--- idempotent (IF EXISTS / IF NOT EXISTS, and MODIFY COLUMN to the target type is
--- a no-op when already that type), so on a FRESH env the CREATE above already
--- built the final schema and every ALTER below no-ops.
+-- ⚠️ ORDER MATTERS: a column that backs a secondary index cannot be MODIFYed
+-- (CH error 524 ALTER_OF_COLUMN_IS_FORBIDDEN). So DROP the indexes that 000001
+-- created on event_name / source FIRST, then re-type the columns.
 --
 -- ⚠️ HEAVY ON LARGE EXISTING TABLES. `MODIFY COLUMN` (codec/LowCardinality change)
 -- and `MATERIALIZE PROJECTION` rewrite every data part in the BACKGROUND. CH
 -- accepts the statements quickly (mutation is async — see system.mutations), but
 -- the actual rewrite of a multi-hundred-GiB events table takes hours of disk I/O.
--- Schedule the deploy that ships this migration into a low-traffic window and
--- watch `SELECT * FROM system.mutations WHERE is_done = 0` until it drains.
+-- Ship the deploy carrying this migration in a low-traffic window and watch
+-- `SELECT * FROM system.mutations WHERE is_done = 0` until it drains.
+
+-- 1. Drop the 000001 secondary indexes FIRST (they block MODIFY of their columns).
+ALTER TABLE flexprice.events DROP INDEX IF EXISTS external_customer_id_idx;
+ALTER TABLE flexprice.events DROP INDEX IF EXISTS event_name_idx;
+ALTER TABLE flexprice.events DROP INDEX IF EXISTS source_idx;
+
+-- 2. Re-type columns + add codecs to match prod.
 ALTER TABLE flexprice.events MODIFY COLUMN event_name LowCardinality(String) CODEC(ZSTD(3));
 ALTER TABLE flexprice.events MODIFY COLUMN source LowCardinality(String) DEFAULT '' CODEC(ZSTD(3));
 ALTER TABLE flexprice.events MODIFY COLUMN customer_id String DEFAULT '' CODEC(ZSTD(3));
@@ -77,10 +46,13 @@ ALTER TABLE flexprice.events MODIFY COLUMN environment_id String CODEC(ZSTD(3));
 ALTER TABLE flexprice.events MODIFY COLUMN timestamp DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
 ALTER TABLE flexprice.events MODIFY COLUMN ingested_at DateTime64(3) DEFAULT now() CODEC(Delta(8), ZSTD(3));
 ALTER TABLE flexprice.events MODIFY COLUMN properties String CODEC(ZSTD(6));
-ALTER TABLE flexprice.events DROP INDEX IF EXISTS external_customer_id_idx;
-ALTER TABLE flexprice.events DROP INDEX IF EXISTS event_name_idx;
-ALTER TABLE flexprice.events DROP INDEX IF EXISTS source_idx;
+
+-- 3. Set merge/insert settings FIRST. deduplicate_merge_projection_mode MUST be
+--    set before ADD PROJECTION — a ReplacingMergeTree rejects a projection while
+--    the mode is the default 'throw' (CH error 344 SUPPORT_IS_DISABLED).
+ALTER TABLE flexprice.events MODIFY SETTING parts_to_delay_insert = 2000, parts_to_throw_insert = 4000, deduplicate_merge_projection_mode = 'rebuild';
+
+-- 4. Add + materialize the prod projection.
 ALTER TABLE flexprice.events ADD PROJECTION IF NOT EXISTS proj_by_customer_event
   (SELECT * ORDER BY tenant_id, environment_id, external_customer_id, event_name, timestamp, id);
 ALTER TABLE flexprice.events MATERIALIZE PROJECTION proj_by_customer_event;
-ALTER TABLE flexprice.events MODIFY SETTING parts_to_delay_insert = 2000, parts_to_throw_insert = 4000, deduplicate_merge_projection_mode = 'rebuild';

--- a/migrations/clickhouse/SCHEMA_DRIFT_2026-06-17.md
+++ b/migrations/clickhouse/SCHEMA_DRIFT_2026-06-17.md
@@ -23,17 +23,28 @@ in-place reconciliation ALTERs included but commented — heavy, run deliberatel
 
 | Table | Drift observed on prod (not in migrations) |
 |---|---|
-| `events` | column CODECs (ZSTD/Delta); `event_name`/`source` → `LowCardinality`; `customer_id` → `String DEFAULT ''`; **PROJECTION `proj_by_customer_event`**; **3 secondary indexes DROPPED**; `parts_to_*` raised; `deduplicate_merge_projection_mode='rebuild'` |
-| `feature_usage` | column CODECs; indexes `bf_feature_id`/`mm_ts`/`bf_external_customer_id`/`bf_id`; `ReplacingMergeTree(version)` with `version`/`sign` cols |
-| `meter_usage` | heavy `LowCardinality` typing; `DoubleDelta`/`ZSTD` codecs; `min_bytes_for_wide_part`, `enable_mixed_granularity_parts` settings |
-| `costsheet_usage` | `processing_lag_ms` MATERIALIZED column; 6 bloom_filter + set indexes; codecs |
-| `raw_events` | `field1..field10` Nullable columns; `bf_id` index; `version`/`sign` |
-| `analytics_benchmark` | extensive `LowCardinality` + array columns + codecs |
-| `usage_benchmark` | `LowCardinality` + Delta/ZSTD codecs |
+Verified by comparing live-prod `SHOW CREATE` against the committed migration
+for each table (codec / index / projection / LowCardinality / engine counts):
 
-Only `events` is reconciled in `000010` (billing-critical, verified, the
-dominant restore table). The remaining tables should be reconciled the same way
-before the GCP cutover — dump live-prod `SHOW CREATE` and make the repo match,
-OR build the GCP target schema directly from `clickhouse-backup` backup
-metadata. See infrastructure `docs/CH-MIGRATION-PROD-TO-STAGING-REHEARSAL.md`
-(finding R10) and `docs/CH-MIGRATION-DETAIL.md` §1.1.
+| Table | Drift? | repo → prod |
+|---|---|---|
+| `events` | 🔴 **MAJOR** | LowCardinality 0→2, CODEC 0→10, **PROJECTION 0→1** (`proj_by_customer_event`), **INDEX 3→0** (all dropped); `parts_to_*` raised; `deduplicate_merge_projection_mode='rebuild'` |
+| `feature_usage` | 🔴 **YES** | CODEC 1→9, INDEX 3→4 (one extra) |
+| `raw_events` | 🟠 **YES** | INDEX 3→1 (two dropped) |
+| `analytics_benchmark` | 🟠 **minor** | LowCardinality 5→7 (two more cols) |
+| `costsheet_usage` | ✅ match | identical (CODEC 1, INDEX 7, MATERIALIZED 1) |
+| `meter_usage` | ✅ match | identical (LowCardinality 6, CODEC 6) |
+| `usage_benchmark` | ✅ match | identical (`MergeTree()` vs `MergeTree` is cosmetic) |
+| `events_processed` | ⚪ N/A | not present on prod source CH |
+
+**4 of 7 in-scope tables drift** (events, feature_usage, raw_events,
+analytics_benchmark); 3 match; `events_processed` is GCP/staging-only.
+
+Each drifted attribute independently breaks `clickhouse-backup restore --data`
+ATTACH (codecs/projections/indexes must be byte-identical). Only `events` is
+reconciled in `000010` (billing-critical, verified, dominant restore table).
+The other 3 drifted tables must be reconciled the same way before the GCP
+cutover — dump live-prod `SHOW CREATE` and make the repo match, OR build the GCP
+target schema directly from `clickhouse-backup` backup metadata. See
+infrastructure `docs/CH-MIGRATION-PROD-TO-STAGING-REHEARSAL.md` (finding R10) and
+`docs/CH-MIGRATION-DETAIL.md` §1.1.

--- a/migrations/clickhouse/SCHEMA_DRIFT_2026-06-17.md
+++ b/migrations/clickhouse/SCHEMA_DRIFT_2026-06-17.md
@@ -1,0 +1,39 @@
+# ClickHouse schema drift — production vs migrations (2026-06-17)
+
+Surfaced by the AWS→GCP prod-scale ClickHouse migration rehearsal. The live
+production CH (`clickhousev2-mafga`, us-west-2) has drifted from the migrations
+in this directory via hand-applied `ALTER`s that were never committed. The
+existing **staging** CH still matches the migrations, so this is true
+out-of-band production drift, not a partial migration apply.
+
+## Why it matters
+
+`clickhouse-backup restore --data` ATTACHes physical parts, which requires
+byte-identical column types, CODECs, and projections between the backup source
+(production) and the restore target. The AWS→GCP cutover restores production
+parts into the **new GCP CH**, so the GCP table schemas must match production —
+not the (older) migration schema. A migration-built `events` table fails the
+ATTACH.
+
+**Action taken:** `000010_align_events_with_prod_schema` captures the production
+`events` schema as the repo source of truth (fresh CREATE matches prod;
+in-place reconciliation ALTERs included but commented — heavy, run deliberately).
+
+## Drift inventory (production `SHOW CREATE` vs migrations)
+
+| Table | Drift observed on prod (not in migrations) |
+|---|---|
+| `events` | column CODECs (ZSTD/Delta); `event_name`/`source` → `LowCardinality`; `customer_id` → `String DEFAULT ''`; **PROJECTION `proj_by_customer_event`**; **3 secondary indexes DROPPED**; `parts_to_*` raised; `deduplicate_merge_projection_mode='rebuild'` |
+| `feature_usage` | column CODECs; indexes `bf_feature_id`/`mm_ts`/`bf_external_customer_id`/`bf_id`; `ReplacingMergeTree(version)` with `version`/`sign` cols |
+| `meter_usage` | heavy `LowCardinality` typing; `DoubleDelta`/`ZSTD` codecs; `min_bytes_for_wide_part`, `enable_mixed_granularity_parts` settings |
+| `costsheet_usage` | `processing_lag_ms` MATERIALIZED column; 6 bloom_filter + set indexes; codecs |
+| `raw_events` | `field1..field10` Nullable columns; `bf_id` index; `version`/`sign` |
+| `analytics_benchmark` | extensive `LowCardinality` + array columns + codecs |
+| `usage_benchmark` | `LowCardinality` + Delta/ZSTD codecs |
+
+Only `events` is reconciled in `000010` (billing-critical, verified, the
+dominant restore table). The remaining tables should be reconciled the same way
+before the GCP cutover — dump live-prod `SHOW CREATE` and make the repo match,
+OR build the GCP target schema directly from `clickhouse-backup` backup
+metadata. See infrastructure `docs/CH-MIGRATION-PROD-TO-STAGING-REHEARSAL.md`
+(finding R10) and `docs/CH-MIGRATION-DETAIL.md` §1.1.


### PR DESCRIPTION
> **Draft** — surfaced by the AWS→GCP ClickHouse migration rehearsal. Reconciles `events` only; 3 other drifted tables documented for follow-up. Review the heavy-ALTER warning before merging.

## What

Production ClickHouse `flexprice.events` has drifted **out-of-band** from migration `000001` — hand-applied `ALTER`s that were never committed. Verified across the 7 in-scope tables by diffing live-prod `SHOW CREATE` against each committed migration: **4 drift** (`events`, `feature_usage`, `raw_events`, `analytics_benchmark`), 3 match (`costsheet_usage`, `meter_usage`, `usage_benchmark`); `events_processed` is not on the prod source.

Prod `events` vs `000001`:
- per-column CODECs (`ZSTD`/`Delta`)
- `event_name` / `source` → `LowCardinality(String)`
- `customer_id` → `String DEFAULT ''`
- PROJECTION `proj_by_customer_event`
- the 3 secondary indexes from `000001` **dropped**
- raised `parts_to_*`, `deduplicate_merge_projection_mode='rebuild'`

## Why it matters

`clickhouse-backup restore --data` ATTACHes physical parts, which requires **byte-identical** column types, codecs, projections and indexes between source (prod) and target. The AWS→GCP cutover restores prod parts into the new GCP CH, so the GCP `events` schema must match prod. A `000001`-built table fails the ATTACH. The repo currently does not describe the real production schema.

## What this PR does

`000010_align_events_with_prod_schema` — **ALTER-only** (no CREATE; `000001` already creates `events`, every env runs it first). Reconciles an existing `000001`-era `events` to the production schema:
- DROP the 3 old indexes **first** (a column backing an index can't be `MODIFY`ed — CH error 524),
- then `MODIFY COLUMN` for codecs + LowCardinality,
- `MODIFY SETTING deduplicate_merge_projection_mode='rebuild'` **before** `ADD PROJECTION` (ReplacingMergeTree rejects a projection under the default `throw` — CH error 344),
- `ADD` + `MATERIALIZE` the projection.

Idempotent (`IF EXISTS`/`IF NOT EXISTS` + MODIFY-to-target-type no-op). **Validated live** on CH `24.8.14`: applied to a fresh `000001`-schema table → converges to byte-identical prod schema; re-run is a clean no-op.

⚠️ **Heavy on large existing tables:** `MODIFY COLUMN` + `MATERIALIZE PROJECTION` rewrite every part in the background (async mutation). On a multi-hundred-GiB `events` this is hours of disk I/O — ship the carrying deploy in a low-traffic window and watch `system.mutations`.

`SCHEMA_DRIFT_2026-06-17.md` documents the full 7-table drift inventory. The other 3 drifted tables (`feature_usage`, `raw_events`, `analytics_benchmark`) need the same treatment before the GCP cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)