### PR TITLE
ci(deploy): add shared buildx registry layer cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,10 @@ jobs:
           push: true
           tags: ${{ steps.image-tag.outputs.ecr_tag }}
           provenance: false
+          # Shared layer cache in GHCR (both AWS + GCP self-hosted runners reach it).
+          # First build of a commit populates it; rebuilds and the GHCR step below hit it.
+          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache,mode=max
 
       - name: Push image to GHCR
         uses: docker/build-push-action@v7
@@ -127,6 +131,8 @@ jobs:
           push: true
           tags: ${{ steps.image-tag.outputs.ghcr_tags }}
           provenance: false
+          # Reuses the cache the ECR build just populated -> all layers hit, no rebuild.
+          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
 
       - name: Set image output
         id: set-image


### PR DESCRIPTION
## What

Docker builds on the self-hosted runners (`deploy.yml`) ran **fully cold every time**. Worse, the ECR and GHCR steps built the *identical* image twice from scratch.

## Change

Registry-backed buildx layer cache in GHCR (`ghcr.io/flexprice/flexprice:buildcache`):
- **ECR build** populates it — `cache-to ... mode=max`
- **GHCR push** reuses it — `cache-from` → all-layer cache hit, no second build
- Cache lives in a registry **both the AWS (`sandbox`) and GCP (`gcp-uswest1`) runners reach**, so warm builds work whichever runner picks the job

## Impact

- First build of a commit: same as today (populates cache)
- Subsequent builds / the GHCR step: warm, near-instant on unchanged layers
- GHCR push stays `continue-on-error` (soft) — ECR remains the hard deploy source; no behavior change

## Test

YAML validated. Cache effect observable on next tag build — first run seeds `:buildcache`, second shows `CACHED` layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build caching for release deployments, which should speed up image creation and reduce repeated work during deploys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->