### PR TITLE
ci(deploy): publish GHCR :main tag on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,7 @@ jobs:
           echo "tag=${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
           IS_DEVELOP="${{ github.ref_name == 'develop' }}"
+          IS_MAIN="${{ github.ref_name == 'main' }}"
 
           {
             echo "ghcr_tags<<TAGS_EOF"
@@ -93,11 +94,13 @@ jobs:
               echo "${GHCR_IMAGE}:latest"
             elif [ "$IS_DEVELOP" = "true" ]; then
               echo "${GHCR_IMAGE}:develop"
+            elif [ "$IS_MAIN" = "true" ]; then
+              echo "${GHCR_IMAGE}:main"
             fi
             echo "TAGS_EOF"
           } >> $GITHUB_OUTPUT
 
-          if [ "$IS_RELEASE" = "true" ] || [ "$IS_DEVELOP" = "true" ]; then
+          if [ "$IS_RELEASE" = "true" ] || [ "$IS_DEVELOP" = "true" ] || [ "$IS_MAIN" = "true" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/arm64" >> $GITHUB_OUTPUT

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -423,7 +423,7 @@ func (s *userService) DeleteUser(ctx context.Context, id string) error {
 	}
 
 	// Block archive if the service account has active (published, non-expired) API keys.
-	// Service accounts are tenant-scoped (not per-environment), so check across all environments.
+	// Service accounts are tenant-scoped, so check across all environments.
 	now := time.Now().UTC()
 	tenantCtx := types.SetEnvironmentID(ctx, "")
 	activeCount, err := s.secretRepo.Count(tenantCtx, &types.SecretFilter{


### PR DESCRIPTION
## What

Mirror the develop GHCR publish behavior for `main`.

Previously, a push to `main` only published the SHA-tagged image to GHCR, and built single-arch (`linux/arm64`). `develop` additionally got a `:develop` tag built multi-arch (`amd64,arm64`).

After this change, a push to `main` publishes `ghcr.io/flexprice/flexprice:main` built for `linux/amd64,linux/arm64`, matching `develop`.

## Change

In `deploy.yml` `Prepare image tags` step:
- Added `IS_MAIN` check (`github.ref_name == 'main'`).
- `:main` tag added to `ghcr_tags` on main push.
- `main` added to the multi-arch platform condition.

No change to ECR push or deploy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration for main branch consistency
  * Updated internal documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->