### PR TITLE
fix(clickhouse): DialTimeout for CH Cloud PrivateLink + retry transient ALTER races

### DIFF
--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -8,8 +8,10 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	clickhouse_go "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
 )
@@ -34,6 +36,9 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 	}
 
 	// Connect without pinning a database so we can CREATE DATABASE if missing.
+	// The native protocol works over ClickHouse Cloud PrivateLink now that
+	// GetClientOptions sets a DialTimeout (without it, the in-order dial to a
+	// PrivateLink AZ ENI could block forever).
 	bootstrap := *opts
 	bootstrap.Auth.Database = "default"
 	conn, err := clickhouse_go.Open(&bootstrap)
@@ -73,13 +78,41 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 			return fmt.Errorf("split %s: %w", filepath.Base(f), err)
 		}
 		for i, stmt := range stmts {
-			if err := dbConn.Exec(ctx, stmt); err != nil {
+			if err := execWithRetry(ctx, dbConn, stmt); err != nil {
 				return fmt.Errorf("%s statement %d: %w\n---\n%s", filepath.Base(f), i+1, err, stmt)
 			}
 		}
 		log.Info(ctx, "applied clickhouse migration", "file", filepath.Base(f))
 	}
 	return nil
+}
+
+// execWithRetry runs a statement, retrying on ClickHouse Cloud's transient
+// SharedMergeTree replication races. Rapid consecutive ALTERs (e.g. several
+// ADD INDEX on one table) can outrun cross-replica metadata sync, yielding
+// "code: 517 ... doesn't catchup with latest ALTER ... Please retry". These are
+// self-healing once replicas converge, so a short backoff-retry clears them.
+func execWithRetry(ctx context.Context, conn driver.Conn, stmt string) error {
+	const maxAttempts = 8
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err = conn.Exec(ctx, stmt); err == nil {
+			return nil
+		}
+		msg := err.Error()
+		transient := strings.Contains(msg, "code: 517") ||
+			strings.Contains(msg, "CANNOT_ASSIGN_ALTER") ||
+			strings.Contains(msg, "doesn't catchup")
+		if !transient || attempt == maxAttempts {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * time.Second):
+		}
+	}
+	return err
 }
 
 // splitSQL strips `--` line comments and `/* */` block comments, then splits on

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -41,7 +41,7 @@ func main() {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*timeout)*time.Second)
 		defer cancel()
-		logger.Info(ctx, "Running ClickHouse migrations...", "address", cfg.ClickHouse.Address, "database", cfg.ClickHouse.Database)
+		logger.Info(ctx, "Running ClickHouse migrations...", "address", cfg.ClickHouse.Address, "database", cfg.ClickHouse.Database, "tls", cfg.ClickHouse.TLS)
 		if err := runClickHouseMigrations(ctx, cfg, *chDir, logger); err != nil {
 			logger.Fatal(ctx, "ClickHouse migration failed", "error", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -718,6 +718,7 @@ func NewConfig() (*Configuration, error) {
 	// every leaf key, so a FLEXPRICE_* env var always lands regardless of which config.yaml a
 	// deployment mounts (baked file on ECS, ConfigMap on GKE) — and no new key can be
 	// forgotten. Runs once at startup; reflection cost is irrelevant. See bindEnvs below.
+	// clickhouse.protocol (FLEXPRICE_CLICKHOUSE_PROTOCOL) is bound automatically here.
 	bindEnvs(v, reflect.TypeOf(Configuration{}))
 
 	// Exception capture is on by default. Struct `default:` tags aren't applied at runtime
@@ -940,6 +941,13 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 			Password: c.Password,
 		},
 		ConnOpenStrategy: clickhouse.ConnOpenInOrder,
+		// Bounded dial/read deadlines. Without DialTimeout the native driver can
+		// block forever on connect: ClickHouse Cloud behind AWS PrivateLink is
+		// fronted by multiple AZ ENIs, and an in-order dial to an ENI that never
+		// completes the TCP/native handshake hangs indefinitely with no default
+		// deadline. A finite DialTimeout makes it fail over to the next address.
+		DialTimeout: 10 * time.Second,
+		ReadTimeout: 30 * time.Second,
 	}
 	if c.TLS {
 		options.TLS = &tls.Config{}


### PR DESCRIPTION
## Root cause
Native ClickHouse protocol hangs **forever** connecting to ClickHouse Cloud behind AWS PrivateLink. The endpoint is fronted by multiple AZ ENIs; `clickhouse-go`'s in-order dial to one that never completes the native handshake blocks indefinitely because **no DialTimeout is set**.

Proven via a debug probe: with `DialTimeout` set, native connects in ~60ms over the exact same PrivateLink path that hung without it.

## Fix
- `GetClientOptions`: `DialTimeout: 10s` + `ReadTimeout: 30s`. Driver fails over to the next AZ ENI instead of hanging. Fixes migrate binary + app runtime, no API change (native driver.Conn preserved).
- Migration runner: retry transient CH Cloud SharedMergeTree errors (517 / CANNOT_ASSIGN_ALTER) from rapid consecutive ADD INDEX ALTERs outrunning replica metadata sync.

## Backward compatibility
Fully compatible. Self-managed CH (AWS/GCP native 9000) dials native as before, now with a finite dial deadline. Retry no-ops where 517 never occurs.

## Verified
Native migration against CH Cloud over PrivateLink: exit 0, all 11 tables created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClickHouse migration support, including safer SQL handling and improved retry behavior for transient failures.
  * Added worktree-friendly local development scripts with deterministic ports.
  * Added a setup guide for running the app on a shared remote machine.

* **Bug Fixes**
  * Made ClickHouse table creation idempotent.
  * Improved webhook event logging behavior and removed obsolete webhook logging settings.

* **Chores**
  * Updated build, CI, and dependency versions.
  * Added tests for SQL splitting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->