### PR TITLE
feat(helm): consumer-only extraEnv (enables cache on consumer only)

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
@@ -55,6 +55,13 @@ spec:
               value: "consumer"
             - name: TMPDIR
               value: "/tmp"
+            {{- /* consumer-only env overrides — rendered AFTER flexprice.env so these
+                   win over the global .Values.extraEnv for duplicate keys (k8s last-wins).
+                   Used for settings that differ on the consumer vs api/worker, e.g.
+                   FLEXPRICE_CACHE_ENABLED (cache is on for the consumer only). */}}
+            {{- with .Values.consumer.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if and .Values.consumer.preStop .Values.consumer.preStop.enabled }}
           lifecycle:
             preStop:

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -184,6 +184,10 @@ api:
 consumer:
   enabled: true
   replicaCount: 1
+  # Consumer-only env overrides (rendered after the shared flexprice.env, so these
+  # win for duplicate keys). For settings that differ on the consumer vs api/worker —
+  # e.g. FLEXPRICE_CACHE_ENABLED (cache enabled on the consumer only).
+  extraEnv: []
   resources:
     requests:
       cpu: "500m"


### PR DESCRIPTION
## Summary
Adds `.Values.consumer.extraEnv` (default `[]`) and renders it on the **consumer** Deployment, **after** the shared `flexprice.env` helper so it wins for duplicate keys (k8s last-wins).

## Why
The chart's `flexprice.env` helper renders only the **global** `.Values.extraEnv`, shared by api/consumer/worker — there's no per-component env knob. And the GCP single release uses **one shared ConfigMap**, so per-workload differentiation can't be done at the configmap level either. That makes it impossible to set a value on the consumer alone.

This is needed to enable **`FLEXPRICE_CACHE_ENABLED=true` on the consumer only** (matching the AWS `web_consumer`, which ran with the Redis cache on; api/worker were deliberately cacheless). It also unblocks the consumer-only kafka-secondary-null case.

## Verification (`helm template`)
- Consumer renders `FLEXPRICE_CACHE_ENABLED` **last** in its env block (after `DEPLOYMENT_MODE`/`TMPDIR`) → overrides any global value.
- **api and worker render nothing** — zero leakage.
- Default (`extraEnv: []`) renders clean, no empty-env artifacts.
- `helm lint` passes.

## Paired with
infra PR #92 sets `consumer.extraEnv: [{name: FLEXPRICE_CACHE_ENABLED, value: "true"}]` in `values-production-gcp.yaml`. That value is inert until this chart change is on `main` (prod renders the chart from `main`); the live break-glass env override keeps cache on in the meantime, so there's no gap.

> Note: should also be back-ported to `develop` to avoid main/develop chart drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for consumer-specific environment variable overrides in the deployment configuration.
  * Consumer environment variables can now be appended after shared settings, allowing later values to take precedence when keys overlap.
  * Added a dedicated consumer-only environment list in the values configuration for easier customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->