### PR TITLE
fix(user): ensure tenant-scoped API key checks in DeleteUser function

### DIFF
--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -423,8 +423,10 @@ func (s *userService) DeleteUser(ctx context.Context, id string) error {
 	}
 
 	// Block archive if the service account has active (published, non-expired) API keys.
+	// Service accounts are tenant-scoped (not per-environment), so check across all environments.
 	now := time.Now().UTC()
-	activeCount, err := s.secretRepo.Count(ctx, &types.SecretFilter{
+	tenantCtx := types.SetEnvironmentID(ctx, "")
+	activeCount, err := s.secretRepo.Count(tenantCtx, &types.SecretFilter{
 		QueryFilter: &types.QueryFilter{
 			Status: lo.ToPtr(types.StatusPublished),
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed service account deletion to correctly block removal when API keys exist across all environments, not just the current environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->