### PR TITLE
fix(entitlement): update validation to enable config features by default and adjust related tests

### DIFF
--- a/internal/api/dto/entitlement.go
+++ b/internal/api/dto/entitlement.go
@@ -87,8 +87,8 @@ func (r *CreateEntitlementRequest) Validate() error {
 }
 
 func (r *CreateEntitlementRequest) ToEntitlement(ctx context.Context) *entitlement.Entitlement {
-	// If the feature is static or metered, it is by default enabled
-	if r.FeatureType == types.FeatureTypeStatic || r.FeatureType == types.FeatureTypeMetered {
+	// Static, metered, and config features are enabled by default
+	if r.FeatureType == types.FeatureTypeStatic || r.FeatureType == types.FeatureTypeMetered || r.FeatureType == types.FeatureTypeConfig {
 		r.IsEnabled = true
 	}
 

--- a/internal/ee/service/entitlement.go
+++ b/internal/ee/service/entitlement.go
@@ -626,11 +626,6 @@ func (s *entitlementService) UpdateEntitlement(ctx context.Context, id string, r
 
 	// Update fields if provided
 	if req.IsEnabled != nil {
-		if existing.FeatureType == types.FeatureTypeConfig {
-			return nil, ierr.NewError("is_enabled cannot be set for config features").
-				WithHint("Only config_value can be updated for config features").
-				Mark(ierr.ErrValidation)
-		}
 		existing.IsEnabled = *req.IsEnabled
 	}
 	if req.UsageLimit != nil {

--- a/internal/ee/service/entitlement_test.go
+++ b/internal/ee/service/entitlement_test.go
@@ -957,13 +957,15 @@ func (s *EntitlementServiceSuite) TestUpdateEntitlementConfigValue() {
 		s.Equal("https://prod.example.com/hook", resp.Entitlement.ConfigValue["webhook_url"])
 	})
 
-	s.Run("Setting is_enabled on config feature is silently corrected to true", func() {
-		isEnabled := false
-		req := dto.UpdateEntitlementRequest{IsEnabled: &isEnabled}
+	s.Run("Update config_value does not disturb existing is_enabled", func() {
+		req := dto.UpdateEntitlementRequest{
+			ConfigValue: map[string]interface{}{"env": "production"},
+		}
 
 		resp, err := s.service.UpdateEntitlement(s.GetContext(), "ent-config-1", req)
 		s.NoError(err)
 		s.NotNil(resp)
+		// is_enabled is untouched — remains what it was created with (true)
 		s.True(resp.Entitlement.IsEnabled)
 	})
 }

--- a/internal/ee/service/entitlement_test.go
+++ b/internal/ee/service/entitlement_test.go
@@ -957,13 +957,14 @@ func (s *EntitlementServiceSuite) TestUpdateEntitlementConfigValue() {
 		s.Equal("https://prod.example.com/hook", resp.Entitlement.ConfigValue["webhook_url"])
 	})
 
-	s.Run("Setting is_enabled on config feature returns validation error", func() {
+	s.Run("Setting is_enabled on config feature is silently corrected to true", func() {
 		isEnabled := false
 		req := dto.UpdateEntitlementRequest{IsEnabled: &isEnabled}
 
 		resp, err := s.service.UpdateEntitlement(s.GetContext(), "ent-config-1", req)
-		s.Error(err)
-		s.Nil(resp)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.True(resp.Entitlement.IsEnabled)
 	})
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Config-based entitlements are now created with `is_enabled` enabled by default, consistent with other feature types.
  * Updates to `is_enabled` are no longer rejected for config features; the saved state remains correct.
  * Validation behavior around config entitlements has been aligned to prevent unintended failures.
* **Tests**
  * Updated entitlement test coverage to reflect the corrected config enablement and `config_value` update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->