### PR TITLE
fix(config): bind FLEXPRICE_CHECKOUT_BASE_URL env var

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -723,6 +723,11 @@ func NewConfig() (*Configuration, error) {
 	// NOTE: auth.api_key.keys is intentionally NOT bound here because the env var is a
 	// JSON string but Viper/mapstructure expects a map. It is handled manually in Step 6.
 
+	// checkout.base_url is delivered only as an env var (extraEnv) and is absent from the
+	// Helm-rendered ConfigMap, so Unmarshal would otherwise leave it empty. Bind it so the
+	// FLEXPRICE_CHECKOUT_BASE_URL value is actually read.
+	_ = v.BindEnv("checkout.base_url", "FLEXPRICE_CHECKOUT_BASE_URL")
+
 	// Explicitly bind the second-cluster keys — their segment (kafka_secondary) contains an
 	// underscore, which AutomaticEnv cannot disambiguate, and kafka_secondary is absent from
 	// the YAML defaults (nil unless configured). Without these binds, FLEXPRICE_KAFKA_SECONDARY_*


### PR DESCRIPTION
## What

Adds an explicit `v.BindEnv("checkout.base_url", "FLEXPRICE_CHECKOUT_BASE_URL")`.

## Why

`CheckoutConfig.BaseURL` is delivered to GKE deployments only as an env var (Helm `extraEnv`) and is **not** rendered into the mounted ConfigMap. viper's `Unmarshal` does not consult `AutomaticEnv` for keys absent from the config file, so without this bind `checkout.base_url` resolves to empty and checkout links break. (No boot failure — the parent field is `validate:"omitempty"` — but the feature silently doesn't get its base URL.)

Same class/pattern as the existing `auth.secret`, `redis.*`, `svix`, and `clickhouse.*` binds.

## Companion

Staging value delivered via infra `extraEnv` (`FLEXPRICE_CHECKOUT_BASE_URL=https://admin-dev.flexprice.io`). Takes effect once a develop image with this bind is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading so the checkout base URL can now be set from an environment variable even when it is missing from the main configuration file.
  * This makes checkout setup more reliable across environments where configuration values may be injected externally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->