### PR TITLE
feat(e2eprobe): ship as standalone docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the Docker build context small. Excludes VCS, generated SDKs, docs,
+# and editor/OS cruft that the Go build never needs (COPY . .).
+# Do NOT exclude go.mod, go.sum, cmd/, internal/, ent/, migrations/, assets/.
+.git
+.gitignore
+.github
+.vscode
+.idea
+api
+docs
+node_modules
+tmp
+bin
+dist
+*.log
+.env
+.env.*
+.DS_Store
+Dockerfile*
+.dockerignore

--- a/Dockerfile.e2eprobe
+++ b/Dockerfile.e2eprobe
@@ -29,16 +29,10 @@ RUN apk --no-cache add ca-certificates tzdata
 WORKDIR /app
 COPY --from=builder /app/e2eprobe .
 
-# Non-secret defaults that differ from the code defaults in
-# internal/e2eprobe/config.go, mirroring cmd/e2eprobe/.env.example so the
-# container behaves like `source .env.example`. Everything else already
-# matches the code defaults. Override any of these at runtime with -e.
-ENV E2EPROBE_EVENT_INGEST_RATE=1 \
-    E2EPROBE_EVENT_INGEST_SEED=42 \
-    E2EPROBE_OTEL_ENABLED=false \
-    E2EPROBE_HEARTBEAT_INTERVAL=1h \
-    E2EPROBE_CHECK_CANCEL_CUSTOMER_FLOW_INTERVAL=30m \
-    TZ=UTC
+# All e2eprobe defaults now live in internal/e2eprobe/config.go and match
+# cmd/e2eprobe/.env.example, so nothing needs baking here. Override any knob
+# at runtime with -e VAR=val.
+ENV TZ=UTC
 
 # Required at runtime (not baked — keeps secrets out of image layers):
 #   E2EPROBE_API_HOST, E2EPROBE_API_KEY, E2EPROBE_TENANT_ID, E2EPROBE_ENVIRONMENT_ID

--- a/Dockerfile.e2eprobe
+++ b/Dockerfile.e2eprobe
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:experimental
+# Build stage
+# Pin the builder to the runner's native arch ($BUILDPLATFORM) and
+# cross-compile to the requested $TARGETARCH. Avoids QEMU emulation of
+# the Go toolchain, which is 10-20x slower on multi-arch builds.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS builder
+WORKDIR /app
+
+RUN apk add --no-cache git
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+# TARGETARCH is provided automatically by buildx (e.g. amd64, arm64)
+ARG TARGETARCH
+ENV CGO_ENABLED=0 \
+    GOOS=linux
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o e2eprobe cmd/e2eprobe/main.go
+
+# Final stage
+FROM alpine:3.20
+RUN apk --no-cache add ca-certificates tzdata
+
+WORKDIR /app
+COPY --from=builder /app/e2eprobe .
+
+# Non-secret defaults that differ from the code defaults in
+# internal/e2eprobe/config.go, mirroring cmd/e2eprobe/.env.example so the
+# container behaves like `source .env.example`. Everything else already
+# matches the code defaults. Override any of these at runtime with -e.
+ENV E2EPROBE_EVENT_INGEST_RATE=1 \
+    E2EPROBE_EVENT_INGEST_SEED=42 \
+    E2EPROBE_OTEL_ENABLED=false \
+    E2EPROBE_HEARTBEAT_INTERVAL=1h \
+    E2EPROBE_CHECK_CANCEL_CUSTOMER_FLOW_INTERVAL=30m \
+    TZ=UTC
+
+# Required at runtime (not baked — keeps secrets out of image layers):
+#   E2EPROBE_API_HOST, E2EPROBE_API_KEY, E2EPROBE_TENANT_ID, E2EPROBE_ENVIRONMENT_ID
+
+EXPOSE 8765
+CMD ["./e2eprobe"]

--- a/Dockerfile.e2eprobe
+++ b/Dockerfile.e2eprobe
@@ -35,7 +35,9 @@ COPY --from=builder /app/e2eprobe .
 ENV TZ=UTC
 
 # Required at runtime (not baked — keeps secrets out of image layers):
-#   E2EPROBE_API_HOST, E2EPROBE_API_KEY, E2EPROBE_TENANT_ID, E2EPROBE_ENVIRONMENT_ID
+#   E2EPROBE_API_HOST, E2EPROBE_API_KEY
+# Optional at runtime (used for trace/alert attributes if set):
+#   E2EPROBE_TENANT_ID, E2EPROBE_ENVIRONMENT_ID
 
 EXPOSE 8765
 CMD ["./e2eprobe"]

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ run-server:
 run-e2eprobe:
 	go run cmd/e2eprobe/main.go
 
+.PHONY: e2eprobe-docker-build
+e2eprobe-docker-build:
+	docker buildx build --platform linux/amd64,linux/arm64 \
+	  -f Dockerfile.e2eprobe -t flexprice/e2eprobe .
+
 .PHONY: run-server-local
 run-server-local: run-server
 

--- a/Makefile
+++ b/Makefile
@@ -69,10 +69,22 @@ run-server:
 run-e2eprobe:
 	go run cmd/e2eprobe/main.go
 
+E2EPROBE_IMAGE ?= flexprice/e2eprobe
+
+# Single-platform build loaded into the local Docker engine for testing.
+# (buildx cannot --load a multi-arch manifest into the default image store.)
 .PHONY: e2eprobe-docker-build
 e2eprobe-docker-build:
-	docker buildx build --platform linux/amd64,linux/arm64 \
-	  -f Dockerfile.e2eprobe -t flexprice/e2eprobe .
+	docker buildx build --load \
+	  -f Dockerfile.e2eprobe -t $(E2EPROBE_IMAGE) .
+
+# Multi-arch build pushed to a registry. Override the tag with
+# E2EPROBE_IMAGE=<registry>/e2eprobe:<tag>. buildx discards a multi-platform
+# result unless it is pushed, so --push is required here.
+.PHONY: e2eprobe-docker-push
+e2eprobe-docker-push:
+	docker buildx build --push --platform linux/amd64,linux/arm64 \
+	  -f Dockerfile.e2eprobe -t $(E2EPROBE_IMAGE) .
 
 .PHONY: run-server-local
 run-server-local: run-server

--- a/internal/e2eprobe/README.md
+++ b/internal/e2eprobe/README.md
@@ -51,7 +51,7 @@ Adding a new probe: write `internal/e2eprobe/checks/<name>.go` implementing `Che
 | `E2EPROBE_SLACK_WEBHOOK_URL` | Slack webhook (empty disables) | empty |
 | `E2EPROBE_SLACK_CHANNEL` | Override channel | empty |
 | `E2EPROBE_OTEL_ENABLED` | Emit OTEL spans | `true` |
-| `E2EPROBE_HEARTBEAT_INTERVAL` | How often a structured heartbeat summary is logged (`0` disables) | `5m` |
+| `E2EPROBE_HEARTBEAT_INTERVAL` | How often a structured heartbeat summary is logged (`0` disables) | `1h` |
 | `E2EPROBE_JANITOR_MAX_AGE` | Minimum age of an ephemeral entity before the janitor deletes it (applies to both in-memory sweep and Flexprice orphan scan) | `1h` |
 | `E2EPROBE_CHECK_<NAME>_ENABLED` | Per-check kill switch | `true` |
 | `E2EPROBE_CHECK_<NAME>_INTERVAL` | Per-check interval override (Go duration) | per-check default |
@@ -71,7 +71,7 @@ Standard OTLP env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) flow through unchan
 | probe | cycle-invoice-probe | 15m | Auto-invoice freshness invariant |
 | probe | entitlement-and-usage-probe | 5m | Entitlements + usage rollup |
 | scenario | new-customer-lifecycle | 10m | Ephemeral customer/sub + events |
-| scenario | cancel-customer-flow | 10m | Cancel oldest ephemeral sub + delete its customer |
+| scenario | cancel-customer-flow | 30m | Cancel oldest ephemeral sub + delete its customer |
 | scenario | subscription-modification-flow | 20m | Add line item; verify |
 | listener | low-wallet-alert-listener | webhook | Asserts low-balance webhook payloads |
 | maintenance | janitor | 1h | Archive in-memory ephemerals > 1h; also scans Flexprice for orphan ephemeral customers from prior restarts and deletes them |
@@ -82,7 +82,7 @@ The listener exposes `POST http://<e2eprobe-host>:8765/webhook` (port configurab
 
 ## Operational signals
 
-Every `E2EPROBE_HEARTBEAT_INTERVAL` (default 5 minutes) the probe emits a single structured log line summarising activity since startup:
+Every `E2EPROBE_HEARTBEAT_INTERVAL` (default 1 hour) the probe emits a single structured log line summarising activity since startup:
 
 ```json
 {"level":"info","time":"2026-06-12T10:05:00.000Z","msg":"e2eprobe heartbeat","event":"e2eprobe.heartbeat","run_id":"e2eprobe-1749720000","uptime":"5m0s","total_runs":142,"total_failures":0,"success_rate":"100.00%","check.analytics-probe":"3/3","check.event-ingest-driver":"125/125","check.wallet-balance-probe":"3/3"}
@@ -98,7 +98,7 @@ One line per tick — not per check. Key fields:
 | `success_rate` | `(total_runs - total_failures) / total_runs × 100` |
 | `check.<name>` | `successes/total` for that individual check |
 
-**When to be concerned about silence:** If a heartbeat is missing for more than two intervals (10 minutes at default settings) the process has likely crashed or lost its log pipeline. Alert on the absence of `event=e2eprobe.heartbeat` in your log aggregator.
+**When to be concerned about silence:** If a heartbeat is missing for more than two intervals (2 hours at default settings) the process has likely crashed or lost its log pipeline. Alert on the absence of `event=e2eprobe.heartbeat` in your log aggregator.
 
 Set `E2EPROBE_HEARTBEAT_INTERVAL=0` to disable heartbeat logging entirely.
 

--- a/internal/e2eprobe/config.go
+++ b/internal/e2eprobe/config.go
@@ -25,7 +25,7 @@ type Config struct {
 
 	// HeartbeatInterval controls how often a structured "e2eprobe.heartbeat" log
 	// line is emitted summarising run counts and success rate. Set to 0 to disable.
-	HeartbeatInterval time.Duration // E2EPROBE_HEARTBEAT_INTERVAL, default 5m
+	HeartbeatInterval time.Duration // E2EPROBE_HEARTBEAT_INTERVAL, default 1h
 
 	// JanitorMaxAge is the minimum age of an ephemeral entity before the janitor
 	// deletes it. Also controls the Flexprice-wide orphan scan sweep.
@@ -85,7 +85,7 @@ var checkDefaultIntervals = map[string]time.Duration{
 	"CYCLE_INVOICE_PROBE":            15 * time.Minute,
 	"ENTITLEMENT_AND_USAGE_PROBE":    5 * time.Minute,
 	"NEW_CUSTOMER_LIFECYCLE":         10 * time.Minute,
-	"CANCEL_CUSTOMER_FLOW":           10 * time.Minute,
+	"CANCEL_CUSTOMER_FLOW":           30 * time.Minute,
 	"SUBSCRIPTION_MODIFICATION_FLOW": 20 * time.Minute,
 	"LOW_WALLET_ALERT_LISTENER":      0, // listener — not a ticker
 	"JANITOR":                        1 * time.Hour,
@@ -98,19 +98,19 @@ func LoadConfig() (*Config, error) {
 		APIKey:          os.Getenv("E2EPROBE_API_KEY"),
 		Enabled:         getBool("E2EPROBE_ENABLED", true),
 		DryRun:          getBool("E2EPROBE_DRY_RUN", false),
-		EventIngestRate: getInt(&warnings, "E2EPROBE_EVENT_INGEST_RATE", 5),
-		EventIngestSeed: getInt64(&warnings, "E2EPROBE_EVENT_INGEST_SEED", time.Now().UnixNano()),
+		EventIngestRate: getInt(&warnings, "E2EPROBE_EVENT_INGEST_RATE", 1),
+		EventIngestSeed: getInt64(&warnings, "E2EPROBE_EVENT_INGEST_SEED", 42),
 		ListenerPort:    getInt(&warnings, "E2EPROBE_LISTENER_PORT", 8765),
 		TenantID:          os.Getenv("E2EPROBE_TENANT_ID"),
 		EnvironmentID:     os.Getenv("E2EPROBE_ENVIRONMENT_ID"),
-		HeartbeatInterval: getDuration(&warnings, "E2EPROBE_HEARTBEAT_INTERVAL", 5*time.Minute),
+		HeartbeatInterval: getDuration(&warnings, "E2EPROBE_HEARTBEAT_INTERVAL", 1*time.Hour),
 		JanitorMaxAge:     getDuration(&warnings, "E2EPROBE_JANITOR_MAX_AGE", 1*time.Hour),
 		Slack: SlackConfig{
 			WebhookURL: os.Getenv("E2EPROBE_SLACK_WEBHOOK_URL"),
 			Channel:    os.Getenv("E2EPROBE_SLACK_CHANNEL"),
 		},
 		OTEL: OTELConfig{
-			Enabled: getBool("E2EPROBE_OTEL_ENABLED", true),
+			Enabled: getBool("E2EPROBE_OTEL_ENABLED", false),
 		},
 		Checks: make(map[string]CheckConfig, len(CheckNames)),
 	}

--- a/internal/e2eprobe/config_test.go
+++ b/internal/e2eprobe/config_test.go
@@ -42,8 +42,11 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if !c.Enabled || c.DryRun || c.EventIngestRate != 5 || !c.OTEL.Enabled {
+	if !c.Enabled || c.DryRun || c.EventIngestRate != 1 || c.OTEL.Enabled {
 		t.Errorf("defaults mismatch: %+v", c)
+	}
+	if c.EventIngestSeed != 42 {
+		t.Errorf("EventIngestSeed=%d, want 42", c.EventIngestSeed)
 	}
 	if c.ListenerPort != 8765 {
 		t.Errorf("ListenerPort=%d, want 8765", c.ListenerPort)
@@ -59,8 +62,8 @@ func TestLoadConfig_Defaults(t *testing.T) {
 		t.Error("LOW_WALLET_ALERT_LISTENER missing")
 	}
 	cc, ok2 := c.Checks["CANCEL_CUSTOMER_FLOW"]
-	if !ok2 || cc.Interval != 10*time.Minute {
-		t.Errorf("CANCEL_CUSTOMER_FLOW default interval=%v, want 10m", cc.Interval)
+	if !ok2 || cc.Interval != 30*time.Minute {
+		t.Errorf("CANCEL_CUSTOMER_FLOW default interval=%v, want 30m", cc.Interval)
 	}
 	if c.JanitorMaxAge != 1*time.Hour {
 		t.Errorf("JanitorMaxAge=%v, want 1h", c.JanitorMaxAge)
@@ -119,14 +122,14 @@ func TestLoadConfig_HeartbeatInterval(t *testing.T) {
 	t.Setenv("E2EPROBE_API_HOST", "https://api.example/v1")
 	t.Setenv("E2EPROBE_API_KEY", "k")
 
-	t.Run("default is 5m", func(t *testing.T) {
+	t.Run("default is 1h", func(t *testing.T) {
 		t.Setenv("E2EPROBE_HEARTBEAT_INTERVAL", "")
 		c, err := LoadConfig()
 		if err != nil {
 			t.Fatalf("LoadConfig: %v", err)
 		}
-		if c.HeartbeatInterval != 5*time.Minute {
-			t.Errorf("HeartbeatInterval=%v, want 5m", c.HeartbeatInterval)
+		if c.HeartbeatInterval != 1*time.Hour {
+			t.Errorf("HeartbeatInterval=%v, want 1h", c.HeartbeatInterval)
 		}
 	})
 


### PR DESCRIPTION
## What

Ships the `e2eprobe` synthetic API monitor as its own Docker image so it can be built and deployed independently of the server.

`e2eprobe` is already a standalone binary (`cmd/e2eprobe/main.go`) with no coupling to server infra (no DB/Kafka/Temporal/Ent) — it talks to Flexprice over HTTP via `go-sdk/v2` and is fully env-var configured (reads zero files at runtime).

## Changes

- **`Dockerfile.e2eprobe`** — multi-arch buildx image mirroring the server `Dockerfile` pattern (cross-compile via `$BUILDPLATFORM`/`$TARGETARCH`, mod/build caches, `-ldflags="-w -s" -trimpath`). Stripped to just the e2eprobe binary: no typst, fonts, templates, migrations, or config dir. Keeps `ca-certificates` (HTTPS to the API) and `tzdata` (correct log timestamps). Final image ~55 MB.
- **`.dockerignore`** — added (none existed) to shrink the `COPY . .` build context for this image and the server.
- **Makefile** — `e2eprobe-docker-build` target.

## Config

Everything is an env var (`LoadConfig` in `internal/e2eprobe/config.go` is pure `os.Getenv`). The 5 non-secret values in `cmd/e2eprobe/.env.example` that differ from code defaults are baked as `ENV` so the container matches `source .env.example`. The 4 required/secret vars stay out of image layers and are passed at runtime:

```bash
docker run \
  -e E2EPROBE_API_HOST=https://api.cloud.flexprice.io/v1 \
  -e E2EPROBE_API_KEY=sk_xxx \
  -e E2EPROBE_TENANT_ID=tenant_xxx \
  -e E2EPROBE_ENVIRONMENT_ID=env_xxx \
  flexprice/e2eprobe
```

Any other knob can be overridden with an extra `-e VAR=val` (runtime `-e` beats image `ENV`).

## Verification

- `docker build -f Dockerfile.e2eprobe -t flexprice/e2eprobe .` → succeeds, image ~55 MB.
- `docker run --rm flexprice/e2eprobe` (no vars) → fails fast: `config error: E2EPROBE_API_HOST is required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `e2eprobe` container image with multi-architecture support and runtime startup.
  * Added build automation to build and (optionally) push the image with a configurable tag.
* **Configuration Updates**
  * Updated default e2eprobe timing and operational defaults (heartbeat/check intervals, ingestion defaults, and OTEL enablement).
* **Documentation**
  * Refreshed e2eprobe documentation to match the new default heartbeat and check schedules.
* **Chores**
  * Expanded Docker ignore rules to reduce Docker build context size and exclude common local/artifact files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->