### PR TITLE
refactor(subscription): rename AssociationID to CouponAssociationID and TaxAssociationID

### DIFF
--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -136,11 +136,8 @@ const (
 	SubscriptionModifyTypeQuantityChange   SubscriptionModifyType = "quantity_change"
 	SubscriptionModifyTypeGroupedInvoicing SubscriptionModifyType = "grouped_invoicing"
 	SubscriptionModifyTypeTrialEnd         SubscriptionModifyType = "trial_end"
-)
-
-const (
-	SubscriptionModifyTypeCoupon SubscriptionModifyType = "coupon"
-	SubscriptionModifyTypeTax    SubscriptionModifyType = "tax"
+	SubscriptionModifyTypeCoupon           SubscriptionModifyType = "coupon"
+	SubscriptionModifyTypeTax              SubscriptionModifyType = "tax"
 )
 
 // SubModifyCouponAction is the action to perform on a coupon association.
@@ -204,7 +201,7 @@ type SubModifyCouponParams struct {
 	// Required for action="add". Coupon code of the coupon to attach.
 	CouponCode *string `json:"coupon_code,omitempty"`
 	// Required when action="remove". ID of the CouponAssociation to soft-delete.
-	AssociationID *string `json:"association_id,omitempty"`
+	CouponAssociationID *string `json:"coupon_association_id,omitempty"`
 	// Optional. When the coupon association starts; defaults to now.
 	StartDate *time.Time `json:"start_date,omitempty"`
 	// Optional. When the coupon association ends.
@@ -229,8 +226,8 @@ func (r *SubModifyCouponParams) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 	case SubModifyCouponActionRemove:
-		if r.AssociationID == nil || *r.AssociationID == "" {
-			return ierr.NewError("association_id is required for action 'remove'").
+		if r.CouponAssociationID == nil || *r.CouponAssociationID == "" {
+			return ierr.NewError("coupon_association_id is required for action 'remove'").
 				WithHint("Provide the coupon association ID to remove").
 				Mark(ierr.ErrValidation)
 		}
@@ -250,7 +247,7 @@ type SubModifyTaxParams struct {
 	// Required when action="add". ID of the active tax rate to attach.
 	TaxRateID *string `json:"tax_rate_id,omitempty"`
 	// Required when action="remove". ID of the TaxAssociation to soft-delete.
-	AssociationID *string `json:"association_id,omitempty"`
+	TaxAssociationID *string `json:"tax_association_id,omitempty"`
 	// Optional. When to apply the change; defaults to now if omitted.
 	EffectiveDate *time.Time `json:"effective_date,omitempty"`
 }
@@ -264,8 +261,8 @@ func (r *SubModifyTaxParams) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 	case SubModifyTaxActionRemove:
-		if r.AssociationID == nil || *r.AssociationID == "" {
-			return ierr.NewError("association_id is required for action 'remove'").
+		if r.TaxAssociationID == nil || *r.TaxAssociationID == "" {
+			return ierr.NewError("tax_association_id is required for action 'remove'").
 				WithHint("Provide the tax association ID to remove").
 				Mark(ierr.ErrValidation)
 		}

--- a/internal/ee/service/subscription_modification_coupon.go
+++ b/internal/ee/service/subscription_modification_coupon.go
@@ -20,7 +20,7 @@ func (s *subscriptionModificationService) executeCouponModification(
 	case dto.SubModifyCouponActionAdd:
 		return s.executeAddCoupon(ctx, subscriptionID, params, effectiveDate)
 	case dto.SubModifyCouponActionRemove:
-		return s.executeRemoveCoupon(ctx, subscriptionID, *params.AssociationID, effectiveDate)
+		return s.executeRemoveCoupon(ctx, subscriptionID, *params.CouponAssociationID, effectiveDate)
 	default:
 		return nil, ierr.NewError("unknown coupon action: " + string(params.Action)).
 			Mark(ierr.ErrValidation)
@@ -210,7 +210,7 @@ func (s *subscriptionModificationService) previewCouponModification(
 	case dto.SubModifyCouponActionAdd:
 		return s.previewAddCoupon(ctx, subscriptionID, params, effectiveDate)
 	case dto.SubModifyCouponActionRemove:
-		return s.previewRemoveCoupon(ctx, subscriptionID, *params.AssociationID, effectiveDate)
+		return s.previewRemoveCoupon(ctx, subscriptionID, *params.CouponAssociationID, effectiveDate)
 	default:
 		return nil, ierr.NewError("unknown coupon action: " + string(params.Action)).
 			Mark(ierr.ErrValidation)

--- a/internal/ee/service/subscription_modification_coupon_test.go
+++ b/internal/ee/service/subscription_modification_coupon_test.go
@@ -223,8 +223,8 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionRemove,
-						AssociationID: &assoc.ID,
+						Action:              dto.SubModifyCouponActionRemove,
+						CouponAssociationID: &assoc.ID,
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -248,8 +248,8 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionRemove,
-						AssociationID: &bogusID,
+						Action:              dto.SubModifyCouponActionRemove,
+						CouponAssociationID: &bogusID,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub.ID, req)
@@ -273,8 +273,8 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionRemove,
-						AssociationID: &assoc.ID,
+						Action:              dto.SubModifyCouponActionRemove,
+						CouponAssociationID: &assoc.ID,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub1.ID, req)
@@ -298,8 +298,8 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeCoupon,
 					CouponParams: &dto.SubModifyCouponParams{
-						Action:        dto.SubModifyCouponActionRemove,
-						AssociationID: &assoc.ID,
+						Action:              dto.SubModifyCouponActionRemove,
+						CouponAssociationID: &assoc.ID,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub.ID, req)

--- a/internal/ee/service/subscription_modification_tax.go
+++ b/internal/ee/service/subscription_modification_tax.go
@@ -23,7 +23,7 @@ func (s *subscriptionModificationService) executeTaxModification(
 	case dto.SubModifyTaxActionAdd:
 		return s.executeAddTax(ctx, subscriptionID, *params.TaxRateID, effectiveDate)
 	case dto.SubModifyTaxActionRemove:
-		return s.executeRemoveTax(ctx, subscriptionID, *params.AssociationID, effectiveDate)
+		return s.executeRemoveTax(ctx, subscriptionID, *params.TaxAssociationID, effectiveDate)
 	default:
 		return nil, ierr.NewError("unknown tax action: " + string(params.Action)).
 			Mark(ierr.ErrValidation)
@@ -191,7 +191,7 @@ func (s *subscriptionModificationService) previewTaxModification(
 	case dto.SubModifyTaxActionAdd:
 		return s.previewAddTax(ctx, subscriptionID, *params.TaxRateID, effectiveDate)
 	case dto.SubModifyTaxActionRemove:
-		return s.previewRemoveTax(ctx, subscriptionID, *params.AssociationID, effectiveDate)
+		return s.previewRemoveTax(ctx, subscriptionID, *params.TaxAssociationID, effectiveDate)
 	default:
 		return nil, ierr.NewError("unknown tax action: " + string(params.Action)).
 			Mark(ierr.ErrValidation)

--- a/internal/ee/service/subscription_modification_tax_test.go
+++ b/internal/ee/service/subscription_modification_tax_test.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
-	taxassociation "github.com/flexprice/flexprice/internal/domain/taxassociation"
 	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
+	taxassociation "github.com/flexprice/flexprice/internal/domain/taxassociation"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 )
@@ -230,9 +230,9 @@ func (s *SubscriptionModificationServiceSuite) TestTaxModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeTax,
 					TaxParams: &dto.SubModifyTaxParams{
-						Action:        dto.SubModifyTaxActionRemove,
-						AssociationID: &assoc.ID,
-						EffectiveDate: &past,
+						Action:           dto.SubModifyTaxActionRemove,
+						TaxAssociationID: &assoc.ID,
+						EffectiveDate:    &past,
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -261,9 +261,9 @@ func (s *SubscriptionModificationServiceSuite) TestTaxModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeTax,
 					TaxParams: &dto.SubModifyTaxParams{
-						Action:        dto.SubModifyTaxActionRemove,
-						AssociationID: &assoc.ID,
-						EffectiveDate: &future,
+						Action:           dto.SubModifyTaxActionRemove,
+						TaxAssociationID: &assoc.ID,
+						EffectiveDate:    &future,
 					},
 				}
 				resp, err := s.service.Execute(ctx, sub.ID, req)
@@ -292,8 +292,8 @@ func (s *SubscriptionModificationServiceSuite) TestTaxModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeTax,
 					TaxParams: &dto.SubModifyTaxParams{
-						Action:        dto.SubModifyTaxActionRemove,
-						AssociationID: &assoc.ID,
+						Action:           dto.SubModifyTaxActionRemove,
+						TaxAssociationID: &assoc.ID,
 						// EffectiveDate nil → defaults to now
 					},
 				}
@@ -318,8 +318,8 @@ func (s *SubscriptionModificationServiceSuite) TestTaxModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeTax,
 					TaxParams: &dto.SubModifyTaxParams{
-						Action:        dto.SubModifyTaxActionRemove,
-						AssociationID: &bogusID,
+						Action:           dto.SubModifyTaxActionRemove,
+						TaxAssociationID: &bogusID,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub.ID, req)
@@ -343,8 +343,8 @@ func (s *SubscriptionModificationServiceSuite) TestTaxModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeTax,
 					TaxParams: &dto.SubModifyTaxParams{
-						Action:        dto.SubModifyTaxActionRemove,
-						AssociationID: &assoc.ID,
+						Action:           dto.SubModifyTaxActionRemove,
+						TaxAssociationID: &assoc.ID,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub1.ID, req)
@@ -369,9 +369,9 @@ func (s *SubscriptionModificationServiceSuite) TestTaxModification() {
 				req := dto.ExecuteSubscriptionModifyRequest{
 					Type: dto.SubscriptionModifyTypeTax,
 					TaxParams: &dto.SubModifyTaxParams{
-						Action:        dto.SubModifyTaxActionRemove,
-						AssociationID: &assoc.ID,
-						EffectiveDate: &effectiveDate,
+						Action:           dto.SubModifyTaxActionRemove,
+						TaxAssociationID: &assoc.ID,
+						EffectiveDate:    &effectiveDate,
 					},
 				}
 				_, err := s.service.Execute(ctx, sub.ID, req)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Updated subscription modification API request fields: `association_id` is now `coupon_association_id` when removing coupons and `tax_association_id` when removing taxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->