### PR TITLE
fix(billing): remove line items from entitlements response

### DIFF
--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -3344,6 +3344,8 @@ func (s *billingService) GetCustomerEntitlements(ctx context.Context, customerID
 			allEntitlements = append(allEntitlements, subEntitlements...)
 		}
 
+		// Line items are not needed in the entitlements response
+		sub.LineItems = nil
 		allSubscriptions = append(allSubscriptions, &dto.SubscriptionResponse{Subscription: sub})
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where entitlement responses could include extra subscription line-item details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->