### PR TITLE
feat(meter-usage): Enable billing via meter usage

### DIFF
--- a/cmd/e2eprobe/.env.example
+++ b/cmd/e2eprobe/.env.example
@@ -50,6 +50,15 @@ export E2EPROBE_CHECK_SUBSCRIPTION_MODIFICATION_FLOW_INTERVAL=20m
 export E2EPROBE_CHECK_LOW_WALLET_ALERT_LISTENER_ENABLED=true
 # (listener is webhook-driven; interval ignored)
 
+# LOW_BALANCE_ALERT_PROBE actively drives the alert-canary wallet across its
+# low-balance thresholds and asserts the webhook lands within 2m (grace absorbs
+# Kafka + Svix / native HTTP propagation delay). Missing webhooks page Slack
+# via the existing reporter chain. Needs the canary wallet provisioned by
+# SEED_ENSURE and the Flexprice-side webhook endpoint pointed at
+# http://<probe-host>:E2EPROBE_LISTENER_PORT/webhook.
+export E2EPROBE_CHECK_LOW_BALANCE_ALERT_PROBE_ENABLED=true
+export E2EPROBE_CHECK_LOW_BALANCE_ALERT_PROBE_INTERVAL=5m
+
 export E2EPROBE_CHECK_JANITOR_ENABLED=true
 export E2EPROBE_CHECK_JANITOR_INTERVAL=1h
 

--- a/cmd/e2eprobe/main.go
+++ b/cmd/e2eprobe/main.go
@@ -145,10 +145,19 @@ func main() {
 		runner.Add(smf, e2eprobe.NewTickerScheduler(smf, cfg.Checks["SUBSCRIPTION_MODIFICATION_FLOW"].Interval))
 	}
 
-	if cfg.Checks["LOW_WALLET_ALERT_LISTENER"].Enabled {
+	// The listener is created regardless of the LOW_WALLET_ALERT_LISTENER flag
+	// because LOW_BALANCE_ALERT_PROBE reads SeenThresholds from it to verify
+	// webhook receipt. If neither the listener check nor the probe is enabled,
+	// no HTTP server is bound.
+	lwl := checks_pkg.NewLowWalletAlertListener(runID)
+	if cfg.Checks["LOW_WALLET_ALERT_LISTENER"].Enabled || cfg.Checks["LOW_BALANCE_ALERT_PROBE"].Enabled {
 		wl := e2eprobe.NewHTTPWebhookListener(cfg.ListenerPort)
-		lwl := checks_pkg.NewLowWalletAlertListener(runID)
 		runner.Add(lwl, e2eprobe.NewListenerScheduler(lwl, wl))
+	}
+
+	if cfg.Checks["LOW_BALANCE_ALERT_PROBE"].Enabled {
+		lbap := checks_pkg.NewLowBalanceAlertProbe(client, reg, lwl, runID, checks_pkg.LowBalanceAlertOpts{})
+		runner.Add(lbap, e2eprobe.NewTickerScheduler(lbap, cfg.Checks["LOW_BALANCE_ALERT_PROBE"].Interval))
 	}
 
 	if cfg.Checks["JANITOR"].Enabled {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -564,6 +564,7 @@ type FeatureFlagConfig struct {
 	ForceV1ForTenant                  string `mapstructure:"force_v1_for_tenant" validate:"omitempty"`
 	EnableMeterUsageForPreviewInvoice bool   `mapstructure:"enable_meter_usage_for_preview_invoice" validate:"omitempty"`
 	EnableMeterUsageForAnalytics      bool   `mapstructure:"enable_meter_usage_for_analytics" validate:"omitempty"`
+	EnableMeterUsageForBilling        bool   `mapstructure:"enable_meter_usage_for_billing" validate:"omitempty"`
 	EnableUsageBenchmark              bool   `mapstructure:"enable_usage_benchmark" validate:"omitempty"`
 
 	// Per-tenant overrides for the meter-usage rollout. Resolution order:
@@ -574,8 +575,21 @@ type FeatureFlagConfig struct {
 	MeterUsageForPreviewInvoiceDisabledTenants []string `mapstructure:"meter_usage_for_preview_invoice_disabled_tenants" validate:"omitempty"`
 	MeterUsageForAnalyticsEnabledTenants       []string `mapstructure:"meter_usage_for_analytics_enabled_tenants" validate:"omitempty"`
 	MeterUsageForAnalyticsDisabledTenants      []string `mapstructure:"meter_usage_for_analytics_disabled_tenants" validate:"omitempty"`
+	MeterUsageForBillingEnabledTenants         []string `mapstructure:"meter_usage_for_billing_enabled_tenants" validate:"omitempty"`
+	MeterUsageForBillingDisabledTenants        []string `mapstructure:"meter_usage_for_billing_disabled_tenants" validate:"omitempty"`
 	UsageBenchmarkEnabledTenants               []string `mapstructure:"usage_benchmark_enabled_tenants" validate:"omitempty"`
 	UsageBenchmarkDisabledTenants              []string `mapstructure:"usage_benchmark_disabled_tenants" validate:"omitempty"`
+}
+
+// IsMeterUsageEnabledForBilling resolves the meter-usage rollout for the
+// billing service for a specific tenant.
+func (c *FeatureFlagConfig) IsMeterUsageEnabledForBilling(tenantID string) bool {
+	return resolveTenantRollout(
+		tenantID,
+		c.EnableMeterUsageForBilling,
+		c.MeterUsageForBillingEnabledTenants,
+		c.MeterUsageForBillingDisabledTenants,
+	)
 }
 
 // IsMeterUsageEnabledForPreviewInvoice resolves the meter-usage rollout for the

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -361,12 +361,16 @@ feature_flag:
   enable_meter_usage_for_preview_invoice: true
   # Switch /events/analytics to use meter-usage
   enable_meter_usage_for_analytics: true
+    # Switch invoice billing to use meter-usage
+  enable_meter_usage_for_billing: false
   # Per-tenant rollout overrides for meter-usage. Resolution order per tenant:
   #   disabled_tenants > enabled_tenants > global enable_* flag above.
   meter_usage_for_preview_invoice_enabled_tenants: []
   meter_usage_for_preview_invoice_disabled_tenants: []
   meter_usage_for_analytics_enabled_tenants: []
   meter_usage_for_analytics_disabled_tenants: []
+  meter_usage_for_billing_enabled_tenants: []
+  meter_usage_for_billing_disabled_tenants: []
   enable_usage_benchmark: false
   usage_benchmark_enabled_tenants: []
   usage_benchmark_disabled_tenants: []

--- a/internal/e2eprobe/README.md
+++ b/internal/e2eprobe/README.md
@@ -73,12 +73,22 @@ Standard OTLP env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) flow through unchan
 | scenario | new-customer-lifecycle | 10m | Ephemeral customer/sub + events |
 | scenario | cancel-customer-flow | 10m | Cancel oldest ephemeral sub + delete its customer |
 | scenario | subscription-modification-flow | 20m | Add line item; verify |
-| listener | low-wallet-alert-listener | webhook | Asserts low-balance webhook payloads |
+| listener | low-wallet-alert-listener | webhook | Asserts low-balance webhook payloads and tracks per-wallet, per-alert-type receipts |
+| probe | low-balance-alert-probe | 5m | Actively drives the canary wallet across its low-balance threshold and asserts the webhook lands within 2m (Slack-pages on absence) |
 | maintenance | janitor | 1h | Archive in-memory ephemerals > 1h; also scans Flexprice for orphan ephemeral customers from prior restarts and deletes them |
 
-## Webhook wiring (low-wallet-alert-listener)
+## Webhook pipeline verification (low-balance-alert-probe + low-wallet-alert-listener)
 
-The listener exposes `POST http://<e2eprobe-host>:8765/webhook` (port configurable). Wire Flexprice's webhook delivery to it for low-balance alerts. Until wired, the listener sits idle.
+The listener exposes `POST http://<e2eprobe-host>:8765/webhook` (port configurable). Flexprice must be pointed at that URL — either via `webhook.tenants.<tenant_id>.endpoint` in the Flexprice config (native HTTP delivery) or via a Svix endpoint subscribed to `wallet.credit_balance.dropped` / `wallet.ongoing_balance.dropped` (when Svix is enabled).
+
+`seed-ensure` provisions a dedicated `e2eprobe-cust-alert-canary` persistent customer with one wallet initially topped up to **$30** and alert thresholds `{info=25, warning=10, critical=0}` all enabled. The three pre-funded seed wallets carry the same thresholds but sit at $100 with no draining — they exist as a safety net only.
+
+`low-balance-alert-probe` alternates between two legs on the canary wallet:
+
+1. **Drop leg** (wallet state = `ok`): ingest one `e2eprobe_sum` event (default `amount=600`, priced at `$0.01/unit` = `$6.00` of current-period usage) to push ongoing balance below the info threshold, then poll the listener's receipt map for up to **2 minutes**. This grace absorbs typical Kafka + Svix/native-HTTP propagation delay; only truly missing webhooks page.
+2. **Recovery leg** (wallet state = `in_alarm`): top-up back to `$30` so Flexprice's binary alert state machine can re-arm.
+
+A missing webhook in the drop leg fails the check → routes through the standard reporter chain → posts to Slack. Full cycle time at defaults: 10 minutes per verification.
 
 ## Operational signals
 

--- a/internal/e2eprobe/checks/low_balance_alert_probe.go
+++ b/internal/e2eprobe/checks/low_balance_alert_probe.go
@@ -1,0 +1,181 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/e2eprobe"
+	"github.com/flexprice/go-sdk/v2/models/types"
+)
+
+// LowBalanceAlertProbe drives the canary wallet across its low-balance
+// alert threshold and asserts the corresponding webhook lands within a
+// bounded window. Missing webhook → check error → Slack via reporter.
+//
+// Flexprice's wallet alert-state machine is binary (ok / in_alarm), so we
+// cannot exercise info / warning / critical in one tick. The probe cycles:
+//
+//   Tick T0 (wallet=ok):    ingest usage → drop projected balance below
+//                           the info threshold (25) → wait for the webhook.
+//   Tick T1 (wallet=in_alarm): top-up the wallet back to $30 to recover.
+//
+// One end-to-end verification per two ticks. At default 5m interval,
+// full cycle every 10m.
+type LowBalanceAlertProbe struct {
+	client   e2eprobe.Client
+	reg      e2eprobe.Registry
+	listener *LowWalletAlertListener
+	runID    string
+	opts     LowBalanceAlertOpts
+}
+
+// LowBalanceAlertOpts are runtime knobs. Zero-value falls through to sane
+// defaults set by NewLowBalanceAlertProbe.
+type LowBalanceAlertOpts struct {
+	// UsageAmount is the value of the "amount" property on the driver event.
+	// Combined with the $0.01 e2eprobe_sum unit price and the 30/25/10/0
+	// threshold spread, a single event with amount=600 pushes ongoing_balance
+	// from $30 to $24 (below info=25). Default 600.
+	UsageAmount int
+
+	// RecoveryTopUp is the credit re-added when the wallet is found in_alarm.
+	// Default matches AlertCanaryInitialBalance ($30).
+	RecoveryTopUp string
+
+	// WebhookWait bounds how long we poll SeenThresholds after ingesting
+	// the drop event before we Slack-page. Default 2m — comfortably longer
+	// than typical Kafka + Svix/native-HTTP propagation so a slow-but-alive
+	// pipeline does not false-alert, but short enough to fit inside the 5m
+	// tick interval and surface real regressions the same day.
+	WebhookWait time.Duration
+
+	// PollInterval controls SeenThresholds polling cadence during WebhookWait.
+	// Default 2s.
+	PollInterval time.Duration
+}
+
+func NewLowBalanceAlertProbe(c e2eprobe.Client, r e2eprobe.Registry, listener *LowWalletAlertListener, runID string, opts LowBalanceAlertOpts) *LowBalanceAlertProbe {
+	if opts.UsageAmount == 0 {
+		opts.UsageAmount = 600
+	}
+	if opts.RecoveryTopUp == "" {
+		opts.RecoveryTopUp = AlertCanaryInitialBalance
+	}
+	if opts.WebhookWait == 0 {
+		opts.WebhookWait = 2 * time.Minute
+	}
+	if opts.PollInterval == 0 {
+		opts.PollInterval = 2 * time.Second
+	}
+	return &LowBalanceAlertProbe{client: c, reg: r, listener: listener, runID: runID, opts: opts}
+}
+
+func (p *LowBalanceAlertProbe) Name() string        { return "low-balance-alert-probe" }
+func (p *LowBalanceAlertProbe) Kind() e2eprobe.Kind { return e2eprobe.KindProbe }
+
+func (p *LowBalanceAlertProbe) Run(ctx context.Context) error {
+	ext := p.reg.Seeds().AlertCanaryExternalCustomerID
+	if ext == "" {
+		return nil // seed hasn't completed yet
+	}
+
+	walletIDs, _, err := lookupWalletIDsAndCustomerForExternalCustomer(ctx, p.client, ext)
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": ext}, "lookup canary wallet: %w", err)
+	}
+	if len(walletIDs) == 0 {
+		return nil // wallet not yet provisioned
+	}
+	walletID := walletIDs[0]
+
+	balResp, err := p.client.Wallets().GetBalance(ctx, walletID)
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{
+			"external_customer_id": ext, "wallet_id": walletID,
+		}, "read canary balance: %w", err)
+	}
+	if balResp == nil || balResp.DtoWalletBalanceResponse == nil {
+		return nil
+	}
+	b := balResp.DtoWalletBalanceResponse
+
+	state := "unknown"
+	if b.AlertState != nil {
+		state = string(*b.AlertState)
+	}
+	attrs := map[string]string{
+		"external_customer_id": ext,
+		"wallet_id":            walletID,
+		"alert_state":          state,
+	}
+	if b.RealTimeBalance != nil {
+		attrs["real_time_balance"] = *b.RealTimeBalance
+	}
+
+	if state != "ok" {
+		// Recovery leg: top-up so the state machine can re-arm for the next
+		// alert cycle. The recovery webhook (wallet.updated) is not asserted
+		// here — this check owns the drop → alert leg.
+		return p.recover(ctx, walletID, ext, attrs)
+	}
+
+	// Drop leg: ingest usage to push ongoing_balance below the info threshold,
+	// then wait for the webhook to reach the listener.
+	return p.driveAndVerify(ctx, walletID, ext, attrs)
+}
+
+func (p *LowBalanceAlertProbe) driveAndVerify(ctx context.Context, walletID, ext string, attrs map[string]string) error {
+	before := len(p.listener.SeenThresholds(walletID))
+
+	amountStr := strconv.Itoa(p.opts.UsageAmount)
+	ingestReq := types.DtoIngestEventRequest{
+		EventName:          "e2eprobe_sum",
+		ExternalCustomerID: ext,
+		Properties: map[string]string{
+			"amount":          amountStr,
+			"e2eprobe":        "true",
+			"e2eprobe_role":   "alert-canary",
+			"e2eprobe_run_id": p.runID,
+		},
+	}
+	if _, err := p.client.Events().Ingest(ctx, ingestReq); err != nil {
+		return e2eprobe.Errorf(attrs, "ingest canary drop event: %w", err)
+	}
+
+	deadline := time.Now().Add(p.opts.WebhookWait)
+	for {
+		if got := len(p.listener.SeenThresholds(walletID)); got > before {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return e2eprobe.Errorf(attrs,
+				"no low-balance webhook received within %s after ingesting $%s (rate=$0.01/unit) on wallet %s",
+				p.opts.WebhookWait, decimalDollars(p.opts.UsageAmount), walletID)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(p.opts.PollInterval):
+		}
+	}
+}
+
+func (p *LowBalanceAlertProbe) recover(ctx context.Context, walletID, ext string, attrs map[string]string) error {
+	topUpReq := types.DtoTopUpWalletRequest{
+		Amount:            strPtr(p.opts.RecoveryTopUp),
+		Description:       strPtr("e2eprobe alert canary recovery top-up"),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+	}
+	if _, err := p.client.Wallets().TopUp(ctx, walletID, topUpReq); err != nil {
+		return e2eprobe.Errorf(attrs, "recovery top-up of canary wallet %s: %w", walletID, err)
+	}
+	return nil
+}
+
+// decimalDollars renders unit-count as dollars given the $0.01/unit price.
+// Purely for error messages — no math elsewhere.
+func decimalDollars(units int) string {
+	return fmt.Sprintf("%.2f", float64(units)*0.01)
+}

--- a/internal/e2eprobe/checks/low_wallet_alert_listener.go
+++ b/internal/e2eprobe/checks/low_wallet_alert_listener.go
@@ -3,6 +3,8 @@ package checks
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/e2eprobe"
@@ -10,45 +12,120 @@ import (
 
 const lowWalletAlertMaxAge = 5 * time.Minute
 
+// Wallet-alert event types Flexprice dispatches when a threshold is crossed.
+// Anything else on /webhook is ignored (not an error) so this listener can
+// safely share the endpoint with unrelated webhook traffic.
+var walletAlertEventTypes = map[string]struct{}{
+	"wallet.credit_balance.dropped":    {},
+	"wallet.credit_balance.recovered":  {},
+	"wallet.ongoing_balance.dropped":   {},
+	"wallet.ongoing_balance.recovered": {},
+}
+
 type LowWalletAlertListener struct {
 	runID string
+
+	mu       sync.Mutex
+	lastSeen map[string]time.Time // key: "<wallet_id>:<alert_type>"
 }
 
 func NewLowWalletAlertListener(runID string) *LowWalletAlertListener {
-	return &LowWalletAlertListener{runID: runID}
+	return &LowWalletAlertListener{runID: runID, lastSeen: map[string]time.Time{}}
 }
 
-func (l *LowWalletAlertListener) Name() string         { return "low-wallet-alert-listener" }
+func (l *LowWalletAlertListener) Name() string        { return "low-wallet-alert-listener" }
 func (l *LowWalletAlertListener) Kind() e2eprobe.Kind { return e2eprobe.KindListener }
-
-var requiredFields = []string{"alert_type", "wallet_id", "customer_id"}
 
 func (l *LowWalletAlertListener) Run(ctx context.Context) error {
 	ev := e2eprobe.EventFromContext(ctx)
 	if ev == nil {
 		return nil
 	}
-	// Build attributes from payload fields that are present.
-	alertAttrs := map[string]string{}
-	for _, f := range requiredFields {
-		if v, ok := ev.Payload[f]; ok {
-			alertAttrs[f] = fmt.Sprintf("%v", v)
-		}
+
+	eventType, _ := ev.Payload["event_type"].(string)
+	if _, ok := walletAlertEventTypes[eventType]; !ok {
+		// Not a wallet-alert webhook (e.g. invoice.created); ignore.
+		return nil
+	}
+
+	walletID := nestedString(ev.Payload, "wallet", "id")
+	customerID := nestedString(ev.Payload, "customer", "id")
+	alertType := nestedString(ev.Payload, "alert", "alert_type")
+	alertState := nestedString(ev.Payload, "alert", "state")
+	currentBalance := nestedString(ev.Payload, "alert", "current_balance")
+
+	attrs := map[string]string{
+		"event_type":      eventType,
+		"wallet_id":       walletID,
+		"customer_id":     customerID,
+		"alert_type":      alertType,
+		"alert_state":     alertState,
+		"current_balance": currentBalance,
 	}
 
 	if !ev.ReceivedAt.IsZero() && time.Since(ev.ReceivedAt) > lowWalletAlertMaxAge {
-		return e2eprobe.Errorf(alertAttrs,
+		return e2eprobe.Errorf(attrs,
 			"low-wallet alert delivered late: received_at=%s age=%s",
 			ev.ReceivedAt.Format(time.RFC3339), time.Since(ev.ReceivedAt))
 	}
-	missing := []string{}
-	for _, f := range requiredFields {
-		if _, ok := ev.Payload[f]; !ok {
-			missing = append(missing, f)
-		}
+
+	var missing []string
+	if walletID == "" {
+		missing = append(missing, "wallet.id")
+	}
+	if customerID == "" {
+		missing = append(missing, "customer.id")
+	}
+	if alertType == "" {
+		missing = append(missing, "alert.alert_type")
 	}
 	if len(missing) > 0 {
-		return e2eprobe.Errorf(alertAttrs, "low-wallet alert missing fields: %v", missing)
+		return e2eprobe.Errorf(attrs, "low-wallet alert missing fields: %v", missing)
 	}
+
+	l.recordReceipt(walletID, alertType)
 	return nil
+}
+
+func (l *LowWalletAlertListener) recordReceipt(walletID, alertType string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lastSeen[walletID+":"+strings.ToLower(alertType)] = time.Now()
+}
+
+// SeenThresholds returns the alert_type → last-seen timestamp map for a wallet.
+// Consumed by heartbeat / debug tooling to report which of {info, warning,
+// critical} have been observed for each configured wallet.
+func (l *LowWalletAlertListener) SeenThresholds(walletID string) map[string]time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := map[string]time.Time{}
+	prefix := walletID + ":"
+	for k, v := range l.lastSeen {
+		if strings.HasPrefix(k, prefix) {
+			out[strings.TrimPrefix(k, prefix)] = v
+		}
+	}
+	return out
+}
+
+// nestedString reads payload[keys[0]][keys[1]]... as a string; returns "" if
+// any hop is missing or the leaf isn't a string.
+func nestedString(payload map[string]any, keys ...string) string {
+	var cur any = payload
+	for _, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur = m[k]
+	}
+	switch v := cur.(type) {
+	case string:
+		return v
+	case float64:
+		return fmt.Sprintf("%v", v)
+	default:
+		return ""
+	}
 }

--- a/internal/e2eprobe/checks/low_wallet_alert_listener_test.go
+++ b/internal/e2eprobe/checks/low_wallet_alert_listener_test.go
@@ -8,24 +8,41 @@ import (
 	"github.com/flexprice/flexprice/internal/e2eprobe"
 )
 
-func TestLowWalletAlertListener_ValidPayload(t *testing.T) {
-	l := NewLowWalletAlertListener("run-1")
-	ev := e2eprobe.ListenerEvent{
-		Payload: map[string]any{
-			"alert_type":  "low_balance",
-			"wallet_id":   "wal_1",
-			"customer_id": "cust_1",
+func validAlertPayload() map[string]any {
+	return map[string]any{
+		"event_type":   "wallet.credit_balance.dropped",
+		"alert_type":   "info",
+		"alert_status": "in_alarm",
+		"wallet":       map[string]any{"id": "wal_1"},
+		"customer":     map[string]any{"id": "cust_1"},
+		"alert": map[string]any{
+			"state":           "critical",
+			"alert_type":      "critical",
+			"current_balance": "5.00",
+			"credit_balance":  "5.00",
 		},
 	}
+}
+
+func TestLowWalletAlertListener_ValidPayload(t *testing.T) {
+	l := NewLowWalletAlertListener("run-1")
+	ev := e2eprobe.ListenerEvent{Payload: validAlertPayload()}
 	ctx := e2eprobe.ContextWithEvent(context.Background(), ev)
 	if err := l.Run(ctx); err != nil {
 		t.Errorf("Run: %v", err)
+	}
+	seen := l.SeenThresholds("wal_1")
+	if _, ok := seen["critical"]; !ok {
+		t.Errorf("expected critical threshold recorded, got %v", seen)
 	}
 }
 
 func TestLowWalletAlertListener_MissingFields(t *testing.T) {
 	l := NewLowWalletAlertListener("run-1")
-	ev := e2eprobe.ListenerEvent{Payload: map[string]any{"alert_type": "low_balance"}}
+	// alert.alert_type / wallet.id / customer.id all missing.
+	ev := e2eprobe.ListenerEvent{Payload: map[string]any{
+		"event_type": "wallet.credit_balance.dropped",
+	}}
 	ctx := e2eprobe.ContextWithEvent(context.Background(), ev)
 	if err := l.Run(ctx); err == nil {
 		t.Fatal("expected error for missing fields")
@@ -39,15 +56,22 @@ func TestLowWalletAlertListener_NoEventInContextIsNoOp(t *testing.T) {
 	}
 }
 
+func TestLowWalletAlertListener_IgnoresUnrelatedEventTypes(t *testing.T) {
+	l := NewLowWalletAlertListener("run-1")
+	ev := e2eprobe.ListenerEvent{Payload: map[string]any{
+		"event_type": "invoice.created",
+	}}
+	ctx := e2eprobe.ContextWithEvent(context.Background(), ev)
+	if err := l.Run(ctx); err != nil {
+		t.Errorf("non-wallet-alert events must be no-ops, got %v", err)
+	}
+}
+
 func TestLowWalletAlertListener_StaleEventRejected(t *testing.T) {
 	l := NewLowWalletAlertListener("run-1")
 	ev := e2eprobe.ListenerEvent{
 		ReceivedAt: time.Now().Add(-2 * time.Hour),
-		Payload: map[string]any{
-			"alert_type":  "low_balance",
-			"wallet_id":   "wal_1",
-			"customer_id": "cust_1",
-		},
+		Payload:    validAlertPayload(),
 	}
 	ctx := e2eprobe.ContextWithEvent(context.Background(), ev)
 	if err := l.Run(ctx); err == nil {

--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -16,10 +16,37 @@ import (
 const (
 	PersistentCustomerCount = 10
 	PreFundedWalletCount    = 3
+
+	// AlertCanaryExternalCustomerID owns the dedicated $30 wallet used by
+	// LowBalanceAlertProbe to exercise the low-balance webhook pipeline
+	// end-to-end. Held outside PreFundedCustomerIDs so wallet_debit_verification
+	// / wallet_balance_probe never touch it.
+	AlertCanaryExternalCustomerID = "e2eprobe-cust-alert-canary"
+
+	// AlertCanaryInitialBalance sits $5 above the info threshold (25).
+	// Any drop of >$5 in current-period usage crosses info; >$20 crosses
+	// warning; >$30 crosses critical.
+	AlertCanaryInitialBalance = "30.00"
 )
 
-func strPtr(s string) *string { return &s }
-func int64Ptr(i int64) *int64 { return &i }
+func strPtr(s string) *string       { return &s }
+func int64Ptr(i int64) *int64       { return &i }
+func float64Ptr(f float64) *float64 { return &f }
+func boolPtr(b bool) *bool          { return &b }
+
+// lowBalanceAlertSettings returns the alert thresholds seed wallets are
+// created with: info at 25, warning at 10, critical at 0 (all "below").
+// Fires wallet.credit_balance.dropped webhooks; consumed by the
+// low-wallet-alert-listener check.
+func lowBalanceAlertSettings() *types.AlertSettings {
+	below := types.AlertConditionBelow
+	return &types.AlertSettings{
+		AlertEnabled: boolPtr(true),
+		Info:         &types.AlertThreshold{Threshold: float64Ptr(25), Condition: &below},
+		Warning:      &types.AlertThreshold{Threshold: float64Ptr(10), Condition: &below},
+		Critical:     &types.AlertThreshold{Threshold: float64Ptr(0), Condition: &below},
+	}
+}
 
 func persistentExternalCustomerID(i int) string {
 	return fmt.Sprintf("e2eprobe-cust-persistent-%d", i)
@@ -36,7 +63,7 @@ func NewSeedEnsure(c e2eprobe.Client, r e2eprobe.Registry, runID string, lg *log
 	return &SeedEnsure{client: c, reg: r, runID: runID, logger: lg}
 }
 
-func (s *SeedEnsure) Name() string         { return "seed-ensure" }
+func (s *SeedEnsure) Name() string        { return "seed-ensure" }
 func (s *SeedEnsure) Kind() e2eprobe.Kind { return e2eprobe.KindBootstrap }
 func (s *SeedEnsure) Run(ctx context.Context) error {
 	seeds := e2eprobe.Seeds{
@@ -254,6 +281,44 @@ func (s *SeedEnsure) ensureCustomers(ctx context.Context, out *e2eprobe.Seeds) e
 	for i := 0; i < PreFundedWalletCount && i < PersistentCustomerCount; i++ {
 		out.PreFundedCustomerIDs = append(out.PreFundedCustomerIDs, persistentExternalCustomerID(i))
 	}
+
+	// Alert-canary customer: separate persistent customer used only for
+	// low-balance webhook pipeline verification. Added to PersistentCustomerIDs
+	// so ensureSubscriptions gives it a plan sub (required for ongoing-balance
+	// projection), but deliberately kept out of PreFundedCustomerIDs.
+	if err := s.ensureAlertCanaryCustomer(ctx); err != nil {
+		return err
+	}
+	out.PersistentCustomerIDs = append(out.PersistentCustomerIDs, AlertCanaryExternalCustomerID)
+	out.AlertCanaryExternalCustomerID = AlertCanaryExternalCustomerID
+	return nil
+}
+
+func (s *SeedEnsure) ensureAlertCanaryCustomer(ctx context.Context) error {
+	ext := AlertCanaryExternalCustomerID
+	_, err := s.client.Customers().GetByExternalID(ctx, ext)
+	if err == nil {
+		return nil
+	}
+	var apiErr *sdkerrors.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode != http.StatusNotFound {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": ext}, "lookup alert canary: %w", err)
+	}
+	req := types.DtoCreateCustomerRequest{
+		ExternalID: ext,
+		Name:       strPtr("E2EProbe Alert Canary"),
+		Email:      strPtr(fmt.Sprintf("%s@e2eprobe.flexprice.invalid", ext)),
+		Metadata: map[string]string{
+			"e2eprobe":        "true",
+			"e2eprobe_cohort": "persistent",
+			"e2eprobe_role":   "alert-canary",
+			"e2eprobe_run_id": s.runID,
+			"created_unix_ns": fmt.Sprintf("%d", time.Now().UnixNano()),
+		},
+	}
+	if _, err := s.client.Customers().Create(ctx, req); err != nil {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": ext}, "create alert canary: %w", err)
+	}
 	return nil
 }
 
@@ -458,8 +523,14 @@ func (s *SeedEnsure) ensureSubscriptions(ctx context.Context, seeds *e2eprobe.Se
 	return nil
 }
 
-// ensureWallets creates and tops up a wallet for the first 3 persistent customers.
+// ensureWallets creates and tops up a wallet for the first 3 persistent customers
+// plus the dedicated alert-canary customer (lower balance, alert-driven).
 func (s *SeedEnsure) ensureWallets(ctx context.Context, seeds *e2eprobe.Seeds) error {
+	if seeds.AlertCanaryExternalCustomerID != "" {
+		if err := s.ensureAlertCanaryWallet(ctx, seeds.AlertCanaryExternalCustomerID); err != nil {
+			return err
+		}
+	}
 	if len(seeds.PreFundedCustomerIDs) == 0 {
 		return nil
 	}
@@ -484,7 +555,10 @@ func (s *SeedEnsure) ensureWallets(ctx context.Context, seeds *e2eprobe.Seeds) e
 			continue // wallet already exists
 		}
 
-		// Create wallet.
+		// Create wallet with low-balance alert thresholds (info=25, warning=10,
+		// critical=0). Enables the low-wallet-alert-listener check end-to-end:
+		// Flexprice fires wallet.credit_balance.dropped webhooks as the balance
+		// crosses each threshold, and the listener validates + tracks receipts.
 		createReq := types.DtoCreateWalletRequest{
 			ExternalCustomerID: &extCustID,
 			Currency:           "USD",
@@ -492,6 +566,7 @@ func (s *SeedEnsure) ensureWallets(ctx context.Context, seeds *e2eprobe.Seeds) e
 				"e2eprobe":      "true",
 				"e2eprobe_role": "seed",
 			},
+			AlertSettings: lowBalanceAlertSettings(),
 		}
 		walletResp, err := s.client.Wallets().Create(ctx, createReq)
 		if err != nil {
@@ -511,6 +586,56 @@ func (s *SeedEnsure) ensureWallets(ctx context.Context, seeds *e2eprobe.Seeds) e
 		if _, err := s.client.Wallets().TopUp(ctx, walletID, topUpReq); err != nil {
 			return e2eprobe.Errorf(map[string]string{"external_customer_id": extCustID, "wallet_id": walletID}, "top up wallet %s for customer %s: %w", walletID, extCustID, err)
 		}
+	}
+	return nil
+}
+
+// ensureAlertCanaryWallet provisions the canary customer's single low-balance
+// wallet ($30 initial) with the {info=25, warning=10, critical=0} thresholds
+// enabled. Idempotent — skips when a wallet already exists.
+func (s *SeedEnsure) ensureAlertCanaryWallet(ctx context.Context, extCustID string) error {
+	custResp, err := s.client.Customers().GetByExternalID(ctx, extCustID)
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": extCustID}, "get alert canary %s: %w", extCustID, err)
+	}
+	if custResp.DtoCustomerResponse == nil || custResp.DtoCustomerResponse.ID == nil {
+		return nil
+	}
+	internalCustID := *custResp.DtoCustomerResponse.ID
+
+	walletsResp, err := s.client.Wallets().GetWalletsByCustomerID(ctx, internalCustID)
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": extCustID, "internal_customer_id": internalCustID}, "get alert canary wallets: %w", err)
+	}
+	if walletsResp != nil && len(walletsResp.DtoWalletResponses) > 0 {
+		return nil
+	}
+
+	createReq := types.DtoCreateWalletRequest{
+		ExternalCustomerID: strPtr(extCustID),
+		Currency:           "USD",
+		Metadata: map[string]string{
+			"e2eprobe":      "true",
+			"e2eprobe_role": "alert-canary",
+		},
+		AlertSettings: lowBalanceAlertSettings(),
+	}
+	walletResp, err := s.client.Wallets().Create(ctx, createReq)
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": extCustID}, "create alert canary wallet: %w", err)
+	}
+	if walletResp.DtoWalletResponse == nil || walletResp.DtoWalletResponse.ID == nil {
+		return nil
+	}
+	walletID := *walletResp.DtoWalletResponse.ID
+
+	topUpReq := types.DtoTopUpWalletRequest{
+		Amount:            strPtr(AlertCanaryInitialBalance),
+		Description:       strPtr("e2eprobe alert canary initial top-up"),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+	}
+	if _, err := s.client.Wallets().TopUp(ctx, walletID, topUpReq); err != nil {
+		return e2eprobe.Errorf(map[string]string{"external_customer_id": extCustID, "wallet_id": walletID}, "top up alert canary wallet: %w", err)
 	}
 	return nil
 }

--- a/internal/e2eprobe/checks/seed_ensure_test.go
+++ b/internal/e2eprobe/checks/seed_ensure_test.go
@@ -54,18 +54,18 @@ func TestSeedEnsure(t *testing.T) {
 				// subs and wallets are empty — they'll be created
 			},
 			wantErr:                 false,
-			wantFeaturesCreated:     0,  // all 9 found via Query
-			wantCustomersCreated:    0,  // all 10 already present
-			wantPlansCreated:        0,  // plan found via Query
+			wantFeaturesCreated:     0, // all 9 found via Query
+			wantCustomersCreated:    1, // 10 pre-populated; alert canary still needs creating
+			wantPlansCreated:        0, // plan found via Query
 			wantPricesCreated:       10, // base + 9 usage prices
-			wantSubsCreated:         10, // one per persistent customer
-			wantWalletsCreated:      3,  // one per pre-funded customer
-			wantPersistentCustomers: 10,
+			wantSubsCreated:         11, // 10 persistent + 1 alert canary
+			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
+			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
 			wantMeterIDs:            9,
 			wantFeatureIDs:          9,
 			wantPlanIDs:             1,
-			wantSubIDs:              10,
+			wantSubIDs:              11,
 		},
 		{
 			name: "CreatesMissing: all empty, all entities created",
@@ -75,17 +75,17 @@ func TestSeedEnsure(t *testing.T) {
 			},
 			wantErr:                 false,
 			wantFeaturesCreated:     9,
-			wantCustomersCreated:    10,
+			wantCustomersCreated:    11, // 10 persistent + 1 alert canary
 			wantPlansCreated:        1,
 			wantPricesCreated:       10, // base + 9 usage
-			wantSubsCreated:         10,
-			wantWalletsCreated:      3,
-			wantPersistentCustomers: 10,
+			wantSubsCreated:         11, // 10 persistent + 1 alert canary
+			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
+			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
 			wantMeterIDs:            9,
 			wantFeatureIDs:          9,
 			wantPlanIDs:             1,
-			wantSubIDs:              10,
+			wantSubIDs:              11,
 		},
 		{
 			name: "PartialExisting: features exist but plan/subs/wallets don't",
@@ -109,17 +109,17 @@ func TestSeedEnsure(t *testing.T) {
 			},
 			wantErr:                 false,
 			wantFeaturesCreated:     0,
-			wantCustomersCreated:    0,
+			wantCustomersCreated:    1, // alert canary still needs creating
 			wantPlansCreated:        1,
 			wantPricesCreated:       10,
-			wantSubsCreated:         10,
-			wantWalletsCreated:      3,
-			wantPersistentCustomers: 10,
+			wantSubsCreated:         11, // 10 persistent + 1 alert canary
+			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
+			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
 			wantMeterIDs:            9,
 			wantFeatureIDs:          9,
 			wantPlanIDs:             1,
-			wantSubIDs:              10,
+			wantSubIDs:              11,
 		},
 	}
 

--- a/internal/e2eprobe/config.go
+++ b/internal/e2eprobe/config.go
@@ -72,6 +72,7 @@ var CheckNames = []string{
 	"CANCEL_CUSTOMER_FLOW",
 	"SUBSCRIPTION_MODIFICATION_FLOW",
 	"LOW_WALLET_ALERT_LISTENER",
+	"LOW_BALANCE_ALERT_PROBE",
 	"JANITOR",
 }
 
@@ -88,6 +89,7 @@ var checkDefaultIntervals = map[string]time.Duration{
 	"CANCEL_CUSTOMER_FLOW":           10 * time.Minute,
 	"SUBSCRIPTION_MODIFICATION_FLOW": 20 * time.Minute,
 	"LOW_WALLET_ALERT_LISTENER":      0, // listener — not a ticker
+	"LOW_BALANCE_ALERT_PROBE":        5 * time.Minute,
 	"JANITOR":                        1 * time.Hour,
 }
 

--- a/internal/e2eprobe/registry.go
+++ b/internal/e2eprobe/registry.go
@@ -12,6 +12,12 @@ type Seeds struct {
 	PlanIDs               []string
 	FeatureIDs            []string
 	MeterIDs              map[string]string // event_name -> meter ID
+
+	// AlertCanaryExternalCustomerID is the persistent ext customer id that
+	// owns the low-balance alert-webhook canary wallet. Kept out of
+	// PreFundedCustomerIDs so wallet_debit_verification / wallet_balance_probe
+	// don't top it up or read it. Consumed only by LowBalanceAlertProbe.
+	AlertCanaryExternalCustomerID string
 }
 
 type EphemeralEntity struct {
@@ -42,12 +48,13 @@ func (r *registry) LoadSeeds(s Seeds) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.seeds = Seeds{
-		PersistentCustomerIDs: append([]string(nil), s.PersistentCustomerIDs...),
-		PreFundedCustomerIDs:  append([]string(nil), s.PreFundedCustomerIDs...),
-		PersistentSubIDs:      append([]string(nil), s.PersistentSubIDs...),
-		PlanIDs:               append([]string(nil), s.PlanIDs...),
-		FeatureIDs:            append([]string(nil), s.FeatureIDs...),
-		MeterIDs:              copyStringMap(s.MeterIDs),
+		PersistentCustomerIDs:         append([]string(nil), s.PersistentCustomerIDs...),
+		PreFundedCustomerIDs:          append([]string(nil), s.PreFundedCustomerIDs...),
+		PersistentSubIDs:              append([]string(nil), s.PersistentSubIDs...),
+		PlanIDs:                       append([]string(nil), s.PlanIDs...),
+		FeatureIDs:                    append([]string(nil), s.FeatureIDs...),
+		MeterIDs:                      copyStringMap(s.MeterIDs),
+		AlertCanaryExternalCustomerID: s.AlertCanaryExternalCustomerID,
 	}
 }
 
@@ -55,12 +62,13 @@ func (r *registry) Seeds() Seeds {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return Seeds{
-		PersistentCustomerIDs: append([]string(nil), r.seeds.PersistentCustomerIDs...),
-		PreFundedCustomerIDs:  append([]string(nil), r.seeds.PreFundedCustomerIDs...),
-		PersistentSubIDs:      append([]string(nil), r.seeds.PersistentSubIDs...),
-		PlanIDs:               append([]string(nil), r.seeds.PlanIDs...),
-		FeatureIDs:            append([]string(nil), r.seeds.FeatureIDs...),
-		MeterIDs:              copyStringMap(r.seeds.MeterIDs),
+		PersistentCustomerIDs:         append([]string(nil), r.seeds.PersistentCustomerIDs...),
+		PreFundedCustomerIDs:          append([]string(nil), r.seeds.PreFundedCustomerIDs...),
+		PersistentSubIDs:              append([]string(nil), r.seeds.PersistentSubIDs...),
+		PlanIDs:                       append([]string(nil), r.seeds.PlanIDs...),
+		FeatureIDs:                    append([]string(nil), r.seeds.FeatureIDs...),
+		MeterIDs:                      copyStringMap(r.seeds.MeterIDs),
+		AlertCanaryExternalCustomerID: r.seeds.AlertCanaryExternalCustomerID,
 	}
 }
 

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -2110,6 +2110,8 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		NextPeriodEnd:      nextPeriodEnd,
 	})
 
+	isMeterUsageEnabledForBilling := s.Config.FeatureFlag.IsMeterUsageEnabledForBilling(sub.TenantID)
+
 	var calculationResult *dto.BillingCalculationResult
 	var metadata types.Metadata = make(types.Metadata)
 	var description string
@@ -2148,7 +2150,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 
 	case types.ReferencePointPeriodEnd:
 		// Include both arrear charges for current period and advance charges for next period
-		// Use calculateFeatureUsageCharges for arrear so cumulative commitment is applied (feature_usage path)
+		// Use calculateFeatureUsageCharges (or calculateMeterUsageCharges) for arrear so cumulative commitment is applied (feature_usage or meter_usage path)
 		arrearLineItems, err := s.FilterLineItemsToBeInvoiced(ctx, &dto.FilterLineItemsToBeInvoicedParams{
 			Subscription:     sub,
 			PeriodStart:      periodStart,
@@ -2178,26 +2180,50 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			return zeroAmountInvoice, nil
 		}
 
-		// For current period arrear charges (feature_usage path for cumulative commitment support)
-		arrearResult, err := s.CalculateCharges(ctx, &dto.CalculateChargesParams{
-			Subscription: sub,
-			LineItems:    arrearLineItems,
-			PeriodStart:  periodStart,
-			PeriodEnd:    periodEnd,
-			IncludeUsage: classification.HasUsageCharges, // Include usage for arrear
-		})
+		// For current period arrear charges (feature_usage or meter_usage path for cumulative commitment support)
+		var arrearResult *dto.BillingCalculationResult
+		if isMeterUsageEnabledForBilling {
+			arrearResult, err = s.calculateMeterUsageCharges(
+				ctx,
+				sub,
+				arrearLineItems,
+				periodStart,
+				periodEnd,
+				classification.HasUsageCharges, // Include usage for arrear
+			)
+		} else {
+			arrearResult, err = s.CalculateCharges(ctx, &dto.CalculateChargesParams{
+				Subscription: sub,
+				LineItems:    arrearLineItems,
+				PeriodStart:  periodStart,
+				PeriodEnd:    periodEnd,
+				IncludeUsage: classification.HasUsageCharges, // Include usage for arrear
+			})
+		}
 		if err != nil {
 			return nil, err
 		}
 
 		// For next period advance charges
-		advanceResult, err := s.CalculateCharges(ctx, &dto.CalculateChargesParams{
-			Subscription: sub,
-			LineItems:    advanceLineItems,
-			PeriodStart:  nextPeriodStart,
-			PeriodEnd:    nextPeriodEnd,
-			IncludeUsage: false, // No usage for advance
-		})
+		var advanceResult *dto.BillingCalculationResult
+		if isMeterUsageEnabledForBilling {
+			advanceResult, err = s.calculateMeterUsageCharges(
+				ctx,
+				sub,
+				advanceLineItems,
+				nextPeriodStart,
+				nextPeriodEnd,
+				false, // No usage for advance
+			)
+		} else {
+			advanceResult, err = s.CalculateCharges(ctx, &dto.CalculateChargesParams{
+				Subscription: sub,
+				LineItems:    advanceLineItems,
+				PeriodStart:  nextPeriodStart,
+				PeriodEnd:    nextPeriodEnd,
+				IncludeUsage: false, // No usage for advance
+			})
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -2334,7 +2360,7 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		metadata["is_preview"] = "true"
 
 	case types.ReferencePointCancel:
-		// for cancel, include arrear line items only (feature_usage path for cumulative commitment)
+		// for cancel, include arrear line items only (feature_usage or meter_usage path for cumulative commitment)
 		arrearLineItems, err := s.FilterLineItemsToBeInvoiced(ctx, &dto.FilterLineItemsToBeInvoicedParams{
 			Subscription:     sub,
 			PeriodStart:      periodStart,
@@ -2347,14 +2373,26 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 		}
 
 		// For current period arrear charges
-		arrearResult, err := s.calculateFeatureUsageCharges(
-			ctx,
-			sub,
-			arrearLineItems,
-			periodStart,
-			periodEnd,
-			true, // Include usage for arrear
-		)
+		var arrearResult *dto.BillingCalculationResult
+		if isMeterUsageEnabledForBilling {
+			arrearResult, err = s.calculateMeterUsageCharges(
+				ctx,
+				sub,
+				arrearLineItems,
+				periodStart,
+				periodEnd,
+				true, // Include usage for arrear
+			)
+		} else {
+			arrearResult, err = s.calculateFeatureUsageCharges(
+				ctx,
+				sub,
+				arrearLineItems,
+				periodStart,
+				periodEnd,
+				true, // Include usage for arrear
+			)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -104,6 +104,7 @@ func (s *BillingServiceSuite) setupService() {
 		ProrationCalculator:      s.GetCalculator(),
 		AlertLogsRepo:            s.GetStores().AlertLogsRepo,
 		FeatureUsageRepo:         s.GetStores().FeatureUsageRepo,
+		MeterUsageRepo:           s.GetStores().MeterUsageRepo,
 	})
 }
 
@@ -847,7 +848,7 @@ func (s *BillingServiceSuite) TestCalculateFixedCharges_MixedCadence() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
 	// Line items: monthly fixed (same cadence as sub), quarterly fixed (longer cadence, start Jan 1)
@@ -984,7 +985,7 @@ func (s *BillingServiceSuite) setupScenario1DailySub(ctx context.Context) (*subs
 		BillingPeriod:      types.BILLING_PERIOD_DAILY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone, // full amounts in tests
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -1074,7 +1075,7 @@ func (s *BillingServiceSuite) setupScenario2MonthlySub(ctx context.Context) (*su
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone, // full amounts in tests
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -1248,7 +1249,7 @@ func (s *BillingServiceSuite) setupSubWithFixedLineItemsForPeriodTests(
 		BillingPeriod:      subBillingPeriod,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -3682,7 +3683,7 @@ func (s *BillingServiceSuite) TestApplyProrationToLineItem_RuntimeSafetyNet_Mixe
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorCreateProrations, // mixed + proration -> safety net
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -3870,7 +3871,7 @@ func (s *BillingServiceSuite) TestClassifyLineItems_MultiCadencePRD() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 		LineItems:          []*subscription.SubscriptionLineItem{liM, liQ, liH},
@@ -3992,7 +3993,7 @@ func (s *BillingServiceSuite) setupMultiCadenceSubMQH(ctx context.Context, start
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -4069,7 +4070,7 @@ func (s *BillingServiceSuite) TestMultiCadence_Stress_AllSamePeriod() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -4209,7 +4210,7 @@ func (s *BillingServiceSuite) setupMultiCadenceSubMQA(ctx context.Context, start
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -4317,7 +4318,7 @@ func (s *BillingServiceSuite) setupMultiCadenceSubQA(ctx context.Context, start 
 		BillingPeriod:      types.BILLING_PERIOD_QUARTER,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -4555,7 +4556,7 @@ func (s *BillingServiceSuite) TestMultiCadence_MidMonthStart() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -4664,7 +4665,7 @@ func (s *BillingServiceSuite) setupMultiCadenceSubMQHA(ctx context.Context, star
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
@@ -4761,7 +4762,7 @@ func (s *BillingServiceSuite) TestMultiCadence_SingleQuarterlyLine() {
 		BillingPeriod:      types.BILLING_PERIOD_QUARTER,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		ProrationBehavior:  types.ProrationBehaviorNone,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -288,6 +288,7 @@ func (s *SubscriptionServiceSuite) setupService() {
 		WebhookPublisher:           s.GetWebhookPublisher(),
 		ProrationCalculator:        s.GetCalculator(),
 		FeatureUsageRepo:           s.GetStores().FeatureUsageRepo,
+		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
 		IntegrationFactory:         s.GetIntegrationFactory(),
 		PlanPriceSyncRepo:          s.GetStores().PlanPriceSyncRepo,
 	})
@@ -2135,6 +2136,7 @@ func (s *SubscriptionServiceSuite) createInvoiceService() InvoiceService {
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
 		ConnectionRepo:             s.GetStores().ConnectionRepo,
 		SettingsRepo:               s.GetStores().SettingsRepo,
+		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
 		EventPublisher:             s.GetPublisher(),
 		WebhookPublisher:           s.GetWebhookPublisher(),
 	})
@@ -5695,6 +5697,7 @@ func (s *SubscriptionServiceSuite) TestFilterLineItemsWithEndDate() {
 		AuthRepo:                 s.GetStores().AuthRepo,
 		WalletRepo:               s.GetStores().WalletRepo,
 		PaymentRepo:              s.GetStores().PaymentRepo,
+		MeterUsageRepo:           s.GetStores().MeterUsageRepo,
 		EventPublisher:           s.GetPublisher(),
 		WebhookPublisher:         s.GetWebhookPublisher(),
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing now supports tenant-specific rollout controls for metered meter-usage charges.
  * Added a low-balance alert end-to-end probe to validate the full alert webhook lifecycle.
* **Bug Fixes**
  * Billing invoice charge calculation now switches to the correct metered-usage path for period-end and cancellation scenarios when enabled.
* **Documentation**
  * Updated e2e probe configuration examples and README to describe the new low-balance alert verification flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->