### PR TITLE
feat(chart): render webhook.rate_limit + integration_events block

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -168,6 +168,7 @@ data:
       topic: {{ .Values.webhook.topic | quote }}
       pubsub: {{ .Values.webhook.pubsub | quote }}
       consumer_group: {{ .Values.webhook.consumerGroup | quote }}
+      rate_limit: {{ .Values.webhook.rateLimit }}
       max_retries: {{ .Values.webhook.maxRetries }}
       initial_interval: {{ .Values.webhook.initialInterval | quote }}
       max_interval: {{ .Values.webhook.maxInterval | quote }}
@@ -178,7 +179,16 @@ data:
         enabled: {{ .Values.webhook.svixConfig.enabled }}
         base_url: {{ .Values.webhook.svixConfig.baseUrl | quote }}
     {{- end }}
-    
+
+    # Integration events: consumed from the SAME system_events topic as webhooks,
+    # but under an independent consumer group. Rendered here because viper does not
+    # apply Go `default` tags on Unmarshal (same class as event_processing) — without
+    # this block enabled resolves to false and the integration-events consumer never starts.
+    integration_events:
+      enabled: {{ .Values.integrationEvents.enabled }}
+      consumer_group: {{ .Values.integrationEvents.consumerGroup | quote }}
+      rate_limit: {{ .Values.integrationEvents.rateLimit }}
+
     billing:
       tenant_id: {{ .Values.billing.tenantId | quote }}
       environment_id: {{ .Values.billing.environmentId | quote }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -818,7 +818,8 @@ webhook:
   enabled: true
   topic: "system_events"
   pubsub: "memory"
-  consumerGroup: "webhook-consumer"
+  consumerGroup: "system-events-consumer"
+  rateLimit: 5
   maxRetries: 3
   initialInterval: "1s"
   maxInterval: "10s"
@@ -829,6 +830,12 @@ webhook:
     enabled: false
     authToken: "" # Set via secret
     baseUrl: "https://api.us.svix.com"
+
+# Integration events consumer — same system_events topic, independent consumer group.
+integrationEvents:
+  enabled: true
+  consumerGroup: "integration-events-consumer"
+  rateLimit: 10
 
 # ---------------------------------------------------------------------------
 # Secrets management


### PR DESCRIPTION
## Problem
On GKE, the `system_events` topic has **no active consumer group** — neither the webhook (system-events) consumer nor the integration-events consumer subscribes. Root cause: the chart ConfigMap never rendered `webhook.rate_limit` or any `integration_events` block, and viper does **not** apply Go `default:` tags on Unmarshal. So at runtime:
- `webhook.rate_limit = 0` → `handler.RegisterHandler` bails (`"webhook rate limit is invalid"`)
- `integration_events.enabled = false` → `"integration_events: handler disabled by configuration, skipping registration"`

Same class as the `wallet_balance_alert.topic`, `auth.secret`, `deployment.mode` bugs — the chart ConfigMap is the only config source in-cluster, and it omitted these fields.

## Changes
- `configmap.yaml`: render `webhook.rate_limit` and a new `integration_events` block (`enabled`/`consumer_group`/`rate_limit`).
- `values.yaml`: add `webhook.rateLimit: 5`, `integrationEvents` (enabled/consumerGroup/rateLimit: 10), and align `webhook.consumerGroup` to `system-events-consumer` to match the existing AWS config (`internal/config/config.yaml`).

## Effect
A ModeConsumer deployment will now register `webhook_handler` (group `system-events-consumer`) and `integration_events_handler` (group `integration-events-consumer`) → both subscribe to `system_events`. Values mirror AWS staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rate limits for webhook processing.
  * Introduced a new integration events consumer with its own enable/disable setting, consumer group, and rate limit.
  * Updated event consumption settings so webhooks and integration events can be handled independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->