### PR TITLE
feat(subscription): add ConfigValue field to OverrideEntitlementRequest and update processing logic

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1451,6 +1451,9 @@ type OverrideEntitlementRequest struct {
 
 	// StaticValue is the static value for static features
 	StaticValue *string `json:"static_value,omitempty"`
+
+	// ConfigValue is the config value for config features
+	ConfigValue map[string]interface{} `json:"config_value,omitempty"`
 }
 
 // Validate validates the entitlement override request

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -6861,6 +6861,11 @@ func (s *subscriptionService) ProcessSubscriptionEntitlementOverrides(
 					"parent_entitlement_id", parentEnt.ID,
 					"feature_id", parentEnt.FeatureID)
 			}
+			if override.ConfigValue != nil {
+				return ierr.NewError("config_value cannot be set for metered features").
+					WithHint("Only usage_limit and is_enabled can be overridden for metered features").
+					Mark(ierr.ErrValidation)
+			}
 		case types.FeatureTypeStatic:
 			// For static features, static_value is required
 			if newEnt.StaticValue == "" {
@@ -6871,6 +6876,22 @@ func (s *subscriptionService) ProcessSubscriptionEntitlementOverrides(
 			if override.UsageLimit != nil {
 				return ierr.NewError("usage_limit cannot be set for static features").
 					WithHint("Only static_value and is_enabled can be overridden for static features").
+					Mark(ierr.ErrValidation)
+			}
+			if override.ConfigValue != nil {
+				return ierr.NewError("config_value cannot be set for static features").
+					WithHint("Only static_value and is_enabled can be overridden for static features").
+					Mark(ierr.ErrValidation)
+			}
+		case types.FeatureTypeConfig:
+			if override.UsageLimit != nil {
+				return ierr.NewError("usage_limit cannot be set for config features").
+					WithHint("Only config_value and is_enabled can be overridden for config features").
+					Mark(ierr.ErrValidation)
+			}
+			if override.StaticValue != nil {
+				return ierr.NewError("static_value cannot be set for config features").
+					WithHint("Only config_value and is_enabled can be overridden for config features").
 					Mark(ierr.ErrValidation)
 			}
 		}

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -6837,6 +6837,12 @@ func (s *subscriptionService) ProcessSubscriptionEntitlementOverrides(
 			newEnt.StaticValue = parentEnt.StaticValue
 		}
 
+		if override.ConfigValue != nil {
+			newEnt.ConfigValue = override.ConfigValue
+		} else {
+			newEnt.ConfigValue = parentEnt.ConfigValue
+		}
+
 		// Validate based on feature type
 		switch parentEnt.FeatureType {
 		case types.FeatureTypeMetered:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription entitlement overrides now support an optional configuration value in API requests.
  * When provided, the configuration is carried through to the resulting subscription override; otherwise, it inherits the existing value.
* **Bug Fixes**
  * Added stricter request validation: configuration values are now rejected for non-config feature types (such as metered and static features), while config features continue to allow them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->