### PR TITLE
feat(dev): worktree-aware server runner with deterministic port assignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,40 @@ run-local:
 	@set -a && [ -f .env ] && . ./.env; [ -f .env.local ] && . ./.env.local; set +a; \
 	FLEXPRICE_DEPLOYMENT_MODE=local go run cmd/server/main.go
 
+# ---------------------------------------------------------------------------
+# Worktree-aware server — deterministic port from branch name, shared .env
+# ---------------------------------------------------------------------------
+
+# Run server on a port derived from the current branch name (8080 for main,
+# 8100-8899 for other branches). Loads .env from the main worktree so there
+# is only ever one .env file regardless of how many worktrees are active.
+.PHONY: run-wt
+run-wt:
+	@export PATH="/usr/local/go/bin:$$HOME/.local/bin:$$PATH"; \
+	BRANCH=$$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached); \
+	if [ "$$BRANCH" = "main" ] || [ "$$BRANCH" = "master" ]; then PORT=8080; \
+	else PORT=$$((8100 + $$(printf '%s' "$$BRANCH" | cksum | awk '{print $$1}') % 800)); fi; \
+	MAIN_WT=$$(git worktree list --porcelain | awk '/^worktree /{print $$2; exit}'); \
+	ENV_FILE="$$MAIN_WT/.env"; \
+	REPO_ROOT=$$(git rev-parse --show-toplevel); \
+	printf '\n+---------------------------------------------+\n'; \
+	printf '|  branch : %-34s|\n' "$$BRANCH"; \
+	printf '|  port   : %-34s|\n' "$$PORT"; \
+	printf '|  url    : %-34s|\n' "http://localhost:$$PORT"; \
+	printf '|  .env   : %-34s|\n' "$$ENV_FILE"; \
+	printf '+---------------------------------------------+\n\n'; \
+	[ -f "$$ENV_FILE" ] || { printf 'ERROR: .env not found at %s\n' "$$ENV_FILE" >&2; exit 1; }; \
+	set -a && . "$$ENV_FILE" && set +a; \
+	export FLEXPRICE_SERVER_ADDRESS=":$$PORT"; \
+	exec go run "$$REPO_ROOT/cmd/server/main.go"
+
+# Show all worktrees, their computed ports, and whether a server is running.
+# Calls scripts/wt-ports.sh from the main worktree (works before and after commit).
+.PHONY: wt-ports
+wt-ports:
+	@MAIN_WT=$$(git worktree list --porcelain | awk '/^worktree /{print $$2; exit}'); \
+	bash "$$MAIN_WT/scripts/wt-ports.sh"
+
 # Run Ent schema migrations against local Docker postgres
 .PHONY: migrate-local
 migrate-local:

--- a/docs/REMOTE_DEV_INSTANCE_SETUP.md
+++ b/docs/REMOTE_DEV_INSTANCE_SETUP.md
@@ -1,0 +1,152 @@
+# Remote Dev Instance Setup
+
+Guidance for running Flexprice on a **shared remote Linux box** where several
+developers each work in their own folder, against **shared cloud/staging
+infrastructure** (rather than spinning up local Docker for Postgres, Kafka,
+ClickHouse, etc.).
+
+This is meant for AI-agent-driven sessions (Claude Code / Cursor) as well as
+humans. It complements [`LOCAL_TESTING.md`](../LOCAL_TESTING.md) (Docker-based
+local setup) — use this doc when you want to point a locally-built server at
+already-deployed staging resources.
+
+> Paths below use `$HOME` and `<dev>` placeholders. Substitute your own home
+> directory and folder name. Never commit real secrets, IPs, tokens, or a
+> `.env` file.
+
+---
+
+## Per-folder layout
+
+- Each developer works in their own folder, e.g. `$HOME/<dev>-claude/`.
+- The flexprice clone lives at `$HOME/<dev>-claude/flexprice` (i.e. `./flexprice`
+  relative to the session working directory).
+- Clone if missing: `git clone https://github.com/flexprice/flexprice`.
+- **`.env`** must exist at `./flexprice/.env` (permissions `600`). It holds
+  staging credentials for Postgres, Redis, ClickHouse, Kafka, Temporal, and the
+  various third-party integrations. Obtain it from your team's secrets manager;
+  **never commit it or print its values.** The repo already ships `.env.local`
+  (local Docker defaults) and `.env.vault` — those are separate from this file.
+
+---
+
+## Toolchain
+
+Install once on the box (versions track `go.mod` and the `install-typst` target):
+
+- **Go** — version pinned by `go.mod` (e.g. `go 1.25.0`); install to `/usr/local/go`.
+- **typst** — installed by `scripts/install-typst.sh` to `~/.local/bin/typst`;
+  required by the `internal/typst` tests and the `install-typst` make dep.
+- `git`, `make`, `gcc`.
+- Put the toolchain on `PATH` before building/testing:
+  ```bash
+  export PATH="/usr/local/go/bin:$HOME/.local/bin:$PATH"
+  ```
+
+---
+
+## Running the server against staging resources
+
+To test local code changes against shared staging infra **without** Docker, run
+the plain server target so it loads `.env` directly (the `run-local*` targets
+layer `.env.local` on top, which would override staging endpoints with local
+Docker ones):
+
+```bash
+make run-server        # go run cmd/server/main.go, loads .env
+curl http://localhost:8080/health   # -> {"status":"ok"}
+```
+
+---
+
+## Working across multiple worktrees
+
+When juggling several branches at once, give each its own git worktree and its
+own server port so they never collide — see `make run-wt` / `make wt-ports`
+(documented in the Makefile). Each branch gets a deterministic port and they all
+share the single `.env` from the main clone, so there is only ever one secrets
+file regardless of how many worktrees are active.
+
+```bash
+# From the main clone
+git worktree add -b <branch> ../flexprice-worktrees/<name>
+
+# From any worktree
+make run-wt      # server on this branch's deterministic port
+make wt-ports    # list all worktrees, their ports, running/stopped status
+```
+
+---
+
+## Testing
+
+```bash
+make test              # install-typst + go test -v -race ./internal/...
+go test ./internal/... # quicker smoke check (no -race; still needs typst on PATH)
+```
+
+> Some event-service tests (`internal/ee/service`, e.g.
+> `TestEventService/TestGetEvents`) can be order-sensitive and fail
+> intermittently only under the full parallel run; they pass in isolation.
+
+### Integration sanity suite
+
+Run the orchestrated sanity suite against one or more deployed targets (see
+[`integration-testing-suite/go`](../integration-testing-suite/go)). Provide
+targets via a JSON file — keep real API keys out of version control:
+
+```bash
+# targets.json (do not commit real keys)
+# [
+#   { "name": "staging", "api_host": "api-dev.example/v1", "api_key": "sk_..." },
+#   { "name": "local",   "api_host": "localhost:8080/v1",  "api_key": "sk_..." }
+# ]
+FLEXPRICE_TARGETS_FILE=targets.json make test-suite
+```
+
+When a locally-run server is pointed at the same staging database, the same API
+keys work against both `localhost` and the deployed host.
+
+---
+
+## Per-developer GitHub auth isolation (shared home)
+
+On a shared box, all folders share one Linux home, so a plain `gh auth login`
+writes to `~/.config/gh` and **every folder would push / open PRs as that one
+GitHub user.** To keep identities separate, pin a per-folder `gh` config dir:
+
+1. Create a private config dir per folder:
+   ```bash
+   mkdir -p -m 700 $HOME/<dev>-claude/.gh
+   ```
+2. Point the folder's sessions at it via `$HOME/<dev>-claude/.claude/settings.json`:
+   ```json
+   { "env": { "GH_CONFIG_DIR": "/home/<user>/<dev>-claude/.gh" } }
+   ```
+   (Or export `GH_CONFIG_DIR` in the shell before running `gh`.)
+3. Authenticate and wire up git, once, in that folder:
+   ```bash
+   gh auth login          # token stored in <dev>-claude/.gh, not the shared default
+   gh auth setup-git      # git credential helper defers to GH_CONFIG_DIR at runtime
+   git -C flexprice config user.name  "<handle>"
+   git -C flexprice config user.email "<id>@users.noreply.github.com"
+   ```
+4. Verify: `gh auth status` shows the account for the active folder.
+
+The credential helper (`!gh auth git-credential`) is identity-agnostic — it
+returns whichever token `GH_CONFIG_DIR` points at when a command runs, so each
+folder pushes as the right person on the same machine.
+
+> On a developer's own laptop this isn't needed — separate machines already mean
+> separate homes and separate `gh` auth. This isolation matters only on a shared
+> remote box.
+
+---
+
+## Notes
+
+- Shared remote boxes are often modest (e.g. 2 vCPU). `-race` roughly doubles
+  compile/run time, so the first `make test` is slow; the build cache makes
+  reruns fast.
+- Prefer real dedicated tools over ad-hoc shell where possible; keep secrets in
+  `.env` / a secrets manager, never in committed files.

--- a/scripts/run-wt.sh
+++ b/scripts/run-wt.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# scripts/run-wt.sh — Run the Flexprice server with a worktree-specific port.
+#
+# Computes a deterministic port from the current branch name (range 8100-8899)
+# so each worktree always binds the same port without touching .env.
+# The shared .env is loaded from the main worktree — no per-worktree copies.
+#
+# Usage:
+#   make run-wt            (from any worktree)
+#   bash scripts/run-wt.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "detached")"
+
+# Deterministic port: cksum of branch name, mapped to 8100–8899 (800 slots).
+# Same branch = same port across restarts. main/master keeps its original 8080.
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+  PORT=8080
+else
+  PORT=$((8100 + $(printf '%s' "$BRANCH" | cksum | awk '{print $1}') % 800))
+fi
+
+# Always load .env from the main (original) worktree — first entry in the list.
+MAIN_WORKTREE="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+ENV_FILE="$MAIN_WORKTREE/.env"
+
+echo "┌─────────────────────────────────────────────┐"
+printf "│  branch : %-34s│\n" "$BRANCH"
+printf "│  port   : %-34s│\n" "$PORT"
+printf "│  url    : %-34s│\n" "http://localhost:$PORT"
+printf "│  .env   : %-34s│\n" "$ENV_FILE"
+echo "└─────────────────────────────────────────────┘"
+echo
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: .env not found at $ENV_FILE" >&2
+  exit 1
+fi
+
+# Load the shared .env (no .env.local overlay — we want cloud resources)
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+# Override only the port; everything else (DB, Kafka, etc.) unchanged
+export FLEXPRICE_SERVER_ADDRESS=":$PORT"
+
+exec go run "$REPO_ROOT/cmd/server/main.go"

--- a/scripts/wt-ports.sh
+++ b/scripts/wt-ports.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/wt-ports.sh — Show all worktrees, their computed ports, and whether
+# a server is currently listening on that port.
+#
+# Usage:
+#   make wt-ports
+
+set -euo pipefail
+
+echo "┌──────────────────────────────────────────────────────────────────┐"
+echo "│  Worktree port map                                               │"
+echo "├──────────────────────────────────────────────────────────────────┤"
+printf "│  %-30s  %6s  %-14s  %s\n" "BRANCH" "PORT" "STATUS" "PATH"
+echo "├──────────────────────────────────────────────────────────────────┤"
+
+git worktree list --porcelain | awk '
+  /^worktree / { path=$2 }
+  /^branch /   { branch=$2; sub(/^refs\/heads\//, "", branch) }
+  /^HEAD / && !branch { branch="(detached)" }
+  /^$/ {
+    if (path != "") {
+      print path "\t" branch
+      path=""; branch=""
+    }
+  }
+  END {
+    if (path != "") print path "\t" branch
+  }
+' | while IFS=$'\t' read -r wt_path branch; do
+  if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+    port=8080
+  else
+    port=$((8100 + $(printf '%s' "$branch" | cksum | awk '{print $1}') % 800))
+  fi
+
+  # Check if something is listening on that port
+  if 2>/dev/null bash -c "echo >/dev/tcp/localhost/$port"; then
+    status="● running"
+  else
+    status="○ stopped"
+  fi
+
+  printf "│  %-30s  %6s  %-14s  %s\n" "${branch:0:30}" "$port" "$status" "${wt_path/$HOME/\~}"
+done
+
+echo "└──────────────────────────────────────────────────────────────────┘"
+echo
+echo "  Run server in any worktree:  make run-wt"
+echo "  Integration tests:           FLEXPRICE_TARGETS_FILE=... make test-suite"


### PR DESCRIPTION
## What

Dev-experience tooling for running **multiple Flexprice servers from different git worktrees at once**, plus a setup guide for shared remote dev boxes.

**Worktree server runner:**
- `make run-wt` / `fp-run-wt` — start the server on a port derived from the current branch
- `make wt-ports` / `fp-wt-ports` — list all worktrees, their ports, and running/stopped status

**Docs:**
- `docs/REMOTE_DEV_INSTANCE_SETUP.md` — running Flexprice on a shared remote box against staging resources (vs local Docker): per-folder layout, toolchain, running the server against a staging `.env`, multi-worktree servers, the integration sanity suite, and per-developer GitHub auth isolation via `GH_CONFIG_DIR`. Fully sanitized — `$HOME/<dev>` placeholders, no secrets/IPs/paths.

## Why

When working across several worktrees at once, every server wants port 8080. This gives each branch its **own deterministic port** so they never collide, while sharing a single `.env`.

## How it works

- **Port assignment:** `main`/`master` → `8080`; any other branch → `8100–8899`, computed as `cksum(branch) % 800 + 8100`. Deterministic (same branch always binds the same port), and `cksum` is portable across macOS and Linux.
- **Single `.env`:** always loaded from the **main worktree**, so there's only ever one secrets file regardless of how many worktrees are active. Only `FLEXPRICE_SERVER_ADDRESS` is overridden.

## Test plan

- [x] `make wt-ports` lists worktrees with correct ports and live status
- [x] `make run-wt` binds `:8080` on main and the computed port on feature branches
- [x] `.env` resolved from the main worktree when run inside a child worktree
- [x] Verified end-to-end: server boots against staging resources and passes the integration sanity suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worktree-aware local development commands to run the server on deterministic per-branch ports.
  * Added a command to list Git worktrees and show their assigned ports, including whether each port is currently in use.
  * Standardized server startup to use the shared environment file from the main worktree.
* **Documentation**
  * Added setup guidance for running on a shared remote Linux machine without local Docker for backing services, including multi-worktree workflows and testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->