### PR TITLE
fix(config): bind FLEXPRICE_REDIS_CLUSTER_MODE & REDIS_KEY_PREFIX env vars

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -674,6 +674,14 @@ func NewConfig() (*Configuration, error) {
 	_ = v.BindEnv("clickhouse.address", "FLEXPRICE_CLICKHOUSE_ADDRESS")
 	_ = v.BindEnv("clickhouse.database", "FLEXPRICE_CLICKHOUSE_DATABASE")
 
+	// Redis cluster_mode/key_prefix are supplied only as env vars by the Helm chart
+	// (they are not rendered into config.yaml). viper's Unmarshal does not consult
+	// AutomaticEnv for keys absent from the config file, so without these explicit
+	// binds ClusterMode silently resolves to false and a single-node client is used
+	// against a cluster-mode endpoint, causing "MOVED" errors on every off-slot key.
+	_ = v.BindEnv("redis.cluster_mode", "FLEXPRICE_REDIS_CLUSTER_MODE")
+	_ = v.BindEnv("redis.key_prefix", "FLEXPRICE_REDIS_KEY_PREFIX")
+
 	// Explicitly bind unified OTel config vars — AutomaticEnv misses nested keys with underscores
 	_ = v.BindEnv("otel.enabled", "FLEXPRICE_OTEL_ENABLED")
 	_ = v.BindEnv("otel.service_name", "FLEXPRICE_OTEL_SERVICE_NAME")


### PR DESCRIPTION
## Problem

On GKE, prod (`production-us-gcp`) Redis throws continuous `MOVED <slot> <node>` errors against the ElastiCache **cluster-mode-enabled** endpoint, causing failed distributed-lock acquisitions (e.g. `price_sync_lock_acquire_failed`) and broadly degraded cache/lock ops (~2/3 of keys land off the connected shard).

## Root cause

The Helm chart supplies `redis.cluster_mode` and `redis.key_prefix` **only as env vars** (`FLEXPRICE_REDIS_CLUSTER_MODE`, `FLEXPRICE_REDIS_KEY_PREFIX` via `_helpers.tpl`) and does **not** render them into the mounted `config.yaml`. viper's `Unmarshal` does not consult `AutomaticEnv` for keys absent from every config source unless explicitly bound, so `RedisConfig.ClusterMode` resolved to its zero value (`false`) → app used a single-node `*redis.Client` against the cluster configuration endpoint → `MOVED`. Same class of bug previously fixed for `auth.secret`, `clickhouse.*`, `otel.*`, and `webhook.svix_config.auth_token`.

## Fix

Add two explicit `BindEnv` calls so the chart-provided env vars take effect:
```go
_ = v.BindEnv("redis.cluster_mode", "FLEXPRICE_REDIS_CLUSTER_MODE")
_ = v.BindEnv("redis.key_prefix",   "FLEXPRICE_REDIS_KEY_PREFIX")
```

## Validation

Verified live on prod via a temporary ConfigMap patch (rendering `cluster_mode: true` into the file): all 3 api pods picked it up, `MOVED` count dropped to **0**, and `price_sync_lock_acquire_failed` stopped. This PR makes that durable (survives ArgoCD sync / pod restarts) and is a no-op on AWS (env vars already set there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redis cluster mode and key prefix settings are now reliably read from environment variables, preventing incorrect default values when configuration is provided through deployment settings.
  * This improves configuration consistency for environments that supply Redis settings outside of the main config file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->