### PR TITLE
fix(config): bind deployment.mode from FLEXPRICE_DEPLOYMENT_MODE

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -749,6 +749,15 @@ func NewConfig() (*Configuration, error) {
 	_ = v.BindEnv("kafka.sasl_user", "FLEXPRICE_KAFKA_SASL_USER")
 	_ = v.BindEnv("kafka.sasl_password", "FLEXPRICE_KAFKA_SASL_PASSWORD")
 
+	// Explicitly bind deployment.mode — the helm ConfigMap is one shared object across the
+	// api/consumer/worker Deployments, so it cannot carry a per-component mode; the only
+	// per-component signal is the FLEXPRICE_DEPLOYMENT_MODE env each Deployment sets. Since
+	// deployment.mode is absent from the rendered config.yaml and was not bound, AutomaticEnv+
+	// Unmarshal ignored the env and every pod fell back to ModeLocal (running API + Temporal +
+	// Kafka consumers regardless of role — e.g. the api consuming prod topics). This bind makes
+	// Unmarshal honor the per-Deployment env. See infrastructure/docs/gcp-mumbai-gmk-consumer-runbook.md.
+	_ = v.BindEnv("deployment.mode", "FLEXPRICE_DEPLOYMENT_MODE")
+
 	// Step 5: Read the YAML file
 	if err := v.ReadInConfig(); err != nil {
 		fmt.Printf("Error reading config file: %v\n", err)


### PR DESCRIPTION
## Problem
On GKE, the `FLEXPRICE_DEPLOYMENT_MODE` env (set per Deployment: `api` / `consumer` / `temporal_worker`) was being **ignored**, so every pod fell back to `ModeLocal` and ran the HTTP API + Temporal workers + Kafka consumers regardless of its intended role.

**Observed impact (Mumbai staging):** the `api` pod joined consumer group `flexprice-consumer` and consumed the shared-cluster **prod `events`** topic — i.e. a staging api draining prod events into the staging ClickHouse (cross-environment leak). Prod's own pipeline was unaffected (separate `flexprice-consumer-production` group), but the api should never consume in `api` mode.

## Root cause
Same viper bug class as the `auth.secret` / `kafka.sasl_*` binds (#2035): `deployment.mode` is **absent from the rendered `config.yaml`** and had **no `BindEnv`**, so `AutomaticEnv` + `Unmarshal` never mapped the env var → `cfg.Deployment.Mode` stayed empty → `main.go` defaults it to `ModeLocal`.

A config-only fix isn't possible: the helm ConfigMap is a **single shared object** across the api/consumer/worker Deployments, so it can't carry a per-component mode. The per-Deployment env is the only signal — and it was unbound.

## Fix
One line in `internal/config/config.go`, alongside the existing binds:
```go
_ = v.BindEnv("deployment.mode", "FLEXPRICE_DEPLOYMENT_MODE")
```

## Verification
With the bind, `FLEXPRICE_DEPLOYMENT_MODE=consumer` → `cfg.Deployment.Mode == "consumer"` via real `NewConfig()` (was silently `local` before). `go build` + `go vet` clean.

After this ships: `api` stops consuming, `temporal_worker` runs workers only, `consumer` consumes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment mode configuration to properly load from environment variables, ensuring correct behavior during local development and production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->