### PR TITLE
fix(stripe): preserve original quantity in invoice line item

### DIFF
--- a/internal/domain/invoice/line_item.go
+++ b/internal/domain/invoice/line_item.go
@@ -1,6 +1,7 @@
 package invoice
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/flexprice/flexprice/ent"
@@ -155,6 +156,27 @@ func (i *InvoiceLineItem) Validate() error {
 	}
 
 	return nil
+}
+
+// GetDescription builds a human-readable description for this line item,
+// falling back through DisplayName, PlanDisplayName and MeterDisplayName.
+// When the quantity is not 1, it is appended to the description so that
+// integrations which can only sync an amount (e.g. Stripe, which sends
+// Amount instead of Quantity) don't lose the original quantity.
+func (i *InvoiceLineItem) GetDescription() string {
+	name := lo.FromPtr(i.DisplayName)
+	if name == "" {
+		name = lo.FromPtr(i.PlanDisplayName)
+	}
+	if name == "" {
+		name = lo.FromPtr(i.MeterDisplayName)
+	}
+
+	if i.Quantity.Equal(decimal.NewFromInt(1)) {
+		return name
+	}
+
+	return fmt.Sprintf("%s (Qty: %s)", name, i.Quantity.String())
 }
 
 // LineItemFromEnt converts an Ent InvoiceLineItem to the domain model.

--- a/internal/integration/stripe/invoice_sync.go
+++ b/internal/integration/stripe/invoice_sync.go
@@ -261,7 +261,7 @@ func (s *InvoiceSyncService) addLineItemToStripeInvoice(ctx context.Context, str
 		Customer:    stripe.String(customerID),
 		Invoice:     stripe.String(stripeInvoiceID),
 		Currency:    stripe.String(strings.ToLower(lineItem.Currency)),
-		Description: stripe.String(lo.FromPtr(lineItem.DisplayName)),
+		Description: stripe.String(lineItem.GetDescription()),
 		Metadata: map[string]string{
 			"flexprice_line_item_id": lineItem.ID,
 			"flexprice_price_id":     lo.FromPtr(lineItem.PriceID),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice line items now show clearer descriptions using the best available name.
  * Quantities are included in descriptions when more than one item is billed.

* **Bug Fixes**
  * Improved how invoice item descriptions are sent to billing, helping ensure more accurate and readable invoice details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->