### PR TITLE
fix(docker): keep swagger docs.go in build context (fixes develop build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@
 .idea
 api
 docs
+# but keep the generated swagger Go package — main.go imports it (blank import for swagger docs)
+!docs/swagger/docs.go
 node_modules
 tmp
 bin


### PR DESCRIPTION
## Problem

The `develop` Docker build is failing:

```
cmd/server/main.go:43:2: no required module provides package github.com/flexprice/flexprice/docs/swagger
```

([failing run](https://github.com/flexprice/flexprice/actions/runs/28516839398/job/84530581411))

## Root cause

`.dockerignore` excludes the whole `docs/` dir, but `cmd/server/main.go:43` blank-imports `github.com/flexprice/flexprice/docs/swagger`. The one `.go` file in that package (`docs/swagger/docs.go`, git-tracked) got stripped from the Docker build context, so `go build` fails inside the container. Local builds work because the file is on disk.

Regression from `68ed2f82` (feat(e2eprobe): ship as standalone docker image), which introduced `.dockerignore` with the `docs` line.

## Fix

Re-include just the generated Go file; keep the rest of `docs/` (json/yaml specs) out to keep the build context small.

```
docs
!docs/swagger/docs.go
```

## Verification

Built a throwaway image that `COPY . .` and `ls docs/swagger/docs.go` — file is present after the change (was absent before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker ignore rules to exclude a generated Swagger source file from build contexts, helping keep container builds cleaner and smaller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->