### PR TITLE
fix(ent): pin partial-index predicates to canonical form + guard index churn

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"entgo.io/ent/dialect/sql/schema"
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -49,17 +50,33 @@ func main() {
 	// Run auto migration
 	logger.Info(ctx, "Running database migrations...")
 
+	// Safety guard: never let auto-migration drop or recreate (modify) an index.
+	// Ent/Atlas's partial-index predicate comparison is lossy (it false-detects
+	// drift between `status = 'published'` and Postgres' canonical
+	// `((status)::text = 'published'::text)`), which previously caused ~30 indexes
+	// on hot tables to be dropped+recreated on every run, taking exclusive table
+	// locks. Adding ModifyIndex to the skip set makes index DDL deliberate (handled
+	// via reviewed/versioned migrations), not an auto-migrate side effect. New
+	// indexes (AddIndex) are still created. See RCA: prod DDL-lock incident 2026-06-25.
+	//
+	// IMPORTANT: WithSkipChanges OVERWRITES Ent's default skip set, which is
+	// (DropIndex | DropColumn). We MUST re-include both here, or auto-migrate would
+	// start dropping columns (data loss). So the set is default + ModifyIndex.
+	migrateOpts := []schema.MigrateOption{
+		schema.WithSkipChanges(schema.DropIndex | schema.DropColumn | schema.ModifyIndex),
+	}
+
 	// Check if we're in dry-run mode
 	if *dryRun {
 		logger.Info(ctx, "Dry run mode - printing migration SQL without executing")
 		// In dry-run mode, we just print the SQL that would be executed
-		err = client.Schema.WriteTo(ctx, os.Stdout)
+		err = client.Schema.WriteTo(ctx, os.Stdout, migrateOpts...)
 		if err != nil {
 			logger.Fatal(ctx, "Failed to generate migration SQL", "error", err)
 		}
 	} else {
 		// Run the actual migration
-		err = client.Schema.Create(ctx)
+		err = client.Schema.Create(ctx, migrateOpts...)
 		if err != nil {
 			logger.Fatal(ctx, "Failed to create schema resources", "error", err)
 		}

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -35,7 +35,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{AddonsColumns[1], AddonsColumns[7], AddonsColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND lookup_key IS NOT NULL AND lookup_key != ''",
+					Where: "(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))",
 				},
 			},
 		},
@@ -146,7 +146,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{AuthsColumns[1]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 			{
@@ -252,7 +252,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{CostsheetsColumns[1], CostsheetsColumns[7], CostsheetsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND lookup_key IS NOT NULL AND lookup_key != ''",
+					Where: "(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))",
 				},
 			},
 			{
@@ -303,7 +303,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{CouponsColumns[1], CouponsColumns[7], CouponsColumns[21]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "coupon_code IS NOT NULL AND coupon_code != '' AND status = 'published'",
+					Where: "((coupon_code IS NOT NULL) AND ((coupon_code)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 		},
@@ -522,7 +522,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[24]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "plan_id IS NOT NULL",
+					Where: "(plan_id IS NOT NULL)",
 				},
 			},
 			{
@@ -530,7 +530,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[25]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "subscription_id IS NOT NULL",
+					Where: "(subscription_id IS NOT NULL)",
 				},
 			},
 		},
@@ -603,7 +603,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{CreditNotesColumns[1], CreditNotesColumns[7], CreditNotesColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "credit_note_number IS NOT NULL AND credit_note_number != '' AND status = 'published'",
+					Where: "((credit_note_number IS NOT NULL) AND ((credit_note_number)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 			{
@@ -611,7 +611,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{CreditNotesColumns[1], CreditNotesColumns[7], CreditNotesColumns[18]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "idempotency_key IS NOT NULL AND idempotency_key != ''",
+					Where: "((idempotency_key IS NOT NULL) AND ((idempotency_key)::text <> ''::text))",
 				},
 			},
 			{
@@ -704,7 +704,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{CustomersColumns[1], CustomersColumns[7], CustomersColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "(external_id IS NOT NULL AND external_id != '') AND status = 'published'",
+					Where: "((external_id IS NOT NULL) AND ((external_id)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 			{
@@ -717,7 +717,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{CustomersColumns[1], CustomersColumns[7], CustomersColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "email IS NOT NULL AND email != '' AND status = 'published'",
+					Where: "((email IS NOT NULL) AND ((email)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 			{
@@ -774,7 +774,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{EntitlementsColumns[1], EntitlementsColumns[7], EntitlementsColumns[8], EntitlementsColumns[9], EntitlementsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 			{
@@ -797,7 +797,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{EntitlementsColumns[9], EntitlementsColumns[8], EntitlementsColumns[10], EntitlementsColumns[19], EntitlementsColumns[20]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "entity_type = 'SUBSCRIPTION' AND status = 'published'",
+					Where: "(((entity_type)::text = 'SUBSCRIPTION'::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 		},
@@ -829,7 +829,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{EntityIntegrationMappingsColumns[1], EntityIntegrationMappingsColumns[7], EntityIntegrationMappingsColumns[9], EntityIntegrationMappingsColumns[8], EntityIntegrationMappingsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 			{
@@ -909,7 +909,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{FeaturesColumns[1], FeaturesColumns[7], FeaturesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "(lookup_key IS NOT NULL AND lookup_key != '') AND status = 'published'",
+					Where: "((lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 			{
@@ -917,7 +917,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{FeaturesColumns[1], FeaturesColumns[7], FeaturesColumns[12]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "meter_id IS NOT NULL",
+					Where: "(meter_id IS NOT NULL)",
 				},
 			},
 			{
@@ -968,7 +968,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{GroupsColumns[1], GroupsColumns[7], GroupsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND lookup_key IS NOT NULL AND lookup_key != ''",
+					Where: "(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))",
 				},
 			},
 			{
@@ -1075,7 +1075,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[8], InvoicesColumns[12], InvoicesColumns[13], InvoicesColumns[2]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 			{
@@ -1098,7 +1098,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{InvoicesColumns[1], InvoicesColumns[7], InvoicesColumns[38]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "invoice_number IS NOT NULL AND invoice_number != '' AND status = 'published'",
+					Where: "((invoice_number IS NOT NULL) AND ((invoice_number)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 			{
@@ -1114,7 +1114,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{InvoicesColumns[9], InvoicesColumns[32], InvoicesColumns[33]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "invoice_status != 'VOIDED' AND subscription_id IS NOT NULL",
+					Where: "(((invoice_status)::text <> 'VOIDED'::text) AND (subscription_id IS NOT NULL))",
 				},
 			},
 		},
@@ -1311,7 +1311,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{PaymentsColumns[1], PaymentsColumns[7], PaymentsColumns[13], PaymentsColumns[14]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "payment_gateway IS NOT NULL AND gateway_payment_id IS NOT NULL",
+					Where: "((payment_gateway IS NOT NULL) AND (gateway_payment_id IS NOT NULL))",
 				},
 			},
 		},
@@ -1362,7 +1362,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{PaymentAttemptsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "gateway_attempt_id IS NOT NULL",
+					Where: "(gateway_attempt_id IS NOT NULL)",
 				},
 			},
 		},
@@ -1396,7 +1396,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{PaymentMethodsColumns[1], PaymentMethodsColumns[7], PaymentMethodsColumns[8], PaymentMethodsColumns[2]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 		},
@@ -1428,7 +1428,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{PlansColumns[1], PlansColumns[7], PlansColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND lookup_key IS NOT NULL AND lookup_key != ''",
+					Where: "(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))",
 				},
 			},
 			{
@@ -1502,7 +1502,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[31]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND lookup_key IS NOT NULL AND lookup_key != '' AND end_date IS NULL",
+					Where: "(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text) AND (end_date IS NULL))",
 				},
 			},
 			{
@@ -1525,7 +1525,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[35], PricesColumns[34], PricesColumns[40]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 		},
@@ -1558,7 +1558,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{PriceUnitsColumns[1], PriceUnitsColumns[7], PriceUnitsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 		},
@@ -1747,7 +1747,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[9], SubscriptionsColumns[2]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published'",
+					Where: "((status)::text = 'published'::text)",
 				},
 			},
 			{
@@ -1770,7 +1770,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[10], SubscriptionsColumns[44]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND subscription_type IN ('standalone','delegated_invoicing','parent','grouped_invoicing')",
+					Where: "(((status)::text = 'published'::text) AND ((subscription_type)::text = ANY (ARRAY[('standalone'::character varying)::text, ('delegated_invoicing'::character varying)::text, ('parent'::character varying)::text, ('grouped_invoicing'::character varying)::text])))",
 				},
 			},
 		},
@@ -2000,7 +2000,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionSchedulesColumns[2], SubscriptionSchedulesColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'pending'",
+					Where: "((status)::text = 'pending'::text)",
 				},
 			},
 			{
@@ -2008,7 +2008,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionSchedulesColumns[10], SubscriptionSchedulesColumns[2]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'pending'",
+					Where: "((status)::text = 'pending'::text)",
 				},
 			},
 			{
@@ -2021,7 +2021,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{SubscriptionSchedulesColumns[16], SubscriptionSchedulesColumns[9]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'pending'",
+					Where: "((status)::text = 'pending'::text)",
 				},
 			},
 		},
@@ -2217,7 +2217,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{TaxRatesColumns[1], TaxRatesColumns[7], TaxRatesColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "(code IS NOT NULL AND code != '' and status = 'published')",
+					Where: "((code IS NOT NULL) AND ((code)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 		},
@@ -2272,7 +2272,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{UsersColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "status = 'published' AND email IS NOT NULL AND email != ''",
+					Where: "(((status)::text = 'published'::text) AND (email IS NOT NULL) AND ((email)::text <> ''::text))",
 				},
 			},
 			{
@@ -2393,7 +2393,7 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{WalletTransactionsColumns[1], WalletTransactionsColumns[7], WalletTransactionsColumns[8], WalletTransactionsColumns[10], WalletTransactionsColumns[21], WalletTransactionsColumns[20]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "credits_available > 0 AND type = 'credit'",
+					Where: "((credits_available > (0)::numeric) AND ((type)::text = 'credit'::text))",
 				},
 			},
 			{
@@ -2401,7 +2401,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{WalletTransactionsColumns[1], WalletTransactionsColumns[7], WalletTransactionsColumns[25]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "idempotency_key IS NOT NULL AND idempotency_key <> '' AND status='published'",
+					Where: "((idempotency_key IS NOT NULL) AND ((idempotency_key)::text <> ''::text) AND ((status)::text = 'published'::text))",
 				},
 			},
 		},

--- a/ent/schema/addon.go
+++ b/ent/schema/addon.go
@@ -73,6 +73,6 @@ func (Addon) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "lookup_key").
 			Unique().
 			StorageKey(AddonTenantIDEnvironmentIDLookupKeyConstraint).
-			Annotations(entsql.IndexWhere("status = 'published'" + " AND lookup_key IS NOT NULL AND lookup_key != ''")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))")),
 	}
 }

--- a/ent/schema/auth.go
+++ b/ent/schema/auth.go
@@ -51,7 +51,7 @@ func (Auth) Indexes() []ent.Index {
 		index.Fields("user_id").
 			Unique().
 			StorageKey("idx_auth_user_id_unique").
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 		index.Fields("provider").
 			StorageKey("idx_auth_provider"),
 		index.Fields("status").

--- a/ent/schema/costsheet.go
+++ b/ent/schema/costsheet.go
@@ -72,7 +72,7 @@ func (Costsheet) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "lookup_key").
 			Unique().
 			StorageKey(Idx_costsheet_tenant_environment_lookup_key).
-			Annotations(entsql.IndexWhere("status = 'published'" + " AND lookup_key IS NOT NULL AND lookup_key != ''")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))")),
 		index.Fields("tenant_id", "environment_id"), // Supports multi-tenant, multi-environment queries
 	}
 }

--- a/ent/schema/coupon.go
+++ b/ent/schema/coupon.go
@@ -124,7 +124,7 @@ func (Coupon) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id"),
 		index.Fields("tenant_id", "environment_id", "coupon_code").
 			Unique().
-			Annotations(entsql.IndexWhere("coupon_code IS NOT NULL AND coupon_code != '' AND status = 'published'")).
+			Annotations(entsql.IndexWhere("((coupon_code IS NOT NULL) AND ((coupon_code)::text <> ''::text) AND ((status)::text = 'published'::text))")).
 			StorageKey("idx_coupon_tenant_environment_coupon_code_unique"),
 	}
 }

--- a/ent/schema/creditgrant.go
+++ b/ent/schema/creditgrant.go
@@ -174,11 +174,11 @@ func (CreditGrant) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "status"),
 		index.Fields("tenant_id", "environment_id", "scope", "plan_id").
-			Annotations(entsql.IndexWhere("plan_id IS NOT NULL")).
+			Annotations(entsql.IndexWhere("(plan_id IS NOT NULL)")).
 			StorageKey("idx_plan_id_not_null"),
 
 		index.Fields("tenant_id", "environment_id", "scope", "subscription_id").
-			Annotations(entsql.IndexWhere("subscription_id IS NOT NULL")).
+			Annotations(entsql.IndexWhere("(subscription_id IS NOT NULL)")).
 			StorageKey("idx_subscription_id_not_null"),
 	}
 }

--- a/ent/schema/creditnote.go
+++ b/ent/schema/creditnote.go
@@ -142,10 +142,10 @@ func (CreditNote) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "credit_note_number").
 			Unique().
 			StorageKey(Idx_tenant_environment_credit_note_number_unique).
-			Annotations(entsql.IndexWhere("credit_note_number IS NOT NULL AND credit_note_number != '' AND status = 'published'")),
+			Annotations(entsql.IndexWhere("((credit_note_number IS NOT NULL) AND ((credit_note_number)::text <> ''::text) AND ((status)::text = 'published'::text))")),
 
 		index.Fields("tenant_id", "environment_id", "idempotency_key").
-			Annotations(entsql.IndexWhere("idempotency_key IS NOT NULL AND idempotency_key != ''")),
+			Annotations(entsql.IndexWhere("((idempotency_key IS NOT NULL) AND ((idempotency_key)::text <> ''::text))")),
 
 		index.Fields("tenant_id", "environment_id", "invoice_id"),
 

--- a/ent/schema/customer.go
+++ b/ent/schema/customer.go
@@ -93,12 +93,12 @@ func (Customer) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "external_id").
 			Unique().
-			Annotations(entsql.IndexWhere("(external_id IS NOT NULL AND external_id != '') AND status = 'published'")).
+			Annotations(entsql.IndexWhere("((external_id IS NOT NULL) AND ((external_id)::text <> ''::text) AND ((status)::text = 'published'::text))")).
 			StorageKey(Idx_tenant_environment_external_id_unique),
 		index.Fields("tenant_id", "environment_id"),
 		// Add email index for efficient email-based lookups
 		index.Fields("tenant_id", "environment_id", "email").
-			Annotations(entsql.IndexWhere("email IS NOT NULL AND email != '' AND status = 'published'")).
+			Annotations(entsql.IndexWhere("((email IS NOT NULL) AND ((email)::text <> ''::text) AND ((status)::text = 'published'::text))")).
 			StorageKey("idx_customer_tenant_environment_email"),
 		// GIN index for efficient JSONB containment queries on metadata (@> operator)
 		index.Fields("metadata").

--- a/ent/schema/entitlement.go
+++ b/ent/schema/entitlement.go
@@ -101,7 +101,7 @@ func (Entitlement) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "entity_type", "entity_id", "feature_id").
 			Unique().
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 
 		index.Fields("tenant_id", "environment_id", "entity_type", "entity_id"),
 		index.Fields("tenant_id", "environment_id", "feature_id"),
@@ -109,6 +109,6 @@ func (Entitlement) Indexes() []ent.Index {
 
 		// Index for time-based queries on subscription-scoped entitlements
 		index.Fields("entity_id", "entity_type", "feature_id", "start_date", "end_date").
-			Annotations(entsql.IndexWhere("entity_type = 'SUBSCRIPTION' AND status = 'published'")),
+			Annotations(entsql.IndexWhere("(((entity_type)::text = 'SUBSCRIPTION'::text) AND ((status)::text = 'published'::text))")),
 	}
 }

--- a/ent/schema/entityintegrationmapping.go
+++ b/ent/schema/entityintegrationmapping.go
@@ -71,7 +71,7 @@ func (EntityIntegrationMapping) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "entity_type", "entity_id", "provider_type").
 			Unique().
 			StorageKey(Idx_entity_integration_mapping_unique).
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 		// Index for provider entity lookups (not covered by primary index)
 		index.Fields("provider_type", "provider_entity_id"),
 	}

--- a/ent/schema/feature.go
+++ b/ent/schema/feature.go
@@ -112,10 +112,10 @@ func (Feature) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "lookup_key").
 			Unique().
 			StorageKey("idx_feature_tenant_env_lookup_key_unique").
-			Annotations(entsql.IndexWhere("(lookup_key IS NOT NULL AND lookup_key != '') AND status = 'published'")),
+			Annotations(entsql.IndexWhere("((lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text) AND ((status)::text = 'published'::text))")),
 		index.Fields("tenant_id", "environment_id", "meter_id").
 			StorageKey("idx_feature_tenant_env_meter_id").
-			Annotations(entsql.IndexWhere("meter_id IS NOT NULL")),
+			Annotations(entsql.IndexWhere("(meter_id IS NOT NULL)")),
 		index.Fields("tenant_id", "environment_id", "type").
 			StorageKey("idx_feature_tenant_env_type"),
 		index.Fields("tenant_id", "environment_id", "status").

--- a/ent/schema/group.go
+++ b/ent/schema/group.go
@@ -59,7 +59,7 @@ func (Group) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "lookup_key").
 			Unique().
 			StorageKey(Idx_group_tenant_environment_lookup_key).
-			Annotations(entsql.IndexWhere("status = 'published'" + " AND lookup_key IS NOT NULL AND lookup_key != ''")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))")),
 		index.Fields("tenant_id", "environment_id"),
 	}
 }

--- a/ent/schema/invoice.go
+++ b/ent/schema/invoice.go
@@ -242,7 +242,7 @@ func (Invoice) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "customer_id", "invoice_status", "payment_status", "status").
 			StorageKey("idx_tenant_customer_status").
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 		index.Fields("tenant_id", "environment_id", "subscription_id", "invoice_status", "payment_status", "status").
 			StorageKey("idx_tenant_subscription_status"),
 		index.Fields("tenant_id", "environment_id", "invoice_type", "invoice_status", "payment_status", "status").
@@ -253,7 +253,7 @@ func (Invoice) Indexes() []ent.Index {
 		// Invoice number is unique per tenant and environment
 		index.Fields("tenant_id", "environment_id", "invoice_number").
 			Unique().
-			Annotations(entsql.IndexWhere("invoice_number IS NOT NULL AND invoice_number != '' AND status = 'published'")).
+			Annotations(entsql.IndexWhere("((invoice_number IS NOT NULL) AND ((invoice_number)::text <> ''::text) AND ((status)::text = 'published'::text))")).
 			StorageKey(Idx_tenant_environment_invoice_number_unique),
 		// idempotency key is unique per tenant and environment
 		index.Fields("tenant_id", "environment_id", "idempotency_key").
@@ -262,6 +262,6 @@ func (Invoice) Indexes() []ent.Index {
 			Annotations(entsql.IndexWhere("((idempotency_key IS NOT NULL) AND ((status)::text = 'published'::text) AND ((invoice_status)::text <> 'VOIDED'::text))")),
 		index.Fields("subscription_id", "period_start", "period_end").
 			StorageKey("idx_subscription_period_unique").
-			Annotations(entsql.IndexWhere("invoice_status != 'VOIDED' AND subscription_id IS NOT NULL")),
+			Annotations(entsql.IndexWhere("(((invoice_status)::text <> 'VOIDED'::text) AND (subscription_id IS NOT NULL))")),
 	}
 }

--- a/ent/schema/payment.go
+++ b/ent/schema/payment.go
@@ -144,6 +144,6 @@ func (Payment) Indexes() []ent.Index {
 			StorageKey("idx_tenant_payment_method_status"),
 		index.Fields("tenant_id", "environment_id", "payment_gateway", "gateway_payment_id").
 			StorageKey("idx_tenant_gateway_payment").
-			Annotations(entsql.IndexWhere("payment_gateway IS NOT NULL AND gateway_payment_id IS NOT NULL")),
+			Annotations(entsql.IndexWhere("((payment_gateway IS NOT NULL) AND (gateway_payment_id IS NOT NULL))")),
 	}
 }

--- a/ent/schema/payment_attempt.go
+++ b/ent/schema/payment_attempt.go
@@ -88,6 +88,6 @@ func (PaymentAttempt) Indexes() []ent.Index {
 			StorageKey("idx_payment_attempt_status"),
 		index.Fields("gateway_attempt_id").
 			StorageKey("idx_gateway_attempt").
-			Annotations(entsql.IndexWhere("gateway_attempt_id IS NOT NULL")),
+			Annotations(entsql.IndexWhere("(gateway_attempt_id IS NOT NULL)")),
 	}
 }

--- a/ent/schema/paymentmethod.go
+++ b/ent/schema/paymentmethod.go
@@ -75,6 +75,6 @@ func (PaymentMethod) Edges() []ent.Edge {
 func (PaymentMethod) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "customer_id", "status").
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 	}
 }

--- a/ent/schema/plan.go
+++ b/ent/schema/plan.go
@@ -64,7 +64,7 @@ func (Plan) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "lookup_key").
 			Unique().
 			StorageKey(Idx_tenant_environment_lookup_key).
-			Annotations(entsql.IndexWhere("status = 'published'" + " AND lookup_key IS NOT NULL AND lookup_key != ''")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text))")),
 		index.Fields("tenant_id", "environment_id"),
 	}
 }

--- a/ent/schema/price.go
+++ b/ent/schema/price.go
@@ -300,12 +300,12 @@ func (Price) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "lookup_key").
 			Unique().
-			Annotations(entsql.IndexWhere("status = 'published' AND lookup_key IS NOT NULL AND lookup_key != '' AND end_date IS NULL")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND (lookup_key IS NOT NULL) AND ((lookup_key)::text <> ''::text) AND (end_date IS NULL))")),
 		index.Fields("tenant_id", "environment_id"),
 		index.Fields("start_date", "end_date"),
 		index.Fields("tenant_id", "environment_id", "group_id"),
 		// To get "what changed since the sub's last synced_price_sequence"
 		index.Fields("tenant_id", "environment_id", "entity_id", "entity_type", "sequence").
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 	}
 }

--- a/ent/schema/priceunit.go
+++ b/ent/schema/priceunit.go
@@ -82,6 +82,6 @@ func (PriceUnit) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "code").
 			Unique().
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 	}
 }

--- a/ent/schema/subscription.go
+++ b/ent/schema/subscription.go
@@ -244,7 +244,7 @@ func (Subscription) Indexes() []ent.Index {
 	return []ent.Index{
 		// Common query patterns from repository layer
 		index.Fields("tenant_id", "environment_id", "customer_id", "status").
-			Annotations(entsql.IndexWhere("status = 'published'")),
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 		index.Fields("tenant_id", "environment_id", "plan_id", "status"),
 		index.Fields("tenant_id", "environment_id", "subscription_status", "status"),
 		// For billing period updates
@@ -252,6 +252,6 @@ func (Subscription) Indexes() []ent.Index {
 		// Drives the plan-price sync's "which subs are behind?" lookup.
 		index.Fields("tenant_id", "environment_id", "plan_id", "synced_price_sequence").
 			Annotations(entsql.IndexWhere(
-				"status = 'published' AND subscription_type IN ('standalone','delegated_invoicing','parent','grouped_invoicing')")),
+				"(((status)::text = 'published'::text) AND ((subscription_type)::text = ANY (ARRAY[('standalone'::character varying)::text, ('delegated_invoicing'::character varying)::text, ('parent'::character varying)::text, ('grouped_invoicing'::character varying)::text])))")),
 	}
 }

--- a/ent/schema/subscriptionschedule.go
+++ b/ent/schema/subscriptionschedule.go
@@ -88,7 +88,7 @@ func (SubscriptionSchedule) Indexes() []ent.Index {
 		index.Fields("status", "schedule_type").
 			Annotations(
 				entsql.IndexAnnotation{
-					Where: "status = 'pending'",
+					Where: "((status)::text = 'pending'::text)",
 				},
 			),
 
@@ -96,7 +96,7 @@ func (SubscriptionSchedule) Indexes() []ent.Index {
 		index.Fields("scheduled_at", "status").
 			Annotations(
 				entsql.IndexAnnotation{
-					Where: "status = 'pending'",
+					Where: "((status)::text = 'pending'::text)",
 				},
 			),
 
@@ -108,7 +108,7 @@ func (SubscriptionSchedule) Indexes() []ent.Index {
 			Unique().
 			Annotations(
 				entsql.IndexAnnotation{
-					Where: "status = 'pending'",
+					Where: "((status)::text = 'pending'::text)",
 				},
 			),
 	}

--- a/ent/schema/taxrate.go
+++ b/ent/schema/taxrate.go
@@ -93,6 +93,6 @@ func (TaxRate) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "code").
 			Unique().
 			StorageKey(Idx_code_tenant_id_environment_id).
-			Annotations(entsql.IndexWhere("(code IS NOT NULL AND code != '' and status = 'published')")),
+			Annotations(entsql.IndexWhere("((code IS NOT NULL) AND ((code)::text <> ''::text) AND ((status)::text = 'published'::text))")),
 	}
 }

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -56,7 +56,7 @@ func (User) Indexes() []ent.Index {
 		index.Fields("email").
 			Unique().
 			StorageKey("idx_user_email_unique").
-			Annotations(entsql.IndexWhere("status = 'published' AND email IS NOT NULL AND email != ''")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND (email IS NOT NULL) AND ((email)::text <> ''::text))")),
 		index.Fields("tenant_id", "status", "type").
 			StorageKey("idx_user_tenant_status"),
 		index.Fields("tenant_id", "created_at").

--- a/ent/schema/wallettransaction.go
+++ b/ent/schema/wallettransaction.go
@@ -163,11 +163,11 @@ func (WalletTransaction) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "created_at"),
 		index.Fields("tenant_id", "environment_id", "wallet_id", "type", "credits_available", "expiry_date").
 			StorageKey("idx_tenant_wallet_type_credits_available_expiry_date").
-			Annotations(entsql.IndexWhere("credits_available > 0 AND type = 'credit'")),
+			Annotations(entsql.IndexWhere("((credits_available > (0)::numeric) AND ((type)::text = 'credit'::text))")),
 		index.Fields("tenant_id", "environment_id", "idempotency_key").
 			Unique().
 			Annotations(
-				entsql.IndexWhere("idempotency_key IS NOT NULL AND idempotency_key <> '' AND status='published'"),
+				entsql.IndexWhere("((idempotency_key IS NOT NULL) AND ((idempotency_key)::text <> ''::text) AND ((status)::text = 'published'::text))"),
 			).
 			StorageKey("idx_tenant_environment_idempotency_key"),
 	}


### PR DESCRIPTION
## Problem

Ent/Atlas (v0.19) string-compares partial-index `WHERE` predicates against the canonical form Postgres stores. The schema declares e.g. `status = 'published'`, but Postgres stores/introspects `((status)::text = 'published'::text)`. These are semantically identical but textually different, so Atlas reports **drift that doesn't exist** for ~35 partial indexes across hot tables (customers, invoices, subscriptions, prices, entitlements, wallet_transactions, ...).

Every `make migrate-ent` then **drops + recreates all of them without `CONCURRENTLY`**, taking ACCESS EXCLUSIVE / SHARE locks on each table.

This is the root cause of the **2026-06-25 production incident**: a manual `migrate-ent` against prod during peak traffic triggered a lock storm on Aurora (~100 active sessions, `Lock:relation` ≈ 100% of DB load) → connection pool exhausted → API stalled (90s timeouts, broad 5xx, failed event writes) → ClickHouse starved (CPU→0 then backlog burst).

## Fix

1. **Pin predicates to canonical form** (23 schema files) — rewritten to exactly the form Ent generates and Postgres stores, so the diff is a no-op. Includes the `IN (...)` → element-wise `= ANY (ARRAY[(...)::text, ...])` form for the subscription index.
2. **Guard in `cmd/migrate`** — `schema.WithSkipChanges(DropIndex | DropColumn | ModifyIndex)` so auto-migrate never drops/recreates an index (defense-in-depth for any future un-canonicalized index).
   - ⚠️ `WithSkipChanges` **overwrites** Ent's default skip set (`DropIndex | DropColumn`); we re-include both so **column-drop protection is preserved** — otherwise auto-migrate would begin dropping columns.

No functional change to any index (predicates are semantically identical).

## Verification

On a **fresh local Postgres** (schema built by this code), `make migrate-ent-dry-run`:
- **0 DDL with the guard**
- **0 DDL without the guard** ← proves all 35 indexes round-trip; the guard isn't masking drift
- (before this change: ~35 spurious `DROP/CREATE INDEX`)

`go build ./ent/... ./cmd/migrate/` + `go vet` clean.

## Follow-ups (separate PRs)
- Lower the 90s request timeout on PG-backed paths + pool caps + circuit breaker (the amplifier that turned a DB blip into an outage).
- Move to **versioned migrations** + upgrade Ent/Atlas (newer Atlas normalizes these predicates, removing the need to hand-pin).
- Observed during verification: `develop` schema appears behind what's deployed to staging (~50 columns) — worth reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
