### PR TITLE
feat(helm): render checkout.base_url into app configmap

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -204,6 +204,9 @@ data:
     billing:
       tenant_id: {{ .Values.billing.tenantId | quote }}
       environment_id: {{ .Values.billing.environmentId | quote }}
+
+    checkout:
+      base_url: {{ .Values.checkout.baseUrl | quote }}
     
     email:
       enabled: {{ .Values.email.enabled }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -945,6 +945,10 @@ app:
   customerPortalUrl: ""   # e.g. "https://admin.flexprice.io/customer-portal"
   oauthRedirectUri: ""    # e.g. "https://admin.flexprice.io/tools/integrations/oauth/callback"
 
+# Checkout flow base URL → rendered into config.yaml as checkout.base_url
+checkout:
+  baseUrl: ""   # e.g. "https://admin.flexprice.io"
+
 # Feature flag configuration
 featureFlag:
   enableFeatureUsageForAnalytics: true


### PR DESCRIPTION
## What
Renders `checkout.base_url` into the app ConfigMap from a new chart value `checkout.baseUrl` (default empty), mirroring the existing `billing`/`email`/`webhook` blocks.

## Why
`CheckoutConfig.BaseURL` exists in the Go config, but the chart never rendered it into the ConfigMap. On GKE the mounted ConfigMap *replaces* the baked `config.yaml`, so `checkout.base_url` resolved to empty and checkout links had no base URL. This wires it through the standard configmap path — the app reads it straight from the config file, so **no BindEnv is needed** (this is the non-secret-config pattern, distinct from the env-only `auth.secret`/`redis.*` binds).

No boot risk: the parent field is `validate:"omitempty"`, so an empty value is skipped.

## Verified
`helm template` renders:
```yaml
    checkout:
      base_url: "https://admin-dev.flexprice.io"
```

## Companion
Staging value set in infra `values-staging-mumbai-aws-backed.yaml` (`checkout.baseUrl: https://admin-dev.flexprice.io`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)