### PR TITLE
fix(invoice,priceunit): return typed errors instead of nil-pointer panics

### DIFF
--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -549,6 +549,14 @@ func (s *invoiceService) GetInvoice(ctx context.Context, id string) (*dto.Invoic
 	response := dto.NewInvoiceResponse(inv)
 
 	if inv.InvoiceType == types.InvoiceTypeSubscription {
+		if inv.SubscriptionID == nil || *inv.SubscriptionID == "" {
+			return nil, ierr.NewError("subscription invoice is missing subscription id").
+				WithHint("Invoice is marked as subscription type but has no subscription reference").
+				WithReportableDetails(map[string]interface{}{
+					"invoice_id": inv.ID,
+				}).
+				Mark(ierr.ErrInternal)
+		}
 		subscription, err := subscriptionService.GetSubscription(ctx, *inv.SubscriptionID)
 		if err != nil {
 			return nil, err

--- a/internal/ee/service/invoice_get_regression_test.go
+++ b/internal/ee/service/invoice_get_regression_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// InvoiceGetRegressionSuite pins GetInvoice guard behavior for malformed
+// subscription invoices. Regression for a nil-pointer panic: GetInvoice
+// dereferenced *inv.SubscriptionID for SUBSCRIPTION-type invoices without a
+// nil check, so an invoice missing its subscription reference crashed the
+// read path instead of returning a typed error.
+type InvoiceGetRegressionSuite struct {
+	testutil.BaseServiceTestSuite
+	service InvoiceService
+}
+
+func TestInvoiceGetRegression(t *testing.T) {
+	suite.Run(t, new(InvoiceGetRegressionSuite))
+}
+
+func (s *InvoiceGetRegressionSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.service = NewInvoiceService(newTestServiceParams(&s.BaseServiceTestSuite))
+}
+
+func (s *InvoiceGetRegressionSuite) createInvoiceFixture(id string, subscriptionID *string) *invoice.Invoice {
+	cust := &customer.Customer{
+		ID:        "cust_" + id,
+		Name:      "Regression Customer",
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(s.GetContext(), cust))
+
+	inv := &invoice.Invoice{
+		ID:              id,
+		CustomerID:      cust.ID,
+		SubscriptionID:  subscriptionID,
+		InvoiceType:     types.InvoiceTypeSubscription,
+		InvoiceStatus:   types.InvoiceStatusDraft,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		Subtotal:        decimal.Zero,
+		Total:           decimal.Zero,
+		AmountDue:       decimal.Zero,
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.Zero,
+		BaseModel:       types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(s.GetContext(), inv))
+	return inv
+}
+
+func (s *InvoiceGetRegressionSuite) TestGetInvoiceSubscriptionTypeWithoutSubscriptionReference() {
+	testCases := []struct {
+		name           string
+		invoiceID      string
+		subscriptionID *string
+	}{
+		{
+			name:           "nil_subscription_id_returns_internal_error_not_panic",
+			invoiceID:      "inv_regr_nil_sub_id",
+			subscriptionID: nil,
+		},
+		{
+			name:           "empty_subscription_id_returns_internal_error_not_panic",
+			invoiceID:      "inv_regr_empty_sub_id",
+			subscriptionID: lo.ToPtr(""),
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			inv := s.createInvoiceFixture(tc.invoiceID, tc.subscriptionID)
+
+			resp, err := s.service.GetInvoice(s.GetContext(), inv.ID)
+
+			s.Error(err)
+			s.Nil(resp)
+			s.True(ierr.IsInternal(err), "expected internal error, got: %v", err)
+
+			// The invoice itself must remain readable at the repo level —
+			// the guard rejects the read, it must not mutate anything.
+			stored, repoErr := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
+			s.NoError(repoErr)
+			s.Equal(types.InvoiceTypeSubscription, stored.InvoiceType)
+		})
+	}
+}

--- a/internal/ee/service/priceunit.go
+++ b/internal/ee/service/priceunit.go
@@ -81,17 +81,16 @@ func (s *priceUnitService) GetPriceUnitByCode(ctx context.Context, code string) 
 }
 
 func (s *priceUnitService) ListPriceUnits(ctx context.Context, filter *types.PriceUnitFilter) (*dto.ListPriceUnitsResponse, error) {
+	if filter == nil {
+		filter = types.NewPriceUnitFilter()
+	}
+	if filter.QueryFilter == nil {
+		filter.QueryFilter = types.NewDefaultQueryFilter()
+	}
+
 	// Validate filter
 	if err := filter.Validate(); err != nil {
 		return nil, err
-	}
-
-	if filter.GetLimit() == 0 {
-		filter.QueryFilter = types.NewDefaultQueryFilter()
-	}
-
-	if filter.QueryFilter == nil {
-		filter.QueryFilter = types.NewDefaultQueryFilter()
 	}
 
 	// Get price units from repository

--- a/internal/ee/service/priceunit_list_regression_test.go
+++ b/internal/ee/service/priceunit_list_regression_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/domain/priceunit"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// PriceUnitListRegressionSuite pins ListPriceUnits filter-guard behavior.
+// Regressions covered:
+//  1. a nil *types.PriceUnitFilter panicked inside filter.Validate()
+//     (field access on a nil receiver) instead of listing with defaults;
+//  2. a no-limit filter (GetLimit() == 0) was silently replaced with the
+//     default limit-50 QueryFilter, making unlimited listing impossible and
+//     clobbering any other QueryFilter fields the caller had set.
+type PriceUnitListRegressionSuite struct {
+	testutil.BaseServiceTestSuite
+	service PriceUnitService
+}
+
+func TestPriceUnitListRegression(t *testing.T) {
+	suite.Run(t, new(PriceUnitListRegressionSuite))
+}
+
+func (s *PriceUnitListRegressionSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.service = NewPriceUnitService(newTestServiceParams(&s.BaseServiceTestSuite))
+}
+
+func (s *PriceUnitListRegressionSuite) seedPriceUnits(count int) {
+	for i := 0; i < count; i++ {
+		pu := &priceunit.PriceUnit{
+			ID:             fmt.Sprintf("pu_regr_%03d", i),
+			Name:           fmt.Sprintf("Regression Unit %03d", i),
+			Code:           fmt.Sprintf("r%02d", i),
+			Symbol:         "RU",
+			BaseCurrency:   "usd",
+			ConversionRate: decimal.NewFromInt(1),
+			BaseModel:      types.GetDefaultBaseModel(s.GetContext()),
+		}
+		_, err := s.GetStores().PriceUnitRepo.Create(s.GetContext(), pu)
+		s.NoError(err)
+	}
+}
+
+func (s *PriceUnitListRegressionSuite) TestListPriceUnitsFilterGuards() {
+	// 55 units: one more than fits in the default limit-50 page, so the
+	// unlimited and default paths return observably different counts.
+	const seeded = 55
+	s.seedPriceUnits(seeded)
+
+	s.Run("nil_filter_lists_with_defaults_not_panic", func() {
+		resp, err := s.service.ListPriceUnits(s.GetContext(), nil)
+		s.NoError(err)
+		s.NotNil(resp)
+		s.Len(resp.Items, 50)
+		s.Equal(50, resp.Pagination.Limit)
+	})
+
+	s.Run("nil_query_filter_is_defaulted_not_panic", func() {
+		resp, err := s.service.ListPriceUnits(s.GetContext(), &types.PriceUnitFilter{})
+		s.NoError(err)
+		s.NotNil(resp)
+		s.Len(resp.Items, 50)
+		s.Equal(50, resp.Pagination.Limit)
+	})
+
+	s.Run("no_limit_filter_returns_all_items", func() {
+		filter := types.NewNoLimitPriceUnitFilter()
+		resp, err := s.service.ListPriceUnits(s.GetContext(), filter)
+		s.NoError(err)
+		s.Len(resp.Items, seeded)
+		// The caller's filter must not be clobbered into a limited one.
+		s.True(filter.IsUnlimited())
+	})
+
+	s.Run("default_filter_caps_at_default_page_size", func() {
+		resp, err := s.service.ListPriceUnits(s.GetContext(), types.NewPriceUnitFilter())
+		s.NoError(err)
+		s.Len(resp.Items, 50)
+	})
+}


### PR DESCRIPTION
## Summary
Fixes two nil-pointer panics surfaced by the unit-test coverage push. Stacked on #2167 (the regression tests use `newTestServiceParams` from that PR; auto-retargets to `main` when it merges).

### 1. `GetInvoice` — nil `SubscriptionID` on a SUBSCRIPTION-type invoice
`invoice.go` dereferenced `*inv.SubscriptionID` unguarded when `InvoiceType == SUBSCRIPTION`. An invoice missing its subscription reference (constructible via `UpdateInvoice`) crashed the whole read path. Now returns a typed `ierr` internal error with the invoice ID in reportable details; nil and empty-string cases both guarded.

### 2. `ListPriceUnits` — nil-filter panic + no-limit clobbering
- `ListPriceUnits(ctx, nil)` panicked inside `filter.Validate()` (field access on a nil receiver). Now defaults a nil filter / nil QueryFilter first, matching the convention used by sibling services (e.g. `GetAddons`).
- The `GetLimit() == 0` branch replaced **no-limit** filters (`Limit == nil` → `GetLimit()` returns 0) with the default limit-50 QueryFilter — unlimited listing was impossible and any status/sort fields on the caller's QueryFilter were clobbered. The branch is removed; the Ent repo already treats `limit == 0` as unlimited (`ApplyPaginationFilter` applies `Limit` only when `> 0`).

**Bonus fix:** `price.go`'s bulk price-unit expansion builds a `NewNoLimitPriceUnitFilter` with `PriceUnitIDs` — the clobbering silently capped that expansion at 50 units. It is now genuinely unlimited.

**No API behavior change:** the v1 handlers apply their own `limit==0 → default` normalization *before* calling the service, so HTTP pagination semantics are untouched.

## Regression tests
- `invoice_get_regression_test.go` — nil and empty SubscriptionID → typed internal error, invoice still readable at repo level.
- `priceunit_list_regression_test.go` — nil filter / nil QueryFilter list with defaults; no-limit filter returns all 55 seeded units (default returns 50) and the caller's filter is not mutated.
- **Verified both ways:** with the production fixes reverted, the invoice test panics with the exact nil-deref and the nil-filter test fails; with the fixes, all pass.

## Test plan
- `go test -race -count=1 ./internal/ee/service/...` — 2,811 cases green on the full stack; regression suites green on this branch in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)