### PR TITLE
fix(subscription): activate inherited children stuck in incomplete after trial end

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7685,16 +7685,24 @@ func (s *subscriptionService) ExternalCustomerIDsForSubscription(ctx context.Con
 	return lo.Uniq(out), nil
 }
 
-// getInheritedSubscriptions retrieves all INHERITED child subscriptions for a parent subscription.
+// getInheritedSubscriptions retrieves all INHERITED child subscriptions for a parent subscription
+// in the default lifecycle statuses (active/trialing/draft).
 func (s *subscriptionService) getInheritedSubscriptions(ctx context.Context, parentSubID string) ([]*subscription.Subscription, error) {
-	filter := types.NewNoLimitSubscriptionFilter()
-	filter.ParentSubscriptionIDs = []string{parentSubID}
-	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeInherited}
-	filter.SubscriptionStatus = []types.SubscriptionStatus{
+	return s.getInheritedSubscriptionsInStatuses(ctx, parentSubID, []types.SubscriptionStatus{
 		types.SubscriptionStatusActive,
 		types.SubscriptionStatusTrialing,
 		types.SubscriptionStatusDraft,
-	}
+	})
+}
+
+// getInheritedSubscriptionsInStatuses retrieves INHERITED child subscriptions in the given statuses.
+// Cascades that must reach children parked in other states (e.g. incomplete after a trial-end
+// cascade) pass their own status list instead of the defaults.
+func (s *subscriptionService) getInheritedSubscriptionsInStatuses(ctx context.Context, parentSubID string, statuses []types.SubscriptionStatus) ([]*subscription.Subscription, error) {
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{parentSubID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeInherited}
+	filter.SubscriptionStatus = statuses
 
 	return s.SubRepo.List(ctx, filter)
 }

--- a/internal/ee/service/subscription_trial.go
+++ b/internal/ee/service/subscription_trial.go
@@ -262,7 +262,15 @@ func (s *subscriptionService) cascadeTrialActivationToInherited(ctx context.Cont
 	if parentSub.SubscriptionType != types.SubscriptionTypeParent {
 		return nil
 	}
-	children, err := s.getInheritedSubscriptions(ctx, parentSub.ID)
+	// cascadeTrialEndToInherited parks children in incomplete while the parent's
+	// trial-end invoice is unpaid — the default status set (active/trialing/draft)
+	// would never find them, leaving them incomplete forever.
+	children, err := s.getInheritedSubscriptionsInStatuses(ctx, parentSub.ID, []types.SubscriptionStatus{
+		types.SubscriptionStatusActive,
+		types.SubscriptionStatusTrialing,
+		types.SubscriptionStatusDraft,
+		types.SubscriptionStatusIncomplete,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/ee/service/subscription_trial_cascade_e2e_test.go
+++ b/internal/ee/service/subscription_trial_cascade_e2e_test.go
@@ -1,0 +1,192 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// SubscriptionTrialCascadeE2ESuite is a regression suite for inherited children
+// getting stuck after a parent's trial ends: cascadeTrialEndToInherited parks
+// children in `incomplete`, but the activation cascade fetched children with the
+// default status set (active/trialing/draft) — an incomplete child was never
+// found, so it was never activated.
+type SubscriptionTrialCascadeE2ESuite struct {
+	testutil.BaseServiceTestSuite
+	svc SubscriptionService
+}
+
+func TestSubscriptionTrialCascadeE2E(t *testing.T) {
+	suite.Run(t, new(SubscriptionTrialCascadeE2ESuite))
+}
+
+func (s *SubscriptionTrialCascadeE2ESuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.svc = NewSubscriptionService(newTestServiceParams(&s.BaseServiceTestSuite))
+}
+
+func (s *SubscriptionTrialCascadeE2ESuite) internalService() *subscriptionService {
+	return s.svc.(*subscriptionService)
+}
+
+// createTrialSubWithParent creates customer + plan + subscription whose trial
+// ended an hour ago. withFixedCharge controls whether the trial-end invoice
+// has an amount (paid path) or is zero-amount (auto-activation path).
+func (s *SubscriptionTrialCascadeE2ESuite) createTrialSubWithParent(subType types.SubscriptionType, parentSubID *string, withFixedCharge bool) *subscription.Subscription {
+	ctx := s.GetContext()
+
+	cust := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: "ext_" + s.GetUUID(),
+		Name:       "Trial Cascade Customer",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().CustomerRepo.Create(ctx, cust))
+
+	pl := &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Trial Cascade Plan",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PlanRepo.Create(ctx, pl))
+
+	trialStart := time.Now().UTC().Add(-14 * 24 * time.Hour)
+	trialEnd := time.Now().UTC().Add(-1 * time.Hour)
+
+	sub := &subscription.Subscription{
+		ID:                   types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		CustomerID:           cust.ID,
+		PlanID:               pl.ID,
+		SubscriptionStatus:   types.SubscriptionStatusTrialing,
+		SubscriptionType:     subType,
+		ParentSubscriptionID: parentSubID,
+		Currency:             "usd",
+		BillingAnchor:        trialStart,
+		BillingCycle:         types.BillingCycleAnniversary,
+		BillingPeriod:        types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount:   1,
+		BillingCadence:       types.BILLING_CADENCE_RECURRING,
+		StartDate:            trialStart,
+		CurrentPeriodStart:   trialStart,
+		CurrentPeriodEnd:     trialEnd,
+		TrialStart:           &trialStart,
+		TrialEnd:             &trialEnd,
+		CollectionMethod:     string(types.CollectionMethodSendInvoice),
+		PaymentBehavior:      string(types.PaymentBehaviorDefaultIncomplete),
+		BaseModel:            types.GetDefaultBaseModel(ctx),
+	}
+
+	var lineItems []*subscription.SubscriptionLineItem
+	if withFixedCharge {
+		p := &price.Price{
+			ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+			Amount:             decimal.NewFromInt(10),
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+			EntityID:           pl.ID,
+			Type:               types.PRICE_TYPE_FIXED,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			InvoiceCadence:     types.InvoiceCadenceAdvance,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+		lineItems = append(lineItems, &subscription.SubscriptionLineItem{
+			ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+			SubscriptionID:  sub.ID,
+			CustomerID:      cust.ID,
+			EntityID:        pl.ID,
+			EntityType:      types.SubscriptionLineItemEntityTypePlan,
+			PlanDisplayName: pl.Name,
+			PriceID:         p.ID,
+			PriceType:       p.Type,
+			DisplayName:     "Fixed Charge",
+			Quantity:        decimal.NewFromInt(1),
+			Currency:        sub.Currency,
+			BillingPeriod:   sub.BillingPeriod,
+			InvoiceCadence:  types.InvoiceCadenceAdvance,
+			StartDate:       trialStart,
+			BaseModel:       types.GetDefaultBaseModel(ctx),
+		})
+	}
+
+	s.Require().NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, lineItems))
+	return sub
+}
+
+func (s *SubscriptionTrialCascadeE2ESuite) subStatus(id string) types.SubscriptionStatus {
+	stored, err := s.GetStores().SubscriptionRepo.Get(s.GetContext(), id)
+	s.Require().NoError(err)
+	return stored.SubscriptionStatus
+}
+
+// TestTrialEndThenInvoicePaidActivatesInheritedChildren covers the full paid
+// path: trial ends → parent + children go incomplete with an open trial-end
+// invoice → invoice is paid → parent AND children become active.
+func (s *SubscriptionTrialCascadeE2ESuite) TestTrialEndThenInvoicePaidActivatesInheritedChildren() {
+	ctx := s.GetContext()
+	now := time.Now().UTC()
+
+	parent := s.createTrialSubWithParent(types.SubscriptionTypeParent, nil, true)
+	childA := s.createTrialSubWithParent(types.SubscriptionTypeInherited, &parent.ID, false)
+	childB := s.createTrialSubWithParent(types.SubscriptionTypeInherited, &parent.ID, false)
+
+	inv, err := s.internalService().ProcessSingleSubscriptionTrialEnd(ctx, parent, now)
+	s.Require().NoError(err)
+	s.Require().NotNil(inv, "fixed charge must produce a trial-end invoice")
+
+	s.Run("trial_end_parks_parent_and_children_in_incomplete", func() {
+		s.Equal(types.SubscriptionStatusIncomplete, s.subStatus(parent.ID))
+		s.Equal(types.SubscriptionStatusIncomplete, s.subStatus(childA.ID))
+		s.Equal(types.SubscriptionStatusIncomplete, s.subStatus(childB.ID))
+	})
+
+	s.Run("paying_the_trial_end_invoice_activates_parent_and_children", func() {
+		domainInv, err := s.GetStores().InvoiceRepo.Get(ctx, inv.ID)
+		s.Require().NoError(err)
+
+		s.Require().NoError(s.internalService().HandleSubscriptionActivatingInvoicePaid(ctx, domainInv))
+
+		s.Equal(types.SubscriptionStatusActive, s.subStatus(parent.ID))
+		s.Equal(types.SubscriptionStatusActive, s.subStatus(childA.ID),
+			"inherited child must not stay stuck in incomplete after the activating invoice is paid")
+		s.Equal(types.SubscriptionStatusActive, s.subStatus(childB.ID),
+			"inherited child must not stay stuck in incomplete after the activating invoice is paid")
+	})
+
+	s.Run("repeat_activation_is_idempotent", func() {
+		domainInv, err := s.GetStores().InvoiceRepo.Get(ctx, inv.ID)
+		s.Require().NoError(err)
+		s.Require().NoError(s.internalService().HandleSubscriptionActivatingInvoicePaid(ctx, domainInv))
+		s.Equal(types.SubscriptionStatusActive, s.subStatus(parent.ID))
+		s.Equal(types.SubscriptionStatusActive, s.subStatus(childA.ID))
+	})
+}
+
+// TestZeroAmountTrialEndActivatesInheritedChildren covers the zero-amount
+// path: no trial-end invoice is created, the parent auto-activates inline —
+// the children must come along instead of staying incomplete.
+func (s *SubscriptionTrialCascadeE2ESuite) TestZeroAmountTrialEndActivatesInheritedChildren() {
+	ctx := s.GetContext()
+	now := time.Now().UTC()
+
+	parent := s.createTrialSubWithParent(types.SubscriptionTypeParent, nil, false)
+	child := s.createTrialSubWithParent(types.SubscriptionTypeInherited, &parent.ID, false)
+
+	inv, err := s.internalService().ProcessSingleSubscriptionTrialEnd(ctx, parent, now)
+	s.Require().NoError(err)
+	s.Nil(inv, "zero-amount trial end must not create an invoice")
+
+	s.Equal(types.SubscriptionStatusActive, s.subStatus(parent.ID))
+	s.Equal(types.SubscriptionStatusActive, s.subStatus(child.ID),
+		"inherited child must be activated by the zero-amount trial-end path")
+}


### PR DESCRIPTION
## Summary
Fixes a subscription-lifecycle bug surfaced during the coverage push: **inherited child subscriptions got permanently stuck in `incomplete` after their parent's trial ended.**

`cascadeTrialEndToInherited` (internal/ee/service/subscription_trial.go) parks children in `incomplete` while the parent's trial-end invoice is unpaid — correct, it mirrors the parent's own state. But the activation cascade (`cascadeTrialActivationToInherited`, reached from **both** `HandleSubscriptionActivatingInvoicePaid` and the zero-amount auto-activation path via `completeTrialConversionToActive`) fetched children through `getInheritedSubscriptions`, which filters to active/trialing/draft. An `incomplete` child was never returned, so it was never activated.

## The fix (and the decision)
Between widening `getInheritedSubscriptions` vs. changing the parked status:
- Keeping `incomplete` as the parked status is intentional — children active while the parent's activating invoice is unpaid would misrepresent billing state.
- Widening the shared helper would silently change **all 8 call sites** (pause/resume/cancel cascades, usage attribution, external-customer resolution).

So the fix is targeted: a new `getInheritedSubscriptionsInStatuses` variant, and `cascadeTrialActivationToInherited` now fetches active/trialing/draft **+ incomplete** — the exact states the trial-end cascade produces. All other callers keep their existing semantics.

## Regression tests (`subscription_trial_cascade_e2e_test.go`)
End-to-end coverage the existing `SubscriptionTrialLifecycleSuite` deliberately avoided (it tested each cascade in isolation because the e2e path was broken):
- **Paid path**: parent + 2 inherited children, trial ends → all three `incomplete` with an open trial-end invoice → `HandleSubscriptionActivatingInvoicePaid` → all three `active`.
- **Zero-amount path**: no invoice created → parent auto-activates inline → child comes along.
- **Idempotent re-activation**: repeat delivery of the paid event changes nothing.

**Verified both ways**: with the production fix reverted, the paid-path and zero-amount cases fail exactly as the bug predicts (children stay `incomplete`); with it, all 6 cases pass under `-race`.

## Stacking
Based on #2167 (foundation — the test uses `newTestServiceParams`). Production changes are self-contained. Full stack: 2,969 tests green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)