### PR TITLE
fix(config): BindEnv auth.supabase.service_key so GKE reads it (fixes /v1/users 500)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -749,6 +749,13 @@ func NewConfig() (*Configuration, error) {
 	// broken, and an empty key makes tokens forgeable). The FLEXPRICE_AUTH_SECRET env is
 	// injected from the secret; this bind makes Unmarshal actually read it.
 	_ = v.BindEnv("auth.secret", "FLEXPRICE_AUTH_SECRET")
+	// Explicitly bind auth.supabase.* — same trap as auth.secret. The helm ConfigMap's
+	// rendered config.yaml carries only supabase.base_url (no service_key), so on GKE the
+	// service_key stays empty and every Supabase Admin call (e.g. user invite/create) fails
+	// with a swallowed 500. The FLEXPRICE_AUTH_SUPABASE_* envs are injected from the secret;
+	// these binds make Unmarshal actually read them.
+	_ = v.BindEnv("auth.supabase.service_key", "FLEXPRICE_AUTH_SUPABASE_SERVICE_KEY")
+	_ = v.BindEnv("auth.supabase.base_url", "FLEXPRICE_AUTH_SUPABASE_BASE_URL")
 	// NOTE: auth.api_key.keys is intentionally NOT bound here because the env var is a
 	// JSON string but Viper/mapstructure expects a map. It is handled manually in Step 6.
 


### PR DESCRIPTION
## Problem
On GKE prod, **`POST /v1/users` returns 500** (`failed to create user`, empty error). Root-caused to the **viper `BindEnv` trap** — the same class of bug previously fixed for `auth.secret`.

- The helm ConfigMap's rendered `config.yaml` under `auth.supabase` carries **only `base_url`** — there is **no `service_key`** in the file.
- `viper.Unmarshal` does **not** consult `AutomaticEnv` for keys absent from the config file unless they're explicitly `BindEnv`'d.
- So on GKE, `cfg.Auth.Supabase.ServiceKey` is **empty** — even though `FLEXPRICE_AUTH_SUPABASE_SERVICE_KEY` is injected into the pod from the secret (verified: 219-char key present in env).
- Result: the Supabase client initializes with an **empty `service_role` key** → every `Admin` call (`UserInvite` → `Admin.CreateUser`) is rejected → swallowed as a generic 500.

**Why local/AWS were fine:** they load `service_key` from the config file (no ConfigMap override dropping it). Confirmed in prod: the key value itself is correct and works when used directly — only the app's viper-loaded copy was empty.

## Fix
```go
_ = v.BindEnv("auth.supabase.service_key", "FLEXPRICE_AUTH_SUPABASE_SERVICE_KEY")
_ = v.BindEnv("auth.supabase.base_url",   "FLEXPRICE_AUTH_SUPABASE_BASE_URL")
```
Placed alongside the existing `auth.secret` bind. Keeps the key in the **k8s Secret/env** — no plaintext in ConfigMap or values.

## Verification
- `go build ./internal/config/` ✅
- Root cause proven live: injecting the key into the ConfigMap (break-glass) made `POST /v1/users` return `201`. This PR is the secure equivalent (key stays in the secret).

## Deploy note
Prod is currently held up by a **break-glass ConfigMap edit** (plaintext key) that keeps `/v1/users` working. Once this ships, that plaintext should be removed and the key rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading so Supabase settings are read reliably from environment variables.
  * Prevented empty Supabase credentials from causing admin-related failures in deployments where some settings are omitted from the config file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->