### PR TITLE
feat: support credit grants in addons

### DIFF
--- a/docs/design/credit-grants-in-addons.md
+++ b/docs/design/credit-grants-in-addons.md
@@ -1,0 +1,64 @@
+# Credit Grants in Addons — Design & Test
+
+**Goal:** Let an addon carry credit grants (like a plan does), and deposit those credits into the wallet when the addon is attached to a subscription.
+
+**Approach:** Add `ADDON` as a third source on the existing `credit_grants` table, then reuse the plan → subscription materialization flow as-is.
+
+---
+
+## What we're building
+
+**1. Data model** — make `credit_grants` polymorphic over a third source
+- New nullable `addon_id` column + `addon` edge on `credit_grants` (+ partial index `idx_addon_id_not_null`).
+- New scope enum value `ADDON`.
+- `addon` schema: back-reference `credit_grants` edge.
+
+**2. Define grants on an addon** (`POST /creditgrants` with `scope=ADDON` + `addon_id`)
+
+Adding the request field alone isn't enough — `ADDON` is rejected at three scope-gates today. Mirror every place `PLAN` is handled:
+- `types/creditgrant.go`: add `CreditGrantScopeAddon = "ADDON"` to the const **and** to `Scope.Validate()`'s allowed values (first blocker).
+- `dto/creditgrant.go` `CreateCreditGrantRequest`: add `AddonID *string` (`json:"addon_id"`).
+- `dto/creditgrant.go` `Validate()` scope switch: add `case ADDON` → require `addon_id`, forbid `start_date`/`end_date` (template); update the `default` hint text.
+- `dto/creditgrant.go` `ToCreditGrant()` scope switch: add `case ADDON` → set `AddonID`, nil out subscription/start/end/anchor (else the id is silently dropped).
+- `service/creditgrant.go` `CreateCreditGrant`: add an "addon exists + published" check (mirror the plan block), and a `case ADDON` doing the uniform-conversion-rate check across the addon's grants.
+- Add `GetCreditGrantsByAddon` (repo + service) and `AddonIDs` filter.
+- **Do not** initialize a workflow for `scope=ADDON` (leave the SUBSCRIPTION-only branch as-is) — an addon grant is an inert template, like a plan grant.
+
+**3. Apply grants when the addon is attached** (the core hook)
+- In the attach-addon flow (`POST /subscriptions/addon`), after the association + line items are committed (inside the same tx):
+  - load the addon's grants,
+  - clone each into a `scope=SUBSCRIPTION` grant (keep `addon_id` for provenance),
+  - run them through the existing credit-grant handler → wallet top-up path.
+- Anchor = addon-attach date (mid-cycle grants apply immediately). To make this possible, `handleCreditGrants` was split into `handleCreditGrantsWithStart(startDate)` so the start can be the attach date instead of the subscription start.
+
+**4. Handle removal**
+- On addon removal / subscription cancel: cancel **future** applications of that addon's grants only (scoped via `filter.AddonIDs`). Do **not** clawback already-granted credits, and don't touch plan or other-addon grants.
+
+**5. Surface grants in the read API (UI parity with plans)**
+
+The dashboard renders a plan's credit grants from the plan read API. To get the same UI behavior for addons, the addon read API must expose credit grants the same way — no frontend contract invented, just mirror plans:
+- `AddonResponse` gets a `CreditGrants []*CreditGrantResponse` field (like `Prices`/`Entitlements`).
+- `GetAddon` / `GetAddonByLookupKey` always attach the addon's grants.
+- `GetAddons` (list) expands them when the `ExpandCreditGrant` flag is set.
+- Dedicated `GET /addons/:id/creditgrants` endpoint (mirrors `GET /plans/:id/creditgrants`).
+
+This is a backend-only change: it makes the data available in the exact shape the plan page already consumes. Whether the addon page in `flexprice-front` renders it depends on that repo (out of scope for this PR).
+
+*Reused untouched:* `credit_grant_applications`, `wallets`, `wallet_transactions`, the recurring cron.
+
+---
+
+## What we'll test
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| 1 | Create addon grant | `credit_grants` row: `scope=ADDON`, `addon_id` set, `subscription_id` NULL. Wallet unchanged. |
+| 2 | Attach addon (one-time grant) | Clone row `scope=SUBSCRIPTION` (with `addon_id`), one `APPLIED` application, wallet balance up, one `wallet_transaction`. |
+| 3 | Attach addon mid-cycle | Credits applied immediately, anchored to attach date. |
+| 4 | Recurring addon grant → next period | Cron applies the next period's credits automatically. |
+| 5 | Remove addon | Future applications for that addon cancelled; wallet balance unchanged; plan grants unaffected. |
+| 6 | Attach same addon twice / retry | No double deposit (idempotency holds). |
+| 7 | Validation | Reject `scope=ADDON` with missing/unpublished addon, or mismatched conversion rates. |
+| 8 | Read API | Addon detail returns `credit_grants`; `GET /addons/:id/creditgrants` lists them. |
+
+**Test types:** unit tests for validation + the clone/apply mapping (`internal/ee/service/creditgrant_test.go`); integration tests (real DB) for scenarios 2–6 end-to-end.

--- a/ent/addon.go
+++ b/ent/addon.go
@@ -50,9 +50,11 @@ type Addon struct {
 type AddonEdges struct {
 	// Entitlements holds the value of the entitlements edge.
 	Entitlements []*Entitlement `json:"entitlements,omitempty"`
+	// CreditGrants holds the value of the credit_grants edge.
+	CreditGrants []*CreditGrant `json:"credit_grants,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [1]bool
+	loadedTypes [2]bool
 }
 
 // EntitlementsOrErr returns the Entitlements value or an error if the edge
@@ -62,6 +64,15 @@ func (e AddonEdges) EntitlementsOrErr() ([]*Entitlement, error) {
 		return e.Entitlements, nil
 	}
 	return nil, &NotLoadedError{edge: "entitlements"}
+}
+
+// CreditGrantsOrErr returns the CreditGrants value or an error if the edge
+// was not loaded in eager-loading.
+func (e AddonEdges) CreditGrantsOrErr() ([]*CreditGrant, error) {
+	if e.loadedTypes[1] {
+		return e.CreditGrants, nil
+	}
+	return nil, &NotLoadedError{edge: "credit_grants"}
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -180,6 +191,11 @@ func (a *Addon) Value(name string) (ent.Value, error) {
 // QueryEntitlements queries the "entitlements" edge of the Addon entity.
 func (a *Addon) QueryEntitlements() *EntitlementQuery {
 	return NewAddonClient(a.config).QueryEntitlements(a)
+}
+
+// QueryCreditGrants queries the "credit_grants" edge of the Addon entity.
+func (a *Addon) QueryCreditGrants() *CreditGrantQuery {
+	return NewAddonClient(a.config).QueryCreditGrants(a)
 }
 
 // Update returns a builder for updating this Addon.

--- a/ent/addon/addon.go
+++ b/ent/addon/addon.go
@@ -38,6 +38,8 @@ const (
 	FieldMetadata = "metadata"
 	// EdgeEntitlements holds the string denoting the entitlements edge name in mutations.
 	EdgeEntitlements = "entitlements"
+	// EdgeCreditGrants holds the string denoting the credit_grants edge name in mutations.
+	EdgeCreditGrants = "credit_grants"
 	// Table holds the table name of the addon in the database.
 	Table = "addons"
 	// EntitlementsTable is the table that holds the entitlements relation/edge.
@@ -47,6 +49,13 @@ const (
 	EntitlementsInverseTable = "entitlements"
 	// EntitlementsColumn is the table column denoting the entitlements relation/edge.
 	EntitlementsColumn = "addon_entitlements"
+	// CreditGrantsTable is the table that holds the credit_grants relation/edge.
+	CreditGrantsTable = "credit_grants"
+	// CreditGrantsInverseTable is the table name for the CreditGrant entity.
+	// It exists in this package in order to avoid circular dependency with the "creditgrant" package.
+	CreditGrantsInverseTable = "credit_grants"
+	// CreditGrantsColumn is the table column denoting the credit_grants relation/edge.
+	CreditGrantsColumn = "addon_id"
 )
 
 // Columns holds all SQL columns for addon fields.
@@ -165,10 +174,31 @@ func ByEntitlements(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newEntitlementsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
+
+// ByCreditGrantsCount orders the results by credit_grants count.
+func ByCreditGrantsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCreditGrantsStep(), opts...)
+	}
+}
+
+// ByCreditGrants orders the results by credit_grants terms.
+func ByCreditGrants(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCreditGrantsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
 func newEntitlementsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(EntitlementsInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, EntitlementsTable, EntitlementsColumn),
+	)
+}
+func newCreditGrantsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CreditGrantsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CreditGrantsTable, CreditGrantsColumn),
 	)
 }

--- a/ent/addon/where.go
+++ b/ent/addon/where.go
@@ -788,6 +788,29 @@ func HasEntitlementsWith(preds ...predicate.Entitlement) predicate.Addon {
 	})
 }
 
+// HasCreditGrants applies the HasEdge predicate on the "credit_grants" edge.
+func HasCreditGrants() predicate.Addon {
+	return predicate.Addon(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, CreditGrantsTable, CreditGrantsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasCreditGrantsWith applies the HasEdge predicate on the "credit_grants" edge with a given conditions (other predicates).
+func HasCreditGrantsWith(preds ...predicate.CreditGrant) predicate.Addon {
+	return predicate.Addon(func(s *sql.Selector) {
+		step := newCreditGrantsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.Addon) predicate.Addon {
 	return predicate.Addon(sql.AndPredicates(predicates...))

--- a/ent/addon_create.go
+++ b/ent/addon_create.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/addon"
+	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/entitlement"
 )
 
@@ -162,6 +163,21 @@ func (ac *AddonCreate) AddEntitlements(e ...*Entitlement) *AddonCreate {
 		ids[i] = e[i].ID
 	}
 	return ac.AddEntitlementIDs(ids...)
+}
+
+// AddCreditGrantIDs adds the "credit_grants" edge to the CreditGrant entity by IDs.
+func (ac *AddonCreate) AddCreditGrantIDs(ids ...string) *AddonCreate {
+	ac.mutation.AddCreditGrantIDs(ids...)
+	return ac
+}
+
+// AddCreditGrants adds the "credit_grants" edges to the CreditGrant entity.
+func (ac *AddonCreate) AddCreditGrants(c ...*CreditGrant) *AddonCreate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return ac.AddCreditGrantIDs(ids...)
 }
 
 // Mutation returns the AddonMutation object of the builder.
@@ -340,6 +356,22 @@ func (ac *AddonCreate) createSpec() (*Addon, *sqlgraph.CreateSpec) {
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(entitlement.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := ac.mutation.CreditGrantsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/ent/addon_query.go
+++ b/ent/addon_query.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/addon"
+	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/entitlement"
 	"github.com/flexprice/flexprice/ent/predicate"
 )
@@ -25,6 +26,7 @@ type AddonQuery struct {
 	inters           []Interceptor
 	predicates       []predicate.Addon
 	withEntitlements *EntitlementQuery
+	withCreditGrants *CreditGrantQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -76,6 +78,28 @@ func (aq *AddonQuery) QueryEntitlements() *EntitlementQuery {
 			sqlgraph.From(addon.Table, addon.FieldID, selector),
 			sqlgraph.To(entitlement.Table, entitlement.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, addon.EntitlementsTable, addon.EntitlementsColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(aq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryCreditGrants chains the current query on the "credit_grants" edge.
+func (aq *AddonQuery) QueryCreditGrants() *CreditGrantQuery {
+	query := (&CreditGrantClient{config: aq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := aq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := aq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(addon.Table, addon.FieldID, selector),
+			sqlgraph.To(creditgrant.Table, creditgrant.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, addon.CreditGrantsTable, addon.CreditGrantsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(aq.driver.Dialect(), step)
 		return fromU, nil
@@ -276,6 +300,7 @@ func (aq *AddonQuery) Clone() *AddonQuery {
 		inters:           append([]Interceptor{}, aq.inters...),
 		predicates:       append([]predicate.Addon{}, aq.predicates...),
 		withEntitlements: aq.withEntitlements.Clone(),
+		withCreditGrants: aq.withCreditGrants.Clone(),
 		// clone intermediate query.
 		sql:  aq.sql.Clone(),
 		path: aq.path,
@@ -290,6 +315,17 @@ func (aq *AddonQuery) WithEntitlements(opts ...func(*EntitlementQuery)) *AddonQu
 		opt(query)
 	}
 	aq.withEntitlements = query
+	return aq
+}
+
+// WithCreditGrants tells the query-builder to eager-load the nodes that are connected to
+// the "credit_grants" edge. The optional arguments are used to configure the query builder of the edge.
+func (aq *AddonQuery) WithCreditGrants(opts ...func(*CreditGrantQuery)) *AddonQuery {
+	query := (&CreditGrantClient{config: aq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	aq.withCreditGrants = query
 	return aq
 }
 
@@ -371,8 +407,9 @@ func (aq *AddonQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Addon,
 	var (
 		nodes       = []*Addon{}
 		_spec       = aq.querySpec()
-		loadedTypes = [1]bool{
+		loadedTypes = [2]bool{
 			aq.withEntitlements != nil,
+			aq.withCreditGrants != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
@@ -397,6 +434,13 @@ func (aq *AddonQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Addon,
 		if err := aq.loadEntitlements(ctx, query, nodes,
 			func(n *Addon) { n.Edges.Entitlements = []*Entitlement{} },
 			func(n *Addon, e *Entitlement) { n.Edges.Entitlements = append(n.Edges.Entitlements, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := aq.withCreditGrants; query != nil {
+		if err := aq.loadCreditGrants(ctx, query, nodes,
+			func(n *Addon) { n.Edges.CreditGrants = []*CreditGrant{} },
+			func(n *Addon, e *CreditGrant) { n.Edges.CreditGrants = append(n.Edges.CreditGrants, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -429,6 +473,39 @@ func (aq *AddonQuery) loadEntitlements(ctx context.Context, query *EntitlementQu
 		node, ok := nodeids[*fk]
 		if !ok {
 			return fmt.Errorf(`unexpected referenced foreign-key "addon_entitlements" returned %v for node %v`, *fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
+func (aq *AddonQuery) loadCreditGrants(ctx context.Context, query *CreditGrantQuery, nodes []*Addon, init func(*Addon), assign func(*Addon, *CreditGrant)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*Addon)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(creditgrant.FieldAddonID)
+	}
+	query.Where(predicate.CreditGrant(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(addon.CreditGrantsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.AddonID
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "addon_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "addon_id" returned %v for node %v`, *fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/ent/addon_update.go
+++ b/ent/addon_update.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/flexprice/flexprice/ent/addon"
+	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/entitlement"
 	"github.com/flexprice/flexprice/ent/predicate"
 )
@@ -130,6 +131,21 @@ func (au *AddonUpdate) AddEntitlements(e ...*Entitlement) *AddonUpdate {
 	return au.AddEntitlementIDs(ids...)
 }
 
+// AddCreditGrantIDs adds the "credit_grants" edge to the CreditGrant entity by IDs.
+func (au *AddonUpdate) AddCreditGrantIDs(ids ...string) *AddonUpdate {
+	au.mutation.AddCreditGrantIDs(ids...)
+	return au
+}
+
+// AddCreditGrants adds the "credit_grants" edges to the CreditGrant entity.
+func (au *AddonUpdate) AddCreditGrants(c ...*CreditGrant) *AddonUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return au.AddCreditGrantIDs(ids...)
+}
+
 // Mutation returns the AddonMutation object of the builder.
 func (au *AddonUpdate) Mutation() *AddonMutation {
 	return au.mutation
@@ -154,6 +170,27 @@ func (au *AddonUpdate) RemoveEntitlements(e ...*Entitlement) *AddonUpdate {
 		ids[i] = e[i].ID
 	}
 	return au.RemoveEntitlementIDs(ids...)
+}
+
+// ClearCreditGrants clears all "credit_grants" edges to the CreditGrant entity.
+func (au *AddonUpdate) ClearCreditGrants() *AddonUpdate {
+	au.mutation.ClearCreditGrants()
+	return au
+}
+
+// RemoveCreditGrantIDs removes the "credit_grants" edge to CreditGrant entities by IDs.
+func (au *AddonUpdate) RemoveCreditGrantIDs(ids ...string) *AddonUpdate {
+	au.mutation.RemoveCreditGrantIDs(ids...)
+	return au
+}
+
+// RemoveCreditGrants removes "credit_grants" edges to CreditGrant entities.
+func (au *AddonUpdate) RemoveCreditGrants(c ...*CreditGrant) *AddonUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return au.RemoveCreditGrantIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -292,6 +329,51 @@ func (au *AddonUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if au.mutation.CreditGrantsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := au.mutation.RemovedCreditGrantsIDs(); len(nodes) > 0 && !au.mutation.CreditGrantsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := au.mutation.CreditGrantsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, au.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{addon.Label}
@@ -413,6 +495,21 @@ func (auo *AddonUpdateOne) AddEntitlements(e ...*Entitlement) *AddonUpdateOne {
 	return auo.AddEntitlementIDs(ids...)
 }
 
+// AddCreditGrantIDs adds the "credit_grants" edge to the CreditGrant entity by IDs.
+func (auo *AddonUpdateOne) AddCreditGrantIDs(ids ...string) *AddonUpdateOne {
+	auo.mutation.AddCreditGrantIDs(ids...)
+	return auo
+}
+
+// AddCreditGrants adds the "credit_grants" edges to the CreditGrant entity.
+func (auo *AddonUpdateOne) AddCreditGrants(c ...*CreditGrant) *AddonUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return auo.AddCreditGrantIDs(ids...)
+}
+
 // Mutation returns the AddonMutation object of the builder.
 func (auo *AddonUpdateOne) Mutation() *AddonMutation {
 	return auo.mutation
@@ -437,6 +534,27 @@ func (auo *AddonUpdateOne) RemoveEntitlements(e ...*Entitlement) *AddonUpdateOne
 		ids[i] = e[i].ID
 	}
 	return auo.RemoveEntitlementIDs(ids...)
+}
+
+// ClearCreditGrants clears all "credit_grants" edges to the CreditGrant entity.
+func (auo *AddonUpdateOne) ClearCreditGrants() *AddonUpdateOne {
+	auo.mutation.ClearCreditGrants()
+	return auo
+}
+
+// RemoveCreditGrantIDs removes the "credit_grants" edge to CreditGrant entities by IDs.
+func (auo *AddonUpdateOne) RemoveCreditGrantIDs(ids ...string) *AddonUpdateOne {
+	auo.mutation.RemoveCreditGrantIDs(ids...)
+	return auo
+}
+
+// RemoveCreditGrants removes "credit_grants" edges to CreditGrant entities.
+func (auo *AddonUpdateOne) RemoveCreditGrants(c ...*CreditGrant) *AddonUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return auo.RemoveCreditGrantIDs(ids...)
 }
 
 // Where appends a list predicates to the AddonUpdate builder.
@@ -598,6 +716,51 @@ func (auo *AddonUpdateOne) sqlSave(ctx context.Context) (_node *Addon, err error
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(entitlement.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if auo.mutation.CreditGrantsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := auo.mutation.RemovedCreditGrantsIDs(); len(nodes) > 0 && !auo.mutation.CreditGrantsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := auo.mutation.CreditGrantsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   addon.CreditGrantsTable,
+			Columns: []string{addon.CreditGrantsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(creditgrant.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/ent/client.go
+++ b/ent/client.go
@@ -743,6 +743,22 @@ func (c *AddonClient) QueryEntitlements(a *Addon) *EntitlementQuery {
 	return query
 }
 
+// QueryCreditGrants queries the credit_grants edge of a Addon.
+func (c *AddonClient) QueryCreditGrants(a *Addon) *CreditGrantQuery {
+	query := (&CreditGrantClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := a.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(addon.Table, addon.FieldID, id),
+			sqlgraph.To(creditgrant.Table, creditgrant.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, addon.CreditGrantsTable, addon.CreditGrantsColumn),
+		)
+		fromV = sqlgraph.Neighbors(a.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *AddonClient) Hooks() []Hook {
 	return c.hooks.Addon
@@ -2407,6 +2423,22 @@ func (c *CreditGrantClient) QuerySubscription(cg *CreditGrant) *SubscriptionQuer
 			sqlgraph.From(creditgrant.Table, creditgrant.FieldID, id),
 			sqlgraph.To(subscription.Table, subscription.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, creditgrant.SubscriptionTable, creditgrant.SubscriptionColumn),
+		)
+		fromV = sqlgraph.Neighbors(cg.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryAddon queries the addon edge of a CreditGrant.
+func (c *CreditGrantClient) QueryAddon(cg *CreditGrant) *AddonQuery {
+	query := (&AddonClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := cg.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(creditgrant.Table, creditgrant.FieldID, id),
+			sqlgraph.To(addon.Table, addon.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, creditgrant.AddonTable, creditgrant.AddonColumn),
 		)
 		fromV = sqlgraph.Neighbors(cg.driver.Dialect(), step)
 		return fromV, nil

--- a/ent/creditgrant.go
+++ b/ent/creditgrant.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/flexprice/flexprice/ent/addon"
 	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/plan"
 	"github.com/flexprice/flexprice/ent/subscription"
@@ -44,6 +45,8 @@ type CreditGrant struct {
 	PlanID *string `json:"plan_id,omitempty"`
 	// SubscriptionID holds the value of the "subscription_id" field.
 	SubscriptionID *string `json:"subscription_id,omitempty"`
+	// AddonID holds the value of the "addon_id" field.
+	AddonID *string `json:"addon_id,omitempty"`
 	// Credits holds the value of the "credits" field.
 	Credits decimal.Decimal `json:"credits,omitempty"`
 	// ConversionRate holds the value of the "conversion_rate" field.
@@ -84,9 +87,11 @@ type CreditGrantEdges struct {
 	Plan *Plan `json:"plan,omitempty"`
 	// Subscription holds the value of the subscription edge.
 	Subscription *Subscription `json:"subscription,omitempty"`
+	// Addon holds the value of the addon edge.
+	Addon *Addon `json:"addon,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
+	loadedTypes [3]bool
 }
 
 // PlanOrErr returns the Plan value or an error if the edge
@@ -111,6 +116,17 @@ func (e CreditGrantEdges) SubscriptionOrErr() (*Subscription, error) {
 	return nil, &NotLoadedError{edge: "subscription"}
 }
 
+// AddonOrErr returns the Addon value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e CreditGrantEdges) AddonOrErr() (*Addon, error) {
+	if e.Addon != nil {
+		return e.Addon, nil
+	} else if e.loadedTypes[2] {
+		return nil, &NotFoundError{label: addon.Label}
+	}
+	return nil, &NotLoadedError{edge: "addon"}
+}
+
 // scanValues returns the types for scanning values from sql.Rows.
 func (*CreditGrant) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
@@ -124,7 +140,7 @@ func (*CreditGrant) scanValues(columns []string) ([]any, error) {
 			values[i] = new(decimal.Decimal)
 		case creditgrant.FieldPeriodCount, creditgrant.FieldExpirationDuration, creditgrant.FieldPriority:
 			values[i] = new(sql.NullInt64)
-		case creditgrant.FieldID, creditgrant.FieldTenantID, creditgrant.FieldStatus, creditgrant.FieldCreatedBy, creditgrant.FieldUpdatedBy, creditgrant.FieldEnvironmentID, creditgrant.FieldName, creditgrant.FieldScope, creditgrant.FieldPlanID, creditgrant.FieldSubscriptionID, creditgrant.FieldCadence, creditgrant.FieldPeriod, creditgrant.FieldExpirationType, creditgrant.FieldExpirationDurationUnit:
+		case creditgrant.FieldID, creditgrant.FieldTenantID, creditgrant.FieldStatus, creditgrant.FieldCreatedBy, creditgrant.FieldUpdatedBy, creditgrant.FieldEnvironmentID, creditgrant.FieldName, creditgrant.FieldScope, creditgrant.FieldPlanID, creditgrant.FieldSubscriptionID, creditgrant.FieldAddonID, creditgrant.FieldCadence, creditgrant.FieldPeriod, creditgrant.FieldExpirationType, creditgrant.FieldExpirationDurationUnit:
 			values[i] = new(sql.NullString)
 		case creditgrant.FieldCreatedAt, creditgrant.FieldUpdatedAt, creditgrant.FieldStartDate, creditgrant.FieldEndDate, creditgrant.FieldCreditGrantAnchor:
 			values[i] = new(sql.NullTime)
@@ -216,6 +232,13 @@ func (cg *CreditGrant) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				cg.SubscriptionID = new(string)
 				*cg.SubscriptionID = value.String
+			}
+		case creditgrant.FieldAddonID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field addon_id", values[i])
+			} else if value.Valid {
+				cg.AddonID = new(string)
+				*cg.AddonID = value.String
 			}
 		case creditgrant.FieldCredits:
 			if value, ok := values[i].(*decimal.Decimal); !ok {
@@ -336,6 +359,11 @@ func (cg *CreditGrant) QuerySubscription() *SubscriptionQuery {
 	return NewCreditGrantClient(cg.config).QuerySubscription(cg)
 }
 
+// QueryAddon queries the "addon" edge of the CreditGrant entity.
+func (cg *CreditGrant) QueryAddon() *AddonQuery {
+	return NewCreditGrantClient(cg.config).QueryAddon(cg)
+}
+
 // Update returns a builder for updating this CreditGrant.
 // Note that you need to call CreditGrant.Unwrap() before calling this method if this CreditGrant
 // was returned from a transaction, and the transaction was committed or rolled back.
@@ -393,6 +421,11 @@ func (cg *CreditGrant) String() string {
 	builder.WriteString(", ")
 	if v := cg.SubscriptionID; v != nil {
 		builder.WriteString("subscription_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := cg.AddonID; v != nil {
+		builder.WriteString("addon_id=")
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")

--- a/ent/creditgrant/creditgrant.go
+++ b/ent/creditgrant/creditgrant.go
@@ -37,6 +37,8 @@ const (
 	FieldPlanID = "plan_id"
 	// FieldSubscriptionID holds the string denoting the subscription_id field in the database.
 	FieldSubscriptionID = "subscription_id"
+	// FieldAddonID holds the string denoting the addon_id field in the database.
+	FieldAddonID = "addon_id"
 	// FieldCredits holds the string denoting the credits field in the database.
 	FieldCredits = "credits"
 	// FieldConversionRate holds the string denoting the conversion_rate field in the database.
@@ -69,6 +71,8 @@ const (
 	EdgePlan = "plan"
 	// EdgeSubscription holds the string denoting the subscription edge name in mutations.
 	EdgeSubscription = "subscription"
+	// EdgeAddon holds the string denoting the addon edge name in mutations.
+	EdgeAddon = "addon"
 	// Table holds the table name of the creditgrant in the database.
 	Table = "credit_grants"
 	// PlanTable is the table that holds the plan relation/edge.
@@ -85,6 +89,13 @@ const (
 	SubscriptionInverseTable = "subscriptions"
 	// SubscriptionColumn is the table column denoting the subscription relation/edge.
 	SubscriptionColumn = "subscription_id"
+	// AddonTable is the table that holds the addon relation/edge.
+	AddonTable = "credit_grants"
+	// AddonInverseTable is the table name for the Addon entity.
+	// It exists in this package in order to avoid circular dependency with the "addon" package.
+	AddonInverseTable = "addons"
+	// AddonColumn is the table column denoting the addon relation/edge.
+	AddonColumn = "addon_id"
 )
 
 // Columns holds all SQL columns for creditgrant fields.
@@ -101,6 +112,7 @@ var Columns = []string{
 	FieldScope,
 	FieldPlanID,
 	FieldSubscriptionID,
+	FieldAddonID,
 	FieldCredits,
 	FieldConversionRate,
 	FieldTopupConversionRate,
@@ -217,6 +229,11 @@ func BySubscriptionID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSubscriptionID, opts...).ToFunc()
 }
 
+// ByAddonID orders the results by the addon_id field.
+func ByAddonID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAddonID, opts...).ToFunc()
+}
+
 // ByCredits orders the results by the credits field.
 func ByCredits(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCredits, opts...).ToFunc()
@@ -295,6 +312,13 @@ func BySubscriptionField(field string, opts ...sql.OrderTermOption) OrderOption 
 		sqlgraph.OrderByNeighborTerms(s, newSubscriptionStep(), sql.OrderByField(field, opts...))
 	}
 }
+
+// ByAddonField orders the results by addon field.
+func ByAddonField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newAddonStep(), sql.OrderByField(field, opts...))
+	}
+}
 func newPlanStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
@@ -307,5 +331,12 @@ func newSubscriptionStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(SubscriptionInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, SubscriptionTable, SubscriptionColumn),
+	)
+}
+func newAddonStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(AddonInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, AddonTable, AddonColumn),
 	)
 }

--- a/ent/creditgrant/where.go
+++ b/ent/creditgrant/where.go
@@ -123,6 +123,11 @@ func SubscriptionID(v string) predicate.CreditGrant {
 	return predicate.CreditGrant(sql.FieldEQ(FieldSubscriptionID, v))
 }
 
+// AddonID applies equality check predicate on the "addon_id" field. It's identical to AddonIDEQ.
+func AddonID(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldEQ(FieldAddonID, v))
+}
+
 // Credits applies equality check predicate on the "credits" field. It's identical to CreditsEQ.
 func Credits(v decimal.Decimal) predicate.CreditGrant {
 	return predicate.CreditGrant(sql.FieldEQ(FieldCredits, v))
@@ -924,6 +929,81 @@ func SubscriptionIDEqualFold(v string) predicate.CreditGrant {
 // SubscriptionIDContainsFold applies the ContainsFold predicate on the "subscription_id" field.
 func SubscriptionIDContainsFold(v string) predicate.CreditGrant {
 	return predicate.CreditGrant(sql.FieldContainsFold(FieldSubscriptionID, v))
+}
+
+// AddonIDEQ applies the EQ predicate on the "addon_id" field.
+func AddonIDEQ(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldEQ(FieldAddonID, v))
+}
+
+// AddonIDNEQ applies the NEQ predicate on the "addon_id" field.
+func AddonIDNEQ(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldNEQ(FieldAddonID, v))
+}
+
+// AddonIDIn applies the In predicate on the "addon_id" field.
+func AddonIDIn(vs ...string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldIn(FieldAddonID, vs...))
+}
+
+// AddonIDNotIn applies the NotIn predicate on the "addon_id" field.
+func AddonIDNotIn(vs ...string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldNotIn(FieldAddonID, vs...))
+}
+
+// AddonIDGT applies the GT predicate on the "addon_id" field.
+func AddonIDGT(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldGT(FieldAddonID, v))
+}
+
+// AddonIDGTE applies the GTE predicate on the "addon_id" field.
+func AddonIDGTE(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldGTE(FieldAddonID, v))
+}
+
+// AddonIDLT applies the LT predicate on the "addon_id" field.
+func AddonIDLT(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldLT(FieldAddonID, v))
+}
+
+// AddonIDLTE applies the LTE predicate on the "addon_id" field.
+func AddonIDLTE(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldLTE(FieldAddonID, v))
+}
+
+// AddonIDContains applies the Contains predicate on the "addon_id" field.
+func AddonIDContains(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldContains(FieldAddonID, v))
+}
+
+// AddonIDHasPrefix applies the HasPrefix predicate on the "addon_id" field.
+func AddonIDHasPrefix(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldHasPrefix(FieldAddonID, v))
+}
+
+// AddonIDHasSuffix applies the HasSuffix predicate on the "addon_id" field.
+func AddonIDHasSuffix(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldHasSuffix(FieldAddonID, v))
+}
+
+// AddonIDIsNil applies the IsNil predicate on the "addon_id" field.
+func AddonIDIsNil() predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldIsNull(FieldAddonID))
+}
+
+// AddonIDNotNil applies the NotNil predicate on the "addon_id" field.
+func AddonIDNotNil() predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldNotNull(FieldAddonID))
+}
+
+// AddonIDEqualFold applies the EqualFold predicate on the "addon_id" field.
+func AddonIDEqualFold(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldEqualFold(FieldAddonID, v))
+}
+
+// AddonIDContainsFold applies the ContainsFold predicate on the "addon_id" field.
+func AddonIDContainsFold(v string) predicate.CreditGrant {
+	return predicate.CreditGrant(sql.FieldContainsFold(FieldAddonID, v))
 }
 
 // CreditsEQ applies the EQ predicate on the "credits" field.
@@ -1770,6 +1850,29 @@ func HasSubscription() predicate.CreditGrant {
 func HasSubscriptionWith(preds ...predicate.Subscription) predicate.CreditGrant {
 	return predicate.CreditGrant(func(s *sql.Selector) {
 		step := newSubscriptionStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasAddon applies the HasEdge predicate on the "addon" edge.
+func HasAddon() predicate.CreditGrant {
+	return predicate.CreditGrant(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, AddonTable, AddonColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasAddonWith applies the HasEdge predicate on the "addon" edge with a given conditions (other predicates).
+func HasAddonWith(preds ...predicate.Addon) predicate.CreditGrant {
+	return predicate.CreditGrant(func(s *sql.Selector) {
+		step := newAddonStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/ent/creditgrant_create.go
+++ b/ent/creditgrant_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/flexprice/flexprice/ent/addon"
 	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/plan"
 	"github.com/flexprice/flexprice/ent/subscription"
@@ -150,6 +151,20 @@ func (cgc *CreditGrantCreate) SetSubscriptionID(s string) *CreditGrantCreate {
 func (cgc *CreditGrantCreate) SetNillableSubscriptionID(s *string) *CreditGrantCreate {
 	if s != nil {
 		cgc.SetSubscriptionID(*s)
+	}
+	return cgc
+}
+
+// SetAddonID sets the "addon_id" field.
+func (cgc *CreditGrantCreate) SetAddonID(s string) *CreditGrantCreate {
+	cgc.mutation.SetAddonID(s)
+	return cgc
+}
+
+// SetNillableAddonID sets the "addon_id" field if the given value is not nil.
+func (cgc *CreditGrantCreate) SetNillableAddonID(s *string) *CreditGrantCreate {
+	if s != nil {
+		cgc.SetAddonID(*s)
 	}
 	return cgc
 }
@@ -340,6 +355,11 @@ func (cgc *CreditGrantCreate) SetPlan(p *Plan) *CreditGrantCreate {
 // SetSubscription sets the "subscription" edge to the Subscription entity.
 func (cgc *CreditGrantCreate) SetSubscription(s *Subscription) *CreditGrantCreate {
 	return cgc.SetSubscriptionID(s.ID)
+}
+
+// SetAddon sets the "addon" edge to the Addon entity.
+func (cgc *CreditGrantCreate) SetAddon(a *Addon) *CreditGrantCreate {
+	return cgc.SetAddonID(a.ID)
 }
 
 // Mutation returns the CreditGrantMutation object of the builder.
@@ -626,6 +646,23 @@ func (cgc *CreditGrantCreate) createSpec() (*CreditGrant, *sqlgraph.CreateSpec) 
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.SubscriptionID = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := cgc.mutation.AddonIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   creditgrant.AddonTable,
+			Columns: []string{creditgrant.AddonColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(addon.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.AddonID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/ent/creditgrant_query.go
+++ b/ent/creditgrant_query.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/flexprice/flexprice/ent/addon"
 	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/plan"
 	"github.com/flexprice/flexprice/ent/predicate"
@@ -26,6 +27,7 @@ type CreditGrantQuery struct {
 	predicates       []predicate.CreditGrant
 	withPlan         *PlanQuery
 	withSubscription *SubscriptionQuery
+	withAddon        *AddonQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -99,6 +101,28 @@ func (cgq *CreditGrantQuery) QuerySubscription() *SubscriptionQuery {
 			sqlgraph.From(creditgrant.Table, creditgrant.FieldID, selector),
 			sqlgraph.To(subscription.Table, subscription.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, creditgrant.SubscriptionTable, creditgrant.SubscriptionColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(cgq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryAddon chains the current query on the "addon" edge.
+func (cgq *CreditGrantQuery) QueryAddon() *AddonQuery {
+	query := (&AddonClient{config: cgq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := cgq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := cgq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(creditgrant.Table, creditgrant.FieldID, selector),
+			sqlgraph.To(addon.Table, addon.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, creditgrant.AddonTable, creditgrant.AddonColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(cgq.driver.Dialect(), step)
 		return fromU, nil
@@ -300,6 +324,7 @@ func (cgq *CreditGrantQuery) Clone() *CreditGrantQuery {
 		predicates:       append([]predicate.CreditGrant{}, cgq.predicates...),
 		withPlan:         cgq.withPlan.Clone(),
 		withSubscription: cgq.withSubscription.Clone(),
+		withAddon:        cgq.withAddon.Clone(),
 		// clone intermediate query.
 		sql:  cgq.sql.Clone(),
 		path: cgq.path,
@@ -325,6 +350,17 @@ func (cgq *CreditGrantQuery) WithSubscription(opts ...func(*SubscriptionQuery)) 
 		opt(query)
 	}
 	cgq.withSubscription = query
+	return cgq
+}
+
+// WithAddon tells the query-builder to eager-load the nodes that are connected to
+// the "addon" edge. The optional arguments are used to configure the query builder of the edge.
+func (cgq *CreditGrantQuery) WithAddon(opts ...func(*AddonQuery)) *CreditGrantQuery {
+	query := (&AddonClient{config: cgq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	cgq.withAddon = query
 	return cgq
 }
 
@@ -406,9 +442,10 @@ func (cgq *CreditGrantQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]
 	var (
 		nodes       = []*CreditGrant{}
 		_spec       = cgq.querySpec()
-		loadedTypes = [2]bool{
+		loadedTypes = [3]bool{
 			cgq.withPlan != nil,
 			cgq.withSubscription != nil,
+			cgq.withAddon != nil,
 		}
 	)
 	_spec.ScanValues = func(columns []string) ([]any, error) {
@@ -438,6 +475,12 @@ func (cgq *CreditGrantQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]
 	if query := cgq.withSubscription; query != nil {
 		if err := cgq.loadSubscription(ctx, query, nodes, nil,
 			func(n *CreditGrant, e *Subscription) { n.Edges.Subscription = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := cgq.withAddon; query != nil {
+		if err := cgq.loadAddon(ctx, query, nodes, nil,
+			func(n *CreditGrant, e *Addon) { n.Edges.Addon = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -508,6 +551,38 @@ func (cgq *CreditGrantQuery) loadSubscription(ctx context.Context, query *Subscr
 	}
 	return nil
 }
+func (cgq *CreditGrantQuery) loadAddon(ctx context.Context, query *AddonQuery, nodes []*CreditGrant, init func(*CreditGrant), assign func(*CreditGrant, *Addon)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*CreditGrant)
+	for i := range nodes {
+		if nodes[i].AddonID == nil {
+			continue
+		}
+		fk := *nodes[i].AddonID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(addon.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "addon_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
 
 func (cgq *CreditGrantQuery) sqlCount(ctx context.Context) (int, error) {
 	_spec := cgq.querySpec()
@@ -539,6 +614,9 @@ func (cgq *CreditGrantQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if cgq.withSubscription != nil {
 			_spec.Node.AddColumnOnce(creditgrant.FieldSubscriptionID)
+		}
+		if cgq.withAddon != nil {
+			_spec.Node.AddColumnOnce(creditgrant.FieldAddonID)
 		}
 	}
 	if ps := cgq.predicates; len(ps) > 0 {

--- a/ent/creditgrant_update.go
+++ b/ent/creditgrant_update.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/flexprice/flexprice/ent/addon"
 	"github.com/flexprice/flexprice/ent/creditgrant"
 	"github.com/flexprice/flexprice/ent/plan"
 	"github.com/flexprice/flexprice/ent/predicate"
@@ -139,6 +140,26 @@ func (cgu *CreditGrantUpdate) ClearSubscriptionID() *CreditGrantUpdate {
 	return cgu
 }
 
+// SetAddonID sets the "addon_id" field.
+func (cgu *CreditGrantUpdate) SetAddonID(s string) *CreditGrantUpdate {
+	cgu.mutation.SetAddonID(s)
+	return cgu
+}
+
+// SetNillableAddonID sets the "addon_id" field if the given value is not nil.
+func (cgu *CreditGrantUpdate) SetNillableAddonID(s *string) *CreditGrantUpdate {
+	if s != nil {
+		cgu.SetAddonID(*s)
+	}
+	return cgu
+}
+
+// ClearAddonID clears the value of the "addon_id" field.
+func (cgu *CreditGrantUpdate) ClearAddonID() *CreditGrantUpdate {
+	cgu.mutation.ClearAddonID()
+	return cgu
+}
+
 // SetMetadata sets the "metadata" field.
 func (cgu *CreditGrantUpdate) SetMetadata(m map[string]string) *CreditGrantUpdate {
 	cgu.mutation.SetMetadata(m)
@@ -181,6 +202,11 @@ func (cgu *CreditGrantUpdate) SetSubscription(s *Subscription) *CreditGrantUpdat
 	return cgu.SetSubscriptionID(s.ID)
 }
 
+// SetAddon sets the "addon" edge to the Addon entity.
+func (cgu *CreditGrantUpdate) SetAddon(a *Addon) *CreditGrantUpdate {
+	return cgu.SetAddonID(a.ID)
+}
+
 // Mutation returns the CreditGrantMutation object of the builder.
 func (cgu *CreditGrantUpdate) Mutation() *CreditGrantMutation {
 	return cgu.mutation
@@ -195,6 +221,12 @@ func (cgu *CreditGrantUpdate) ClearPlan() *CreditGrantUpdate {
 // ClearSubscription clears the "subscription" edge to the Subscription entity.
 func (cgu *CreditGrantUpdate) ClearSubscription() *CreditGrantUpdate {
 	cgu.mutation.ClearSubscription()
+	return cgu
+}
+
+// ClearAddon clears the "addon" edge to the Addon entity.
+func (cgu *CreditGrantUpdate) ClearAddon() *CreditGrantUpdate {
+	cgu.mutation.ClearAddon()
 	return cgu
 }
 
@@ -382,6 +414,35 @@ func (cgu *CreditGrantUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if cgu.mutation.AddonCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   creditgrant.AddonTable,
+			Columns: []string{creditgrant.AddonColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(addon.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cgu.mutation.AddonIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   creditgrant.AddonTable,
+			Columns: []string{creditgrant.AddonColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(addon.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, cgu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{creditgrant.Label}
@@ -510,6 +571,26 @@ func (cguo *CreditGrantUpdateOne) ClearSubscriptionID() *CreditGrantUpdateOne {
 	return cguo
 }
 
+// SetAddonID sets the "addon_id" field.
+func (cguo *CreditGrantUpdateOne) SetAddonID(s string) *CreditGrantUpdateOne {
+	cguo.mutation.SetAddonID(s)
+	return cguo
+}
+
+// SetNillableAddonID sets the "addon_id" field if the given value is not nil.
+func (cguo *CreditGrantUpdateOne) SetNillableAddonID(s *string) *CreditGrantUpdateOne {
+	if s != nil {
+		cguo.SetAddonID(*s)
+	}
+	return cguo
+}
+
+// ClearAddonID clears the value of the "addon_id" field.
+func (cguo *CreditGrantUpdateOne) ClearAddonID() *CreditGrantUpdateOne {
+	cguo.mutation.ClearAddonID()
+	return cguo
+}
+
 // SetMetadata sets the "metadata" field.
 func (cguo *CreditGrantUpdateOne) SetMetadata(m map[string]string) *CreditGrantUpdateOne {
 	cguo.mutation.SetMetadata(m)
@@ -552,6 +633,11 @@ func (cguo *CreditGrantUpdateOne) SetSubscription(s *Subscription) *CreditGrantU
 	return cguo.SetSubscriptionID(s.ID)
 }
 
+// SetAddon sets the "addon" edge to the Addon entity.
+func (cguo *CreditGrantUpdateOne) SetAddon(a *Addon) *CreditGrantUpdateOne {
+	return cguo.SetAddonID(a.ID)
+}
+
 // Mutation returns the CreditGrantMutation object of the builder.
 func (cguo *CreditGrantUpdateOne) Mutation() *CreditGrantMutation {
 	return cguo.mutation
@@ -566,6 +652,12 @@ func (cguo *CreditGrantUpdateOne) ClearPlan() *CreditGrantUpdateOne {
 // ClearSubscription clears the "subscription" edge to the Subscription entity.
 func (cguo *CreditGrantUpdateOne) ClearSubscription() *CreditGrantUpdateOne {
 	cguo.mutation.ClearSubscription()
+	return cguo
+}
+
+// ClearAddon clears the "addon" edge to the Addon entity.
+func (cguo *CreditGrantUpdateOne) ClearAddon() *CreditGrantUpdateOne {
+	cguo.mutation.ClearAddon()
 	return cguo
 }
 
@@ -776,6 +868,35 @@ func (cguo *CreditGrantUpdateOne) sqlSave(ctx context.Context) (_node *CreditGra
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(subscription.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if cguo.mutation.AddonCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   creditgrant.AddonTable,
+			Columns: []string{creditgrant.AddonColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(addon.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cguo.mutation.AddonIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   creditgrant.AddonTable,
+			Columns: []string{creditgrant.AddonColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(addon.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -547,6 +547,7 @@ var (
 		{Name: "start_date", Type: field.TypeTime, Nullable: true},
 		{Name: "end_date", Type: field.TypeTime, Nullable: true},
 		{Name: "credit_grant_anchor", Type: field.TypeTime, Nullable: true},
+		{Name: "addon_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "plan_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
@@ -557,14 +558,20 @@ var (
 		PrimaryKey: []*schema.Column{CreditGrantsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "credit_grants_plans_credit_grants",
+				Symbol:     "credit_grants_addons_credit_grants",
 				Columns:    []*schema.Column{CreditGrantsColumns[24]},
+				RefColumns: []*schema.Column{AddonsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "credit_grants_plans_credit_grants",
+				Columns:    []*schema.Column{CreditGrantsColumns[25]},
 				RefColumns: []*schema.Column{PlansColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "credit_grants_subscriptions_credit_grants",
-				Columns:    []*schema.Column{CreditGrantsColumns[25]},
+				Columns:    []*schema.Column{CreditGrantsColumns[26]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -578,7 +585,7 @@ var (
 			{
 				Name:    "idx_plan_id_not_null",
 				Unique:  false,
-				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[24]},
+				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[25]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "plan_id IS NOT NULL",
 				},
@@ -586,9 +593,17 @@ var (
 			{
 				Name:    "idx_subscription_id_not_null",
 				Unique:  false,
-				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[25]},
+				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[26]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "subscription_id IS NOT NULL",
+				},
+			},
+			{
+				Name:    "idx_addon_id_not_null",
+				Unique:  false,
+				Columns: []*schema.Column{CreditGrantsColumns[1], CreditGrantsColumns[7], CreditGrantsColumns[9], CreditGrantsColumns[24]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "addon_id IS NOT NULL",
 				},
 			},
 		},
@@ -2621,8 +2636,9 @@ func init() {
 	CouponAssociationsTable.ForeignKeys[0].RefTable = CouponsTable
 	CouponAssociationsTable.ForeignKeys[1].RefTable = SubscriptionsTable
 	CouponAssociationsTable.ForeignKeys[2].RefTable = SubscriptionLineItemsTable
-	CreditGrantsTable.ForeignKeys[0].RefTable = PlansTable
-	CreditGrantsTable.ForeignKeys[1].RefTable = SubscriptionsTable
+	CreditGrantsTable.ForeignKeys[0].RefTable = AddonsTable
+	CreditGrantsTable.ForeignKeys[1].RefTable = PlansTable
+	CreditGrantsTable.ForeignKeys[2].RefTable = SubscriptionsTable
 	CreditNoteLineItemsTable.ForeignKeys[0].RefTable = CreditNotesTable
 	EntitlementsTable.ForeignKeys[0].RefTable = AddonsTable
 	InvoiceLineItemsTable.ForeignKeys[0].RefTable = InvoicesTable

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -131,27 +131,30 @@ const (
 // AddonMutation represents an operation that mutates the Addon nodes in the graph.
 type AddonMutation struct {
 	config
-	op                  Op
-	typ                 string
-	id                  *string
-	tenant_id           *string
-	status              *string
-	created_at          *time.Time
-	updated_at          *time.Time
-	created_by          *string
-	updated_by          *string
-	environment_id      *string
-	lookup_key          *string
-	name                *string
-	description         *string
-	metadata            *map[string]interface{}
-	clearedFields       map[string]struct{}
-	entitlements        map[string]struct{}
-	removedentitlements map[string]struct{}
-	clearedentitlements bool
-	done                bool
-	oldValue            func(context.Context) (*Addon, error)
-	predicates          []predicate.Addon
+	op                   Op
+	typ                  string
+	id                   *string
+	tenant_id            *string
+	status               *string
+	created_at           *time.Time
+	updated_at           *time.Time
+	created_by           *string
+	updated_by           *string
+	environment_id       *string
+	lookup_key           *string
+	name                 *string
+	description          *string
+	metadata             *map[string]interface{}
+	clearedFields        map[string]struct{}
+	entitlements         map[string]struct{}
+	removedentitlements  map[string]struct{}
+	clearedentitlements  bool
+	credit_grants        map[string]struct{}
+	removedcredit_grants map[string]struct{}
+	clearedcredit_grants bool
+	done                 bool
+	oldValue             func(context.Context) (*Addon, error)
+	predicates           []predicate.Addon
 }
 
 var _ ent.Mutation = (*AddonMutation)(nil)
@@ -773,6 +776,60 @@ func (m *AddonMutation) ResetEntitlements() {
 	m.removedentitlements = nil
 }
 
+// AddCreditGrantIDs adds the "credit_grants" edge to the CreditGrant entity by ids.
+func (m *AddonMutation) AddCreditGrantIDs(ids ...string) {
+	if m.credit_grants == nil {
+		m.credit_grants = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.credit_grants[ids[i]] = struct{}{}
+	}
+}
+
+// ClearCreditGrants clears the "credit_grants" edge to the CreditGrant entity.
+func (m *AddonMutation) ClearCreditGrants() {
+	m.clearedcredit_grants = true
+}
+
+// CreditGrantsCleared reports if the "credit_grants" edge to the CreditGrant entity was cleared.
+func (m *AddonMutation) CreditGrantsCleared() bool {
+	return m.clearedcredit_grants
+}
+
+// RemoveCreditGrantIDs removes the "credit_grants" edge to the CreditGrant entity by IDs.
+func (m *AddonMutation) RemoveCreditGrantIDs(ids ...string) {
+	if m.removedcredit_grants == nil {
+		m.removedcredit_grants = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.credit_grants, ids[i])
+		m.removedcredit_grants[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedCreditGrants returns the removed IDs of the "credit_grants" edge to the CreditGrant entity.
+func (m *AddonMutation) RemovedCreditGrantsIDs() (ids []string) {
+	for id := range m.removedcredit_grants {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// CreditGrantsIDs returns the "credit_grants" edge IDs in the mutation.
+func (m *AddonMutation) CreditGrantsIDs() (ids []string) {
+	for id := range m.credit_grants {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetCreditGrants resets all changes to the "credit_grants" edge.
+func (m *AddonMutation) ResetCreditGrants() {
+	m.credit_grants = nil
+	m.clearedcredit_grants = false
+	m.removedcredit_grants = nil
+}
+
 // Where appends a list predicates to the AddonMutation builder.
 func (m *AddonMutation) Where(ps ...predicate.Addon) {
 	m.predicates = append(m.predicates, ps...)
@@ -1109,9 +1166,12 @@ func (m *AddonMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *AddonMutation) AddedEdges() []string {
-	edges := make([]string, 0, 1)
+	edges := make([]string, 0, 2)
 	if m.entitlements != nil {
 		edges = append(edges, addon.EdgeEntitlements)
+	}
+	if m.credit_grants != nil {
+		edges = append(edges, addon.EdgeCreditGrants)
 	}
 	return edges
 }
@@ -1126,15 +1186,24 @@ func (m *AddonMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case addon.EdgeCreditGrants:
+		ids := make([]ent.Value, 0, len(m.credit_grants))
+		for id := range m.credit_grants {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *AddonMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 1)
+	edges := make([]string, 0, 2)
 	if m.removedentitlements != nil {
 		edges = append(edges, addon.EdgeEntitlements)
+	}
+	if m.removedcredit_grants != nil {
+		edges = append(edges, addon.EdgeCreditGrants)
 	}
 	return edges
 }
@@ -1149,15 +1218,24 @@ func (m *AddonMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case addon.EdgeCreditGrants:
+		ids := make([]ent.Value, 0, len(m.removedcredit_grants))
+		for id := range m.removedcredit_grants {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *AddonMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 1)
+	edges := make([]string, 0, 2)
 	if m.clearedentitlements {
 		edges = append(edges, addon.EdgeEntitlements)
+	}
+	if m.clearedcredit_grants {
+		edges = append(edges, addon.EdgeCreditGrants)
 	}
 	return edges
 }
@@ -1168,6 +1246,8 @@ func (m *AddonMutation) EdgeCleared(name string) bool {
 	switch name {
 	case addon.EdgeEntitlements:
 		return m.clearedentitlements
+	case addon.EdgeCreditGrants:
+		return m.clearedcredit_grants
 	}
 	return false
 }
@@ -1186,6 +1266,9 @@ func (m *AddonMutation) ResetEdge(name string) error {
 	switch name {
 	case addon.EdgeEntitlements:
 		m.ResetEntitlements()
+		return nil
+	case addon.EdgeCreditGrants:
+		m.ResetCreditGrants()
 		return nil
 	}
 	return fmt.Errorf("unknown Addon edge %s", name)
@@ -14096,6 +14179,8 @@ type CreditGrantMutation struct {
 	clearedplan              bool
 	subscription             *string
 	clearedsubscription      bool
+	addon                    *string
+	clearedaddon             bool
 	done                     bool
 	oldValue                 func(context.Context) (*CreditGrant, error)
 	predicates               []predicate.CreditGrant
@@ -14664,6 +14749,55 @@ func (m *CreditGrantMutation) SubscriptionIDCleared() bool {
 func (m *CreditGrantMutation) ResetSubscriptionID() {
 	m.subscription = nil
 	delete(m.clearedFields, creditgrant.FieldSubscriptionID)
+}
+
+// SetAddonID sets the "addon_id" field.
+func (m *CreditGrantMutation) SetAddonID(s string) {
+	m.addon = &s
+}
+
+// AddonID returns the value of the "addon_id" field in the mutation.
+func (m *CreditGrantMutation) AddonID() (r string, exists bool) {
+	v := m.addon
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAddonID returns the old "addon_id" field's value of the CreditGrant entity.
+// If the CreditGrant object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CreditGrantMutation) OldAddonID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAddonID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAddonID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAddonID: %w", err)
+	}
+	return oldValue.AddonID, nil
+}
+
+// ClearAddonID clears the value of the "addon_id" field.
+func (m *CreditGrantMutation) ClearAddonID() {
+	m.addon = nil
+	m.clearedFields[creditgrant.FieldAddonID] = struct{}{}
+}
+
+// AddonIDCleared returns if the "addon_id" field was cleared in this mutation.
+func (m *CreditGrantMutation) AddonIDCleared() bool {
+	_, ok := m.clearedFields[creditgrant.FieldAddonID]
+	return ok
+}
+
+// ResetAddonID resets all changes to the "addon_id" field.
+func (m *CreditGrantMutation) ResetAddonID() {
+	m.addon = nil
+	delete(m.clearedFields, creditgrant.FieldAddonID)
 }
 
 // SetCredits sets the "credits" field.
@@ -15430,6 +15564,33 @@ func (m *CreditGrantMutation) ResetSubscription() {
 	m.clearedsubscription = false
 }
 
+// ClearAddon clears the "addon" edge to the Addon entity.
+func (m *CreditGrantMutation) ClearAddon() {
+	m.clearedaddon = true
+	m.clearedFields[creditgrant.FieldAddonID] = struct{}{}
+}
+
+// AddonCleared reports if the "addon" edge to the Addon entity was cleared.
+func (m *CreditGrantMutation) AddonCleared() bool {
+	return m.AddonIDCleared() || m.clearedaddon
+}
+
+// AddonIDs returns the "addon" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// AddonID instead. It exists only for internal usage by the builders.
+func (m *CreditGrantMutation) AddonIDs() (ids []string) {
+	if id := m.addon; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetAddon resets all changes to the "addon" edge.
+func (m *CreditGrantMutation) ResetAddon() {
+	m.addon = nil
+	m.clearedaddon = false
+}
+
 // Where appends a list predicates to the CreditGrantMutation builder.
 func (m *CreditGrantMutation) Where(ps ...predicate.CreditGrant) {
 	m.predicates = append(m.predicates, ps...)
@@ -15464,7 +15625,7 @@ func (m *CreditGrantMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CreditGrantMutation) Fields() []string {
-	fields := make([]string, 0, 25)
+	fields := make([]string, 0, 26)
 	if m.tenant_id != nil {
 		fields = append(fields, creditgrant.FieldTenantID)
 	}
@@ -15497,6 +15658,9 @@ func (m *CreditGrantMutation) Fields() []string {
 	}
 	if m.subscription != nil {
 		fields = append(fields, creditgrant.FieldSubscriptionID)
+	}
+	if m.addon != nil {
+		fields = append(fields, creditgrant.FieldAddonID)
 	}
 	if m.credits != nil {
 		fields = append(fields, creditgrant.FieldCredits)
@@ -15570,6 +15734,8 @@ func (m *CreditGrantMutation) Field(name string) (ent.Value, bool) {
 		return m.PlanID()
 	case creditgrant.FieldSubscriptionID:
 		return m.SubscriptionID()
+	case creditgrant.FieldAddonID:
+		return m.AddonID()
 	case creditgrant.FieldCredits:
 		return m.Credits()
 	case creditgrant.FieldConversionRate:
@@ -15629,6 +15795,8 @@ func (m *CreditGrantMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldPlanID(ctx)
 	case creditgrant.FieldSubscriptionID:
 		return m.OldSubscriptionID(ctx)
+	case creditgrant.FieldAddonID:
+		return m.OldAddonID(ctx)
 	case creditgrant.FieldCredits:
 		return m.OldCredits(ctx)
 	case creditgrant.FieldConversionRate:
@@ -15742,6 +15910,13 @@ func (m *CreditGrantMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetSubscriptionID(v)
+		return nil
+	case creditgrant.FieldAddonID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAddonID(v)
 		return nil
 	case creditgrant.FieldCredits:
 		v, ok := value.(decimal.Decimal)
@@ -15925,6 +16100,9 @@ func (m *CreditGrantMutation) ClearedFields() []string {
 	if m.FieldCleared(creditgrant.FieldSubscriptionID) {
 		fields = append(fields, creditgrant.FieldSubscriptionID)
 	}
+	if m.FieldCleared(creditgrant.FieldAddonID) {
+		fields = append(fields, creditgrant.FieldAddonID)
+	}
 	if m.FieldCleared(creditgrant.FieldConversionRate) {
 		fields = append(fields, creditgrant.FieldConversionRate)
 	}
@@ -15986,6 +16164,9 @@ func (m *CreditGrantMutation) ClearField(name string) error {
 		return nil
 	case creditgrant.FieldSubscriptionID:
 		m.ClearSubscriptionID()
+		return nil
+	case creditgrant.FieldAddonID:
+		m.ClearAddonID()
 		return nil
 	case creditgrant.FieldConversionRate:
 		m.ClearConversionRate()
@@ -16061,6 +16242,9 @@ func (m *CreditGrantMutation) ResetField(name string) error {
 	case creditgrant.FieldSubscriptionID:
 		m.ResetSubscriptionID()
 		return nil
+	case creditgrant.FieldAddonID:
+		m.ResetAddonID()
+		return nil
 	case creditgrant.FieldCredits:
 		m.ResetCredits()
 		return nil
@@ -16109,12 +16293,15 @@ func (m *CreditGrantMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *CreditGrantMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.plan != nil {
 		edges = append(edges, creditgrant.EdgePlan)
 	}
 	if m.subscription != nil {
 		edges = append(edges, creditgrant.EdgeSubscription)
+	}
+	if m.addon != nil {
+		edges = append(edges, creditgrant.EdgeAddon)
 	}
 	return edges
 }
@@ -16131,13 +16318,17 @@ func (m *CreditGrantMutation) AddedIDs(name string) []ent.Value {
 		if id := m.subscription; id != nil {
 			return []ent.Value{*id}
 		}
+	case creditgrant.EdgeAddon:
+		if id := m.addon; id != nil {
+			return []ent.Value{*id}
+		}
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *CreditGrantMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	return edges
 }
 
@@ -16149,12 +16340,15 @@ func (m *CreditGrantMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *CreditGrantMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 3)
 	if m.clearedplan {
 		edges = append(edges, creditgrant.EdgePlan)
 	}
 	if m.clearedsubscription {
 		edges = append(edges, creditgrant.EdgeSubscription)
+	}
+	if m.clearedaddon {
+		edges = append(edges, creditgrant.EdgeAddon)
 	}
 	return edges
 }
@@ -16167,6 +16361,8 @@ func (m *CreditGrantMutation) EdgeCleared(name string) bool {
 		return m.clearedplan
 	case creditgrant.EdgeSubscription:
 		return m.clearedsubscription
+	case creditgrant.EdgeAddon:
+		return m.clearedaddon
 	}
 	return false
 }
@@ -16181,6 +16377,9 @@ func (m *CreditGrantMutation) ClearEdge(name string) error {
 	case creditgrant.EdgeSubscription:
 		m.ClearSubscription()
 		return nil
+	case creditgrant.EdgeAddon:
+		m.ClearAddon()
+		return nil
 	}
 	return fmt.Errorf("unknown CreditGrant unique edge %s", name)
 }
@@ -16194,6 +16393,9 @@ func (m *CreditGrantMutation) ResetEdge(name string) error {
 		return nil
 	case creditgrant.EdgeSubscription:
 		m.ResetSubscription()
+		return nil
+	case creditgrant.EdgeAddon:
+		m.ResetAddon()
 		return nil
 	}
 	return fmt.Errorf("unknown CreditGrant edge %s", name)

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -541,19 +541,19 @@ func init() {
 	// creditgrant.ScopeValidator is a validator for the "scope" field. It is called by the builders before save.
 	creditgrant.ScopeValidator = creditgrantDescScope.Validators[0].(func(string) error)
 	// creditgrantDescCredits is the schema descriptor for credits field.
-	creditgrantDescCredits := creditgrantFields[5].Descriptor()
+	creditgrantDescCredits := creditgrantFields[6].Descriptor()
 	// creditgrant.DefaultCredits holds the default value on creation for the credits field.
 	creditgrant.DefaultCredits = creditgrantDescCredits.Default.(decimal.Decimal)
 	// creditgrantDescCadence is the schema descriptor for cadence field.
-	creditgrantDescCadence := creditgrantFields[8].Descriptor()
+	creditgrantDescCadence := creditgrantFields[9].Descriptor()
 	// creditgrant.CadenceValidator is a validator for the "cadence" field. It is called by the builders before save.
 	creditgrant.CadenceValidator = creditgrantDescCadence.Validators[0].(func(string) error)
 	// creditgrantDescExpirationType is the schema descriptor for expiration_type field.
-	creditgrantDescExpirationType := creditgrantFields[11].Descriptor()
+	creditgrantDescExpirationType := creditgrantFields[12].Descriptor()
 	// creditgrant.ExpirationTypeValidator is a validator for the "expiration_type" field. It is called by the builders before save.
 	creditgrant.ExpirationTypeValidator = creditgrantDescExpirationType.Validators[0].(func(string) error)
 	// creditgrantDescMetadata is the schema descriptor for metadata field.
-	creditgrantDescMetadata := creditgrantFields[15].Descriptor()
+	creditgrantDescMetadata := creditgrantFields[16].Descriptor()
 	// creditgrant.DefaultMetadata holds the default value on creation for the metadata field.
 	creditgrant.DefaultMetadata = creditgrantDescMetadata.Default.(map[string]string)
 	creditgrantapplicationMixin := schema.CreditGrantApplication{}.Mixin()

--- a/ent/schema/addon.go
+++ b/ent/schema/addon.go
@@ -64,6 +64,7 @@ func (Addon) Fields() []ent.Field {
 func (Addon) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("entitlements", Entitlement.Type),
+		edge.To("credit_grants", CreditGrant.Type),
 	}
 }
 

--- a/ent/schema/creditgrant.go
+++ b/ent/schema/creditgrant.go
@@ -61,6 +61,13 @@ func (CreditGrant) Fields() []ent.Field {
 			Optional().
 			Nillable(),
 
+		field.String("addon_id").
+			SchemaType(map[string]string{
+				"postgres": "varchar(50)",
+			}).
+			Optional().
+			Nillable(),
+
 		field.Other("credits", decimal.Decimal{}).
 			SchemaType(map[string]string{
 				"postgres": "numeric(20,8)",
@@ -166,6 +173,10 @@ func (CreditGrant) Edges() []ent.Edge {
 			Ref("credit_grants").
 			Field("subscription_id").
 			Unique(),
+		edge.From("addon", Addon.Type).
+			Ref("credit_grants").
+			Field("addon_id").
+			Unique(),
 	}
 }
 
@@ -180,5 +191,9 @@ func (CreditGrant) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "scope", "subscription_id").
 			Annotations(entsql.IndexWhere("subscription_id IS NOT NULL")).
 			StorageKey("idx_subscription_id_not_null"),
+
+		index.Fields("tenant_id", "environment_id", "scope", "addon_id").
+			Annotations(entsql.IndexWhere("addon_id IS NOT NULL")).
+			StorageKey("idx_addon_id_not_null"),
 	}
 }

--- a/internal/api/dto/addon.go
+++ b/internal/api/dto/addon.go
@@ -62,6 +62,7 @@ type AddonResponse struct {
 	// Optional expanded fields
 	Prices       []*PriceResponse       `json:"prices,omitempty"`
 	Entitlements []*EntitlementResponse `json:"entitlements,omitempty"`
+	CreditGrants []*CreditGrantResponse `json:"credit_grants,omitempty"`
 }
 
 // CreateAddonResponse represents the response after creating an addon

--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -19,6 +19,7 @@ type CreateCreditGrantRequest struct {
 	Scope                  types.CreditGrantScope               `json:"scope" binding:"required"`
 	PlanID                 *string                              `json:"plan_id,omitempty"`
 	SubscriptionID         *string                              `json:"subscription_id,omitempty"`
+	AddonID                *string                              `json:"addon_id,omitempty"`
 	Credits                decimal.Decimal                      `json:"credits" binding:"required" swaggertype:"string"`
 	Cadence                types.CreditGrantCadence             `json:"cadence" binding:"required"`
 	Period                 *types.CreditGrantPeriod             `json:"period,omitempty"`
@@ -153,9 +154,27 @@ func (r *CreateCreditGrantRequest) Validate() error {
 				}).
 				Mark(errors.ErrValidation)
 		}
+	case types.CreditGrantScopeAddon:
+		if r.AddonID == nil || *r.AddonID == "" {
+			return errors.NewError("addon_id is required for ADDON-scoped grants").
+				WithHint("Please provide a valid addon ID").
+				WithReportableDetails(map[string]interface{}{
+					"scope": r.Scope,
+				}).
+				Mark(errors.ErrValidation)
+		}
+		// ADDON-scoped grants are templates (like PLAN): start/end dates are not allowed
+		if r.StartDate != nil || r.EndDate != nil {
+			return errors.NewError("start_date and end_date are not allowed for ADDON-scoped grants").
+				WithHint("Start date and end date are not allowed for ADDON-scoped grants").
+				WithReportableDetails(map[string]interface{}{
+					"scope": r.Scope,
+				}).
+				Mark(errors.ErrValidation)
+		}
 	default:
 		return errors.NewError("invalid scope").
-			WithHint("Scope must be either PLAN or SUBSCRIPTION").
+			WithHint("Scope must be one of PLAN, SUBSCRIPTION or ADDON").
 			WithReportableDetails(map[string]interface{}{
 				"scope": r.Scope,
 			}).
@@ -286,10 +305,23 @@ func (r *CreateCreditGrantRequest) ToCreditGrant(ctx context.Context) *creditgra
 		if r.CreditGrantAnchor != nil {
 			cg.CreditGrantAnchor = r.CreditGrantAnchor
 		}
-		// PlanID can be provided for subscription-scoped grants
+		// PlanID can be provided for subscription-scoped grants (provenance)
 		if r.PlanID != nil {
 			cg.PlanID = r.PlanID
 		}
+		// AddonID can be provided for subscription-scoped grants (provenance)
+		if r.AddonID != nil {
+			cg.AddonID = r.AddonID
+		}
+
+	case types.CreditGrantScopeAddon:
+		cg.AddonID = r.AddonID
+		// For ADDON scope (template), these fields must be nil
+		cg.SubscriptionID = nil
+		cg.PlanID = nil
+		cg.StartDate = nil
+		cg.EndDate = nil
+		cg.CreditGrantAnchor = nil
 	}
 
 	// Set fields based on cadence
@@ -440,6 +472,9 @@ func (r *CreateCreditGrantApplicationRequest) ToCreditGrantApplication(ctx conte
 type CancelFutureSubscriptionGrantsRequest struct {
 	SubscriptionID string     `json:"subscription_id" binding:"required"`
 	EffectiveDate  *time.Time `json:"effective_date,omitempty"`
+	// AddonID, when set, scopes cancellation to grants materialized from this addon
+	// (via addon_id provenance). Leave empty to cancel all of the subscription's grants.
+	AddonID *string `json:"addon_id,omitempty"`
 }
 
 // Validate validates the cancel future subscription grants request

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -290,6 +290,7 @@ func NewRouter(
 			addon.GET("/lookup/:lookup_key", handlers.Addon.GetAddonByLookupKey)
 			addon.PUT("/:id", write(types.EntityAddon, types.ActionWrite), handlers.Addon.UpdateAddon)
 			addon.GET("/:id/entitlements", handlers.Addon.GetAddonEntitlements)
+			addon.GET("/:id/creditgrants", handlers.Addon.GetAddonCreditGrants)
 			addon.DELETE("/:id", write(types.EntityAddon, types.ActionWrite), handlers.Addon.DeleteAddon)
 		}
 

--- a/internal/api/v1/addon.go
+++ b/internal/api/v1/addon.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 )
@@ -271,6 +271,37 @@ func (h *AddonHandler) GetAddonEntitlements(c *gin.Context) {
 	resp, err := h.entitlementService.GetAddonEntitlements(c.Request.Context(), id)
 	if err != nil {
 		h.log.Error(c.Request.Context(), "Failed to get addon entitlements", "error", err)
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// @Summary Get addon credit grants
+// @ID getAddonCreditGrants
+// @Description Use when listing credits attached to an addon (e.g. included prepaid or promo credits).
+// @Tags Credit Grants
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "Addon ID"
+// @Success 200 {object} dto.ListCreditGrantsResponse
+// @Failure 400 {object} ierr.ErrorResponse "Invalid request"
+// @Failure 404 {object} ierr.ErrorResponse "Resource not found"
+// @Failure 500 {object} ierr.ErrorResponse "Server error"
+// @Router /addons/{id}/creditgrants [get]
+func (h *AddonHandler) GetAddonCreditGrants(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.Error(ierr.NewError("addon ID is required").
+			WithHint("Addon ID is required").
+			Mark(ierr.ErrValidation))
+		return
+	}
+
+	resp, err := h.service.GetAddonCreditGrants(c.Request.Context(), id)
+	if err != nil {
+		h.log.Error(c.Request.Context(), "Failed to get addon credit grants", "error", err)
 		c.Error(err)
 		return
 	}

--- a/internal/domain/creditgrant/model.go
+++ b/internal/domain/creditgrant/model.go
@@ -18,6 +18,7 @@ type CreditGrant struct {
 	Scope                  types.CreditGrantScope               `json:"scope"`
 	PlanID                 *string                              `json:"plan_id,omitempty"`
 	SubscriptionID         *string                              `json:"subscription_id,omitempty"`
+	AddonID                *string                              `json:"addon_id,omitempty"`
 	Credits                decimal.Decimal                      `json:"credits" swaggertype:"string"`
 	Cadence                types.CreditGrantCadence             `json:"cadence"`
 	Period                 *types.CreditGrantPeriod             `json:"period,omitempty"`
@@ -52,6 +53,7 @@ type CreditGrantCloneOverrides struct {
 	ID            *string
 	Scope         *types.CreditGrantScope
 	PlanID        *string
+	AddonID       *string
 	EnvironmentID *string // nil = derive from ctx; non-nil = use explicit value
 	BaseModel     *types.BaseModel
 }
@@ -75,6 +77,9 @@ func (c *CreditGrant) CopyWith(ctx context.Context, overrides *CreditGrantCloneO
 	}
 	if overrides.PlanID != nil {
 		out.PlanID = overrides.PlanID
+	}
+	if overrides.AddonID != nil {
+		out.AddonID = overrides.AddonID
 	}
 	if overrides.BaseModel != nil {
 		out.BaseModel = lo.FromPtr(overrides.BaseModel)
@@ -125,9 +130,19 @@ func (c *CreditGrant) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 
+	case types.CreditGrantScopeAddon:
+		if c.AddonID == nil || *c.AddonID == "" {
+			return ierr.NewError("addon_id is required for ADDON-scoped grants").
+				WithHint("Please provide a valid addon ID").
+				WithReportableDetails(map[string]interface{}{
+					"scope": c.Scope,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+
 	default:
 		return ierr.NewError("invalid scope").
-			WithHint("Scope must be either PLAN or SUBSCRIPTION").
+			WithHint("Scope must be one of PLAN, SUBSCRIPTION or ADDON").
 			WithReportableDetails(map[string]interface{}{
 				"scope": c.Scope,
 			}).
@@ -200,6 +215,7 @@ func FromEnt(c *ent.CreditGrant) *CreditGrant {
 		Scope:                  types.CreditGrantScope(c.Scope),
 		PlanID:                 c.PlanID,
 		SubscriptionID:         c.SubscriptionID,
+		AddonID:                c.AddonID,
 		Credits:                c.Credits,
 		Cadence:                types.CreditGrantCadence(c.Cadence),
 		Period:                 period,

--- a/internal/domain/creditgrant/repository.go
+++ b/internal/domain/creditgrant/repository.go
@@ -38,4 +38,7 @@ type Repository interface {
 
 	// GetBySubscription retrieves credit grants for a specific subscription
 	GetBySubscription(ctx context.Context, subscriptionID string) ([]*CreditGrant, error)
+
+	// GetByAddon retrieves ADDON-scoped credit grants for a specific addon
+	GetByAddon(ctx context.Context, addonID string) ([]*CreditGrant, error)
 }

--- a/internal/ee/service/addon.go
+++ b/internal/ee/service/addon.go
@@ -21,6 +21,9 @@ type AddonService interface {
 	UpdateAddon(ctx context.Context, id string, req dto.UpdateAddonRequest) (*dto.AddonResponse, error)
 	DeleteAddon(ctx context.Context, id string) error
 
+	// GetAddonCreditGrants lists the ADDON-scoped credit grants defined on an addon
+	GetAddonCreditGrants(ctx context.Context, id string) (*dto.ListCreditGrantsResponse, error)
+
 	// Addon Association operations
 	ListAddonAssociations(ctx context.Context, filter *types.AddonAssociationFilter) (*dto.ListAddonAssociationsResponse, error)
 	GetActiveAddonAssociation(ctx context.Context, req dto.GetActiveAddonAssociationRequest) (*dto.ListAddonAssociationsResponse, error)
@@ -100,6 +103,17 @@ func (s *addonService) GetAddon(ctx context.Context, id string) (*dto.AddonRespo
 		copy(response.Entitlements, entitlements.Items)
 	}
 
+	// Get credit grants for this addon
+	creditGrants, err := NewCreditGrantService(s.ServiceParams).GetCreditGrantsByAddon(ctx, id)
+	if err != nil {
+		s.Logger.Error(ctx, "failed to fetch credit grants for addon", "addon_id", id, "error", err)
+		return nil, err
+	}
+
+	if len(creditGrants.Items) > 0 {
+		response.CreditGrants = creditGrants.Items
+	}
+
 	return response, nil
 }
 
@@ -131,10 +145,17 @@ func (s *addonService) GetAddonByLookupKey(ctx context.Context, lookupKey string
 		return nil, err
 	}
 
+	creditGrants, err := NewCreditGrantService(s.ServiceParams).GetCreditGrantsByAddon(ctx, domainAddon.ID)
+	if err != nil {
+		s.Logger.Error(ctx, "failed to fetch credit grants for addon", "addon_id", domainAddon.ID, "error", err)
+		return nil, err
+	}
+
 	return &dto.AddonResponse{
 		Addon:        domainAddon,
 		Prices:       pricesResponse.Items,
 		Entitlements: entitlements.Items,
+		CreditGrants: creditGrants.Items,
 	}, nil
 }
 
@@ -185,6 +206,7 @@ func (s *addonService) GetAddons(ctx context.Context, filter *types.AddonFilter)
 	// Create maps for storing expanded data
 	pricesByAddonID := make(map[string][]*dto.PriceResponse)
 	entitlementsByAddonID := make(map[string][]*dto.EntitlementResponse)
+	creditGrantsByAddonID := make(map[string][]*dto.CreditGrantResponse)
 
 	priceService := NewPriceService(s.ServiceParams)
 	entitlementService := NewEntitlementService(s.ServiceParams)
@@ -233,6 +255,19 @@ func (s *addonService) GetAddons(ctx context.Context, filter *types.AddonFilter)
 		}
 	}
 
+	// If credit grants expansion is requested, fetch them per addon
+	if filter.GetExpand().Has(types.ExpandCreditGrant) {
+		for _, addonID := range addonIDs {
+			creditGrants, err := s.CreditGrantRepo.GetByAddon(ctx, addonID)
+			if err != nil {
+				return nil, err
+			}
+			for _, cg := range creditGrants {
+				creditGrantsByAddonID[addonID] = append(creditGrantsByAddonID[addonID], &dto.CreditGrantResponse{CreditGrant: cg})
+			}
+		}
+	}
+
 	// Attach expanded data to responses
 	for i, addon := range result {
 		if prices, ok := pricesByAddonID[addon.ID]; ok {
@@ -240,6 +275,9 @@ func (s *addonService) GetAddons(ctx context.Context, filter *types.AddonFilter)
 		}
 		if entitlements, ok := entitlementsByAddonID[addon.ID]; ok {
 			response.Items[i].Entitlements = entitlements
+		}
+		if creditGrants, ok := creditGrantsByAddonID[addon.ID]; ok {
+			response.Items[i].CreditGrants = creditGrants
 		}
 	}
 
@@ -286,6 +324,23 @@ func (s *addonService) UpdateAddon(ctx context.Context, id string, req dto.Updat
 }
 
 // DeleteAddon soft deletes an addon
+// GetAddonCreditGrants lists the ADDON-scoped credit grants defined on an addon.
+func (s *addonService) GetAddonCreditGrants(ctx context.Context, id string) (*dto.ListCreditGrantsResponse, error) {
+	if id == "" {
+		return nil, ierr.NewError("addon ID is required").
+			WithHint("Please provide a valid addon ID").
+			Mark(ierr.ErrValidation)
+	}
+
+	// Ensure the addon exists (returns 404 otherwise)
+	if _, err := s.AddonRepo.GetByID(ctx, id); err != nil {
+		return nil, err
+	}
+
+	creditGrantService := NewCreditGrantService(s.ServiceParams)
+	return creditGrantService.GetCreditGrantsByAddon(ctx, id)
+}
+
 func (s *addonService) DeleteAddon(ctx context.Context, id string) error {
 	if id == "" {
 		return ierr.NewError("addon ID is required").

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -38,6 +38,9 @@ type CreditGrantService interface {
 	// GetCreditGrantsBySubscription retrieves credit grants for a specific subscription
 	GetCreditGrantsBySubscription(ctx context.Context, subscriptionID string) (*dto.ListCreditGrantsResponse, error)
 
+	// GetCreditGrantsByAddon retrieves ADDON-scoped credit grants for a specific addon
+	GetCreditGrantsByAddon(ctx context.Context, addonID string) (*dto.ListCreditGrantsResponse, error)
+
 	// NOTE: THIS IS ONLY FOR CRON JOB SHOULD NOT BE USED ELSEWHERE IN OTHER WORKFLOWS
 	// This runs every 15 mins
 	// ProcessScheduledCreditGrantApplications processes scheduled credit grant applications
@@ -101,6 +104,31 @@ func (s *creditGrantService) CreateCreditGrant(ctx context.Context, req dto.Crea
 		}
 	}
 
+	// Validate addon if addon_id is provided (addon_id presence is validated in DTO)
+	if req.AddonID != nil && lo.FromPtr(req.AddonID) != "" {
+		addon, err := s.AddonRepo.GetByID(ctx, lo.FromPtr(req.AddonID))
+		if err != nil {
+			return nil, err
+		}
+		if addon == nil {
+			return nil, ierr.NewError("addon not found").
+				WithHint(fmt.Sprintf("Addon with ID %s does not exist", lo.FromPtr(req.AddonID))).
+				WithReportableDetails(map[string]interface{}{
+					"addon_id": lo.FromPtr(req.AddonID),
+				}).
+				Mark(ierr.ErrNotFound)
+		}
+
+		if addon.Status != types.StatusPublished {
+			return nil, ierr.NewError("addon is not published").
+				WithHint("Addon is not published").
+				WithReportableDetails(map[string]interface{}{
+					"addon_id": lo.FromPtr(req.AddonID),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
 	// Validate based on scope
 	switch req.Scope {
 	case types.CreditGrantScopePlan:
@@ -112,6 +140,31 @@ func (s *creditGrantService) CreateCreditGrant(ctx context.Context, req dto.Crea
 		if len(existingGrants.Items) > 0 {
 			validationError := ierr.NewError("all credit grants for a plan must have the same conversion_rate and topup_conversion_rate").
 				WithHint("All credit grants for a plan must have the same conversion rates").
+				Mark(ierr.ErrValidation)
+
+			for _, existingGrant := range existingGrants.Items {
+				// Check if conversion_rate doesn't match
+				if (req.ConversionRate == nil) != (existingGrant.ConversionRate == nil) ||
+					(req.ConversionRate != nil && !req.ConversionRate.Equal(lo.FromPtr(existingGrant.ConversionRate))) {
+					return nil, validationError
+				}
+
+				// Check if topup_conversion_rate doesn't match
+				if (req.TopupConversionRate == nil) != (existingGrant.TopupConversionRate == nil) ||
+					(req.TopupConversionRate != nil && !req.TopupConversionRate.Equal(lo.FromPtr(existingGrant.TopupConversionRate))) {
+					return nil, validationError
+				}
+			}
+		}
+	case types.CreditGrantScopeAddon:
+		existingGrants, err := s.GetCreditGrantsByAddon(ctx, lo.FromPtr(req.AddonID))
+		if err != nil {
+			return nil, err
+		}
+
+		if len(existingGrants.Items) > 0 {
+			validationError := ierr.NewError("all credit grants for an addon must have the same conversion_rate and topup_conversion_rate").
+				WithHint("All credit grants for an addon must have the same conversion rates").
 				Mark(ierr.ErrValidation)
 
 			for _, existingGrant := range existingGrants.Items {
@@ -460,6 +513,17 @@ func (s *creditGrantService) GetCreditGrantsBySubscription(ctx context.Context, 
 	}
 
 	return resp, nil
+}
+
+func (s *creditGrantService) GetCreditGrantsByAddon(ctx context.Context, addonID string) (*dto.ListCreditGrantsResponse, error) {
+	// Create a filter for the addon's credit grants
+	filter := types.NewNoLimitCreditGrantFilter()
+	filter.AddonIDs = []string{addonID}
+	filter.WithStatus(types.StatusPublished)
+	filter.Scope = lo.ToPtr(types.CreditGrantScopeAddon)
+
+	// Use the standard list function to get the credit grants with expansion
+	return s.ListCreditGrants(ctx, filter)
 }
 
 func (s *creditGrantService) ProcessCreditGrantApplication(ctx context.Context, applicationID string) error {
@@ -1212,10 +1276,15 @@ func (s *creditGrantService) CancelFutureSubscriptionGrants(ctx context.Context,
 		return err
 	}
 
-	// Get all credit grants for this subscription
+	// Get credit grants for this subscription. When AddonID is set, scope the
+	// cancellation to grants materialized from that addon (addon_id provenance),
+	// leaving plan-sourced and other-addon grants untouched.
 	filter := types.NewNoLimitCreditGrantFilter()
 	filter.SubscriptionIDs = []string{req.SubscriptionID}
 	filter.WithStatus(types.StatusPublished)
+	if req.AddonID != nil && lo.FromPtr(req.AddonID) != "" {
+		filter.AddonIDs = []string{lo.FromPtr(req.AddonID)}
+	}
 
 	creditGrants, err := s.CreditGrantRepo.List(ctx, filter)
 	if err != nil {

--- a/internal/ee/service/creditgrant_test.go
+++ b/internal/ee/service/creditgrant_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/addon"
 	"github.com/flexprice/flexprice/internal/domain/creditgrantapplication"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/plan"
@@ -90,6 +91,7 @@ func (s *CreditGrantServiceTestSuite) setupServices() {
 		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
 		WalletBalanceAlertPubSub:   types.WalletBalanceAlertPubSub{PubSub: testutil.NewInMemoryPubSub()},
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
+		AddonRepo:                  s.GetStores().AddonRepo,
 	}
 
 	s.creditGrantService = NewCreditGrantService(serviceParams)
@@ -2368,4 +2370,157 @@ func (s *CreditGrantServiceTestSuite) TestCatchUp_FutureStartDate() {
 	applied, pending := s.countCGAStatuses(resp.CreditGrant.ID)
 	s.Equal(0, applied, "expected no applied CGAs for future grant")
 	s.Equal(1, pending, "expected 1 pending CGA waiting for future schedule")
+}
+
+// ---------------------------------------------------------------------------
+// Addon-scoped credit grants
+// ---------------------------------------------------------------------------
+
+// createTestAddon creates and stores a published addon for use in tests.
+func (s *CreditGrantServiceTestSuite) createTestAddon(id, lookupKey, name string) *addon.Addon {
+	a := &addon.Addon{
+		ID:            id,
+		LookupKey:     lookupKey,
+		Name:          name,
+		EnvironmentID: types.GetEnvironmentID(s.GetContext()),
+		BaseModel:     types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().AddonRepo.Create(s.GetContext(), a))
+	return a
+}
+
+// An ADDON-scoped grant is an inert template: it is stored with scope=ADDON and
+// addon_id set (subscription_id/plan_id nil) and does NOT initialize a workflow,
+// so no credit grant application is created and no wallet is touched.
+func (s *CreditGrantServiceTestSuite) TestCreateAddonScopedCreditGrant_IsInertTemplate() {
+	a := s.createTestAddon("addon_cg_inert", "addon_cg_inert", "Credit Booster")
+
+	req := dto.CreateCreditGrantRequest{
+		Name:           "Addon Monthly Credits",
+		Scope:          types.CreditGrantScopeAddon,
+		AddonID:        &a.ID,
+		Credits:        decimal.NewFromInt(5000),
+		Cadence:        types.CreditGrantCadenceRecurring,
+		Period:         lo.ToPtr(types.CREDIT_GRANT_PERIOD_MONTHLY),
+		PeriodCount:    lo.ToPtr(1),
+		ExpirationType: types.CreditGrantExpiryTypeBillingCycle,
+		Priority:       lo.ToPtr(1),
+	}
+
+	resp, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(types.CreditGrantScopeAddon, resp.CreditGrant.Scope)
+	s.Equal(a.ID, lo.FromPtr(resp.CreditGrant.AddonID))
+	s.Nil(resp.CreditGrant.SubscriptionID)
+	s.Nil(resp.CreditGrant.PlanID)
+
+	// Inert: no credit grant application created (no wallet effect).
+	filter := &types.CreditGrantApplicationFilter{
+		CreditGrantIDs: []string{resp.CreditGrant.ID},
+		QueryFilter:    types.NewDefaultQueryFilter(),
+	}
+	apps, err := s.GetStores().CreditGrantApplicationRepo.List(s.GetContext(), filter)
+	s.NoError(err)
+	s.Len(apps, 0)
+}
+
+// Validation for ADDON-scoped grants: addon_id is required, the addon must exist,
+// and start/end dates are not allowed (it is a template, like a plan grant).
+func (s *CreditGrantServiceTestSuite) TestCreateAddonScopedCreditGrant_Validation() {
+	a := s.createTestAddon("addon_cg_val", "addon_cg_val", "Credit Booster")
+	now := s.testData.now
+
+	base := func() dto.CreateCreditGrantRequest {
+		return dto.CreateCreditGrantRequest{
+			Name:           "Addon Grant",
+			Scope:          types.CreditGrantScopeAddon,
+			AddonID:        &a.ID,
+			Credits:        decimal.NewFromInt(100),
+			Cadence:        types.CreditGrantCadenceOneTime,
+			ExpirationType: types.CreditGrantExpiryTypeNever,
+		}
+	}
+
+	s.Run("missing addon_id", func() {
+		req := base()
+		req.AddonID = nil
+		_, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), req)
+		s.Error(err)
+	})
+
+	s.Run("nonexistent addon", func() {
+		req := base()
+		req.AddonID = lo.ToPtr("addon_does_not_exist")
+		_, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), req)
+		s.Error(err)
+	})
+
+	s.Run("start_date not allowed for addon scope", func() {
+		req := base()
+		req.StartDate = &now
+		_, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), req)
+		s.Error(err)
+	})
+}
+
+// All of an addon's grants must share the same conversion rates (same rule plans have).
+func (s *CreditGrantServiceTestSuite) TestAddonGrants_UniformConversionRate() {
+	a := s.createTestAddon("addon_cg_cr", "addon_cg_cr", "Credit Booster")
+
+	first := dto.CreateCreditGrantRequest{
+		Name:           "Grant 1",
+		Scope:          types.CreditGrantScopeAddon,
+		AddonID:        &a.ID,
+		Credits:        decimal.NewFromInt(100),
+		Cadence:        types.CreditGrantCadenceOneTime,
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		ConversionRate: lo.ToPtr(decimal.NewFromInt(1)),
+	}
+	_, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), first)
+	s.NoError(err)
+
+	second := first
+	second.Name = "Grant 2"
+	second.ConversionRate = lo.ToPtr(decimal.NewFromInt(2)) // mismatched rate
+	_, err = s.creditGrantService.CreateCreditGrant(s.GetContext(), second)
+	s.Error(err)
+}
+
+// GetCreditGrantsByAddon returns only that addon's ADDON-scoped grants, not plan grants.
+func (s *CreditGrantServiceTestSuite) TestGetCreditGrantsByAddon() {
+	a := s.createTestAddon("addon_cg_get", "addon_cg_get", "Credit Booster")
+
+	for i := 0; i < 2; i++ {
+		req := dto.CreateCreditGrantRequest{
+			Name:           fmt.Sprintf("Addon Grant %d", i),
+			Scope:          types.CreditGrantScopeAddon,
+			AddonID:        &a.ID,
+			Credits:        decimal.NewFromInt(10),
+			Cadence:        types.CreditGrantCadenceOneTime,
+			ExpirationType: types.CreditGrantExpiryTypeNever,
+		}
+		_, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), req)
+		s.NoError(err)
+	}
+
+	// A plan-scoped grant that must NOT be returned by GetCreditGrantsByAddon.
+	planGrant := dto.CreateCreditGrantRequest{
+		Name:           "Plan Grant",
+		Scope:          types.CreditGrantScopePlan,
+		PlanID:         &s.testData.plan.ID,
+		Credits:        decimal.NewFromInt(10),
+		Cadence:        types.CreditGrantCadenceOneTime,
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+	}
+	_, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), planGrant)
+	s.NoError(err)
+
+	resp, err := s.creditGrantService.GetCreditGrantsByAddon(s.GetContext(), a.ID)
+	s.NoError(err)
+	s.Len(resp.Items, 2)
+	for _, cg := range resp.Items {
+		s.Equal(types.CreditGrantScopeAddon, cg.Scope)
+		s.Equal(a.ID, lo.FromPtr(cg.AddonID))
+	}
 }

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1498,7 +1498,7 @@ func (s *subscriptionService) handleCreditGrants(
 	if subscription.TrialEnd != nil {
 		startDate = lo.FromPtr(subscription.TrialEnd)
 	}
-	return s.handleCreditGrantsWithStart(ctx, subscription, creditGrantRequests, startDate)
+	return s.handleCreditGrantsWithStart(ctx, subscription, creditGrantRequests, startDate, nil)
 }
 
 // handleCreditGrantsWithStart materializes the given credit grant requests onto the
@@ -1510,6 +1510,7 @@ func (s *subscriptionService) handleCreditGrantsWithStart(
 	subscription *subscription.Subscription,
 	creditGrantRequests []dto.CreateCreditGrantRequest,
 	startDate time.Time,
+	endDateOverride *time.Time,
 ) error {
 	if len(creditGrantRequests) == 0 {
 		return nil
@@ -1556,13 +1557,22 @@ func (s *subscriptionService) handleCreditGrantsWithStart(
 		}
 	}
 
+	// Cap the grant end at the addon's end date when materializing addon-sourced
+	// grants: min(addonEnd, subscriptionEnd). Plan/subscription grants pass a nil
+	// override and keep the subscription end. This stops recurring grants from a
+	// time-bounded (onetime) addon from continuing to apply after the addon ends.
+	effectiveEnd := subscription.EndDate
+	if endDateOverride != nil && (effectiveEnd == nil || endDateOverride.Before(lo.FromPtr(effectiveEnd))) {
+		effectiveEnd = endDateOverride
+	}
+
 	// Create and apply credit grants anchored at startDate
 	for _, grantReq := range creditGrantRequests {
 		// Ensure subscription ID is set and scope is SUBSCRIPTION
 		grantReq.SubscriptionID = lo.ToPtr(subscription.ID)
 		grantReq.Scope = types.CreditGrantScopeSubscription
 		grantReq.StartDate = lo.ToPtr(startDate)
-		grantReq.EndDate = subscription.EndDate
+		grantReq.EndDate = effectiveEnd
 
 		// Use subscription start date as the anchor for the credit grant chain
 		grantReq.CreditGrantAnchor = lo.ToPtr(startDate)
@@ -4587,7 +4597,7 @@ func (s *subscriptionService) addAddonToSubscription(
 		// Materialize the addon's credit grants (if any) onto the subscription,
 		// anchored at the addon attach date so mid-cycle grants apply immediately.
 		// Kept in-transaction so grant application is atomic with the addon attach.
-		if err := s.materializeAddonCreditGrants(ctx, sub, req.AddonID, addonRequestedStart); err != nil {
+		if err := s.materializeAddonCreditGrants(ctx, sub, req.AddonID, addonRequestedStart, addonAssociation.EndDate); err != nil {
 			return err
 		}
 
@@ -4627,6 +4637,7 @@ func (s *subscriptionService) materializeAddonCreditGrants(
 	sub *subscription.Subscription,
 	addonID string,
 	startDate time.Time,
+	addonEndDate *time.Time,
 ) error {
 	creditGrantService := NewCreditGrantService(s.ServiceParams)
 	addonGrants, err := creditGrantService.GetCreditGrantsByAddon(ctx, addonID)
@@ -4663,7 +4674,7 @@ func (s *subscriptionService) materializeAddonCreditGrants(
 		})
 	}
 
-	return s.handleCreditGrantsWithStart(ctx, sub, requests, startDate)
+	return s.handleCreditGrantsWithStart(ctx, sub, requests, startDate, addonEndDate)
 }
 
 // validateEntitlementCompatibility checks if addon entitlements are compatible with existing subscription entitlements

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1493,6 +1493,24 @@ func (s *subscriptionService) handleCreditGrants(
 	subscription *subscription.Subscription,
 	creditGrantRequests []dto.CreateCreditGrantRequest,
 ) error {
+	// Plan/subscription grants anchor at the subscription start (or trial end).
+	startDate := subscription.StartDate
+	if subscription.TrialEnd != nil {
+		startDate = lo.FromPtr(subscription.TrialEnd)
+	}
+	return s.handleCreditGrantsWithStart(ctx, subscription, creditGrantRequests, startDate)
+}
+
+// handleCreditGrantsWithStart materializes the given credit grant requests onto the
+// subscription, anchoring the grant chain at startDate. Callers that attach grants
+// mid-cycle (e.g. addon application) pass the attach date so the first grant applies
+// immediately and recurs from there, instead of the subscription start.
+func (s *subscriptionService) handleCreditGrantsWithStart(
+	ctx context.Context,
+	subscription *subscription.Subscription,
+	creditGrantRequests []dto.CreateCreditGrantRequest,
+	startDate time.Time,
+) error {
 	if len(creditGrantRequests) == 0 {
 		return nil
 	}
@@ -1538,12 +1556,7 @@ func (s *subscriptionService) handleCreditGrants(
 		}
 	}
 
-	// Create and apply credit grants
-	startDate := subscription.StartDate
-	if subscription.TrialEnd != nil {
-		startDate = lo.FromPtr(subscription.TrialEnd)
-	}
-
+	// Create and apply credit grants anchored at startDate
 	for _, grantReq := range creditGrantRequests {
 		// Ensure subscription ID is set and scope is SUBSCRIPTION
 		grantReq.SubscriptionID = lo.ToPtr(subscription.ID)
@@ -4571,6 +4584,13 @@ func (s *subscriptionService) addAddonToSubscription(
 			}
 		}
 
+		// Materialize the addon's credit grants (if any) onto the subscription,
+		// anchored at the addon attach date so mid-cycle grants apply immediately.
+		// Kept in-transaction so grant application is atomic with the addon attach.
+		if err := s.materializeAddonCreditGrants(ctx, sub, req.AddonID, addonRequestedStart); err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -4596,6 +4616,54 @@ func (s *subscriptionService) addAddonToSubscription(
 	}
 
 	return addonAssociation, nil
+}
+
+// materializeAddonCreditGrants clones the addon's ADDON-scoped credit grant templates
+// into SUBSCRIPTION-scoped grants on the subscription and applies them, anchored at
+// startDate (the addon attach date). AddonID is carried through as provenance so
+// removal can target these grants specifically. No-op when the addon has no grants.
+func (s *subscriptionService) materializeAddonCreditGrants(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	addonID string,
+	startDate time.Time,
+) error {
+	creditGrantService := NewCreditGrantService(s.ServiceParams)
+	addonGrants, err := creditGrantService.GetCreditGrantsByAddon(ctx, addonID)
+	if err != nil {
+		return err
+	}
+	if len(addonGrants.Items) == 0 {
+		return nil
+	}
+
+	s.Logger.Info(ctx, "addon has credit grants",
+		"addon_id", addonID,
+		"subscription_id", sub.ID,
+		"credit_grants_count", len(addonGrants.Items))
+
+	requests := make([]dto.CreateCreditGrantRequest, 0, len(addonGrants.Items))
+	for _, cg := range addonGrants.Items {
+		requests = append(requests, dto.CreateCreditGrantRequest{
+			Name:                   cg.Name,
+			Scope:                  types.CreditGrantScopeSubscription,
+			Credits:                cg.Credits,
+			Cadence:                cg.Cadence,
+			ExpirationType:         cg.ExpirationType,
+			Priority:               cg.Priority,
+			SubscriptionID:         lo.ToPtr(sub.ID),
+			AddonID:                lo.ToPtr(addonID), // provenance for targeted removal
+			Period:                 cg.Period,
+			ExpirationDuration:     cg.ExpirationDuration,
+			ExpirationDurationUnit: cg.ExpirationDurationUnit,
+			Metadata:               cg.Metadata,
+			PeriodCount:            cg.PeriodCount,
+			ConversionRate:         cg.ConversionRate,
+			TopupConversionRate:    cg.TopupConversionRate,
+		})
+	}
+
+	return s.handleCreditGrantsWithStart(ctx, sub, requests, startDate)
 }
 
 // validateEntitlementCompatibility checks if addon entitlements are compatible with existing subscription entitlements
@@ -4899,6 +4967,18 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 			if _, err := s.DeleteSubscriptionLineItem(ctx, lineItem.ID, deleteReq); err != nil {
 				return err
 			}
+		}
+
+		// Cancel future applications of credit grants materialized from THIS addon only
+		// (scoped by addon_id provenance). Already-granted credits are not clawed back;
+		// plan-sourced and other-addon grants are left untouched.
+		creditGrantService := NewCreditGrantService(s.ServiceParams)
+		if err := creditGrantService.CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
+			SubscriptionID: association.EntityID,
+			AddonID:        lo.ToPtr(association.AddonID),
+			EffectiveDate:  effectiveEndDate,
+		}); err != nil {
+			return err
 		}
 
 		return nil

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addon"
+	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
@@ -17,6 +18,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/settings"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/domain/wallet"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
@@ -106,6 +108,104 @@ func (s *SubscriptionServiceSuite) TestPaymentBehaviorValidation() {
 			}
 		})
 	}
+}
+
+// A recurring credit grant sourced from a ONETIME (time-bounded) addon must be
+// capped at the addon association's end date, not the subscription end date, so
+// the grant stops applying once the addon's single period is over.
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_OnetimeAddonCapsGrantEndDate() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	// Addon carrying a recurring ADDON-scoped credit grant template.
+	addonID := "addon_cg_endcap"
+	a := &addon.Addon{
+		ID:          addonID,
+		LookupKey:   addonID,
+		Name:        "Credit Booster",
+		Description: "Recurring credits addon",
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(subService.AddonRepo.Create(ctx, a))
+
+	// Addon needs at least one price so attach can create a line item.
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, &price.Price{
+		ID:                 "price_addon_cg_endcap",
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meters.apiCalls.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}))
+
+	// Customer wallet so the eager grant application has a top-up target.
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(ctx, &wallet.Wallet{
+		ID:                  "wallet_cg_endcap",
+		CustomerID:          s.testData.customer.ID,
+		Name:                "Test Wallet",
+		Currency:            "usd",
+		WalletStatus:        types.WalletStatusActive,
+		ConversionRate:      decimal.NewFromInt(1),
+		TopupConversionRate: decimal.NewFromInt(1),
+		BaseModel:           types.GetDefaultBaseModel(ctx),
+	}))
+
+	cgSvc := NewCreditGrantService(subService.ServiceParams)
+	_, err := cgSvc.CreateCreditGrant(ctx, dto.CreateCreditGrantRequest{
+		Name:           "Addon Monthly Credits",
+		Scope:          types.CreditGrantScopeAddon,
+		AddonID:        &addonID,
+		Credits:        decimal.NewFromInt(100),
+		Cadence:        types.CreditGrantCadenceRecurring,
+		Period:         lo.ToPtr(types.CREDIT_GRANT_PERIOD_MONTHLY),
+		PeriodCount:    lo.ToPtr(1),
+		ExpirationType: types.CreditGrantExpiryTypeBillingCycle,
+		Priority:       lo.ToPtr(1),
+	})
+	s.NoError(err)
+
+	// Subscription is open-ended (EndDate == nil): before the fix, the materialized
+	// grant would inherit a nil end and recur forever.
+	s.Nil(s.testData.subscription.EndDate)
+
+	// Attach as a ONETIME addon -> the addon association gets a bounded EndDate.
+	now := s.testData.now
+	_, err = s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:   addonID,
+		Cadence:   types.AddonCadenceOnetime,
+		StartDate: &now,
+	})
+	s.NoError(err)
+
+	expectedEnd, err := addonPeriodEndForStartDate(s.testData.subscription, now)
+	s.NoError(err)
+
+	// Find the materialized SUBSCRIPTION-scoped grant carrying addon provenance.
+	filter := types.NewNoLimitCreditGrantFilter()
+	filter.SubscriptionIDs = []string{s.testData.subscription.ID}
+	grants, err := subService.CreditGrantRepo.List(ctx, filter)
+	s.NoError(err)
+
+	var materialized *creditgrant.CreditGrant
+	for _, g := range grants {
+		if g.AddonID != nil && *g.AddonID == addonID && g.Scope == types.CreditGrantScopeSubscription {
+			materialized = g
+			break
+		}
+	}
+	s.NotNil(materialized, "expected a materialized addon-sourced subscription grant")
+	if materialized == nil {
+		return
+	}
+	s.NotNil(materialized.EndDate, "addon-sourced grant must have a bounded end date")
+	s.WithinDuration(expectedEnd, lo.FromPtr(materialized.EndDate), time.Second,
+		"grant end date must equal the addon association end date, not the subscription end")
 }
 
 func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionLineItemCommitments() {
@@ -280,6 +380,8 @@ func (s *SubscriptionServiceSuite) setupService() {
 		CouponRepo:                 s.GetStores().CouponRepo,
 		CouponAssociationRepo:      s.GetStores().CouponAssociationRepo,
 		CouponApplicationRepo:      s.GetStores().CouponApplicationRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
+		WalletBalanceAlertPubSub:   types.WalletBalanceAlertPubSub{PubSub: testutil.NewInMemoryPubSub()},
 		AddonRepo:                  s.GetStores().AddonRepo,
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
 		ConnectionRepo:             s.GetStores().ConnectionRepo,

--- a/internal/repository/ent/creditgrant.go
+++ b/internal/repository/ent/creditgrant.go
@@ -59,6 +59,7 @@ func (r *creditGrantRepository) Create(ctx context.Context, cg *domainCreditGran
 		SetCadence(cg.Cadence).
 		SetNillablePlanID(cg.PlanID).
 		SetNillableSubscriptionID(cg.SubscriptionID).
+		SetNillableAddonID(cg.AddonID).
 		SetNillablePeriod(cg.Period).
 		SetNillablePeriodCount(cg.PeriodCount).
 		SetExpirationType(cg.ExpirationType).
@@ -146,6 +147,7 @@ func (r *creditGrantRepository) CreateBulk(ctx context.Context, creditGrants []*
 			SetCadence(cg.Cadence).
 			SetNillablePlanID(cg.PlanID).
 			SetNillableSubscriptionID(cg.SubscriptionID).
+			SetNillableAddonID(cg.AddonID).
 			SetNillablePeriod(cg.Period).
 			SetNillablePeriodCount(cg.PeriodCount).
 			SetExpirationType(cg.ExpirationType).
@@ -506,6 +508,31 @@ func (r *creditGrantRepository) GetBySubscription(ctx context.Context, subscript
 	return r.List(ctx, filter)
 }
 
+// GetByAddon retrieves all ADDON-scoped credit grants for the given addon ID
+func (r *creditGrantRepository) GetByAddon(ctx context.Context, addonID string) ([]*domainCreditGrant.CreditGrant, error) {
+	// Start a span for this repository operation
+	span := StartRepositorySpan(ctx, "creditgrant", "list_by_addon_id", map[string]interface{}{
+		"addon_id":  addonID,
+		"tenant_id": types.GetTenantID(ctx),
+	})
+	defer FinishSpan(span)
+
+	if addonID == "" {
+		return []*domainCreditGrant.CreditGrant{}, nil
+	}
+
+	r.log.Debug(ctx, "listing credit grants by addon ID", "addon_id", addonID)
+
+	// Create a filter with addon ID
+	filter := types.NewNoLimitCreditGrantFilter()
+	filter.AddonIDs = []string{addonID}
+	filter.Status = lo.ToPtr(types.StatusPublished)
+	filter.Scope = lo.ToPtr(types.CreditGrantScopeAddon)
+
+	// Use the existing List method
+	return r.List(ctx, filter)
+}
+
 // CreditGrantQuery type alias for better readability
 type CreditGrantQuery = *ent.CreditGrantQuery
 
@@ -568,6 +595,11 @@ func (o CreditGrantQueryOptions) applyEntityQueryOptions(_ context.Context, f *t
 	// Apply subscription IDs filter if specified
 	if len(f.SubscriptionIDs) > 0 {
 		query = query.Where(creditgrant.SubscriptionIDIn(f.SubscriptionIDs...))
+	}
+
+	// Apply addon IDs filter if specified
+	if len(f.AddonIDs) > 0 {
+		query = query.Where(creditgrant.AddonIDIn(f.AddonIDs...))
 	}
 
 	// Apply scope filter if specified

--- a/internal/testutil/inmemory_creditgrant_store.go
+++ b/internal/testutil/inmemory_creditgrant_store.go
@@ -221,6 +221,18 @@ func (s *InMemoryCreditGrantStore) GetBySubscription(ctx context.Context, subscr
 	return s.List(ctx, filter)
 }
 
+// GetByAddon retrieves ADDON-scoped credit grants for a specific addon
+func (s *InMemoryCreditGrantStore) GetByAddon(ctx context.Context, addonID string) ([]*creditgrant.CreditGrant, error) {
+	filter := &types.CreditGrantFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		AddonIDs:    []string{addonID},
+		Scope:       lo.ToPtr(types.CreditGrantScopeAddon),
+	}
+	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+
+	return s.List(ctx, filter)
+}
+
 // creditGrantFilterFn implements filtering logic for credit grants
 func creditGrantFilterFn(ctx context.Context, cg *creditgrant.CreditGrant, filter interface{}) bool {
 	f, ok := filter.(*types.CreditGrantFilter)
@@ -260,12 +272,16 @@ func creditGrantFilterFn(ctx context.Context, cg *creditgrant.CreditGrant, filte
 		}
 	}
 
-	// Check scope filter
-	if f.Scope != nil {
-		if *f.Scope == types.CreditGrantScopeSubscription && cg.SubscriptionID == nil {
+	// Check addon IDs filter
+	if len(f.AddonIDs) > 0 {
+		if cg.AddonID == nil || !lo.Contains(f.AddonIDs, *cg.AddonID) {
 			return false
 		}
-		if *f.Scope == types.CreditGrantScopePlan && cg.SubscriptionID != nil {
+	}
+
+	// Check scope filter
+	if f.Scope != nil {
+		if cg.Scope != *f.Scope {
 			return false
 		}
 	}

--- a/internal/types/creditgrant.go
+++ b/internal/types/creditgrant.go
@@ -14,6 +14,7 @@ type CreditGrantScope string
 const (
 	CreditGrantScopePlan         CreditGrantScope = "PLAN"
 	CreditGrantScopeSubscription CreditGrantScope = "SUBSCRIPTION"
+	CreditGrantScopeAddon        CreditGrantScope = "ADDON"
 )
 
 // Validate validates the credit grant scope
@@ -21,6 +22,7 @@ func (s CreditGrantScope) Validate() error {
 	allowedValues := []CreditGrantScope{
 		CreditGrantScopePlan,
 		CreditGrantScopeSubscription,
+		CreditGrantScopeAddon,
 	}
 
 	if !lo.Contains(allowedValues, s) {
@@ -175,6 +177,7 @@ type CreditGrantFilter struct {
 	// Specific filters for credit grants
 	PlanIDs         []string          `form:"plan_ids" json:"plan_ids,omitempty"`
 	SubscriptionIDs []string          `form:"subscription_ids" json:"subscription_ids,omitempty"`
+	AddonIDs        []string          `form:"addon_ids" json:"addon_ids,omitempty"`
 	Scope           *CreditGrantScope `form:"scope" json:"scope,omitempty"`
 	CreditGrantIDs  []string          `form:"credit_grant_ids" json:"credit_grant_ids,omitempty"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ADDON-scoped credit grants, including create/update, addon linking, and query support.
  * Added `GET /addons/:id/creditgrants`; addon responses can now include related credit grants.
  * Extended filtering/sorting to support addon-linked credit grants, including count-based ordering.
* **Bug Fixes**
  * Improved materialization and cancellation so addon-scoped grants apply only to the intended addon (not plan/subscription grants).
  * Strengthened validation for addon-scoped grants, requiring a published addon and consistent conversion settings across an addon’s grants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->