### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -380,7 +380,7 @@ spec:
         # Topics are NOT auto-created by the broker (autoCreateTopicsEnable: false).
         # This init container creates all required topics idempotently.
         - name: create-kafka-topics
-          image: "{{ if .Values.kafkaConfig.enabled }}bitnami/kafka:latest{{ else }}confluentinc/cp-kafka:{{ .Values.kafkaConfig.internal.image.tag | default "7.7.1" }}{{ end }}"
+          image: "{{ if .Values.kafkaConfig.enabled }}soldevelo/kafka:latest{{ else }}confluentinc/cp-kafka:{{ .Values.kafkaConfig.internal.image.tag | default "7.7.1" }}{{ end }}"
           command:
             - sh
             - -c


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kafka:latest` → [`soldevelo/kafka:latest`](https://hub.docker.com/r/soldevelo/kafka)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Kafka-related migration step to use a newer container image when Kafka is enabled, improving consistency for deployments that rely on topic creation during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->