### PR TITLE
fix(chart): remove HTTP /health probes from consumer + worker deployments

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
@@ -63,22 +63,10 @@ spec:
                 # Kafka consumer-group rebalance kicks off the new owner.
                 command: ["/bin/sh", "-c", "sleep {{ .Values.consumer.preStop.sleepSeconds | default 15 }}"]
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
+          # No HTTP probes: this runs in deployment.mode=consumer and serves no HTTP
+          # server, so an httpGet /health probe always fails and crashloops the pod.
+          # No Service routes to it either, so readiness is moot. (Matches the AWS ECS
+          # consumer, which runs with no health checks.)
           resources:
             {{- toYaml .Values.consumer.resources | nindent 12 }}
           volumeMounts:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
@@ -61,22 +61,10 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "sleep {{ .Values.worker.preStop.sleepSeconds | default 0 }}"]
           {{- end }}
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
+          # No HTTP probes: this runs in deployment.mode=temporal_worker and serves no
+          # HTTP server, so an httpGet /health probe always fails and crashloops the pod.
+          # No Service routes to it either, so readiness is moot. (Matches the AWS ECS
+          # worker, which runs with no health checks.)
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
## Problem
The Helm chart attaches `httpGet: /health` **liveness + readiness** probes to the `consumer` and `worker` deployments. But those run in `deployment.mode=consumer` / `temporal_worker` and serve **no HTTP server** — so once deployment mode is honored the probes always fail and the pods crashloop. (No Service routes to them either, so readiness gates nothing.)

On the GKE Mumbai staging cluster we currently work around this with a live `kubectl patch` removing the probes — which can't be expressed in GitOps and is lost on any re-render, blocking ArgoCD reconcile.

## Change
Remove the HTTP probe blocks from `deployment-consumer.yaml` and `deployment-worker.yaml`. The **api** deployment keeps its probes (it serves HTTP). This matches the AWS ECS consumer/worker, which run with no health checks.

## Verification
- `helm lint` clean.
- `helm template` confirms: `api` → liveness+readiness present; `consumer` + `worker` → none.

## Notes
- Targets `develop` (normal flow); promotes to `main` — which the ArgoCD Applications render the chart from — on release.
- Alternative/complement to #2042 (app serving `/health` in consumer/worker modes). With probes removed, re-enabling ArgoCD reconcile no longer depends on #2042 + an image bump.
- No liveness probe means a hung consumer/worker won't be auto-restarted; if desired later, an `exec`/TCP probe could be added instead of HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed HTTP-based liveness and readiness probes from the consumer and worker deployment modes.  
  * These modes don’t expose an HTTP `/health` endpoint and aren’t routed through a service for readiness checks, so the previous probes could fail and trigger repeated pod restart cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->