### PR TITLE
feat(migrate): add ClickHouse migration runner to migrate binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ ENV CGO_ENABLED=0 \
     GOOS=linux
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o server cmd/server/main.go && \
-    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o migrate cmd/migrate/main.go
+    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o server ./cmd/server && \
+    GOARCH=$TARGETARCH go build -ldflags="-w -s" -trimpath -o migrate ./cmd/migrate
 
 # Typst stage
 FROM ghcr.io/typst/typst:v0.13.1 AS typst

--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	clickhouse_go "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/flexprice/flexprice/internal/config"
+)
+
+// runClickHouseMigrations applies every migrations/clickhouse/*.sql file (in
+// filename order) against ClickHouse. All statements use `IF NOT EXISTS`, so
+// re-runs are idempotent and no migration-tracking table is needed.
+//
+// It ensures the target database exists first, then executes each statement in
+// each file individually (the native protocol runs one statement per Exec).
+func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir string) error {
+	opts := cfg.ClickHouse.GetClientOptions()
+	db := cfg.ClickHouse.Database
+
+	// Connect without pinning a database so we can CREATE DATABASE if missing.
+	bootstrap := *opts
+	bootstrap.Auth.Database = "default"
+	conn, err := clickhouse_go.Open(&bootstrap)
+	if err != nil {
+		return fmt.Errorf("open clickhouse: %w", err)
+	}
+	defer conn.Close()
+
+	if err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)); err != nil {
+		return fmt.Errorf("create database %q: %w", db, err)
+	}
+	conn.Close()
+
+	// Reconnect scoped to the target database so unqualified names resolve.
+	dbConn, err := clickhouse_go.Open(opts)
+	if err != nil {
+		return fmt.Errorf("open clickhouse (db=%s): %w", db, err)
+	}
+	defer dbConn.Close()
+
+	files, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	if err != nil {
+		return fmt.Errorf("glob %s: %w", dir, err)
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		return fmt.Errorf("no .sql files found in %s", dir)
+	}
+
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", f, err)
+		}
+		for i, stmt := range splitSQL(string(raw)) {
+			if err := dbConn.Exec(ctx, stmt); err != nil {
+				return fmt.Errorf("%s statement %d: %w\n---\n%s", filepath.Base(f), i+1, err, stmt)
+			}
+		}
+		fmt.Printf(">>> applied %s\n", filepath.Base(f))
+	}
+	return nil
+}
+
+// splitSQL strips `--` line comments and `/* */` block comments, then splits on
+// `;` into individual statements. The CH migration files contain no semicolons
+// inside string literals, so a literal-aware scanner is unnecessary. Empty
+// statements are dropped.
+func splitSQL(sql string) []string {
+	var b strings.Builder
+	for i := 0; i < len(sql); i++ {
+		// Block comment /* ... */
+		if i+1 < len(sql) && sql[i] == '/' && sql[i+1] == '*' {
+			end := strings.Index(sql[i+2:], "*/")
+			if end < 0 {
+				break // unterminated; ignore remainder
+			}
+			i += end + 3
+			continue
+		}
+		// Line comment -- ... \n
+		if i+1 < len(sql) && sql[i] == '-' && sql[i+1] == '-' {
+			nl := strings.IndexByte(sql[i:], '\n')
+			if nl < 0 {
+				break
+			}
+			i += nl
+			b.WriteByte('\n')
+			continue
+		}
+		b.WriteByte(sql[i])
+	}
+
+	var out []string
+	for _, part := range strings.Split(b.String(), ";") {
+		if s := strings.TrimSpace(part); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
 	clickhouse_go "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/logger"
 )
+
+// validCHIdent guards database identifiers interpolated into DDL. ClickHouse
+// does not support parameterized identifiers, so an allowlist is the only way
+// to keep a misconfigured value from producing broken/unexpected DDL.
+var validCHIdent = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // runClickHouseMigrations applies every migrations/clickhouse/*.sql file (in
 // filename order) against ClickHouse. All statements use `IF NOT EXISTS`, so
@@ -18,9 +25,13 @@ import (
 //
 // It ensures the target database exists first, then executes each statement in
 // each file individually (the native protocol runs one statement per Exec).
-func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir string) error {
+func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir string, log *logger.Logger) error {
 	opts := cfg.ClickHouse.GetClientOptions()
 	db := cfg.ClickHouse.Database
+
+	if !validCHIdent.MatchString(db) {
+		return fmt.Errorf("invalid clickhouse database name %q", db)
+	}
 
 	// Connect without pinning a database so we can CREATE DATABASE if missing.
 	bootstrap := *opts
@@ -57,21 +68,34 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 		if err != nil {
 			return fmt.Errorf("read %s: %w", f, err)
 		}
-		for i, stmt := range splitSQL(string(raw)) {
+		stmts, err := splitSQL(string(raw))
+		if err != nil {
+			return fmt.Errorf("split %s: %w", filepath.Base(f), err)
+		}
+		for i, stmt := range stmts {
 			if err := dbConn.Exec(ctx, stmt); err != nil {
 				return fmt.Errorf("%s statement %d: %w\n---\n%s", filepath.Base(f), i+1, err, stmt)
 			}
 		}
-		fmt.Printf(">>> applied %s\n", filepath.Base(f))
+		log.Info(ctx, "applied clickhouse migration", "file", filepath.Base(f))
 	}
 	return nil
 }
 
 // splitSQL strips `--` line comments and `/* */` block comments, then splits on
-// `;` into individual statements. The CH migration files contain no semicolons
-// inside string literals, so a literal-aware scanner is unnecessary. Empty
-// statements are dropped.
-func splitSQL(sql string) []string {
+// `;` into individual statements. Empty statements are dropped.
+//
+// It is NOT a literal-aware scanner: it does not treat `;`, `--`, or `/* */`
+// specially when they appear inside a quoted string literal. The current CH
+// migration set contains none, so this is safe today. To keep that assumption
+// honest for future authors, splitSQL fails loudly (returns an error) if it
+// detects any of those sequences inside a `'`- or `` ` ``-quoted literal rather
+// than silently mis-splitting or truncating a statement.
+func splitSQL(sql string) ([]string, error) {
+	if err := checkNoMarkersInLiterals(sql); err != nil {
+		return nil, err
+	}
+
 	var b strings.Builder
 	for i := 0; i < len(sql); i++ {
 		// Block comment /* ... */
@@ -102,5 +126,45 @@ func splitSQL(sql string) []string {
 			out = append(out, s)
 		}
 	}
-	return out
+	return out, nil
+}
+
+// checkNoMarkersInLiterals scans for `;`, `--`, and `/* */` occurring inside a
+// single-quoted or backtick-quoted literal, returning an error if found. This
+// guards the non-literal-aware splitSQL against silent mis-splitting. `''` and
+// backslash escapes inside single quotes are handled so escaped quotes don't
+// prematurely close a literal.
+func checkNoMarkersInLiterals(sql string) error {
+	for i := 0; i < len(sql); i++ {
+		c := sql[i]
+		if c != '\'' && c != '`' {
+			continue
+		}
+		quote := c
+		i++
+		for i < len(sql) {
+			if quote == '\'' && sql[i] == '\\' {
+				i += 2 // skip escaped char
+				continue
+			}
+			if sql[i] == quote {
+				// doubled quote ('' or ``) = escaped quote, stay in literal
+				if i+1 < len(sql) && sql[i+1] == quote {
+					i += 2
+					continue
+				}
+				break // closing quote
+			}
+			switch {
+			case sql[i] == ';':
+				return fmt.Errorf("splitSQL: %q inside a string literal is not supported", ";")
+			case sql[i] == '-' && i+1 < len(sql) && sql[i+1] == '-':
+				return fmt.Errorf("splitSQL: %q inside a string literal is not supported", "--")
+			case sql[i] == '/' && i+1 < len(sql) && sql[i+1] == '*':
+				return fmt.Errorf("splitSQL: %q inside a string literal is not supported", "/*")
+			}
+			i++
+		}
+	}
+	return nil
 }

--- a/cmd/migrate/clickhouse_test.go
+++ b/cmd/migrate/clickhouse_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitSQL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "line comments stripped, split on semicolon",
+			in:   "-- a comment\nCREATE TABLE IF NOT EXISTS x (a Int8);\n-- another\nALTER TABLE x ADD INDEX IF NOT EXISTS i a TYPE minmax GRANULARITY 1;",
+			want: []string{"CREATE TABLE IF NOT EXISTS x (a Int8)", "ALTER TABLE x ADD INDEX IF NOT EXISTS i a TYPE minmax GRANULARITY 1"},
+		},
+		{
+			name: "block comment stripped",
+			in:   "/* header\nmulti line */ CREATE TABLE y (a Int8);",
+			want: []string{"CREATE TABLE y (a Int8)"},
+		},
+		{
+			name: "trailing empty statement dropped",
+			in:   "SELECT 1;   \n  ;",
+			want: []string{"SELECT 1"},
+		},
+		{
+			name: "no trailing semicolon still yields statement",
+			in:   "CREATE TABLE z (a Int8)",
+			want: []string{"CREATE TABLE z (a Int8)"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := splitSQL(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("splitSQL()\n got=%#v\nwant=%#v", got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/migrate/clickhouse_test.go
+++ b/cmd/migrate/clickhouse_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestSplitSQL(t *testing.T) {
 	cases := []struct {
-		name string
-		in   string
-		want []string
+		name    string
+		in      string
+		want    []string
+		wantErr bool
 	}{
 		{
 			name: "line comments stripped, split on semicolon",
@@ -31,10 +32,49 @@ func TestSplitSQL(t *testing.T) {
 			in:   "CREATE TABLE z (a Int8)",
 			want: []string{"CREATE TABLE z (a Int8)"},
 		},
+		{
+			name: "plain string literal without markers is fine",
+			in:   "SELECT 'hello world';",
+			want: []string{"SELECT 'hello world'"},
+		},
+		{
+			name: "escaped and doubled quotes stay in literal",
+			in:   "SELECT 'a''b', 'c\\'d';",
+			want: []string{"SELECT 'a''b', 'c\\'d'"},
+		},
+		{
+			name:    "semicolon inside literal fails loudly",
+			in:      "SELECT 'a;b';",
+			wantErr: true,
+		},
+		{
+			name:    "line comment marker inside literal fails loudly",
+			in:      "SELECT 'a -- b';",
+			wantErr: true,
+		},
+		{
+			name:    "block comment marker inside literal fails loudly",
+			in:      "SELECT 'a /* b';",
+			wantErr: true,
+		},
+		{
+			name:    "marker inside backtick identifier fails loudly",
+			in:      "SELECT `a;b`;",
+			wantErr: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := splitSQL(c.in)
+			got, err := splitSQL(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("splitSQL() expected error, got nil (out=%#v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitSQL() unexpected error: %v", err)
+			}
 			if !reflect.DeepEqual(got, c.want) {
 				t.Fatalf("splitSQL()\n got=%#v\nwant=%#v", got, c.want)
 			}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -36,10 +36,13 @@ func main() {
 
 	// ClickHouse migrations: separate path, idempotent .sql files.
 	if *clickhouse {
+		if *dryRun {
+			log.Fatalf("-dry-run is not supported with -clickhouse")
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeout)*time.Second)
 		defer cancel()
 		logger.Info(ctx, "Running ClickHouse migrations...", "address", cfg.ClickHouse.Address, "database", cfg.ClickHouse.Database)
-		if err := runClickHouseMigrations(ctx, cfg, *chDir); err != nil {
+		if err := runClickHouseMigrations(ctx, cfg, *chDir, logger); err != nil {
 			logger.Fatal(ctx, "ClickHouse migration failed", "error", err)
 		}
 		logger.Info(ctx, "ClickHouse migrations completed successfully")

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -18,6 +18,8 @@ func main() {
 	// Parse command line flags
 	dryRun := flag.Bool("dry-run", false, "Print migration SQL without executing it")
 	timeout := flag.Int("timeout", 300, "Timeout in seconds for the migration")
+	clickhouse := flag.Bool("clickhouse", false, "Run ClickHouse migrations (migrations/clickhouse/*.sql) instead of Postgres")
+	chDir := flag.String("clickhouse-dir", "migrations/clickhouse", "Directory of ClickHouse .sql migration files")
 	flag.Parse()
 
 	// Load configuration
@@ -30,6 +32,19 @@ func main() {
 	logger, err := logger.NewLogger(cfg)
 	if err != nil {
 		log.Fatalf("Failed to create logger: %v", err)
+	}
+
+	// ClickHouse migrations: separate path, idempotent .sql files.
+	if *clickhouse {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeout)*time.Second)
+		defer cancel()
+		logger.Info(ctx, "Running ClickHouse migrations...", "address", cfg.ClickHouse.Address, "database", cfg.ClickHouse.Database)
+		if err := runClickHouseMigrations(ctx, cfg, *chDir); err != nil {
+			logger.Fatal(ctx, "ClickHouse migration failed", "error", err)
+		}
+		logger.Info(ctx, "ClickHouse migrations completed successfully")
+		fmt.Println("Migration process completed")
+		return
 	}
 
 	// Get DSN from config

--- a/migrations/clickhouse/000006_create_raw_events.sql
+++ b/migrations/clickhouse/000006_create_raw_events.sql
@@ -1,4 +1,4 @@
-CREATE TABLE flexprice.raw_events
+CREATE TABLE IF NOT EXISTS flexprice.raw_events
 (
     `id` String,
     `tenant_id` String,


### PR DESCRIPTION
## What

Adds a `-clickhouse` flag to `cmd/migrate` that applies `migrations/clickhouse/*.sql` against ClickHouse using the `clickhouse-go` driver already linked into the image. A single Fargate task (same image) can now run **both** migration types:

- `./migrate`              → Postgres (Ent, unchanged)
- `./migrate -clickhouse`  → ClickHouse

## Why

There was no ClickHouse migration runner in the image — CH schema was applied ad-hoc via `clickhouse client` bash scripts. We need CH migrations to run from a one-shot ECS/Fargate task in BYOC deployments. Shipping an external `clickhouse` binary is not viable: the clickhouse-server image binary is glibc-linked and won't run on the musl `alpine` runtime. Reusing the already-compiled `clickhouse-go` driver is smaller and portable.

## Changes

- **New `cmd/migrate/clickhouse.go`** — ensures the target database exists, then executes each statement of each `.sql` file in filename order. `splitSQL` strips `--` line and `/* */` block comments and splits on `;` (the migration files contain no `;` inside string literals).
- **`cmd/migrate/clickhouse_test.go`** — unit tests for `splitSQL`.
- **Idempotency fix** — `migrations/clickhouse/000006_create_raw_events.sql`: add `IF NOT EXISTS` to the `raw_events` `CREATE TABLE` (the only non-idempotent statement across the 9 files). Re-runs are now safe with no migration-tracking table.
- **Dockerfile** — build `./cmd/server` and `./cmd/migrate` as packages (were single-file `main.go` builds) so the new file compiles. Server binary is functionally identical; `CMD ["./server"]` unchanged.

## Verification (local)

- Fresh ClickHouse → applies all 9 files → 11 objects (9 tables + agg table + MV).
- Second run → clean no-op, exit 0, object count unchanged (idempotent).
- `go test ./cmd/migrate/` passes; `go vet` clean.
- Image boots `./server` (Fx DI starts) — main service unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ClickHouse migration mode with `--clickhouse` and `--clickhouse-dir`.
  * Supports auto-creating the target ClickHouse database and applying ClickHouse SQL files in order.
* **Bug Fixes**
  * Improved SQL splitting to ignore comments and prevent unsafe semicolon/comment markers inside literals.
  * Updated the raw events table creation to use `IF NOT EXISTS`.
* **Tests**
  * Added SQL-splitting test coverage, including comment/semicolon handling and literal-safety error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->