### PR TITLE
feat(checkout): add support for checkout session cleanup

### DIFF
--- a/internal/ee/service/checkout_session.go
+++ b/internal/ee/service/checkout_session.go
@@ -9,40 +9,18 @@ import (
 	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/types"
 	webhookDto "github.com/flexprice/flexprice/internal/webhook/dto"
 )
 
-// CheckoutSessionCleanupResult holds per-run counts from CleanupAllExpiredSessions.
-type CheckoutSessionCleanupResult struct {
-	Total     int
-	Succeeded int
-	Failed    int
-}
-
-type CheckoutSessionService interface {
-	Create(ctx context.Context, req dto.CreateCheckoutSessionRequest) (*dto.CheckoutSessionResponse, error)
-	Get(ctx context.Context, id string) (*dto.CheckoutSessionResponse, error)
-	List(ctx context.Context, filter *types.CheckoutSessionFilter) (*dto.ListCheckoutSessionsResponse, error)
-	Delete(ctx context.Context, id string) error
-	// CleanupCheckoutSession archives all entities created during fulfillment (subscription,
-	// invoice, payment) and marks the session as failed with the given reason.
-	// Pass reason=nil when cleaning up without an error (e.g. session expiry).
-	CleanupCheckoutSession(ctx context.Context, session *domainCheckout.CheckoutSession, reason error) error
-	// CleanupAllExpiredSessions finds all active sessions whose ExpiresAt is before
-	// effectiveDate (defaults to now) within the tenant+environment in ctx, and
-	// archives them in batches of 1000. Returns total/succeeded/failed counts.
-	CleanupAllExpiredSessions(ctx context.Context, effectiveDate *time.Time) (*CheckoutSessionCleanupResult, error)
-	// CompleteCheckoutSession activates the subscription, finalizes the invoice, and marks
-	// the payment succeeded. Called by gateway webhook handlers after payment confirmation.
-	CompleteCheckoutSession(ctx context.Context, sessionID string, providerResult *types.CheckoutProviderResult) error
-}
+type CheckoutSessionService = interfaces.CheckoutSessionService
 
 type checkoutSessionService struct {
 	ServiceParams
 }
 
-func NewCheckoutSessionService(params ServiceParams) CheckoutSessionService {
+func NewCheckoutSessionService(params ServiceParams) interfaces.CheckoutSessionService {
 	return &checkoutSessionService{ServiceParams: params}
 }
 
@@ -74,7 +52,7 @@ func (s *checkoutSessionService) Create(ctx context.Context, req dto.CreateCheck
 	if err := s.executeCheckoutAction(ctx, session); err != nil {
 		// Best-effort cleanup: archive entities + mark session failed.
 		// Log cleanup errors but return the original fulfillment error.
-		if cleanupErr := s.CleanupCheckoutSession(ctx, session, err); cleanupErr != nil {
+		if cleanupErr := s.cleanupCheckoutSession(ctx, session, err); cleanupErr != nil {
 			s.Logger.Error(ctx, "checkout cleanup failed after fulfillment error",
 				"session_id", session.ID,
 				"error", cleanupErr,
@@ -145,7 +123,20 @@ func (s *checkoutSessionService) Delete(ctx context.Context, id string) error {
 	return s.CheckoutSessionRepo.Delete(ctx, id)
 }
 
-func (s *checkoutSessionService) CleanupCheckoutSession(ctx context.Context, session *domainCheckout.CheckoutSession, reason error) error {
+func (s *checkoutSessionService) CleanupCheckoutSession(ctx context.Context, sessionID string, reason error) error {
+	if sessionID == "" {
+		return ierr.NewError("session ID is required").
+			WithHint("checkout session ID cannot be empty").
+			Mark(ierr.ErrValidation)
+	}
+	session, err := s.CheckoutSessionRepo.Get(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	return s.cleanupCheckoutSession(ctx, session, reason)
+}
+
+func (s *checkoutSessionService) cleanupCheckoutSession(ctx context.Context, session *domainCheckout.CheckoutSession, reason error) error {
 	// Guard: already in a terminal state — idempotent no-op.
 	switch session.CheckoutStatus {
 	case types.CheckoutStatusCompleted, types.CheckoutStatusFailed, types.CheckoutStatusExpired:
@@ -198,13 +189,13 @@ func (s *checkoutSessionService) CleanupCheckoutSession(ctx context.Context, ses
 
 const cleanupExpiredBatchSize = 1000
 
-func (s *checkoutSessionService) CleanupAllExpiredSessions(ctx context.Context, effectiveDate *time.Time) (*CheckoutSessionCleanupResult, error) {
+func (s *checkoutSessionService) CleanupAllExpiredSessions(ctx context.Context, effectiveDate *time.Time) (*types.CheckoutSessionCleanupResult, error) {
 	cutoff := time.Now().UTC()
 	if effectiveDate != nil {
 		cutoff = effectiveDate.UTC()
 	}
 
-	result := &CheckoutSessionCleanupResult{}
+	result := &types.CheckoutSessionCleanupResult{}
 
 	for {
 		sessions, err := s.CheckoutSessionRepo.ListExpiredCheckoutSessions(ctx, cutoff, cleanupExpiredBatchSize, 0)
@@ -216,7 +207,7 @@ func (s *checkoutSessionService) CleanupAllExpiredSessions(ctx context.Context, 
 			result.Total++
 			sessCtx := context.WithValue(ctx, types.CtxTenantID, sess.TenantID)
 			sessCtx = context.WithValue(sessCtx, types.CtxEnvironmentID, sess.EnvironmentID)
-			if err := s.CleanupCheckoutSession(sessCtx, sess, nil); err != nil {
+			if err := s.cleanupCheckoutSession(sessCtx, sess, nil); err != nil {
 				s.Logger.Error(ctx, "failed to cleanup expired checkout session",
 					"session_id", sess.ID, "error", err)
 				result.Failed++

--- a/internal/integration/razorpay/webhook/handler.go
+++ b/internal/integration/razorpay/webhook/handler.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -77,6 +78,8 @@ func (h *Handler) HandleWebhookEvent(ctx context.Context, event *RazorpayWebhook
 		return h.handlePaymentFailed(ctx, event, environmentID, services)
 	case EventPaymentLinkPaid:
 		return h.handlePaymentLinkPaid(ctx, event, environmentID, services)
+	case EventPaymentLinkCancelled, EventPaymentLinkExpired:
+		return h.handlePaymentLinkFailed(ctx, event, environmentID, services)
 	default:
 		h.logger.Info(ctx, "unhandled Razorpay webhook event type", "type", event.Event)
 		return nil // Not an error, just unhandled
@@ -366,6 +369,59 @@ func (h *Handler) handlePaymentLinkPaid(ctx context.Context, event *RazorpayWebh
 		h.logger.Error(ctx, "failed to complete checkout session", "error", err, "session_id", sessionID)
 		return err
 	}
+	return nil
+}
+
+// handlePaymentLinkFailed processes payment_link.cancelled and payment_link.expired webhook events.
+// If a pending checkout session is associated with the payment link, it is cleaned up as failed.
+func (h *Handler) handlePaymentLinkFailed(ctx context.Context, event *RazorpayWebhookEvent, environmentID string, services *ServiceDependencies) error {
+	paymentLinkID := event.Payload.PaymentLink.Entity.ID
+	if paymentLinkID == "" {
+		h.logger.Info(ctx, "payment link webhook missing payment_link ID", "event_type", event.Event)
+		return nil
+	}
+
+	mappings, err := services.EntityIntegrationMappingService.GetEntityIntegrationMappings(
+		ctx,
+		&types.EntityIntegrationMappingFilter{
+			ProviderEntityIDs: []string{paymentLinkID},
+			ProviderTypes:     []string{string(types.CheckoutPaymentProviderRazorpay)},
+			EntityType:        types.IntegrationEntityTypePayment,
+		},
+	)
+	if err != nil {
+		h.logger.Error(ctx, "failed to get EntityIntegrationMapping for Razorpay payment link",
+			"error", err,
+			"payment_link_id", paymentLinkID)
+		return nil
+	}
+	if mappings == nil || len(mappings.Items) == 0 {
+		h.logger.Info(ctx, "no EntityIntegrationMapping found for Razorpay payment link", "payment_link_id", paymentLinkID)
+		return nil
+	}
+
+	filter := types.NewDefaultCheckoutSessionFilter()
+	filter.CheckoutPaymentIDs = []string{mappings.Items[0].EntityID}
+	filter.CheckoutStatuses = []types.CheckoutStatus{types.CheckoutStatusPending}
+	filter.Limit = lo.ToPtr(1)
+	filter.Status = lo.ToPtr(types.StatusPublished)
+
+	sessions, err := services.CheckoutSessionService.List(ctx, filter)
+	if err != nil || sessions == nil || len(sessions.Items) == 0 {
+		return nil
+	}
+
+	sessionID := sessions.Items[0].ID
+	reason := fmt.Errorf("payment link %s by provider", event.Event)
+	if err := services.CheckoutSessionService.CleanupCheckoutSession(ctx, sessionID, reason); err != nil {
+		h.logger.Error(ctx, "failed to cleanup checkout session on payment link failure",
+			"error", err,
+			"session_id", sessionID,
+			"payment_link_id", paymentLinkID,
+			"event_type", event.Event)
+		return nil
+	}
+
 	return nil
 }
 

--- a/internal/integration/razorpay/webhook/types.go
+++ b/internal/integration/razorpay/webhook/types.go
@@ -15,7 +15,9 @@ const (
 	EventPaymentAuthorized RazorpayEventType = "payment.authorized"
 
 	// Payment link events
-	EventPaymentLinkPaid RazorpayEventType = "payment_link.paid"
+	EventPaymentLinkPaid      RazorpayEventType = "payment_link.paid"
+	EventPaymentLinkCancelled RazorpayEventType = "payment_link.cancelled"
+	EventPaymentLinkExpired   RazorpayEventType = "payment_link.expired"
 )
 
 // RazorpayPaymentMethod represents the payment method used in Razorpay

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -205,11 +205,22 @@ type CreditAdjustmentService interface {
 	ApplyCreditsToInvoice(ctx context.Context, inv *invoice.Invoice) (*dto.CreditAdjustmentResult, error)
 }
 
-// CheckoutSessionService defines the minimal interface needed by webhook handlers
-// to complete checkout sessions. The full service lives in internal/ee/service.
 type CheckoutSessionService interface {
-	CompleteCheckoutSession(ctx context.Context, sessionID string, providerResult *types.CheckoutProviderResult) error
+	Create(ctx context.Context, req dto.CreateCheckoutSessionRequest) (*dto.CheckoutSessionResponse, error)
+	Get(ctx context.Context, id string) (*dto.CheckoutSessionResponse, error)
 	List(ctx context.Context, filter *types.CheckoutSessionFilter) (*dto.ListCheckoutSessionsResponse, error)
+	Delete(ctx context.Context, id string) error
+	// CleanupCheckoutSession fetches the session by ID, archives all fulfillment entities
+	// (subscription, invoice, payment), and marks the session failed or expired.
+	// Pass reason=nil to mark as expired; pass a non-nil error to mark as failed.
+	CleanupCheckoutSession(ctx context.Context, sessionID string, reason error) error
+	// CleanupAllExpiredSessions finds all active sessions whose ExpiresAt is before
+	// effectiveDate (defaults to now) and archives them in batches of 1000.
+	// Returns total/succeeded/failed counts.
+	CleanupAllExpiredSessions(ctx context.Context, effectiveDate *time.Time) (*types.CheckoutSessionCleanupResult, error)
+	// CompleteCheckoutSession activates the subscription, finalizes the invoice, and marks
+	// the payment succeeded. Called by gateway webhook handlers after payment confirmation.
+	CompleteCheckoutSession(ctx context.Context, sessionID string, providerResult *types.CheckoutProviderResult) error
 }
 
 type ServiceDependencies struct {

--- a/internal/types/checkout.go
+++ b/internal/types/checkout.go
@@ -159,3 +159,10 @@ func (f *CheckoutSessionFilter) Validate() error {
 
 	return nil
 }
+
+// CheckoutSessionCleanupResult holds per-run counts from CleanupAllExpiredSessions.
+type CheckoutSessionCleanupResult struct {
+	Total     int
+	Succeeded int
+	Failed    int
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout sessions can now be cleaned up from payment webhooks when a payment link is cancelled or expired.
  * Cleanup runs now report totals for succeeded and failed sessions.

* **Bug Fixes**
  * Failed or expired payment link events now trigger automatic checkout-session cleanup instead of leaving sessions active.
  * Webhook processing continues even if cleanup-related lookups fail, helping avoid event handling interruptions.

* **Refactor**
  * Checkout-session management was expanded to support broader lifecycle operations and more consistent cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->