### PR TITLE
feat(secret): add support for service account name in list api keys response

### DIFF
--- a/internal/api/dto/secret.go
+++ b/internal/api/dto/secret.go
@@ -62,18 +62,20 @@ func (r *CreateIntegrationRequest) Validate() error {
 
 // SecretResponse represents a secret in responses
 type SecretResponse struct {
-	ID         string               `json:"id"`
-	Name       string               `json:"name"`
-	Type       types.SecretType     `json:"type"`
-	Provider   types.SecretProvider `json:"provider"`
-	DisplayID  string               `json:"display_id"`
-	Roles      []string             `json:"roles,omitempty"`     // RBAC roles
-	UserType   types.UserType       `json:"user_type,omitempty"` // "user" or "service_account"
-	ExpiresAt  *time.Time           `json:"expires_at,omitempty"`
-	LastUsedAt *time.Time           `json:"last_used_at,omitempty"`
-	Status     types.Status         `json:"status"`
-	CreatedAt  time.Time            `json:"created_at"`
-	UpdatedAt  time.Time            `json:"updated_at"`
+	ID                 string               `json:"id"`
+	Name               string               `json:"name"`
+	Type               types.SecretType     `json:"type"`
+	Provider           types.SecretProvider `json:"provider"`
+	DisplayID          string               `json:"display_id"`
+	Roles              []string             `json:"roles,omitempty"`                // RBAC roles
+	UserType           types.UserType       `json:"user_type,omitempty"`            // "user" or "service_account"
+	UserID             string               `json:"user_id,omitempty"`              // user or service account this key belongs to
+	ServiceAccountName string               `json:"service_account_name,omitempty"` // name of the service account (populated for service_account user_type)
+	ExpiresAt          *time.Time           `json:"expires_at,omitempty"`
+	LastUsedAt         *time.Time           `json:"last_used_at,omitempty"`
+	Status             types.Status         `json:"status"`
+	CreatedAt          time.Time            `json:"created_at"`
+	UpdatedAt          time.Time            `json:"updated_at"`
 }
 
 // CreateAPIKeyResponse represents the response when creating a new API key
@@ -98,8 +100,9 @@ func ToSecretResponse(s *secret.Secret) *SecretResponse {
 		Type:       s.Type,
 		Provider:   s.Provider,
 		DisplayID:  s.DisplayID,
-		Roles:      s.Roles,                    // RBAC roles
-		UserType:   types.UserType(s.UserType), // User type
+		Roles:      s.Roles,
+		UserType:   types.UserType(s.UserType),
+		UserID:     s.UserID,
 		ExpiresAt:  s.ExpiresAt,
 		LastUsedAt: s.LastUsedAt,
 		Status:     s.Status,

--- a/internal/ee/service/secret.go
+++ b/internal/ee/service/secret.go
@@ -190,11 +190,28 @@ func (s *secretService) ListAPIKeys(ctx context.Context, filter *types.SecretFil
 	}
 
 	items := dto.ToSecretResponseList(secrets)
+
+	serviceAccountNameByID := make(map[string]string)
 	for _, item := range items {
 		if item.UserType == types.UserTypeServiceAccount && item.UserID != "" {
-			u, err := s.userRepo.GetByID(ctx, item.UserID)
-			if err == nil {
-				item.ServiceAccountName = u.Name
+			serviceAccountNameByID[item.UserID] = ""
+		}
+	}
+	if len(serviceAccountNameByID) > 0 {
+		serviceAccountIDs := make([]string, 0, len(serviceAccountNameByID))
+		for id := range serviceAccountNameByID {
+			serviceAccountIDs = append(serviceAccountIDs, id)
+		}
+		serviceAccounts, _, err := s.userRepo.ListByFilter(ctx, &types.UserFilter{
+			QueryFilter: types.NewNoLimitPublishedQueryFilter(),
+			UserIDs:     serviceAccountIDs,
+		})
+		if err == nil {
+			for _, serviceAccount := range serviceAccounts {
+				serviceAccountNameByID[serviceAccount.ID] = serviceAccount.Name
+			}
+			for _, item := range items {
+				item.ServiceAccountName = serviceAccountNameByID[item.UserID]
 			}
 		}
 	}

--- a/internal/ee/service/secret.go
+++ b/internal/ee/service/secret.go
@@ -189,8 +189,18 @@ func (s *secretService) ListAPIKeys(ctx context.Context, filter *types.SecretFil
 		return nil, err
 	}
 
+	items := dto.ToSecretResponseList(secrets)
+	for _, item := range items {
+		if item.UserType == types.UserTypeServiceAccount && item.UserID != "" {
+			u, err := s.userRepo.GetByID(ctx, item.UserID)
+			if err == nil {
+				item.ServiceAccountName = u.Name
+			}
+		}
+	}
+
 	return &dto.ListSecretsResponse{
-		Items:      dto.ToSecretResponseList(secrets),
+		Items:      items,
 		Pagination: types.NewPaginationResponse(count, filter.GetLimit(), filter.GetOffset()),
 	}, nil
 }

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -141,6 +141,11 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 					Mark(ierr.ErrValidation)
 			}
 		}
+		if lo.Contains(req.Roles, "super_admin") && len(req.Roles) > 1 {
+			return nil, ierr.NewError("super admin role need not be combined with other roles").
+				WithHint("When super_admin is selected, no other roles need to be assigned").
+				Mark(ierr.ErrValidation)
+		}
 		newUser = &user.User{
 			ID:    types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USER),
 			Name:  req.Name,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret-related API responses now include user ownership metadata, including `user_id` and `service_account_name`.
  * When listing API keys, the associated service account name is now shown.

* **Bug Fixes**
  * Added validation to prevent creating service accounts with `super_admin` included alongside other roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->