### PR TITLE
feat(helm): render meter/replay/raw/benchmark consumer blocks in configmap

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -156,6 +156,59 @@ data:
       rate_limit: {{ .Values.featureUsageTrackingLazy.rateLimit }}
       consumer_group: {{ .Values.featureUsageTrackingLazy.consumerGroup | quote }}
 
+    # The blocks below were previously absent from this ConfigMap, so on GKE (where the
+    # mounted ConfigMap replaces the baked config.yaml) their FLEXPRICE_* env overrides were
+    # ignored by viper Unmarshal and the consumers silently never started — diverging from the
+    # AWS web_consumer task def. Rendered here so they can be configured per-deployment.
+    event_processing_replay:
+      enabled: {{ .Values.eventProcessingReplay.enabled }}
+      topic: {{ .Values.eventProcessingReplay.topic | quote }}
+      rate_limit: {{ .Values.eventProcessingReplay.rateLimit }}
+      consumer_group: {{ .Values.eventProcessingReplay.consumerGroup | quote }}
+
+    feature_usage_tracking_replay:
+      enabled: {{ .Values.featureUsageTrackingReplay.enabled }}
+      topic: {{ .Values.featureUsageTrackingReplay.topic | quote }}
+      rate_limit: {{ .Values.featureUsageTrackingReplay.rateLimit }}
+      consumer_group: {{ .Values.featureUsageTrackingReplay.consumerGroup | quote }}
+
+    meter_usage_tracking:
+      enabled: {{ .Values.meterUsageTracking.enabled }}
+      topic: {{ .Values.meterUsageTracking.topic | quote }}
+      rate_limit: {{ .Values.meterUsageTracking.rateLimit }}
+      consumer_group: {{ .Values.meterUsageTracking.consumerGroup | quote }}
+
+    meter_usage_tracking_lazy:
+      enabled: {{ .Values.meterUsageTrackingLazy.enabled }}
+      topic: {{ .Values.meterUsageTrackingLazy.topic | quote }}
+      rate_limit: {{ .Values.meterUsageTrackingLazy.rateLimit }}
+      consumer_group: {{ .Values.meterUsageTrackingLazy.consumerGroup | quote }}
+
+    costsheet_usage_tracking:
+      enabled: {{ .Values.costsheetUsageTracking.enabled }}
+      topic: {{ .Values.costsheetUsageTracking.topic | quote }}
+      rate_limit: {{ .Values.costsheetUsageTracking.rateLimit }}
+      consumer_group: {{ .Values.costsheetUsageTracking.consumerGroup | quote }}
+
+    costsheet_usage_tracking_lazy:
+      enabled: {{ .Values.costsheetUsageTrackingLazy.enabled }}
+      topic: {{ .Values.costsheetUsageTrackingLazy.topic | quote }}
+      rate_limit: {{ .Values.costsheetUsageTrackingLazy.rateLimit }}
+      consumer_group: {{ .Values.costsheetUsageTrackingLazy.consumerGroup | quote }}
+
+    raw_event_consumption:
+      enabled: {{ .Values.rawEventConsumption.enabled }}
+      topic: {{ .Values.rawEventConsumption.topic | quote }}
+      output_topic: {{ .Values.rawEventConsumption.outputTopic | quote }}
+      rate_limit: {{ .Values.rawEventConsumption.rateLimit }}
+      consumer_group: {{ .Values.rawEventConsumption.consumerGroup | quote }}
+
+    usage_benchmark:
+      enabled: {{ .Values.usageBenchmark.enabled }}
+      topic: {{ .Values.usageBenchmark.topic | quote }}
+      rate_limit: {{ .Values.usageBenchmark.rateLimit }}
+      consumer_group: {{ .Values.usageBenchmark.consumerGroup | quote }}
+
     onboarding_events:
       enabled: {{ .Values.onboardingEvents.enabled }}
       topic: {{ .Values.onboardingEvents.topic | quote }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -803,6 +803,50 @@ rawEventConsumption:
   consumerGroup: "raw_events_consumer"
   rateLimit: 100
 
+# Consumer blocks below are off by default (a deployment opts in per-env). They are rendered
+# into the ConfigMap so they can actually be configured on GKE; defaults mirror config.yaml.
+eventProcessingReplay:
+  enabled: false
+  topic: "events_backfill"
+  rateLimit: 1
+  consumerGroup: "v1_event_processing_replay"
+
+featureUsageTrackingReplay:
+  enabled: false
+  topic: "events_backfill"
+  rateLimit: 1
+  consumerGroup: "v1_feature_tracking_service_replay"
+
+meterUsageTracking:
+  enabled: false
+  topic: "events"
+  rateLimit: 1
+  consumerGroup: "v1_meter_usage_tracking_service"
+
+meterUsageTrackingLazy:
+  enabled: false
+  topic: "events_lazy"
+  rateLimit: 1
+  consumerGroup: "v1_meter_usage_tracking_service_lazy"
+
+costsheetUsageTracking:
+  enabled: false
+  topic: "events"
+  rateLimit: 1
+  consumerGroup: "v1_costsheet_usage_tracking_service"
+
+costsheetUsageTrackingLazy:
+  enabled: false
+  topic: "events_lazy"
+  rateLimit: 1
+  consumerGroup: "v1_costsheet_usage_tracking_service_lazy"
+
+usageBenchmark:
+  enabled: false
+  topic: "benchmarking"
+  rateLimit: 10
+  consumerGroup: "v1_usage_benchmark_service"
+
 # DynamoDB configuration
 dynamodb:
   inUse: false


### PR DESCRIPTION
## Problem
The app ConfigMap rendered only a subset of consumer blocks. **Absent:** `meter_usage_tracking`, `meter_usage_tracking_lazy`, `costsheet_usage_tracking(_lazy)`, `event_processing_replay`, `feature_usage_tracking_replay`, `usage_benchmark` (and `raw_event_consumption` had a values entry but no configmap render).

On GKE the mounted ConfigMap **replaces** the baked `config.yaml`, so for these absent blocks viper's `Unmarshal` ignored the `FLEXPRICE_*` env overrides (the recurring viper trap) and those consumers **silently never started**. That diverges from the AWS ECS `web_consumer` task def, which runs `meter_usage_tracking` + `event_processing_replay` + `feature_usage_tracking_replay` on the `events` topic. So GCP was missing real consumers.

## Fix
Render every consumer block into `configmap.yaml` from chart values, mirroring the existing `event_processing`/`feature_usage_tracking` style. Added matching `values.yaml` defaults (all **off by default**, topics/groups/rates mirroring `config.yaml`), so deployments opt in per-env.

## Validated
`go build ./internal/config/` clean; `helm template … --show-only configmap.yaml` renders all 8 blocks.

## Follow-up
Companion infra PR sets the GCP consumer values to mirror `web_consumer` exactly (group names + enabled state). **This must also reach `main`** — prod (`flexprice-production` + the GCP consumer release) renders the chart from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new optional event replay and usage-tracking consumer settings.
  * Expanded configuration support for additional tracking streams, including raw event consumption and usage benchmarking.
  * These new options are disabled by default and can be turned on per environment as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->