### PR TITLE
feat(kafka): add topic_dlq for remaining consumer groups in helm conf…

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -125,12 +125,14 @@ data:
       topic: {{ .Values.eventProcessing.topic | quote }}
       rate_limit: {{ .Values.eventProcessing.rateLimit }}
       consumer_group: {{ .Values.eventProcessing.consumerGroup | quote }}
+      topic_dlq: {{ .Values.eventProcessing.topicDLQ | quote }}
 
     event_processing_lazy:
       enabled: {{ .Values.eventProcessingLazy.enabled }}
       topic: {{ .Values.eventProcessingLazy.topic | quote }}
       rate_limit: {{ .Values.eventProcessingLazy.rateLimit }}
       consumer_group: {{ .Values.eventProcessingLazy.consumerGroup | quote }}
+      topic_dlq: {{ .Values.eventProcessingLazy.topicDLQ | quote }}
 
     event_post_processing:
       enabled: {{ .Values.eventPostProcessing.enabled }}
@@ -149,12 +151,14 @@ data:
       topic_backfill: {{ .Values.featureUsageTracking.topicBackfill | quote }}
       rate_limit_backfill: {{ .Values.featureUsageTracking.rateLimitBackfill }}
       consumer_group_backfill: {{ .Values.featureUsageTracking.consumerGroupBackfill | quote }}
+      topic_dlq: {{ .Values.featureUsageTracking.topicDLQ | quote }}
 
     feature_usage_tracking_lazy:
       enabled: {{ .Values.featureUsageTrackingLazy.enabled }}
       topic: {{ .Values.featureUsageTrackingLazy.topic | quote }}
       rate_limit: {{ .Values.featureUsageTrackingLazy.rateLimit }}
       consumer_group: {{ .Values.featureUsageTrackingLazy.consumerGroup | quote }}
+      topic_dlq: {{ .Values.featureUsageTrackingLazy.topicDLQ | quote }}
 
     # The blocks below were previously absent from this ConfigMap, so on GKE (where the
     # mounted ConfigMap replaces the baked config.yaml) their FLEXPRICE_* env overrides were
@@ -177,24 +181,28 @@ data:
       topic: {{ .Values.meterUsageTracking.topic | quote }}
       rate_limit: {{ .Values.meterUsageTracking.rateLimit }}
       consumer_group: {{ .Values.meterUsageTracking.consumerGroup | quote }}
+      topic_dlq: {{ .Values.meterUsageTracking.topicDLQ | quote }}
 
     meter_usage_tracking_lazy:
       enabled: {{ .Values.meterUsageTrackingLazy.enabled }}
       topic: {{ .Values.meterUsageTrackingLazy.topic | quote }}
       rate_limit: {{ .Values.meterUsageTrackingLazy.rateLimit }}
       consumer_group: {{ .Values.meterUsageTrackingLazy.consumerGroup | quote }}
+      topic_dlq: {{ .Values.meterUsageTrackingLazy.topicDLQ | quote }}
 
     costsheet_usage_tracking:
       enabled: {{ .Values.costsheetUsageTracking.enabled }}
       topic: {{ .Values.costsheetUsageTracking.topic | quote }}
       rate_limit: {{ .Values.costsheetUsageTracking.rateLimit }}
       consumer_group: {{ .Values.costsheetUsageTracking.consumerGroup | quote }}
+      topic_dlq: {{ .Values.costsheetUsageTracking.topicDLQ | quote }}
 
     costsheet_usage_tracking_lazy:
       enabled: {{ .Values.costsheetUsageTrackingLazy.enabled }}
       topic: {{ .Values.costsheetUsageTrackingLazy.topic | quote }}
       rate_limit: {{ .Values.costsheetUsageTrackingLazy.rateLimit }}
       consumer_group: {{ .Values.costsheetUsageTrackingLazy.consumerGroup | quote }}
+      topic_dlq: {{ .Values.costsheetUsageTrackingLazy.topicDLQ | quote }}
 
     raw_event_consumption:
       enabled: {{ .Values.rawEventConsumption.enabled }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -752,12 +752,14 @@ eventProcessing:
   topic: "events"
   rateLimit: 12
   consumerGroup: "flexprice-consumer"
+  topicDLQ: "event_processing_dlq"
 
 eventProcessingLazy:
   enabled: true
   topic: "events_lazy"
   rateLimit: 12
   consumerGroup: "v1_event_processing_lazy"
+  topicDLQ: "event_processing_lazy_dlq"
 
 eventPostProcessing:
   enabled: true
@@ -776,12 +778,14 @@ featureUsageTracking:
   topicBackfill: "events_post_processing_backfill"
   rateLimitBackfill: 1
   consumerGroupBackfill: "v1_feature_tracking_service_backfill"
+  topicDLQ: "feature_tracking_service_dlq"
 
 featureUsageTrackingLazy:
   enabled: true
   topic: "events_lazy"
   rateLimit: 1
   consumerGroup: "v1_feature_tracking_service_lazy"
+  topicDLQ: "feature_tracking_service_lazy_dlq"
 
 # Onboarding event-generator (POST /v1/portal/onboarding/events).
 # The app's OnboardingEvents.Topic resolves to empty if this is not rendered
@@ -822,24 +826,28 @@ meterUsageTracking:
   topic: "events"
   rateLimit: 1
   consumerGroup: "v1_meter_usage_tracking_service"
+  topicDLQ: "meter_usage_tracking_service_dlq"
 
 meterUsageTrackingLazy:
   enabled: false
   topic: "events_lazy"
   rateLimit: 1
   consumerGroup: "v1_meter_usage_tracking_service_lazy"
+  topicDLQ: "meter_usage_tracking_service_lazy_dlq"
 
 costsheetUsageTracking:
   enabled: false
   topic: "events"
   rateLimit: 1
   consumerGroup: "v1_costsheet_usage_tracking_service"
+  topicDLQ: "costsheet_usage_tracking_service_dlq"
 
 costsheetUsageTrackingLazy:
   enabled: false
   topic: "events_lazy"
   rateLimit: 1
   consumerGroup: "v1_costsheet_usage_tracking_service_lazy"
+  topicDLQ: "costsheet_usage_tracking_service_lazy_dlq"
 
 usageBenchmark:
   enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dead-letter queue topic settings across multiple Kafka consumer groups.
  * Extended configuration so both regular and lazy event, feature usage, meter usage, and costsheet usage consumers can use dedicated DLQ topics.

* **Bug Fixes**
  * Improved message handling flexibility by allowing failed messages to be routed to the appropriate DLQ topic for each consumer group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->