### PR TITLE
fix(price): apply PriceFilter.SubscriptionID — cross-subscription price leak

### DIFF
--- a/internal/ee/service/price_subscription_scope_test.go
+++ b/internal/ee/service/price_subscription_scope_test.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// PriceSubscriptionScopeSuite is a regression suite for a cross-subscription
+// price leak: PriceFilter.SubscriptionID was validated and set by
+// GetPricesBySubscriptionID but never applied as a query predicate, so the
+// method returned every subscription-scoped price in the tenant/environment
+// instead of only the requested subscription's.
+type PriceSubscriptionScopeSuite struct {
+	testutil.BaseServiceTestSuite
+	service PriceService
+}
+
+func TestPriceSubscriptionScope(t *testing.T) {
+	suite.Run(t, new(PriceSubscriptionScopeSuite))
+}
+
+func (s *PriceSubscriptionScopeSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.service = NewPriceService(newTestServiceParams(&s.BaseServiceTestSuite))
+}
+
+func (s *PriceSubscriptionScopeSuite) createSubscriptionPrice(id, subscriptionID string, amount int64) {
+	p := &price.Price{
+		ID:                 id,
+		Amount:             decimal.NewFromInt(amount),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
+		EntityID:           subscriptionID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(s.GetContext(), p))
+}
+
+func (s *PriceSubscriptionScopeSuite) TestGetPricesBySubscriptionIDScopedToSubscription() {
+	// Two subscriptions with their own override prices in the same
+	// tenant/environment — the leak returned all of them for any subscription.
+	s.createSubscriptionPrice("price_sub_a_1", "sub_a", 10)
+	s.createSubscriptionPrice("price_sub_a_2", "sub_a", 20)
+	s.createSubscriptionPrice("price_sub_b_1", "sub_b", 30)
+
+	testCases := []struct {
+		name           string
+		subscriptionID string
+		expectedIDs    []string
+	}{
+		{
+			name:           "returns_only_prices_of_the_requested_subscription",
+			subscriptionID: "sub_a",
+			expectedIDs:    []string{"price_sub_a_1", "price_sub_a_2"},
+		},
+		{
+			name:           "other_subscription_sees_only_its_own_price",
+			subscriptionID: "sub_b",
+			expectedIDs:    []string{"price_sub_b_1"},
+		},
+		{
+			name:           "subscription_without_prices_gets_empty_result",
+			subscriptionID: "sub_without_overrides",
+			expectedIDs:    []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp, err := s.service.GetPricesBySubscriptionID(s.GetContext(), tc.subscriptionID)
+			s.NoError(err)
+
+			gotIDs := lo.Map(resp.Items, func(p *dto.PriceResponse, _ int) string { return p.ID })
+			s.ElementsMatch(tc.expectedIDs, gotIDs)
+		})
+	}
+}
+
+func (s *PriceSubscriptionScopeSuite) TestGetPricesBySubscriptionIDValidation() {
+	resp, err := s.service.GetPricesBySubscriptionID(s.GetContext(), "")
+	s.Error(err)
+	s.Nil(resp)
+}

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -629,6 +629,15 @@ func (o PriceQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.P
 		query = query.Where(price.EntityIDIn(f.EntityIDs...))
 	}
 
+	// subscription id filter: subscription-scoped prices store the
+	// subscription ID in entity_id
+	if f.SubscriptionID != nil && *f.SubscriptionID != "" {
+		query = query.Where(
+			price.EntityType(types.PRICE_ENTITY_TYPE_SUBSCRIPTION),
+			price.EntityID(*f.SubscriptionID),
+		)
+	}
+
 	// meter id filter
 	if len(f.MeterIDs) > 0 {
 		query = query.Where(price.MeterIDIn(f.MeterIDs...))

--- a/internal/testutil/inmemory_price_store.go
+++ b/internal/testutil/inmemory_price_store.go
@@ -96,11 +96,14 @@ func priceFilterFn(ctx context.Context, p *price.Price, filter interface{}) bool
 		}
 	}
 
-	// NOTE: PriceFilter.SubscriptionID is intentionally NOT applied here.
-	// The real Ent repository (internal/repository/ent/price.go,
-	// applyEntityQueryOptions) does not consume it either — the field is
-	// validated in types.PriceFilter but never translated into a query
-	// predicate, so the in-memory store mirrors that behavior.
+	// subscription id filter: mirrors the real Ent repo
+	// (internal/repository/ent/price.go applyEntityQueryOptions) —
+	// subscription-scoped prices store the subscription ID in entity_id
+	if f.SubscriptionID != nil && *f.SubscriptionID != "" {
+		if p.EntityType != types.PRICE_ENTITY_TYPE_SUBSCRIPTION || p.EntityID != *f.SubscriptionID {
+			return false
+		}
+	}
 
 	return true
 }

--- a/internal/testutil/inmemory_price_store_test.go
+++ b/internal/testutil/inmemory_price_store_test.go
@@ -74,16 +74,6 @@ func TestInMemoryPriceStore_List_AllowExpiredPrices(t *testing.T) {
 				WithAllowExpiredPrices(true),
 			expectedIDs: []string{"price-active-no-end", "price-active-future-end", "price-expired"},
 		},
-		{
-			name: "subscription_id_is_not_applied_matching_real_repo",
-			// The real Ent repository (internal/repository/ent/price.go,
-			// applyEntityQueryOptions) never consumes PriceFilter.SubscriptionID,
-			// so setting it must not narrow results here either. If the real
-			// repo ever starts applying it, mirror that change in
-			// priceFilterFn and update this case.
-			filter:      types.NewNoLimitPriceFilter().WithSubscriptionID("sub-does-not-exist"),
-			expectedIDs: []string{"price-active-no-end", "price-active-future-end"},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -121,4 +111,71 @@ func TestInMemoryPriceStore_GetByPlanID_IncludesExpiredPrices(t *testing.T) {
 
 	gotIDs := lo.Map(prices, func(p *price.Price, _ int) string { return p.ID })
 	assert.ElementsMatch(t, []string{"price-active", "price-expired"}, gotIDs)
+}
+
+// newTestSubscriptionPrice builds a published subscription-scoped price —
+// subscription-scoped prices store the subscription ID in entity_id.
+func newTestSubscriptionPrice(id, subscriptionID string) *price.Price {
+	p := newTestPrice(id, subscriptionID, nil)
+	p.EntityType = types.PRICE_ENTITY_TYPE_SUBSCRIPTION
+	return p
+}
+
+// TestInMemoryPriceStore_List_SubscriptionIDFilter mirrors the real Ent repo
+// (internal/repository/ent/price.go applyEntityQueryOptions): SubscriptionID
+// filters to subscription-scoped prices whose entity_id matches — prices of
+// other subscriptions or plans must never leak into the result.
+func TestInMemoryPriceStore_List_SubscriptionIDFilter(t *testing.T) {
+	ctx := SetupContext()
+
+	setupStore := func(t *testing.T) *InMemoryPriceStore {
+		t.Helper()
+		store := NewInMemoryPriceStore()
+		require.NoError(t, store.Create(ctx, newTestSubscriptionPrice("price-sub-1a", "sub-1")))
+		require.NoError(t, store.Create(ctx, newTestSubscriptionPrice("price-sub-1b", "sub-1")))
+		require.NoError(t, store.Create(ctx, newTestSubscriptionPrice("price-sub-2", "sub-2")))
+		require.NoError(t, store.Create(ctx, newTestPrice("price-plan", "plan-1", nil)))
+		return store
+	}
+
+	testCases := []struct {
+		name        string
+		filter      *types.PriceFilter
+		expectedIDs []string
+	}{
+		{
+			name:        "returns_only_the_requested_subscriptions_prices",
+			filter:      types.NewNoLimitPriceFilter().WithSubscriptionID("sub-1"),
+			expectedIDs: []string{"price-sub-1a", "price-sub-1b"},
+		},
+		{
+			name: "combined_with_entity_type_subscription",
+			filter: types.NewNoLimitPriceFilter().
+				WithSubscriptionID("sub-2").
+				WithEntityType(types.PRICE_ENTITY_TYPE_SUBSCRIPTION),
+			expectedIDs: []string{"price-sub-2"},
+		},
+		{
+			name:        "unknown_subscription_returns_nothing",
+			filter:      types.NewNoLimitPriceFilter().WithSubscriptionID("sub-does-not-exist"),
+			expectedIDs: []string{},
+		},
+		{
+			name:        "no_subscription_id_returns_everything",
+			filter:      types.NewNoLimitPriceFilter(),
+			expectedIDs: []string{"price-sub-1a", "price-sub-1b", "price-sub-2", "price-plan"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := setupStore(t)
+
+			prices, err := store.List(ctx, tc.filter)
+			require.NoError(t, err)
+
+			gotIDs := lo.Map(prices, func(p *price.Price, _ int) string { return p.ID })
+			assert.ElementsMatch(t, tc.expectedIDs, gotIDs)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
Fixes a latent data-scoping bug: `types.PriceFilter.SubscriptionID` is validated (`internal/types/price.go:464`) and set by `priceService.GetPricesBySubscriptionID`, but the Ent price repository never consumed it — `applyEntityQueryOptions` had no SubscriptionID predicate. The method therefore filtered only on `EntityType=SUBSCRIPTION` + published, returning **every subscription-scoped price in the tenant/environment**, not just the requested subscription's.

Blast radius today is limited — `GetPricesBySubscriptionID` has no production callers yet (interface + impl + tests only) — but the filter field also binds from API queries (`form:"subscription_id"`), where it was silently ignored.

## Which layer owns it
The **repository** now applies the predicate: `entity_type = SUBSCRIPTION AND entity_id = <subscription_id>` (subscription-scoped prices store the subscription ID in `entity_id` — see `subscription_line_item.go:1035`). Fixing it at the repo layer heals both the service method and any API query in one place; the alternative (switching the service to `WithEntityIDs`) would have left a validated-but-inert public filter field as a trap for the next caller.

## Changes
- `internal/repository/ent/price.go` — SubscriptionID predicate in `applyEntityQueryOptions`.
- `internal/testutil/inmemory_price_store.go` — mirrors the predicate; the `subscription_id_is_not_applied_matching_real_repo` fidelity pin is replaced by positive filter cases (`TestInMemoryPriceStore_List_SubscriptionIDFilter`, 4 cases).
- `internal/ee/service/price_subscription_scope_test.go` — new regression suite: two subscriptions with their own override prices; each sees only its own (plus empty-result and validation cases).

**Verified both ways:** with the predicate reverted, the regression cases fail exactly as the leak predicts (each subscription sees the other's prices); with it, all pass.

## Stacking
Based on #2189 (store-fidelity) — the in-memory store test file and `newTestServiceParams` come from that stack. Merge order: #2167 → #2189 → this.

## Test plan
- `go test -race -count=1 ./internal/ee/service/ ./internal/testutil/` — green on this branch; full stack 2,963 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)