### PR TITLE
feat(meter_usage): add support for expand sources in meter usage analytics

### DIFF
--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -153,6 +153,12 @@ type MeterUsageRepository interface {
 	// mirrors feature_usage's getMaxBucketTotals + getAnalyticsPoints shape.
 	GetUsageForBucketedMetersDetailed(ctx context.Context, params *MeterUsageQueryParams) ([]*MeterUsageDetailedResult, error)
 
+	// GetSourcesForBucketedMeter returns the distinct source values for a bucketed meter
+	// using the same WHERE conditions as GetUsageForBucketedMeters. Used by the analytics
+	// path to populate expand:"source" without polluting MeterUsageQueryParams with an
+	// analytics-only concern.
+	GetSourcesForBucketedMeter(ctx context.Context, params *MeterUsageQueryParams) ([]string, error)
+
 	// GetDistinctMeterIDs returns the set of meter_ids that have data in the meter_usage table
 	// for the given customer(s) and time range. Used to skip meters with zero usage.
 	GetDistinctMeterIDs(ctx context.Context, params *MeterUsageQueryParams) ([]string, error)

--- a/internal/domain/events/repository.go
+++ b/internal/domain/events/repository.go
@@ -204,6 +204,8 @@ type AggregationResult struct {
 	Metadata   map[string]string     `json:"metadata,omitempty"`
 	MeterID    string                `json:"meter_id"`
 	PriceID    string                `json:"price_id"`
+	// Sources holds distinct source values when CollectSources is requested (analytics expand:"source").
+	Sources []string `json:"sources,omitempty"`
 }
 
 type EventIterator struct {

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -120,6 +120,9 @@ type GetSubscriptionMeterUsageRequest struct {
 	GroupBy         []string            // appended after "meter_id"; "meter_id" is always present
 	PropertyFilters map[string][]string // e.g. {"model": ["gpt-4"]}
 	Sources         []string            // event source filter
+	// CollectSources when true fetches distinct source values for bucketed meters
+	// via a secondary query (used when expand:"source" is requested by analytics callers).
+	CollectSources bool
 }
 
 // dateRangeGroup is the key used to batch standard-meter queries that share
@@ -579,7 +582,7 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			bucketedResult, err := s.queryBucketedMeterUsage(
 				ctx, m, externalCustomerIDs,
 				itemStart, itemEnd, req.BillingAnchor, req.UseFinal,
-				req.PropertyFilters, req.Sources,
+				req.PropertyFilters, req.Sources, req.CollectSources,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to query bucketed meter usage for meter %s: %w", meterID, err)
@@ -795,6 +798,7 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	useFinal bool,
 	propertyFilters map[string][]string,
 	sources []string,
+	collectSources bool,
 ) (*events.AggregationResult, error) {
 	aggType := m.Aggregation.Type
 	meterGroupBy := m.Aggregation.GroupBy
@@ -808,7 +812,8 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	if meterGroupBy != "" {
 		paramsGroupBy = []string{"properties." + meterGroupBy}
 	}
-	return s.repo.GetUsageForBucketedMeters(ctx, &events.MeterUsageQueryParams{
+
+	queryParams := &events.MeterUsageQueryParams{
 		TenantID:            types.GetTenantID(ctx),
 		EnvironmentID:       types.GetEnvironmentID(ctx),
 		ExternalCustomerIDs: externalCustomerIDs,
@@ -822,7 +827,23 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 		UseFinal:            useFinal,
 		PropertyFilters:     propertyFilters,
 		Sources:             sources,
-	})
+	}
+
+	result, err := s.repo.GetUsageForBucketedMeters(ctx, queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	if collectSources {
+		sourcesResult, sourcesErr := s.repo.GetSourcesForBucketedMeter(ctx, queryParams)
+		if sourcesErr != nil {
+			s.logger.Warn(ctx, "failed to collect sources for bucketed meter", "error", sourcesErr, "meter_id", m.ID)
+		} else {
+			result.Sources = sourcesResult
+		}
+	}
+
+	return result, nil
 }
 
 // hasUserBucketedGroupBy reports whether the request asks for fan-out on a
@@ -1076,6 +1097,7 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 			GroupBy:         params.GroupBy,
 			PropertyFilters: params.PropertyFilters,
 			Sources:         params.Sources,
+			CollectSources:  lo.Contains(params.Expand, "source"),
 		})
 		if err != nil {
 			s.logger.Info(ctx, "failed to get subscription meter usage, skipping",
@@ -1186,6 +1208,8 @@ func (s *meterUsageService) mergeSubscriptionUsagesToAnalyticsData(
 				analytic.Source = lu.AnalyticsResult.Source
 				analytic.Sources = lu.AnalyticsResult.Sources
 				analytic.Properties = lu.AnalyticsResult.Properties
+			} else if lu.BucketedResult != nil && len(lu.BucketedResult.Sources) > 0 {
+				analytic.Sources = lu.BucketedResult.Sources
 			}
 
 			// Set usage values from the line item usage

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -837,7 +837,7 @@ func (s *meterUsageService) queryBucketedMeterUsage(
 	if collectSources {
 		sourcesResult, sourcesErr := s.repo.GetSourcesForBucketedMeter(ctx, queryParams)
 		if sourcesErr != nil {
-			s.logger.Warn(ctx, "failed to collect sources for bucketed meter", "error", sourcesErr, "meter_id", m.ID)
+			s.logger.Error(ctx, "failed to collect sources for bucketed meter, sources omitted from response", "error", sourcesErr, "meter_id", m.ID)
 		} else {
 			result.Sources = sourcesResult
 		}

--- a/internal/ee/service/meter_usage_test.go
+++ b/internal/ee/service/meter_usage_test.go
@@ -4357,3 +4357,169 @@ func (s *MeterUsageServiceSuite) TestBucketedMeter_FanOutOmitsEmptyPropertyValue
 	s.False(present,
 		"missing property must be omitted from Properties (feature-side parity); got %v", item.Properties)
 }
+
+// ---------------------------------------------------------------------------
+// Sources expand — regression tests for bucketed-meter path (fix/analytics)
+//
+// Root cause: for bucketed meters whose group_by does NOT contain "source" or
+// "properties.*", the non-detailed bucketed path (queryBucketedMeterUsage) was
+// used. That path never queried distinct sources, so lu.BucketedResult.Sources
+// remained nil and expand:"source" silently produced no output.
+// ---------------------------------------------------------------------------
+
+// TestBucketedMeter_ExpandSource_PopulatesSources is the primary regression
+// guard: a bucketed SUM meter (BucketSize set, no "source" in group_by) with
+// expand:"source" must return Sources populated with all distinct source values.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_ExpandSource_PopulatesSources() {
+	ctx := s.GetContext()
+
+	// BucketSize set → IsBucketedSumMeter() = true → non-detailed bucketed path
+	// when "source" is absent from GroupBy (the exact broken scenario).
+	m := &meter.Meter{
+		ID:        "mtr_bkt_src",
+		Name:      "Bucketed SUM sources",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+	p := s.createPriceForMeter(ctx, "pr_bkt_src", m.ID, decimal.NewFromFloat(0.01))
+	s.createLineItemForMeter(ctx, "li_bkt_src", m.ID, p.ID)
+
+	// Two distinct sources contributing to the same bucketed meter.
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "stripe",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, nil)
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "stripe",
+		time.Date(2026, 1, 5, 11, 0, 0, 0, time.UTC), 20, nil)
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "internal",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 5, nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		Expand:             []string{"source"},
+	})
+	s.NoError(err)
+	s.Require().NotEmpty(resp.Items, "expected at least one analytic item")
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_bkt_src" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "analytic item for bucketed line item not found")
+	s.Require().NotEmpty(item.Sources,
+		"expand:source on bucketed meter must populate Sources; got nil/empty")
+	s.True(slices.Contains(item.Sources, "stripe"),
+		"Sources must include 'stripe'; got %v", item.Sources)
+	s.True(slices.Contains(item.Sources, "internal"),
+		"Sources must include 'internal'; got %v", item.Sources)
+}
+
+// TestBucketedMeter_NoExpandSource_EmptySources confirms the secondary sources
+// query is NOT issued when expand:"source" is absent — Sources must be nil.
+func (s *MeterUsageServiceSuite) TestBucketedMeter_NoExpandSource_EmptySources() {
+	ctx := s.GetContext()
+
+	m := &meter.Meter{
+		ID:        "mtr_bkt_nosrc",
+		Name:      "Bucketed SUM no-sources",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+	p := s.createPriceForMeter(ctx, "pr_bkt_nosrc", m.ID, decimal.NewFromFloat(0.01))
+	s.createLineItemForMeter(ctx, "li_bkt_nosrc", m.ID, p.ID)
+
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "stripe",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, nil)
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "internal",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 5, nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		// No Expand → collectSources=false → Sources must remain nil.
+	})
+	s.NoError(err)
+	s.Require().NotEmpty(resp.Items)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_bkt_nosrc" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "analytic item for bucketed line item not found")
+	s.Empty(item.Sources,
+		"Sources must be nil when expand:source is absent; got %v", item.Sources)
+}
+
+// TestStandardMeter_ExpandSource_StillWorks is a regression guard for the
+// non-bucketed path: a standard SUM meter (no BucketSize) with expand:"source"
+// and a GroupBy must return populated Sources. GroupBy is required to trigger
+// the analytics code path (isAnalyticsQuery=true) for non-bucketed meters;
+// without it the request falls through to the scalar billing path that doesn't
+// collect sources — not a bug, just the intended routing.
+func (s *MeterUsageServiceSuite) TestStandardMeter_ExpandSource_StillWorks() {
+	ctx := s.GetContext()
+
+	// No BucketSize → IsBucketedSumMeter() = false → standard analytics path.
+	m := s.createMeterWithAggregation(ctx, "mtr_std_src", "ev_std_src", types.AggregationSum)
+	p := s.createPriceForMeter(ctx, "pr_std_src", m.ID, decimal.NewFromFloat(0.01))
+	s.createLineItemForMeter(ctx, "li_std_src", m.ID, p.ID)
+
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "api", "ev_std_src",
+		time.Date(2026, 1, 5, 10, 0, 0, 0, time.UTC), 10, "", nil)
+	s.insertMeterUsageFull(ctx, m.ID, s.customer.ExternalID, "sdk", "ev_std_src",
+		time.Date(2026, 1, 6, 10, 0, 0, 0, time.UTC), 20, "", nil)
+
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		MeterIDs:           []string{m.ID},
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		// GroupBy triggers isAnalyticsQuery=true so the GetDetailedAnalytics
+		// repo path is used (which collects sources). Real callers of
+		// expand:source always pair it with a group_by.
+		GroupBy: []string{"meter_id"},
+		Expand:  []string{"source"},
+	})
+	s.NoError(err)
+	s.Require().NotEmpty(resp.Items)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_std_src" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "analytic item for standard meter not found")
+	s.Require().NotEmpty(item.Sources,
+		"expand:source on standard (non-bucketed) meter must still populate Sources; got nil/empty")
+	s.True(slices.Contains(item.Sources, "api"),
+		"Sources must include 'api'; got %v", item.Sources)
+	s.True(slices.Contains(item.Sources, "sdk"),
+		"Sources must include 'sdk'; got %v", item.Sources)
+}

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -344,6 +344,27 @@ func (r *MeterUsageRepository) GetUsageForBucketedMeters(ctx context.Context, pa
 	return &result, nil
 }
 
+// GetSourcesForBucketedMeter returns distinct source values for a bucketed meter using
+// the same WHERE conditions as GetUsageForBucketedMeters. Called by the analytics service
+// layer when expand:"source" is requested, keeping MeterUsageQueryParams free of analytics concerns.
+func (r *MeterUsageRepository) GetSourcesForBucketedMeter(ctx context.Context, params *events.MeterUsageQueryParams) ([]string, error) {
+	if params == nil {
+		return nil, ierr.NewError("params are required").Mark(ierr.ErrValidation)
+	}
+
+	where, args := r.qb.BuildWhereClause(params)
+	query := fmt.Sprintf("SELECT groupUniqArray(source) FROM meter_usage WHERE %s", where)
+
+	var sources []string
+	if err := r.store.GetConn().QueryRow(ctx, query, args...).Scan(&sources); err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to collect distinct sources for bucketed meter").
+			WithReportableDetails(map[string]interface{}{"meter_id": params.MeterID}).
+			Mark(ierr.ErrDatabase)
+	}
+	return sources, nil
+}
+
 // GetUsageForBucketedMetersDetailed runs the analytics-side bucketed query:
 // 1) the aggregate query returns one row per (source, properties) combo with
 // per-combo TotalUsage / EventCount; 2) for each combo, a follow-up query

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -762,6 +762,27 @@ func (s *InMemoryMeterUsageStore) GetDistinctMeterIDs(_ context.Context, params 
 	return ids, nil
 }
 
+func (s *InMemoryMeterUsageStore) GetSourcesForBucketedMeter(_ context.Context, params *events.MeterUsageQueryParams) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	seen := make(map[string]struct{})
+	for _, r := range s.records {
+		if !matchRecord(r, params) {
+			continue
+		}
+		if r.Source != "" {
+			seen[r.Source] = struct{}{}
+		}
+	}
+	sources := make([]string, 0, len(seen))
+	for src := range seen {
+		sources = append(sources, src)
+	}
+	sort.Strings(sources)
+	return sources, nil
+}
+
 // ---------------------------------------------------------------------------
 // GetDetailedAnalytics
 // ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics for bucketed meter usage can now optionally return distinct `source` values when expanding with `source`.
  * Added support for supplying these sources alongside bucketed usage results.
* **Bug Fixes**
  * Improved analytics merging to retain and populate `source` values when detailed analytics payloads are missing.
* **Tests**
  * Added regression coverage for `expand:source` behavior across bucketed and non-bucketed meter scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->