### PR TITLE
fix(config): bind auth.secret + primary kafka SASL creds from env

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -715,6 +715,11 @@ func NewConfig() (*Configuration, error) {
 
 	// Explicitly bind auth.api_key.header — AutomaticEnv misses keys containing underscores
 	_ = v.BindEnv("auth.api_key.header", "FLEXPRICE_AUTH_API_KEY_HEADER")
+	// Explicitly bind auth.secret — the helm ConfigMap's rendered config.yaml omits this key,
+	// so on GKE deployments it stays empty and supabase/JWT token validation fails (login
+	// broken, and an empty key makes tokens forgeable). The FLEXPRICE_AUTH_SECRET env is
+	// injected from the secret; this bind makes Unmarshal actually read it.
+	_ = v.BindEnv("auth.secret", "FLEXPRICE_AUTH_SECRET")
 	// NOTE: auth.api_key.keys is intentionally NOT bound here because the env var is a
 	// JSON string but Viper/mapstructure expects a map. It is handled manually in Step 6.
 
@@ -735,6 +740,14 @@ func NewConfig() (*Configuration, error) {
 	_ = v.BindEnv("kafka_secondary.sasl_oauth_scopes", "FLEXPRICE_KAFKA_SECONDARY_SASL_OAUTH_SCOPES")
 	_ = v.BindEnv("kafka_secondary.client_id", "FLEXPRICE_KAFKA_SECONDARY_CLIENT_ID")
 	_ = v.BindEnv("kafka_secondary.route_tenants_on_lazy_mode", "FLEXPRICE_KAFKA_SECONDARY_ROUTE_TENANTS_ON_LAZY_MODE")
+
+	// Explicitly bind the PRIMARY kafka SASL credentials. The helm ConfigMap renders the
+	// kafka block without sasl_user/sasl_password, so on a GKE deployment whose primary
+	// cluster uses a password mechanism (e.g. AWS MSK SCRAM-SHA-512) these stay empty and
+	// SCRAM auth fails. The FLEXPRICE_KAFKA_SASL_{USER,PASSWORD} envs are injected by the
+	// chart; these binds make Unmarshal read them. (OAUTHBEARER/GMK needs neither.)
+	_ = v.BindEnv("kafka.sasl_user", "FLEXPRICE_KAFKA_SASL_USER")
+	_ = v.BindEnv("kafka.sasl_password", "FLEXPRICE_KAFKA_SASL_PASSWORD")
 
 	// Step 5: Read the YAML file
 	if err := v.ReadInConfig(); err != nil {


### PR DESCRIPTION
## What
Adds three `BindEnv` calls in `config.go`:
- `auth.secret` ← `FLEXPRICE_AUTH_SECRET`
- `kafka.sasl_user` ← `FLEXPRICE_KAFKA_SASL_USER`
- `kafka.sasl_password` ← `FLEXPRICE_KAFKA_SASL_PASSWORD`

## Why
The helm ConfigMap's rendered `config.yaml` omits these keys. viper only reads an env var into a nested key it already knows (present in config file **or** explicitly bound) — `AutomaticEnv` alone doesn't register unknown nested keys for `Unmarshal`. So on GKE deployments these resolved to **empty** even though the chart injects the env vars from the secret, causing:
- **`auth.secret` empty** → supabase/JWT token validation fails → **login broken** on GKE (Mumbai). An empty verify key also makes tokens forgeable.
- **`kafka.sasl_user`/`sasl_password` empty** → for a SCRAM primary cluster (AWS MSK) **SCRAM auth fails**.

This matches the existing explicit-bind pattern already used for `temporal.api_key`, `auth.api_key.header`, and `kafka_secondary.*`.

## Validation
- `NewConfig()` resolves all three from env, overriding even a non-empty baked default (env wins).
- In-cluster probe against **Mumbai MSK**: configmap-style `config.yaml` (no sasl_user/password) + env creds + these binds → resolved creds → **SCRAM auth OK** on `staging_events_v2` (3 partitions). Throwaway pod, no impact to the running deployment.

## Urgency / coupling
`infrastructure#29` already switched Mumbai's primary Kafka to **MSK (SCRAM)**. The running image lacks these binds, so the new MSK pods are **CrashLoopBackOff** (empty creds → SCRAM fail); old GMK pods are holding the service (degraded). **This fix unblocks that** — once merged and the develop image is deployed (Image Updater), Mumbai's MSK pods authenticate and go Healthy. No revert of #29 required.

## Notes
- Code-only; ships via the develop image. Does not touch the chart/configmap (BindEnv chosen over rendering `""` in the configmap).
- `flexprice_s3_exports.*` is broken the same way (env-injected, not in configmap, not bound) — parked for a follow-up.
- Follow-up idea: replace the hand-maintained bind list with a reflection auto-binder over the mapstructure tags, so this class of bug can't recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration loading to properly support authentication and Kafka credentials provided through environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->