### PR TITLE
fix(meter-usage): Handle non-subscription meters in usage

### DIFF
--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -140,10 +140,60 @@ type lineItemWithMeter struct {
 // Simple passthrough methods
 // ---------------------------------------------------------------------------
 
+// activeSubscriptionMeterIDs returns the set of meter_ids that belong to any
+// currently-active (active or trialing) subscription for the given customer.
+//
+// The meter ingestion pipeline no longer validates that a meter belongs to an
+// active subscription before writing, so meter_usage now contains rows for
+// "stale" meters — meters that match the customer's event_name but aren't on
+// any of their current subscription line items. Reads must filter those out.
+//
+// Returns an empty set (not an error) if the customer doesn't exist; callers
+// should treat that as "no usage to return".
+func (s *meterUsageService) activeSubscriptionMeterIDs(ctx context.Context, externalCustomerID string) (map[string]struct{}, error) {
+	out := make(map[string]struct{})
+	if externalCustomerID == "" {
+		return out, nil
+	}
+	cust, err := s.CustomerRepo.GetByLookupKey(ctx, externalCustomerID)
+	if err != nil {
+		if ierr.IsNotFound(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+	subs, err := s.SubRepo.ListByCustomerID(ctx, cust.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, sub := range subs {
+		for _, li := range sub.LineItems {
+			if li.PriceType == types.PRICE_TYPE_USAGE && li.MeterID != "" {
+				out[li.MeterID] = struct{}{}
+			}
+		}
+	}
+	return out, nil
+}
+
 func (s *meterUsageService) GetUsage(ctx context.Context, params *events.MeterUsageQueryParams) (*events.MeterUsageAggregationResult, error) {
 	if params == nil {
 		return nil, ierr.NewError("params are required").Mark(ierr.ErrValidation)
 	}
+
+	activeMeters, err := s.activeSubscriptionMeterIDs(ctx, params.ExternalCustomerID)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := activeMeters[params.MeterID]; !ok {
+		// meter_id is not on any active subscription line item for this
+		// customer — return zeroed result rather than leaking stale rows.
+		return &events.MeterUsageAggregationResult{
+			MeterID:         params.MeterID,
+			AggregationType: params.AggregationType,
+		}, nil
+	}
+
 	return s.repo.GetUsage(ctx, params)
 }
 
@@ -151,7 +201,27 @@ func (s *meterUsageService) GetUsageMultiMeter(ctx context.Context, params *even
 	if params == nil || len(params.MeterIDs) == 0 {
 		return nil, ierr.NewError("params with meter_ids are required").Mark(ierr.ErrValidation)
 	}
-	return s.repo.GetUsageMultiMeter(ctx, params)
+
+	activeMeters, err := s.activeSubscriptionMeterIDs(ctx, params.ExternalCustomerID)
+	if err != nil {
+		return nil, err
+	}
+	filtered := params.MeterIDs[:0:0]
+	for _, id := range params.MeterIDs {
+		if _, ok := activeMeters[id]; ok {
+			filtered = append(filtered, id)
+		}
+	}
+	if len(filtered) == 0 {
+		// None of the requested meters are on the customer's active
+		// subscriptions — nothing to fetch.
+		return nil, nil
+	}
+
+	// Don't mutate caller's params slice — make a shallow copy.
+	q := *params
+	q.MeterIDs = filtered
+	return s.repo.GetUsageMultiMeter(ctx, &q)
 }
 
 // ---------------------------------------------------------------------------
@@ -867,12 +937,8 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 		params.StartTime = params.EndTime.Add(-6 * time.Hour)
 	}
 
-	// feature_id is a feature_usage-table column; meter_usage doesn't carry it.
-	// Since feature.meter_id is 1:1, group_by=[feature_id] is semantically
-	// equivalent to group_by=[meter_id] — rewrite at the entry point so the
-	// downstream query builder (which only knows meter_id/source/properties.*)
-	// accepts it, and the converter populates FeatureID from the meter→feature
-	// lookup. Dedupe so [feature_id, meter_id] doesn't become [meter_id, meter_id].
+	// feature_id ≡ meter_id (1:1). Rewrite at entry so the SQL builder accepts
+	// it; the converter restores FeatureID via the meter→feature lookup.
 	if len(params.GroupBy) > 0 {
 		rewritten := make([]string, 0, len(params.GroupBy))
 		for _, g := range params.GroupBy {
@@ -882,17 +948,14 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 			rewritten = append(rewritten, g)
 		}
 		params.GroupBy = lo.Uniq(rewritten)
-		// Reject malformed entries before they hit the SQL builder, where
-		// they'd be silently dropped (debugging nightmare). Accepted forms:
-		// "meter_id" / "source" / "properties.<valid name>". Everything else
-		// is a user error worth surfacing as a 400.
+		// Surface invalid group_by as 400 — the SQL builder would otherwise drop it silently.
 		if err := validateAnalyticsGroupBy(params.GroupBy); err != nil {
 			return nil, err
 		}
 	}
 
-	// Resolve FeatureIDs → MeterIDs (only when MeterIDs not already specified).
-	// Fail closed: a feature-scoped request must not silently broaden to all meters.
+	// Resolve FeatureIDs → MeterIDs. Fail closed so an unresolvable feature
+	// list doesn't silently broaden to "all meters".
 	if len(params.FeatureIDs) > 0 && len(params.MeterIDs) == 0 {
 		features, err := s.FeatureRepo.ListByIDs(ctx, params.FeatureIDs)
 		if err != nil {
@@ -912,11 +975,58 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 		}
 	}
 
-	// Resolve customer → subscriptions
 	cust, subscriptions, err := s.resolveCustomerAndSubscriptions(ctx, params.ExternalCustomerID)
 	if err != nil || len(subscriptions) == 0 {
-		// No customer context — fallback to direct repo queries
+		// No customer context — admin-style query across raw meter_usage.
 		return s.getDetailedAnalyticsWithoutSubscriptionContext(ctx, params)
+	}
+
+	// Filter to meters on a subscription line item overlapping the query window.
+	// Ingestion doesn't validate "meter on active sub", so meter_usage can carry
+	// stale rows from shared event_name fan-out. Uses the same CancelledAt and
+	// GetPeriodStart/End clamps as the GSMU loop below so the bounds agree.
+	activeMeters := make(map[string]struct{})
+	for _, sub := range subscriptions {
+		subEnd := params.EndTime
+		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled && sub.CancelledAt != nil {
+			if sub.CancelledAt.Before(subEnd) {
+				subEnd = *sub.CancelledAt
+			}
+		}
+		if !subEnd.After(params.StartTime) {
+			continue // sub's effective window ended before query window starts
+		}
+		for _, li := range sub.LineItems {
+			if li.PriceType != types.PRICE_TYPE_USAGE || li.MeterID == "" {
+				continue
+			}
+			liStart := li.GetPeriodStart(params.StartTime)
+			liEnd := li.GetPeriodEnd(subEnd)
+			if liStart.Before(liEnd) {
+				activeMeters[li.MeterID] = struct{}{}
+			}
+		}
+	}
+	if len(params.MeterIDs) > 0 {
+		filtered := make([]string, 0, len(params.MeterIDs))
+		for _, id := range params.MeterIDs {
+			if _, ok := activeMeters[id]; ok {
+				filtered = append(filtered, id)
+			}
+		}
+		params.MeterIDs = filtered
+	} else {
+		// No caller filter → restrict to the active set.
+		params.MeterIDs = make([]string, 0, len(activeMeters))
+		for id := range activeMeters {
+			params.MeterIDs = append(params.MeterIDs, id)
+		}
+	}
+	if len(params.MeterIDs) == 0 {
+		return &dto.GetUsageAnalyticsResponse{
+			TotalCost: decimal.Zero,
+			Items:     []dto.UsageAnalyticItem{},
+		}, nil
 	}
 
 	// Call GetSubscriptionMeterUsage per subscription
@@ -927,13 +1037,9 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 			billingAnchor = &sub.BillingAnchor
 		}
 
-		// Clamp the query window by CancelledAt for cancelled subs. meter_usage
-		// has no per-event subscription linkage — the per-line-item date bound
-		// (lineItem.GetPeriodEnd) falls back to the request EndTime when the
-		// line item has no EndDate, which is the common case after a cancel.
-		// Without this clamp, a cancelled sub's line items would re-attribute
-		// post-cancellation events from whichever sub is now active for the
-		// same meter. Skip entirely when the clamped window has no overlap.
+		// Clamp by CancelledAt: meter_usage has no per-event sub linkage, so
+		// without this a cancelled sub's line items would steal post-cancel
+		// events from whichever sub is now active for the same meter.
 		subEndTime := params.EndTime
 		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled && sub.CancelledAt != nil {
 			if sub.CancelledAt.Before(subEndTime) {

--- a/internal/ee/service/meter_usage_test.go
+++ b/internal/ee/service/meter_usage_test.go
@@ -3631,6 +3631,247 @@ func (s *MeterUsageServiceSuite) TestMeterUsage_CancelledSubInsideWindow_Attribu
 }
 
 // ---------------------------------------------------------------------------
+// Stale-meter filter — GetDetailedAnalytics restricts to meters on at least
+// one subscription line item that overlaps the query window. The ingestion
+// pipeline no longer validates that an event's matching meter is on an active
+// subscription, so meter_usage can carry rows for "stale" meters that fanned
+// out from a shared event_name. Reads must not surface those.
+// ---------------------------------------------------------------------------
+
+// TestGetDetailedAnalytics_StaleMeterExplicit_FilteredOut covers the case the
+// user reported in production: two meters fired for the same event_name, only
+// one of them is on the customer's subscription, but the caller passed both
+// in MeterIDs. The stale one must be filtered out.
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_StaleMeterExplicit_FilteredOut() {
+	ctx := s.GetContext()
+
+	// Subscribed meter — linked to s.sub via a line item.
+	subscribed := s.createMeterWithAggregation(ctx, "mtr_subscribed_explicit", "ev_shared", types.AggregationCount)
+	p := s.createPriceForMeter(ctx, "pr_subscribed_explicit", subscribed.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_subscribed_explicit", subscribed.ID, p.ID)
+
+	// Stale meter — exists and has rows in meter_usage but is NOT on any line
+	// item for this customer (mimics the shared-event_name fan-out).
+	stale := s.createMeterWithAggregation(ctx, "mtr_stale_explicit", "ev_shared", types.AggregationCount)
+
+	// Same event timestamp on both meters (the two-rows-per-event pattern).
+	ts := s.periodStart.Add(24 * time.Hour)
+	s.insertMeterUsageFull(ctx, subscribed.ID, s.customer.ExternalID, "", "ev_shared", ts, 1, "", nil)
+	s.insertMeterUsageFull(ctx, stale.ID, s.customer.ExternalID, "", "ev_shared", ts, 1, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{subscribed.ID, stale.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	subscribedSeen, staleSeen := false, false
+	for _, item := range resp.Items {
+		switch item.MeterID {
+		case subscribed.ID:
+			subscribedSeen = true
+		case stale.ID:
+			staleSeen = true
+		}
+	}
+	s.True(subscribedSeen, "subscribed meter must appear in response")
+	s.False(staleSeen, "stale meter (not on any line item) must be filtered out even when explicitly requested")
+}
+
+// TestGetDetailedAnalytics_StaleMeterImplicit_FilteredOut: same as above but
+// the caller passes an empty MeterIDs — exercises the "auto-fill from active
+// set" branch of the filter (no explicit caller list).
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_StaleMeterImplicit_FilteredOut() {
+	ctx := s.GetContext()
+
+	subscribed := s.createMeterWithAggregation(ctx, "mtr_subscribed_impl", "ev_impl", types.AggregationCount)
+	p := s.createPriceForMeter(ctx, "pr_subscribed_impl", subscribed.ID, decimal.NewFromInt(1))
+	s.createLineItemForMeter(ctx, "li_subscribed_impl", subscribed.ID, p.ID)
+
+	stale := s.createMeterWithAggregation(ctx, "mtr_stale_impl", "ev_impl", types.AggregationCount)
+
+	ts := s.periodStart.Add(24 * time.Hour)
+	s.insertMeterUsageFull(ctx, subscribed.ID, s.customer.ExternalID, "", "ev_impl", ts, 1, "", nil)
+	s.insertMeterUsageFull(ctx, stale.ID, s.customer.ExternalID, "", "ev_impl", ts, 1, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		// No MeterIDs — filter auto-fills from sub line items.
+		StartTime: s.periodStart,
+		EndTime:   s.periodEnd,
+	})
+	s.NoError(err)
+
+	subscribedSeen, staleSeen := false, false
+	for _, item := range resp.Items {
+		switch item.MeterID {
+		case subscribed.ID:
+			subscribedSeen = true
+		case stale.ID:
+			staleSeen = true
+		}
+	}
+	s.True(subscribedSeen, "subscribed meter must appear in response")
+	s.False(staleSeen, "stale meter must not appear when caller omits MeterIDs")
+}
+
+// TestGetDetailedAnalytics_CancelledMidWindowMeterOnly_PreCancelUsageReturned
+// proves the filter is window-aware (not just "currently Active+Trialing"):
+// a meter that lives ONLY on a subscription cancelled mid-window must still
+// contribute its pre-cancellation usage, even though that subscription is no
+// longer in Active/Trialing status. Without the GetPeriodEnd / CancelledAt
+// clamp in the filter, a naive "active subscriptions only" pass would drop
+// this meter and silently lose valid analytics data.
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_CancelledMidWindowMeterOnly_PreCancelUsageReturned() {
+	ctx := s.GetContext()
+
+	cancelledAt := s.periodStart.Add(72 * time.Hour)
+	cancelledSub := &subscription.Subscription{
+		ID:                 "sub_mid_cancel_unique_meter",
+		CustomerID:         s.customer.ID,
+		PlanID:             "plan_1",
+		Currency:           "usd",
+		SubscriptionStatus: types.SubscriptionStatusCancelled,
+		CurrentPeriodStart: s.periodStart,
+		CurrentPeriodEnd:   s.periodEnd,
+		BillingAnchor:      s.periodStart,
+		StartDate:          s.periodStart,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		CancelledAt:        &cancelledAt,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, cancelledSub))
+
+	// Meter lives ONLY on the cancelled subscription — no line item ties it
+	// to s.sub (the suite's active subscription). SUM aggregation lets us
+	// distinguish the two event quantities (100 pre-cancel, 50 post-cancel)
+	// rather than just count rows.
+	onlyMeter := s.createMeterWithAggregation(ctx, "mtr_cancel_only", "ev_cancel_only", types.AggregationSum)
+	pCancel := s.createPriceForMeter(ctx, "pr_cancel_only", onlyMeter.ID, decimal.NewFromInt(1))
+	cancelledLI := &subscription.SubscriptionLineItem{
+		ID:             "li_cancel_only",
+		SubscriptionID: cancelledSub.ID,
+		CustomerID:     s.customer.ID,
+		PriceID:        pCancel.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        onlyMeter.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      s.periodStart,
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, cancelledLI))
+
+	// Pre-cancellation event (24h after start → before 72h cancellation).
+	s.insertMeterUsageFull(ctx, onlyMeter.ID, s.customer.ExternalID, "", "ev_cancel_only",
+		s.periodStart.Add(24*time.Hour), 100, "", nil)
+	// Post-cancellation event (96h after start → after 72h cancellation).
+	s.insertMeterUsageFull(ctx, onlyMeter.ID, s.customer.ExternalID, "", "ev_cancel_only",
+		s.periodStart.Add(96*time.Hour), 50, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{onlyMeter.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	var seen bool
+	var totalUsage decimal.Decimal
+	for _, item := range resp.Items {
+		if item.MeterID == onlyMeter.ID {
+			seen = true
+			totalUsage = item.TotalUsage
+		}
+	}
+	s.True(seen, "meter on cancelled-mid-window subscription must still appear in response (window-aware filter)")
+	s.True(totalUsage.Equal(decimal.NewFromInt(100)),
+		"only pre-cancellation event qty (100) should count; post-cancel qty (50) is clamped out — got %s", totalUsage)
+}
+
+// TestGetDetailedAnalytics_OnlyPreWindowCancelledSubs_ReturnsEmpty: when every
+// subscription the customer has was cancelled before the query window started,
+// the filter produces an empty active-meter set and we return empty without
+// hitting any per-subscription query. This is the early-return at the bottom
+// of the filter block (params.MeterIDs becomes empty after intersection).
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_OnlyPreWindowCancelledSubs_ReturnsEmpty() {
+	ctx := s.GetContext()
+
+	// Use a fresh customer so the suite's default active s.sub doesn't shadow
+	// the "only-cancelled-subs" condition.
+	cust := &customer.Customer{
+		ID:         "cust_only_cancelled",
+		ExternalID: "ext_only_cancelled",
+		Name:       "Only Cancelled Customer",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, cust))
+
+	cancelledAt := s.periodStart.Add(-180 * 24 * time.Hour)
+	cancelledStart := s.periodStart.Add(-200 * 24 * time.Hour)
+	cancelledSub := &subscription.Subscription{
+		ID:                 "sub_only_cancelled",
+		CustomerID:         cust.ID,
+		PlanID:             "plan_1",
+		Currency:           "usd",
+		SubscriptionStatus: types.SubscriptionStatusCancelled,
+		CurrentPeriodStart: cancelledStart,
+		CurrentPeriodEnd:   cancelledStart.Add(30 * 24 * time.Hour),
+		BillingAnchor:      cancelledStart,
+		StartDate:          cancelledStart,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		CancelledAt:        &cancelledAt,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, cancelledSub))
+
+	li := &subscription.SubscriptionLineItem{
+		ID:             "li_only_cancelled",
+		SubscriptionID: cancelledSub.ID,
+		CustomerID:     cust.ID,
+		PriceID:        s.priceAPI.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        s.meterAPI.ID,
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      cancelledStart,
+		Quantity:       decimal.NewFromInt(1),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// Events inside the query window — must NOT be attributed because no
+	// subscription is in-window.
+	s.insertMeterUsage(ctx, s.meterAPI.ID, cust.ExternalID,
+		s.periodStart.Add(24*time.Hour), 100)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: cust.ExternalID,
+		MeterIDs:           []string{s.meterAPI.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+	s.Empty(resp.Items, "no subscription overlaps the query window → empty response")
+}
+
+// ---------------------------------------------------------------------------
 // skipSyntheticZeros — suppress zero-usage line-item injection under filters.
 //
 // When PropertyFilters or Sources are present, the SQL result is a deliberate

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -202,8 +202,24 @@ func (s *InMemorySubscriptionStore) List(ctx context.Context, filter *types.Subs
 			WithHint("Failed to list subscriptions").
 			Mark(ierr.ErrDatabase)
 	}
-	// Attach line items to each subscription
+	// Attach line items to each subscription. Mirror GetWithLineItems:
+	// when lineItemStore is wired (the standard test setup wires it via
+	// SetLineItemStore), source from it so line items added via the
+	// SubscriptionLineItemRepo are visible here too. Falls back to the
+	// initial-batch map populated by CreateWithLineItems.
 	for _, sub := range subs {
+		if s.lineItemStore != nil {
+			liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+			liFilter.SubscriptionIDs = []string{sub.ID}
+			liFilter.ActiveFilter = true
+			liFilter.CurrentPeriodStart = &sub.CurrentPeriodStart
+			items, lerr := s.lineItemStore.List(ctx, liFilter)
+			if lerr != nil {
+				return nil, lerr
+			}
+			sub.LineItems = items
+			continue
+		}
 		if items, ok := s.lineItems[sub.ID]; ok {
 			sub.LineItems = items
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed meter usage reporting to exclude inactive meters not tied to active subscriptions, improving data accuracy.
  * Enhanced analytics query validation to flag invalid meter selections with clear error messages.
  * Improved usage calculation for cancelled subscriptions by properly clamping to cancellation timestamps.

* **Tests**
  * Added regression tests covering stale meter filtering, cancelled subscription edge cases, and implicit meter selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->