### PR TITLE
feat(server): serve /health in consumer + temporal_worker modes

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -553,6 +553,7 @@ func startServer(
 		registerRouterHandlers(router, webhookService, integrationEventService, onboardingService, eventPostProcessingSvc, eventConsumptionSvc, featureUsageSvc, costSheetUsageSvc, walletBalanceAlertSvc, rawEventConsumptionSvc, meterUsageTrackingSvc, usageBenchmarkSvc, cfg, false)
 		startRouter(lc, router, log)
 		startTemporalWorker(lc, log, temporalClient, temporalService, params, webhookService)
+		startHealthServer(lc, cfg, log) // temporal_worker serves no API; expose /health for k8s probes
 	case types.ModeConsumer:
 		if consumer == nil {
 			log.Fatal(context.Background(), "Kafka consumer required for consumer mode")
@@ -561,6 +562,7 @@ func startServer(
 		// Register all handlers and start router once
 		registerRouterHandlers(router, webhookService, integrationEventService, onboardingService, eventPostProcessingSvc, eventConsumptionSvc, featureUsageSvc, costSheetUsageSvc, walletBalanceAlertSvc, rawEventConsumptionSvc, meterUsageTrackingSvc, usageBenchmarkSvc, cfg, true)
 		startRouter(lc, router, log)
+		startHealthServer(lc, cfg, log) // consumer serves no API; expose /health for k8s probes
 	default:
 		log.Fatalf("Unknown deployment mode: %s", mode)
 	}
@@ -620,6 +622,29 @@ func startAPIServer(
 		OnStop: func(ctx context.Context) error {
 			log.Info(ctx, "Shutting down server...")
 			log.Shutdown(ctx)
+			return nil
+		},
+	})
+}
+
+// startHealthServer runs a minimal HTTP server exposing only /health on the
+// configured server address. Modes that don't run the full API server
+// (consumer, temporal_worker) still need it: the k8s readiness/liveness probes
+// hit /health, so without it those pods fail health checks even though they
+// serve no business traffic.
+func startHealthServer(lc fx.Lifecycle, cfg *config.Configuration, log *logger.Logger) {
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			h := gin.New()
+			health := func(c *gin.Context) { c.JSON(200, gin.H{"status": "ok"}) }
+			h.GET("/health", health)
+			h.POST("/health", health)
+			log.Info(ctx, "Starting health-only HTTP server", "address", cfg.Server.Address)
+			go func() {
+				if err := h.Run(cfg.Server.Address); err != nil {
+					log.Fatalf("Failed to start health server: %v", err)
+				}
+			}()
 			return nil
 		},
 	})


### PR DESCRIPTION
## Problem
The helm chart attaches HTTP `/health` readiness+liveness probes to **every** component, but `consumer` and `temporal_worker` modes start **no HTTP server**. Once deployment mode is actually honored (#2041), those probes fail → the consumer/worker pods crashloop / never become ready.

(On GKE staging we had to work around this by live-patching the probes off — which can't be expressed in chart values and is lost if ArgoCD re-renders.)

## Fix
Add a minimal `/health`-only HTTP server (on `cfg.Server.Address`) for `consumer` and `temporal_worker` modes:
```go
func startHealthServer(lc, cfg, log) { /* gin.New() with GET/POST /health -> 200 */ }
```
Wired into both modes in `startServer`. `api`/`local` modes are unchanged (they already serve `/health` via the full router).

## Why
- Makes the chart's standard probes pass for **all** components → no per-component probe hacks.
- Removes the need for the live "delete the probes" patch on GKE, so ArgoCD can manage consumer/worker with probes intact (unblocks re-enabling reconcile for the AWS→GCP migration).

## Verification
`go build ./cmd/server/` + `go vet` clean. The probe just needs a 200 on `/health`, which this returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoint for deployments that don't run the full API server, enabling Kubernetes health probes for improved deployment monitoring and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->