### PR TITLE
feat(payment): update CreateSetupIntentRequest to use SecretProviderand enhance Moyasar setup intent handling with improved logging and success URL management

### DIFF
--- a/internal/api/dto/payment_method.go
+++ b/internal/api/dto/payment_method.go
@@ -181,7 +181,9 @@ func (r *CreateSetupIntentRequest) Validate() error {
 			Mark(errors.ErrValidation)
 	}
 
-	if err := r.Provider.Validate(); err != nil {
+	switch r.Provider {
+	case types.SecretProviderStripe, types.SecretProviderMoyasar:
+	default:
 		return errors.NewError("unsupported payment provider").
 			WithHint("Supported providers: stripe, moyasar").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/api/dto/payment_method.go
+++ b/internal/api/dto/payment_method.go
@@ -105,13 +105,13 @@ type StripeInvoiceSyncResponse struct {
 
 // CreateSetupIntentRequest represents a request to create a Setup Intent session
 type CreateSetupIntentRequest struct {
-	Provider           string         `json:"provider" binding:"required"`    // Payment provider: "stripe", "razorpay", etc.
-	Usage              string         `json:"usage,omitempty"`                // "on_session" or "off_session" (default: "off_session")
-	PaymentMethodTypes []string       `json:"payment_method_types,omitempty"` // defaults to ["card"]
-	SuccessURL         string         `json:"success_url,omitempty"`          // User-configurable success redirect URL
-	CancelURL          string         `json:"cancel_url,omitempty"`           // User-configurable cancel redirect URL
-	SetDefault         bool           `json:"set_default,omitempty"`          // Whether to set the payment method as default when setup succeeds
-	Metadata           types.Metadata `json:"metadata,omitempty"`
+	Provider           types.SecretProvider `json:"provider" binding:"required"`    // Payment provider: "stripe", "moyasar", etc.
+	Usage              string               `json:"usage,omitempty"`                // "on_session" or "off_session" (default: "off_session")
+	PaymentMethodTypes []string             `json:"payment_method_types,omitempty"` // defaults to ["card"]
+	SuccessURL         string               `json:"success_url,omitempty"`          // User-configurable success redirect URL
+	CancelURL          string               `json:"cancel_url,omitempty"`           // User-configurable cancel redirect URL
+	SetDefault         bool                 `json:"set_default,omitempty"`          // Whether to set the payment method as default when setup succeeds
+	Metadata           types.Metadata       `json:"metadata,omitempty"`
 }
 
 // SetupIntentResponse represents a response from creating a Setup Intent session
@@ -120,7 +120,6 @@ type SetupIntentResponse struct {
 	CheckoutSessionID string `json:"checkout_session_id"`
 	CheckoutURL       string `json:"checkout_url"`
 	ClientSecret      string `json:"client_secret"`
-	CheckoutToken     string `json:"checkout_token,omitempty"`
 	Status            string `json:"status"`
 	Usage             string `json:"usage"`
 	CustomerID        string `json:"customer_id"`
@@ -176,16 +175,13 @@ type ListPaymentMethodsRequest struct {
 
 // Validate validates the create Setup Intent request
 func (r *CreateSetupIntentRequest) Validate() error {
-	// Validate provider parameter
 	if r.Provider == "" {
 		return errors.NewError("provider is required").
 			WithHint("Please provide a payment provider").
 			Mark(errors.ErrValidation)
 	}
 
-	switch r.Provider {
-	case string(types.PaymentMethodProviderStripe), string(types.SecretProviderMoyasar):
-	default:
+	if err := r.Provider.Validate(); err != nil {
 		return errors.NewError("unsupported payment provider").
 			WithHint("Supported providers: stripe, moyasar").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/api/v1/setupintent.go
+++ b/internal/api/v1/setupintent.go
@@ -2,8 +2,11 @@ package v1
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/google/uuid"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	flexpricejwt "github.com/flexprice/flexprice/internal/auth"
@@ -64,14 +67,14 @@ func (h *SetupIntentHandler) CreateSetupIntentSession(c *gin.Context) {
 	}
 
 	switch req.Provider {
-	case string(types.SecretProviderMoyasar):
-		h.createMoyasarSetupIntent(c, customerID)
+	case types.SecretProviderMoyasar:
+		h.createMoyasarSetupIntent(c, customerID, &req)
 	default:
 		h.createStripeSetupIntent(c, customerID, &req)
 	}
 }
 
-func (h *SetupIntentHandler) createMoyasarSetupIntent(c *gin.Context, customerID string) {
+func (h *SetupIntentHandler) createMoyasarSetupIntent(c *gin.Context, customerID string, req *dto.CreateSetupIntentRequest) {
 	ctx := c.Request.Context()
 
 	if _, err := h.customerService.GetCustomer(ctx, customerID); err != nil {
@@ -94,10 +97,24 @@ func (h *SetupIntentHandler) createMoyasarSetupIntent(c *gin.Context, customerID
 		return
 	}
 
+	// given_id is a deterministic UUID v5 derived from the Flexprice payment ID.
+	// Moyasar requires a UUID for idempotency; ULIDs are not valid UUIDs.
+	givenID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(flexpricePaymentID)).String()
+
+	// success_url is where the checkout page redirects after the card save completes.
+	// Falls back to the customer overview page when not provided by the caller.
+	appBaseURL := h.config.Checkout.BaseURL
+	successURL := req.SuccessURL
+	if successURL == "" {
+		successURL = fmt.Sprintf("%s/customers/%s", appBaseURL, customerID)
+	}
+
 	authProvider := flexpricejwt.NewProvider(h.config)
 	checkoutToken, err := authProvider.GenerateCheckoutToken(map[string]interface{}{
 		"publishable_key":      publishableKey,
 		"flexprice_payment_id": flexpricePaymentID,
+		"given_id":             givenID,
+		"success_url":          successURL,
 	})
 	if err != nil {
 		h.log.Error(ctx, "Failed to generate checkout token", "error", err)
@@ -105,10 +122,13 @@ func (h *SetupIntentHandler) createMoyasarSetupIntent(c *gin.Context, customerID
 		return
 	}
 
+	// JWT is embedded in the checkout URL — the checkout page decodes it client-side.
+	checkoutURL := fmt.Sprintf("%s/checkout?provider=moyasar&token=%s", appBaseURL, checkoutToken)
+
 	c.JSON(http.StatusCreated, dto.SetupIntentResponse{
-		Status:        "pending_card_entry",
-		CustomerID:    customerID,
-		CheckoutToken: checkoutToken,
+		Status:      "pending_card_entry",
+		CustomerID:  customerID,
+		CheckoutURL: checkoutURL,
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,10 +19,10 @@ import (
 )
 
 type Configuration struct {
-	Deployment                 DeploymentConfig                 `validate:"required"`
-	Server                     ServerConfig                     `validate:"required"`
-	Auth                       AuthConfig                       `validate:"required"`
-	Kafka                      KafkaConfig                      `validate:"required"`
+	Deployment DeploymentConfig `validate:"required"`
+	Server     ServerConfig     `validate:"required"`
+	Auth       AuthConfig       `validate:"required"`
+	Kafka      KafkaConfig      `validate:"required"`
 	// KafkaSecondary is the optional second Kafka cluster the source event publisher also
 	// writes to during the AWS→GCP migration (the "other" cloud's cluster). When set
 	// (non-nil) every event is published to it in addition to the local `kafka` cluster;
@@ -63,6 +63,7 @@ type Configuration struct {
 	OAuth                      OAuthConfig                      `mapstructure:"oauth" validate:"required"`
 	WalletBalanceAlert         WalletBalanceAlertConfig         `mapstructure:"wallet_balance_alert" validate:"required"`
 	CustomerPortal             CustomerPortalConfig             `mapstructure:"customer_portal" validate:"required"`
+	Checkout                   CheckoutConfig                   `mapstructure:"checkout" validate:"omitempty"`
 	Redis                      RedisConfig                      `mapstructure:"redis" validate:"required"`
 	RawEventsReprocessing      RawEventsReprocessingConfig      `mapstructure:"raw_events_reprocessing" validate:"required"`
 	RawEventConsumption        RawEventConsumptionConfig        `mapstructure:"raw_event_consumption" validate:"required"`
@@ -624,6 +625,10 @@ type CostSheetUsageTrackingLazyConfig struct {
 	Topic         string `mapstructure:"topic" default:"events_lazy"`
 	RateLimit     int64  `mapstructure:"rate_limit" default:"1"`
 	ConsumerGroup string `mapstructure:"consumer_group" default:"v1_costsheet_usage_tracking_service_lazy"`
+}
+
+type CheckoutConfig struct {
+	BaseURL string `mapstructure:"base_url" validate:"required"`
 }
 
 type CustomerPortalConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -628,7 +628,7 @@ type CostSheetUsageTrackingLazyConfig struct {
 }
 
 type CheckoutConfig struct {
-	BaseURL string `mapstructure:"base_url" validate:"required"`
+	BaseURL string `mapstructure:"base_url" validate:"required,url"`
 }
 
 type CustomerPortalConfig struct {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -433,3 +433,7 @@ onboarding_events:
   rate_limit: 10
   consumer_group: "onboarding_events_consumer"
   max_retries: 3
+
+# Checkout base URL for the checkout page
+checkout:
+  base_url: "http://localhost:3000"

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -75,6 +75,7 @@ func (r *paymentRepository) Create(ctx context.Context, p *domainPayment.Payment
 		SetNillableSucceededAt(p.SucceededAt).
 		SetNillableFailedAt(p.FailedAt).
 		SetNillableRefundedAt(p.RefundedAt).
+		SetNillableVoidedAt(p.VoidedAt).
 		SetNillableErrorMessage(p.ErrorMessage).
 		SetNillableRecordedAt(p.RecordedAt).
 		SetTenantID(p.TenantID).
@@ -302,6 +303,7 @@ func (r *paymentRepository) Update(ctx context.Context, p *domainPayment.Payment
 		SetNillableSucceededAt(p.SucceededAt).
 		SetNillableFailedAt(p.FailedAt).
 		SetNillableRefundedAt(p.RefundedAt).
+		SetNillableVoidedAt(p.VoidedAt).
 		SetNillableErrorMessage(p.ErrorMessage).
 		Save(ctx)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup-intent creation now returns a checkout URL (JWT embedded in the URL) instead of a raw checkout token.
  * Added configurable `checkout.base_url` for building checkout links.

* **Bug Fixes**
  * Payment `VoidedAt` timestamps are now persisted on both creation and updates.
  * Improved setup-intent provider validation for clearer handling of unsupported providers.

* **Documentation**
  * Updated setup-intent request/response field descriptions and added notes for checkout configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->