### PR TITLE
fix(cache): remove environment id prefix from user cache

### DIFF
--- a/internal/repository/ent/user.go
+++ b/internal/repository/ent/user.go
@@ -412,7 +412,7 @@ func (r *userRepository) SetCache(ctx context.Context, user *domainUser.User) {
 	})
 	defer cache.FinishSpan(span)
 
-	cacheKey := cache.GenerateKey(ctx, cache.PrefixUser, user.ID)
+	cacheKey := cache.GenerateKey(nil, cache.PrefixUser, types.GetTenantID(ctx), user.ID)
 	r.redisCache.Set(ctx, cacheKey, user, cache.ExpiryDefaultRedis)
 }
 
@@ -422,7 +422,7 @@ func (r *userRepository) GetCache(ctx context.Context, id string) *domainUser.Us
 	})
 	defer cache.FinishSpan(span)
 
-	cacheKey := cache.GenerateKey(ctx, cache.PrefixUser, id)
+	cacheKey := cache.GenerateKey(nil, cache.PrefixUser, types.GetTenantID(ctx), id)
 	value, found := r.redisCache.Get(ctx, cacheKey)
 	if !found {
 		return nil
@@ -440,6 +440,6 @@ func (r *userRepository) DeleteCache(ctx context.Context, id string) {
 	})
 	defer cache.FinishSpan(span)
 
-	cacheKey := cache.GenerateKey(ctx, cache.PrefixUser, id)
+	cacheKey := cache.GenerateKey(nil, cache.PrefixUser, types.GetTenantID(ctx), id)
 	r.redisCache.Delete(ctx, cacheKey)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User records are now cached separately per tenant, reducing the chance of seeing data from the wrong tenant in multi-tenant environments.
  * Improved consistency between cached user data and tenant-scoped queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->