### PR TITLE
 feat(subscription): allow addons on draft subscriptions

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4434,13 +4434,16 @@ func (s *subscriptionService) addAddonToSubscription(
 	}
 
 	// Check if subscription is in a state that allows addon attachment
+	// Draft is allowed to support shopping-cart preview flows where addons are
+	// attached before the subscription goes live. Trialing is intentionally
+	// excluded — add it here if trialing subscriptions should also accept addons.
 	allowedStatuses := []types.SubscriptionStatus{
 		types.SubscriptionStatusActive,
 		types.SubscriptionStatusDraft,
 	}
 	if !lo.Contains(allowedStatuses, sub.SubscriptionStatus) {
-		return nil, ierr.NewError("subscription is not active").
-			WithHint("Cannot add addon to inactive subscription").
+		return nil, ierr.NewError("subscription status does not allow addon attachment").
+			WithHint("Addon can only be added to active or draft subscriptions").
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -620,6 +620,11 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 			}
 		}
 
+		// Shift addon line item dates to the new activation start date
+		if err := s.shiftAddonLineItemDates(ctx, sub, newStartDate); err != nil {
+			return err
+		}
+
 		// Create invoice for the subscription
 		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID)
 		// Apply backward compatibility normalization
@@ -4951,6 +4956,62 @@ func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, price
 	lineItem.PriceUnit = price.PriceUnit
 
 	return lineItem
+}
+
+// shiftAddonLineItemDates updates StartDate (and EndDate for one-time addons) of all
+// addon associations and their line items to newStartDate. Called during draft activation
+// so that addon dates stay consistent with the new subscription start date.
+func (s *subscriptionService) shiftAddonLineItemDates(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	newStartDate time.Time,
+) error {
+	assocFilter := types.NewNoLimitAddonAssociationFilter()
+	assocFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	assocFilter.EntityIDs = []string{sub.ID}
+
+	associations, err := s.AddonAssociationRepo.List(ctx, assocFilter)
+	if err != nil {
+		return err
+	}
+
+	for _, assoc := range associations {
+		isOnetime := assoc.EndDate != nil
+
+		var newEnd time.Time
+		if isOnetime {
+			newEnd, err = addonPeriodEndForStartDate(sub, newStartDate)
+			if err != nil {
+				return err
+			}
+			assoc.EndDate = &newEnd
+			if err := s.AddonAssociationRepo.Update(ctx, assoc); err != nil {
+				return err
+			}
+		}
+
+		liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+		liFilter.SubscriptionIDs = []string{sub.ID}
+		liFilter.AddonAssociationIDs = []string{assoc.ID}
+		liFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+
+		lineItems, err := s.SubscriptionLineItemRepo.List(ctx, liFilter)
+		if err != nil {
+			return err
+		}
+
+		for _, item := range lineItems {
+			item.StartDate = newStartDate
+			if isOnetime {
+				item.EndDate = newEnd
+			}
+			if err := s.SubscriptionLineItemRepo.Update(ctx, item); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // addonPeriodEndForStartDate returns the end of the billing period that contains startDate.

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4433,8 +4433,12 @@ func (s *subscriptionService) addAddonToSubscription(
 			Mark(ierr.ErrValidation)
 	}
 
-	// Check if sub exists and is active
-	if sub.SubscriptionStatus != types.SubscriptionStatusActive {
+	// Check if subscription is in a state that allows addon attachment
+	allowedStatuses := []types.SubscriptionStatus{
+		types.SubscriptionStatusActive,
+		types.SubscriptionStatusDraft,
+	}
+	if !lo.Contains(allowedStatuses, sub.SubscriptionStatus) {
 		return nil, ierr.NewError("subscription is not active").
 			WithHint("Cannot add addon to inactive subscription").
 			Mark(ierr.ErrValidation)

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4969,6 +4969,7 @@ func (s *subscriptionService) shiftAddonLineItemDates(
 	assocFilter := types.NewNoLimitAddonAssociationFilter()
 	assocFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
 	assocFilter.EntityIDs = []string{sub.ID}
+	assocFilter.AddonStatus = lo.ToPtr(string(types.AddonStatusActive))
 
 	associations, err := s.AddonAssociationRepo.List(ctx, assocFilter)
 	if err != nil {
@@ -4976,6 +4977,10 @@ func (s *subscriptionService) shiftAddonLineItemDates(
 	}
 
 	for _, assoc := range associations {
+		// EndDate is set only for one-time cadence addons at creation time.
+		// Draft subscriptions cannot have cancelled associations (cancellation
+		// requires an active/trialing subscription), so EndDate != nil reliably
+		// identifies one-time addons here.
 		isOnetime := assoc.EndDate != nil
 
 		var newEnd time.Time

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7314,3 +7314,66 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_TrialStart_Invoice() {
 		})
 	}
 }
+
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_Draft() {
+	ctx := s.GetContext()
+
+	// Create a published addon with a monthly fixed price
+	subSvc := s.service.(*subscriptionService)
+	addonID := "addon_draft_test"
+	priceID := "price_addon_draft_test"
+
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Draft Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(subSvc.AddonRepo.Create(ctx, a))
+
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.NewFromFloat(10),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+
+	// Create a draft subscription
+	draftStart := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	draftResp, err := s.service.CreateSubscription(ctx, dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		StartDate:          lo.ToPtr(draftStart),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		SubscriptionStatus: types.SubscriptionStatusDraft,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(types.SubscriptionStatusDraft, draftResp.SubscriptionStatus)
+
+	// Adding an addon to a draft subscription must succeed (currently fails)
+	_, err = s.service.AddAddonToSubscription(ctx, draftResp.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID: addonID,
+	})
+	s.NoError(err)
+
+	// Addon line item must be stored
+	filter := types.NewNoLimitSubscriptionLineItemFilter()
+	filter.SubscriptionIDs = []string{draftResp.ID}
+	filter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+	items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, filter)
+	s.Require().NoError(err)
+	s.Require().Len(items, 1)
+	s.Equal(addonID, items[0].EntityID)
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7439,8 +7439,7 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_DraftWithAddons() {
 
 	// Addon association must be persisted
 	assocFilter := types.NewNoLimitAddonAssociationFilter()
-	entityType := types.AddonAssociationEntityTypeSubscription
-	assocFilter.EntityType = &entityType
+	assocFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
 	assocFilter.EntityIDs = []string{resp.ID}
 	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, assocFilter)
 	s.Require().NoError(err)

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7362,7 +7362,7 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_Draft() {
 	s.Require().NoError(err)
 	s.Require().Equal(types.SubscriptionStatusDraft, draftResp.SubscriptionStatus)
 
-	// Adding an addon to a draft subscription must succeed (currently fails)
+	// Adding an addon to a draft subscription must succeed
 	_, err = s.service.AddAddonToSubscription(ctx, draftResp.ID, &dto.AddAddonToSubscriptionRequest{
 		AddonID: addonID,
 	})
@@ -7376,4 +7376,14 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_Draft() {
 	s.Require().NoError(err)
 	s.Require().Len(items, 1)
 	s.Equal(addonID, items[0].EntityID)
+
+	// Addon association must also be persisted
+	aaFilter := types.NewNoLimitAddonAssociationFilter()
+	aaEntityType := types.AddonAssociationEntityTypeSubscription
+	aaFilter.EntityType = &aaEntityType
+	aaFilter.EntityIDs = []string{draftResp.ID}
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+	s.Require().NoError(err)
+	s.Require().Len(associations, 1)
+	s.Equal(addonID, associations[0].AddonID)
 }

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7387,3 +7387,72 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_Draft() {
 	s.Require().Len(associations, 1)
 	s.Equal(addonID, associations[0].AddonID)
 }
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_DraftWithAddons() {
+	ctx := s.GetContext()
+	subSvc := s.service.(*subscriptionService)
+
+	addonID := "addon_draft_create"
+	priceID := "price_addon_draft_create"
+
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Draft Create Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(subSvc.AddonRepo.Create(ctx, a))
+
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.NewFromFloat(20),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+
+	draftStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	resp, err := s.service.CreateSubscription(ctx, dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		StartDate:          lo.ToPtr(draftStart),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		SubscriptionStatus: types.SubscriptionStatusDraft,
+		Addons: []dto.AddAddonToSubscriptionRequest{
+			{AddonID: addonID},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(types.SubscriptionStatusDraft, resp.SubscriptionStatus)
+
+	// Addon association must be persisted
+	assocFilter := types.NewNoLimitAddonAssociationFilter()
+	entityType := types.AddonAssociationEntityTypeSubscription
+	assocFilter.EntityType = &entityType
+	assocFilter.EntityIDs = []string{resp.ID}
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, assocFilter)
+	s.Require().NoError(err)
+	s.Require().Len(associations, 1)
+	s.Equal(addonID, associations[0].AddonID)
+
+	// Addon line item must be persisted
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{resp.ID}
+	liFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+	items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.Require().NoError(err)
+	s.Require().Len(items, 1)
+	s.Equal(addonID, items[0].EntityID)
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7455,3 +7455,147 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_DraftWithAddons() {
 	s.Require().Len(items, 1)
 	s.Equal(addonID, items[0].EntityID)
 }
+
+func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_WithAddons_DatesShifted() {
+	ctx := s.GetContext()
+	subSvc := s.service.(*subscriptionService)
+
+	addonID := "addon_activate_shift"
+	priceID := "price_addon_activate_shift"
+
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Activate Shift Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(subSvc.AddonRepo.Create(ctx, a))
+
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.NewFromFloat(15),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+
+	// Create draft with addon (original start = T0)
+	t0 := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	resp, err := s.service.CreateSubscription(ctx, dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		StartDate:          lo.ToPtr(t0),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		PaymentBehavior:    lo.ToPtr(types.PaymentBehaviorDefaultActive),
+		SubscriptionStatus: types.SubscriptionStatusDraft,
+		Addons: []dto.AddAddonToSubscriptionRequest{
+			{AddonID: addonID},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Activate with new start = T1
+	t1 := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	_, err = s.service.ActivateDraftSubscription(ctx, resp.ID, dto.ActivateDraftSubscriptionRequest{
+		StartDate: lo.ToPtr(t1),
+	})
+	s.Require().NoError(err)
+
+	// Addon line item StartDate must equal T1
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{resp.ID}
+	liFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+	items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.Require().NoError(err)
+	s.Require().Len(items, 1)
+	s.True(items[0].StartDate.Equal(t1), "addon line item StartDate should equal activation start date")
+}
+
+func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_OnetimeAddon_EndDateRecomputed() {
+	ctx := s.GetContext()
+	subSvc := s.service.(*subscriptionService)
+
+	addonID := "addon_onetime_shift"
+	priceID := "price_onetime_shift"
+
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Onetime Shift Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(subSvc.AddonRepo.Create(ctx, a))
+
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.NewFromFloat(50),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+
+	// Create draft at T0 with a one-time addon
+	t0 := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	resp, err := s.service.CreateSubscription(ctx, dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		StartDate:          lo.ToPtr(t0),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		PaymentBehavior:    lo.ToPtr(types.PaymentBehaviorDefaultActive),
+		SubscriptionStatus: types.SubscriptionStatusDraft,
+		Addons: []dto.AddAddonToSubscriptionRequest{
+			{AddonID: addonID, Cadence: types.AddonCadenceOnetime},
+		},
+	})
+	s.Require().NoError(err)
+
+	// Activate at T1 (one month later)
+	t1 := time.Date(2026, 10, 1, 0, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(2026, 11, 1, 0, 0, 0, 0, time.UTC) // period end after T1 for monthly
+	_, err = s.service.ActivateDraftSubscription(ctx, resp.ID, dto.ActivateDraftSubscriptionRequest{
+		StartDate: lo.ToPtr(t1),
+	})
+	s.Require().NoError(err)
+
+	// Line item StartDate == T1, EndDate == expectedEnd
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{resp.ID}
+	liFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+	items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.Require().NoError(err)
+	s.Require().Len(items, 1)
+	s.True(items[0].StartDate.Equal(t1), "addon line item StartDate should equal activation start date")
+	s.True(items[0].EndDate.Equal(expectedEnd), "one-time addon line item EndDate should be recomputed from activation start date")
+
+	// Association EndDate must also equal expectedEnd
+	assocFilter := types.NewNoLimitAddonAssociationFilter()
+	assocFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	assocFilter.EntityIDs = []string{resp.ID}
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, assocFilter)
+	s.Require().NoError(err)
+	s.Require().Len(associations, 1)
+	s.Require().NotNil(associations[0].EndDate)
+	s.True(associations[0].EndDate.Equal(expectedEnd), "one-time addon association EndDate should be recomputed from activation start date")
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7520,6 +7520,7 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_WithAddons_Date
 	s.Require().NoError(err)
 	s.Require().Len(items, 1)
 	s.True(items[0].StartDate.Equal(t1), "addon line item StartDate should equal activation start date")
+	s.True(items[0].EndDate.IsZero(), "recurring addon EndDate should not be set after activation")
 }
 
 func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_OnetimeAddon_EndDateRecomputed() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Addons can now be attached to draft subscriptions, providing greater flexibility in subscription setup
- Draft subscription activation automatically adjusts addon dates to match the new subscription start date
- One-time addon billing periods are correctly recalculated when activating draft subscriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->