### PR TITLE
fix(config): BindEnv email.resend_api_key + render email.zapier_webhook_url

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -756,6 +756,11 @@ func NewConfig() (*Configuration, error) {
 	// these binds make Unmarshal actually read them.
 	_ = v.BindEnv("auth.supabase.service_key", "FLEXPRICE_AUTH_SUPABASE_SERVICE_KEY")
 	_ = v.BindEnv("auth.supabase.base_url", "FLEXPRICE_AUTH_SUPABASE_BASE_URL")
+	// Explicitly bind email.resend_api_key — same trap: the ConfigMap renders email
+	// {enabled, from_address, reply_to, calendar_url} but NOT resend_api_key (a secret, injected
+	// as FLEXPRICE_EMAIL_RESEND_API_KEY). Without this bind, transactional email (invoices,
+	// receipts, notifications) silently fails to send on GKE.
+	_ = v.BindEnv("email.resend_api_key", "FLEXPRICE_EMAIL_RESEND_API_KEY")
 	// NOTE: auth.api_key.keys is intentionally NOT bound here because the env var is a
 	// JSON string but Viper/mapstructure expects a map. It is handled manually in Step 6.
 

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -266,6 +266,9 @@ data:
       from_address: {{ .Values.email.fromAddress | quote }}
       reply_to: {{ .Values.email.replyTo | quote }}
       calendar_url: {{ .Values.email.calendarUrl | quote }}
+      # Plain config value (user-signup automation), not a secret → rendered here. The secret
+      # (resend_api_key) is NOT rendered — it's bound from FLEXPRICE_EMAIL_RESEND_API_KEY via BindEnv.
+      zapier_webhook_url: {{ .Values.email.zapierWebhookUrl | quote }}
     
     feature_flag:
       enable_feature_usage_for_analytics: {{ .Values.featureFlag.enableFeatureUsageForAnalytics }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -979,10 +979,11 @@ billing:
 # Email configuration
 email:
   enabled: false
-  resendApiKey: "" # Set via secret
+  resendApiKey: "" # secret — bound via FLEXPRICE_EMAIL_RESEND_API_KEY (config.go BindEnv); not rendered in configmap
   fromAddress: ""
   replyTo: ""
   calendarUrl: ""
+  zapierWebhookUrl: "" # plain value (user-signup automation) — rendered into config.yaml
 
 # App URL configuration
 app:


### PR DESCRIPTION
## What
Closes the two remaining GKE **config-trap** gaps in the email path. (The `auth.supabase.*` binds already landed in **#2123**, so this PR is additive — *not* a supersede.)

| Change | Why |
|---|---|
| **BindEnv `email.resend_api_key`** (← `FLEXPRICE_EMAIL_RESEND_API_KEY`) | chart configmap renders email `{enabled, from_address, reply_to, calendar_url}` but **not** `resend_api_key` (a secret), so `viper.Unmarshal` leaves it empty on GKE → transactional email (invoices/receipts/notifications) silently never sends. Bind it (key stays in the secret; same pattern as `auth.secret`/`auth.supabase.service_key`). |
| **Render `email.zapier_webhook_url`** in the chart configmap + values default | it's a **plain** value (user-signup automation), not a secret → belongs in `config.yaml`. |

`sentry.dsn` is the same trap class but intentionally left unbound for now (ops decision).

## Context
Part of the GCP single-release consolidation. Pairs with the infra-repo single-release values (separate PR). Verified live (break-glass) that supplying these restores email + the signup Zapier hook.

## Test
`go build ./internal/config/` clean. Diff is 3 files / 10 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring transactional email settings from deployment values, including a new webhook URL option.
  * Email API key values are now populated automatically from the runtime environment when provided.

* **Bug Fixes**
  * Prevented the email API key from being left empty when configuration files omit it, improving email delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->