### PR TITLE
fix(resp-rbac): update error marking for existing credit notes and  handle entity, action for logs

### DIFF
--- a/internal/repository/ent/creditnote.go
+++ b/internal/repository/ent/creditnote.go
@@ -101,7 +101,7 @@ func (r *creditnoteRepository) Create(ctx context.Context, cn *domainCreditNote.
 				WithReportableDetails(map[string]any{
 					"creditnote_id": cn.ID,
 				}).
-				Mark(ierr.ErrDatabase)
+				Mark(ierr.ErrAlreadyExists)
 		}
 		return ierr.WithError(err).
 			WithHint("credit note creation failed").

--- a/internal/types/rbac.go
+++ b/internal/types/rbac.go
@@ -1,9 +1,5 @@
 package types
 
-type Entity string
-
-func (e Entity) String() string { return string(e) }
-
 type Action string
 
 func (a Action) String() string { return string(a) }
@@ -12,6 +8,10 @@ const (
 	ActionRead  Action = "read"
 	ActionWrite Action = "write"
 )
+
+type Entity string
+
+func (e Entity) String() string { return string(e) }
 
 const (
 	EntityUser            Entity = "user"

--- a/internal/types/rbac.go
+++ b/internal/types/rbac.go
@@ -1,7 +1,12 @@
 package types
 
-type Action string
 type Entity string
+
+func (e Entity) String() string { return string(e) }
+
+type Action string
+
+func (a Action) String() string { return string(a) }
 
 const (
 	ActionRead  Action = "read"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate credit note handling so create failures are now reported more accurately when a credit note number already exists.
  * Kept the existing message and details, while making the error easier for callers to classify consistently.
* **Refactor**
  * Added `String()` support for RBAC action and entity values to improve readability in string outputs (e.g., logging and UI text where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->