### PR TITLE
fix(meter-usage): Group by properties in bucketed meters

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -124,7 +124,15 @@ type GetUsageRequest struct {
 	// GroupByProperty is the property name in event.properties to group by before aggregating.
 	// When set, aggregation is applied per unique value of this property within each bucket,
 	// then the per-group results are summed to produce the bucket total.
+	//
+	// Deprecated: prefer GroupBy []string{"properties.<X>"} for parity with
+	// other analytics endpoints. ToUsageParams translates this field into
+	// GroupBy when GroupBy is otherwise empty.
 	GroupByProperty string `form:"group_by_property" json:"group_by_property,omitempty"`
+	// GroupBy lists the analytics group_by dimensions.
+	//   - "source"        — group by event source column
+	//   - "properties.X"  — group by JSON property X
+	GroupBy []string `form:"group_by" json:"group_by,omitempty"`
 }
 
 type GetUsageByMeterRequest struct {
@@ -256,6 +264,13 @@ func (r *GetUsageRequest) ToUsageParams() *events.UsageParams {
 		r.AggregationType = types.AggregationCount
 	}
 
+	// Honor the modern GroupBy slice when set; otherwise translate the
+	// deprecated singular GroupByProperty for backward compat.
+	groupBy := r.GroupBy
+	if len(groupBy) == 0 && r.GroupByProperty != "" {
+		groupBy = []string{"properties." + r.GroupByProperty}
+	}
+
 	return &events.UsageParams{
 		ExternalCustomerID:  r.ExternalCustomerID,
 		ExternalCustomerIDs: r.ExternalCustomerIDs,
@@ -270,7 +285,7 @@ func (r *GetUsageRequest) ToUsageParams() *events.UsageParams {
 		Filters:             r.Filters,
 		Multiplier:          r.Multiplier,
 		BillingAnchor:       r.BillingAnchor,
-		GroupByProperty:     r.GroupByProperty,
+		GroupBy:             groupBy,
 	}
 }
 

--- a/internal/domain/events/feature_usage.go
+++ b/internal/domain/events/feature_usage.go
@@ -104,12 +104,12 @@ type GetFeatureUsageBySubscriptionParams struct {
 
 // MaxBucketFeatureInfo contains information about a feature that uses MAX with bucket aggregation
 type MaxBucketFeatureInfo struct {
-	FeatureID       string
-	MeterID         string
-	BucketSize      types.WindowSize
-	EventName       string
-	PropertyName    string
-	GroupByProperty string // Property name in event.properties to group by before aggregating
+	FeatureID    string
+	MeterID      string
+	BucketSize   types.WindowSize
+	EventName    string
+	PropertyName string
+	GroupBy      []string // GroupBy: "source" or "properties.X"
 }
 
 // SumBucketFeatureInfo contains information about a feature that uses SUM with bucket aggregation

--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -38,8 +38,12 @@ type MeterUsageQueryParams struct {
 	AggregationType     types.AggregationType
 	WindowSize          types.WindowSize
 	BillingAnchor       *time.Time
-	// GroupByProperty is the JSON property key for group-by aggregation (e.g. for bucketed MAX meters)
-	GroupByProperty string
+	// GroupBy is the group_by dimension list. Allowed entries:
+	//   - "source"        — group by event source column
+	//   - "properties.X"  — group by JSON property X
+	// Naming matches UsageAnalyticsParams.GroupBy (feature-usage). Billing
+	// callers populating from meter.Aggregation.GroupBy wrap as "properties.<X>".
+	GroupBy []string
 	// UseFinal enables FINAL for ReplacingMergeTree deduplication (use for billing queries)
 	UseFinal bool
 	// PropertyFilters restrict events whose properties match. e.g. {"model": ["gpt-4"]}
@@ -136,6 +140,12 @@ type MeterUsageRepository interface {
 	// GetUsageForBucketedMeters returns windowed aggregation results for bucketed meters (MAX/SUM with bucket_size).
 	// Returns *AggregationResult (shared type with feature_usage) for compatibility with calculateBucketedMeterCost.
 	GetUsageForBucketedMeters(ctx context.Context, params *MeterUsageQueryParams) (*AggregationResult, error)
+
+	// GetUsageForBucketedMetersDetailed is the analytics-side variant: returns one
+	// MeterUsageDetailedResult per (source, properties) combo when UserGroupBy is
+	// set, with per-combo TotalUsage / EventCount / Points pre-rolled by SQL —
+	// mirrors feature_usage's getMaxBucketTotals + getAnalyticsPoints shape.
+	GetUsageForBucketedMetersDetailed(ctx context.Context, params *MeterUsageQueryParams) ([]*MeterUsageDetailedResult, error)
 
 	// GetDistinctMeterIDs returns the set of meter_ids that have data in the meter_usage table
 	// for the given customer(s) and time range. Used to skip meters with zero usage.

--- a/internal/domain/events/repository.go
+++ b/internal/domain/events/repository.go
@@ -170,17 +170,23 @@ type UsageResult struct {
 	GroupKey   string          `json:"group_key,omitempty"` // group identifier when group_by is used (e.g., KRN value)
 }
 
-// FirstGroupByProperty extracts the first "properties.X" entry from a GroupBy
-// list and returns the bare property name. Returns "" when the list is empty
-// or the first dim isn't a "properties.X" form. Legacy SQL paths that only
-// support a single property dim use this helper instead of carrying a separate
-// scalar GroupByProperty field.
+// FirstGroupByProperty extracts the bare property name from the FIRST entry of
+// a GroupBy list when that entry is a "properties.X" form. Returns "" when the
+// list is empty or the first dim isn't a "properties.X" form.
+//
+// Positional semantics matter here: legacy SQL paths only support a single
+// dimension, and the primary dim is whatever the user listed first. Treating
+// later entries as candidates would silently demote the user's primary dim
+// (e.g., ["source", "properties.org_id"] would otherwise group by org_id and
+// drop source, which is the opposite of what the user asked).
 func FirstGroupByProperty(groupBy []string) string {
+	if len(groupBy) == 0 {
+		return ""
+	}
 	const prefix = "properties."
-	for _, g := range groupBy {
-		if len(g) > len(prefix) && g[:len(prefix)] == prefix {
-			return g[len(prefix):]
-		}
+	first := groupBy[0]
+	if len(first) > len(prefix) && first[:len(prefix)] == prefix {
+		return first[len(prefix):]
 	}
 	return ""
 }

--- a/internal/domain/events/repository.go
+++ b/internal/domain/events/repository.go
@@ -111,11 +111,14 @@ type UsageParams struct {
 	// - Custom business cycles (fiscal months, quarterly periods)
 	// - Multi-tenant billing with different anchor dates per customer
 	BillingAnchor *time.Time `json:"billing_anchor,omitempty"`
-	// GroupByProperty is the property name in event.properties to group by before aggregating.
-	// When set, aggregation is applied per unique value of this property within each bucket,
-	// then the per-group results are summed to produce the bucket total.
-	// Currently only supported for MAX aggregation with bucket_size.
-	GroupByProperty string `json:"group_by_property,omitempty"`
+	// GroupBy lists the analytics group_by dimensions.
+	//   - "source"        — group by event source
+	//   - "properties.X"  — group by JSON property X
+	// Naming matches UsageAnalyticsParams.GroupBy + MeterUsageQueryParams.GroupBy.
+	// Currently only supported for MAX aggregation with bucket_size; the events
+	// repo's per-row SQL consumes the first dim for legacy single-property
+	// grouping (multi-dim support is on the bucketed-meter path).
+	GroupBy []string `json:"group_by,omitempty"`
 }
 
 // UsageSummaryParams defines parameters for querying pre-computed usage
@@ -165,6 +168,21 @@ type UsageResult struct {
 	Value      decimal.Decimal `json:"value"`
 	EventCount uint64          `json:"event_count"`         // Distinct event count in this window
 	GroupKey   string          `json:"group_key,omitempty"` // group identifier when group_by is used (e.g., KRN value)
+}
+
+// FirstGroupByProperty extracts the first "properties.X" entry from a GroupBy
+// list and returns the bare property name. Returns "" when the list is empty
+// or the first dim isn't a "properties.X" form. Legacy SQL paths that only
+// support a single property dim use this helper instead of carrying a separate
+// scalar GroupByProperty field.
+func FirstGroupByProperty(groupBy []string) string {
+	const prefix = "properties."
+	for _, g := range groupBy {
+		if len(g) > len(prefix) && g[:len(prefix)] == prefix {
+			return g[len(prefix):]
+		}
+	}
+	return ""
 }
 
 type AggregationResult struct {

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -1274,6 +1274,10 @@ func (s *billingService) CalculateFeatureUsageCharges(
 					aggType = types.AggregationSum
 					groupBy = "" // sum meters don't use per-group pricing
 				}
+				var usageGroupBy []string
+				if groupBy != "" {
+					usageGroupBy = []string{"properties." + groupBy}
+				}
 				usageRequest := &events.FeatureUsageParams{
 					PriceID:       item.PriceID,
 					MeterID:       item.MeterID,
@@ -1286,7 +1290,7 @@ func (s *billingService) CalculateFeatureUsageCharges(
 						EndTime:             item.GetPeriodEnd(periodEnd),
 						WindowSize:          meter.Aggregation.BucketSize,
 						BillingAnchor:       &sub.BillingAnchor,
-						GroupByProperty:     groupBy,
+						GroupBy:             usageGroupBy,
 					},
 				}
 				usageResult, err := s.FeatureUsageRepo.GetUsageForBucketedMeters(ctx, usageRequest)
@@ -1603,6 +1607,10 @@ func (s *billingService) CalculateFeatureUsageCharges(
 						// ClickHouse round-trip with the same parameters.
 						commitmentUsageResult := cachedBucketedUsageResult
 						if commitmentUsageResult == nil {
+							var commitmentGroupBy []string
+							if meter.Aggregation.GroupBy != "" {
+								commitmentGroupBy = []string{"properties." + meter.Aggregation.GroupBy}
+							}
 							usageRequest := &events.FeatureUsageParams{
 								PriceID:       item.PriceID,
 								MeterID:       item.MeterID,
@@ -1615,7 +1623,7 @@ func (s *billingService) CalculateFeatureUsageCharges(
 									EndTime:             effectiveCommitmentEnd,
 									WindowSize:          meter.Aggregation.BucketSize,
 									BillingAnchor:       &sub.BillingAnchor,
-									GroupByProperty:     meter.Aggregation.GroupBy,
+									GroupBy:             commitmentGroupBy,
 								},
 							}
 

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -532,6 +532,12 @@ func (s *billingService) queryBucketedMeterUsageDirect(
 		aggType = types.AggregationSum
 		groupBy = ""
 	}
+	// Translate meter-level Aggregation.GroupBy (a single property name) to the
+	// unified GroupBy []string convention: "properties.<X>".
+	var paramsGroupBy []string
+	if groupBy != "" {
+		paramsGroupBy = []string{"properties." + groupBy}
+	}
 	return s.MeterUsageRepo.GetUsageForBucketedMeters(ctx, &events.MeterUsageQueryParams{
 		TenantID:            types.GetTenantID(ctx),
 		EnvironmentID:       types.GetEnvironmentID(ctx),
@@ -542,7 +548,7 @@ func (s *billingService) queryBucketedMeterUsageDirect(
 		AggregationType:     aggType,
 		WindowSize:          m.Aggregation.BucketSize,
 		BillingAnchor:       &sub.BillingAnchor,
-		GroupByProperty:     groupBy,
+		GroupBy:             paramsGroupBy,
 		UseFinal:            querySource.UseFinal(),
 	})
 }

--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -1137,13 +1137,17 @@ func (s *costsheetUsageTrackingService) buildBucketFeaturesFromCostsheet(ctx con
 		if f.MeterID != "" {
 			if m, exists := meterMap[f.MeterID]; exists {
 				if m.IsBucketedMaxMeter() {
+					var featGroupBy []string
+					if m.Aggregation.GroupBy != "" {
+						featGroupBy = []string{"properties." + m.Aggregation.GroupBy}
+					}
 					maxBucketFeatures[f.ID] = &events.MaxBucketFeatureInfo{
-						FeatureID:       f.ID,
-						MeterID:         f.MeterID,
-						BucketSize:      types.WindowSize(m.Aggregation.BucketSize),
-						EventName:       m.EventName,
-						PropertyName:    m.Aggregation.Field,
-						GroupByProperty: m.Aggregation.GroupBy,
+						FeatureID:    f.ID,
+						MeterID:      f.MeterID,
+						BucketSize:   types.WindowSize(m.Aggregation.BucketSize),
+						EventName:    m.EventName,
+						PropertyName: m.Aggregation.Field,
+						GroupBy:      featGroupBy,
 					}
 				} else if m.IsBucketedSumMeter() {
 					sumBucketFeatures[f.ID] = &events.SumBucketFeatureInfo{

--- a/internal/ee/service/event.go
+++ b/internal/ee/service/event.go
@@ -167,9 +167,10 @@ func (s *eventService) GetUsageByMeter(ctx context.Context, req *dto.GetUsageByM
 		getUsageRequest.BucketSize = m.Aggregation.BucketSize
 	}
 
-	// Pass GroupByProperty from meter configuration for aggregation with group_by
+	// Pass meter-level GroupBy through as "properties.<X>" so the request
+	// matches the unified GroupBy []string contract.
 	if m.Aggregation.GroupBy != "" {
-		getUsageRequest.GroupByProperty = m.Aggregation.GroupBy
+		getUsageRequest.GroupBy = []string{"properties." + m.Aggregation.GroupBy}
 	}
 
 	usage, err := s.GetUsage(ctx, &getUsageRequest)

--- a/internal/ee/service/feature_usage_tracking.go
+++ b/internal/ee/service/feature_usage_tracking.go
@@ -1787,13 +1787,17 @@ func (s *featureUsageTrackingService) buildBucketFeatures(ctx context.Context, p
 			if meterID := featureToMeterMap[f.ID]; meterID != "" {
 				if m, exists := meterMap[meterID]; exists {
 					if m.IsBucketedMaxMeter() {
+						var featGroupBy []string
+						if m.Aggregation.GroupBy != "" {
+							featGroupBy = []string{"properties." + m.Aggregation.GroupBy}
+						}
 						maxBucketFeatures[f.ID] = &events.MaxBucketFeatureInfo{
-							FeatureID:       f.ID,
-							MeterID:         meterID,
-							BucketSize:      types.WindowSize(m.Aggregation.BucketSize),
-							EventName:       m.EventName,
-							PropertyName:    m.Aggregation.Field,
-							GroupByProperty: m.Aggregation.GroupBy,
+							FeatureID:    f.ID,
+							MeterID:      meterID,
+							BucketSize:   types.WindowSize(m.Aggregation.BucketSize),
+							EventName:    m.EventName,
+							PropertyName: m.Aggregation.Field,
+							GroupBy:      featGroupBy,
 						}
 					} else if m.IsBucketedSumMeter() {
 						sumBucketFeatures[f.ID] = &events.SumBucketFeatureInfo{

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -768,6 +769,48 @@ func hasUserBucketedGroupBy(groupBy []string) bool {
 	return false
 }
 
+// analyticsGroupByPropertyName matches safe property names for "properties.X"
+// dims. Same shape as clickhouse.validMeterUsageGroupByPattern so the service
+// layer's validation matches what the SQL builder will actually accept.
+var analyticsGroupByPropertyName = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
+
+// validateAnalyticsGroupBy rejects entries the SQL builder would silently drop.
+// Accepted forms:
+//   - "meter_id"          (no-op at SQL level; implicit at the meter)
+//   - "source"
+//   - "properties.<name>" where name matches a safe identifier pattern
+//
+// Anything else (empty string, "properties." with no name, unknown tokens) is
+// a user error and surfaces as a 400 with a clear hint, rather than being
+// dropped on the floor inside clickhouse.bucketedGroupByDims where it would
+// show up as a successful response with surprising shape.
+func validateAnalyticsGroupBy(groupBy []string) error {
+	for _, g := range groupBy {
+		switch {
+		case g == "meter_id" || g == "source":
+			// ok
+		case strings.HasPrefix(g, "properties."):
+			name := strings.TrimPrefix(g, "properties.")
+			if name == "" || !analyticsGroupByPropertyName.MatchString(name) {
+				return ierr.NewError("invalid group_by entry").
+					WithHintf("group_by entry %q has an invalid property name (allowed: alphanumerics, '_', '.')", g).
+					WithReportableDetails(map[string]interface{}{
+						"group_by_entry": g,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		default:
+			return ierr.NewError("invalid group_by entry").
+				WithHintf("group_by entry %q is not recognized (allowed: 'meter_id', 'source', 'properties.<name>')", g).
+				WithReportableDetails(map[string]interface{}{
+					"group_by_entry": g,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+	return nil
+}
+
 // queryBucketedMeterAnalyticsDetailed is the analytics-side bucketed query: one
 // MeterUsageDetailedResult per (source, properties) combo, with per-combo
 // Points pre-fetched by the repo. Bypassed entirely for billing — billing
@@ -839,6 +882,13 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 			rewritten = append(rewritten, g)
 		}
 		params.GroupBy = lo.Uniq(rewritten)
+		// Reject malformed entries before they hit the SQL builder, where
+		// they'd be silently dropped (debugging nightmare). Accepted forms:
+		// "meter_id" / "source" / "properties.<valid name>". Everything else
+		// is a user error worth surfacing as a 400.
+		if err := validateAnalyticsGroupBy(params.GroupBy); err != nil {
+			return nil, err
+		}
 	}
 
 	// Resolve FeatureIDs → MeterIDs (only when MeterIDs not already specified).
@@ -1622,6 +1672,40 @@ func (s *meterUsageService) getBucketedMeterAnalytics(
 	params *events.MeterUsageDetailedAnalyticsParams,
 	m *meter.Meter,
 ) ([]*events.MeterUsageDetailedResult, error) {
+	// Mirror the subscription path: when the request has source/properties.*
+	// dims, fan out via the detailed query so each combo becomes its own
+	// MeterUsageDetailedResult with Source/Properties populated and per-combo
+	// Points. The basic GetUsageForBucketedMeters can't surface those — it
+	// returns a single AggregationResult and the user's request GroupBy would
+	// be silently dropped.
+	if hasUserBucketedGroupBy(params.GroupBy) {
+		bucketParams := &events.MeterUsageQueryParams{
+			TenantID:           params.TenantID,
+			EnvironmentID:      params.EnvironmentID,
+			ExternalCustomerID: params.ExternalCustomerID,
+			MeterID:            m.ID,
+			StartTime:          params.StartTime,
+			EndTime:            params.EndTime,
+			AggregationType:    m.Aggregation.Type,
+			WindowSize:         m.Aggregation.BucketSize,
+			// Intentionally use only params.GroupBy here. Meter-level
+			// Aggregation.GroupBy is a billing concept (per-KRN pricing); the
+			// analytics fan-out shape is owned by the request. Matches the
+			// subscription path's queryBucketedMeterAnalyticsDetailed contract.
+			GroupBy:         params.GroupBy,
+			UseFinal:        params.UseFinal,
+			BillingAnchor:   params.BillingAnchor,
+			PropertyFilters: params.PropertyFilters,
+			Sources:         params.Sources,
+		}
+		if len(params.ExternalCustomerIDs) > 0 {
+			bucketParams.ExternalCustomerIDs = params.ExternalCustomerIDs
+		}
+		return s.repo.GetUsageForBucketedMetersDetailed(ctx, bucketParams)
+	}
+
+	// No user fan-out: use the basic path with meter-level Aggregation.GroupBy
+	// (the billing / KRN-style convention).
 	var bucketParamsGroupBy []string
 	if m.Aggregation.GroupBy != "" {
 		bucketParamsGroupBy = []string{"properties." + m.Aggregation.GroupBy}

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -451,6 +452,8 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 	// committed line items can have their commitment fire on no usage).
 	skipBucketedZeros := len(req.PropertyFilters) > 0 || len(req.Sources) > 0
 
+	useDetailed := hasUserBucketedGroupBy(req.GroupBy)
+
 	for meterID := range bucketedMeterIDs {
 		m := result.MeterMap[meterID]
 		if m == nil {
@@ -460,6 +463,47 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 		for _, item := range items {
 			itemStart := item.GetPeriodStart(usageStartTime)
 			itemEnd := item.GetPeriodEnd(usageEndTime)
+
+			if useDetailed {
+				// Analytics fan-out: one LineItemMeterUsage per (source, properties)
+				// combo. Repo does the per-combo aggregation in SQL; nothing to
+				// re-group in Go.
+				detailedResults, err := s.queryBucketedMeterAnalyticsDetailed(
+					ctx, m, externalCustomerIDs,
+					itemStart, itemEnd, req.BillingAnchor, req.UseFinal,
+					req.PropertyFilters, req.Sources, req.GroupBy,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to query bucketed meter analytics for meter %s: %w", meterID, err)
+				}
+				if skipBucketedZeros && len(detailedResults) == 0 {
+					continue
+				}
+				for _, dr := range detailedResults {
+					if dr == nil {
+						continue
+					}
+					result.LineItemUsages = append(result.LineItemUsages, &LineItemMeterUsage{
+						LineItem:        item,
+						MeterID:         meterID,
+						Meter:           m,
+						Price:           result.PriceMap[item.PriceID],
+						PeriodStart:     itemStart,
+						PeriodEnd:       itemEnd,
+						Usage:           dr.TotalUsage,
+						EventCount:      dr.EventCount,
+						Points:          dr.Points,
+						AnalyticsResult: dr,
+						// BucketedResult intentionally nil: this LIMU is one
+						// (source, properties) combo, not the line-item total.
+						// Per-combo commitment math would over-charge (commitment
+						// fires once per combo instead of once per line item) —
+						// calculateCosts gates this via skipCommitment when
+						// hasUserBucketedGroupBy(data.Params.GroupBy) is true.
+					})
+				}
+				continue
+			}
 
 			bucketedResult, err := s.queryBucketedMeterUsage(
 				ctx, m, externalCustomerIDs,
@@ -668,6 +712,9 @@ func (s *meterUsageService) queryAndAppendAnalyticsEntries(
 // queryBucketedMeterUsage queries the meter_usage table for a single bucketed meter,
 // returning a per-bucket AggregationResult. propertyFilters and sources are forwarded
 // from analytics callers; pass nil for billing callers that don't use them.
+// For analytics requests with user GroupBy on source/properties, use
+// queryBucketedMeterAnalyticsDetailed instead — this method returns a single
+// line-item total, not per-combo rows.
 func (s *meterUsageService) queryBucketedMeterUsage(
 	ctx context.Context,
 	m *meter.Meter,
@@ -679,10 +726,16 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	sources []string,
 ) (*events.AggregationResult, error) {
 	aggType := m.Aggregation.Type
-	groupBy := m.Aggregation.GroupBy
+	meterGroupBy := m.Aggregation.GroupBy
 	if m.IsBucketedSumMeter() {
 		aggType = types.AggregationSum
-		groupBy = ""
+		meterGroupBy = ""
+	}
+	// Translate meter-level Aggregation.GroupBy (a single property name) to the
+	// unified GroupBy []string convention used by BuildBucketedQuery.
+	var paramsGroupBy []string
+	if meterGroupBy != "" {
+		paramsGroupBy = []string{"properties." + meterGroupBy}
 	}
 	return s.repo.GetUsageForBucketedMeters(ctx, &events.MeterUsageQueryParams{
 		TenantID:            types.GetTenantID(ctx),
@@ -694,10 +747,63 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 		AggregationType:     aggType,
 		WindowSize:          m.Aggregation.BucketSize,
 		BillingAnchor:       billingAnchor,
-		GroupByProperty:     groupBy,
+		GroupBy:             paramsGroupBy,
 		UseFinal:            useFinal,
 		PropertyFilters:     propertyFilters,
 		Sources:             sources,
+	})
+}
+
+// hasUserBucketedGroupBy reports whether the request asks for fan-out on a
+// bucketed-meter analytics result. Mirrors the dim filter in
+// clickhouse.bucketedGroupByDims so the dispatch decision lives next to the
+// call site, and so calculateCosts can use the same predicate to gate
+// commitment math (commitment applied per combo would over-charge).
+func hasUserBucketedGroupBy(groupBy []string) bool {
+	for _, g := range groupBy {
+		if g == "source" || strings.HasPrefix(g, "properties.") {
+			return true
+		}
+	}
+	return false
+}
+
+// queryBucketedMeterAnalyticsDetailed is the analytics-side bucketed query: one
+// MeterUsageDetailedResult per (source, properties) combo, with per-combo
+// Points pre-fetched by the repo. Bypassed entirely for billing — billing
+// callers use queryBucketedMeterUsage which returns a single line-item total.
+func (s *meterUsageService) queryBucketedMeterAnalyticsDetailed(
+	ctx context.Context,
+	m *meter.Meter,
+	externalCustomerIDs []string,
+	periodStart, periodEnd time.Time,
+	billingAnchor *time.Time,
+	useFinal bool,
+	propertyFilters map[string][]string,
+	sources []string,
+	groupBy []string,
+) ([]*events.MeterUsageDetailedResult, error) {
+	aggType := m.Aggregation.Type
+	if m.IsBucketedSumMeter() {
+		aggType = types.AggregationSum
+	}
+	return s.repo.GetUsageForBucketedMetersDetailed(ctx, &events.MeterUsageQueryParams{
+		TenantID:            types.GetTenantID(ctx),
+		EnvironmentID:       types.GetEnvironmentID(ctx),
+		ExternalCustomerIDs: externalCustomerIDs,
+		MeterID:             m.ID,
+		StartTime:           periodStart,
+		EndTime:             periodEnd,
+		AggregationType:     aggType,
+		WindowSize:          m.Aggregation.BucketSize,
+		BillingAnchor:       billingAnchor,
+		// Intentionally do NOT forward m.Aggregation.GroupBy — the analytics
+		// fan-out shape is owned by the request's GroupBy. The meter-level
+		// GroupBy is a billing concept handled by GetUsageForBucketedMeters.
+		GroupBy:         groupBy,
+		UseFinal:        useFinal,
+		PropertyFilters: propertyFilters,
+		Sources:         sources,
 	})
 }
 
@@ -892,7 +998,7 @@ func (s *meterUsageService) mergeSubscriptionUsagesToAnalyticsData(
 		maps.Copy(data.Prices, su.PriceMap)
 		maps.Copy(data.Features, su.FeatureMap)
 
-		// Convert each LineItemMeterUsage → DetailedUsageAnalytic.
+		// Convert each LineItemMeterUsage → DetailedUsageAnalytic(s).
 		// Skip line items with zero usage to avoid noise, EXCEPT when the line item
 		// has a commitment — those need to flow through calculateCosts so the
 		// committed minimum (and true-up, if windowed) is applied even with no usage.
@@ -1516,6 +1622,10 @@ func (s *meterUsageService) getBucketedMeterAnalytics(
 	params *events.MeterUsageDetailedAnalyticsParams,
 	m *meter.Meter,
 ) ([]*events.MeterUsageDetailedResult, error) {
+	var bucketParamsGroupBy []string
+	if m.Aggregation.GroupBy != "" {
+		bucketParamsGroupBy = []string{"properties." + m.Aggregation.GroupBy}
+	}
 	bucketParams := &events.MeterUsageQueryParams{
 		TenantID:           params.TenantID,
 		EnvironmentID:      params.EnvironmentID,
@@ -1525,7 +1635,7 @@ func (s *meterUsageService) getBucketedMeterAnalytics(
 		EndTime:            params.EndTime,
 		AggregationType:    m.Aggregation.Type,
 		WindowSize:         m.Aggregation.BucketSize,
-		GroupByProperty:    m.Aggregation.GroupBy,
+		GroupBy:            bucketParamsGroupBy,
 		UseFinal:           params.UseFinal,
 		BillingAnchor:      params.BillingAnchor,
 		PropertyFilters:    params.PropertyFilters,
@@ -1779,7 +1889,14 @@ func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsD
 	// zero matching events would otherwise show the full commitment as unutilized
 	// and report it as cost). When any analytics-only filter is active, skip
 	// commitment application and report the raw filtered cost.
-	skipCommitment := len(data.Params.PropertyFilters) > 0 || len(data.Params.Sources) > 0
+	//
+	// User group_by also triggers skip: each fanned-out (source, properties)
+	// combo analytic carries its own per-combo Usage and Points, and applying
+	// commitment math per combo would over-charge — the line item's commitment
+	// would fire once per combo instead of once across the whole line item.
+	skipCommitment := len(data.Params.PropertyFilters) > 0 ||
+		len(data.Params.Sources) > 0 ||
+		hasUserBucketedGroupBy(data.Params.GroupBy)
 
 	for _, item := range data.Analytics {
 		// Resolve meter: prefer via feature, fall back to direct MeterID lookup.

--- a/internal/ee/service/meter_usage_test.go
+++ b/internal/ee/service/meter_usage_test.go
@@ -3979,3 +3979,80 @@ func (s *MeterUsageServiceSuite) TestBucketedMeter_EventCount() {
 	s.Equal(uint64(5), pointEventCount,
 		"sum of per-point EventCount: expected 5, got %d", pointEventCount)
 }
+
+// TestBucketedMeter_UserGroupByFansOutSourceAndProperties pins the prod report
+// where a bucketed MAX meter analytics request with
+// group_by=[source, properties.X] returned items with empty source and missing
+// properties. queryBucketedMeterUsage only forwarded the meter-level
+// Aggregation.GroupBy and silently dropped the user's group_by, so the bucketed
+// SQL never grouped by source/properties and the merge stamped one analytic per
+// line item with both fields blank.
+//
+// Setup: HOUR bucketed MAX meter, two events on the same day in different hours
+// with distinct (source, properties.region) combos. Request HOUR window with
+// group_by=[source, properties.region].
+//
+// Expected: two response items, one per combo, each with Source set and
+// Properties carrying the requested key.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_UserGroupByFansOutSourceAndProperties() {
+	ctx := s.GetContext()
+
+	bucketedMeter := &meter.Meter{
+		ID:        "mtr_ug_buck",
+		Name:      "Bucketed MAX user group_by",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationMax,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, bucketedMeter))
+	bucketedPrice := s.createPriceForMeter(ctx, "pr_ug_buck", bucketedMeter.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_ug_buck", bucketedMeter.ID, bucketedPrice.ID)
+
+	// Two events in different hours so the bucket maxes are independent.
+	s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "api",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 100,
+		map[string]interface{}{"region": "us-east"})
+	s.insertMeterUsageWithProps(ctx, bucketedMeter.ID, s.customer.ExternalID, "sdk",
+		time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 50,
+		map[string]interface{}{"region": "eu-west"})
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{bucketedMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		WindowSize:         types.WindowSizeHour,
+		GroupBy:            []string{"source", "properties.region"},
+	})
+	s.NoError(err)
+
+	byCombo := make(map[string]*dto.UsageAnalyticItem, 2)
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID != "li_ug_buck" {
+			continue
+		}
+		key := resp.Items[i].Source + "|" + resp.Items[i].Properties["region"]
+		byCombo[key] = &resp.Items[i]
+	}
+
+	s.Require().Lenf(byCombo, 2, "expected one item per (source, region) combo (total 2 combos), got %d items total", len(byCombo))
+
+	apiItem, ok := byCombo["api|us-east"]
+	s.Require().True(ok, "missing item for source=api region=us-east")
+	s.Equal("api", apiItem.Source)
+	s.Equal("us-east", apiItem.Properties["region"])
+	s.True(apiItem.TotalUsage.Equal(decimal.NewFromInt(100)),
+		"api/us-east total: expected 100, got %s", apiItem.TotalUsage)
+
+	sdkItem, ok := byCombo["sdk|eu-west"]
+	s.Require().True(ok, "missing item for source=sdk region=eu-west")
+	s.Equal("sdk", sdkItem.Source)
+	s.Equal("eu-west", sdkItem.Properties["region"])
+	s.True(sdkItem.TotalUsage.Equal(decimal.NewFromInt(50)),
+		"sdk/eu-west total: expected 50, got %s", sdkItem.TotalUsage)
+}

--- a/internal/ee/service/price_test.go
+++ b/internal/ee/service/price_test.go
@@ -997,8 +997,10 @@ func (s *PriceServiceSuite) TestCalculateCostFromUsageResults_TieredSlab() {
 	// krn1: 3 × ₹1 = ₹3; krn2: 10×₹1 + 2×₹2 = ₹14; total = ₹17
 	bucketStart := time.Now().Truncate(time.Hour)
 	results := []events.UsageResult{
-		{WindowSize: bucketStart, Value: decimal.NewFromInt(3), GroupKey: "krn1"},
-		{WindowSize: bucketStart, Value: decimal.NewFromInt(12), GroupKey: "krn2"},
+		// Per-group rows: GroupKey no longer carried on UsageResult — the per-row
+		// Value is what CalculateCostFromUsageResults consumes.
+		{WindowSize: bucketStart, Value: decimal.NewFromInt(3)},
+		{WindowSize: bucketStart, Value: decimal.NewFromInt(12)},
 	}
 
 	result := s.priceService.CalculateCostFromUsageResults(s.ctx, price, results)
@@ -1028,8 +1030,8 @@ func (s *PriceServiceSuite) TestCalculateCostFromUsageResults_TieredVolume() {
 	// One bucket: group A max=5 (tier 1 → 5*0.10=$0.50), group B max=15 (tier 2 → 15*0.05=$0.75); total=$1.25
 	bucketStart := time.Now().Truncate(time.Hour)
 	results := []events.UsageResult{
-		{WindowSize: bucketStart, Value: decimal.NewFromInt(5), GroupKey: "A"},
-		{WindowSize: bucketStart, Value: decimal.NewFromInt(15), GroupKey: "B"},
+		{WindowSize: bucketStart, Value: decimal.NewFromInt(5)},
+		{WindowSize: bucketStart, Value: decimal.NewFromInt(15)},
 	}
 
 	result := s.priceService.CalculateCostFromUsageResults(s.ctx, price, results)

--- a/internal/ee/service/usage_benchmark.go
+++ b/internal/ee/service/usage_benchmark.go
@@ -96,7 +96,7 @@ func (s *usageBenchmarkService) PublishEvent(ctx context.Context, event *events.
 	// events remain debuggable; analytics-kind events fall back to a timestamp suffix.
 	msgID := fmt.Sprintf("bench-%s-%d", event.SubscriptionID, time.Now().UnixNano())
 	if event.Kind == events.UsageBenchmarkKindAnalytics {
-		msgID = fmt.Sprintf("bench-analytics-%d", time.Now().UnixNano())
+		msgID = fmt.Sprintf("bench-analytics-%s", types.GenerateUUID())
 	}
 	msg := message.NewMessage(msgID, payload)
 	msg.Metadata.Set("tenant_id", event.TenantID)

--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -697,11 +697,13 @@ func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 	filterConditions := buildFilterConditions(params.Filters)
 	timeConditions := buildTimeConditions(params)
 
-	// When GroupByProperty is set, return per-group rows so tiered pricing can be applied per group (e.g. per KRN).
+	// When GroupBy has a "properties.X" entry, return per-group rows so tiered pricing
+	// can be applied per group (e.g. per KRN). The events-table SQL only supports
+	// a single property dim here; multi-dim grouping is on the bucketed-meter path.
 	// 1. per_group CTE: max per group per bucket (e.g., MAX per krn per hour)
 	// 2. Return each group's value with group_key; total is sum of all group values for backward compat
-	if params.GroupByProperty != "" && validateGroupByProperty(params.GroupByProperty) == nil {
-		groupByExpr := fmt.Sprintf("JSONExtractString(assumeNotNull(properties), '%s')", params.GroupByProperty)
+	if groupByProperty := events.FirstGroupByProperty(params.GroupBy); groupByProperty != "" && validateGroupByProperty(groupByProperty) == nil {
+		groupByExpr := fmt.Sprintf("JSONExtractString(assumeNotNull(properties), '%s')", groupByProperty)
 
 		return fmt.Sprintf(`
 			WITH per_group AS (

--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -304,9 +304,10 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 				value = decimal.NewFromUint64(countValue)
 			case types.AggregationMax, types.AggregationSum:
 				if params.BucketSize != "" {
+					groupByProperty := events.FirstGroupByProperty(params.GroupBy)
 					hasGroupBy := params.AggregationType == types.AggregationMax &&
-						params.GroupByProperty != "" &&
-						validateGroupByProperty(params.GroupByProperty) == nil
+						groupByProperty != "" &&
+						validateGroupByProperty(groupByProperty) == nil
 
 					bucketTotal, bucketValue, bucketTime, groupKey, err := scanBucketedRow(rows, hasGroupBy)
 					if err != nil {

--- a/internal/repository/clickhouse/feature_usage.go
+++ b/internal/repository/clickhouse/feature_usage.go
@@ -973,11 +973,11 @@ func (r *FeatureUsageRepository) getMaxBucketTotals(ctx context.Context, params 
 
 	// Add meter-level group_by property to inner query GROUP BY
 	// This ensures aggregation is applied per unique value of the group_by property within each bucket
-	if featureInfo.GroupByProperty != "" {
-		if err := validateGroupByProperty(featureInfo.GroupByProperty); err != nil {
+	if meterGroupByProp := events.FirstGroupByProperty(featureInfo.GroupBy); meterGroupByProp != "" {
+		if err := validateGroupByProperty(meterGroupByProp); err != nil {
 			return nil, err
 		}
-		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", featureInfo.GroupByProperty)
+		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", meterGroupByProp)
 		groupByColumns = append(groupByColumns, groupByExpr)
 		innerSelectColumns = append(innerSelectColumns, fmt.Sprintf("%s as meter_group_by", groupByExpr))
 	}
@@ -1295,12 +1295,12 @@ func (r *FeatureUsageRepository) getMaxBucketPointsForGroup(ctx context.Context,
 
 	// Complete the query with GROUP BY and ORDER BY
 	// Return bucket-level points with window metadata for service-layer merging
-	if featureInfo.GroupByProperty != "" {
+	if meterGroupByProp := events.FirstGroupByProperty(featureInfo.GroupBy); meterGroupByProp != "" {
 		// When group_by is set, add property to GROUP BY and wrap with a SUM across groups
-		if err := validateGroupByProperty(featureInfo.GroupByProperty); err != nil {
+		if err := validateGroupByProperty(meterGroupByProp); err != nil {
 			return nil, err
 		}
-		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", featureInfo.GroupByProperty)
+		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", meterGroupByProp)
 		innerQuery += fmt.Sprintf(" GROUP BY bucket_start, window_start, %s ORDER BY bucket_start", groupByExpr)
 
 		// Wrap the inner query to sum across groups per bucket
@@ -2343,7 +2343,8 @@ func (r *FeatureUsageRepository) GetUsageForBucketedMeters(ctx context.Context, 
 	var result events.AggregationResult
 	result.Type = params.UsageParams.AggregationType
 
-	hasGroupBy := params.UsageParams.GroupByProperty != "" && validateGroupByProperty(params.UsageParams.GroupByProperty) == nil
+	usageGroupByProp := events.FirstGroupByProperty(params.UsageParams.GroupBy)
+	hasGroupBy := usageGroupByProp != "" && validateGroupByProperty(usageGroupByProp) == nil
 
 	// For windowed queries, we need to process all rows
 	for rows.Next() {
@@ -2443,8 +2444,8 @@ func (r *FeatureUsageRepository) getWindowedQuery(ctx context.Context, params *e
 	// 1. Inner CTE: aggregate per group per bucket (e.g., MAX per krn per hour)
 	// 2. Middle CTE: SUM across groups per bucket (e.g., SUM of group maxes per hour)
 	// 3. Outer query: return per-bucket values and overall total
-	if params.UsageParams.GroupByProperty != "" && validateGroupByProperty(params.UsageParams.GroupByProperty) == nil {
-		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", params.UsageParams.GroupByProperty)
+	if usageGroupByProp := events.FirstGroupByProperty(params.UsageParams.GroupBy); usageGroupByProp != "" && validateGroupByProperty(usageGroupByProp) == nil {
+		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", usageGroupByProp)
 
 		return fmt.Sprintf(`
 			WITH per_group AS (

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -290,7 +290,7 @@ func (r *MeterUsageRepository) GetUsageForBucketedMeters(ctx context.Context, pa
 	r.logger.Debug(ctx, "executing bucketed meter usage query",
 		"meter_id", params.MeterID,
 		"window_size", params.WindowSize,
-		"group_by", params.GroupByProperty,
+		"group_by", params.GroupBy,
 	)
 
 	rows, err := r.store.GetConn().Query(ctx, query, args...)
@@ -309,8 +309,9 @@ func (r *MeterUsageRepository) GetUsageForBucketedMeters(ctx context.Context, pa
 	result.Type = params.AggregationType
 	result.MeterID = params.MeterID
 
-	hasGroupBy := params.GroupByProperty != "" && validMeterUsageGroupByPattern.MatchString(params.GroupByProperty)
-
+	// Both no-group and grouped SQL paths emit the same 5 columns: total,
+	// total_event_count, timestamp, value, event_count. Per-row dim values
+	// are no longer surfaced — no consumer reads them.
 	for rows.Next() {
 		var total decimal.Decimal
 		var totalEventCount uint64
@@ -318,38 +319,164 @@ func (r *MeterUsageRepository) GetUsageForBucketedMeters(ctx context.Context, pa
 		var value decimal.Decimal
 		var eventCount uint64
 
-		if hasGroupBy {
-			var groupKey string
-			if err := rows.Scan(&total, &totalEventCount, &windowStart, &value, &eventCount, &groupKey); err != nil {
-				return nil, ierr.WithError(err).
-					WithHint("Failed to scan bucketed meter usage row (with group_key)").
-					Mark(ierr.ErrDatabase)
-			}
-			result.Value = total
-			result.EventCount = totalEventCount
-			result.Results = append(result.Results, events.UsageResult{
-				WindowSize: windowStart,
-				Value:      value,
-				EventCount: eventCount,
-				GroupKey:   groupKey,
-			})
-		} else {
-			if err := rows.Scan(&total, &totalEventCount, &windowStart, &value, &eventCount); err != nil {
-				return nil, ierr.WithError(err).
-					WithHint("Failed to scan bucketed meter usage row").
-					Mark(ierr.ErrDatabase)
-			}
-			result.Value = total
-			result.EventCount = totalEventCount
-			result.Results = append(result.Results, events.UsageResult{
-				WindowSize: windowStart,
-				Value:      value,
-				EventCount: eventCount,
-			})
+		if err := rows.Scan(&total, &totalEventCount, &windowStart, &value, &eventCount); err != nil {
+			return nil, ierr.WithError(err).
+				WithHint("Failed to scan bucketed meter usage row").
+				Mark(ierr.ErrDatabase)
 		}
+		result.Value = total
+		result.EventCount = totalEventCount
+		result.Results = append(result.Results, events.UsageResult{
+			WindowSize: windowStart,
+			Value:      value,
+			EventCount: eventCount,
+		})
 	}
 
 	return &result, nil
+}
+
+// GetUsageForBucketedMetersDetailed runs the analytics-side bucketed query:
+// 1) the aggregate query returns one row per (source, properties) combo with
+// per-combo TotalUsage / EventCount; 2) for each combo, a follow-up query
+// fetches per-bucket Points. Matches feature_usage's two-query pattern so the
+// service layer doesn't have to re-group rows in Go.
+//
+// Callers MUST set params.GroupBy; otherwise an empty slice is returned (no
+// combos to enumerate). For the no-grouping case use GetUsageForBucketedMeters.
+func (r *MeterUsageRepository) GetUsageForBucketedMetersDetailed(ctx context.Context, params *events.MeterUsageQueryParams) ([]*events.MeterUsageDetailedResult, error) {
+	if params == nil {
+		return nil, ierr.NewError("params are required").Mark(ierr.ErrValidation)
+	}
+
+	aggQuery, aggArgs, dims := r.qb.BuildBucketedAggregateQuery(params)
+	if aggQuery == "" {
+		return nil, nil
+	}
+
+	r.logger.Debug(ctx, "executing bucketed detailed aggregate query",
+		"meter_id", params.MeterID,
+		"window_size", params.WindowSize,
+		"group_by", params.GroupBy,
+	)
+
+	rows, err := r.store.GetConn().Query(ctx, aggQuery, aggArgs...)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to execute bucketed detailed aggregate query").
+			WithReportableDetails(map[string]interface{}{
+				"meter_id":    params.MeterID,
+				"window_size": params.WindowSize,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+	defer rows.Close()
+
+	// Each row carries (dim values..., group_total, group_event_count).
+	results := make([]*events.MeterUsageDetailedResult, 0)
+	for rows.Next() {
+		dimVals := make([]string, len(dims))
+		var groupTotal decimal.Decimal
+		var groupEC uint64
+
+		scanArgs := make([]interface{}, 0, len(dims)+2)
+		for i := range dimVals {
+			scanArgs = append(scanArgs, &dimVals[i])
+		}
+		scanArgs = append(scanArgs, &groupTotal, &groupEC)
+
+		if err := rows.Scan(scanArgs...); err != nil {
+			return nil, ierr.WithError(err).
+				WithHint("Failed to scan bucketed detailed aggregate row").
+				Mark(ierr.ErrDatabase)
+		}
+
+		res := &events.MeterUsageDetailedResult{
+			MeterID:    params.MeterID,
+			Properties: make(map[string]string),
+			TotalUsage: groupTotal,
+			EventCount: groupEC,
+		}
+		// MAX bucketed meters also surface MaxUsage = TotalUsage for response parity.
+		if params.AggregationType != types.AggregationSum {
+			res.MaxUsage = groupTotal
+		}
+		for i, d := range dims {
+			if d.IsSource() {
+				res.Source = dimVals[i]
+			} else if d.IsProperty() {
+				res.Properties[d.PropertyName] = dimVals[i]
+			}
+		}
+		results = append(results, res)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Error iterating bucketed detailed aggregate rows").
+			Mark(ierr.ErrDatabase)
+	}
+
+	// Fetch Points per combo (one query each) when the caller asked for a
+	// window_size. Skip the round-trips when no time-series is needed.
+	if params.WindowSize != "" {
+		for _, res := range results {
+			pts, err := r.fetchBucketedComboPoints(ctx, params, dims, res.Source, res.Properties, params.AggregationType)
+			if err != nil {
+				return nil, err
+			}
+			res.Points = pts
+		}
+	}
+
+	return results, nil
+}
+
+// fetchBucketedComboPoints runs BuildBucketedPointsQuery for one combo and
+// converts the bucket rows into the MeterUsageDetailedPoint shape the response
+// builder consumes.
+func (r *MeterUsageRepository) fetchBucketedComboPoints(
+	ctx context.Context,
+	params *events.MeterUsageQueryParams,
+	dims []BucketedGroupByDim,
+	comboSource string,
+	comboProps map[string]string,
+	aggType types.AggregationType,
+) ([]events.MeterUsageDetailedPoint, error) {
+	query, args := r.qb.BuildBucketedPointsQuery(params, dims, comboSource, comboProps)
+	rows, err := r.store.GetConn().Query(ctx, query, args...)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to execute bucketed combo points query").
+			Mark(ierr.ErrDatabase)
+	}
+	defer rows.Close()
+
+	pts := make([]events.MeterUsageDetailedPoint, 0)
+	for rows.Next() {
+		var bucketStart time.Time
+		var bucketValue decimal.Decimal
+		var bucketEC uint64
+		if err := rows.Scan(&bucketStart, &bucketValue, &bucketEC); err != nil {
+			return nil, ierr.WithError(err).
+				WithHint("Failed to scan bucketed combo points row").
+				Mark(ierr.ErrDatabase)
+		}
+		p := events.MeterUsageDetailedPoint{
+			WindowStart: bucketStart,
+			TotalUsage:  bucketValue,
+			EventCount:  bucketEC,
+		}
+		if aggType != types.AggregationSum {
+			p.MaxUsage = bucketValue
+		}
+		pts = append(pts, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Error iterating bucketed combo points rows").
+			Mark(ierr.ErrDatabase)
+	}
+	return pts, nil
 }
 
 // GetDistinctMeterIDs returns the set of meter_ids that have data in meter_usage

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -332,6 +332,14 @@ func (r *MeterUsageRepository) GetUsageForBucketedMeters(ctx context.Context, pa
 			EventCount: eventCount,
 		})
 	}
+	// rows.Next() returns false on both end-of-rows and iteration error.
+	// Without this check we'd silently return partial results as success and
+	// downstream billing totals would be wrong.
+	if err := rows.Err(); err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Error iterating bucketed meter usage rows").
+			Mark(ierr.ErrDatabase)
+	}
 
 	return &result, nil
 }

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -12,6 +12,77 @@ import (
 // validMeterUsageGroupByPattern matches safe property names (alphanumeric, underscores, dots).
 var validMeterUsageGroupByPattern = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
 
+// BucketedGroupByDim describes one group_by dimension supported by the bucketed
+// query: "source" and "properties.X" only. Public so the repo's scan code can
+// read the alias / property name without re-parsing the input.
+type BucketedGroupByDim struct {
+	// kind: "source" or "property"
+	kind string
+	// PropertyName: the JSON property name when kind=="property", "" when kind=="source"
+	PropertyName string
+	// sql is the column expression used inside the inner CTE
+	sql string
+	// alias is the column alias used in the SELECT and the outer GROUP BY/ORDER BY
+	alias string
+}
+
+// IsSource reports whether this dim is the "source" axis.
+func (d BucketedGroupByDim) IsSource() bool { return d.kind == "source" }
+
+// IsProperty reports whether this dim is a property axis.
+func (d BucketedGroupByDim) IsProperty() bool { return d.kind == "property" }
+
+// Alias is the output column alias for the dim (used by the scanner).
+func (d BucketedGroupByDim) Alias() string { return d.alias }
+
+// bucketedGroupByDims parses the GroupBy list into the dimensions
+// BuildBucketedQuery / BuildBucketedAggregateQuery know how to emit.
+// feature_id / meter_id are silently dropped (implicit at the meter level);
+// unknown entries and invalid property names are also dropped. Duplicate names
+// are deduped. Empty input → nil → caller takes the non-grouped path.
+func bucketedGroupByDims(groupBy []string) []BucketedGroupByDim {
+	if len(groupBy) == 0 {
+		return nil
+	}
+	out := make([]BucketedGroupByDim, 0, len(groupBy))
+	seen := make(map[string]struct{}, len(groupBy))
+	for _, g := range groupBy {
+		switch {
+		case g == "source":
+			if _, ok := seen["source"]; ok {
+				continue
+			}
+			seen["source"] = struct{}{}
+			out = append(out, BucketedGroupByDim{
+				kind:  "source",
+				sql:   "source",
+				alias: "grp_source",
+			})
+		case strings.HasPrefix(g, "properties."):
+			propName := strings.TrimPrefix(g, "properties.")
+			if propName == "" || !validMeterUsageGroupByPattern.MatchString(propName) {
+				continue
+			}
+			key := "p:" + propName
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			alias := "prop_" + strings.ReplaceAll(propName, ".", "_")
+			out = append(out, BucketedGroupByDim{
+				kind:         "property",
+				PropertyName: propName,
+				sql:          fmt.Sprintf("JSONExtractString(properties, '%s')", propName),
+				alias:        alias,
+			})
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // MeterUsageQueryBuilder constructs SQL queries for the meter_usage table.
 // It encapsulates WHERE clause construction, FINAL handling, and window grouping
 // so that aggregators only need to specify their aggregation expression.
@@ -202,32 +273,44 @@ func (qb *MeterUsageQueryBuilder) BuildBucketedQuery(params *events.MeterUsageQu
 		tableRef = "meter_usage " + finalClause
 	}
 
-	// With GroupBy: 3-level aggregation
-	if params.GroupByProperty != "" && validMeterUsageGroupByPattern.MatchString(params.GroupByProperty) {
-		groupByExpr := fmt.Sprintf("JSONExtractString(properties, '%s')", params.GroupByProperty)
+	// With GroupBy (billing per-KRN, source, properties.*): per-(bucket, dim
+	// combo) rows. Same shape downstream consumers used to get from the legacy
+	// group_key path — multiple Values per WindowSize, which
+	// CalculateCostFromUsageResults prices independently and
+	// aggregateUsageResultsByWindow rolls up. Analytics callers go through
+	// BuildBucketedAggregateQuery instead for per-combo totals + separate
+	// Points; this method is for billing and the legacy path.
+	if dims := bucketedGroupByDims(params.GroupBy); len(dims) > 0 {
+		selectExprs := make([]string, 0, len(dims))
+		aliases := make([]string, 0, len(dims))
+		for _, d := range dims {
+			selectExprs = append(selectExprs, fmt.Sprintf("%s as %s", d.sql, d.alias))
+			aliases = append(aliases, d.alias)
+		}
+		dimSelects := strings.Join(selectExprs, ",\n\t\t\t\t\t")
+		dimGroupBy := strings.Join(aliases, ", ")
 
 		query := fmt.Sprintf(`
 			WITH per_group AS (
 				SELECT
 					%s as bucket_start,
-					%s as group_key,
+					%s,
 					%s(qty_total) as group_value,
 					COUNT(DISTINCT id) as group_event_count
 				FROM %s
 				WHERE %s
-				GROUP BY bucket_start, group_key
+				GROUP BY bucket_start, %s
 			)
 			SELECT
 				(SELECT sum(group_value) FROM per_group) as total,
 				(SELECT sum(group_event_count) FROM per_group) as total_event_count,
 				bucket_start as timestamp,
 				group_value as value,
-				group_event_count as event_count,
-				group_key
+				group_event_count as event_count
 			FROM per_group
-			ORDER BY bucket_start, group_key
+			ORDER BY bucket_start, %s
 			%s
-		`, bucketWindow, groupByExpr, aggFunc, tableRef, where, settings)
+		`, bucketWindow, dimSelects, aggFunc, tableRef, where, dimGroupBy, dimGroupBy, settings)
 
 		return query, args
 	}
@@ -262,6 +345,128 @@ func (qb *MeterUsageQueryBuilder) BuildBucketedQuery(params *events.MeterUsageQu
 		bucketColumnName,
 		bucketTableName,
 		settings)
+
+	return query, args
+}
+
+// BuildBucketedAggregateQuery returns a per-combo aggregate query for the
+// bucketed-meter analytics path with GroupBy (subset of {"source",
+// "properties.X"}). Two-level CTE — inner per-(bucket, combo), outer per-combo —
+// so ClickHouse does the bucket→total roll-up and we ship one row per combo
+// instead of bucket × combo rows. Mirrors feature_usage's getMaxBucketTotals.
+//
+// Output columns (in order):
+//
+//	<dim aliases (one per GroupBy entry)>, group_total, group_event_count
+//
+// Returns ("", nil) when params.GroupBy yields no valid dims — caller should
+// fall back to BuildBucketedQuery in that case.
+func (qb *MeterUsageQueryBuilder) BuildBucketedAggregateQuery(params *events.MeterUsageQueryParams) (string, []interface{}, []BucketedGroupByDim) {
+	dims := bucketedGroupByDims(params.GroupBy)
+	if len(dims) == 0 {
+		return "", nil, nil
+	}
+
+	bucketWindow := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor)
+	where, args := qb.BuildWhereClause(params)
+	finalClause, settings := qb.BuildFinalClause(params.UseFinal)
+
+	aggFunc := "MAX"
+	if params.AggregationType == types.AggregationSum {
+		aggFunc = "SUM"
+	}
+	tableRef := "meter_usage"
+	if finalClause != "" {
+		tableRef = "meter_usage " + finalClause
+	}
+
+	selectExprs := make([]string, 0, len(dims))
+	aliases := make([]string, 0, len(dims))
+	for _, d := range dims {
+		selectExprs = append(selectExprs, fmt.Sprintf("%s as %s", d.sql, d.alias))
+		aliases = append(aliases, d.alias)
+	}
+	dimSelects := strings.Join(selectExprs, ",\n\t\t\t\t\t")
+	dimAliases := strings.Join(aliases, ", ")
+
+	query := fmt.Sprintf(`
+		WITH per_group_bucket AS (
+			SELECT
+				%s as bucket_start,
+				%s,
+				%s(qty_total) as bucket_value,
+				COUNT(DISTINCT id) as bucket_event_count
+			FROM %s
+			WHERE %s
+			GROUP BY bucket_start, %s
+		)
+		SELECT
+			%s,
+			sum(bucket_value) as group_total,
+			sum(bucket_event_count) as group_event_count
+		FROM per_group_bucket
+		GROUP BY %s
+		ORDER BY %s
+		%s
+	`,
+		bucketWindow, dimSelects, aggFunc, tableRef, where, dimAliases,
+		dimAliases, dimAliases, dimAliases, settings)
+
+	return query, args, dims
+}
+
+// BuildBucketedPointsQuery returns a per-bucket time-series query narrowed to
+// a single (source, properties) combo. Mirrors feature_usage's
+// getAnalyticsPoints — invoked once per row returned by
+// BuildBucketedAggregateQuery to populate that result's Points slice.
+//
+// comboSource is "" when "source" is not in GroupBy; comboProps maps each
+// property dim's name → its concrete value for this combo (empty map allowed).
+//
+// Output columns: bucket_start, bucket_value, bucket_event_count.
+func (qb *MeterUsageQueryBuilder) BuildBucketedPointsQuery(
+	params *events.MeterUsageQueryParams,
+	dims []BucketedGroupByDim,
+	comboSource string,
+	comboProps map[string]string,
+) (string, []interface{}) {
+	bucketWindow := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor)
+	where, args := qb.BuildWhereClause(params)
+	finalClause, settings := qb.BuildFinalClause(params.UseFinal)
+
+	aggFunc := "MAX"
+	if params.AggregationType == types.AggregationSum {
+		aggFunc = "SUM"
+	}
+	tableRef := "meter_usage"
+	if finalClause != "" {
+		tableRef = "meter_usage " + finalClause
+	}
+
+	// Append combo equality predicates so this query returns only the rows
+	// that contributed to one specific aggregate row.
+	extraWhere := where
+	for _, d := range dims {
+		if d.IsSource() {
+			extraWhere += " AND source = ?"
+			args = append(args, comboSource)
+		} else if d.IsProperty() {
+			extraWhere += " AND JSONExtractString(properties, ?) = ?"
+			args = append(args, d.PropertyName, comboProps[d.PropertyName])
+		}
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			%s as bucket_start,
+			%s(qty_total) as bucket_value,
+			COUNT(DISTINCT id) as bucket_event_count
+		FROM %s
+		WHERE %s
+		GROUP BY bucket_start
+		ORDER BY bucket_start
+		%s
+	`, bucketWindow, aggFunc, tableRef, extraWhere, settings)
 
 	return query, args
 }

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -450,7 +450,7 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 		return aggregateScalar(recs, types.AggregationMax)
 	}
 
-	hasGroupBy := params.GroupByProperty != ""
+	dims := parseInMemoryGroupBy(params.GroupBy)
 
 	// Bucket records by window first.
 	byBucket := make(map[time.Time][]*events.MeterUsage)
@@ -461,25 +461,37 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 
 	type entry struct {
 		bucket     time.Time
-		group      string
+		groupKey   string
 		value      decimal.Decimal
 		eventCount uint64
 	}
 	entries := make([]entry, 0)
 
-	if hasGroupBy {
+	if len(dims) > 0 {
+		// Build a deterministic per-(bucket, combo) entry. We don't surface the
+		// combo dim values on UsageResult — billing's CalculateCostFromUsageResults
+		// only reads Value, and per-row group identity isn't consumed downstream.
+		// groupKey is just used here for stable sort order within a bucket.
 		for bucket, recs := range byBucket {
-			byGroup := make(map[string][]*events.MeterUsage)
+			byCombo := make(map[string][]*events.MeterUsage)
 			for _, r := range recs {
-				gk := propertyValue(r.Properties, params.GroupByProperty)
-				byGroup[gk] = append(byGroup[gk], r)
+				var parts []string
+				for _, d := range dims {
+					if d.isSource {
+						parts = append(parts, "s="+r.Source)
+					} else {
+						parts = append(parts, d.propName+"="+propertyValue(r.Properties, d.propName))
+					}
+				}
+				k := strings.Join(parts, "|")
+				byCombo[k] = append(byCombo[k], r)
 			}
-			for gk, grecs := range byGroup {
+			for k, crecs := range byCombo {
 				entries = append(entries, entry{
 					bucket:     bucket,
-					group:      gk,
-					value:      aggFn(grecs),
-					eventCount: uint64(distinctIDCount(grecs)),
+					groupKey:   k,
+					value:      aggFn(crecs),
+					eventCount: uint64(distinctIDCount(crecs)),
 				})
 			}
 		}
@@ -487,7 +499,7 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 			if !entries[i].bucket.Equal(entries[j].bucket) {
 				return entries[i].bucket.Before(entries[j].bucket)
 			}
-			return entries[i].group < entries[j].group
+			return entries[i].groupKey < entries[j].groupKey
 		})
 	} else {
 		for bucket, recs := range byBucket {
@@ -503,13 +515,218 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 	for _, e := range entries {
 		result.Value = result.Value.Add(e.value)
 		result.EventCount += e.eventCount
-		ur := events.UsageResult{WindowSize: e.bucket, Value: e.value, EventCount: e.eventCount}
-		if hasGroupBy {
-			ur.GroupKey = e.group
-		}
-		result.Results = append(result.Results, ur)
+		// Legacy group_key is intentionally dropped; per-group rows still
+		// carry their own Value, which is what billing consumes.
+		result.Results = append(result.Results, events.UsageResult{
+			WindowSize: e.bucket,
+			Value:      e.value,
+			EventCount: e.eventCount,
+		})
 	}
 	return result, nil
+}
+
+// GetUsageForBucketedMetersDetailed mirrors the SQL pattern:
+//   - aggregate per (combo) → one MeterUsageDetailedResult per combo
+//     with TotalUsage / EventCount / MaxUsage already rolled up across buckets,
+//   - then per-bucket Points filtered to that combo.
+//
+// When GroupBy is empty, returns nil so the caller falls back to
+// GetUsageForBucketedMeters.
+func (s *InMemoryMeterUsageStore) GetUsageForBucketedMetersDetailed(_ context.Context, params *events.MeterUsageQueryParams) ([]*events.MeterUsageDetailedResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dims := parseInMemoryGroupBy(params.GroupBy)
+	if len(dims) == 0 {
+		return nil, nil
+	}
+
+	matched := make([]*events.MeterUsage, 0)
+	for _, r := range s.records {
+		if matchRecord(r, params) {
+			matched = append(matched, r)
+		}
+	}
+
+	aggFn := func(recs []*events.MeterUsage) decimal.Decimal {
+		if params.AggregationType == types.AggregationSum {
+			return aggregateScalar(recs, types.AggregationSum)
+		}
+		return aggregateScalar(recs, types.AggregationMax)
+	}
+
+	// Group matched records by (bucket, combo) — the inner CTE in SQL.
+	type comboKey struct {
+		source string
+		props  string
+	}
+	dimCombo := func(r *events.MeterUsage) (comboKey, string, map[string]string) {
+		ck := comboKey{}
+		propMap := make(map[string]string)
+		var parts []string
+		for _, d := range dims {
+			if d.isSource {
+				ck.source = r.Source
+			} else {
+				v := propertyValue(r.Properties, d.propName)
+				propMap[d.propName] = v
+				parts = append(parts, d.propName+"="+v)
+			}
+		}
+		ck.props = strings.Join(parts, "|")
+		return ck, ck.source, propMap
+	}
+
+	type bucketCell struct {
+		value      decimal.Decimal
+		eventCount uint64
+	}
+	type comboState struct {
+		source string
+		props  map[string]string
+		// per-bucket cells in chronological order
+		buckets []time.Time
+		cells   map[time.Time]*bucketCell
+		total   decimal.Decimal
+		eventTC uint64
+	}
+	combos := make(map[comboKey]*comboState)
+
+	byBucket := make(map[time.Time][]*events.MeterUsage)
+	for _, r := range matched {
+		bk := truncateToWindow(r.Timestamp, params.WindowSize, params.BillingAnchor)
+		byBucket[bk] = append(byBucket[bk], r)
+	}
+	for bucket, recs := range byBucket {
+		byComboBucket := make(map[comboKey][]*events.MeterUsage)
+		for _, r := range recs {
+			ck, _, _ := dimCombo(r)
+			byComboBucket[ck] = append(byComboBucket[ck], r)
+		}
+		for ck, crecs := range byComboBucket {
+			cs, ok := combos[ck]
+			if !ok {
+				_, src, props := dimCombo(crecs[0])
+				cs = &comboState{
+					source: src,
+					props:  props,
+					cells:  make(map[time.Time]*bucketCell),
+				}
+				combos[ck] = cs
+			}
+			v := aggFn(crecs)
+			ec := uint64(distinctIDCount(crecs))
+			cs.cells[bucket] = &bucketCell{value: v, eventCount: ec}
+			cs.buckets = append(cs.buckets, bucket)
+			cs.total = cs.total.Add(v)
+			cs.eventTC += ec
+		}
+	}
+
+	// Materialize sorted by source then props, then per-combo buckets sorted by time.
+	keys := make([]comboKey, 0, len(combos))
+	for k := range combos {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].source != keys[j].source {
+			return keys[i].source < keys[j].source
+		}
+		return keys[i].props < keys[j].props
+	})
+
+	results := make([]*events.MeterUsageDetailedResult, 0, len(keys))
+	for _, k := range keys {
+		cs := combos[k]
+		res := &events.MeterUsageDetailedResult{
+			MeterID:    params.MeterID,
+			Source:     cs.source,
+			Properties: cs.props,
+			TotalUsage: cs.total,
+			EventCount: cs.eventTC,
+		}
+		if params.AggregationType != types.AggregationSum {
+			res.MaxUsage = cs.total
+		}
+		if params.WindowSize != "" {
+			sort.Slice(cs.buckets, func(i, j int) bool { return cs.buckets[i].Before(cs.buckets[j]) })
+			pts := make([]events.MeterUsageDetailedPoint, 0, len(cs.buckets))
+			for _, bk := range cs.buckets {
+				cell := cs.cells[bk]
+				p := events.MeterUsageDetailedPoint{
+					WindowStart: bk,
+					TotalUsage:  cell.value,
+					EventCount:  cell.eventCount,
+				}
+				if params.AggregationType != types.AggregationSum {
+					p.MaxUsage = cell.value
+				}
+				pts = append(pts, p)
+			}
+			res.Points = pts
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+// inMemoryGroupByDim is the in-memory mirror of the SQL builder's
+// BucketedGroupByDim. Defined locally to avoid the testutil → clickhouse
+// repo import that would create a cycle.
+type inMemoryGroupByDim struct {
+	isSource bool
+	propName string
+}
+
+// parseInMemoryGroupBy mirrors clickhouse.bucketedGroupByDims: honors
+// "source" and "properties.X" entries, drops anything else (feature_id,
+// meter_id, unrecognized values), dedupes.
+func parseInMemoryGroupBy(groupBy []string) []inMemoryGroupByDim {
+	if len(groupBy) == 0 {
+		return nil
+	}
+	out := make([]inMemoryGroupByDim, 0, len(groupBy))
+	seen := make(map[string]struct{}, len(groupBy))
+	for _, g := range groupBy {
+		switch {
+		case g == "source":
+			if _, ok := seen["source"]; ok {
+				continue
+			}
+			seen["source"] = struct{}{}
+			out = append(out, inMemoryGroupByDim{isSource: true})
+		case strings.HasPrefix(g, "properties."):
+			propName := strings.TrimPrefix(g, "properties.")
+			if propName == "" {
+				continue
+			}
+			key := "p:" + propName
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, inMemoryGroupByDim{propName: propName})
+		}
+	}
+	return out
+}
+
+// propsString produces a deterministic serialization for entry.props sorting.
+func propsString(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k+"="+m[k])
+	}
+	return strings.Join(out, "|")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Usage analytics now supports grouping by multiple dimensions at once (for example, `source` plus specific `properties` fields).
  * Billing/feature usage analytics can return **detailed** bucketed breakdowns per `(source, properties...)` combination.
  * Existing single-property grouping configurations continue to work for backward compatibility.

* **Improvements / Bug Fixes**
  * More rigorous handling of invalid `group_by` inputs to prevent silently dropped dimensions.

* **Tests**
  * Added coverage for fan-out when grouping by `source` and `properties.region`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->