### PR TITLE
test(billing): billing.go 59→83%, billing_meter_usage.go 0→84%

### DIFF
--- a/internal/ee/service/billing_meter_usage_test.go
+++ b/internal/ee/service/billing_meter_usage_test.go
@@ -1,0 +1,973 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/domain/meter"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// BillingMeterUsageSuite exercises the meter_usage-backed billing path
+// (billing_meter_usage.go): CalculateMeterUsageCharges and its helpers, plus
+// the calculateMeterUsageCharges / calculateAllMeterUsageCharges pipeline.
+//
+// All fixtures use fixed dates so window bucketing (daily / monthly) is
+// deterministic and independent of wall-clock time.
+type BillingMeterUsageSuite struct {
+	testutil.BaseServiceTestSuite
+	service   BillingService
+	billing   *billingService
+	usageRepo *testutil.InMemoryMeterUsageStore
+	data      struct {
+		customer    *customer.Customer
+		plan        *plan.Plan
+		meterSum    *meter.Meter
+		meterBucket *meter.Meter
+		feature     *feature.Feature
+		priceSum    *price.Price
+		priceBucket *price.Price
+		priceFixed  *price.Price
+		sub         *subscription.Subscription
+		usageItem   *subscription.SubscriptionLineItem
+		bucketItem  *subscription.SubscriptionLineItem
+		fixedItem   *subscription.SubscriptionLineItem
+		periodStart time.Time
+		periodEnd   time.Time
+	}
+}
+
+func TestBillingMeterUsage(t *testing.T) {
+	suite.Run(t, new(BillingMeterUsageSuite))
+}
+
+func (s *BillingMeterUsageSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.usageRepo = s.GetStores().MeterUsageRepo.(*testutil.InMemoryMeterUsageStore)
+	s.service = NewBillingService(newTestServiceParams(&s.BaseServiceTestSuite))
+	s.billing = s.service.(*billingService)
+	s.setupTestData()
+}
+
+func (s *BillingMeterUsageSuite) setupTestData() {
+	ctx := s.GetContext()
+
+	s.data.periodStart = time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	s.data.periodEnd = time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
+
+	s.data.customer = &customer.Customer{
+		ID:         "cust_bmu",
+		ExternalID: "ext_bmu",
+		Name:       "BMU Customer",
+		Email:      "bmu@test.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, s.data.customer))
+
+	s.data.plan = &plan.Plan{
+		ID:        "plan_bmu",
+		Name:      "BMU Plan",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, s.data.plan))
+
+	s.data.meterSum = &meter.Meter{
+		ID:        "meter_bmu_sum",
+		Name:      "BMU Sum Meter",
+		EventName: "bmu_event",
+		Aggregation: meter.Aggregation{
+			Type:  types.AggregationSum,
+			Field: "qty",
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, s.data.meterSum))
+
+	s.data.meterBucket = &meter.Meter{
+		ID:        "meter_bmu_bucket",
+		Name:      "BMU Bucketed Meter",
+		EventName: "bmu_bucket_event",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationMax,
+			Field:      "qty",
+			BucketSize: types.WindowSizeDay,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, s.data.meterBucket))
+
+	s.data.feature = &feature.Feature{
+		ID:        "feat_bmu_sum",
+		Name:      "BMU Sum Feature",
+		Type:      types.FeatureTypeMetered,
+		MeterID:   s.data.meterSum.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, s.data.feature))
+
+	// Tiered slab price: $0.02/unit up to 1000, $0.01 after.
+	upTo1000 := uint64(1000)
+	s.data.priceSum = &price.Price{
+		ID:                 "price_bmu_sum",
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.data.plan.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_TIERED,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		TierMode:           types.BILLING_TIER_SLAB,
+		MeterID:            s.data.meterSum.ID,
+		Tiers: []price.PriceTier{
+			{UpTo: &upTo1000, UnitAmount: decimal.RequireFromString("0.02")},
+			{UpTo: nil, UnitAmount: decimal.RequireFromString("0.01")},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.data.priceSum))
+
+	s.data.priceBucket = &price.Price{
+		ID:                 "price_bmu_bucket",
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.data.plan.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_TIERED,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		TierMode:           types.BILLING_TIER_SLAB,
+		MeterID:            s.data.meterBucket.ID,
+		Tiers: []price.PriceTier{
+			{UpTo: &upTo1000, UnitAmount: decimal.RequireFromString("0.02")},
+			{UpTo: nil, UnitAmount: decimal.RequireFromString("0.01")},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.data.priceBucket))
+
+	s.data.priceFixed = &price.Price{
+		ID:                 "price_bmu_fixed",
+		Amount:             decimal.NewFromInt(5),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.data.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, s.data.priceFixed))
+
+	startDate := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	s.data.sub = &subscription.Subscription{
+		ID:                 "sub_bmu",
+		PlanID:             s.data.plan.ID,
+		CustomerID:         s.data.customer.ID,
+		StartDate:          startDate,
+		BillingAnchor:      s.data.periodStart,
+		CurrentPeriodStart: s.data.periodStart,
+		CurrentPeriodEnd:   s.data.periodEnd,
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+
+	s.data.usageItem = &subscription.SubscriptionLineItem{
+		ID:               "li_bmu_sum",
+		SubscriptionID:   s.data.sub.ID,
+		CustomerID:       s.data.customer.ID,
+		EntityID:         s.data.plan.ID,
+		EntityType:       types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName:  s.data.plan.Name,
+		PriceID:          s.data.priceSum.ID,
+		PriceType:        types.PRICE_TYPE_USAGE,
+		MeterID:          s.data.meterSum.ID,
+		MeterDisplayName: s.data.meterSum.Name,
+		DisplayName:      "Sum Usage",
+		Quantity:         decimal.Zero,
+		Currency:         "usd",
+		BillingPeriod:    types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:   types.InvoiceCadenceArrear,
+		StartDate:        startDate,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	s.data.bucketItem = &subscription.SubscriptionLineItem{
+		ID:               "li_bmu_bucket",
+		SubscriptionID:   s.data.sub.ID,
+		CustomerID:       s.data.customer.ID,
+		EntityID:         s.data.plan.ID,
+		EntityType:       types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName:  s.data.plan.Name,
+		PriceID:          s.data.priceBucket.ID,
+		PriceType:        types.PRICE_TYPE_USAGE,
+		MeterID:          s.data.meterBucket.ID,
+		MeterDisplayName: s.data.meterBucket.Name,
+		DisplayName:      "Bucketed Usage",
+		Quantity:         decimal.Zero,
+		Currency:         "usd",
+		BillingPeriod:    types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:   types.InvoiceCadenceArrear,
+		StartDate:        startDate,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	s.data.fixedItem = &subscription.SubscriptionLineItem{
+		ID:              "li_bmu_fixed",
+		SubscriptionID:  s.data.sub.ID,
+		CustomerID:      s.data.customer.ID,
+		EntityID:        s.data.plan.ID,
+		EntityType:      types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName: s.data.plan.Name,
+		PriceID:         s.data.priceFixed.ID,
+		PriceType:       types.PRICE_TYPE_FIXED,
+		DisplayName:     "Fixed Fee",
+		Quantity:        decimal.NewFromInt(1),
+		Currency:        "usd",
+		BillingPeriod:   types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:  types.InvoiceCadenceArrear,
+		StartDate:       startDate,
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, s.data.sub,
+		[]*subscription.SubscriptionLineItem{s.data.usageItem, s.data.fixedItem, s.data.bucketItem}))
+	s.data.sub.LineItems = []*subscription.SubscriptionLineItem{s.data.usageItem, s.data.fixedItem, s.data.bucketItem}
+}
+
+// insertMeterUsage seeds one meter_usage row.
+func (s *BillingMeterUsageSuite) insertMeterUsage(meterID, eventName string, ts time.Time, qty float64) {
+	ctx := s.GetContext()
+	s.NoError(s.usageRepo.BulkInsertMeterUsage(ctx, []*events.MeterUsage{
+		{
+			Event: events.Event{
+				ID:                 types.GenerateUUID(),
+				TenantID:           types.GetTenantID(ctx),
+				EnvironmentID:      types.GetEnvironmentID(ctx),
+				ExternalCustomerID: s.data.customer.ExternalID,
+				EventName:          eventName,
+				Timestamp:          ts,
+			},
+			MeterID:  meterID,
+			QtyTotal: decimal.NewFromFloat(qty),
+		},
+	}))
+}
+
+// createEntitlement creates a plan-level metered entitlement for the sum meter feature.
+func (s *BillingMeterUsageSuite) createEntitlement(id string, limit *int64, reset types.EntitlementUsageResetPeriod) {
+	ent := &entitlement.Entitlement{
+		ID:               id,
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         s.data.plan.ID,
+		FeatureID:        s.data.feature.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       limit,
+		UsageResetPeriod: reset,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(s.GetContext(), ent)
+	s.NoError(err)
+}
+
+// usageWithCharge builds a GetUsageBySubscriptionResponse carrying a single charge.
+func usageWithCharge(charge *dto.SubscriptionUsageByMetersResponse) *dto.GetUsageBySubscriptionResponse {
+	return &dto.GetUsageBySubscriptionResponse{
+		Charges: []*dto.SubscriptionUsageByMetersResponse{charge},
+	}
+}
+
+func (s *BillingMeterUsageSuite) sumCharge(qty float64) *dto.SubscriptionUsageByMetersResponse {
+	return &dto.SubscriptionUsageByMetersResponse{
+		SubscriptionLineItemID: s.data.usageItem.ID,
+		MeterID:                s.data.meterSum.ID,
+		MeterDisplayName:       s.data.meterSum.Name,
+		Quantity:               qty,
+		Currency:               "usd",
+		Price:                  s.data.priceSum,
+	}
+}
+
+// subWithItems returns a shallow copy of the base subscription restricted to
+// the given line items — so tests never mutate the shared fixture.
+func (s *BillingMeterUsageSuite) subWithItems(items ...*subscription.SubscriptionLineItem) *subscription.Subscription {
+	subCopy := *s.data.sub
+	subCopy.LineItems = items
+	return &subCopy
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_Basics() {
+	ctx := s.GetContext()
+	ps, pe := s.data.periodStart, s.data.periodEnd
+
+	testCases := []struct {
+		name          string
+		usage         *dto.GetUsageBySubscriptionResponse
+		expectedLen   int
+		expectedTotal decimal.Decimal
+		validate      func(charges []dto.CreateInvoiceLineItemRequest)
+	}{
+		{
+			name:          "nil_usage_returns_no_charges_and_zero_total",
+			usage:         nil,
+			expectedLen:   0,
+			expectedTotal: decimal.Zero,
+		},
+		{
+			name: "charge_for_unknown_line_item_is_skipped",
+			usage: usageWithCharge(&dto.SubscriptionUsageByMetersResponse{
+				SubscriptionLineItemID: "li_does_not_exist",
+				MeterID:                s.data.meterSum.ID,
+				Quantity:               100,
+				Price:                  s.data.priceSum,
+			}),
+			expectedLen:   0,
+			expectedTotal: decimal.Zero,
+		},
+		{
+			name: "charge_without_price_keeps_provided_amount",
+			usage: usageWithCharge(&dto.SubscriptionUsageByMetersResponse{
+				SubscriptionLineItemID: s.data.usageItem.ID,
+				MeterID:                s.data.meterSum.ID,
+				Quantity:               100,
+				Amount:                 7.5,
+			}),
+			expectedLen:   1,
+			expectedTotal: decimal.RequireFromString("7.5"),
+			validate: func(charges []dto.CreateInvoiceLineItemRequest) {
+				s.True(charges[0].Amount.Equal(decimal.RequireFromString("7.5")))
+				s.True(charges[0].Quantity.Equal(decimal.NewFromInt(100)))
+			},
+		},
+		{
+			name: "recalculates_amount_from_price_when_no_entitlement",
+			usage: usageWithCharge(func() *dto.SubscriptionUsageByMetersResponse {
+				c := s.sumCharge(500)
+				c.Amount = 999 // deliberately wrong; must be recomputed as 500 * $0.02
+				return c
+			}()),
+			expectedLen:   1,
+			expectedTotal: decimal.NewFromInt(10),
+			validate: func(charges []dto.CreateInvoiceLineItemRequest) {
+				c := charges[0]
+				s.True(c.Amount.Equal(decimal.NewFromInt(10)), "amount should be 500 * 0.02 = 10, got %s", c.Amount)
+				s.True(c.Quantity.Equal(decimal.NewFromInt(500)))
+				s.Equal("Sum Usage (Usage Charge)", c.Metadata["description"])
+				s.Equal(s.data.priceSum.ID, lo.FromPtr(c.PriceID))
+				s.Equal(s.data.meterSum.ID, lo.FromPtr(c.MeterID))
+				s.True(ps.Equal(lo.FromPtr(c.PeriodStart)))
+				s.True(pe.Equal(lo.FromPtr(c.PeriodEnd)))
+				s.Nil(c.AdjustedEntitlementQuantity)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			charges, total, err := s.billing.CalculateMeterUsageCharges(
+				ctx, s.subWithItems(s.data.usageItem), tc.usage, ps, pe, types.UsageSourceInvoiceCreation)
+			s.NoError(err)
+			s.Len(charges, tc.expectedLen)
+			s.True(total.Equal(tc.expectedTotal), "expected total %s, got %s", tc.expectedTotal, total)
+			if tc.validate != nil {
+				tc.validate(charges)
+			}
+		})
+	}
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_MeterNotFoundReturnsError() {
+	ctx := s.GetContext()
+	missingMeterItem := &subscription.SubscriptionLineItem{
+		ID:             "li_bmu_missing_meter",
+		SubscriptionID: s.data.sub.ID,
+		PriceID:        s.data.priceSum.ID,
+		PriceType:      types.PRICE_TYPE_USAGE,
+		MeterID:        "meter_missing",
+		DisplayName:    "Missing Meter",
+		Currency:       "usd",
+		StartDate:      s.data.sub.StartDate,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	usage := usageWithCharge(&dto.SubscriptionUsageByMetersResponse{
+		SubscriptionLineItemID: missingMeterItem.ID,
+		MeterID:                "meter_missing",
+		Quantity:               10,
+		Price:                  s.data.priceSum,
+	})
+
+	charges, _, err := s.billing.CalculateMeterUsageCharges(
+		ctx, s.subWithItems(missingMeterItem), usage, s.data.periodStart, s.data.periodEnd,
+		types.UsageSourceInvoiceCreation)
+	s.Error(err)
+	s.Nil(charges)
+	s.ErrorContains(err, "meter not found")
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_EntitlementBillingPeriodReset() {
+	ctx := s.GetContext()
+	// Reset period == billing period (MONTHLY): billable = usage - allowance.
+	s.createEntitlement("ent_bmu_bp", lo.ToPtr(int64(200)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+	charges, total, err := s.billing.CalculateMeterUsageCharges(
+		ctx, s.subWithItems(s.data.usageItem), usageWithCharge(s.sumCharge(500)),
+		s.data.periodStart, s.data.periodEnd, types.UsageSourceInvoiceCreation)
+	s.NoError(err)
+	s.Len(charges, 1)
+
+	// billable = 500 - 200 = 300 → 300 * $0.02 = $6
+	s.True(charges[0].Quantity.Equal(decimal.NewFromInt(300)), "quantity should be 300, got %s", charges[0].Quantity)
+	s.True(charges[0].Amount.Equal(decimal.NewFromInt(6)), "amount should be 6, got %s", charges[0].Amount)
+	s.True(total.Equal(decimal.NewFromInt(6)))
+	s.NotNil(charges[0].AdjustedEntitlementQuantity)
+	s.True(charges[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(200)),
+		"adjusted entitlement quantity should be 200, got %s", charges[0].AdjustedEntitlementQuantity)
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_EntitlementUnlimitedZeroesCharge() {
+	ctx := s.GetContext()
+	s.createEntitlement("ent_bmu_unlimited", nil, types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+	charges, total, err := s.billing.CalculateMeterUsageCharges(
+		ctx, s.subWithItems(s.data.usageItem), usageWithCharge(s.sumCharge(500)),
+		s.data.periodStart, s.data.periodEnd, types.UsageSourceInvoiceCreation)
+	s.NoError(err)
+	s.Len(charges, 1)
+	s.True(charges[0].Amount.IsZero(), "unlimited entitlement must zero the amount, got %s", charges[0].Amount)
+	s.True(charges[0].Quantity.IsZero())
+	s.True(total.IsZero())
+	s.NotNil(charges[0].AdjustedEntitlementQuantity)
+	s.True(charges[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(500)))
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_EntitlementDailyReset() {
+	ctx := s.GetContext()
+	s.createEntitlement("ent_bmu_daily", lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_DAILY)
+
+	// Day 1: 150 (overage 50), Day 2: 90 (no overage) → billable = 50.
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 6, 3, 10, 0, 0, 0, time.UTC), 150)
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 6, 10, 10, 0, 0, 0, time.UTC), 90)
+
+	charges, total, err := s.billing.CalculateMeterUsageCharges(
+		ctx, s.subWithItems(s.data.usageItem), usageWithCharge(s.sumCharge(240)),
+		s.data.periodStart, s.data.periodEnd, types.UsageSourceInvoiceCreation)
+	s.NoError(err)
+	s.Len(charges, 1)
+	s.True(charges[0].Quantity.Equal(decimal.NewFromInt(50)), "daily overage should be 50, got %s", charges[0].Quantity)
+	s.True(charges[0].Amount.Equal(decimal.NewFromInt(1)), "amount should be 50 * 0.02 = 1, got %s", charges[0].Amount)
+	s.True(total.Equal(decimal.NewFromInt(1)))
+	s.Equal("daily", charges[0].Metadata["usage_reset_period"])
+	s.NotNil(charges[0].AdjustedEntitlementQuantity)
+	s.True(charges[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(190)),
+		"adjusted qty should be 240 - 50 = 190, got %s", charges[0].AdjustedEntitlementQuantity)
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_EntitlementMonthlyResetOnAnnualSub() {
+	ctx := s.GetContext()
+	s.createEntitlement("ent_bmu_monthly", lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+	// Annual subscription so MONTHLY reset != billing period → per-month overage path.
+	annualStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	annualEnd := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Line item must start with the annual period so Jan/Feb usage is in range.
+	annualItem := *s.data.usageItem
+	annualItem.StartDate = annualStart
+	subCopy := *s.data.sub
+	subCopy.BillingPeriod = types.BILLING_PERIOD_ANNUAL
+	subCopy.StartDate = annualStart
+	subCopy.BillingAnchor = annualStart
+	subCopy.CurrentPeriodStart = annualStart
+	subCopy.CurrentPeriodEnd = annualEnd
+	subCopy.LineItems = []*subscription.SubscriptionLineItem{&annualItem}
+
+	// Jan: 150 (overage 50), Feb: 80 (no overage) → billable = 50.
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC), 150)
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 2, 15, 12, 0, 0, 0, time.UTC), 80)
+
+	charges, total, err := s.billing.CalculateMeterUsageCharges(
+		ctx, &subCopy, usageWithCharge(s.sumCharge(230)), annualStart, annualEnd,
+		types.UsageSourceInvoiceCreation)
+	s.NoError(err)
+	s.Len(charges, 1)
+	s.True(charges[0].Quantity.Equal(decimal.NewFromInt(50)), "monthly overage should be 50, got %s", charges[0].Quantity)
+	s.True(charges[0].Amount.Equal(decimal.NewFromInt(1)), "amount should be 1, got %s", charges[0].Amount)
+	s.True(total.Equal(decimal.NewFromInt(1)))
+	s.Equal("monthly", charges[0].Metadata["usage_reset_period"])
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_EntitlementNeverReset() {
+	ctx := s.GetContext()
+	s.createEntitlement("ent_bmu_never", lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_NEVER)
+
+	// Pre-period usage 300 (already billed), in-period usage 500.
+	// billable = (800 - 300) - 100 = 400 → $8.
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 4, 10, 0, 0, 0, 0, time.UTC), 300)
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC), 500)
+
+	charges, total, err := s.billing.CalculateMeterUsageCharges(
+		ctx, s.subWithItems(s.data.usageItem), usageWithCharge(s.sumCharge(500)),
+		s.data.periodStart, s.data.periodEnd, types.UsageSourceInvoiceCreation)
+	s.NoError(err)
+	s.Len(charges, 1)
+	s.True(charges[0].Quantity.Equal(decimal.NewFromInt(400)), "never-reset billable should be 400, got %s", charges[0].Quantity)
+	s.True(charges[0].Amount.Equal(decimal.NewFromInt(8)), "amount should be 8, got %s", charges[0].Amount)
+	s.True(total.Equal(decimal.NewFromInt(8)))
+	s.Equal("never", charges[0].Metadata["usage_reset_period"])
+	s.NotNil(charges[0].AdjustedEntitlementQuantity)
+	s.True(charges[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(100)))
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_LineItemCommitment() {
+	ctx := s.GetContext()
+	ps, pe := s.data.periodStart, s.data.periodEnd
+
+	// Bucketed usage for the windowed commitment case: Jun 3 max 10, Jun 4 max 20.
+	s.insertMeterUsage(s.data.meterBucket.ID, "bmu_bucket_event", time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), 10)
+	s.insertMeterUsage(s.data.meterBucket.ID, "bmu_bucket_event", time.Date(2025, 6, 4, 8, 0, 0, 0, time.UTC), 20)
+
+	commitItem := func(amount string, trueUp, windowed bool) *subscription.SubscriptionLineItem {
+		item := *s.data.usageItem
+		item.CommitmentAmount = lo.ToPtr(decimal.RequireFromString(amount))
+		item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+		item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		item.CommitmentTrueUpEnabled = trueUp
+		item.CommitmentWindowed = windowed
+		return &item
+	}
+
+	testCases := []struct {
+		name             string
+		item             *subscription.SubscriptionLineItem
+		charge           *dto.SubscriptionUsageByMetersResponse
+		expectedAmount   decimal.Decimal
+		expectedUtilized decimal.Decimal
+		expectedOverage  decimal.Decimal
+		expectedTrueUp   decimal.Decimal
+	}{
+		{
+			// usage $10 over $5 commitment at 2x → 5 + (10-5)*2 = 15
+			name:             "flat_commitment_overage_billed_at_overage_rate",
+			item:             commitItem("5", false, false),
+			charge:           s.sumCharge(500),
+			expectedAmount:   decimal.NewFromInt(15),
+			expectedUtilized: decimal.NewFromInt(5),
+			expectedOverage:  decimal.NewFromInt(10),
+			expectedTrueUp:   decimal.Zero,
+		},
+		{
+			// usage $10 under $15 commitment with true-up → billed the full $15
+			name:             "flat_commitment_trueup_bills_commitment",
+			item:             commitItem("15", true, false),
+			charge:           s.sumCharge(500),
+			expectedAmount:   decimal.NewFromInt(15),
+			expectedUtilized: decimal.NewFromInt(10),
+			expectedOverage:  decimal.Zero,
+			expectedTrueUp:   decimal.NewFromInt(5),
+		},
+		{
+			// usage $10 under $15 commitment without true-up → billed usage only
+			name:             "flat_commitment_without_trueup_bills_usage",
+			item:             commitItem("15", false, false),
+			charge:           s.sumCharge(500),
+			expectedAmount:   decimal.NewFromInt(10),
+			expectedUtilized: decimal.NewFromInt(10),
+			expectedOverage:  decimal.Zero,
+			expectedTrueUp:   decimal.Zero,
+		},
+		{
+			// per-window commitment $0.30 at 2x: window1 $0.20 (under, no true-up) +
+			// window2 $0.40 → 0.30 + 0.10*2 = $0.50 → total $0.70
+			name: "windowed_commitment_applies_per_bucket",
+			item: func() *subscription.SubscriptionLineItem {
+				item := *s.data.bucketItem
+				item.CommitmentAmount = lo.ToPtr(decimal.RequireFromString("0.3"))
+				item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+				item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+				item.CommitmentWindowed = true
+				return &item
+			}(),
+			charge: &dto.SubscriptionUsageByMetersResponse{
+				SubscriptionLineItemID: s.data.bucketItem.ID,
+				MeterID:                s.data.meterBucket.ID,
+				Quantity:               0,
+				Currency:               "usd",
+				Price:                  s.data.priceBucket,
+			},
+			expectedAmount:   decimal.RequireFromString("0.7"),
+			expectedUtilized: decimal.RequireFromString("0.5"),
+			expectedOverage:  decimal.RequireFromString("0.2"),
+			expectedTrueUp:   decimal.Zero,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			charges, total, err := s.billing.CalculateMeterUsageCharges(
+				ctx, s.subWithItems(tc.item), usageWithCharge(tc.charge), ps, pe,
+				types.UsageSourceInvoiceCreation)
+			s.NoError(err)
+			s.Len(charges, 1)
+			s.True(charges[0].Amount.Equal(tc.expectedAmount), "amount: want %s got %s", tc.expectedAmount, charges[0].Amount)
+			s.True(total.Equal(tc.expectedAmount))
+			info := charges[0].CommitmentInfo
+			s.NotNil(info)
+			s.True(info.ComputedCommitmentUtilizedAmount.Equal(tc.expectedUtilized),
+				"utilized: want %s got %s", tc.expectedUtilized, info.ComputedCommitmentUtilizedAmount)
+			s.True(info.ComputedOverageAmount.Equal(tc.expectedOverage),
+				"overage: want %s got %s", tc.expectedOverage, info.ComputedOverageAmount)
+			s.True(info.ComputedTrueUpAmount.Equal(tc.expectedTrueUp),
+				"true-up: want %s got %s", tc.expectedTrueUp, info.ComputedTrueUpAmount)
+		})
+	}
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_SubscriptionTrueUp() {
+	ctx := s.GetContext()
+	ps, pe := s.data.periodStart, s.data.periodEnd
+
+	testCases := []struct {
+		name           string
+		enableTrueUp   bool
+		hasOverage     bool
+		utilized       float64
+		expectedLen    int
+		expectedTotal  decimal.Decimal
+		validateTrueUp func(li dto.CreateInvoiceLineItemRequest)
+	}{
+		{
+			name:          "trueup_added_when_commitment_underutilized",
+			enableTrueUp:  true,
+			utilized:      10,
+			expectedLen:   2,
+			expectedTotal: decimal.NewFromInt(20),
+			validateTrueUp: func(li dto.CreateInvoiceLineItemRequest) {
+				s.True(li.Amount.Equal(decimal.NewFromInt(10)), "true-up amount should be 20-10=10, got %s", li.Amount)
+				s.Equal("true", li.Metadata["is_commitment_trueup"])
+				s.Equal("20", li.Metadata["commitment_amount"])
+				s.Equal("10", li.Metadata["commitment_utilized"])
+				s.Equal("BMU Plan True Up", lo.FromPtr(li.DisplayName))
+				s.True(li.Quantity.Equal(decimal.NewFromInt(1)))
+			},
+		},
+		{
+			name:          "no_trueup_when_usage_has_overage",
+			enableTrueUp:  true,
+			hasOverage:    true,
+			utilized:      10,
+			expectedLen:   1,
+			expectedTotal: decimal.NewFromInt(10),
+		},
+		{
+			name:          "no_trueup_when_trueup_disabled",
+			enableTrueUp:  false,
+			utilized:      10,
+			expectedLen:   1,
+			expectedTotal: decimal.NewFromInt(10),
+		},
+		{
+			name:          "no_trueup_when_commitment_fully_utilized",
+			enableTrueUp:  true,
+			utilized:      20,
+			expectedLen:   1,
+			expectedTotal: decimal.NewFromInt(10),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			subCopy := *s.data.sub
+			subCopy.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(20))
+			subCopy.OverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+			subCopy.EnableTrueUp = tc.enableTrueUp
+			subCopy.LineItems = []*subscription.SubscriptionLineItem{s.data.usageItem}
+
+			usage := usageWithCharge(s.sumCharge(500))
+			usage.HasOverage = tc.hasOverage
+			usage.CommitmentUtilized = tc.utilized
+
+			charges, total, err := s.billing.CalculateMeterUsageCharges(
+				ctx, &subCopy, usage, ps, pe, types.UsageSourceInvoiceCreation)
+			s.NoError(err)
+			s.Len(charges, tc.expectedLen)
+			s.True(total.Equal(tc.expectedTotal), "total: want %s got %s", tc.expectedTotal, total)
+			if tc.validateTrueUp != nil {
+				tc.validateTrueUp(charges[len(charges)-1])
+			}
+		})
+	}
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_BucketedMeter() {
+	ctx := s.GetContext()
+	ps, pe := s.data.periodStart, s.data.periodEnd
+
+	s.Run("prefetched_bucketed_result_is_used_without_querying", func() {
+		// No meter_usage rows seeded — result must come from the charge itself.
+		charge := &dto.SubscriptionUsageByMetersResponse{
+			SubscriptionLineItemID: s.data.bucketItem.ID,
+			MeterID:                s.data.meterBucket.ID,
+			Currency:               "usd",
+			Price:                  s.data.priceBucket,
+			BucketedUsageResult: &events.AggregationResult{
+				Value: decimal.NewFromInt(30),
+				Results: []events.UsageResult{
+					{WindowSize: time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC), Value: decimal.NewFromInt(10)},
+					{WindowSize: time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC), Value: decimal.NewFromInt(20)},
+				},
+			},
+		}
+		charges, total, err := s.billing.CalculateMeterUsageCharges(
+			ctx, s.subWithItems(s.data.bucketItem), usageWithCharge(charge), ps, pe,
+			types.UsageSourceInvoiceCreation)
+		s.NoError(err)
+		s.Len(charges, 1)
+		// per-bucket slab pricing: 10*0.02 + 20*0.02 = 0.6
+		s.True(charges[0].Amount.Equal(decimal.RequireFromString("0.6")), "amount should be 0.6, got %s", charges[0].Amount)
+		s.True(charges[0].Quantity.Equal(decimal.NewFromInt(30)))
+		s.True(total.Equal(decimal.RequireFromString("0.6")))
+	})
+
+	s.Run("falls_back_to_direct_meter_usage_query", func() {
+		// Jun 3: max(10, 7) = 10; Jun 4: max = 20 → same $0.6 as above.
+		s.insertMeterUsage(s.data.meterBucket.ID, "bmu_bucket_event", time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), 10)
+		s.insertMeterUsage(s.data.meterBucket.ID, "bmu_bucket_event", time.Date(2025, 6, 3, 9, 0, 0, 0, time.UTC), 7)
+		s.insertMeterUsage(s.data.meterBucket.ID, "bmu_bucket_event", time.Date(2025, 6, 4, 8, 0, 0, 0, time.UTC), 20)
+
+		charge := &dto.SubscriptionUsageByMetersResponse{
+			SubscriptionLineItemID: s.data.bucketItem.ID,
+			MeterID:                s.data.meterBucket.ID,
+			Currency:               "usd",
+			Price:                  s.data.priceBucket,
+		}
+		charges, total, err := s.billing.CalculateMeterUsageCharges(
+			ctx, s.subWithItems(s.data.bucketItem), usageWithCharge(charge), ps, pe,
+			types.UsageSourceInvoiceCreation)
+		s.NoError(err)
+		s.Len(charges, 1)
+		s.True(charges[0].Amount.Equal(decimal.RequireFromString("0.6")), "amount should be 0.6, got %s", charges[0].Amount)
+		s.True(charges[0].Quantity.Equal(decimal.NewFromInt(30)))
+		s.True(total.Equal(decimal.RequireFromString("0.6")))
+	})
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_BucketedMeterEntitlement() {
+	ctx := s.GetContext()
+
+	// Feature + entitlement bound to the bucketed meter: allowance of 5 units.
+	featBucket := &feature.Feature{
+		ID:        "feat_bmu_bucket",
+		Name:      "BMU Bucket Feature",
+		Type:      types.FeatureTypeMetered,
+		MeterID:   s.data.meterBucket.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, featBucket))
+	ent := &entitlement.Entitlement{
+		ID:               "ent_bmu_bucket",
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         s.data.plan.ID,
+		FeatureID:        featBucket.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       lo.ToPtr(int64(5)),
+		UsageResetPeriod: types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, ent)
+	s.NoError(err)
+
+	charge := &dto.SubscriptionUsageByMetersResponse{
+		SubscriptionLineItemID: s.data.bucketItem.ID,
+		MeterID:                s.data.meterBucket.ID,
+		Currency:               "usd",
+		Price:                  s.data.priceBucket,
+		BucketedUsageResult: &events.AggregationResult{
+			Value: decimal.NewFromInt(30),
+			Results: []events.UsageResult{
+				{WindowSize: time.Date(2025, 6, 3, 0, 0, 0, 0, time.UTC), Value: decimal.NewFromInt(10)},
+				{WindowSize: time.Date(2025, 6, 4, 0, 0, 0, 0, time.UTC), Value: decimal.NewFromInt(20)},
+			},
+		},
+	}
+	charges, total, err := s.billing.CalculateMeterUsageCharges(
+		ctx, s.subWithItems(s.data.bucketItem), usageWithCharge(charge),
+		s.data.periodStart, s.data.periodEnd, types.UsageSourceInvoiceCreation)
+	s.NoError(err)
+	s.Len(charges, 1)
+	// total 30 - allowance 5 = 25 → 25 * $0.02 = $0.5 (aggregate-level adjustment)
+	s.True(charges[0].Quantity.Equal(decimal.NewFromInt(25)), "quantity should be 25, got %s", charges[0].Quantity)
+	s.True(charges[0].Amount.Equal(decimal.RequireFromString("0.5")), "amount should be 0.5, got %s", charges[0].Amount)
+	s.True(total.Equal(decimal.RequireFromString("0.5")))
+	s.NotNil(charges[0].AdjustedEntitlementQuantity)
+	s.True(charges[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(5)))
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageCharges_CumulativeCommitment() {
+	ctx := s.GetContext()
+	invoiceRepo := s.GetStores().InvoiceRepo.(*testutil.InMemoryInvoiceStore)
+
+	// Monthly subscription with an ANNUAL $60 commitment at 2x overage.
+	annualStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	mkSub := func(ps, pe time.Time, enableTrueUp bool) *subscription.Subscription {
+		subCopy := *s.data.sub
+		subCopy.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(60))
+		subCopy.OverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		subCopy.CommitmentDuration = lo.ToPtr(types.BILLING_PERIOD_ANNUAL)
+		subCopy.EnableTrueUp = enableTrueUp
+		subCopy.StartDate = annualStart
+		subCopy.CurrentPeriodStart = ps
+		subCopy.CurrentPeriodEnd = pe
+		subCopy.BillingAnchor = pe
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{s.data.usageItem}
+		return &subCopy
+	}
+
+	mkPriorInvoice := func(id string, amount int64, ps, pe time.Time) *invoice.Invoice {
+		return &invoice.Invoice{
+			ID:             id,
+			CustomerID:     s.data.customer.ID,
+			SubscriptionID: lo.ToPtr(s.data.sub.ID),
+			InvoiceType:    types.InvoiceTypeSubscription,
+			InvoiceStatus:  types.InvoiceStatusFinalized,
+			PaymentStatus:  types.PaymentStatusPending,
+			Currency:       "usd",
+			AmountDue:      decimal.NewFromInt(amount),
+			PeriodStart:    &ps,
+			PeriodEnd:      &pe,
+			BaseModel:      types.GetDefaultBaseModel(ctx),
+			LineItems: []*invoice.InvoiceLineItem{
+				{
+					ID:             id + "_li",
+					InvoiceID:      id,
+					CustomerID:     s.data.customer.ID,
+					SubscriptionID: lo.ToPtr(s.data.sub.ID),
+					PriceID:        lo.ToPtr(s.data.priceSum.ID),
+					PriceType:      lo.ToPtr(string(types.PRICE_TYPE_USAGE)),
+					Amount:         decimal.NewFromInt(amount),
+					Currency:       "usd",
+					PeriodStart:    &ps,
+					PeriodEnd:      &pe,
+					BaseModel:      types.GetDefaultBaseModel(ctx),
+				},
+			},
+		}
+	}
+
+	s.Run("mid_period_overage_split_between_commitment_and_overage_line", func() {
+		invoiceRepo.Clear()
+		// Prior invoices: $30 (Jan) + $20 (Feb) → prior base $50, remaining commitment $10.
+		s.NoError(invoiceRepo.CreateWithLineItems(ctx, mkPriorInvoice("inv_bmu_1", 30,
+			time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC))))
+		s.NoError(invoiceRepo.CreateWithLineItems(ctx, mkPriorInvoice("inv_bmu_2", 20,
+			time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC))))
+
+		ps := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+		pe := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+		sub := mkSub(ps, pe, false)
+
+		// Current usage 600 units → $12 base; within commitment $10, overage base $2 → $4 charged.
+		charges, total, err := s.billing.CalculateMeterUsageCharges(
+			ctx, sub, usageWithCharge(s.sumCharge(600)), ps, pe, types.UsageSourceInvoiceCreation)
+		s.NoError(err)
+		s.Len(charges, 2)
+		s.True(total.Equal(decimal.NewFromInt(14)), "total should be 10 + 4 = 14, got %s", total)
+
+		// Allocated usage line: $10 at prorated quantity 600 * 10/12 = 500.
+		s.True(charges[0].Amount.Equal(decimal.NewFromInt(10)), "allocated amount should be 10, got %s", charges[0].Amount)
+		s.True(charges[0].Quantity.Equal(decimal.NewFromInt(500)), "allocated quantity should be 500, got %s", charges[0].Quantity)
+
+		// Overage line: $4 with overage metadata.
+		overageLine := charges[1]
+		s.True(overageLine.Amount.Equal(decimal.NewFromInt(4)), "overage amount should be 4, got %s", overageLine.Amount)
+		s.Equal("true", overageLine.Metadata["is_overage"])
+		s.Equal("2", overageLine.Metadata["overage_factor"])
+		s.Equal("BMU Plan Overage", lo.FromPtr(overageLine.DisplayName))
+	})
+
+	s.Run("last_period_trueup_bills_remaining_commitment", func() {
+		invoiceRepo.Clear()
+		s.NoError(invoiceRepo.CreateWithLineItems(ctx, mkPriorInvoice("inv_bmu_3", 30,
+			time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC))))
+
+		ps := time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)
+		pe := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		sub := mkSub(ps, pe, true)
+
+		// Current $12, cumulative 30+12=42 < 60 → true-up $18 on the last period.
+		charges, total, err := s.billing.CalculateMeterUsageCharges(
+			ctx, sub, usageWithCharge(s.sumCharge(600)), ps, pe, types.UsageSourceInvoiceCreation)
+		s.NoError(err)
+		s.Len(charges, 2)
+		s.True(total.Equal(decimal.NewFromInt(30)), "total should be 12 + 18 = 30, got %s", total)
+
+		s.True(charges[0].Amount.Equal(decimal.NewFromInt(12)))
+		trueUpLine := charges[1]
+		s.True(trueUpLine.Amount.Equal(decimal.NewFromInt(18)), "true-up should be 60-42=18, got %s", trueUpLine.Amount)
+		s.Equal("true", trueUpLine.Metadata["is_commitment_trueup"])
+		s.Equal("60", trueUpLine.Metadata["commitment_amount"])
+		s.Equal("BMU Plan True Up", lo.FromPtr(trueUpLine.DisplayName))
+	})
+}
+
+func (s *BillingMeterUsageSuite) TestCalculateMeterUsageChargesPipeline() {
+	ctx := s.GetContext()
+	ps, pe := s.data.periodStart, s.data.periodEnd
+
+	// 500 units in-period on the sum meter → $10 usage; fixed fee $5.
+	s.insertMeterUsage(s.data.meterSum.ID, "bmu_event", time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC), 500)
+
+	lineItems := []*subscription.SubscriptionLineItem{s.data.usageItem, s.data.fixedItem}
+
+	s.Run("include_usage_combines_fixed_and_usage_charges", func() {
+		result, err := s.billing.calculateMeterUsageCharges(ctx, s.data.sub, lineItems, ps, pe, true)
+		s.NoError(err)
+		s.Len(result.FixedCharges, 1)
+		s.True(result.FixedCharges[0].Amount.Equal(decimal.NewFromInt(5)), "fixed charge should be 5, got %s", result.FixedCharges[0].Amount)
+		s.Len(result.UsageCharges, 1)
+		s.True(result.UsageCharges[0].Amount.Equal(decimal.NewFromInt(10)), "usage charge should be 10, got %s", result.UsageCharges[0].Amount)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(15)), "total should be 15, got %s", result.TotalAmount)
+		s.Equal("usd", result.Currency)
+	})
+
+	s.Run("recompute_is_idempotent_and_does_not_double_bill", func() {
+		first, err := s.billing.calculateMeterUsageCharges(ctx, s.data.sub, lineItems, ps, pe, true)
+		s.NoError(err)
+		second, err := s.billing.calculateMeterUsageCharges(ctx, s.data.sub, lineItems, ps, pe, true)
+		s.NoError(err)
+		s.True(first.TotalAmount.Equal(second.TotalAmount),
+			"recompute changed total: %s vs %s", first.TotalAmount, second.TotalAmount)
+		s.Len(second.UsageCharges, len(first.UsageCharges))
+		s.True(second.TotalAmount.Equal(decimal.NewFromInt(15)))
+	})
+
+	s.Run("without_usage_returns_fixed_charges_only", func() {
+		result, err := s.billing.calculateMeterUsageCharges(ctx, s.data.sub, lineItems, ps, pe, false)
+		s.NoError(err)
+		s.Len(result.FixedCharges, 1)
+		s.Empty(result.UsageCharges)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(5)), "total should be fixed-only 5, got %s", result.TotalAmount)
+	})
+}

--- a/internal/ee/service/billing_usage_charges_test.go
+++ b/internal/ee/service/billing_usage_charges_test.go
@@ -1,0 +1,729 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
+	"github.com/flexprice/flexprice/internal/domain/meter"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// BillingUsageChargesSuite drives the raw-events usage billing paths —
+// CalculateUsageCharges and CalculateFeatureUsageCharges — through the
+// entitlement reset-period branches, line-item commitments, overage
+// metadata and subscription true-up.
+//
+// Each scenario builds its own plan + subscription (via newChargesFixture) so
+// plan-level entitlements never leak between table cases.
+type BillingUsageChargesSuite struct {
+	testutil.BaseServiceTestSuite
+	service   BillingService
+	billing   *billingService
+	eventRepo *testutil.InMemoryEventStore
+	customer  *customer.Customer
+
+	meterSum    *meter.Meter
+	meterBucket *meter.Meter
+	featSum     *feature.Feature
+	featBucket  *feature.Feature
+	priceSum    *price.Price
+	priceBucket *price.Price
+
+	monthStart time.Time // 2025-06-01
+	monthEnd   time.Time // 2025-07-01
+	yearStart  time.Time // 2025-01-01
+	yearEnd    time.Time // 2026-01-01
+}
+
+func TestBillingUsageCharges(t *testing.T) {
+	suite.Run(t, new(BillingUsageChargesSuite))
+}
+
+func (s *BillingUsageChargesSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	ctx := s.GetContext()
+	s.eventRepo = s.GetStores().EventRepo.(*testutil.InMemoryEventStore)
+	s.service = NewBillingService(newTestServiceParams(&s.BaseServiceTestSuite))
+	s.billing = s.service.(*billingService)
+
+	s.monthStart = time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	s.monthEnd = time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
+	s.yearStart = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	s.yearEnd = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	s.customer = &customer.Customer{
+		ID:         "cust_buc",
+		ExternalID: "ext_buc",
+		Name:       "Usage Charges Customer",
+		Email:      "buc@test.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, s.customer))
+
+	s.meterSum = &meter.Meter{
+		ID:        "meter_buc_sum",
+		Name:      "BUC Sum Meter",
+		EventName: "buc_event",
+		Aggregation: meter.Aggregation{
+			Type:  types.AggregationSum,
+			Field: "qty",
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, s.meterSum))
+
+	s.meterBucket = &meter.Meter{
+		ID:        "meter_buc_bucket",
+		Name:      "BUC Bucketed Meter",
+		EventName: "buc_bucket_event",
+		Aggregation: meter.Aggregation{
+			Type:  types.AggregationMax,
+			Field: "qty",
+			// Hourly buckets: the in-memory event store routes day/month windows
+			// through SUM/COUNT-only aggregation, so MAX bucketing needs a
+			// non-day window size to exercise the real bucketed-max math.
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, s.meterBucket))
+
+	s.featSum = &feature.Feature{
+		ID:        "feat_buc_sum",
+		Name:      "BUC Sum Feature",
+		Type:      types.FeatureTypeMetered,
+		MeterID:   s.meterSum.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, s.featSum))
+
+	s.featBucket = &feature.Feature{
+		ID:        "feat_buc_bucket",
+		Name:      "BUC Bucket Feature",
+		Type:      types.FeatureTypeMetered,
+		MeterID:   s.meterBucket.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, s.featBucket))
+
+	upTo1000 := uint64(1000)
+	mkPrice := func(id, meterID string) *price.Price {
+		p := &price.Price{
+			ID:                 id,
+			Amount:             decimal.Zero,
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+			EntityID:           "plan_buc_shared",
+			Type:               types.PRICE_TYPE_USAGE,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_TIERED,
+			BillingCadence:     types.BILLING_CADENCE_RECURRING,
+			InvoiceCadence:     types.InvoiceCadenceArrear,
+			TierMode:           types.BILLING_TIER_SLAB,
+			MeterID:            meterID,
+			Tiers: []price.PriceTier{
+				{UpTo: &upTo1000, UnitAmount: decimal.RequireFromString("0.02")},
+				{UpTo: nil, UnitAmount: decimal.RequireFromString("0.01")},
+			},
+			BaseModel: types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+		return p
+	}
+	s.priceSum = mkPrice("price_buc_sum", s.meterSum.ID)
+	s.priceBucket = mkPrice("price_buc_bucket", s.meterBucket.ID)
+}
+
+// chargesFixture is one plan + subscription + line item combination.
+type chargesFixture struct {
+	plan *plan.Plan
+	sub  *subscription.Subscription
+	item *subscription.SubscriptionLineItem
+}
+
+// newChargesFixture creates a plan and an active subscription with a single
+// usage line item. bucketed selects the bucketed MAX meter over the SUM meter.
+func (s *BillingUsageChargesSuite) newChargesFixture(suffix string, billingPeriod types.BillingPeriod, bucketed bool) *chargesFixture {
+	ctx := s.GetContext()
+	fx := &chargesFixture{}
+
+	fx.plan = &plan.Plan{
+		ID:        "plan_buc_" + suffix,
+		Name:      "BUC Plan " + suffix,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, fx.plan))
+
+	periodStart, periodEnd := s.monthStart, s.monthEnd
+	startDate := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	if billingPeriod == types.BILLING_PERIOD_ANNUAL {
+		periodStart, periodEnd = s.yearStart, s.yearEnd
+		startDate = s.yearStart
+	}
+
+	m, p := s.meterSum, s.priceSum
+	if bucketed {
+		m, p = s.meterBucket, s.priceBucket
+	}
+
+	fx.sub = &subscription.Subscription{
+		ID:                 "sub_buc_" + suffix,
+		PlanID:             fx.plan.ID,
+		CustomerID:         s.customer.ID,
+		StartDate:          startDate,
+		BillingAnchor:      periodStart,
+		CurrentPeriodStart: periodStart,
+		CurrentPeriodEnd:   periodEnd,
+		Currency:           "usd",
+		BillingPeriod:      billingPeriod,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	fx.item = &subscription.SubscriptionLineItem{
+		ID:               "li_buc_" + suffix,
+		SubscriptionID:   fx.sub.ID,
+		CustomerID:       s.customer.ID,
+		EntityID:         fx.plan.ID,
+		EntityType:       types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName:  fx.plan.Name,
+		PriceID:          p.ID,
+		PriceType:        types.PRICE_TYPE_USAGE,
+		MeterID:          m.ID,
+		MeterDisplayName: m.Name,
+		DisplayName:      "Usage " + suffix,
+		Quantity:         decimal.Zero,
+		Currency:         "usd",
+		BillingPeriod:    billingPeriod,
+		InvoiceCadence:   types.InvoiceCadenceArrear,
+		StartDate:        startDate,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, fx.sub,
+		[]*subscription.SubscriptionLineItem{fx.item}))
+	fx.sub.LineItems = []*subscription.SubscriptionLineItem{fx.item}
+	return fx
+}
+
+// addEntitlement attaches a metered plan entitlement for the given feature.
+func (s *BillingUsageChargesSuite) addEntitlement(fx *chargesFixture, feat *feature.Feature, limit *int64, reset types.EntitlementUsageResetPeriod) {
+	ent := &entitlement.Entitlement{
+		ID:               "ent_" + fx.plan.ID + "_" + feat.ID,
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         fx.plan.ID,
+		FeatureID:        feat.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       limit,
+		UsageResetPeriod: reset,
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(s.GetContext(), ent)
+	s.NoError(err)
+}
+
+// insertEvent seeds one raw event for a meter's event name.
+func (s *BillingUsageChargesSuite) insertEvent(eventName string, ts time.Time, qty float64) {
+	ctx := s.GetContext()
+	s.NoError(s.eventRepo.InsertEvent(ctx, &events.Event{
+		ID:                 s.GetUUID(),
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		EventName:          eventName,
+		ExternalCustomerID: s.customer.ExternalID,
+		Timestamp:          ts,
+		Properties:         map[string]interface{}{"qty": qty},
+	}))
+}
+
+// charge builds a usage charge for the fixture's line item (price matched by ID
+// for CalculateUsageCharges, line item ID for CalculateFeatureUsageCharges).
+func (s *BillingUsageChargesSuite) charge(fx *chargesFixture, qty, amount float64, p *price.Price) *dto.SubscriptionUsageByMetersResponse {
+	return &dto.SubscriptionUsageByMetersResponse{
+		SubscriptionLineItemID: fx.item.ID,
+		MeterID:                fx.item.MeterID,
+		MeterDisplayName:       fx.item.MeterDisplayName,
+		Quantity:               qty,
+		Amount:                 amount,
+		Currency:               "usd",
+		Price:                  p,
+	}
+}
+
+func (s *BillingUsageChargesSuite) calcUsage(fx *chargesFixture, usage *dto.GetUsageBySubscriptionResponse) (*dto.CalculateUsageChargesResult, error) {
+	return s.billing.CalculateUsageCharges(s.GetContext(), &dto.CalculateUsageChargesParams{
+		Subscription: fx.sub,
+		Usage:        usage,
+		PeriodStart:  fx.sub.CurrentPeriodStart,
+		PeriodEnd:    fx.sub.CurrentPeriodEnd,
+	})
+}
+
+func (s *BillingUsageChargesSuite) calcFeatureUsage(fx *chargesFixture, usage *dto.GetUsageBySubscriptionResponse) (*dto.CalculateFeatureUsageChargesResult, error) {
+	return s.billing.CalculateFeatureUsageCharges(s.GetContext(), &dto.CalculateFeatureUsageChargesParams{
+		Subscription: fx.sub,
+		Usage:        usage,
+		PeriodStart:  fx.sub.CurrentPeriodStart,
+		PeriodEnd:    fx.sub.CurrentPeriodEnd,
+		Source:       types.UsageSourceInvoiceCreation,
+	})
+}
+
+func mkUsage(charges ...*dto.SubscriptionUsageByMetersResponse) *dto.GetUsageBySubscriptionResponse {
+	return &dto.GetUsageBySubscriptionResponse{Charges: charges}
+}
+
+// ---------------------------------------------------------------------------
+// CalculateUsageCharges (raw events path)
+// ---------------------------------------------------------------------------
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_ValidationAndNilUsage() {
+	fx := s.newChargesFixture("val", types.BILLING_PERIOD_MONTHLY, false)
+
+	s.Run("missing_subscription_returns_validation_error", func() {
+		_, err := s.billing.CalculateUsageCharges(s.GetContext(), &dto.CalculateUsageChargesParams{
+			PeriodStart: s.monthStart,
+			PeriodEnd:   s.monthEnd,
+		})
+		s.Error(err)
+	})
+
+	s.Run("nil_usage_returns_zero_total", func() {
+		result, err := s.calcUsage(fx, nil)
+		s.NoError(err)
+		s.True(result.TotalAmount.IsZero())
+		s.Empty(result.LineItems)
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_MonthlyResetOnAnnualSub() {
+	fx := s.newChargesFixture("monthly", types.BILLING_PERIOD_ANNUAL, false)
+	s.addEntitlement(fx, s.featSum, lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+	// Jan: 150 (overage 50), Feb: 80 (none) → billable 50 → $1.
+	s.insertEvent("buc_event", time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC), 150)
+	s.insertEvent("buc_event", time.Date(2025, 2, 15, 12, 0, 0, 0, time.UTC), 80)
+
+	result, err := s.calcUsage(fx, mkUsage(s.charge(fx, 230, 0, s.priceSum)))
+	s.NoError(err)
+	s.Len(result.LineItems, 1)
+	s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(50)), "quantity should be 50, got %s", result.LineItems[0].Quantity)
+	s.True(result.TotalAmount.Equal(decimal.NewFromInt(1)), "total should be 1, got %s", result.TotalAmount)
+	s.Equal("monthly", result.LineItems[0].Metadata["usage_reset_period"])
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_NeverReset() {
+	fx := s.newChargesFixture("never", types.BILLING_PERIOD_MONTHLY, false)
+	s.addEntitlement(fx, s.featSum, lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_NEVER)
+
+	// Pre-period 300 (already billed), in-period 500 → billable (500 - 100) = 400 → $8.
+	s.insertEvent("buc_event", time.Date(2025, 4, 10, 0, 0, 0, 0, time.UTC), 300)
+	s.insertEvent("buc_event", time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC), 500)
+
+	result, err := s.calcUsage(fx, mkUsage(s.charge(fx, 500, 0, s.priceSum)))
+	s.NoError(err)
+	s.Len(result.LineItems, 1)
+	s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(400)), "quantity should be 400, got %s", result.LineItems[0].Quantity)
+	s.True(result.TotalAmount.Equal(decimal.NewFromInt(8)), "total should be 8, got %s", result.TotalAmount)
+	s.Equal("never", result.LineItems[0].Metadata["usage_reset_period"])
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_WeeklyResetFallsBackToSimpleSubtraction() {
+	fx := s.newChargesFixture("weekly", types.BILLING_PERIOD_MONTHLY, false)
+	s.addEntitlement(fx, s.featSum, lo.ToPtr(int64(200)), types.ENTITLEMENT_USAGE_RESET_PERIOD_WEEKLY)
+
+	// Unsupported reset period → default branch: billable = 500 - 200 = 300 → $6.
+	result, err := s.calcUsage(fx, mkUsage(s.charge(fx, 500, 0, s.priceSum)))
+	s.NoError(err)
+	s.Len(result.LineItems, 1)
+	s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(300)), "quantity should be 300, got %s", result.LineItems[0].Quantity)
+	s.True(result.TotalAmount.Equal(decimal.NewFromInt(6)), "total should be 6, got %s", result.TotalAmount)
+	s.NotNil(result.LineItems[0].AdjustedEntitlementQuantity)
+	s.True(result.LineItems[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(200)))
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_BucketedMeterEntitlements() {
+	// Bucketed MAX meter, hourly buckets: 08:00 bucket max(10, 7) = 10,
+	// 09:00 bucket max = 20 → total quantity 30.
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), 10)
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 8, 30, 0, 0, time.UTC), 7)
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 9, 15, 0, 0, time.UTC), 20)
+
+	s.Run("usage_limit_reduces_aggregate_quantity", func() {
+		fx := s.newChargesFixture("bkt_lim", types.BILLING_PERIOD_MONTHLY, true)
+		s.addEntitlement(fx, s.featBucket, lo.ToPtr(int64(5)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+		result, err := s.calcUsage(fx, mkUsage(s.charge(fx, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		// 30 - 5 = 25 → 25 * $0.02 = $0.5
+		s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(25)), "quantity should be 25, got %s", result.LineItems[0].Quantity)
+		s.True(result.TotalAmount.Equal(decimal.RequireFromString("0.5")), "total should be 0.5, got %s", result.TotalAmount)
+	})
+
+	s.Run("unlimited_entitlement_zeroes_bucketed_charge", func() {
+		fx := s.newChargesFixture("bkt_unl", types.BILLING_PERIOD_MONTHLY, true)
+		s.addEntitlement(fx, s.featBucket, nil, types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+		result, err := s.calcUsage(fx, mkUsage(s.charge(fx, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.LineItems[0].Quantity.IsZero())
+		s.True(result.TotalAmount.IsZero(), "unlimited entitlement should bill zero, got %s", result.TotalAmount)
+		s.NotNil(result.LineItems[0].AdjustedEntitlementQuantity)
+		s.True(result.LineItems[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(30)))
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_LineItemCommitment() {
+	// Bucketed usage for the windowed case: two hourly buckets with max 10 and 20.
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), 10)
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 9, 0, 0, 0, time.UTC), 20)
+
+	s.Run("flat_commitment_bills_overage_at_overage_rate", func() {
+		fx := s.newChargesFixture("cmt_flat", types.BILLING_PERIOD_MONTHLY, false)
+		item := *fx.item
+		item.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(5))
+		item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+		item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		subCopy := *fx.sub
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+		// usage $10 over $5 commitment at 2x → 5 + 5*2 = $15
+		result, err := s.calcUsage(fxCopy, mkUsage(s.charge(fxCopy, 500, 10, s.priceSum)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(15)), "total should be 15, got %s", result.TotalAmount)
+		info := result.LineItems[0].CommitmentInfo
+		s.NotNil(info)
+		s.True(info.ComputedCommitmentUtilizedAmount.Equal(decimal.NewFromInt(5)))
+		s.True(info.ComputedOverageAmount.Equal(decimal.NewFromInt(10)))
+	})
+
+	s.Run("windowed_commitment_applies_per_bucket", func() {
+		fx := s.newChargesFixture("cmt_win", types.BILLING_PERIOD_MONTHLY, true)
+		item := *fx.item
+		item.CommitmentAmount = lo.ToPtr(decimal.RequireFromString("0.3"))
+		item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+		item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		item.CommitmentWindowed = true
+		subCopy := *fx.sub
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+		// window costs $0.20 / $0.40 vs $0.30 per-window commitment at 2x
+		// → 0.2 + (0.3 + 0.1*2) = $0.7
+		result, err := s.calcUsage(fxCopy, mkUsage(s.charge(fxCopy, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.Equal(decimal.RequireFromString("0.7")), "total should be 0.7, got %s", result.TotalAmount)
+		info := result.LineItems[0].CommitmentInfo
+		s.NotNil(info)
+		s.True(info.ComputedCommitmentUtilizedAmount.Equal(decimal.RequireFromString("0.5")))
+		s.True(info.ComputedOverageAmount.Equal(decimal.RequireFromString("0.2")))
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_OverageAndTrueUp() {
+	s.Run("overage_charge_keeps_amount_and_gets_overage_metadata", func() {
+		fx := s.newChargesFixture("ovr", types.BILLING_PERIOD_MONTHLY, false)
+		ch := s.charge(fx, 100, 3, s.priceSum)
+		ch.IsOverage = true
+		ch.OverageFactor = 1.5
+
+		result, err := s.calcUsage(fx, mkUsage(ch))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		li := result.LineItems[0]
+		s.True(li.Amount.Equal(decimal.NewFromInt(3)), "overage amount must be kept verbatim, got %s", li.Amount)
+		s.Equal("true", li.Metadata["is_overage"])
+		s.Equal("1.5", li.Metadata["overage_factor"])
+		s.Equal("Usage ovr (Overage)", lo.FromPtr(li.DisplayName))
+	})
+
+	s.Run("trueup_line_added_when_commitment_underutilized", func() {
+		fx := s.newChargesFixture("tru", types.BILLING_PERIOD_MONTHLY, false)
+		subCopy := *fx.sub
+		subCopy.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(20))
+		subCopy.OverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		subCopy.EnableTrueUp = true
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: fx.item}
+		subCopy.LineItems = fx.sub.LineItems
+
+		usage := mkUsage(s.charge(fxCopy, 500, 10, s.priceSum))
+		usage.CommitmentUtilized = 10
+
+		result, err := s.calcUsage(fxCopy, usage)
+		s.NoError(err)
+		s.Len(result.LineItems, 2)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(20)), "total should be 10 + 10 true-up, got %s", result.TotalAmount)
+		trueUp := result.LineItems[1]
+		s.Equal("true", trueUp.Metadata["is_commitment_trueup"])
+		s.Equal("20", trueUp.Metadata["commitment_amount"])
+		s.Equal("10", trueUp.Metadata["commitment_utilized"])
+		s.True(trueUp.Amount.Equal(decimal.NewFromInt(10)))
+	})
+
+	s.Run("no_trueup_when_usage_has_overage", func() {
+		fx := s.newChargesFixture("tru_ovr", types.BILLING_PERIOD_MONTHLY, false)
+		subCopy := *fx.sub
+		subCopy.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(20))
+		subCopy.OverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		subCopy.EnableTrueUp = true
+		subCopy.LineItems = fx.sub.LineItems
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: fx.item}
+
+		usage := mkUsage(s.charge(fxCopy, 500, 10, s.priceSum))
+		usage.CommitmentUtilized = 10
+		usage.HasOverage = true
+
+		result, err := s.calcUsage(fxCopy, usage)
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(10)))
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_MissingPriceUnitSkipsLineItem() {
+	fx := s.newChargesFixture("pu", types.BILLING_PERIOD_MONTHLY, false)
+	item := *fx.item
+	item.PriceUnit = lo.ToPtr("credits_missing") // not registered in PriceUnitRepo
+	subCopy := *fx.sub
+	subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+	fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+	result, err := s.calcUsage(fxCopy, mkUsage(s.charge(fxCopy, 500, 10, s.priceSum)))
+	s.NoError(err)
+	// The line item is skipped when its price unit cannot be resolved.
+	// NOTE: the amount has already been added to the running total before the
+	// price-unit lookup, so TotalAmount still includes the skipped line item.
+	s.Empty(result.LineItems)
+	s.True(result.TotalAmount.Equal(decimal.NewFromInt(10)),
+		"documented behavior: total includes skipped line item amount, got %s", result.TotalAmount)
+}
+
+// ---------------------------------------------------------------------------
+// CalculateFeatureUsageCharges (feature_usage path)
+// ---------------------------------------------------------------------------
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_ValidationAndNilUsage() {
+	fx := s.newChargesFixture("fval", types.BILLING_PERIOD_MONTHLY, false)
+
+	s.Run("missing_subscription_returns_validation_error", func() {
+		_, err := s.billing.CalculateFeatureUsageCharges(s.GetContext(), &dto.CalculateFeatureUsageChargesParams{
+			PeriodStart: s.monthStart,
+			PeriodEnd:   s.monthEnd,
+		})
+		s.Error(err)
+	})
+
+	s.Run("nil_usage_returns_zero_total", func() {
+		result, err := s.calcFeatureUsage(fx, nil)
+		s.NoError(err)
+		s.True(result.TotalAmount.IsZero())
+		s.Empty(result.LineItems)
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_MeterNotFoundReturnsError() {
+	fx := s.newChargesFixture("fmiss", types.BILLING_PERIOD_MONTHLY, false)
+	item := *fx.item
+	item.MeterID = "meter_missing"
+	subCopy := *fx.sub
+	subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+	fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+	_, err := s.calcFeatureUsage(fxCopy, mkUsage(s.charge(fxCopy, 100, 0, s.priceSum)))
+	s.Error(err)
+	s.ErrorContains(err, "meter not found")
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_MonthlyResetOnAnnualSub() {
+	fx := s.newChargesFixture("fmonthly", types.BILLING_PERIOD_ANNUAL, false)
+	s.addEntitlement(fx, s.featSum, lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+	s.insertEvent("buc_event", time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC), 150)
+	s.insertEvent("buc_event", time.Date(2025, 2, 15, 12, 0, 0, 0, time.UTC), 80)
+
+	result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 230, 0, s.priceSum)))
+	s.NoError(err)
+	s.Len(result.LineItems, 1)
+	s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(50)), "quantity should be 50, got %s", result.LineItems[0].Quantity)
+	s.True(result.TotalAmount.Equal(decimal.NewFromInt(1)), "total should be 1, got %s", result.TotalAmount)
+	s.Equal("monthly", result.LineItems[0].Metadata["usage_reset_period"])
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_NeverReset() {
+	fx := s.newChargesFixture("fnever", types.BILLING_PERIOD_MONTHLY, false)
+	s.addEntitlement(fx, s.featSum, lo.ToPtr(int64(100)), types.ENTITLEMENT_USAGE_RESET_PERIOD_NEVER)
+
+	s.insertEvent("buc_event", time.Date(2025, 4, 10, 0, 0, 0, 0, time.UTC), 300)
+	s.insertEvent("buc_event", time.Date(2025, 6, 10, 0, 0, 0, 0, time.UTC), 500)
+
+	result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 500, 0, s.priceSum)))
+	s.NoError(err)
+	s.Len(result.LineItems, 1)
+	s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(400)), "quantity should be 400, got %s", result.LineItems[0].Quantity)
+	s.True(result.TotalAmount.Equal(decimal.NewFromInt(8)), "total should be 8, got %s", result.TotalAmount)
+	s.Equal("never", result.LineItems[0].Metadata["usage_reset_period"])
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_WeeklyAndUnlimitedEntitlements() {
+	s.Run("weekly_reset_falls_back_to_simple_subtraction", func() {
+		fx := s.newChargesFixture("fweekly", types.BILLING_PERIOD_MONTHLY, false)
+		s.addEntitlement(fx, s.featSum, lo.ToPtr(int64(200)), types.ENTITLEMENT_USAGE_RESET_PERIOD_WEEKLY)
+
+		result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 500, 0, s.priceSum)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(300)))
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(6)), "total should be 6, got %s", result.TotalAmount)
+	})
+
+	s.Run("unlimited_entitlement_zeroes_charge", func() {
+		fx := s.newChargesFixture("funl", types.BILLING_PERIOD_MONTHLY, false)
+		s.addEntitlement(fx, s.featSum, nil, types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+		result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 500, 10, s.priceSum)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.LineItems[0].Quantity.IsZero())
+		s.True(result.TotalAmount.IsZero())
+		s.NotNil(result.LineItems[0].AdjustedEntitlementQuantity)
+		s.True(result.LineItems[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(500)))
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_BucketedMeterEntitlements() {
+	// The in-memory FeatureUsageRepo returns empty bucketed usage, so bucketed
+	// feature-usage charges compute to zero — these cases pin the control flow
+	// (bucketed query + entitlement gates), not ClickHouse aggregation math.
+	s.Run("bucketed_meter_with_usage_limit", func() {
+		fx := s.newChargesFixture("fbkt_lim", types.BILLING_PERIOD_MONTHLY, true)
+		s.addEntitlement(fx, s.featBucket, lo.ToPtr(int64(5)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+		result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.IsZero())
+	})
+
+	s.Run("bucketed_meter_with_unlimited_entitlement", func() {
+		fx := s.newChargesFixture("fbkt_unl", types.BILLING_PERIOD_MONTHLY, true)
+		s.addEntitlement(fx, s.featBucket, nil, types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+
+		result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.LineItems[0].Amount.IsZero())
+		s.True(result.LineItems[0].Quantity.IsZero())
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_LineItemCommitment() {
+	s.Run("flat_commitment_bills_overage_at_overage_rate", func() {
+		fx := s.newChargesFixture("fcmt_flat", types.BILLING_PERIOD_MONTHLY, false)
+		item := *fx.item
+		item.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(5))
+		item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+		item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		subCopy := *fx.sub
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+		// recalculated usage cost 500 * 0.02 = $10 over $5 commitment at 2x → $15
+		result, err := s.calcFeatureUsage(fxCopy, mkUsage(s.charge(fxCopy, 500, 0, s.priceSum)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(15)), "total should be 15, got %s", result.TotalAmount)
+		info := result.LineItems[0].CommitmentInfo
+		s.NotNil(info)
+		s.True(info.ComputedOverageAmount.Equal(decimal.NewFromInt(10)))
+	})
+
+	s.Run("windowed_commitment_with_no_usage_bills_zero", func() {
+		fx := s.newChargesFixture("fcmt_win", types.BILLING_PERIOD_MONTHLY, true)
+		item := *fx.item
+		item.CommitmentAmount = lo.ToPtr(decimal.RequireFromString("0.3"))
+		item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+		item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		item.CommitmentWindowed = true
+		subCopy := *fx.sub
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+		// In-memory feature_usage bucketed query returns no windows → $0.
+		result, err := s.calcFeatureUsage(fxCopy, mkUsage(s.charge(fxCopy, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.IsZero())
+	})
+}
+
+func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_OverageTrueUpAndPriceUnit() {
+	s.Run("overage_charge_keeps_amount_and_gets_overage_metadata", func() {
+		fx := s.newChargesFixture("fovr", types.BILLING_PERIOD_MONTHLY, false)
+		ch := s.charge(fx, 100, 3, s.priceSum)
+		ch.IsOverage = true
+		ch.OverageFactor = 1.5
+
+		result, err := s.calcFeatureUsage(fx, mkUsage(ch))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		li := result.LineItems[0]
+		s.True(li.Amount.Equal(decimal.NewFromInt(3)))
+		s.Equal("true", li.Metadata["is_overage"])
+		s.Equal("Usage fovr (Overage)", lo.FromPtr(li.DisplayName))
+	})
+
+	s.Run("trueup_line_added_when_commitment_underutilized", func() {
+		fx := s.newChargesFixture("ftru", types.BILLING_PERIOD_MONTHLY, false)
+		subCopy := *fx.sub
+		subCopy.CommitmentAmount = lo.ToPtr(decimal.NewFromInt(20))
+		subCopy.OverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		subCopy.EnableTrueUp = true
+		subCopy.LineItems = fx.sub.LineItems
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: fx.item}
+
+		usage := mkUsage(s.charge(fxCopy, 500, 0, s.priceSum))
+		usage.CommitmentUtilized = 10
+
+		result, err := s.calcFeatureUsage(fxCopy, usage)
+		s.NoError(err)
+		s.Len(result.LineItems, 2)
+		s.True(result.TotalAmount.Equal(decimal.NewFromInt(20)), "total should be 10 usage + 10 true-up, got %s", result.TotalAmount)
+		trueUp := result.LineItems[1]
+		s.Equal("true", trueUp.Metadata["is_commitment_trueup"])
+		s.True(trueUp.Amount.Equal(decimal.NewFromInt(10)))
+	})
+
+	s.Run("missing_price_unit_returns_error", func() {
+		fx := s.newChargesFixture("fpu", types.BILLING_PERIOD_MONTHLY, false)
+		item := *fx.item
+		item.PriceUnit = lo.ToPtr("credits_missing")
+		subCopy := *fx.sub
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+		// NOTE: unlike CalculateUsageCharges (which skips the line item and keeps
+		// going), CalculateFeatureUsageCharges fails the whole calculation when a
+		// line item's price unit cannot be resolved.
+		_, err := s.calcFeatureUsage(fxCopy, mkUsage(s.charge(fxCopy, 500, 0, s.priceSum)))
+		s.Error(err)
+		s.ErrorContains(err, "price unit")
+	})
+}

--- a/internal/ee/service/billing_usage_charges_test.go
+++ b/internal/ee/service/billing_usage_charges_test.go
@@ -91,10 +91,10 @@ func (s *BillingUsageChargesSuite) SetupTest() {
 		Aggregation: meter.Aggregation{
 			Type:  types.AggregationMax,
 			Field: "qty",
-			// Hourly buckets: the in-memory event store routes day/month windows
-			// through SUM/COUNT-only aggregation, so MAX bucketing needs a
-			// non-day window size to exercise the real bucketed-max math.
-			BucketSize: types.WindowSizeHour,
+			// Day buckets: the in-memory event store now implements windowed
+			// MAX faithfully (per-day max, total = sum of day maxes), matching
+			// the real ClickHouse bucketed-max SQL.
+			BucketSize: types.WindowSizeDay,
 		},
 		BaseModel: types.GetDefaultBaseModel(ctx),
 	}
@@ -249,6 +249,32 @@ func (s *BillingUsageChargesSuite) insertEvent(eventName string, ts time.Time, q
 	}))
 }
 
+// insertFeatureUsage seeds one feature_usage row for a fixture's bucketed line
+// item — the rows CalculateFeatureUsageCharges aggregates via
+// FeatureUsageRepo.GetUsageForBucketedMeters. Sign 1 mirrors production rows.
+func (s *BillingUsageChargesSuite) insertFeatureUsage(fx *chargesFixture, ts time.Time, qty string) {
+	ctx := s.GetContext()
+	store := s.GetStores().FeatureUsageRepo.(*testutil.InMemoryFeatureUsageStore)
+	s.NoError(store.InsertProcessedEvent(ctx, &events.FeatureUsage{
+		Event: events.Event{
+			ID:                 s.GetUUID(),
+			TenantID:           types.GetTenantID(ctx),
+			EnvironmentID:      types.GetEnvironmentID(ctx),
+			EventName:          "buc_bucket_event",
+			CustomerID:         s.customer.ID,
+			ExternalCustomerID: s.customer.ExternalID,
+			Timestamp:          ts,
+		},
+		SubscriptionID: fx.sub.ID,
+		SubLineItemID:  fx.item.ID,
+		PriceID:        fx.item.PriceID,
+		FeatureID:      s.featBucket.ID,
+		MeterID:        fx.item.MeterID,
+		QtyTotal:       decimal.RequireFromString(qty),
+		Sign:           1,
+	}))
+}
+
 // charge builds a usage charge for the fixture's line item (price matched by ID
 // for CalculateUsageCharges, line item ID for CalculateFeatureUsageCharges).
 func (s *BillingUsageChargesSuite) charge(fx *chargesFixture, qty, amount float64, p *price.Price) *dto.SubscriptionUsageByMetersResponse {
@@ -356,11 +382,11 @@ func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_WeeklyResetFallsBac
 }
 
 func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_BucketedMeterEntitlements() {
-	// Bucketed MAX meter, hourly buckets: 08:00 bucket max(10, 7) = 10,
-	// 09:00 bucket max = 20 → total quantity 30.
+	// Bucketed MAX meter, day buckets: Jun 3 bucket max(10, 7) = 10,
+	// Jun 4 bucket max = 20 → total quantity 30.
 	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), 10)
-	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 8, 30, 0, 0, time.UTC), 7)
-	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 9, 15, 0, 0, time.UTC), 20)
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 12, 30, 0, 0, time.UTC), 7)
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 4, 9, 15, 0, 0, time.UTC), 20)
 
 	s.Run("usage_limit_reduces_aggregate_quantity", func() {
 		fx := s.newChargesFixture("bkt_lim", types.BILLING_PERIOD_MONTHLY, true)
@@ -389,9 +415,9 @@ func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_BucketedMeterEntitl
 }
 
 func (s *BillingUsageChargesSuite) TestCalculateUsageCharges_LineItemCommitment() {
-	// Bucketed usage for the windowed case: two hourly buckets with max 10 and 20.
+	// Bucketed usage for the windowed case: two day buckets with max 10 and 20.
 	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), 10)
-	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 3, 9, 0, 0, 0, time.UTC), 20)
+	s.insertEvent("buc_bucket_event", time.Date(2025, 6, 4, 9, 0, 0, 0, time.UTC), 20)
 
 	s.Run("flat_commitment_bills_overage_at_overage_rate", func() {
 		fx := s.newChargesFixture("cmt_flat", types.BILLING_PERIOD_MONTHLY, false)
@@ -609,28 +635,42 @@ func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_WeeklyAndUnl
 }
 
 func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_BucketedMeterEntitlements() {
-	// The in-memory FeatureUsageRepo returns empty bucketed usage, so bucketed
-	// feature-usage charges compute to zero — these cases pin the control flow
-	// (bucketed query + entitlement gates), not ClickHouse aggregation math.
+	// Bucketed MAX meter over feature_usage rows, day buckets:
+	// Jun 3 max(10, 7) = 10, Jun 4 max = 20 → total quantity 30.
+	seedBucketedUsage := func(fx *chargesFixture) {
+		s.insertFeatureUsage(fx, time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), "10")
+		s.insertFeatureUsage(fx, time.Date(2025, 6, 3, 12, 30, 0, 0, time.UTC), "7")
+		s.insertFeatureUsage(fx, time.Date(2025, 6, 4, 9, 15, 0, 0, time.UTC), "20")
+	}
+
 	s.Run("bucketed_meter_with_usage_limit", func() {
 		fx := s.newChargesFixture("fbkt_lim", types.BILLING_PERIOD_MONTHLY, true)
 		s.addEntitlement(fx, s.featBucket, lo.ToPtr(int64(5)), types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+		seedBucketedUsage(fx)
 
 		result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 0, 0, s.priceBucket)))
 		s.NoError(err)
 		s.Len(result.LineItems, 1)
-		s.True(result.TotalAmount.IsZero())
+		// 30 - 5 = 25 → 25 * $0.02 = $0.5
+		s.True(result.LineItems[0].Quantity.Equal(decimal.NewFromInt(25)),
+			"quantity should be 25, got %s", result.LineItems[0].Quantity)
+		s.True(result.TotalAmount.Equal(decimal.RequireFromString("0.5")),
+			"total should be 0.5, got %s", result.TotalAmount)
 	})
 
 	s.Run("bucketed_meter_with_unlimited_entitlement", func() {
 		fx := s.newChargesFixture("fbkt_unl", types.BILLING_PERIOD_MONTHLY, true)
 		s.addEntitlement(fx, s.featBucket, nil, types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY)
+		seedBucketedUsage(fx)
 
 		result, err := s.calcFeatureUsage(fx, mkUsage(s.charge(fx, 0, 0, s.priceBucket)))
 		s.NoError(err)
 		s.Len(result.LineItems, 1)
 		s.True(result.LineItems[0].Amount.IsZero())
 		s.True(result.LineItems[0].Quantity.IsZero())
+		s.NotNil(result.LineItems[0].AdjustedEntitlementQuantity)
+		s.True(result.LineItems[0].AdjustedEntitlementQuantity.Equal(decimal.NewFromInt(30)),
+			"adjusted entitlement quantity should be the full 30, got %s", result.LineItems[0].AdjustedEntitlementQuantity)
 	})
 }
 
@@ -666,11 +706,41 @@ func (s *BillingUsageChargesSuite) TestCalculateFeatureUsageCharges_LineItemComm
 		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
 		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
 
-		// In-memory feature_usage bucketed query returns no windows → $0.
+		// No feature_usage rows seeded → no windows → $0.
 		result, err := s.calcFeatureUsage(fxCopy, mkUsage(s.charge(fxCopy, 0, 0, s.priceBucket)))
 		s.NoError(err)
 		s.Len(result.LineItems, 1)
 		s.True(result.TotalAmount.IsZero())
+	})
+
+	s.Run("windowed_commitment_applies_per_bucket", func() {
+		fx := s.newChargesFixture("fcmt_win2", types.BILLING_PERIOD_MONTHLY, true)
+		item := *fx.item
+		item.CommitmentAmount = lo.ToPtr(decimal.RequireFromString("0.3"))
+		item.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
+		item.CommitmentOverageFactor = lo.ToPtr(decimal.NewFromInt(2))
+		item.CommitmentWindowed = true
+		subCopy := *fx.sub
+		subCopy.LineItems = []*subscription.SubscriptionLineItem{&item}
+		fxCopy := &chargesFixture{plan: fx.plan, sub: &subCopy, item: &item}
+
+		// Two day buckets with max 10 and 20 → window costs $0.20 / $0.40 vs a
+		// $0.30 per-window commitment at 2x → 0.2 + (0.3 + 0.1*2) = $0.7 —
+		// same math as the raw-events windowed commitment path.
+		s.insertFeatureUsage(fxCopy, time.Date(2025, 6, 3, 8, 0, 0, 0, time.UTC), "10")
+		s.insertFeatureUsage(fxCopy, time.Date(2025, 6, 4, 9, 0, 0, 0, time.UTC), "20")
+
+		result, err := s.calcFeatureUsage(fxCopy, mkUsage(s.charge(fxCopy, 0, 0, s.priceBucket)))
+		s.NoError(err)
+		s.Len(result.LineItems, 1)
+		s.True(result.TotalAmount.Equal(decimal.RequireFromString("0.7")),
+			"total should be 0.7, got %s", result.TotalAmount)
+		info := result.LineItems[0].CommitmentInfo
+		s.NotNil(info)
+		s.True(info.ComputedCommitmentUtilizedAmount.Equal(decimal.RequireFromString("0.5")),
+			"utilized should be 0.5, got %s", info.ComputedCommitmentUtilizedAmount)
+		s.True(info.ComputedOverageAmount.Equal(decimal.RequireFromString("0.2")),
+			"overage should be 0.2, got %s", info.ComputedOverageAmount)
 	})
 }
 

--- a/internal/ee/service/billing_usage_summary_test.go
+++ b/internal/ee/service/billing_usage_summary_test.go
@@ -298,15 +298,29 @@ func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_DailyResetUsesTod
 	s.True(f.UsagePercent.Equal(decimal.RequireFromString("0.2")))
 }
 
+// anchoredMonthStart mirrors the anchored monthly bucketing used by the real
+// ClickHouse repo (formatWindowSizeWithBillingAnchor,
+// internal/repository/clickhouse/aggregators.go:187-201) and the in-memory
+// stores: shift by (anchorDay-1) days, truncate to month start, shift back.
+func anchoredMonthStart(t time.Time, anchor time.Time) time.Time {
+	anchorDay := anchor.Day()
+	shifted := t.UTC().AddDate(0, 0, -(anchorDay - 1))
+	monthStart := time.Date(shifted.Year(), shifted.Month(), 1, 0, 0, 0, 0, time.UTC)
+	return monthStart.AddDate(0, 0, anchorDay-1)
+}
+
 func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_MonthlyResetOnAnnualSub() {
 	fx := s.newSummaryFixture("monthly", types.BILLING_PERIOD_ANNUAL,
 		types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY, lo.ToPtr(int64(200)), 150)
 
-	// Mid-month timestamps keep both events safely inside their calendar months.
-	currentMonth15 := time.Date(s.now.Year(), s.now.Month(), 15, 12, 0, 0, 0, time.UTC)
-	prevMonth15 := currentMonth15.AddDate(0, -1, 0)
-	s.insertEvent(fx, prevMonth15, 100)   // previous month
-	s.insertEvent(fx, currentMonth15, 50) // current month
+	// The usage query passes the subscription's BillingAnchor, so monthly
+	// windows are anchored on the anchor's day-of-month — not calendar months.
+	// Seed one event in the anchored window containing "now" and one in the
+	// window before it; the summary must only count the current window.
+	currentWindow := anchoredMonthStart(s.now, fx.sub.BillingAnchor)
+	previousWindow := anchoredMonthStart(currentWindow.Add(-time.Hour), fx.sub.BillingAnchor)
+	s.insertEvent(fx, previousWindow.Add(12*time.Hour), 100) // previous anchored month
+	s.insertEvent(fx, currentWindow.Add(12*time.Hour), 50)   // current anchored month
 
 	resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), s.customer.ID, nil)
 	s.NoError(err)
@@ -314,7 +328,7 @@ func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_MonthlyResetOnAnn
 	f := s.featureSummary(resp, fx.feat.ID)
 	s.NotNil(f)
 	s.True(f.CurrentUsage.Equal(decimal.NewFromInt(50)),
-		"monthly reset must only count the current month's usage (50), got %s", f.CurrentUsage)
+		"monthly reset must only count the current anchored month's usage (50), got %s", f.CurrentUsage)
 }
 
 func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_NeverResetUsesCumulativeUsage() {

--- a/internal/ee/service/billing_usage_summary_test.go
+++ b/internal/ee/service/billing_usage_summary_test.go
@@ -1,0 +1,587 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
+	"github.com/flexprice/flexprice/internal/domain/meter"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// BillingUsageSummarySuite covers GetCustomerUsageSummary and the small billing
+// helpers around it: getUsagePercent, calculateRemainingCommitment,
+// aggregateStaticEntitlementsForBilling and calculateNeverResetUsage.
+type BillingUsageSummarySuite struct {
+	testutil.BaseServiceTestSuite
+	service   BillingService
+	billing   *billingService
+	eventRepo *testutil.InMemoryEventStore
+	customer  *customer.Customer
+	now       time.Time
+}
+
+func TestBillingUsageSummary(t *testing.T) {
+	suite.Run(t, new(BillingUsageSummarySuite))
+}
+
+func (s *BillingUsageSummarySuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.eventRepo = s.GetStores().EventRepo.(*testutil.InMemoryEventStore)
+	s.service = NewBillingService(newTestServiceParams(&s.BaseServiceTestSuite))
+	s.billing = s.service.(*billingService)
+	s.now = time.Now().UTC()
+
+	s.customer = &customer.Customer{
+		ID:         "cust_bus",
+		ExternalID: "ext_bus",
+		Name:       "Usage Summary Customer",
+		Email:      "bus@test.com",
+		BaseModel:  types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(s.GetContext(), s.customer))
+}
+
+// summaryFixture bundles the entities for one metered feature on one subscription.
+type summaryFixture struct {
+	plan    *plan.Plan
+	meterM  *meter.Meter
+	feat    *feature.Feature
+	priceP  *price.Price
+	sub     *subscription.Subscription
+	item    *subscription.SubscriptionLineItem
+	eventNm string
+}
+
+// newSummaryFixture builds a plan + SUM meter + feature + price + entitlement +
+// active subscription with one usage line item, and seeds one feature_usage row
+// with chargeQty so GetFeatureUsageBySubscription produces a charge.
+func (s *BillingUsageSummarySuite) newSummaryFixture(
+	suffix string,
+	billingPeriod types.BillingPeriod,
+	reset types.EntitlementUsageResetPeriod,
+	limit *int64,
+	chargeQty float64,
+) *summaryFixture {
+	ctx := s.GetContext()
+	fx := &summaryFixture{eventNm: "evt_bus_" + suffix}
+
+	fx.plan = &plan.Plan{
+		ID:        "plan_bus_" + suffix,
+		Name:      "Summary Plan " + suffix,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, fx.plan))
+
+	fx.meterM = &meter.Meter{
+		ID:        "meter_bus_" + suffix,
+		Name:      "Summary Meter " + suffix,
+		EventName: fx.eventNm,
+		Aggregation: meter.Aggregation{
+			Type:  types.AggregationSum,
+			Field: "qty",
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, fx.meterM))
+
+	fx.feat = &feature.Feature{
+		ID:        "feat_bus_" + suffix,
+		Name:      "Summary Feature " + suffix,
+		Type:      types.FeatureTypeMetered,
+		MeterID:   fx.meterM.ID,
+		LookupKey: "lk_bus_" + suffix,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, fx.feat))
+
+	upTo1000 := uint64(1000)
+	fx.priceP = &price.Price{
+		ID:                 "price_bus_" + suffix,
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           fx.plan.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      billingPeriod,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_TIERED,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		TierMode:           types.BILLING_TIER_SLAB,
+		MeterID:            fx.meterM.ID,
+		Tiers: []price.PriceTier{
+			{UpTo: &upTo1000, UnitAmount: decimal.RequireFromString("0.02")},
+			{UpTo: nil, UnitAmount: decimal.RequireFromString("0.01")},
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, fx.priceP))
+
+	ent := &entitlement.Entitlement{
+		ID:               "ent_bus_" + suffix,
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         fx.plan.ID,
+		FeatureID:        fx.feat.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       limit,
+		UsageResetPeriod: reset,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, ent)
+	s.NoError(err)
+
+	// Period windows: short window for monthly billing, wide window for annual.
+	periodStart := s.now.Add(-48 * time.Hour)
+	periodEnd := s.now.Add(6 * 24 * time.Hour)
+	startDate := s.now.Add(-30 * 24 * time.Hour)
+	if billingPeriod == types.BILLING_PERIOD_ANNUAL {
+		periodStart = s.now.Add(-60 * 24 * time.Hour)
+		periodEnd = s.now.Add(300 * 24 * time.Hour)
+		startDate = periodStart
+	}
+
+	fx.sub = &subscription.Subscription{
+		ID:                 "sub_bus_" + suffix,
+		PlanID:             fx.plan.ID,
+		CustomerID:         s.customer.ID,
+		StartDate:          startDate,
+		BillingAnchor:      periodStart,
+		CurrentPeriodStart: periodStart,
+		CurrentPeriodEnd:   periodEnd,
+		Currency:           "usd",
+		BillingPeriod:      billingPeriod,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	fx.item = &subscription.SubscriptionLineItem{
+		ID:               "li_bus_" + suffix,
+		SubscriptionID:   fx.sub.ID,
+		CustomerID:       s.customer.ID,
+		EntityID:         fx.plan.ID,
+		EntityType:       types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName:  fx.plan.Name,
+		PriceID:          fx.priceP.ID,
+		PriceType:        types.PRICE_TYPE_USAGE,
+		MeterID:          fx.meterM.ID,
+		MeterDisplayName: fx.meterM.Name,
+		DisplayName:      "Summary Usage " + suffix,
+		Quantity:         decimal.Zero,
+		Currency:         "usd",
+		BillingPeriod:    billingPeriod,
+		InvoiceCadence:   types.InvoiceCadenceArrear,
+		StartDate:        startDate,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, fx.sub,
+		[]*subscription.SubscriptionLineItem{fx.item}))
+
+	// One feature_usage row so a charge exists for this meter.
+	featureUsageStore := s.GetStores().FeatureUsageRepo.(*testutil.InMemoryFeatureUsageStore)
+	s.NoError(featureUsageStore.InsertProcessedEvent(ctx, &events.FeatureUsage{
+		Event: events.Event{
+			ID:                 s.GetUUID(),
+			TenantID:           types.GetTenantID(ctx),
+			EnvironmentID:      types.GetEnvironmentID(ctx),
+			EventName:          fx.eventNm,
+			CustomerID:         s.customer.ID,
+			ExternalCustomerID: s.customer.ExternalID,
+			Timestamp:          s.now.Add(-1 * time.Hour),
+		},
+		SubscriptionID: fx.sub.ID,
+		SubLineItemID:  fx.item.ID,
+		PriceID:        fx.priceP.ID,
+		FeatureID:      fx.feat.ID,
+		MeterID:        fx.meterM.ID,
+		QtyTotal:       decimal.NewFromFloat(chargeQty),
+	}))
+
+	return fx
+}
+
+// insertEvent seeds one raw event with the given qty for a fixture's meter.
+func (s *BillingUsageSummarySuite) insertEvent(fx *summaryFixture, ts time.Time, qty float64) {
+	ctx := s.GetContext()
+	s.NoError(s.eventRepo.InsertEvent(ctx, &events.Event{
+		ID:                 s.GetUUID(),
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		EventName:          fx.eventNm,
+		ExternalCustomerID: s.customer.ExternalID,
+		Timestamp:          ts,
+		Properties:         map[string]interface{}{"qty": qty},
+	}))
+}
+
+func (s *BillingUsageSummarySuite) featureSummary(resp *dto.CustomerUsageSummaryResponse, featureID string) *dto.FeatureUsageSummary {
+	for _, f := range resp.Features {
+		if f.Feature != nil && f.Feature.ID == featureID {
+			return f
+		}
+	}
+	return nil
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_Validation() {
+	testCases := []struct {
+		name       string
+		customerID string
+	}{
+		{name: "empty_customer_id_returns_error", customerID: ""},
+		{name: "unknown_customer_returns_error", customerID: "cust_does_not_exist"},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), tc.customerID, nil)
+			s.Error(err)
+			s.Nil(resp)
+		})
+	}
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_NoSubscriptionsReturnsEmptyFeatures() {
+	resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), s.customer.ID, nil)
+	s.NoError(err)
+	s.Equal(s.customer.ID, resp.CustomerID)
+	s.Empty(resp.Features)
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_BillingPeriodReset() {
+	fx := s.newSummaryFixture("bp", types.BILLING_PERIOD_MONTHLY,
+		types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY, lo.ToPtr(int64(1000)), 500)
+
+	resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), s.customer.ID, nil)
+	s.NoError(err)
+	s.Len(resp.Features, 1)
+
+	f := s.featureSummary(resp, fx.feat.ID)
+	s.NotNil(f)
+	// Reset period == billing period → usage aggregated from charge quantities.
+	s.True(f.CurrentUsage.Equal(decimal.NewFromInt(500)), "usage should be 500, got %s", f.CurrentUsage)
+	s.True(f.UsagePercent.Equal(decimal.RequireFromString("0.5")), "percent should be 0.5, got %s", f.UsagePercent)
+	s.Equal(int64(1000), lo.FromPtr(f.TotalLimit))
+	s.False(f.IsUnlimited)
+	s.True(f.IsEnabled)
+	s.NotNil(f.NextUsageResetAt, "metered features must carry a next usage reset timestamp")
+	s.Len(f.Sources, 1)
+	s.Equal(fx.sub.ID, f.Sources[0].SubscriptionID)
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_DailyResetUsesTodaysUsage() {
+	fx := s.newSummaryFixture("daily", types.BILLING_PERIOD_MONTHLY,
+		types.ENTITLEMENT_USAGE_RESET_PERIOD_DAILY, lo.ToPtr(int64(100)), 50)
+
+	todayStart := time.Date(s.now.Year(), s.now.Month(), s.now.Day(), 0, 0, 0, 0, time.UTC)
+	s.insertEvent(fx, todayStart.Add(-2*time.Hour), 30) // yesterday
+	s.insertEvent(fx, todayStart.Add(1*time.Hour), 20)  // today
+
+	resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), s.customer.ID, nil)
+	s.NoError(err)
+
+	f := s.featureSummary(resp, fx.feat.ID)
+	s.NotNil(f)
+	s.True(f.CurrentUsage.Equal(decimal.NewFromInt(20)),
+		"daily reset must only count today's usage (20), got %s", f.CurrentUsage)
+	s.True(f.UsagePercent.Equal(decimal.RequireFromString("0.2")))
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_MonthlyResetOnAnnualSub() {
+	fx := s.newSummaryFixture("monthly", types.BILLING_PERIOD_ANNUAL,
+		types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY, lo.ToPtr(int64(200)), 150)
+
+	// Mid-month timestamps keep both events safely inside their calendar months.
+	currentMonth15 := time.Date(s.now.Year(), s.now.Month(), 15, 12, 0, 0, 0, time.UTC)
+	prevMonth15 := currentMonth15.AddDate(0, -1, 0)
+	s.insertEvent(fx, prevMonth15, 100)   // previous month
+	s.insertEvent(fx, currentMonth15, 50) // current month
+
+	resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), s.customer.ID, nil)
+	s.NoError(err)
+
+	f := s.featureSummary(resp, fx.feat.ID)
+	s.NotNil(f)
+	s.True(f.CurrentUsage.Equal(decimal.NewFromInt(50)),
+		"monthly reset must only count the current month's usage (50), got %s", f.CurrentUsage)
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_NeverResetUsesCumulativeUsage() {
+	fx := s.newSummaryFixture("never", types.BILLING_PERIOD_MONTHLY,
+		types.ENTITLEMENT_USAGE_RESET_PERIOD_NEVER, lo.ToPtr(int64(1000)), 50)
+
+	s.insertEvent(fx, s.now.Add(-10*24*time.Hour), 100) // before current period, after sub start
+	s.insertEvent(fx, s.now.Add(-1*time.Hour), 50)      // in current period
+
+	resp, err := s.service.GetCustomerUsageSummary(s.GetContext(), s.customer.ID, nil)
+	s.NoError(err)
+
+	f := s.featureSummary(resp, fx.feat.ID)
+	s.NotNil(f)
+	s.True(f.CurrentUsage.Equal(decimal.NewFromInt(150)),
+		"never reset must count cumulative usage since subscription start (150), got %s", f.CurrentUsage)
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_FeatureFilters() {
+	ctx := s.GetContext()
+	// Two boolean features on one plan.
+	pl := &plan.Plan{ID: "plan_bus_filters", Name: "Filter Plan", BaseModel: types.GetDefaultBaseModel(ctx)}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, pl))
+	mkBool := func(id, lookupKey string) *feature.Feature {
+		f := &feature.Feature{
+			ID: id, Name: "Feature " + id, Type: types.FeatureTypeBoolean,
+			LookupKey: lookupKey, BaseModel: types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().FeatureRepo.Create(ctx, f))
+		e := &entitlement.Entitlement{
+			ID: "ent_" + id, EntityType: types.ENTITLEMENT_ENTITY_TYPE_PLAN, EntityID: pl.ID,
+			FeatureID: f.ID, FeatureType: types.FeatureTypeBoolean, IsEnabled: true,
+			BaseModel: types.GetDefaultBaseModel(ctx),
+		}
+		_, err := s.GetStores().EntitlementRepo.Create(ctx, e)
+		s.NoError(err)
+		return f
+	}
+	f1 := mkBool("feat_bus_f1", "lk_bus_f1")
+	mkBool("feat_bus_f2", "lk_bus_f2")
+
+	sub := &subscription.Subscription{
+		ID: "sub_bus_filters", PlanID: pl.ID, CustomerID: s.customer.ID,
+		StartDate:          s.now.Add(-30 * 24 * time.Hour),
+		BillingAnchor:      s.now.Add(-48 * time.Hour),
+		CurrentPeriodStart: s.now.Add(-48 * time.Hour),
+		CurrentPeriodEnd:   s.now.Add(6 * 24 * time.Hour),
+		Currency:           "usd", BillingPeriod: types.BILLING_PERIOD_MONTHLY, BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, sub))
+
+	s.Run("feature_ids_filter_returns_only_matching_features", func() {
+		resp, err := s.service.GetCustomerUsageSummary(ctx, s.customer.ID, &dto.GetCustomerUsageSummaryRequest{
+			FeatureIDs: []string{f1.ID},
+		})
+		s.NoError(err)
+		s.Len(resp.Features, 1)
+		s.Equal(f1.ID, resp.Features[0].Feature.ID)
+		// Boolean features have no limits and no usage.
+		s.True(resp.Features[0].IsUnlimited)
+		s.True(resp.Features[0].CurrentUsage.IsZero())
+		s.Nil(resp.Features[0].NextUsageResetAt)
+	})
+
+	s.Run("feature_lookup_keys_are_resolved_to_feature_ids", func() {
+		resp, err := s.service.GetCustomerUsageSummary(ctx, s.customer.ID, &dto.GetCustomerUsageSummaryRequest{
+			FeatureLookupKeys: []string{"lk_bus_f1"},
+		})
+		s.NoError(err)
+		f := s.featureSummary(resp, f1.ID)
+		s.NotNil(f, "feature resolved via lookup key must be present")
+		s.True(f.IsEnabled)
+	})
+}
+
+func (s *BillingUsageSummarySuite) TestGetCustomerUsageSummary_SortsFeaturesByType() {
+	ctx := s.GetContext()
+	// Metered feature via fixture (sorted first) …
+	fx := s.newSummaryFixture("sort", types.BILLING_PERIOD_MONTHLY,
+		types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY, lo.ToPtr(int64(1000)), 10)
+
+	// … plus one static and one boolean feature on the same plan.
+	statFeat := &feature.Feature{
+		ID: "feat_bus_static", Name: "A Static Feature", Type: types.FeatureTypeStatic,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, statFeat))
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, &entitlement.Entitlement{
+		ID: "ent_bus_static", EntityType: types.ENTITLEMENT_ENTITY_TYPE_PLAN, EntityID: fx.plan.ID,
+		FeatureID: statFeat.ID, FeatureType: types.FeatureTypeStatic, IsEnabled: true,
+		StaticValue: "gold", BaseModel: types.GetDefaultBaseModel(ctx),
+	})
+	s.NoError(err)
+
+	boolFeat := &feature.Feature{
+		ID: "feat_bus_bool", Name: "A Boolean Feature", Type: types.FeatureTypeBoolean,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, boolFeat))
+	_, err = s.GetStores().EntitlementRepo.Create(ctx, &entitlement.Entitlement{
+		ID: "ent_bus_bool", EntityType: types.ENTITLEMENT_ENTITY_TYPE_PLAN, EntityID: fx.plan.ID,
+		FeatureID: boolFeat.ID, FeatureType: types.FeatureTypeBoolean, IsEnabled: true,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	})
+	s.NoError(err)
+
+	resp, err := s.service.GetCustomerUsageSummary(ctx, s.customer.ID, nil)
+	s.NoError(err)
+	s.Len(resp.Features, 3)
+	// Order: metered < static < boolean.
+	s.Equal(fx.feat.ID, resp.Features[0].Feature.ID)
+	s.Equal(statFeat.ID, resp.Features[1].Feature.ID)
+	s.Equal(boolFeat.ID, resp.Features[2].Feature.ID)
+}
+
+func (s *BillingUsageSummarySuite) TestGetUsagePercent() {
+	testCases := []struct {
+		name     string
+		usage    decimal.Decimal
+		limit    *int64
+		expected decimal.Decimal
+	}{
+		{
+			name:     "nil_limit_returns_zero",
+			usage:    decimal.NewFromInt(50),
+			limit:    nil,
+			expected: decimal.Zero,
+		},
+		{
+			name:     "zero_limit_returns_hundred",
+			usage:    decimal.NewFromInt(50),
+			limit:    lo.ToPtr(int64(0)),
+			expected: decimal.NewFromInt(100),
+		},
+		{
+			name:     "negative_limit_returns_hundred",
+			usage:    decimal.NewFromInt(50),
+			limit:    lo.ToPtr(int64(-5)),
+			expected: decimal.NewFromInt(100),
+		},
+		{
+			name:     "usage_divided_by_limit",
+			usage:    decimal.NewFromInt(50),
+			limit:    lo.ToPtr(int64(200)),
+			expected: decimal.RequireFromString("0.25"),
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			got := s.billing.getUsagePercent(tc.usage, tc.limit)
+			s.True(got.Equal(tc.expected), "want %s got %s", tc.expected, got)
+		})
+	}
+}
+
+func (s *BillingUsageSummarySuite) TestCalculateRemainingCommitment() {
+	testCases := []struct {
+		name       string
+		usage      *dto.GetUsageBySubscriptionResponse
+		commitment decimal.Decimal
+		expected   decimal.Decimal
+	}{
+		{
+			name:       "nil_usage_returns_zero",
+			usage:      nil,
+			commitment: decimal.NewFromInt(100),
+			expected:   decimal.Zero,
+		},
+		{
+			name:       "partial_utilization_returns_difference_with_decimals",
+			usage:      &dto.GetUsageBySubscriptionResponse{CommitmentUtilized: 10.25},
+			commitment: decimal.RequireFromString("25.75"),
+			expected:   decimal.RequireFromString("15.5"),
+		},
+		{
+			name:       "over_utilization_clamps_to_zero",
+			usage:      &dto.GetUsageBySubscriptionResponse{CommitmentUtilized: 30},
+			commitment: decimal.NewFromInt(20),
+			expected:   decimal.Zero,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			got := s.billing.calculateRemainingCommitment(tc.usage, tc.commitment)
+			s.True(got.Equal(tc.expected), "want %s got %s", tc.expected, got)
+		})
+	}
+}
+
+func (s *BillingUsageSummarySuite) TestAggregateStaticEntitlementsForBilling() {
+	mkEnt := func(enabled bool, value string) *entitlement.Entitlement {
+		return &entitlement.Entitlement{IsEnabled: enabled, StaticValue: value}
+	}
+	testCases := []struct {
+		name            string
+		entitlements    []*entitlement.Entitlement
+		expectedEnabled bool
+		expectedValues  []string
+	}{
+		{
+			name:            "all_disabled_returns_disabled_with_no_values",
+			entitlements:    []*entitlement.Entitlement{mkEnt(false, "silver")},
+			expectedEnabled: false,
+			expectedValues:  []string{},
+		},
+		{
+			name:            "duplicate_values_are_deduplicated",
+			entitlements:    []*entitlement.Entitlement{mkEnt(true, "gold"), mkEnt(true, "gold"), mkEnt(true, "silver")},
+			expectedEnabled: true,
+			expectedValues:  []string{"gold", "silver"},
+		},
+		{
+			name:            "empty_static_values_are_skipped",
+			entitlements:    []*entitlement.Entitlement{mkEnt(true, ""), mkEnt(true, "gold")},
+			expectedEnabled: true,
+			expectedValues:  []string{"gold"},
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			got := aggregateStaticEntitlementsForBilling(tc.entitlements)
+			s.Equal(tc.expectedEnabled, got.IsEnabled)
+			s.Equal(tc.expectedValues, got.StaticValues)
+		})
+	}
+}
+
+func (s *BillingUsageSummarySuite) TestCalculateNeverResetUsage() {
+	ctx := s.GetContext()
+	fx := s.newSummaryFixture("nru", types.BILLING_PERIOD_MONTHLY,
+		types.ENTITLEMENT_USAGE_RESET_PERIOD_NEVER, lo.ToPtr(int64(100)), 0)
+
+	// 100 units before the current period (already billed), 500 in-period.
+	s.insertEvent(fx, s.now.Add(-10*24*time.Hour), 100)
+	s.insertEvent(fx, s.now.Add(-1*time.Hour), 500)
+
+	eventService := NewEventService(
+		s.billing.EventRepo, s.billing.MeterRepo, s.billing.EventPublisher,
+		s.billing.Logger, s.billing.Config, s.billing.TracingSvc)
+
+	testCases := []struct {
+		name     string
+		allowed  decimal.Decimal
+		expected decimal.Decimal
+	}{
+		{
+			// (600 - 100) - 50 = 450
+			name:     "period_usage_minus_allowance_is_billable",
+			allowed:  decimal.NewFromInt(50),
+			expected: decimal.NewFromInt(450),
+		},
+		{
+			// allowance larger than period usage → clamp at zero
+			name:     "allowance_covering_usage_bills_zero",
+			allowed:  decimal.NewFromInt(600),
+			expected: decimal.Zero,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			got, err := s.billing.calculateNeverResetUsage(
+				ctx, fx.sub, fx.item, []string{s.customer.ExternalID}, eventService,
+				fx.sub.CurrentPeriodStart, fx.sub.CurrentPeriodEnd, tc.allowed)
+			s.NoError(err)
+			s.True(got.Equal(tc.expected), "want %s got %s", tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Stacked on #2167 (retargets to `main` when it merges). Part of the `internal/ee/service` coverage initiative.

3 new test files, +99 table-driven cases, no existing files touched:
- `billing_meter_usage_test.go` — CalculateMeterUsageCharges: entitlement adjustments across all reset cadences (billing-period/unlimited/daily/monthly-on-annual/never), flat + true-up + windowed commitments with CommitmentInfo breakdown, bucketed meters (prefetch vs direct-query fallback), cumulative ANNUAL commitment (mid-period overage split + last-period true-up), full pipeline incl. **recompute idempotency (no double-billing)**.
- `billing_usage_summary_test.go` — GetCustomerUsageSummary across reset cadences + filters; direct decimal tables for getUsagePercent, calculateRemainingCommitment, aggregateStaticEntitlementsForBilling, calculateNeverResetUsage.
- `billing_usage_charges_test.go` — CalculateUsageCharges / CalculateFeatureUsageCharges branch coverage: resets, bucketed-max entitlements, commitments, overage metadata, price-unit failure paths.

| File | Before | After |
|---|---|---|
| billing.go | 59.1% | **83.0%** |
| billing_meter_usage.go | 0% | **83.6%** |

## Note for reviewers
One test pins current (suspect) behavior with a NOTE comment: when a line item's PriceUnit can't be resolved, `CalculateUsageCharges` skips the line item but its amount is already in `TotalAmount` (total ≠ sum of line items; the sibling `CalculateFeatureUsageCharges` errors instead). Flagged for a separate fix — this PR does not change production code.

## Test plan
- `go test -race -count=1 ./internal/ee/service/` green on this branch and on the full stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)