### PR TITLE
fix: propagate Kafka message context in handlers

### DIFF
--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -215,8 +215,8 @@ func (s *costsheetUsageTrackingService) processMessage(msg *message.Message) err
 		"environment_id", environmentID,
 	)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Start from the Watermill message context so cancellation and trace values propagate.
+	ctx := msg.Context()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/ee/service/event_consumption.go
+++ b/internal/ee/service/event_consumption.go
@@ -224,8 +224,8 @@ func (s *eventConsumptionService) processMessage(msg *message.Message) error {
 		environmentID = event.EnvironmentID
 	}
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Start from the Watermill message context so cancellation and trace values propagate.
+	ctx := msg.Context()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/ee/service/event_post_processing.go
+++ b/internal/ee/service/event_post_processing.go
@@ -231,8 +231,8 @@ func (s *eventPostProcessingService) processMessage(msg *message.Message) error 
 		"environment_id", environmentID,
 	)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Start from the Watermill message context so cancellation and trace values propagate.
+	ctx := msg.Context()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/ee/service/feature_usage_tracking.go
+++ b/internal/ee/service/feature_usage_tracking.go
@@ -361,8 +361,8 @@ func (s *featureUsageTrackingService) processMessage(msg *message.Message) error
 
 	event.EventName = strings.TrimSpace(event.EventName)
 
-	// Create a background context with tenant ID
-	ctx := context.Background()
+	// Start from the Watermill message context so cancellation and trace values propagate.
+	ctx := msg.Context()
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	}

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -224,7 +224,7 @@ func (s *meterUsageTrackingService) processMessage(msg *message.Message) error {
 		return nil // non-retriable
 	}
 
-	ctx := context.Background()
+	ctx := msg.Context()
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 

--- a/internal/ee/service/usage_benchmark.go
+++ b/internal/ee/service/usage_benchmark.go
@@ -178,7 +178,7 @@ func (s *usageBenchmarkService) ProcessMessageForTest(msg *message.Message) erro
 		return nil
 	}
 
-	ctx := context.Background()
+	ctx := msg.Context()
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 

--- a/internal/ee/service/wallet_balance_alert.go
+++ b/internal/ee/service/wallet_balance_alert.go
@@ -203,7 +203,7 @@ func (s *walletBalanceAlertService) processMessage(msg *message.Message) error {
 	)
 
 	// Create context with tenant and environment IDs
-	ctx := context.Background()
+	ctx := msg.Context()
 	if event.TenantID != "" {
 		ctx = context.WithValue(ctx, types.CtxTenantID, event.TenantID)
 	}


### PR DESCRIPTION
## Summary
- start the listed Kafka processMessage handlers from `msg.Context()` instead of `context.Background()`
- preserve existing tenant and environment context enrichment
- leave onboarding detached because it intentionally uses background work after message handling

Closes #1986

## Validation
- git diff --check

Note: `go`/`gofmt` are not installed in this local environment, so I could not run Go formatting or tests locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background processing to carry over incoming request context, helping preserve cancellations, deadlines, and trace information throughout event handling.
  * Made several message-processing flows more consistent so downstream work follows the original context from the source message.
  * This should improve reliability and observability for asynchronous processing without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->