### PR TITLE
feat(targets): add Enabled field to control target inclusion in runs

### DIFF
--- a/integration-testing-suite/go/targets.go
+++ b/integration-testing-suite/go/targets.go
@@ -22,6 +22,16 @@ type Target struct {
 	// for environments whose cert does not cover the host (e.g. preprod).
 	// Can also be forced for all targets via FLEXPRICE_INSECURE_SKIP_VERIFY.
 	Insecure bool `json:"insecure"`
+	// Enabled controls whether this target is included in the run.
+	// Optional — omitting the field (or setting it to true) keeps the target active.
+	// Set to false to skip a target without removing it from the file.
+	Enabled *bool `json:"enabled"`
+}
+
+// isEnabled reports whether this target should be included in a run.
+// Defaults to true when the field is omitted from JSON.
+func (t Target) isEnabled() bool {
+	return t.Enabled == nil || *t.Enabled
 }
 
 // skipTLSVerify reports whether TLS verification should be skipped for this
@@ -129,10 +139,19 @@ func parseTargets(data []byte, source string) ([]Target, error) {
 	if len(targets) == 0 {
 		return nil, fmt.Errorf("%s contains no targets", source)
 	}
+	enabled := targets[:0]
 	for i, t := range targets {
 		if t.APIKey == "" {
 			return nil, fmt.Errorf("%s: target #%d (%s) is missing api_key", source, i+1, t.label())
 		}
+		if !t.isEnabled() {
+			fmt.Printf("  (skipping disabled target #%d: %s)\n", i+1, t.label())
+			continue
+		}
+		enabled = append(enabled, t)
 	}
-	return targets, nil
+	if len(enabled) == 0 {
+		return nil, fmt.Errorf("%s: all targets are disabled", source)
+	}
+	return enabled, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling specific targets in the integration testing suite. Targets can now be marked as disabled and will be skipped during test execution. Configuration validation ensures at least one target remains enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->