### PR TITLE
fix(chart): render email/logging/redis keys in config.yaml (GKE config parity)

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -47,6 +47,7 @@ data:
       db: {{ .Values.redisConfig.db | default 0 }}
       use_tls: {{ .Values.redisConfig.useTLS | default false }}
       timeout: {{ .Values.redisConfig.timeout | default "5s" | quote }}
+      pool_size: {{ .Values.redisConfig.poolSize | default 10 }}
 
     kafka:
       brokers:
@@ -76,7 +77,8 @@ data:
     
     logging:
       level: {{ .Values.logging.level | quote }}
-    
+      format: {{ .Values.logging.format | default "json" | quote }}
+
     sentry:
       enabled: {{ .Values.sentry.enabled }}
       environment: {{ .Values.sentry.environment | quote }}
@@ -266,7 +268,12 @@ data:
       from_address: {{ .Values.email.fromAddress | quote }}
       reply_to: {{ .Values.email.replyTo | quote }}
       calendar_url: {{ .Values.email.calendarUrl | quote }}
-    
+      # resend_api_key is a secret — rendered EMPTY here so the key exists in config.yaml;
+      # the env FLEXPRICE_EMAIL_RESEND_API_KEY (injected from the secret) then fills it via
+      # AutomaticEnv. Without this key the env was ignored on GKE (silent empty → email broken).
+      resend_api_key: {{ .Values.email.resendApiKey | quote }}
+      zapier_webhook_url: {{ .Values.email.zapierWebhookUrl | quote }}
+
     feature_flag:
       enable_feature_usage_for_analytics: {{ .Values.featureFlag.enableFeatureUsageForAnalytics }}
       force_v1_for_tenant: {{ .Values.featureFlag.forceV1ForTenant | quote }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -979,10 +979,11 @@ billing:
 # Email configuration
 email:
   enabled: false
-  resendApiKey: "" # Set via secret
+  resendApiKey: "" # Set via secret (rendered empty in config.yaml; env FLEXPRICE_EMAIL_RESEND_API_KEY from the secret fills it)
   fromAddress: ""
   replyTo: ""
   calendarUrl: ""
+  zapierWebhookUrl: "" # Zapier webhook for user-signup automation
 
 # App URL configuration
 app:


### PR DESCRIPTION
## Problem
On GKE the mounted ConfigMap's `config.yaml` replaces the baked one, and `viper.Unmarshal` only reads env vars for keys **present in that file** (or `BindEnv`'d). Several keys weren't rendered, so their `FLEXPRICE_*` env vars (injected from secrets/values) were **silently ignored → empty** on GCP — same class as the Supabase `service_key` bug. Surfaced by an AWS→GCP env diff.

## Fix — render the missing keys in `configmap.yaml`
| Key | How | Effect |
|---|---|---|
| `email.resend_api_key` | rendered **empty**; secret-injected `FLEXPRICE_EMAIL_RESEND_API_KEY` fills it via AutomaticEnv (no plaintext — same as `postgres.password`) | **email sending fixed** on GCP |
| `email.zapier_webhook_url` | newly rendered from values | user-signup Zapier automation works on GCP |
| `logging.format` / `redis.pool_size` | rendered (defaults `json` / `10`) | matches AWS |

Render-tested with `helm template`. **Sentry DSN intentionally not added** (disabled on GCP).

## Deploy
Values to set in `values-production-gcp.yaml`: `email.fromAddress`, `email.zapierWebhookUrl` (the actual values). `resend_api_key` stays empty in values — it flows from the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration options for Redis pool size, logging format, and email integrations.
  * Support is now available for setting a Zapier webhook URL for signup-related automation.
* **Bug Fixes**
  * Improved default configuration output to better reflect environment-based email API key injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->