### PR TITLE
fix(wallet-alert): render config in chart + gate producer on enabled

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -163,6 +163,16 @@ data:
       consumer_group: {{ .Values.onboardingEvents.consumerGroup | quote }}
       max_retries: {{ .Values.onboardingEvents.maxRetries }}
 
+    wallet_balance_alert:
+      # Rendered here because viper does NOT apply Go `default` tags on Unmarshal
+      # (same class as event_processing above). Without this block the topic
+      # resolves to "" and Kafka rejects the publish as an invalid topic. The
+      # producer is also gated on `enabled`, so enabled:false => no publish.
+      enabled: {{ .Values.walletBalanceAlert.enabled }}
+      topic: {{ .Values.walletBalanceAlert.topic | quote }}
+      rate_limit: {{ .Values.walletBalanceAlert.rateLimit }}
+      consumer_group: {{ .Values.walletBalanceAlert.consumerGroup | quote }}
+
     webhook:
       enabled: {{ .Values.webhook.enabled }}
       topic: {{ .Values.webhook.topic | quote }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -795,6 +795,16 @@ onboardingEvents:
   consumerGroup: "onboarding_events_consumer"
   maxRetries: 3
 
+# Wallet balance alert configuration.
+# Default off: enabling requires the topic to exist on the broker and a consumer
+# to be running. The producer is gated on `enabled`, so off => no Kafka publish.
+# Override `enabled: true` per-environment once the topic + consumer are provisioned.
+walletBalanceAlert:
+  enabled: false
+  topic: "wallet_alert"
+  rateLimit: 1
+  consumerGroup: "v1_wallet_alert_service"
+
 # Raw event consumption configuration
 rawEventConsumption:
   enabled: false

--- a/internal/ee/service/wallet_balance_alert.go
+++ b/internal/ee/service/wallet_balance_alert.go
@@ -60,6 +60,15 @@ func NewWalletBalanceAlertService(
 // PublishEvent publishes a wallet balance alert event to Kafka
 func (s *walletBalanceAlertService) PublishEvent(ctx context.Context, event *wallet.WalletBalanceAlertEvent) error {
 
+	// Feature gate: when disabled, do not produce. `enabled` is the single switch
+	// for the whole feature (this producer + the consumer in RegisterHandler). The
+	// call sites in walletService invoke this on every wallet operation regardless
+	// of the flag, so without this guard a disabled deployment would still publish
+	// to a (possibly empty/unprovisioned) topic and error on every operation.
+	if !s.Config.WalletBalanceAlert.Enabled {
+		return nil
+	}
+
 	err := event.Validate()
 	if err != nil {
 		return ierr.WithError(err).


### PR DESCRIPTION
## Problem

Every GKE deployment logs `cannot produce message <id>: kafka server: The request attempted to perform an operation on an invalid topic` on **every wallet operation**. The reported `topic` in the error is `""` (empty).

## Root cause

`wallet_balance_alert` is the **only consumer config block not rendered into the Helm ConfigMap's `config.yaml`**. Viper does **not** apply Go struct `default:` tags on `Unmarshal` (this is already documented in `configmap.yaml` for `event_processing`), so `WalletBalanceAlertConfig.Topic` resolves to `""` on GKE. The repo `internal/config/config.yaml` carries the value, but that file only applies to local/docker dev — not the chart-rendered config used in cluster.

Compounding it: the producer (`walletService` → `walletBalanceAlertService.PublishEvent`) fires on **every** wallet operation regardless of the `enabled` flag (`enabled` only gated the consumer in `RegisterHandler`). So the empty-topic publish ran constantly.

## Fix

1. **Render the block in the chart** — `wallet_balance_alert` added to `templates/app/configmap.yaml`, driven by `.Values.walletBalanceAlert.*`, mirroring `event_processing` / `onboarding_events`.
2. **Chart defaults** — `walletBalanceAlert` added to `values.yaml`, **default `enabled: false`** (enabling requires the topic to exist on the broker and a consumer running, so it's opt-in per-environment).
3. **Gate the producer** — `PublishEvent` returns early when `!Enabled`, making `enabled` the single switch for the whole feature (producer + consumer). Disabled ⇒ no Kafka publish ⇒ no empty/missing-topic errors.

## Effect

- Every GKE environment inherits `enabled: false` ⇒ no publish ⇒ **error gone, with no infra-repo change required.**
- The empty-topic trap is closed: even if someone sets `enabled: true`, the topic renders as `wallet_alert` instead of `""`.
- Enabling the feature later is a one-line per-env values override (`walletBalanceAlert.enabled: true`) **plus** provisioning the `wallet_alert` topic and a consumer in that environment.

## Testing

- `go build ./internal/ee/service/` passes.
- Helm render not verified locally (no `helm` CLI on the dev machine) — the new block is a direct copy of the adjacent rendered blocks; please confirm via CI `helm template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wallet balance alert functionality now available with comprehensive configuration options including enable/disable toggle, customizable Kafka topic and consumer group settings, and rate limiting controls. Disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->