### PR TITLE
feat(payments): update subscription metadata handling

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -577,6 +577,10 @@ type UpdateSubscriptionRequest struct {
 
 	// ParentSubscriptionID sets or clears the parent subscription. Omit to leave unchanged; send "" to clear.
 	ParentSubscriptionID *string `json:"parent_subscription_id,omitempty"`
+
+	// Metadata is a free-form key-value bag for custom administrative fields (CRM IDs, channel tags, contractual refs).
+	// Omit to leave existing metadata untouched; send {} explicitly to clear.
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // Validate checks UpdateSubscriptionRequest fields for basic structural validity.

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1841,6 +1841,12 @@ func (s *subscriptionService) UpdateSubscription(ctx context.Context, subscripti
 
 	subscription.CancelAtPeriodEnd = req.CancelAtPeriodEnd
 
+	// Metadata: replace-in-full when provided, leave untouched when omitted (nil).
+	// Sending an empty map {} clears all keys.
+	if req.Metadata != nil {
+		subscription.Metadata = req.Metadata
+	}
+
 	// Update the subscription in the database
 	err = s.SubRepo.Update(ctx, subscription)
 	if err != nil {


### PR DESCRIPTION
Fixes #2071


## 📝 Description
Adds `metadata` to `UpdateSubscriptionRequest` so subscription metadata can be updated through `PUT /subscriptions/:id`.

Semantics:
- Omit `metadata` → existing metadata is left unchanged
- Send `{}` → all metadata keys are cleared
- Send key-value pairs → metadata is replaced in full

## Related work
Companion frontend PR (to be opened in `flexprice/flexprice-front`): subscription metadata editor on the details page.


---

## 🔨 Changes Made
- [x ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating subscription metadata through the API.
  * You can now leave metadata unchanged, replace it with new key/value pairs, or clear it by sending an empty object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->