### PR TITLE
fix(config): restore FLEXPRICE_SVIX_API_KEY alias dropped by auto-bind (staging Svix 401)

### DIFF
--- a/internal/config/autobind_test.go
+++ b/internal/config/autobind_test.go
@@ -93,3 +93,31 @@ func TestAutoBindLeavesOptionalPointerNil(t *testing.T) {
 		t.Errorf("kafka_secondary = %#v, want nil (reflective bind must not allocate the optional pointer struct)", cfg.KafkaSecondary)
 	}
 }
+
+// TestCustomEnvAliasesBind guards the env-var names that do NOT follow the struct-derived
+// FLEXPRICE_<PATH> convention and therefore CANNOT be covered by the reflection walker —
+// they must stay as explicit v.BindEnv calls. Dropping the svix alias broke Svix with 401s
+// on staging (2026-07-06); this test fails loudly if any such alias is removed again.
+func TestCustomEnvAliasesBind(t *testing.T) {
+	cases := []struct {
+		env, val string
+		get      func(*Configuration) string
+	}{
+		{"SERVICE_NAME", "probe-svc", func(c *Configuration) string { return c.Logging.ServiceName }},
+		{"ENVIRONMENT", "probe-env", func(c *Configuration) string { return c.Logging.Environment }},
+		{"REGION", "probe-region", func(c *Configuration) string { return c.Logging.Region }},
+		{"FLEXPRICE_SVIX_API_KEY", "probe-svix-token", func(c *Configuration) string { return c.Webhook.Svix.AuthToken }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			t.Setenv(tc.env, tc.val)
+			cfg, err := NewConfig()
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if got := tc.get(cfg); got != tc.val {
+				t.Errorf("env %s did not bind: got %q, want %q — custom alias likely dropped", tc.env, got, tc.val)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -732,6 +732,12 @@ func NewConfig() (*Configuration, error) {
 	_ = v.BindEnv("logging.environment", "ENVIRONMENT")
 	_ = v.BindEnv("logging.region", "REGION")
 
+	// Legacy custom env aliases: these keys are fed by an env var whose name does NOT
+	// match the struct-derived FLEXPRICE_<PATH> name, so the reflection walker below cannot
+	// register them. They MUST stay explicit. (svix: deployments set FLEXPRICE_SVIX_API_KEY,
+	// not FLEXPRICE_WEBHOOK_SVIX_CONFIG_AUTH_TOKEN — dropping this bind broke Svix with 401s.)
+	_ = v.BindEnv("webhook.svix_config.auth_token", "FLEXPRICE_SVIX_API_KEY")
+
 	// Auto-bind every scalar/slice key in the Configuration struct to its FLEXPRICE_* env
 	// var. This replaces ~50 hand-written v.BindEnv calls (a graveyard grown one prod
 	// incident at a time). Viper's AutomaticEnv is NOT consulted by Unmarshal for keys


### PR DESCRIPTION
## Symptom
Staging (GCP mumbai) logs: `failed to get/create Svix application: status code 401 Unauthorized`. All pods healthy — this is a webhook auth failure, not a boot problem.

## Root cause
The config-autobind reflection loader (#2180, on develop) binds each key to its **struct-derived** `FLEXPRICE_<PATH>` name. But `webhook.svix_config.auth_token` is fed by a **custom alias** `FLEXPRICE_SVIX_API_KEY` (not `FLEXPRICE_WEBHOOK_SVIX_CONFIG_AUTH_TOKEN`). Replacing the manual `BindEnv` graveyard with reflection silently dropped that alias, so:

- staging injects `FLEXPRICE_SVIX_API_KEY` (from `flexprice-secrets`),
- the loader never maps it → `webhook.svix_config.auth_token` falls back to the baked placeholder,
- Svix rejects the placeholder token → **401**.

The env var *is* present in the pod, but the app doesn't bind it — verified by fingerprinting the running staging binary (`bindEnvs`, `NewValidatedConfig` present) and confirming develop's config.go has **no** svix `BindEnv`. This same 401 was fixed once before in #2078; the reflection refactor re-broke it.

## Fix
Re-add the explicit alias bind alongside the reflection walker (same treatment as the 3 bare `SERVICE_NAME`/`ENVIRONMENT`/`REGION` binds — the only other names the reflection walker can't derive):

```go
_ = v.BindEnv("webhook.svix_config.auth_token", "FLEXPRICE_SVIX_API_KEY")
```

Both names now resolve (Viper checks the alias first, then the derived name).

## Regression guard
Adds `TestCustomEnvAliasesBind` — asserts all four non-derivable aliases (`SERVICE_NAME`, `ENVIRONMENT`, `REGION`, `FLEXPRICE_SVIX_API_KEY`) still bind, so none can be silently dropped again.

Once merged and the develop image redeploys, staging Svix recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved support for existing environment-based configuration values, including a legacy API key setting, so app setup continues to work as expected.
  * Improved configuration reliability by ensuring important environment aliases still load correctly during startup.
* **Tests**
  * Added coverage to prevent future regressions in environment variable binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->