### PR TITLE
chore(cache): Set default deduplication to false

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -476,7 +476,7 @@ type MeterUsageTrackingConfig struct {
 	RateLimit                 int64  `mapstructure:"rate_limit" default:"1"`
 	ConsumerGroup             string `mapstructure:"consumer_group" default:"v1_meter_usage_tracking_service"`
 	TopicDLQ                  string `mapstructure:"topic_dlq" default:""`
-	RedisDeduplicationEnabled bool   `mapstructure:"redis_deduplication_enabled" default:"true"`
+	RedisDeduplicationEnabled bool   `mapstructure:"redis_deduplication_enabled" default:"false"`
 }
 
 // MeterUsageTrackingLazyConfig configures the lazy consumer for tenants that

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -325,7 +325,7 @@ meter_usage_tracking:
   rate_limit: 1
   consumer_group: "v1_meter_usage_tracking_service"
   topic_dlq: "meter_usage_tracking_service_dlq"
-  redis_deduplication_enabled: true
+  redis_deduplication_enabled: false
 
 meter_usage_tracking_lazy:
   enabled: true

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -289,25 +289,30 @@ func (s *meterUsageTrackingService) getMetersForEvent(ctx context.Context, event
 // No subscription/feature/price resolution needed.
 func (s *meterUsageTrackingService) processEvent(ctx context.Context, event *events.Event) error {
 	// Step 0: Check if the event is already processed
-	if s.Config.MeterUsageTracking.RedisDeduplicationEnabled &&
+	if event.ID != "" &&
+		s.Config.MeterUsageTracking.RedisDeduplicationEnabled &&
 		s.ServiceParams.Locker != nil {
 		eventId := event.ID
 		cacheKey := cache.GenerateKey(ctx, cache.PrefixEvent, eventId)
 		lock, err := s.ServiceParams.Locker.AcquireLock(ctx, cacheKey, eventDeduplicationLockTTL)
 		if err != nil {
-			return fmt.Errorf("failed to check if event is already processed: %w", err)
-		}
-		if !lock.AcquiredSuccessfully() {
-			s.Logger.Info(ctx, "event already processed, skipping", "event_id", eventId)
-			return nil
-		}
-
-		// release lock on error so retries don't block
-		defer func() {
-			if err != nil {
-				lock.Release(ctx)
+			s.Logger.Error(ctx, "failed to acquire lock on meter usage tracking event", "error", err, "event_id", eventId)
+		} else {
+			if !lock.AcquiredSuccessfully() {
+				s.Logger.Info(ctx, "event already processed, skipping", "event_id", eventId)
+				return nil
 			}
-		}()
+
+			// release lock on error so retries don't block
+			defer func() {
+				if err != nil {
+					lockErr := lock.Release(ctx)
+					if lockErr != nil {
+						s.Logger.Error(ctx, "failed to release lock on meter usage tracking event", "error", lockErr, "event_id", eventId)
+					}
+				}
+			}()
+		}
 	}
 
 	// Step 1: Lookup meters by event name (cache-first)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Updated meter usage tracking to stop using Redis deduplication by default when the setting is not specified.
  * Event processing now continues even if locking for deduplication cannot be acquired, reducing interruptions.
  * Deduplication is only attempted for events that include an event ID, which may affect how duplicate events are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->