### PR TITLE
feat(kafka): optional second-cluster dual-write for AWS→GCP migration

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -119,6 +119,7 @@ func main() {
 
 			// Producers and Consumers
 			kafka.NewProducer,
+			kafka.NewSecondaryProducer,
 			kafka.NewConsumer,
 
 			// Event Publisher

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,12 @@ type Configuration struct {
 	Server                     ServerConfig                     `validate:"required"`
 	Auth                       AuthConfig                       `validate:"required"`
 	Kafka                      KafkaConfig                      `validate:"required"`
+	// KafkaSecondary is the optional second Kafka cluster the source event publisher also
+	// writes to during the AWS→GCP migration (the "other" cloud's cluster). When set
+	// (non-nil) every event is published to it in addition to the local `kafka` cluster;
+	// when nil, publishing is single-cluster. The `kafka` block is this deployment's own
+	// local cluster — consumed AND always written. See infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
+	KafkaSecondary             *KafkaConfig                     `mapstructure:"kafka_secondary" validate:"omitempty"`
 	ClickHouse                 ClickHouseConfig                 `validate:"required"`
 	Logging                    LoggingConfig                    `validate:"required"`
 	Postgres                   PostgresConfig                   `validate:"required"`
@@ -711,6 +717,24 @@ func NewConfig() (*Configuration, error) {
 	_ = v.BindEnv("auth.api_key.header", "FLEXPRICE_AUTH_API_KEY_HEADER")
 	// NOTE: auth.api_key.keys is intentionally NOT bound here because the env var is a
 	// JSON string but Viper/mapstructure expects a map. It is handled manually in Step 6.
+
+	// Explicitly bind the second-cluster keys — their segment (kafka_secondary) contains an
+	// underscore, which AutomaticEnv cannot disambiguate, and kafka_secondary is absent from
+	// the YAML defaults (nil unless configured). Without these binds, FLEXPRICE_KAFKA_SECONDARY_*
+	// are silently ignored and dual-write never turns on. See infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
+	_ = v.BindEnv("kafka_secondary.brokers", "FLEXPRICE_KAFKA_SECONDARY_BROKERS")
+	_ = v.BindEnv("kafka_secondary.consumer_group", "FLEXPRICE_KAFKA_SECONDARY_CONSUMER_GROUP")
+	_ = v.BindEnv("kafka_secondary.topic", "FLEXPRICE_KAFKA_SECONDARY_TOPIC")
+	_ = v.BindEnv("kafka_secondary.topic_lazy", "FLEXPRICE_KAFKA_SECONDARY_TOPIC_LAZY")
+	_ = v.BindEnv("kafka_secondary.topic_dlq", "FLEXPRICE_KAFKA_SECONDARY_TOPIC_DLQ")
+	_ = v.BindEnv("kafka_secondary.tls", "FLEXPRICE_KAFKA_SECONDARY_TLS")
+	_ = v.BindEnv("kafka_secondary.use_sasl", "FLEXPRICE_KAFKA_SECONDARY_USE_SASL")
+	_ = v.BindEnv("kafka_secondary.sasl_mechanism", "FLEXPRICE_KAFKA_SECONDARY_SASL_MECHANISM")
+	_ = v.BindEnv("kafka_secondary.sasl_user", "FLEXPRICE_KAFKA_SECONDARY_SASL_USER")
+	_ = v.BindEnv("kafka_secondary.sasl_password", "FLEXPRICE_KAFKA_SECONDARY_SASL_PASSWORD")
+	_ = v.BindEnv("kafka_secondary.sasl_oauth_scopes", "FLEXPRICE_KAFKA_SECONDARY_SASL_OAUTH_SCOPES")
+	_ = v.BindEnv("kafka_secondary.client_id", "FLEXPRICE_KAFKA_SECONDARY_CLIENT_ID")
+	_ = v.BindEnv("kafka_secondary.route_tenants_on_lazy_mode", "FLEXPRICE_KAFKA_SECONDARY_ROUTE_TENANTS_ON_LAZY_MODE")
 
 	// Step 5: Read the YAML file
 	if err := v.ReadInConfig(); err != nil {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -34,6 +34,28 @@ kafka:
   client_id: "flexprice-client-local"
   route_tenants_on_lazy_mode: []
 
+# Optional SECOND Kafka cluster for the AWS→GCP migration (GCP-CUTOVER-STEPWISE.md).
+# `kafka` above = this deployment's own/local cluster (consumed AND always written).
+# `kafka_secondary` below = the other cloud's cluster. Dual-write is PRESENCE-BASED:
+#   single cluster (today):  kafka_secondary absent  -> writes local only
+#   dual-write (migration):  kafka_secondary set     -> writes local + secondary
+# Writes are independent (one failing does not block the other). Consumers/webhooks/DLQ
+# always read the local `kafka` cluster. Per deployment:
+#   AWS box: kafka=MSK, kafka_secondary=GMK ;  GCP box: kafka=GMK, kafka_secondary=MSK.
+# Set via FLEXPRICE_KAFKA_SECONDARY_* env. kafka_secondary mirrors the kafka block:
+# kafka_secondary:
+#   brokers: ""
+#   consumer_group: "flexprice-consumer"
+#   topic: "events"
+#   topic_lazy: "events_lazy"
+#   topic_dlq: "events_dlq"
+#   tls: true
+#   use_sasl: true
+#   sasl_mechanism: "OAUTHBEARER"
+#   sasl_oauth_scopes: []   # defaults to https://www.googleapis.com/auth/cloud-platform
+#   client_id: "flexprice-client"
+#   route_tenants_on_lazy_mode: []
+
 clickhouse:
   address: 127.0.0.1:9000 # For local mode
   # Will be overridden by FLEXPRICE_CLICKHOUSE_ADDRESS env var in Docker

--- a/internal/config/dualwrite_env_test.go
+++ b/internal/config/dualwrite_env_test.go
@@ -1,0 +1,41 @@
+package config
+
+import "testing"
+
+// TestKafkaSecondaryEnvBinding verifies the second-cluster keys (whose segment contains an
+// underscore) actually bind from FLEXPRICE_* env vars through the real NewConfig loader, so
+// setting FLEXPRICE_KAFKA_SECONDARY_* makes cfg.KafkaSecondary non-nil (presence-based
+// dual-write). Without the explicit BindEnv calls these would be silently dropped.
+func TestKafkaSecondaryEnvBinding(t *testing.T) {
+	t.Setenv("FLEXPRICE_KAFKA_SECONDARY_BROKERS", "other-bootstrap:9092")
+	t.Setenv("FLEXPRICE_KAFKA_SECONDARY_USE_SASL", "true")
+	t.Setenv("FLEXPRICE_KAFKA_SECONDARY_SASL_MECHANISM", "OAUTHBEARER")
+	t.Setenv("FLEXPRICE_KAFKA_SECONDARY_TOPIC", "events")
+
+	cfg, err := NewConfig()
+	if err != nil {
+		t.Fatalf("NewConfig failed: %v", err)
+	}
+
+	if cfg.KafkaSecondary == nil {
+		t.Fatal("expected KafkaSecondary to be populated from env (dual-write on), got nil")
+	}
+	if len(cfg.KafkaSecondary.Brokers) == 0 || cfg.KafkaSecondary.Brokers[0] != "other-bootstrap:9092" {
+		t.Errorf("expected secondary brokers from env, got %v", cfg.KafkaSecondary.Brokers)
+	}
+	if !cfg.KafkaSecondary.UseSASL || string(cfg.KafkaSecondary.SASLMechanism) != "OAUTHBEARER" {
+		t.Errorf("expected secondary SASL OAUTHBEARER, got use_sasl=%v mechanism=%q",
+			cfg.KafkaSecondary.UseSASL, cfg.KafkaSecondary.SASLMechanism)
+	}
+}
+
+// TestKafkaSecondaryAbsentByDefault confirms single-cluster is the default (no dual-write).
+func TestKafkaSecondaryAbsentByDefault(t *testing.T) {
+	cfg, err := NewConfig()
+	if err != nil {
+		t.Fatalf("NewConfig failed: %v", err)
+	}
+	if cfg.KafkaSecondary != nil {
+		t.Errorf("expected KafkaSecondary nil by default (single-cluster), got %+v", cfg.KafkaSecondary)
+	}
+}

--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -15,12 +15,16 @@ import (
 	"github.com/xdg-go/scram"
 )
 
-func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
+// GetSaramaConfig builds a Sarama config for a single Kafka cluster. It takes the
+// cluster's KafkaConfig directly (rather than the whole Configuration) so the same
+// builder serves both the local cluster (cfg.Kafka) and the optional second cluster
+// (cfg.KafkaSecondary) during the AWS→GCP migration — see infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
+func GetSaramaConfig(kafkaCfg *config.KafkaConfig) *sarama.Config {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_1_0_0
 
 	// Configure client ID regardless of SASL
-	saramaConfig.ClientID = cfg.Kafka.ClientID
+	saramaConfig.ClientID = kafkaCfg.ClientID
 
 	// Set consumer offset reset policy to ensure we don't miss messages
 	// "earliest" ensures that when a consumer starts with no initial offset or
@@ -34,14 +38,14 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 	// When rebalancing happens, use the last committed offset
 	saramaConfig.Consumer.Offsets.Retry.Max = 3
 
-	if cfg.Kafka.TLS {
+	if kafkaCfg.TLS {
 		saramaConfig.Net.TLS.Enable = true
 		saramaConfig.Net.TLS.Config = &tls.Config{
 			InsecureSkipVerify: false,
 		}
 	}
 
-	if !cfg.Kafka.UseSASL {
+	if !kafkaCfg.UseSASL {
 		return saramaConfig
 	}
 
@@ -50,28 +54,28 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 	saramaConfig.Net.TLS.Enable = true
 
 	// sasl configs
-	saramaConfig.Net.SASL.Mechanism = cfg.Kafka.SASLMechanism
+	saramaConfig.Net.SASL.Mechanism = kafkaCfg.SASLMechanism
 
-	switch cfg.Kafka.SASLMechanism {
+	switch kafkaCfg.SASLMechanism {
 	case sarama.SASLTypeOAuth:
 		// OAUTHBEARER (e.g. GCP Managed Kafka). Token comes from Application
 		// Default Credentials — Workload Identity on GKE, gcloud locally.
 		// User/Password are not used.
-		provider, err := newGCPTokenProvider(context.Background(), cfg.Kafka.SASLOAuthScopes)
+		provider, err := newGCPTokenProvider(context.Background(), kafkaCfg.SASLOAuthScopes)
 		if err != nil {
-			panic(fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", cfg.Kafka.SASLOAuthScopes, err))
+			panic(fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", kafkaCfg.SASLOAuthScopes, err))
 		}
 		saramaConfig.Net.SASL.TokenProvider = provider
 	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512:
-		saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
-		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
+		saramaConfig.Net.SASL.User = kafkaCfg.SASLUser
+		saramaConfig.Net.SASL.Password = kafkaCfg.SASLPassword
 		saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
-			return &XDGSCRAMClient{HashGeneratorFcn: getHashGenerator(cfg.Kafka.SASLMechanism)}
+			return &XDGSCRAMClient{HashGeneratorFcn: getHashGenerator(kafkaCfg.SASLMechanism)}
 		}
 	default:
 		// PLAIN and any other mechanism that uses user+password.
-		saramaConfig.Net.SASL.User = cfg.Kafka.SASLUser
-		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
+		saramaConfig.Net.SASL.User = kafkaCfg.SASLUser
+		saramaConfig.Net.SASL.Password = kafkaCfg.SASLPassword
 	}
 
 	return saramaConfig

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -26,7 +26,7 @@ func NewConsumer(cfg *config.Configuration) (MessageConsumer, error) {
 	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
 	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
 
-	saramaConfig := GetSaramaConfig(cfg)
+	saramaConfig := GetSaramaConfig(&cfg.Kafka)
 	if saramaConfig != nil {
 		// Optimize consumer configs for throughput
 		// TODO: move this to config

--- a/internal/kafka/event_publisher.go
+++ b/internal/kafka/event_publisher.go
@@ -14,18 +14,44 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 )
 
-type EventPublisher struct {
-	producer *Producer
-	logger   *logger.Logger
-	config   *config.KafkaConfig
+// messagePublisher is the subset of the watermill publisher that EventPublisher depends
+// on. *Producer satisfies it; tests substitute a fake to exercise the fan-out without a broker.
+type messagePublisher interface {
+	Publish(topic string, messages ...*message.Message) error
 }
 
-func NewEventPublisher(producer *Producer, cfg *config.Configuration, logger *logger.Logger) *EventPublisher {
-	return &EventPublisher{
-		producer: producer,
-		logger:   logger,
-		config:   &cfg.Kafka,
+// EventPublisher publishes source events to Kafka. It always writes to the deployment's
+// local cluster (cfg.Kafka); during the AWS→GCP migration, if a second cluster is
+// configured (cfg.KafkaSecondary), it also writes there (presence-based dual-write). Writes
+// are independent: one cluster failing does not block the other. Ingest is fire-and-forget
+// at the service layer (CreateEvent logs and returns 202), so a failure here is logged
+// per-cluster and returned, not customer-facing. See infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
+type EventPublisher struct {
+	primary      messagePublisher
+	primaryCfg   *config.KafkaConfig
+	secondary    messagePublisher
+	secondaryCfg *config.KafkaConfig
+	logger       *logger.Logger
+}
+
+func NewEventPublisher(primaryProducer *Producer, secondaryProducer *SecondaryProducer, cfg *config.Configuration, logger *logger.Logger) (*EventPublisher, error) {
+	if primaryProducer == nil {
+		return nil, fmt.Errorf("kafka producer is not initialized")
 	}
+	ep := &EventPublisher{
+		logger:     logger,
+		primary:    primaryProducer,   // local cluster is always written
+		primaryCfg: &cfg.Kafka,
+	}
+	// Presence-based dual-write: a configured second cluster ⇒ also write there.
+	if cfg.KafkaSecondary != nil {
+		if secondaryProducer == nil || secondaryProducer.Producer == nil {
+			return nil, fmt.Errorf("kafka_secondary is configured but its producer is not initialized")
+		}
+		ep.secondary = secondaryProducer.Producer
+		ep.secondaryCfg = cfg.KafkaSecondary
+	}
+	return ep, nil
 }
 
 func (p *EventPublisher) Publish(ctx context.Context, event *events.Event) error {
@@ -36,44 +62,61 @@ func (p *EventPublisher) Publish(ctx context.Context, event *events.Event) error
 			Mark(ierr.ErrValidation)
 	}
 
-	topic := p.determineTopic(event)
-	p.logger.With(
-		"event_id", event.ID,
-		"event_name", event.EventName,
-		"tenant_id", event.TenantID,
-		"topic", topic,
-	).Debug("publishing event to kafka")
-
 	if event.ID == "" {
 		event.ID = watermill.NewUUID()
 	}
 
-	msg := message.NewMessage(event.ID, payload)
-
-	// Create a deterministic partition key based on tenant_id and external_customer_id
-	// This ensures all events for the same customer go to the same partition
+	// Deterministic partition key (tenant_id[:external_customer_id]) so all events for a
+	// customer land on the same partition, identically on every cluster.
 	partitionKey := event.TenantID
 	if event.ExternalCustomerID != "" {
 		partitionKey = fmt.Sprintf("%s:%s", event.TenantID, event.ExternalCustomerID)
 	}
+
+	// Write to each cluster independently — one failing must not block the other.
+	// A fresh message per cluster (the watermill publisher consumes the message it is handed);
+	// same event.ID + payload everywhere keeps the streams dedup-identical.
+	// The local cluster is always present (NewEventPublisher guarantees it).
+	var firstErr error
+	if err := p.primary.Publish(determineTopic(p.primaryCfg, event), p.buildMessage(event, payload, partitionKey)); err != nil {
+		p.logFailure("primary", event, err)
+		firstErr = err
+	}
+	if p.secondary != nil {
+		if err := p.secondary.Publish(determineTopic(p.secondaryCfg, event), p.buildMessage(event, payload, partitionKey)); err != nil {
+			p.logFailure("secondary", event, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func (p *EventPublisher) logFailure(cluster string, event *events.Event, err error) {
+	p.logger.With(
+		"cluster", cluster,
+		"event_id", event.ID,
+		"tenant_id", event.TenantID,
+		"error", err,
+	).Error("kafka publish failed")
+}
+
+// buildMessage assembles a watermill message for a single publish. event.ID is the message
+// UUID (and the ClickHouse ReplacingMergeTree dedup key), so every cluster gets the same
+// ID and payload.
+func (p *EventPublisher) buildMessage(event *events.Event, payload []byte, partitionKey string) *message.Message {
+	msg := message.NewMessage(event.ID, payload)
 	msg.Metadata.Set("tenant_id", event.TenantID)
 	msg.Metadata.Set("environment_id", event.EnvironmentID)
 	msg.Metadata.Set("partition_key", partitionKey)
-	/*
-		TODO: Once we support multiple event import integrations (e.g., S3, Postgres, etc.),
-		route those imported events to the lazy topic.
-	*/
-	if err := p.producer.Publish(topic, msg); err != nil {
-		return ierr.WithError(err).
-			WithHint("Failed to publish event").
-			Mark(ierr.ErrValidation)
-	}
-	return nil
+	return msg
 }
 
-func (p *EventPublisher) determineTopic(event *events.Event) string {
-	if slices.Contains(p.config.RouteTenantsOnLazyMode, event.TenantID) {
-		return p.config.TopicLazy
+// determineTopic routes to a cluster's lazy or main topic using that cluster's own config.
+func determineTopic(kc *config.KafkaConfig, event *events.Event) string {
+	if slices.Contains(kc.RouteTenantsOnLazyMode, event.TenantID) {
+		return kc.TopicLazy
 	}
-	return p.config.Topic
+	return kc.Topic
 }

--- a/internal/kafka/event_publisher_test.go
+++ b/internal/kafka/event_publisher_test.go
@@ -1,0 +1,163 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// fakePublisher is a test double for messagePublisher. It records every published message
+// and can be configured to fail, so we can exercise the fan-out without a broker.
+type fakePublisher struct {
+	mu       sync.Mutex
+	err      error
+	calls    int
+	topics   []string
+	messages []*message.Message
+}
+
+func (f *fakePublisher) Publish(topic string, messages ...*message.Message) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	f.topics = append(f.topics, topic)
+	f.messages = append(f.messages, messages...)
+	return nil
+}
+
+func (f *fakePublisher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakePublisher) only() *message.Message {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.messages) != 1 {
+		return nil
+	}
+	return f.messages[0]
+}
+
+func testKafkaCfg() *config.KafkaConfig {
+	return &config.KafkaConfig{
+		Topic:                  "events",
+		TopicLazy:              "events_lazy",
+		RouteTenantsOnLazyMode: []string{"tenant_lazy"},
+	}
+}
+
+// newPub builds an EventPublisher writing to the given clusters (pass nil to disable one).
+func newPub(lg *logger.Logger, primary, secondary messagePublisher) *EventPublisher {
+	ep := &EventPublisher{logger: lg}
+	if primary != nil {
+		ep.primary = primary
+		ep.primaryCfg = testKafkaCfg()
+	}
+	if secondary != nil {
+		ep.secondary = secondary
+		ep.secondaryCfg = testKafkaCfg()
+	}
+	return ep
+}
+
+func sampleEvent() *events.Event {
+	return &events.Event{
+		ID:                 "evt_123",
+		TenantID:           "tenant_1",
+		EnvironmentID:      "env_1",
+		EventName:          "api_call",
+		ExternalCustomerID: "cust_ext_9",
+	}
+}
+
+func TestPublish_PrimaryOnly_Success(t *testing.T) {
+	primary := &fakePublisher{}
+	ep := newPub(logger.NewNoopLogger(), primary, nil)
+
+	if err := ep.Publish(context.Background(), sampleEvent()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if primary.callCount() != 1 || primary.topics[0] != "events" {
+		t.Fatalf("expected one publish on 'events', got calls=%d topics=%v", primary.callCount(), primary.topics)
+	}
+}
+
+func TestPublish_BothClusters_ReceiveSamePayloadAndID(t *testing.T) {
+	primary := &fakePublisher{}
+	secondary := &fakePublisher{}
+	ep := newPub(logger.NewNoopLogger(), primary, secondary)
+
+	if err := ep.Publish(context.Background(), sampleEvent()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	pm, sm := primary.only(), secondary.only()
+	if pm == nil || sm == nil {
+		t.Fatalf("expected one message on each cluster; primary=%d secondary=%d", primary.callCount(), secondary.callCount())
+	}
+	if pm.UUID != sm.UUID || pm.UUID != "evt_123" {
+		t.Fatalf("expected matching UUID 'evt_123', got primary=%q secondary=%q", pm.UUID, sm.UUID)
+	}
+	if string(pm.Payload) != string(sm.Payload) {
+		t.Fatalf("expected identical payloads, got primary=%q secondary=%q", pm.Payload, sm.Payload)
+	}
+	if pm.Metadata.Get("partition_key") != "tenant_1:cust_ext_9" || sm.Metadata.Get("partition_key") != pm.Metadata.Get("partition_key") {
+		t.Fatalf("partition keys wrong/mismatched: primary=%q secondary=%q", pm.Metadata.Get("partition_key"), sm.Metadata.Get("partition_key"))
+	}
+}
+
+func TestPublish_OneClusterFailure_DoesNotBlockOther(t *testing.T) {
+	primary := &fakePublisher{err: context.DeadlineExceeded}
+	secondary := &fakePublisher{}
+	ep := newPub(logger.NewNoopLogger(), primary, secondary)
+
+	// Primary fails, but secondary must still receive the event (independent writes). The
+	// failure is surfaced as the returned error (service logs it and returns 202 regardless).
+	err := ep.Publish(context.Background(), sampleEvent())
+	if err == nil {
+		t.Fatal("expected the primary failure to be returned, got nil")
+	}
+	if secondary.callCount() != 1 {
+		t.Fatalf("expected secondary to still receive the event despite primary failure, got %d", secondary.callCount())
+	}
+}
+
+func TestPublish_AssignsEventIDWhenEmpty(t *testing.T) {
+	primary := &fakePublisher{}
+	ep := newPub(logger.NewNoopLogger(), primary, nil)
+
+	ev := sampleEvent()
+	ev.ID = ""
+	if err := ep.Publish(context.Background(), ev); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if ev.ID == "" {
+		t.Fatal("expected event.ID to be assigned a generated UUID")
+	}
+	if msg := primary.only(); msg == nil || msg.UUID != ev.ID {
+		t.Fatalf("expected message UUID to equal assigned event.ID %q", ev.ID)
+	}
+}
+
+func TestPublish_RoutesLazyTenantToLazyTopic(t *testing.T) {
+	primary := &fakePublisher{}
+	ep := newPub(logger.NewNoopLogger(), primary, nil)
+
+	ev := sampleEvent()
+	ev.TenantID = "tenant_lazy"
+	if err := ep.Publish(context.Background(), ev); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if primary.topics[0] != "events_lazy" {
+		t.Fatalf("expected lazy-routed tenant on 'events_lazy', got %q", primary.topics[0])
+	}
+}

--- a/internal/kafka/monitoring.go
+++ b/internal/kafka/monitoring.go
@@ -34,7 +34,7 @@ func NewMonitoringService(cfg *config.Configuration, log *logger.Logger) *Monito
 // GetConsumerLag calculates the consumer lag for a given topic and consumer group
 func (m *MonitoringService) GetConsumerLag(ctx context.Context, topic string, consumerGroup string) (*ConsumerLag, error) {
 	// Create Sarama config
-	saramaConfig := GetSaramaConfig(m.config)
+	saramaConfig := GetSaramaConfig(&m.config.Kafka)
 	saramaConfig.Consumer.Return.Errors = true
 
 	// Create cluster admin client

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -11,12 +11,41 @@ type Producer struct {
 	*kafka.Publisher
 }
 
+// NewProducer builds the producer for this deployment's local Kafka cluster (cfg.Kafka) —
+// the cluster it consumes from and always writes to.
 func NewProducer(cfg *config.Configuration) (*Producer, error) {
+	return newProducerForCluster(&cfg.Kafka, cfg.Logging.Level == types.LogLevelDebug)
+}
+
+// SecondaryProducer wraps the optional second-cluster producer so it can be provided
+// through fx as a type distinct from the local *Producer. The embedded *Producer is nil
+// when the second cluster is not write-enabled or not configured, in which case publishing
+// is single-cluster (the wrapper itself is always non-nil so fx has a value to inject).
+type SecondaryProducer struct {
+	*Producer
+}
+
+// NewSecondaryProducer is the fx provider for the optional second Kafka cluster
+// (cfg.KafkaSecondary). Dual-write is presence-based: it builds a real producer only when
+// cfg.KafkaSecondary is configured, otherwise it returns an empty wrapper (nil inner) so it
+// is always injectable. A configured cluster that fails to build is a boot-time error; a
+// runtime outage of the second cluster is tolerated by the publish path (its failure is
+// logged, not fatal). See infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
+func NewSecondaryProducer(cfg *config.Configuration) (*SecondaryProducer, error) {
+	if cfg.KafkaSecondary == nil {
+		return &SecondaryProducer{}, nil
+	}
+	producer, err := newProducerForCluster(cfg.KafkaSecondary, cfg.Logging.Level == types.LogLevelDebug)
+	if err != nil {
+		return nil, err
+	}
+	return &SecondaryProducer{Producer: producer}, nil
+}
+
+func newProducerForCluster(kafkaCfg *config.KafkaConfig, enableDebugLogs bool) (*Producer, error) {
 	// enableDebugLogs allows watermill DEBUG messages in debug mode.
 	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
-	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
-
-	saramaConfig := GetSaramaConfig(cfg)
+	saramaConfig := GetSaramaConfig(kafkaCfg)
 	if saramaConfig != nil {
 		// add producer configs
 		saramaConfig.Producer.Return.Successes = true
@@ -25,7 +54,7 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 
 	publisher, err := kafka.NewPublisher(
 		kafka.PublisherConfig{
-			Brokers:               cfg.Kafka.Brokers,
+			Brokers:               kafkaCfg.Brokers,
 			Marshaler:             kafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},

--- a/internal/publisher/event_publisher.go
+++ b/internal/publisher/event_publisher.go
@@ -31,6 +31,7 @@ func NewEventPublisher(
 	cfg *config.Configuration,
 	logger *logger.Logger,
 	kafkaProducer *kafka.Producer,
+	secondaryProducer *kafka.SecondaryProducer,
 	dynamoClient *dynamodb.Client,
 ) (EventPublisher, error) {
 	publisher := &eventPublisher{
@@ -43,7 +44,14 @@ func NewEventPublisher(
 		if kafkaProducer == nil {
 			return nil, fmt.Errorf("kafka producer is not initialized but it is one of the publish destinations")
 		}
-		publisher.kafkaPublisher = kafka.NewEventPublisher(kafkaProducer, cfg, logger)
+		// kafkaProducer (local) and secondaryProducer (optional second cluster) are both
+		// fx-provided. The kafka event publisher fans out to every write-enabled cluster
+		// (AWS→GCP migration, GCP-CUTOVER-STEPWISE.md).
+		kafkaPublisher, err := kafka.NewEventPublisher(kafkaProducer, secondaryProducer, cfg, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize kafka event publisher: %w", err)
+		}
+		publisher.kafkaPublisher = kafkaPublisher
 	}
 
 	if cfg.Event.PublishDestination == types.PublishToDynamoDB || cfg.Event.PublishDestination == types.PublishToAll {

--- a/internal/pubsub/router/router.go
+++ b/internal/pubsub/router/router.go
@@ -38,7 +38,7 @@ func NewRouter(cfg *config.Configuration, logger *logger.Logger, tracingSvc *tra
 	var dlqTopicName string
 
 	if cfg.Kafka.TopicDLQ != "" {
-		// Use real Kafka DLQ when configured
+		// Use real Kafka DLQ when configured (on the deployment's local/consume cluster)
 		var err error
 		poisonQueuePublisher, err = createDLQPublisher(cfg, logger)
 		if err != nil {
@@ -91,8 +91,9 @@ func NewRouter(cfg *config.Configuration, logger *logger.Logger, tracingSvc *tra
 }
 
 func createDLQPublisher(cfg *config.Configuration, logger *logger.Logger) (message.Publisher, error) {
-	// Use the existing Kafka infrastructure
-	saramaConfig := kafka.GetSaramaConfig(cfg)
+	// DLQ lives on the deployment's local/consume cluster (same one its consumers read).
+	kc := &cfg.Kafka
+	saramaConfig := kafka.GetSaramaConfig(kc)
 	if saramaConfig != nil {
 		saramaConfig.Producer.Return.Successes = true
 		saramaConfig.Producer.Return.Errors = true
@@ -100,7 +101,7 @@ func createDLQPublisher(cfg *config.Configuration, logger *logger.Logger) (messa
 
 	publisher, err := watermillKafka.NewPublisher(
 		watermillKafka.PublisherConfig{
-			Brokers:               cfg.Kafka.Brokers,
+			Brokers:               kc.Brokers,
 			Marshaler:             watermillKafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},
@@ -110,7 +111,7 @@ func createDLQPublisher(cfg *config.Configuration, logger *logger.Logger) (messa
 		return nil, err
 	}
 
-	logger.Info(context.Background(), "DLQ publisher initialized", "brokers", cfg.Kafka.Brokers, "dlq_topic", cfg.Kafka.TopicDLQ)
+	logger.Info(context.Background(), "DLQ publisher initialized", "brokers", kc.Brokers, "dlq_topic", kc.TopicDLQ)
 	return publisher, nil
 }
 

--- a/scripts/internal/setup_dummy_billing_customer.go
+++ b/scripts/internal/setup_dummy_billing_customer.go
@@ -167,7 +167,8 @@ func SetupDummyBillingCustomer() error {
 		}
 	}()
 
-	eventPublisher, err := publisher.NewEventPublisher(cfg, appLogger, kafkaProducer, nil)
+	// secondaryProducer=nil (no dual-write in this script), dynamoClient=nil (kafka only)
+	eventPublisher, err := publisher.NewEventPublisher(cfg, appLogger, kafkaProducer, nil, nil)
 	if err != nil {
 		return fmt.Errorf("event publisher: %w", err)
 	}


### PR DESCRIPTION
## What

Adds **optional** dual-write to a second Kafka cluster, gated by config, to support the AWS→GCP migration. When the second cluster is configured, events are published to both clusters; when it isn't, behavior is unchanged (single-cluster, current production path).

## Why

During the AWS→GCP migration we need to mirror the event stream to the GCP-side Kafka without disrupting the live AWS pipeline. A config-gated dual-write lets us cut over incrementally and roll back instantly by flipping config.

## Changes

- `internal/config` — new dual-write config (second cluster connection), env-driven; `dualwrite_env_test.go` covers env wiring.
- `internal/kafka` — `event_publisher.go` / `producer.go` / `base.go` extended for an optional second publisher; `event_publisher_test.go` added.
- `internal/pubsub`, `internal/publisher`, `internal/pubsub/router` — thread the optional second-cluster path through.
- `cmd/server/main.go` — wire the optional second producer.

## Safety / rollback

- **Off by default** — no second cluster configured ⇒ identical to current behavior.
- No schema or consumer changes; purely an additive publish path.

## Testing

- `go build ./cmd/server/ ./internal/kafka/... ./internal/pubsub/... ./internal/publisher/... ./internal/config/...` ✅
- `go test ./internal/config/ ./internal/kafka/` ✅

## Note on base branch

Cut from `main` (not `develop`) intentionally — `develop` is mid-churn from the enterprise-package consolidation. Retarget to `develop` if the team prefers integrating there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional secondary cluster configuration, enabling simultaneous publishing to multiple Kafka clusters when enabled.

* **Tests**
  * Added test coverage for secondary cluster binding and multi-cluster publishing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->