### PR TITLE
fix(config): bind Svix auth token env so webhooks stop 401-ing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -723,6 +723,13 @@ func NewConfig() (*Configuration, error) {
 	// NOTE: auth.api_key.keys is intentionally NOT bound here because the env var is a
 	// JSON string but Viper/mapstructure expects a map. It is handled manually in Step 6.
 
+	// Explicitly bind the Svix auth token. The helm ConfigMap renders webhook.svix_config
+	// {enabled, base_url} but NOT auth_token (it's a secret), and the chart injects the token
+	// as FLEXPRICE_SVIX_API_KEY. Without this bind, webhook.svix_config.auth_token stays empty
+	// on GKE (AutomaticEnv+Unmarshal won't map FLEXPRICE_SVIX_API_KEY to it), so the Svix client
+	// is created with an empty key and every call 401s. Same class as auth.secret above.
+	_ = v.BindEnv("webhook.svix_config.auth_token", "FLEXPRICE_SVIX_API_KEY")
+
 	// Explicitly bind the second-cluster keys — their segment (kafka_secondary) contains an
 	// underscore, which AutomaticEnv cannot disambiguate, and kafka_secondary is absent from
 	// the YAML defaults (nil unless configured). Without these binds, FLEXPRICE_KAFKA_SECONDARY_*


### PR DESCRIPTION
## Problem
Svix webhook delivery fails with `failed to get/create Svix application: 401 Unauthorized` on **both staging and prod GCP** — for every tenant.

## Root cause: the Svix token is empty at runtime (not a bad key)
The Svix client is built from `config.Webhook.Svix.AuthToken` → key `webhook.svix_config.auth_token` (`internal/config/webhook.go`). On GKE that key resolves to **empty**:
- the helm ConfigMap renders `webhook.svix_config.{enabled, base_url}` but **not** `auth_token` (it's a secret);
- the chart injects the token as env **`FLEXPRICE_SVIX_API_KEY`** (`_helpers.tpl`);
- viper's `Unmarshal` does **not** consult `AutomaticEnv` for this key (documented behavior — see the Temporal/auth.secret binds), and there was **no `BindEnv`** mapping `FLEXPRICE_SVIX_API_KEY` → `webhook.svix_config.auth_token`.

So `svix.New("")` runs with an empty key → every Svix call 401s. The 38-char `sk_…` key in the secret was never read.

## Fix
One line, same pattern as `auth.secret`, `kafka.sasl_password`, `temporal.api_key`, etc.:
```go
_ = v.BindEnv("webhook.svix_config.auth_token", "FLEXPRICE_SVIX_API_KEY")
```
No chart change, no secret change — binds the env the chart already sets.

## After this ships
The token reaches the app. **Then** if the key itself is valid, webhooks deliver; if it still 401s, it's a genuine credential issue (wrong region/revoked) to rotate. The empty-token bind is the necessary first step.

`go build ./internal/config/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling so the app can initialize its webhook integration when the token is supplied through environment-based secrets, even if the default config value is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->