### PR TITLE
feat(coupon): add expand for coupon and line item

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -978,6 +978,12 @@ const docTemplate = `{
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Comma-separated fields: coupon, subscription_line_items, subscription_line_items.prices",
+                        "name": "expand",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Page size",
                         "name": "limit",
@@ -13283,7 +13289,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "coupon": {
-                    "$ref": "#/definitions/Coupon"
+                    "$ref": "#/definitions/CouponResponse"
                 },
                 "coupon_id": {
                     "type": "string"
@@ -13319,6 +13325,9 @@ const docTemplate = `{
                 "subscription_id": {
                     "description": "Mandatory",
                     "type": "string"
+                },
+                "subscription_line_item": {
+                    "$ref": "#/definitions/SubscriptionLineItemResponse"
                 },
                 "subscription_line_item_id": {
                     "description": "Optional",
@@ -24506,6 +24515,12 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.Status"
                 },
                 "subscription_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subscription_line_item_ids": {
                     "description": "Specific filters",
                     "type": "array",
                     "items": {

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -1167,6 +1167,14 @@
             }
           },
           {
+            "name": "expand",
+            "in": "query",
+            "description": "Comma-separated fields: coupon, subscription_line_items, subscription_line_items.prices",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "description": "Page size",
@@ -15306,7 +15314,7 @@
         "type": "object",
         "properties": {
           "coupon": {
-            "$ref": "#/components/schemas/Coupon"
+            "$ref": "#/components/schemas/CouponResponse"
           },
           "coupon_id": {
             "type": "string"
@@ -15345,6 +15353,9 @@
           "subscription_id": {
             "type": "string",
             "description": "Mandatory"
+          },
+          "subscription_line_item": {
+            "$ref": "#/components/schemas/SubscriptionLineItemResponse"
           },
           "subscription_line_item_id": {
             "type": "string",
@@ -26260,6 +26271,12 @@
             "$ref": "#/components/schemas/types.Status"
           },
           "subscription_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subscription_line_item_ids": {
             "type": "array",
             "description": "Specific filters",
             "items": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -974,6 +974,12 @@
                         "in": "query"
                     },
                     {
+                        "type": "string",
+                        "description": "Comma-separated fields: coupon, subscription_line_items, subscription_line_items.prices",
+                        "name": "expand",
+                        "in": "query"
+                    },
+                    {
                         "type": "integer",
                         "description": "Page size",
                         "name": "limit",
@@ -13195,7 +13201,7 @@
             "type": "object",
             "properties": {
                 "coupon": {
-                    "$ref": "#/definitions/Coupon"
+                    "$ref": "#/definitions/CouponResponse"
                 },
                 "coupon_id": {
                     "type": "string"
@@ -13231,6 +13237,9 @@
                 "subscription_id": {
                     "description": "Mandatory",
                     "type": "string"
+                },
+                "subscription_line_item": {
+                    "$ref": "#/definitions/SubscriptionLineItemResponse"
                 },
                 "subscription_line_item_id": {
                     "description": "Optional",
@@ -23934,6 +23943,12 @@
                     "$ref": "#/definitions/types.Status"
                 },
                 "subscription_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "subscription_line_item_ids": {
                     "description": "Specific filters",
                     "type": "array",
                     "items": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1056,7 +1056,7 @@ definitions:
   CouponAssociationResponse:
     properties:
       coupon:
-        $ref: '#/definitions/Coupon'
+        $ref: '#/definitions/CouponResponse'
       coupon_id:
         type: string
       created_at:
@@ -1081,6 +1081,8 @@ definitions:
       subscription_id:
         description: Mandatory
         type: string
+      subscription_line_item:
+        $ref: '#/definitions/SubscriptionLineItemResponse'
       subscription_line_item_id:
         description: Optional
         type: string
@@ -9317,6 +9319,10 @@ definitions:
       status:
         $ref: '#/definitions/types.Status'
       subscription_ids:
+        items:
+          type: string
+        type: array
+      subscription_line_item_ids:
         description: Specific filters
         items:
           type: string
@@ -11357,6 +11363,10 @@ paths:
         in: query
         name: active_only
         type: boolean
+      - description: 'Comma-separated fields: coupon, subscription_line_items, subscription_line_items.prices'
+        in: query
+        name: expand
+        type: string
       - description: Page size
         in: query
         name: limit

--- a/internal/api/dto/coupon_association.go
+++ b/internal/api/dto/coupon_association.go
@@ -22,6 +22,8 @@ type CreateCouponAssociationRequest struct {
 // CouponAssociationResponse represents the response for coupon association data
 type CouponAssociationResponse struct {
 	*couponAssociation.CouponAssociation `json:",inline"`
+	Coupon               *CouponResponse               `json:"coupon,omitempty"`
+	SubscriptionLineItem *SubscriptionLineItemResponse `json:"subscription_line_item,omitempty"`
 }
 
 // ListCouponAssociationsResponse represents the response for listing coupon associations

--- a/internal/api/v1/coupon.go
+++ b/internal/api/v1/coupon.go
@@ -294,6 +294,7 @@ func (h *CouponHandler) GetCouponAssociation(c *gin.Context) {
 // @Param subscription_ids query []string false "Filter by subscription IDs (max 100)"
 // @Param coupon_ids query []string false "Filter by coupon IDs (max 100)"
 // @Param active_only query boolean false "Return only currently active associations"
+// @Param expand query string false "Comma-separated fields: coupon, subscription_line_items, subscription_line_items.prices"
 // @Param limit query integer false "Page size"
 // @Param offset query integer false "Page offset"
 // @Success 200 {object} dto.ListCouponAssociationsResponse

--- a/internal/ee/service/coupon_association.go
+++ b/internal/ee/service/coupon_association.go
@@ -5,10 +5,12 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/coupon"
 	"github.com/flexprice/flexprice/internal/domain/coupon_association"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
 
 type CouponAssociationService interface {
@@ -100,6 +102,16 @@ func (s *couponAssociationService) ListCouponAssociations(ctx context.Context, f
 	if filter == nil {
 		filter = types.NewCouponAssociationFilter()
 	}
+	if filter.QueryFilter == nil {
+		filter.QueryFilter = types.NewDefaultQueryFilter()
+	}
+
+	expand := filter.GetExpand()
+	if !expand.IsEmpty() {
+		if err := expand.Validate(types.CouponAssociationExpandConfig); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := filter.Validate(); err != nil {
 		return nil, err
@@ -116,8 +128,72 @@ func (s *couponAssociationService) ListCouponAssociations(ctx context.Context, f
 	}
 
 	items := make([]*dto.CouponAssociationResponse, len(associations))
+
+	var couponsByID map[string]*coupon.Coupon
+	if expand.Has(types.ExpandCoupon) {
+		couponIDs := lo.Uniq(lo.Map(associations, func(ca *coupon_association.CouponAssociation, _ int) string {
+			return ca.CouponID
+		}))
+		if len(couponIDs) > 0 {
+			couponFilter := types.NewNoLimitCouponFilter()
+			couponFilter.CouponIDs = couponIDs
+			couponFilter.Status = lo.ToPtr(types.StatusPublished)
+			coupons, err := s.CouponRepo.List(ctx, couponFilter)
+			if err != nil {
+				return nil, err
+			}
+			couponsByID = make(map[string]*coupon.Coupon, len(coupons))
+			for _, c := range coupons {
+				couponsByID[c.ID] = c
+			}
+			s.Logger.Debug(ctx, "fetched coupons for coupon associations", "count", len(coupons))
+		}
+	}
+
+	var lineItemsByID map[string]*dto.SubscriptionLineItemResponse
+	if expand.Has(types.ExpandSubscriptionLineItems) {
+		lineItemIDs := lo.Uniq(lo.FilterMap(associations, func(ca *coupon_association.CouponAssociation, _ int) (string, bool) {
+			if ca.SubscriptionLineItemID != nil && *ca.SubscriptionLineItemID != "" {
+				return *ca.SubscriptionLineItemID, true
+			}
+			return "", false
+		}))
+		if len(lineItemIDs) > 0 {
+			subService := NewSubscriptionService(s.ServiceParams)
+			liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+			liFilter.SubscriptionLineItemIDs = lineItemIDs
+			liFilter.Status = lo.ToPtr(types.StatusPublished)
+			nested := expand.GetNested(types.ExpandSubscriptionLineItems)
+			if !nested.IsEmpty() {
+				liFilter.Expand = lo.ToPtr(nested.String())
+			}
+			lineItemsResp, err := subService.ListSubscriptionLineItems(ctx, liFilter)
+			if err != nil {
+				return nil, err
+			}
+			lineItemsByID = make(map[string]*dto.SubscriptionLineItemResponse, len(lineItemsResp.Items))
+			for _, li := range lineItemsResp.Items {
+				if li != nil && li.SubscriptionLineItem != nil {
+					lineItemsByID[li.SubscriptionLineItem.ID] = li
+				}
+			}
+			s.Logger.Debug(ctx, "fetched subscription line items for coupon associations", "count", len(lineItemsResp.Items))
+		}
+	}
+
 	for i, ca := range associations {
-		items[i] = s.toCouponAssociationResponse(ca)
+		item := s.toCouponAssociationResponse(ca)
+		if expand.Has(types.ExpandCoupon) {
+			if c, ok := couponsByID[ca.CouponID]; ok {
+				item.Coupon = dto.NewCouponResponse(c)
+			}
+		}
+		if expand.Has(types.ExpandSubscriptionLineItems) && ca.SubscriptionLineItemID != nil {
+			if li, ok := lineItemsByID[*ca.SubscriptionLineItemID]; ok {
+				item.SubscriptionLineItem = li
+			}
+		}
+		items[i] = item
 	}
 
 	return &dto.ListCouponAssociationsResponse{

--- a/internal/ee/service/coupon_association_test.go
+++ b/internal/ee/service/coupon_association_test.go
@@ -1,0 +1,255 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	coupon_domain "github.com/flexprice/flexprice/internal/domain/coupon"
+	"github.com/flexprice/flexprice/internal/domain/coupon_association"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+type CouponAssociationServiceSuite struct {
+	testutil.BaseServiceTestSuite
+	service  CouponAssociationService
+	testData struct {
+		customer              *customer.Customer
+		plan                  *plan.Plan
+		subscription          *subscription.Subscription
+		price                 *price.Price
+		lineItem              *subscription.SubscriptionLineItem
+		coupon                *coupon_domain.Coupon
+		subLevelAssociation   *coupon_association.CouponAssociation
+		lineItemAssociation   *coupon_association.CouponAssociation
+	}
+}
+
+func TestCouponAssociationService(t *testing.T) {
+	suite.Run(t, new(CouponAssociationServiceSuite))
+}
+
+func (s *CouponAssociationServiceSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.setupService()
+	s.setupTestData()
+}
+
+func (s *CouponAssociationServiceSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+}
+
+func (s *CouponAssociationServiceSuite) setupService() {
+	s.service = NewCouponAssociationService(s.newServiceParams())
+}
+
+func (s *CouponAssociationServiceSuite) newServiceParams() ServiceParams {
+	return ServiceParams{
+		Logger:                     s.GetLogger(),
+		Config:                     s.GetConfig(),
+		DB:                         s.GetDB(),
+		TaxAssociationRepo:         s.GetStores().TaxAssociationRepo,
+		TaxRateRepo:                s.GetStores().TaxRateRepo,
+		SubRepo:                    s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo:   s.GetStores().SubscriptionLineItemRepo,
+		SubscriptionPhaseRepo:      s.GetStores().SubscriptionPhaseRepo,
+		SubScheduleRepo:            s.GetStores().SubscriptionScheduleRepo,
+		PlanRepo:                   s.GetStores().PlanRepo,
+		PriceRepo:                  s.GetStores().PriceRepo,
+		PriceUnitRepo:              s.GetStores().PriceUnitRepo,
+		EventRepo:                  s.GetStores().EventRepo,
+		MeterRepo:                  s.GetStores().MeterRepo,
+		CustomerRepo:               s.GetStores().CustomerRepo,
+		InvoiceRepo:                s.GetStores().InvoiceRepo,
+		EntitlementRepo:            s.GetStores().EntitlementRepo,
+		EnvironmentRepo:            s.GetStores().EnvironmentRepo,
+		FeatureRepo:                s.GetStores().FeatureRepo,
+		TenantRepo:                 s.GetStores().TenantRepo,
+		UserRepo:                   s.GetStores().UserRepo,
+		AuthRepo:                   s.GetStores().AuthRepo,
+		WalletRepo:                 s.GetStores().WalletRepo,
+		PaymentRepo:                s.GetStores().PaymentRepo,
+		CreditGrantRepo:            s.GetStores().CreditGrantRepo,
+		CreditGrantApplicationRepo: s.GetStores().CreditGrantApplicationRepo,
+		CouponRepo:                 s.GetStores().CouponRepo,
+		CouponAssociationRepo:      s.GetStores().CouponAssociationRepo,
+		CouponApplicationRepo:      s.GetStores().CouponApplicationRepo,
+		AddonRepo:                  s.GetStores().AddonRepo,
+		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
+		ConnectionRepo:             s.GetStores().ConnectionRepo,
+		SettingsRepo:               s.GetStores().SettingsRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
+		EventPublisher:             s.GetPublisher(),
+		WebhookPublisher:           s.GetWebhookPublisher(),
+		ProrationCalculator:        s.GetCalculator(),
+		FeatureUsageRepo:           s.GetStores().FeatureUsageRepo,
+		IntegrationFactory:         s.GetIntegrationFactory(),
+	}
+}
+
+func (s *CouponAssociationServiceSuite) setupTestData() {
+	ctx := s.GetContext()
+	now := time.Now().UTC()
+
+	s.testData.customer = &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: "ext_cust_coupon_assoc",
+		Name:       "Coupon Association Customer",
+		Email:      "coupon-assoc@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, s.testData.customer))
+
+	s.testData.plan = &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Coupon Association Plan",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, s.testData.plan))
+
+	s.testData.price = &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(100),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.testData.price))
+
+	s.testData.subscription = &subscription.Subscription{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		PlanID:             s.testData.plan.ID,
+		CustomerID:         s.testData.customer.ID,
+		StartDate:          now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   now.Add(6 * 24 * time.Hour),
+		BillingAnchor:      now.Add(-30 * 24 * time.Hour),
+		Currency:           "usd",
+		BillingCycle:       types.BillingCycleAnniversary,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, s.testData.subscription))
+
+	s.testData.lineItem = &subscription.SubscriptionLineItem{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID:  s.testData.subscription.ID,
+		CustomerID:      s.testData.customer.ID,
+		EntityID:        s.testData.plan.ID,
+		EntityType:      types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName: s.testData.plan.Name,
+		PriceID:         s.testData.price.ID,
+		PriceType:       s.testData.price.Type,
+		DisplayName:     "Coupon line item",
+		Quantity:        decimal.NewFromInt(1),
+		Currency:        s.testData.subscription.Currency,
+		BillingPeriod:   s.testData.subscription.BillingPeriod,
+		InvoiceCadence:  types.InvoiceCadenceAdvance,
+		StartDate:       now.Add(-3 * 24 * time.Hour),
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, s.testData.lineItem))
+
+	pct := decimal.NewFromInt(10)
+	s.testData.coupon = &coupon_domain.Coupon{
+		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON),
+		Name:          "Test Coupon",
+		Type:          types.CouponTypePercentage,
+		Cadence:       types.CouponCadenceOnce,
+		PercentageOff: &pct,
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		BaseModel:     types.GetDefaultBaseModel(ctx),
+	}
+	s.testData.coupon.Status = types.StatusPublished
+	s.NoError(s.GetStores().CouponRepo.Create(ctx, s.testData.coupon))
+
+	s.testData.subLevelAssociation = &coupon_association.CouponAssociation{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON_ASSOCIATION),
+		CouponID:       s.testData.coupon.ID,
+		SubscriptionID: s.testData.subscription.ID,
+		StartDate:      now.UTC(),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CouponAssociationRepo.Create(ctx, s.testData.subLevelAssociation))
+
+	s.testData.lineItemAssociation = &coupon_association.CouponAssociation{
+		ID:                     types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON_ASSOCIATION),
+		CouponID:               s.testData.coupon.ID,
+		SubscriptionID:         s.testData.subscription.ID,
+		SubscriptionLineItemID: lo.ToPtr(s.testData.lineItem.ID),
+		StartDate:              now.UTC(),
+		EnvironmentID:          types.GetEnvironmentID(ctx),
+		BaseModel:              types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CouponAssociationRepo.Create(ctx, s.testData.lineItemAssociation))
+}
+
+func (s *CouponAssociationServiceSuite) TestListCouponAssociations_InvalidExpand() {
+	ctx := s.GetContext()
+	filter := types.NewCouponAssociationFilter()
+	filter.SubscriptionIDs = []string{s.testData.subscription.ID}
+	filter.Expand = lo.ToPtr("plan")
+
+	_, err := s.service.ListCouponAssociations(ctx, filter)
+	s.Error(err)
+}
+
+func (s *CouponAssociationServiceSuite) TestListCouponAssociations_ExpandCoupon() {
+	ctx := s.GetContext()
+	filter := types.NewCouponAssociationFilter()
+	filter.SubscriptionIDs = []string{s.testData.subscription.ID}
+	filter.Expand = lo.ToPtr("coupon")
+
+	resp, err := s.service.ListCouponAssociations(ctx, filter)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+	s.GreaterOrEqual(len(resp.Items), 2)
+
+	for _, item := range resp.Items {
+		s.Require().NotNil(item.Coupon)
+		s.Equal(s.testData.coupon.ID, item.Coupon.ID)
+		s.Equal(s.testData.coupon.Name, item.Coupon.Name)
+	}
+}
+
+func (s *CouponAssociationServiceSuite) TestListCouponAssociations_ExpandSubscriptionLineItems() {
+	ctx := s.GetContext()
+	filter := types.NewCouponAssociationFilter()
+	filter.SubscriptionIDs = []string{s.testData.subscription.ID}
+	filter.Expand = lo.ToPtr("subscription_line_items")
+
+	resp, err := s.service.ListCouponAssociations(ctx, filter)
+	s.NoError(err)
+	s.Require().NotNil(resp)
+
+	var subLevelItem, lineItemLevelItem bool
+	for _, item := range resp.Items {
+		if item.ID == s.testData.subLevelAssociation.ID {
+			subLevelItem = true
+			s.Nil(item.SubscriptionLineItem)
+		}
+		if item.ID == s.testData.lineItemAssociation.ID {
+			lineItemLevelItem = true
+			s.Require().NotNil(item.SubscriptionLineItem)
+			s.Equal(s.testData.lineItem.ID, item.SubscriptionLineItem.ID)
+		}
+	}
+	s.True(subLevelItem)
+	s.True(lineItemLevelItem)
+}

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -710,6 +710,11 @@ func (o SubscriptionLineItemQueryOptions) GetFieldResolver(field string) (string
 
 // applyEntityQueryOptions applies subscription line item-specific filters to the query
 func (o *SubscriptionLineItemQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.SubscriptionLineItemFilter, query SubscriptionLineItemQuery) (SubscriptionLineItemQuery, error) {
+	// Apply subscription line item IDs filter if specified
+	if len(f.SubscriptionLineItemIDs) > 0 {
+		query = query.Where(subscriptionlineitem.IDIn(f.SubscriptionLineItemIDs...))
+	}
+
 	// Apply subscription IDs filter if specified
 	if len(f.SubscriptionIDs) > 0 {
 		query = query.Where(subscriptionlineitem.SubscriptionIDIn(f.SubscriptionIDs...))

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -50,6 +50,11 @@ func lineItemFilterFn(ctx context.Context, item *subscription.SubscriptionLineIt
 		return false
 	}
 
+	// Filter by subscription line item IDs
+	if len(f.SubscriptionLineItemIDs) > 0 && !lo.Contains(f.SubscriptionLineItemIDs, item.ID) {
+		return false
+	}
+
 	// Filter by entity type (when set)
 	if f.EntityType != nil && item.EntityType != *f.EntityType {
 		return false

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -174,6 +174,15 @@ var (
 		},
 	}
 
+	// CouponAssociationExpandConfig defines what can be expanded on a coupon association
+	CouponAssociationExpandConfig = ExpandConfig{
+		AllowedFields: []ExpandableField{ExpandCoupon, ExpandSubscriptionLineItems},
+		NestedExpands: map[ExpandableField][]ExpandableField{
+			ExpandCoupon:                {},
+			ExpandSubscriptionLineItems: {ExpandPrices},
+		},
+	}
+
 	// SubscriptionLineItemListExpandConfig defines expands for listing subscription line items (collection APIs).
 	// Supports top-level prices (and nested price fields) and subscription_line_items.prices for parity with subscription expand strings.
 	SubscriptionLineItemListExpandConfig = ExpandConfig{

--- a/internal/types/subscription_line_item_filter.go
+++ b/internal/types/subscription_line_item_filter.go
@@ -11,7 +11,8 @@ type SubscriptionLineItemFilter struct {
 	Sort    []*SortCondition   `json:"sort,omitempty" form:"sort" validate:"omitempty"`
 
 	// Specific filters
-	SubscriptionIDs     []string                        `json:"subscription_ids,omitempty" form:"subscription_ids"`
+	SubscriptionLineItemIDs []string                        `json:"subscription_line_item_ids,omitempty" form:"subscription_line_item_ids"`
+	SubscriptionIDs         []string                        `json:"subscription_ids,omitempty" form:"subscription_ids"`
 	CustomerIDs         []string                        `json:"customer_ids,omitempty" form:"customer_ids"`
 	PriceIDs            []string                        `json:"price_ids,omitempty" form:"price_ids"`
 	MeterIDs            []string                        `json:"meter_ids,omitempty" form:"meter_ids"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expanding coupon associations to include related coupon and subscription line item details.
  * Added new filtering options for subscription line item IDs and subscription line item association IDs.

* **Bug Fixes**
  * Improved list results so expanded related data is included only when requested.
  * Ensured coupon association queries handle default filtering more consistently.

* **Documentation**
  * Updated API documentation to reflect the new `expand` query parameter and revised response/filter fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->