### PR TITLE
hotfix(billing): remove line items from entitlements response

### DIFF
--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -3352,8 +3352,6 @@ func (s *billingService) GetCustomerEntitlements(ctx context.Context, customerID
 			allEntitlements = append(allEntitlements, subEntitlements...)
 		}
 
-		// Line items are not needed in the entitlements response
-		sub.LineItems = nil
 		allSubscriptions = append(allSubscriptions, &dto.SubscriptionResponse{Subscription: sub})
 	}
 

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -3344,6 +3344,8 @@ func (s *billingService) GetCustomerEntitlements(ctx context.Context, customerID
 			allEntitlements = append(allEntitlements, subEntitlements...)
 		}
 
+		// Line items are not needed in the entitlements response
+		sub.LineItems = nil
 		allSubscriptions = append(allSubscriptions, &dto.SubscriptionResponse{Subscription: sub})
 	}
 

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -3289,9 +3289,17 @@ func (s *billingService) GetCustomerEntitlements(ctx context.Context, customerID
 		Features:      []*dto.AggregatedFeature{},
 	}
 
-	// 1. Get active subscriptions for the customer
+	// 1. Get active subscriptions for the customer (without line items — not needed for entitlements)
 	subscriptionService := NewSubscriptionService(s.ServiceParams)
-	subscriptions, err := subscriptionService.ListByCustomerID(ctx, customerID)
+	subscriptions, err := s.SubRepo.List(ctx, &types.SubscriptionFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		CustomerID:  customerID,
+		SubscriptionStatus: []types.SubscriptionStatus{
+			types.SubscriptionStatusActive,
+			types.SubscriptionStatusTrialing,
+		},
+		WithLineItems: false,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated customer entitlement calculation to pull only active and trialing subscriptions when generating results.
  * Entitlements no longer include subscription line-item details, reducing returned payload size.
  * Filtering continues to honor any requested subscription IDs, while keeping the per-subscription entitlement aggregation behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->