### PR TITLE
refactor(docker): reduce duplicated service configuration using YAML anchors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,25 @@
+x-flexprice-env: &flexprice-env
+  FLEXPRICE_POSTGRES_HOST: postgres
+  FLEXPRICE_KAFKA_BROKERS: kafka:9092
+  FLEXPRICE_CLICKHOUSE_ADDRESS: clickhouse:9000
+  FLEXPRICE_TEMPORAL_ADDRESS: temporal:7233
+
+x-flexprice-common: &flexprice-common
+  depends_on:
+    postgres:
+      condition: service_healthy
+    kafka:
+      condition: service_healthy
+    clickhouse:
+      condition: service_healthy
+    temporal:
+      condition: service_started
+
+  volumes:
+    - ./internal/config:/app/internal/config
+
+  restart: unless-stopped
+
 services:
   postgres:
     image: postgres:17
@@ -124,72 +146,35 @@ services:
     command: ["echo", "Build complete"]
 
   flexprice-api:
+    <<: *flexprice-common
     image: flexprice-app:local
-    depends_on:
-      postgres:
-        condition: service_healthy
-      kafka:
-        condition: service_healthy
-      clickhouse:
-        condition: service_healthy
-      temporal:
-        condition: service_started
+
     ports:
       - "127.0.0.1:8080:8080"
+  
     environment:
-      - FLEXPRICE_DEPLOYMENT_MODE=api
-      # Override config.yaml settings for containerized environment
-      - FLEXPRICE_POSTGRES_HOST=postgres
-      - FLEXPRICE_KAFKA_BROKERS=kafka:9092
-      - FLEXPRICE_CLICKHOUSE_ADDRESS=clickhouse:9000
-      - FLEXPRICE_TEMPORAL_ADDRESS=temporal:7233
-    volumes:
-      - ./internal/config:/app/internal/config
-    restart: unless-stopped
+      <<: *flexprice-env
+      FLEXPRICE_DEPLOYMENT_MODE: api
+      
 
   flexprice-consumer:
+    <<: *flexprice-common
     image: flexprice-app:local
-    depends_on:
-      postgres:
-        condition: service_healthy
-      kafka:
-        condition: service_healthy
-      clickhouse:
-        condition: service_healthy
-      temporal:
-        condition: service_started
-    environment:
-      - FLEXPRICE_DEPLOYMENT_MODE=consumer
-      # Override config.yaml settings for containerized environment
-      - FLEXPRICE_POSTGRES_HOST=postgres
-      - FLEXPRICE_KAFKA_BROKERS=kafka:9092
-      - FLEXPRICE_CLICKHOUSE_ADDRESS=clickhouse:9000
-      - FLEXPRICE_TEMPORAL_ADDRESS=temporal:7233
-    volumes:
-      - ./internal/config:/app/internal/config
-    restart: unless-stopped
 
-  flexprice-worker:
-    image: flexprice-app:local
-    depends_on:
-      postgres:
-        condition: service_healthy
-      kafka:
-        condition: service_healthy
-      clickhouse:
-        condition: service_healthy
-      temporal:
-        condition: service_started
     environment:
-      - FLEXPRICE_DEPLOYMENT_MODE=temporal_worker
-      # Override config.yaml settings for containerized environment
-      - FLEXPRICE_POSTGRES_HOST=postgres
-      - FLEXPRICE_KAFKA_BROKERS=kafka:9092
-      - FLEXPRICE_CLICKHOUSE_ADDRESS=clickhouse:9000
-      - FLEXPRICE_TEMPORAL_ADDRESS=temporal:7233
-    volumes:
-      - ./internal/config:/app/internal/config
-    restart: unless-stopped
+      <<: *flexprice-env
+      FLEXPRICE_DEPLOYMENT_MODE: consumer
+      
+
+  
+  flexprice-worker:
+    <<: *flexprice-common
+    image: flexprice-app:local
+
+    environment:
+      <<: *flexprice-env
+      FLEXPRICE_DEPLOYMENT_MODE: temporal_worker
+    
 
 volumes:
   postgres-data:


### PR DESCRIPTION

## 📝 Description

This PR reduces duplication in `docker-compose.yml` by extracting common FlexPrice service configuration into reusable YAML anchors.

### Changes

* Added `x-flexprice-common` anchor for shared:

  * `depends_on`
  * `volumes`
  * `restart`

* Added `x-flexprice-env` anchor for shared environment variables:

  * `FLEXPRICE_POSTGRES_HOST`
  * `FLEXPRICE_KAFKA_BROKERS`
  * `FLEXPRICE_CLICKHOUSE_ADDRESS`
  * `FLEXPRICE_TEMPORAL_ADDRESS`

* Updated:

  * `flexprice-api`
  * `flexprice-consumer`
  * `flexprice-worker`

to reuse the common configuration and only define their deployment-specific environment variable.

### Validation

Verified the resulting configuration with:

```bash
docker compose config
```

which successfully expands all anchors and preserves the generated configuration.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the app stack configuration by sharing common service settings across core components.
  * Improved consistency in how the API, consumer, and worker connect to supporting services.
  * Kept the API available on the same local port while reducing repeated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->