### PR TITLE
feat(pubsub): presence-based dual-write to second Kafka cluster (GMK)

### DIFF
--- a/internal/pubsub/kafka/producer.go
+++ b/internal/pubsub/kafka/producer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
 	"github.com/flexprice/flexprice/internal/config"
+	mainkafka "github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/types"
 )
 
@@ -26,6 +27,40 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 	publisher, err := kafka.NewPublisher(
 		kafka.PublisherConfig{
 			Brokers:               cfg.Kafka.Brokers,
+			Marshaler:             kafka.DefaultMarshaler{},
+			OverwriteSaramaConfig: saramaConfig,
+		},
+		watermill.NewStdLogger(enableDebugLogs, false),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Producer{Publisher: publisher}, nil
+}
+
+// NewSecondaryProducer builds the optional second-cluster producer for the pubsub path
+// (cfg.KafkaSecondary). It enables presence-based dual-write of the non-event topics that
+// flow through PubSub (onboarding, wallet alerts, post-processing, feature usage) to the
+// second cluster during the AWS→GCP migration. Returns (nil, nil) when no second cluster
+// is configured, so callers stay single-cluster. Builds the Sarama config from the second
+// cluster's own KafkaConfig (reusing internal/kafka's per-cluster builder), so OAUTHBEARER
+// for GMK works identically to the events dual-write. See infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
+func NewSecondaryProducer(cfg *config.Configuration) (*Producer, error) {
+	if cfg.KafkaSecondary == nil {
+		return nil, nil
+	}
+	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
+
+	saramaConfig := mainkafka.GetSaramaConfig(cfg.KafkaSecondary)
+	if saramaConfig != nil {
+		saramaConfig.Producer.Return.Successes = true
+		saramaConfig.Producer.Return.Errors = true
+	}
+
+	publisher, err := kafka.NewPublisher(
+		kafka.PublisherConfig{
+			Brokers:               cfg.KafkaSecondary.Brokers,
 			Marshaler:             kafka.DefaultMarshaler{},
 			OverwriteSaramaConfig: saramaConfig,
 		},

--- a/internal/pubsub/kafka/pubsub.go
+++ b/internal/pubsub/kafka/pubsub.go
@@ -11,23 +11,29 @@ import (
 
 type PubSub struct {
 	producer *Producer
-	consumer *Consumer
-	config   *config.Configuration
-	logger   *logger.Logger
+	// secondary is the optional second-cluster producer (cfg.KafkaSecondary). When non-nil,
+	// every Publish ALSO writes to it (presence-based dual-write for the AWS→GCP migration);
+	// nil ⇒ single-cluster. Its failures are logged, never fatal to the primary write.
+	secondary *Producer
+	consumer  *Consumer
+	config    *config.Configuration
+	logger    *logger.Logger
 }
 
-// NewPubSub creates a new kafka-based pubsub
+// NewPubSub creates a new kafka-based pubsub. secondary may be nil (single-cluster).
 func NewPubSub(
 	config *config.Configuration,
 	logger *logger.Logger,
 	producer *Producer,
+	secondary *Producer,
 	consumer *Consumer,
 ) pubsub.PubSub {
 	return &PubSub{
-		producer: producer,
-		consumer: consumer,
-		config:   config,
-		logger:   logger,
+		producer:  producer,
+		secondary: secondary,
+		consumer:  consumer,
+		config:    config,
+		logger:    logger,
 	}
 }
 
@@ -42,18 +48,47 @@ func NewPubSubFromConfig(
 		return nil, err
 	}
 
+	// Optional dual-write producer (present only when cfg.KafkaSecondary is set).
+	// Built eagerly like the primary, so a misconfigured/unreachable second cluster
+	// surfaces as a boot error (rolling update protects capacity) rather than silent loss.
+	secondary, err := NewSecondaryProducer(config)
+	if err != nil {
+		logger.Error(context.Background(), "failed to create secondary producer", "error", err)
+		return nil, err
+	}
+
 	consumer, err := NewConsumer(config, consumerGroupID)
 	if err != nil {
 		logger.Error(context.Background(), "failed to create consumer", "error", err)
 		return nil, err
 	}
 
-	return NewPubSub(config, logger, producer, consumer), nil
+	return NewPubSub(config, logger, producer, secondary, consumer), nil
 }
 
-// Publish publishes a webhook event
+// Publish writes to the local cluster and, when a second cluster is configured, also writes
+// there. The two writes are independent: a secondary failure is logged but does not block or
+// fail the primary write (mirrors EventPublisher's events dual-write). A fresh message copy is
+// handed to the secondary because the watermill publisher consumes the message it is given.
 func (p *PubSub) Publish(ctx context.Context, topic string, msg *message.Message) error {
-	return p.producer.Publish(topic, msg)
+	var secondaryMsg *message.Message
+	if p.secondary != nil {
+		secondaryMsg = msg.Copy()
+	}
+
+	err := p.producer.Publish(topic, msg)
+
+	if p.secondary != nil {
+		if serr := p.secondary.Publish(topic, secondaryMsg); serr != nil {
+			p.logger.Error(ctx, "secondary kafka publish failed",
+				"cluster", "secondary",
+				"topic", topic,
+				"error", serr,
+			)
+		}
+	}
+
+	return err
 }
 
 // Subscribe starts consuming webhook events
@@ -64,6 +99,9 @@ func (p *PubSub) Subscribe(ctx context.Context, topic string) (<-chan *message.M
 // Close closes the pubsub
 func (p *PubSub) Close() error {
 	p.producer.Close()
+	if p.secondary != nil {
+		p.secondary.Close()
+	}
 	p.consumer.Close()
 
 	return nil

--- a/internal/pubsub/kafka/pubsub.go
+++ b/internal/pubsub/kafka/pubsub.go
@@ -9,12 +9,20 @@ import (
 	"github.com/flexprice/flexprice/internal/pubsub"
 )
 
+// messagePublisher is the subset of *Producer that PubSub depends on. *Producer satisfies it;
+// tests substitute a fake to exercise the dual-write fan-out without a broker (mirrors the
+// seam in internal/kafka EventPublisher).
+type messagePublisher interface {
+	Publish(topic string, messages ...*message.Message) error
+	Close() error
+}
+
 type PubSub struct {
-	producer *Producer
+	producer messagePublisher
 	// secondary is the optional second-cluster producer (cfg.KafkaSecondary). When non-nil,
 	// every Publish ALSO writes to it (presence-based dual-write for the AWS→GCP migration);
 	// nil ⇒ single-cluster. Its failures are logged, never fatal to the primary write.
-	secondary *Producer
+	secondary messagePublisher
 	consumer  *Consumer
 	config    *config.Configuration
 	logger    *logger.Logger
@@ -28,13 +36,19 @@ func NewPubSub(
 	secondary *Producer,
 	consumer *Consumer,
 ) pubsub.PubSub {
-	return &PubSub{
-		producer:  producer,
-		secondary: secondary,
-		consumer:  consumer,
-		config:    config,
-		logger:    logger,
+	ps := &PubSub{
+		producer: producer,
+		consumer: consumer,
+		config:   config,
+		logger:   logger,
 	}
+	// Only set the interface field when a real producer is present. A typed-nil *Producer
+	// stored in an interface is itself non-nil, which would break the `p.secondary != nil`
+	// guard in Publish and panic. NewSecondaryProducer returns nil when KafkaSecondary is unset.
+	if secondary != nil {
+		ps.secondary = secondary
+	}
+	return ps
 }
 
 func NewPubSubFromConfig(

--- a/internal/pubsub/kafka/pubsub.go
+++ b/internal/pubsub/kafka/pubsub.go
@@ -80,9 +80,14 @@ func (p *PubSub) Publish(ctx context.Context, topic string, msg *message.Message
 
 	if p.secondary != nil {
 		if serr := p.secondary.Publish(topic, secondaryMsg); serr != nil {
-			p.logger.Error(ctx, "secondary kafka publish failed",
+			// Same message + cluster label as EventPublisher.logFailure so one
+			// alert/grep ("kafka publish failed", cluster=secondary) covers both
+			// dual-write paths.
+			p.logger.Error(ctx, "kafka publish failed",
 				"cluster", "secondary",
 				"topic", topic,
+				"message_id", secondaryMsg.UUID,
+				"tenant_id", secondaryMsg.Metadata.Get("tenant_id"),
 				"error", serr,
 			)
 		}

--- a/internal/pubsub/kafka/pubsub_test.go
+++ b/internal/pubsub/kafka/pubsub_test.go
@@ -1,0 +1,136 @@
+package kafka
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// fakePublisher is a test double for messagePublisher. It records every published message and
+// can be configured to fail, so we exercise the dual-write fan-out without a broker.
+type fakePublisher struct {
+	mu       sync.Mutex
+	err      error
+	calls    int
+	topics   []string
+	messages []*message.Message
+}
+
+func (f *fakePublisher) Publish(topic string, messages ...*message.Message) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	f.topics = append(f.topics, topic)
+	f.messages = append(f.messages, messages...)
+	return nil
+}
+
+func (f *fakePublisher) Close() error { return nil }
+
+func (f *fakePublisher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakePublisher) only() *message.Message {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.messages) != 1 {
+		return nil
+	}
+	return f.messages[0]
+}
+
+// newPubSub builds a PubSub over the given fake clusters (pass nil secondary to disable it).
+func newPubSub(lg *logger.Logger, primary, secondary messagePublisher) *PubSub {
+	ps := &PubSub{logger: lg, producer: primary}
+	if secondary != nil {
+		ps.secondary = secondary
+	}
+	return ps
+}
+
+func sampleMsg() *message.Message {
+	m := message.NewMessage("wh_123", []byte(`{"event":"invoice.finalized"}`))
+	m.Metadata.Set("tenant_id", "tenant_1")
+	return m
+}
+
+func TestPubSubPublish_PrimaryOnly(t *testing.T) {
+	primary := &fakePublisher{}
+	ps := newPubSub(logger.NewNoopLogger(), primary, nil)
+
+	if err := ps.Publish(context.Background(), "onboarding_events", sampleMsg()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if primary.callCount() != 1 || primary.topics[0] != "onboarding_events" {
+		t.Fatalf("expected one publish on 'onboarding_events', got calls=%d topics=%v", primary.callCount(), primary.topics)
+	}
+}
+
+func TestPubSubPublish_BothClusters_SameMessageDistinctCopy(t *testing.T) {
+	primary := &fakePublisher{}
+	secondary := &fakePublisher{}
+	ps := newPubSub(logger.NewNoopLogger(), primary, secondary)
+
+	if err := ps.Publish(context.Background(), "balance_alert", sampleMsg()); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	pm, sm := primary.only(), secondary.only()
+	if pm == nil || sm == nil {
+		t.Fatalf("expected one message on each cluster; primary=%d secondary=%d", primary.callCount(), secondary.callCount())
+	}
+	if pm.UUID != sm.UUID || pm.UUID != "wh_123" {
+		t.Fatalf("expected matching UUID 'wh_123', got primary=%q secondary=%q", pm.UUID, sm.UUID)
+	}
+	if string(pm.Payload) != string(sm.Payload) {
+		t.Fatalf("expected identical payloads, got primary=%q secondary=%q", pm.Payload, sm.Payload)
+	}
+	// The watermill publisher consumes the message it is handed, so the secondary must get a copy.
+	if pm == sm {
+		t.Fatal("expected secondary to receive a distinct copy, got the same *message.Message pointer")
+	}
+}
+
+// TestPubSubPublish_SecondaryFailure_Swallowed locks in the deliberate divergence from
+// EventPublisher: pubsub callers fail the whole operation on a returned error, so a SECONDARY
+// (GMK) failure must be logged but NOT returned — a GMK blip cannot fail an MSK-successful op.
+func TestPubSubPublish_SecondaryFailure_Swallowed(t *testing.T) {
+	primary := &fakePublisher{}
+	secondary := &fakePublisher{err: context.DeadlineExceeded}
+	ps := newPubSub(logger.NewNoopLogger(), primary, secondary)
+
+	err := ps.Publish(context.Background(), "balance_alert", sampleMsg())
+	if err != nil {
+		t.Fatalf("secondary failure must NOT be returned when primary succeeds, got %v", err)
+	}
+	if primary.callCount() != 1 {
+		t.Fatalf("expected primary to receive the message, got %d", primary.callCount())
+	}
+	if secondary.callCount() != 1 {
+		t.Fatalf("expected the secondary publish to be attempted, got %d", secondary.callCount())
+	}
+}
+
+// A PRIMARY failure IS returned (the caller decides what to do), and the secondary still
+// receives the write — writes are independent.
+func TestPubSubPublish_PrimaryFailure_Returned(t *testing.T) {
+	primary := &fakePublisher{err: context.DeadlineExceeded}
+	secondary := &fakePublisher{}
+	ps := newPubSub(logger.NewNoopLogger(), primary, secondary)
+
+	err := ps.Publish(context.Background(), "balance_alert", sampleMsg())
+	if err == nil {
+		t.Fatal("expected the primary failure to be returned, got nil")
+	}
+	if secondary.callCount() != 1 {
+		t.Fatalf("expected secondary to still receive the message despite primary failure, got %d", secondary.callCount())
+	}
+}


### PR DESCRIPTION
## What
Adds an optional **secondary producer** to the shared `internal/pubsub/kafka.PubSub`, so the non-event topics that flow through it also write to `cfg.KafkaSecondary` (GMK) during the AWS→GCP migration — mirroring the events dual-write already in `EventPublisher`.

**Topics now covered** (everything on the pubsub path): `onboarding_events`, `balance_alert`, `events_post_processing` (+ backfill), `feature_usage_tracking`.

## Why only these (not webhooks)
Traced every producing path. The pubsub layer is the produce path for the above. **`system_events` (webhooks) is intentionally excluded** — it uses the shared `internal/kafka.Producer` (a different path), is a pure delivery side-effect with no replay value, and is handled by drain-and-flip at cutover. Covering it would be a separate change for no real benefit.

## Design (mirrors the events dual-write)
- **Presence-based:** `NewSecondaryProducer` returns `nil` when `KafkaSecondary` is unset → single-cluster deployments and GMK-sole-primary staging are unaffected.
- **OAUTHBEARER:** reuses `internal/kafka.GetSaramaConfig(cfg.KafkaSecondary)` — the same per-cluster builder the events secondary uses, so GMK auth is identical/proven.
- **Independent writes:** secondary failure is logged per-cluster, never blocks/fails the primary write (ingest stays 202). A fresh `msg.Copy()` is handed to the secondary (watermill consumes the message it's given).
- **Eager build:** unreachable second cluster ⇒ boot error; rolling update (`maxUnavailable: 0`) protects capacity.

## No new config
Driven by the existing `FLEXPRICE_KAFKA_SECONDARY_*` env (already set on prod for the events dual-write). Infra unchanged.

## Validation
`go build ./cmd/... ./internal/...` + `go vet` clean. Will live-verify on prod before merge to `main` (Ready pods + 0 secondary failures across webhook/onboarding/alert traffic), same flow as the events dual-write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional dual-write support to a secondary Kafka cluster when secondary Kafka settings are configured.

- **Behavior Changes**
  - Publishing remains source-of-truth on the primary cluster; secondary publish failures are logged and do not change the returned result from the primary.
  - Secondary producer setup is performed during initialization; if enabled and it fails, setup fails.
  - Closing the messaging layer now also closes the secondary producer when present.

- **Tests**
  - Added unit tests covering primary-only and dual-write publish/close behavior, including failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->