### PR TITLE
fix(postgres): route TaxApplied.Update through Writer, not Reader

### DIFF
--- a/internal/repository/ent/taxapplied.go
+++ b/internal/repository/ent/taxapplied.go
@@ -169,7 +169,7 @@ func (r *taxappliedRepository) Update(ctx context.Context, ta *domainTaxApplied.
 	})
 	defer FinishSpan(span)
 
-	client := r.client.Reader(ctx)
+	client := r.client.Writer(ctx)
 
 	r.log.Debug(ctx, "updating taxapplied",
 		"taxapplied_id", ta.ID,


### PR DESCRIPTION
## What

`taxappliedRepository.Update` obtained its ent client via `r.client.Reader(ctx)` and then issued an `UPDATE` on it (`internal/repository/ent/taxapplied.go:172` → write at `:185`). This is the **only** write-on-`Reader()` in the codebase — verified by a full sweep of all 198 `Reader()` call sites (inline, raw `ExecContext`, and the two-step `client := ...Reader(ctx)` pattern, scoped per-function). Its own `Create` (L48) and `Delete` (L231) siblings already use `Writer(ctx)`.

## Why it matters now

`Reader(ctx)` routes to the **physical read replica** (recently enabled on GCP staging, prod next) unless the caller is inside a `WithTx` or has the writer pin already flipped by a prior `Writer()` write.

All current callers of `TaxApplied.Update` satisfy one of those:
- three paths run inside `WithTx` → `writer_via_tx`
- the one plain-ctx path (`VoidCreditNote` → `RecalculateInvoiceAmounts`) does a `Writer()` write first, which flips the pin → `writer_pinned`

So it works **today by coincidence**, not by construction. Any future caller that invokes `TaxAppliedRepo.Update` as the first DB op in a request/job — no tx, no prior write — would route to the read-only replica and fail with:

```
cannot execute UPDATE in a read-only transaction
```

That failure would not surface in staging; it would surface in prod against the replica, triggered by some unrelated change that removes the upstream write. This makes the write correct regardless of caller ordering.

## Change

One line: `r.client.Reader(ctx)` → `r.client.Writer(ctx)` at `taxapplied.go:172`.

**No behavioral change on any current path** — every existing caller already resolves this operation to the writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain updates could fail to save correctly, improving reliability when modifying records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->