### PR TITLE
feat(subscriptions): FLE-974 extend subscription end_date via modify APIs

### DIFF
--- a/docs/FLOWS/subscription-lifecycle.md
+++ b/docs/FLOWS/subscription-lifecycle.md
@@ -12,7 +12,7 @@
 2. **Entitlement derivation** aligns feature access snapshots against plan + addon overlays (`EntitlementService` synergy).
 3. **Trial / paused / resumed** nuances encoded in specialized types (`types/pause_mode.go`, subscription schema mixins).
 4. **Renewal ticks** orchestrated primarily through Temporal workflows & schedules — HTTP cron endpoints exist but are secondary helpers.
-5. **Amendments** route through layered services (change vs modification vs schedules) emphasizing non-breaking migration of billing anchors.
+5. **Amendments** route through layered services (change vs modification vs schedules) emphasizing non-breaking migration of billing anchors. Mid-cycle ops use `POST /subscriptions/:id/modify/{preview,execute}` (`SubscriptionModificationService`), including `type: end_date` to extend a fixed-term subscription (and matching line items / credit grants) without recreate.
 6. **Cancellation & dunning semantics** interplay with alerting (`alert_logs`) and wallets where credits applied.
 
 Dominant hotspot: **`internal/ee/service/subscription.go`** (multi-thousand-line orchestrator—see hotspots doc).

--- a/docs/prds/extend_subscription_end_date.md
+++ b/docs/prds/extend_subscription_end_date.md
@@ -1,0 +1,593 @@
+# Extend Subscription End Date — PRD + ERD
+
+**Linear:** [FLE-974](https://linear.app/flexprice/issue/FLE-974)   <!-- pragma: allowlist secret -->
+**Status:** Implemented (v1)  
+**Surface:** Subscription Modifications API (`POST /v1/subscriptions/:id/modify/{preview,execute}`)  
+**Closest precedent:** `trial_end` modification (`internal/ee/service/subscription_modification_trial_end.go`)
+
+---
+
+## 1. Problem Statement
+
+Today, subscriptions can be created with an `end_date`. That value is propagated to plan line items (and phase line items) at create time. After creation there is **no first-class API to push the subscription end further into the future**.
+
+Operators who need a longer fixed term today must either:
+
+1. Cancel and recreate the subscription (lossy: periods, invoices, entitlements, inheritance), or
+2. Hack around via cancellation schedules / `cancel_at` updates (which **shorten** or schedule termination — they do not extend).
+
+We need a controlled **extend end date** operation that:
+
+- Updates `subscription.end_date`
+- Propagates to the **right** line items (those that inherited the subscription end — not overrides / one-time / already-terminated segments)
+- Cascades to inherited children
+- Keeps billing, phases, credit grants, and cancellation state consistent
+- Is available via the existing **subscription modifications** preview/execute APIs
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| ID | Goal |
+|----|------|
+| G1 | Extend `subscription.end_date` to a later timestamp via modify APIs |
+| G2 | Preview the exact subscription + line-item side effects before commit |
+| G3 | Propagate the new end only to line items that currently share the old subscription end (or are open-ended under a fixed-term sub) |
+| G4 | Preserve line items with **earlier override** end dates |
+| G5 | Cascade to inherited child subscriptions |
+| G6 | Clear or reconcile scheduled cancellation when extending past `cancel_at` |
+| G7 | Keep last phase / credit-grant bounds consistent with the new end |
+| G8 | Emit `subscription.updated` webhook (existing pattern) |
+
+### Non-Goals (v1)
+
+| ID | Non-goal |
+|----|----------|
+| NG1 | **Shortening** `end_date` (use cancel / scheduled cancel) |
+| NG2 | Clearing `end_date` to make the subscription indefinite (follow-up) |
+| NG3 | Per-line-item end-date extension as a separate modify type |
+| NG4 | Proration / immediate invoice for the extension itself (extension only unlocks future periods) |
+| NG5 | Extending already-cancelled subscriptions (no “resurrect”) |
+| NG6 | Changing billing period, plan, or quantity as part of this call |
+
+---
+
+## 3. Current State (as-is)
+
+### 3.1 Subscription `EndDate` semantics
+
+| Field | Meaning |
+|-------|---------|
+| `EndDate *time.Time` | Hard term boundary. `nil` = indefinite. |
+| `CancelAt *time.Time` | When cancellation is scheduled to take effect. |
+| `CancelledAt *time.Time` | When cancellation was requested / applied. |
+| `CancelAtPeriodEnd bool` | True for `end_of_period` / `scheduled_date` cancels. |
+
+There is **no** separate `expired` status. Natural term end → period processor sets status `cancelled` when `period.end == *EndDate` and the end is not in the future.
+
+**Create:** `CreateSubscriptionRequest.EndDate` (or last phase end) → `sub.EndDate`. First `CurrentPeriodEnd` is clipped via `types.NextBillingDate(..., SubscriptionEndDate: sub.EndDate)`.
+
+**Cancel:**
+
+| Type | Sub `EndDate` | Notes |
+|------|---------------|-------|
+| `immediate` | `= effectiveDate` | Status → `cancelled` |
+| `end_of_period` | **not set yet** | `CancelAt = CurrentPeriodEnd`; line items bulk-terminated |
+| `scheduled_date` | `= effectiveDate` immediately | May shorten `CurrentPeriodEnd` |
+
+**PATCH update:** setting `cancel_at` also sets `EndDate = cancel_at`. There is **no** direct `end_date` update field today.
+
+### 3.2 Line item `EndDate` semantics
+
+- Domain uses `time.Time` where **zero = open-ended / still active**.
+- On create, plan line items copy phase end or `sub.EndDate` (`subscription.go` create path).
+- Overrides / explicit line-item `end_date` may be **earlier** than subscription end; validation rejects line item end **after** subscription end.
+- Quantity-change versioning ends the old segment at `effective_date` and creates a new segment (often open-ended).
+- One-time prices / one-time addons get short, charge-window end dates — **not** the subscription term.
+
+### 3.3 Modification API pattern
+
+```
+POST /v1/subscriptions/:id/modify/preview
+POST /v1/subscriptions/:id/modify/execute
+```
+
+Unified body: `ExecuteSubscriptionModifyRequest` with `type` + exactly one `*_params` object.
+
+Existing types: `inheritance`, `quantity_change`, `grouped_invoicing`, `trial_end`, `coupon`, `tax`.
+
+Response: `SubscriptionModifyResponse{ subscription, changed_resources }`.
+
+---
+
+## 4. Approaches Considered
+
+### A. New modify type `end_date` (recommended)
+
+Add `SubscriptionModifyTypeEndDate` with `end_date_params`, implemented in `subscription_modification_end_date.go`, mirroring `trial_end`.
+
+| Pros | Cons |
+|------|------|
+| Matches product ask (“via subscription modifications APIs”) | One more type in the switch |
+| Preview/execute + `ChangedResources` for free | Must carefully define line-item selection |
+| Same auth, routing, webhook, cascade patterns | — |
+
+### B. PATCH `/subscriptions/:id` with `end_date`
+
+| Pros | Cons |
+|------|------|
+| Simple REST | No preview; inconsistent with mid-cycle ops |
+| — | Easy to miss line-item / inheritance / grant side effects |
+
+### C. Reuse cancel / schedule APIs “in reverse”
+
+| Pros | Cons |
+|------|------|
+| Reuses schedule restore | Cancel APIs are terminate-oriented; confusing UX |
+| — | Does not express “extend term” |
+
+**Recommendation:** Approach **A**.
+
+---
+
+## 5. Product Requirements
+
+### 5.1 Actor & eligibility
+
+- **Caller:** authenticated tenant API (same RBAC as other modify write ops).
+- **Target:** subscription identified by path `:id`.
+- **Allowed statuses:** `active`, `trialing`, `paused` (paused: metadata-only extend; billing remains paused).
+- **Rejected statuses:** `cancelled`, `draft`, `incomplete` (v1 — incomplete is payment-pending; do not mutate term).
+- **Rejected types:** `inherited` — modify the **parent** instead (same rule as `trial_end`).
+
+### 5.2 Request semantics
+
+```json
+{
+  "type": "end_date",
+  "end_date_params": {
+    "new_end_date": "2027-01-01T00:00:00Z"
+  }
+}
+```
+
+| Field | Rules |
+|-------|-------|
+| `new_end_date` | Required. Must be strictly **after** current `subscription.end_date`. |
+| Current `end_date` | Must be non-nil. Extending an indefinite subscription is out of scope (NG2). |
+| vs `now` | Must be strictly after `time.Now().UTC()` (cannot extend into the past). |
+| vs `start_date` | Must be after `subscription.start_date` (already implied by > old end). |
+| vs `trial_end` | If trialing and `trial_end` is set, `new_end_date` must be **≥** `trial_end` (trial cannot outlive the term). |
+
+**Idempotency:** if `new_end_date` equals current `EndDate` (same UTC instant), return success with empty mutations (no-op). If `new_end_date <= current EndDate` and not equal → validation error (extend-only).
+
+### 5.3 Side effects (execute)
+
+1. Set `sub.EndDate = new_end_date`.
+2. **Line items:** update selected items’ `EndDate` to `new_end_date` (rules in §6).
+3. **Phases:** if the subscription has phases, set the **last phase** `EndDate` to `new_end_date` when it previously equaled the old subscription end (or was the sole driver of sub end).
+4. **CurrentPeriodEnd:** if `CurrentPeriodEnd` was clipped to the old end (equal to old `EndDate`), recompute the next period end via `types.NextBillingDate` with the new `SubscriptionEndDate` (may still cliff at the new end). Do **not** invent a longer current period if the natural cycle end is still before the new end.
+5. **Scheduled cancellation (§7.2):** if `CancelAt` is set and `new_end_date > CancelAt`, clear cancellation intent (see §7.2).
+6. **Inherited children:** cascade `EndDate` (and cancellation clear if applicable) + matching line-item updates.
+7. **Credit grants (implicit):** extend subscription-scoped grants whose `EndDate` equaled the old subscription end to the new end. This is **not** an opt-in request flag — it always runs when matching grants exist. Preview and execute must return the modified grants in `changed_resources.credit_grants` (same pattern as subscriptions / line items).
+8. **Webhook:** `subscription.updated` on the parent (and optionally each child — v1: parent only, matching trial_end).
+9. **No proration invoice** for the extension itself.
+
+### 5.4 Preview
+
+Same validations and computed `changed_resources` as execute, **zero** DB writes. Include:
+
+- `subscriptions[]` with `action: updated` for parent (+ inherited children that would change)
+- `line_items[]` with `action: updated` and old→new end dates for each extended item
+- `credit_grants[]` with `action: updated` for each grant whose end matched `old_end` (implicit side effect; include full grant payload)
+- `invoices`: empty
+
+---
+
+## 6. Line Item Propagation Rules (critical)
+
+### 6.1 Definitions
+
+Let:
+
+- `old_end` = previous `subscription.EndDate` (required, non-nil)
+- `new_end` = requested `new_end_date`
+- Line item end is “open” when domain `EndDate.IsZero()` (DB NULL)
+
+### 6.2 Selection algorithm
+
+For each line item on the subscription (and each inherited child, after cascade):
+
+```
+EXTEND item IFF all of:
+  1. item is not soft-deleted (status active)
+  2. entity is plan or recurring addon (NOT one-time charge window)
+  3. item.EndDate is NOT before now in a way that means "already fully terminated segment"
+     — specifically: skip if !EndDate.IsZero() AND EndDate.Before(old_end)
+       (earlier override / quantity-change old segment / phase that ended earlier)
+  4. AND one of:
+       a. item.EndDate equals old_end (same UTC instant)  → inherited term
+       b. item.EndDate.IsZero() AND subscription had a fixed term
+          → open-ended under fixed-term sub; billing already cliffs at sub end;
+            set EndDate = new_end so the term is explicit after extend
+```
+
+**Skip always:**
+
+| Case | Reason |
+|------|--------|
+| `EndDate` strictly before `old_end` | Explicit override / prior version / earlier phase |
+| One-time price / one-time addon association | Charge window, not term |
+| Quantity-change **old** segments (`EndDate` = version cut) | Historical |
+| Soft-deleted line items | Inactive |
+
+**Do not create new line item versions** for an end-date extend — mutate `EndDate` in place (unlike quantity change).
+
+### 6.3 Why “equals old_end” is the primary signal
+
+At create time, plan line items copy `sub.EndDate`. Overrides that set a **shorter** end keep a different timestamp. After quantity changes, the **current** segment is often open-ended (`EndDate` zero) while the subscription still has a term — rule 4b covers that so billing continues to respect the (new) subscription cliff without leaving stale copied ends on older plan rows.
+
+### 6.4 Addon associations
+
+If an addon association’s `EndDate` equals `old_end` (e.g. scheduled cancel terminated the association to the sub end), extend the association `EndDate` to `new_end` together with its line items. One-time addon associations keep their short ends.
+
+### 6.5 Worked examples
+
+**E1 — Simple fixed term**
+
+- Sub end: `2026-12-31`
+- Line items A,B: end `2026-12-31`
+- Extend to `2027-06-30` → A,B → `2027-06-30`
+
+**E2 — Line item override shorter**
+
+- Sub end: `2026-12-31`
+- Line A: `2026-12-31`, Line B: `2026-06-30` (override)
+- Extend to `2027-06-30` → A updated; **B unchanged**
+
+**E3 — Quantity change mid-term**
+
+- Sub end: `2026-12-31`
+- Old LI ended at `2026-03-01`; new LI open-ended
+- Extend → old LI unchanged; new LI gets `EndDate = 2027-…` (rule 4b)
+
+**E4 — One-time addon**
+
+- Onetime LI end = period boundary in March
+- Extend sub → onetime LI **unchanged**
+
+**E5 — Phased subscription**
+
+- Phase 1 ends `2026-06-01`, Phase 2 ends `2026-12-31` (= sub end)
+- Phase 1 LIs end `2026-06-01` → skip
+- Phase 2 LIs end `2026-12-31` → extend; last phase end → new end; sub end → new end
+
+---
+
+## 7. Edge Cases & Controls
+
+### 7.1 Status matrix
+
+| Status | Behavior |
+|--------|----------|
+| `active` | Allow |
+| `trialing` | Allow; enforce `new_end >= trial_end` |
+| `paused` | Allow (term metadata); no resume/billing side effects |
+| `cancelled` | Reject |
+| `draft` / `incomplete` | Reject |
+| `inherited` | Reject — use parent |
+
+### 7.2 Interaction with scheduled cancellation
+
+| Situation | v1 behavior |
+|-----------|-------------|
+| `CancelAt == nil` | No-op on cancel fields |
+| `CancelAt` set and `new_end_date <= CancelAt` | Reject — extension does not reach past scheduled cancel; cancel or clear cancel first |
+| `CancelAt` set and `new_end_date > CancelAt` | **Unwind scheduled cancellation:** clear `CancelAt`, `CancelAtPeriodEnd`; if a pending cancellation schedule exists, mark cancelled / restore using the same spirit as `restoreCancellationState` but with the **new** end as the restored `EndDate`; re-extend line items that were bulk-terminated to `CancelAt` when they matched the cancel boundary |
+
+Rationale: extending the term past a scheduled cancel is an explicit operator intent to keep the subscription alive longer. Document this clearly in API docs.
+
+**Open product decision (default above):** If product prefers “reject whenever `CancelAt` is set”, flip to hard reject and require an explicit cancel-of-cancellation first. The implementation should keep the unwind path behind a clear code path either way.
+
+### 7.3 `CurrentPeriodEnd` clipped to old end
+
+If `CurrentPeriodEnd.Equal(old_end)`:
+
+1. Recompute candidate next end with `NextBillingDate` from `CurrentPeriodStart` (or from last natural boundary — prefer same params as period processor) with `SubscriptionEndDate: new_end`.
+2. Set `CurrentPeriodEnd` to that candidate (still ≤ `new_end`).
+
+If `CurrentPeriodEnd` is already before `old_end` (normal mid-cycle), leave it unchanged.
+
+### 7.4 Credit grants
+
+- Grants with `EndDate == old_end`: update to `new_end` **implicitly** (no request flag).
+- Grants with earlier ends: unchanged.
+- Grants with nil end: unchanged.
+- Do **not** create new grant applications retrospectively.
+- **Response:** always surface mutated grants in `changed_resources.credit_grants` (id, action, end_date, credit_grant) on both preview and execute — same visibility bar as the updated subscription.
+
+### 7.5 Commitment / true-up
+
+Extending the term may allow additional commitment windows in future periods. v1 does **not** rewrite historical commitment buckets; future billing uses the new sub end via existing `SubscriptionEndDate` clipping.
+
+### 7.6 Inheritance
+
+- Parent extend cascades `EndDate` to each `inherited` child.
+- Apply the **same** line-item selection algorithm on each child.
+- If parent unwind clears `CancelAt`, cascade those clears (mirror `CascadeCancelToInheritedSubscriptions` field set).
+
+### 7.7 Timezone
+
+- Persist and compare in **UTC**.
+- Period recomputation uses `sub.Timezone` + `BillingAnchor` via existing `NextBillingDate`.
+- API accepts RFC3339; normalize with `.UTC()` before compare/store.
+
+### 7.8 Concurrency
+
+- Execute inside `DB.WithTx`.
+- Re-read subscription at start of TX; re-validate `EndDate` still equals the `old_end` used for line-item matching (optimistic concurrency). If another writer changed end/cancel mid-flight → abort with conflict/validation error.
+
+### 7.9 Idempotency
+
+- No new idempotency-key header in v1 (consistent with other modify types).
+- Equal `new_end_date` → no-op success.
+- Clients should treat retries as safe when the end is already at the requested value.
+
+---
+
+## 8. API Contract (ERD / OpenAPI sketch)
+
+### 8.1 Types
+
+```go
+// dto/subscription_modification.go
+
+const SubscriptionModifyTypeEndDate SubscriptionModifyType = "end_date"
+
+type SubModifyEndDateRequest struct {
+    // NewEndDate is the new subscription end. Must be strictly after the current end_date.
+    NewEndDate time.Time `json:"new_end_date" binding:"required"`
+}
+
+func (r *SubModifyEndDateRequest) Validate() error {
+    if r.NewEndDate.IsZero() {
+        return ierr.NewError("new_end_date is required").Mark(ierr.ErrValidation)
+    }
+    return nil
+}
+```
+
+Extend `ExecuteSubscriptionModifyRequest`:
+
+```go
+EndDateParams *SubModifyEndDateRequest `json:"end_date_params,omitempty"`
+```
+
+Update `Validate()` switch + error hint list of valid types.
+
+Optionally enrich `ChangedSubscription` with:
+
+```go
+EndDate *time.Time `json:"end_date,omitempty"`
+```
+
+so preview/execute responses surface the new term without requiring clients to diff full `subscription`.
+
+### 8.2 Example execute
+
+**Request**
+
+```http
+POST /v1/subscriptions/subs_123/modify/execute
+Content-Type: application/json
+
+{
+  "type": "end_date",
+  "end_date_params": {
+    "new_end_date": "2027-06-30T00:00:00Z"
+  }
+}
+```
+
+**Response (200)**
+
+```json
+{
+  "subscription": { "...": "full subscription with end_date=2027-06-30T00:00:00Z" },
+  "changed_resources": {
+    "subscriptions": [
+      {
+        "id": "subs_123",
+        "action": "updated",
+        "status": "active",
+        "end_date": "2027-06-30T00:00:00Z"
+      }
+    ],
+    "line_items": [
+      {
+        "id": "sli_aaa",
+        "price_id": "price_1",
+        "quantity": "1",
+        "end_date": "2027-06-30T00:00:00Z",
+        "change_action": "updated"
+      }
+    ]
+  }
+}
+```
+
+### 8.3 Error catalog (representative)
+
+| Condition | Error (message / hint) |
+|-----------|-------------------------|
+| Missing params | `end_date_params is required for type 'end_date'` |
+| Sub has nil end | `subscription has no end_date to extend` / use create-time end or follow-up clear/set API |
+| `new_end <= old_end` | `new_end_date must be after the current subscription end date` |
+| `new_end` in the past | `new_end_date must be in the future` |
+| Status cancelled | `cannot extend end date on cancelled subscription` |
+| Inherited | `cannot modify end date on inherited subscription` |
+| `new_end < trial_end` | `new_end_date cannot be before trial_end` |
+| CancelAt in the way (if reject mode) | `subscription is scheduled to cancel; clear cancellation before extending` |
+
+---
+
+## 9. Low-Level Technical Design
+
+### 9.1 Files to add / touch
+
+| File | Change |
+|------|--------|
+| `internal/api/dto/subscription_modification.go` | Type, params, validate, optional `ChangedSubscription.EndDate` |
+| `internal/ee/service/subscription_modification.go` | Dispatch `Execute` / `Preview` cases |
+| `internal/ee/service/subscription_modification_end_date.go` | **New** — validate, execute, preview, cascade, line-item select |
+| `internal/ee/service/subscription_modification_test.go` (+ focused `_end_date_test.go`) | Table-driven unit tests |
+| `internal/api/v1/subscription_modification.go` | Swagger description string update only |
+| `docs/swagger/*` | Via `make swagger` after implementation |
+| `internal/e2eprobe/checks/subscription_modification_flow.go` | Optional e2e case |
+| `docs/FLOWS/subscription-lifecycle.md` | Note amend path for end-date extend |
+
+**No Ent schema / migration** — `end_date` columns already exist.
+
+### 9.2 Service sketch
+
+```go
+func (s *subscriptionModificationService) executeEndDate(
+    ctx context.Context,
+    subscriptionID string,
+    params *dto.SubModifyEndDateRequest,
+) (*dto.SubscriptionModifyResponse, error) {
+    // 1. Load sub + line items
+    // 2. validateEndDateRequest(sub, params)  // status, nil end, ordering, trial, cancel policy
+    // 3. oldEnd := *sub.EndDate; newEnd := params.NewEndDate.UTC()
+    // 4. if oldEnd.Equal(newEnd) { return no-op response }
+    // 5. selectLineItemsToExtend(items, oldEnd)
+    // 6. WithTx:
+    //      - optional unwindScheduledCancellation
+    //      - sub.EndDate = &newEnd; maybe recompute CurrentPeriodEnd
+    //      - update last phase if needed
+    //      - for each selected LI: li.EndDate = newEnd; LineItemRepo.Update
+    //      - extend matching credit grants
+    //      - cascade to inherited (subs + LIs + cancel fields)
+    // 7. publishSystemEvent(subscription.updated)
+    // 8. return SubscriptionModifyResponse
+}
+```
+
+Helpers (private on `subscriptionModificationService`):
+
+| Helper | Role |
+|--------|------|
+| `validateEndDateRequest` | Eligibility + date rules |
+| `selectLineItemsToExtend` | §6 algorithm |
+| `recomputePeriodEndAfterExtend` | §7.3 |
+| `unwindScheduledCancellationForExtend` | §7.2 |
+| `cascadeEndDateToInherited` | Children + their LIs |
+| `extendCreditGrantsMatchingEnd` | Grant end == old_end |
+
+Reuse:
+
+- `getInheritedSubscriptions` (already on modification service)
+- `publishSystemEvent`
+- `types.NextBillingDate`
+- Schedule restore patterns from `subscription_schedule.go` / `restoreCancellationState`
+
+### 9.3 Layering
+
+- Handler stays thin (already).
+- All rules in `SubscriptionModificationService` (EE service layer).
+- Repos only: `SubRepo.Update`, line item update, phase update, grant update, schedule update.
+- No business logic in API DTO beyond structural `Validate()`.
+
+### 9.4 Observability
+
+Structured logs (zerolog via existing logger):
+
+- `subscription_id`, `old_end_date`, `new_end_date`, `line_items_extended`, `inherited_cascaded`, `cancellation_unwound`
+
+### 9.5 Billing impact (why no invoice)
+
+`FilterLineItemsToBeInvoiced` already skips periods that start at/after `sub.EndDate`. Extending the end **re-enables** future period generation on the next cron/Temporal tick. Historical invoices remain immutable. No mid-cycle proration is required for a pure term extension.
+
+---
+
+## 10. Testing Plan
+
+### 10.1 Unit / service tests
+
+| Case | Expect |
+|------|--------|
+| Happy path extend + matching LIs | Sub + LIs updated; webhook path invoked |
+| Preview does not persist | DB unchanged |
+| Override LI with earlier end | Unchanged |
+| Open-ended current qty-change segment | Gets new end |
+| One-time LI | Unchanged |
+| Nil sub end | Validation error |
+| `new_end <= old_end` | Validation error |
+| Equal new/old | No-op success |
+| Cancelled / inherited | Reject |
+| Trialing with `new_end < trial_end` | Reject |
+| `CurrentPeriodEnd == old_end` | Recomputed ≤ new_end |
+| Parent with inherited children | Children end + LIs cascade |
+| Phased last phase | Last phase end updated; earlier phase LIs skipped |
+| Grant end == old_end | Grant extended |
+| Scheduled cancel + extend past CancelAt | Unwind (or reject per final product flag) |
+
+### 10.2 Integration / e2e
+
+- Create fixed-term sub → modify preview → execute → get subscription → assert ends.
+- Run period processing across the old end boundary after extend → subscription remains active and invoices the next period.
+
+---
+
+## 11. Rollout
+
+1. Land this design doc (FLE-974 first step).
+2. Implement behind normal API availability (no feature flag required unless product wants gradual expose).
+3. `make swagger` + SDK regen in a follow-up if public SDK consumers need the new enum immediately.
+4. Update customer-facing API docs / changelog: new `type: end_date`.
+
+---
+
+## 12. Open Decisions (defaults chosen)
+
+| # | Question | Default in this doc |
+|---|----------|---------------------|
+| D1 | Shorten / clear end in same API? | **No** (NG1/NG2) — extend only |
+| D2 | Allow when `CancelAt` set? | **Yes if `new_end > CancelAt`**, unwind cancel; else reject |
+| D3 | Extend open-ended LIs under fixed-term sub? | **Yes** (set explicit end = new_end) |
+| D4 | Extend matching credit grants? | **Yes** when grant end == old_end |
+| D5 | Paused subscriptions? | **Allow** |
+| D6 | Incomplete subscriptions? | **Reject** |
+| D7 | Child webhook events? | **Parent only** in v1 |
+
+Product/engineering should confirm D2 and D3 before implementation; they are the highest-impact behavioral choices.
+
+---
+
+## 13. Implementation Checklist (for the coding PR)
+
+- [x] DTO: `end_date` type + `SubModifyEndDateRequest` + request validate switch
+- [x] Service: `subscription_modification_end_date.go` (validate / preview / execute / cascade)
+- [x] Dispatch wiring in `Execute` / `Preview`
+- [x] Line-item selector + tests for override / onetime / qty-change / phase cases
+- [x] Cancellation unwind path + tests
+- [x] Period-end recompute when clipped
+- [x] Credit grant extend (**implicit**) + `changed_resources.credit_grants` on preview/execute
+- [ ] Swagger annotations + `make swagger` (handler description updated; full regen follow-up)
+- [x] Flow doc blurb in `docs/FLOWS/subscription-lifecycle.md`
+- [ ] E2E probe case (optional but recommended)
+
+---
+
+## 14. References (code)
+
+- Domain: `internal/domain/subscription/model.go`, `line_item.go`
+- Create propagation: `internal/ee/service/subscription.go` (plan LI `EndDate` assignment)
+- Line item validation: `internal/api/dto/subscription_line_item.go` (`line item end_date cannot be after subscription end date`)
+- Cancel + period end: `updateSubscriptionForCancellation`, `processSubscriptionPeriod`
+- Billing cliff: `billingService.FilterLineItemsToBeInvoiced`, `types.NextBillingDate`
+- Modify framework: `internal/api/dto/subscription_modification.go`, `internal/ee/service/subscription_modification*.go`
+- Cascade cancel: `CascadeCancelToInheritedSubscriptions`
+- Trial modify template: `subscription_modification_trial_end.go`

--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -138,7 +138,23 @@ const (
 	SubscriptionModifyTypeTrialEnd         SubscriptionModifyType = "trial_end"
 	SubscriptionModifyTypeCoupon           SubscriptionModifyType = "coupon"
 	SubscriptionModifyTypeTax              SubscriptionModifyType = "tax"
+	SubscriptionModifyTypeEndDate          SubscriptionModifyType = "end_date"
 )
+
+// SubModifyEndDateRequest is the payload for extending a subscription's end date.
+type SubModifyEndDateRequest struct {
+	// NewEndDate is the new subscription end. Must be strictly after the current end_date.
+	NewEndDate time.Time `json:"new_end_date" binding:"required"`
+}
+
+func (r *SubModifyEndDateRequest) Validate() error {
+	if r.NewEndDate.IsZero() {
+		return ierr.NewError("new_end_date is required").
+			WithHint("Provide a new_end_date to extend the subscription term").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
 
 // SubModifyCouponAction is the action to perform on a coupon association.
 type SubModifyCouponAction string
@@ -285,6 +301,7 @@ type ExecuteSubscriptionModifyRequest struct {
 	TrialEndParams         *SubModifyTrialEndRequest        `json:"trial_end_params,omitempty"`
 	CouponParams           *SubModifyCouponParams           `json:"coupon_params,omitempty"`
 	TaxParams              *SubModifyTaxParams              `json:"tax_params,omitempty"`
+	EndDateParams          *SubModifyEndDateRequest         `json:"end_date_params,omitempty"`
 }
 
 func (r *ExecuteSubscriptionModifyRequest) Validate() error {
@@ -325,9 +342,15 @@ func (r *ExecuteSubscriptionModifyRequest) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 		return r.TaxParams.Validate()
+	case SubscriptionModifyTypeEndDate:
+		if r.EndDateParams == nil {
+			return ierr.NewError("end_date_params is required for type 'end_date'").
+				Mark(ierr.ErrValidation)
+		}
+		return r.EndDateParams.Validate()
 	default:
 		return ierr.NewError("unknown modification type: " + string(r.Type)).
-			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end, coupon, tax").
+			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end, coupon, tax, end_date").
 			Mark(ierr.ErrValidation)
 	}
 }
@@ -393,6 +416,24 @@ type ChangedSubscription struct {
 	Status           types.SubscriptionStatus  `json:"status"`
 	TrialEnd         *time.Time                `json:"trial_end,omitempty"`
 	CurrentPeriodEnd *time.Time                `json:"current_period_end,omitempty"`
+	EndDate          *time.Time                `json:"end_date,omitempty"`
+}
+
+// ChangedCreditGrantAction describes how a credit grant changed.
+// @Description updated
+type ChangedCreditGrantAction string
+
+const (
+	ChangedCreditGrantActionUpdated ChangedCreditGrantAction = "updated"
+)
+
+// ChangedCreditGrant describes a credit grant mutated by a subscription modification.
+type ChangedCreditGrant struct {
+	ID      string                   `json:"id"`
+	Action  ChangedCreditGrantAction `json:"action"`
+	EndDate *time.Time               `json:"end_date,omitempty"`
+	// CreditGrant is the grant after the modification (execute) or projected (preview).
+	CreditGrant *CreditGrantResponse `json:"credit_grant,omitempty"`
 }
 
 // ChangedInvoice describes a proration invoice or wallet credit from a modification.
@@ -413,6 +454,7 @@ type ChangedResources struct {
 	LineItems     []ChangedLineItem     `json:"line_items,omitempty"`
 	Subscriptions []ChangedSubscription `json:"subscriptions,omitempty"`
 	Invoices      []ChangedInvoice      `json:"invoices,omitempty"`
+	CreditGrants  []ChangedCreditGrant  `json:"credit_grants,omitempty"`
 }
 
 // SubscriptionModifyResponse is the response from execute and preview endpoints.

--- a/internal/api/v1/subscription_modification.go
+++ b/internal/api/v1/subscription_modification.go
@@ -29,7 +29,7 @@ func NewSubscriptionModificationHandler(
 
 // @Summary Execute subscription modification
 // @ID executeSubscriptionModify
-// @Description Execute a mid-cycle subscription modification (inheritance, quantity change, grouped invoicing, trial end, coupon, or tax).
+// @Description Execute a mid-cycle subscription modification (inheritance, quantity change, grouped invoicing, trial end, coupon, tax, or end date).
 // @Tags Subscriptions
 // @Accept json
 // @Produce json
@@ -71,7 +71,7 @@ func (h *SubscriptionModificationHandler) Execute(c *gin.Context) {
 
 // @Summary Preview subscription modification
 // @ID previewSubscriptionModify
-// @Description Preview the impact of a mid-cycle subscription modification (inheritance, quantity change, grouped invoicing, trial end, coupon, or tax) without committing changes.
+// @Description Preview the impact of a mid-cycle subscription modification (inheritance, quantity change, grouped invoicing, trial end, coupon, tax, or end date) without committing changes.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json

--- a/internal/ee/service/subscription_modification.go
+++ b/internal/ee/service/subscription_modification.go
@@ -59,9 +59,11 @@ func (s *subscriptionModificationService) Execute(ctx context.Context, subscript
 		return s.executeCouponModification(ctx, subscriptionID, req.CouponParams)
 	case dto.SubscriptionModifyTypeTax:
 		return s.executeTaxModification(ctx, subscriptionID, req.TaxParams)
+	case dto.SubscriptionModifyTypeEndDate:
+		return s.executeEndDate(ctx, subscriptionID, req.EndDateParams)
 	default:
 		return nil, ierr.NewError("unknown modification type: " + string(req.Type)).
-			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end, coupon, tax").
+			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end, coupon, tax, end_date").
 			Mark(ierr.ErrValidation)
 	}
 }
@@ -85,9 +87,11 @@ func (s *subscriptionModificationService) Preview(ctx context.Context, subscript
 		return s.previewCouponModification(ctx, subscriptionID, req.CouponParams)
 	case dto.SubscriptionModifyTypeTax:
 		return s.previewTaxModification(ctx, subscriptionID, req.TaxParams)
+	case dto.SubscriptionModifyTypeEndDate:
+		return s.previewEndDate(ctx, subscriptionID, req.EndDateParams)
 	default:
 		return nil, ierr.NewError("unknown modification type: " + string(req.Type)).
-			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end, coupon, tax").
+			WithHint("Valid values: inheritance, quantity_change, grouped_invoicing, trial_end, coupon, tax, end_date").
 			Mark(ierr.ErrValidation)
 	}
 }

--- a/internal/ee/service/subscription_modification_end_date.go
+++ b/internal/ee/service/subscription_modification_end_date.go
@@ -1,0 +1,714 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto" // pragma: allowlist secret
+	"github.com/flexprice/flexprice/internal/domain/subscription" // pragma: allowlist secret
+	ierr "github.com/flexprice/flexprice/internal/errors" // pragma: allowlist secret
+	"github.com/flexprice/flexprice/internal/types" // pragma: allowlist secret
+	"github.com/samber/lo"
+)
+
+// validateEndDateRequest checks eligibility and date rules for extending a subscription end date.
+// Returns (isNoOp, error). isNoOp is true when new_end_date equals the current end (same UTC instant).
+func (s *subscriptionModificationService) validateEndDateRequest(
+	sub *subscription.Subscription,
+	subscriptionID string,
+	params *dto.SubModifyEndDateRequest,
+) (bool, error) {
+	switch sub.SubscriptionStatus {
+	case types.SubscriptionStatusActive, types.SubscriptionStatusTrialing, types.SubscriptionStatusPaused:
+		// allowed
+	default:
+		return false, ierr.NewError("cannot extend end date on subscription with status " + string(sub.SubscriptionStatus)).
+			WithHint("Only active, trialing, or paused subscriptions can have their end date extended").
+			WithReportableDetails(map[string]interface{}{
+				"subscription_id": subscriptionID,
+				"status":          sub.SubscriptionStatus,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if sub.SubscriptionType == types.SubscriptionTypeInherited {
+		return false, ierr.NewError("cannot modify end date on inherited subscription").
+			WithHint("Modify the parent subscription's end date instead").
+			WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if sub.EndDate == nil {
+		return false, ierr.NewError("subscription has no end_date to extend").
+			WithHint("Extending an indefinite subscription is not supported; set an end_date at create time first").
+			WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID}).
+			Mark(ierr.ErrValidation)
+	}
+
+	newEnd := params.NewEndDate.UTC()
+	oldEnd := sub.EndDate.UTC()
+	now := time.Now().UTC()
+
+	if newEnd.Equal(oldEnd) {
+		return true, nil
+	}
+
+	if !newEnd.After(oldEnd) {
+		return false, ierr.NewError("new_end_date must be after the current subscription end date").
+			WithHint("This API only extends the term; use cancellation to shorten").
+			WithReportableDetails(map[string]interface{}{
+				"new_end_date":          newEnd,
+				"subscription_end_date": oldEnd,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if !newEnd.After(now) {
+		return false, ierr.NewError("new_end_date must be in the future").
+			WithHint("Provide a new_end_date strictly after the current UTC time").
+			WithReportableDetails(map[string]interface{}{
+				"new_end_date": newEnd,
+				"now":          now,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if sub.SubscriptionStatus == types.SubscriptionStatusTrialing && sub.TrialEnd != nil {
+		if newEnd.Before(sub.TrialEnd.UTC()) {
+			return false, ierr.NewError("new_end_date cannot be before trial_end").
+				WithHint("The subscription term must cover the full trial period").
+				WithReportableDetails(map[string]interface{}{
+					"new_end_date": newEnd,
+					"trial_end":    sub.TrialEnd.UTC(),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	if sub.CancelAt != nil {
+		cancelAt := sub.CancelAt.UTC()
+		if !newEnd.After(cancelAt) {
+			return false, ierr.NewError("new_end_date must be after the scheduled cancellation date").
+				WithHint("Clear or cancel the scheduled cancellation first, or extend past cancel_at").
+				WithReportableDetails(map[string]interface{}{
+					"new_end_date": newEnd,
+					"cancel_at":    cancelAt,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	return false, nil
+}
+
+// selectLineItemsToExtend returns line items whose end should move to newEnd per the ERD §6 rules.
+// When cancelBoundary is set (scheduled cancellation unwind), items terminated exactly at that
+// boundary are also selected so they can be re-extended past the cancelled cancel_at.
+func selectLineItemsToExtend(
+	items []*subscription.SubscriptionLineItem,
+	oldEnd time.Time,
+	cancelBoundary *time.Time,
+) []*subscription.SubscriptionLineItem {
+	selected := make([]*subscription.SubscriptionLineItem, 0)
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		if item.Status != types.StatusPublished {
+			continue
+		}
+		if item.IsOneTime() {
+			continue
+		}
+		if item.EndDate.IsZero() || item.EndDate.Equal(oldEnd) {
+			selected = append(selected, item)
+			continue
+		}
+		if cancelBoundary != nil && item.EndDate.Equal(*cancelBoundary) {
+			selected = append(selected, item)
+			continue
+		}
+		// Earlier override / historical qty-change segment / earlier phase — skip.
+	}
+	return selected
+}
+
+// recomputePeriodEndAfterExtend recomputes CurrentPeriodEnd when it was clipped to the old subscription end.
+func recomputePeriodEndAfterExtend(sub *subscription.Subscription, newEnd time.Time) error {
+	oldEnd := lo.FromPtr(sub.EndDate)
+	if !sub.CurrentPeriodEnd.Equal(oldEnd) {
+		return nil
+	}
+	next, err := types.NextBillingDate(&types.NextBillingDateParams{
+		CurrentPeriodStart:  sub.CurrentPeriodStart,
+		BillingAnchor:       sub.BillingAnchor,
+		Unit:                sub.BillingPeriodCount,
+		Period:              sub.BillingPeriod,
+		SubscriptionEndDate: &newEnd,
+		Timezone:            sub.Timezone,
+	})
+	if err != nil {
+		return err
+	}
+	sub.CurrentPeriodEnd = next
+	return nil
+}
+
+// ─────────────────────────────────────────────
+// Execute: end date
+// ─────────────────────────────────────────────
+
+func (s *subscriptionModificationService) executeEndDate(
+	ctx context.Context,
+	subscriptionID string,
+	params *dto.SubModifyEndDateRequest,
+) (*dto.SubscriptionModifyResponse, error) {
+	sp := s.serviceParams
+
+	sub, lineItems, err := sp.SubRepo.GetWithLineItems(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	isNoOp, err := s.validateEndDateRequest(sub, subscriptionID, params)
+	if err != nil {
+		return nil, err
+	}
+
+	subSvc := NewSubscriptionService(sp)
+	if isNoOp {
+		subResp, getErr := subSvc.GetSubscription(ctx, subscriptionID)
+		if getErr != nil {
+			return nil, getErr
+		}
+		return &dto.SubscriptionModifyResponse{
+			Subscription:     subResp,
+			ChangedResources: dto.ChangedResources{},
+		}, nil
+	}
+
+	oldEnd := sub.EndDate.UTC()
+	newEnd := params.NewEndDate.UTC()
+	cancellationUnwind := false
+
+	var (
+		changedSubs    []dto.ChangedSubscription
+		changedLIs     []dto.ChangedLineItem
+		changedGrants  []dto.ChangedCreditGrant
+		periodEndAfter *time.Time
+	)
+
+	err = sp.DB.WithTx(ctx, func(txCtx context.Context) error {
+		changedSubs = nil
+		changedLIs = nil
+		changedGrants = nil
+		periodEndAfter = nil
+
+		// Optimistic concurrency: re-read and ensure end has not changed mid-flight.
+		fresh, freshLIs, getErr := sp.SubRepo.GetWithLineItems(txCtx, subscriptionID)
+		if getErr != nil {
+			return getErr
+		}
+		if fresh.EndDate == nil || !fresh.EndDate.UTC().Equal(oldEnd) {
+			return ierr.NewError("subscription end_date changed concurrently").
+				WithHint("Retry the end date extension").
+				WithReportableDetails(map[string]interface{}{"subscription_id": subscriptionID}).
+				Mark(ierr.ErrValidation)
+		}
+		sub = fresh
+		lineItems = freshLIs
+
+		var cancelBoundaryInTx *time.Time
+		shouldUnwind := fresh.CancelAt != nil && newEnd.After(fresh.CancelAt.UTC())
+		if shouldUnwind {
+			cancelBoundaryInTx = lo.ToPtr(fresh.CancelAt.UTC())
+			if err := s.unwindScheduledCancellationForExtend(txCtx, sub); err != nil {
+				return err
+			}
+		}
+
+		if err := recomputePeriodEndAfterExtend(sub, newEnd); err != nil {
+			return err
+		}
+		sub.EndDate = lo.ToPtr(newEnd)
+		if err := sp.SubRepo.Update(txCtx, sub); err != nil {
+			return err
+		}
+		periodEndAfter = lo.ToPtr(sub.CurrentPeriodEnd)
+
+		if err := s.extendLastPhaseMatchingEnd(txCtx, subscriptionID, oldEnd, newEnd); err != nil {
+			return err
+		}
+
+		selected := selectLineItemsToExtend(lineItems, oldEnd, cancelBoundaryInTx)
+		for _, li := range selected {
+			li.EndDate = newEnd
+			if err := sp.SubscriptionLineItemRepo.Update(txCtx, li); err != nil {
+				return err
+			}
+			start := li.StartDate
+			end := newEnd
+			changedLIs = append(changedLIs, dto.ChangedLineItem{
+				ID:           li.ID,
+				PriceID:      li.PriceID,
+				Quantity:     li.Quantity,
+				StartDate:    &start,
+				EndDate:      &end,
+				ChangeAction: dto.ChangedLineItemActionUpdated,
+			})
+		}
+
+		if err := s.extendAddonAssociationsMatchingEnd(txCtx, subscriptionID, oldEnd, newEnd, cancelBoundaryInTx); err != nil {
+			return err
+		}
+
+		grants, err := s.extendCreditGrantsMatchingEnd(txCtx, subscriptionID, oldEnd, newEnd)
+		if err != nil {
+			return err
+		}
+		changedGrants = grants
+
+		changedSubs = append(changedSubs, dto.ChangedSubscription{
+			ID:               sub.ID,
+			Action:           dto.ChangedSubscriptionActionUpdated,
+			Status:           sub.SubscriptionStatus,
+			EndDate:          lo.ToPtr(newEnd),
+			CurrentPeriodEnd: periodEndAfter,
+		})
+
+		childSubs, childLIs, childGrants, err := s.cascadeEndDateToInherited(txCtx, sub, oldEnd, newEnd, shouldUnwind, cancelBoundaryInTx)
+		if err != nil {
+			return err
+		}
+		changedSubs = append(changedSubs, childSubs...)
+		changedLIs = append(changedLIs, childLIs...)
+		changedGrants = append(changedGrants, childGrants...)
+		cancellationUnwind = shouldUnwind
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, subscriptionID)
+
+	sp.Logger.Info(ctx, "extended subscription end date",
+		"subscription_id", subscriptionID,
+		"old_end_date", oldEnd,
+		"new_end_date", newEnd,
+		"line_items_extended", len(changedLIs),
+		"credit_grants_extended", len(changedGrants),
+		"cancellation_unwound", cancellationUnwind,
+	)
+
+	subResp, err := subSvc.GetSubscription(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.SubscriptionModifyResponse{
+		Subscription: subResp,
+		ChangedResources: dto.ChangedResources{
+			Subscriptions: changedSubs,
+			LineItems:     changedLIs,
+			CreditGrants:  changedGrants,
+		},
+	}, nil
+}
+
+// ─────────────────────────────────────────────
+// Preview: end date
+// ─────────────────────────────────────────────
+
+func (s *subscriptionModificationService) previewEndDate(
+	ctx context.Context,
+	subscriptionID string,
+	params *dto.SubModifyEndDateRequest,
+) (*dto.SubscriptionModifyResponse, error) {
+	sp := s.serviceParams
+
+	sub, lineItems, err := sp.SubRepo.GetWithLineItems(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	isNoOp, err := s.validateEndDateRequest(sub, subscriptionID, params)
+	if err != nil {
+		return nil, err
+	}
+
+	subSvc := NewSubscriptionService(sp)
+	subResp, err := subSvc.GetSubscription(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if isNoOp {
+		return &dto.SubscriptionModifyResponse{
+			Subscription:     subResp,
+			ChangedResources: dto.ChangedResources{},
+		}, nil
+	}
+
+	oldEnd := sub.EndDate.UTC()
+	newEnd := params.NewEndDate.UTC()
+
+	// Project period end without mutating the loaded sub permanently for response.
+	projectedPeriodEnd := sub.CurrentPeriodEnd
+	if sub.CurrentPeriodEnd.Equal(oldEnd) {
+		next, err := types.NextBillingDate(&types.NextBillingDateParams{
+			CurrentPeriodStart:  sub.CurrentPeriodStart,
+			BillingAnchor:       sub.BillingAnchor,
+			Unit:                sub.BillingPeriodCount,
+			Period:              sub.BillingPeriod,
+			SubscriptionEndDate: &newEnd,
+			Timezone:            sub.Timezone,
+		})
+		if err != nil {
+			return nil, err
+		}
+		projectedPeriodEnd = next
+	}
+
+	changedSubs := []dto.ChangedSubscription{{
+		ID:               sub.ID,
+		Action:           dto.ChangedSubscriptionActionUpdated,
+		Status:           sub.SubscriptionStatus,
+		EndDate:          lo.ToPtr(newEnd),
+		CurrentPeriodEnd: lo.ToPtr(projectedPeriodEnd),
+	}}
+
+	changedLIs := make([]dto.ChangedLineItem, 0)
+	var cancelBoundary *time.Time
+	if sub.CancelAt != nil && newEnd.After(sub.CancelAt.UTC()) {
+		cancelBoundary = lo.ToPtr(sub.CancelAt.UTC())
+	}
+	for _, li := range selectLineItemsToExtend(lineItems, oldEnd, cancelBoundary) {
+		start := li.StartDate
+		end := newEnd
+		changedLIs = append(changedLIs, dto.ChangedLineItem{
+			ID:           li.ID,
+			PriceID:      li.PriceID,
+			Quantity:     li.Quantity,
+			StartDate:    &start,
+			EndDate:      &end,
+			ChangeAction: dto.ChangedLineItemActionUpdated,
+		})
+	}
+
+	changedGrants, err := s.previewCreditGrantsMatchingEnd(ctx, subscriptionID, oldEnd, newEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	if sub.SubscriptionType == types.SubscriptionTypeParent {
+		children, err := s.getInheritedSubscriptions(ctx, sub.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			changedSubs = append(changedSubs, dto.ChangedSubscription{
+				ID:               child.ID,
+				Action:           dto.ChangedSubscriptionActionUpdated,
+				Status:           child.SubscriptionStatus,
+				EndDate:          lo.ToPtr(newEnd),
+				CurrentPeriodEnd: lo.ToPtr(projectedPeriodEnd),
+			})
+			childLIs, err := sp.SubscriptionLineItemRepo.ListBySubscription(ctx, child)
+			if err != nil {
+				return nil, err
+			}
+			for _, li := range selectLineItemsToExtend(childLIs, oldEnd, cancelBoundary) {
+				start := li.StartDate
+				end := newEnd
+				changedLIs = append(changedLIs, dto.ChangedLineItem{
+					ID:           li.ID,
+					PriceID:      li.PriceID,
+					Quantity:     li.Quantity,
+					StartDate:    &start,
+					EndDate:      &end,
+					ChangeAction: dto.ChangedLineItemActionUpdated,
+				})
+			}
+			childGrants, err := s.previewCreditGrantsMatchingEnd(ctx, child.ID, oldEnd, newEnd)
+			if err != nil {
+				return nil, err
+			}
+			changedGrants = append(changedGrants, childGrants...)
+		}
+	}
+
+	return &dto.SubscriptionModifyResponse{
+		Subscription: subResp,
+		ChangedResources: dto.ChangedResources{
+			Subscriptions: changedSubs,
+			LineItems:     changedLIs,
+			CreditGrants:  changedGrants,
+		},
+	}, nil
+}
+
+// ─────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────
+
+func (s *subscriptionModificationService) unwindScheduledCancellationForExtend(
+	ctx context.Context,
+	sub *subscription.Subscription,
+) error {
+	sp := s.serviceParams
+
+	pending, err := sp.SubScheduleRepo.GetPendingBySubscriptionAndType(
+		ctx, sub.ID, types.SubscriptionScheduleChangeTypeCancellation,
+	)
+	if err != nil && !ierr.IsNotFound(err) {
+		return err
+	}
+	if pending != nil && pending.CanBeCancelled() {
+		now := time.Now().UTC()
+		pending.Status = types.ScheduleStatusCancelled
+		pending.CancelledAt = &now
+		pending.UpdatedAt = now
+		pending.UpdatedBy = types.GetUserID(ctx)
+		if err := sp.SubScheduleRepo.Update(ctx, pending); err != nil {
+			return err
+		}
+	}
+
+	sub.CancelAt = nil
+	sub.CancelAtPeriodEnd = false
+	sub.CancelledAt = nil
+	return nil
+}
+
+func (s *subscriptionModificationService) extendLastPhaseMatchingEnd(
+	ctx context.Context,
+	subscriptionID string,
+	oldEnd, newEnd time.Time,
+) error {
+	sp := s.serviceParams
+	if sp.SubscriptionPhaseRepo == nil {
+		return nil
+	}
+
+	filter := types.NewNoLimitSubscriptionPhaseFilter()
+	filter.SubscriptionIDs = []string{subscriptionID}
+	phases, err := sp.SubscriptionPhaseRepo.List(ctx, filter)
+	if err != nil {
+		return err
+	}
+	if len(phases) == 0 {
+		return nil
+	}
+
+	var last *subscription.SubscriptionPhase
+	for _, phase := range phases {
+		if phase.EndDate != nil && phase.EndDate.UTC().Equal(oldEnd) {
+			if last == nil || phase.StartDate.After(last.StartDate) {
+				last = phase
+			}
+		}
+	}
+	if last == nil {
+		return nil
+	}
+	last.EndDate = lo.ToPtr(newEnd)
+	return sp.SubscriptionPhaseRepo.Update(ctx, last)
+}
+
+func (s *subscriptionModificationService) extendAddonAssociationsMatchingEnd(
+	ctx context.Context,
+	subscriptionID string,
+	oldEnd, newEnd time.Time,
+	cancelBoundary *time.Time,
+) error {
+	sp := s.serviceParams
+	if sp.AddonAssociationRepo == nil {
+		return nil
+	}
+
+	filter := types.NewNoLimitAddonAssociationFilter()
+	entityType := types.AddonAssociationEntityTypeSubscription
+	filter.EntityType = &entityType
+	filter.EntityIDs = []string{subscriptionID}
+	assocs, err := sp.AddonAssociationRepo.List(ctx, filter)
+	if err != nil {
+		return err
+	}
+	for _, assoc := range assocs {
+		if assoc == nil || assoc.EndDate == nil {
+			continue
+		}
+		end := assoc.EndDate.UTC()
+		match := end.Equal(oldEnd) || (cancelBoundary != nil && end.Equal(*cancelBoundary))
+		if !match {
+			continue
+		}
+		assoc.EndDate = lo.ToPtr(newEnd)
+		if err := sp.AddonAssociationRepo.Update(ctx, assoc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *subscriptionModificationService) extendCreditGrantsMatchingEnd(
+	ctx context.Context,
+	subscriptionID string,
+	oldEnd, newEnd time.Time,
+) ([]dto.ChangedCreditGrant, error) {
+	sp := s.serviceParams
+	if sp.CreditGrantRepo == nil {
+		return nil, nil
+	}
+
+	filter := types.NewNoLimitCreditGrantFilter().WithSubscriptionIDs([]string{subscriptionID})
+	scope := types.CreditGrantScopeSubscription
+	filter.Scope = &scope
+	grants, err := sp.CreditGrantRepo.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	changed := make([]dto.ChangedCreditGrant, 0)
+	for _, grant := range grants {
+		if grant == nil || grant.EndDate == nil {
+			continue
+		}
+		if !grant.EndDate.UTC().Equal(oldEnd) {
+			continue
+		}
+		grant.EndDate = lo.ToPtr(newEnd)
+		updated, err := sp.CreditGrantRepo.Update(ctx, grant)
+		if err != nil {
+			return nil, err
+		}
+		changed = append(changed, dto.ChangedCreditGrant{
+			ID:          updated.ID,
+			Action:      dto.ChangedCreditGrantActionUpdated,
+			EndDate:     lo.ToPtr(newEnd),
+			CreditGrant: dto.FromCreditGrant(updated),
+		})
+	}
+	return changed, nil
+}
+
+func (s *subscriptionModificationService) previewCreditGrantsMatchingEnd(
+	ctx context.Context,
+	subscriptionID string,
+	oldEnd, newEnd time.Time,
+) ([]dto.ChangedCreditGrant, error) {
+	sp := s.serviceParams
+	if sp.CreditGrantRepo == nil {
+		return nil, nil
+	}
+
+	filter := types.NewNoLimitCreditGrantFilter().WithSubscriptionIDs([]string{subscriptionID})
+	scope := types.CreditGrantScopeSubscription
+	filter.Scope = &scope
+	grants, err := sp.CreditGrantRepo.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	changed := make([]dto.ChangedCreditGrant, 0)
+	for _, grant := range grants {
+		if grant == nil || grant.EndDate == nil {
+			continue
+		}
+		if !grant.EndDate.UTC().Equal(oldEnd) {
+			continue
+		}
+		preview := *grant
+		preview.EndDate = lo.ToPtr(newEnd)
+		changed = append(changed, dto.ChangedCreditGrant{
+			ID:          grant.ID,
+			Action:      dto.ChangedCreditGrantActionUpdated,
+			EndDate:     lo.ToPtr(newEnd),
+			CreditGrant: dto.FromCreditGrant(&preview),
+		})
+	}
+	return changed, nil
+}
+
+func (s *subscriptionModificationService) cascadeEndDateToInherited(
+	ctx context.Context,
+	parent *subscription.Subscription,
+	oldEnd, newEnd time.Time,
+	unwindCancel bool,
+	cancelBoundary *time.Time,
+) ([]dto.ChangedSubscription, []dto.ChangedLineItem, []dto.ChangedCreditGrant, error) {
+	if parent.SubscriptionType != types.SubscriptionTypeParent {
+		return nil, nil, nil, nil
+	}
+
+	sp := s.serviceParams
+	children, err := s.getInheritedSubscriptions(ctx, parent.ID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	changedSubs := make([]dto.ChangedSubscription, 0, len(children))
+	changedLIs := make([]dto.ChangedLineItem, 0)
+	changedGrants := make([]dto.ChangedCreditGrant, 0)
+
+	for _, child := range children {
+		if unwindCancel {
+			if err := s.unwindScheduledCancellationForExtend(ctx, child); err != nil {
+				return nil, nil, nil, err
+			}
+		}
+
+		if err := recomputePeriodEndAfterExtend(child, newEnd); err != nil {
+			return nil, nil, nil, err
+		}
+		child.EndDate = lo.ToPtr(newEnd)
+		if err := sp.SubRepo.Update(ctx, child); err != nil {
+			return nil, nil, nil, err
+		}
+
+		changedSubs = append(changedSubs, dto.ChangedSubscription{
+			ID:               child.ID,
+			Action:           dto.ChangedSubscriptionActionUpdated,
+			Status:           child.SubscriptionStatus,
+			EndDate:          lo.ToPtr(newEnd),
+			CurrentPeriodEnd: lo.ToPtr(child.CurrentPeriodEnd),
+		})
+
+		childLIs, err := sp.SubscriptionLineItemRepo.ListBySubscription(ctx, child)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		for _, li := range selectLineItemsToExtend(childLIs, oldEnd, cancelBoundary) {
+			li.EndDate = newEnd
+			if err := sp.SubscriptionLineItemRepo.Update(ctx, li); err != nil {
+				return nil, nil, nil, err
+			}
+			start := li.StartDate
+			end := newEnd
+			changedLIs = append(changedLIs, dto.ChangedLineItem{
+				ID:           li.ID,
+				PriceID:      li.PriceID,
+				Quantity:     li.Quantity,
+				StartDate:    &start,
+				EndDate:      &end,
+				ChangeAction: dto.ChangedLineItemActionUpdated,
+			})
+		}
+
+		if err := s.extendAddonAssociationsMatchingEnd(ctx, child.ID, oldEnd, newEnd, cancelBoundary); err != nil {
+			return nil, nil, nil, err
+		}
+		if err := s.extendLastPhaseMatchingEnd(ctx, child.ID, oldEnd, newEnd); err != nil {
+			return nil, nil, nil, err
+		}
+
+		grants, err := s.extendCreditGrantsMatchingEnd(ctx, child.ID, oldEnd, newEnd)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		changedGrants = append(changedGrants, grants...)
+	}
+
+	return changedSubs, changedLIs, changedGrants, nil
+}

--- a/internal/ee/service/subscription_modification_end_date_test.go
+++ b/internal/ee/service/subscription_modification_end_date_test.go
@@ -1,0 +1,490 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto" // pragma: allowlist secret
+	"github.com/flexprice/flexprice/internal/domain/creditgrant" // pragma: allowlist secret
+	"github.com/flexprice/flexprice/internal/domain/subscription" // pragma: allowlist secret
+	ierr "github.com/flexprice/flexprice/internal/errors" // pragma: allowlist secret
+	"github.com/flexprice/flexprice/internal/types" // pragma: allowlist secret
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *SubscriptionModificationServiceSuite) createFixedTermSub(customerID string, endDate time.Time) *subscription.Subscription {
+	ctx := s.GetContext()
+	now := s.GetNow()
+	p := s.createPlan()
+	sub := &subscription.Subscription{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		CustomerID:         customerID,
+		PlanID:             p.ID,
+		Currency:           "USD",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		BillingAnchor:      now,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		SubscriptionType:   types.SubscriptionTypeStandalone,
+		CurrentPeriodStart: now,
+		CurrentPeriodEnd:   now.AddDate(0, 1, 0),
+		StartDate:          now,
+		EndDate:            lo.ToPtr(endDate),
+	}
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Create(ctx, sub))
+	return sub
+}
+
+func (s *SubscriptionModificationServiceSuite) createLineItemWithEnd(
+	subID, customerID string,
+	endDate time.Time,
+	billingPeriod types.BillingPeriod,
+) *subscription.SubscriptionLineItem {
+	ctx := s.GetContext()
+	now := s.GetNow()
+	li := &subscription.SubscriptionLineItem{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+		SubscriptionID: subID,
+		CustomerID:     customerID,
+		PriceID:        types.GenerateUUID(),
+		PriceType:      types.PRICE_TYPE_FIXED,
+		Quantity:       decimal.NewFromInt(1),
+		Currency:       "USD",
+		BillingPeriod:  billingPeriod,
+		InvoiceCadence: types.InvoiceCadenceArrear,
+		StartDate:      now,
+		EndDate:        endDate,
+		EntityType:     types.SubscriptionLineItemEntityTypePlan,
+	}
+	s.Require().NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+	return li
+}
+
+func (s *SubscriptionModificationServiceSuite) createSubscriptionCreditGrant(subID string, endDate *time.Time) *creditgrant.CreditGrant {
+	ctx := s.GetContext()
+	now := s.GetNow()
+	grant := &creditgrant.CreditGrant{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT),
+		Name:           "test-grant",
+		Scope:          types.CreditGrantScopeSubscription,
+		SubscriptionID: lo.ToPtr(subID),
+		Credits:        decimal.NewFromInt(100),
+		Cadence:        types.CreditGrantCadenceOneTime,
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		StartDate:      lo.ToPtr(now),
+		EndDate:        endDate,
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	created, err := s.GetStores().CreditGrantRepo.Create(ctx, grant)
+	s.Require().NoError(err)
+	return created
+}
+
+func endDateModifyReq(newEnd time.Time) dto.ExecuteSubscriptionModifyRequest {
+	return dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeEndDate,
+		EndDateParams: &dto.SubModifyEndDateRequest{
+			NewEndDate: newEnd,
+		},
+	}
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_HappyPathExtendsSubAndMatchingLineItems() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-happy")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	newEnd := oldEnd.AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+
+	matching := s.createLineItemWithEnd(sub.ID, cust.ID, oldEnd, types.BILLING_PERIOD_MONTHLY)
+	override := s.createLineItemWithEnd(sub.ID, cust.ID, oldEnd.AddDate(0, -2, 0), types.BILLING_PERIOD_MONTHLY)
+	openEnded := s.createLineItemWithEnd(sub.ID, cust.ID, time.Time{}, types.BILLING_PERIOD_MONTHLY)
+	oneTime := s.createLineItemWithEnd(sub.ID, cust.ID, oldEnd.AddDate(0, -3, 0), types.BILLING_PERIOD_ONETIME)
+
+	resp, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Subscription)
+	s.Require().NotNil(resp.Subscription.EndDate)
+	s.Equal(newEnd, resp.Subscription.EndDate.UTC())
+
+	s.Require().Len(resp.ChangedResources.Subscriptions, 1)
+	s.Equal(sub.ID, resp.ChangedResources.Subscriptions[0].ID)
+	s.Equal(dto.ChangedSubscriptionActionUpdated, resp.ChangedResources.Subscriptions[0].Action)
+	s.Require().NotNil(resp.ChangedResources.Subscriptions[0].EndDate)
+	s.Equal(newEnd, resp.ChangedResources.Subscriptions[0].EndDate.UTC())
+
+	changedIDs := map[string]bool{}
+	for _, li := range resp.ChangedResources.LineItems {
+		changedIDs[li.ID] = true
+		s.Equal(dto.ChangedLineItemActionUpdated, li.ChangeAction)
+		s.Require().NotNil(li.EndDate)
+		s.Equal(newEnd, li.EndDate.UTC())
+	}
+	s.True(changedIDs[matching.ID])
+	s.True(changedIDs[openEnded.ID])
+	s.False(changedIDs[override.ID])
+	s.False(changedIDs[oneTime.ID])
+
+	storedMatching, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, matching.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, storedMatching.EndDate.UTC())
+
+	storedOverride, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, override.ID)
+	s.Require().NoError(err)
+	s.Equal(oldEnd.AddDate(0, -2, 0).UTC(), storedOverride.EndDate.UTC())
+
+	storedOpen, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, openEnded.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, storedOpen.EndDate.UTC())
+
+	storedOneTime, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, oneTime.ID)
+	s.Require().NoError(err)
+	s.Equal(oldEnd.AddDate(0, -3, 0).UTC(), storedOneTime.EndDate.UTC())
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_PreviewDoesNotPersist() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-preview")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	newEnd := oldEnd.AddDate(0, 3, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	li := s.createLineItemWithEnd(sub.ID, cust.ID, oldEnd, types.BILLING_PERIOD_MONTHLY)
+
+	resp, err := s.service.Preview(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.ChangedResources.Subscriptions, 1)
+	s.Require().Len(resp.ChangedResources.LineItems, 1)
+
+	storedSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(storedSub.EndDate)
+	s.Equal(oldEnd, storedSub.EndDate.UTC())
+
+	storedLI, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, li.ID)
+	s.Require().NoError(err)
+	s.Equal(oldEnd, storedLI.EndDate.UTC())
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_NilEndRejects() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-nil")
+	sub := s.createActiveSub(cust.ID) // no EndDate
+	newEnd := s.GetNow().AddDate(1, 0, 0).UTC()
+
+	_, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_ShortenRejects() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-shorten")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+
+	_, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(oldEnd.AddDate(0, -1, 0)))
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_EqualIsNoOp() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-noop")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	li := s.createLineItemWithEnd(sub.ID, cust.ID, oldEnd, types.BILLING_PERIOD_MONTHLY)
+
+	resp, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(oldEnd))
+	s.Require().NoError(err)
+	s.Empty(resp.ChangedResources.Subscriptions)
+	s.Empty(resp.ChangedResources.LineItems)
+
+	storedLI, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, li.ID)
+	s.Require().NoError(err)
+	s.Equal(oldEnd, storedLI.EndDate.UTC())
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_CancelledRejects() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-cancelled")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	sub.SubscriptionStatus = types.SubscriptionStatusCancelled
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	_, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(oldEnd.AddDate(0, 3, 0)))
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_InheritedRejects() {
+	ctx := s.GetContext()
+	_, _, _, inherited := s.createParentSubWithChild("end-date-parent", "end-date-child")
+	inherited.EndDate = lo.ToPtr(s.GetNow().AddDate(0, 6, 0).UTC())
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, inherited))
+
+	_, err := s.service.Execute(ctx, inherited.ID, endDateModifyReq(s.GetNow().AddDate(1, 0, 0).UTC()))
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_TrialingBeforeTrialEndRejects() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-trial")
+	now := s.GetNow()
+	oldEnd := now.AddDate(0, 6, 0).UTC()
+	trialEnd := now.AddDate(0, 2, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	sub.SubscriptionStatus = types.SubscriptionStatusTrialing
+	sub.TrialStart = lo.ToPtr(now)
+	sub.TrialEnd = lo.ToPtr(trialEnd)
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	// new end after old end but before trial end — impossible if trialEnd < oldEnd;
+	// set trial end after old end first to exercise the rule.
+	sub.TrialEnd = lo.ToPtr(oldEnd.AddDate(0, 3, 0).UTC())
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	_, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(oldEnd.AddDate(0, 1, 0).UTC()))
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_ClippedPeriodEndRecomputed() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-period")
+	now := s.GetNow().UTC()
+	// Term cliffs mid-cycle: natural next period would be now+1mo, but EndDate clips to +15d.
+	oldEnd := now.AddDate(0, 0, 15).UTC()
+	newEnd := now.AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	sub.CurrentPeriodStart = now
+	sub.CurrentPeriodEnd = oldEnd
+	sub.BillingAnchor = now
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	resp, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+
+	stored, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, stored.EndDate.UTC())
+	s.True(stored.CurrentPeriodEnd.After(oldEnd),
+		"period end should be recomputed past the old cliff, got %v", stored.CurrentPeriodEnd)
+	s.True(!stored.CurrentPeriodEnd.After(newEnd))
+	s.Require().NotNil(resp.ChangedResources.Subscriptions[0].CurrentPeriodEnd)
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_CreditGrantsExtendedAndReturned() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-grants")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	newEnd := oldEnd.AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+
+	matchingGrant := s.createSubscriptionCreditGrant(sub.ID, lo.ToPtr(oldEnd))
+	earlierGrant := s.createSubscriptionCreditGrant(sub.ID, lo.ToPtr(oldEnd.AddDate(0, -1, 0)))
+	openGrant := s.createSubscriptionCreditGrant(sub.ID, nil)
+
+	resp, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+	s.Require().Len(resp.ChangedResources.CreditGrants, 1)
+	s.Equal(matchingGrant.ID, resp.ChangedResources.CreditGrants[0].ID)
+	s.Equal(dto.ChangedCreditGrantActionUpdated, resp.ChangedResources.CreditGrants[0].Action)
+	s.Require().NotNil(resp.ChangedResources.CreditGrants[0].EndDate)
+	s.Equal(newEnd, resp.ChangedResources.CreditGrants[0].EndDate.UTC())
+	s.Require().NotNil(resp.ChangedResources.CreditGrants[0].CreditGrant)
+
+	storedMatching, err := s.GetStores().CreditGrantRepo.Get(ctx, matchingGrant.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(storedMatching.EndDate)
+	s.Equal(newEnd, storedMatching.EndDate.UTC())
+
+	storedEarlier, err := s.GetStores().CreditGrantRepo.Get(ctx, earlierGrant.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(storedEarlier.EndDate)
+	s.Equal(oldEnd.AddDate(0, -1, 0).UTC(), storedEarlier.EndDate.UTC())
+
+	storedOpen, err := s.GetStores().CreditGrantRepo.Get(ctx, openGrant.ID)
+	s.Require().NoError(err)
+	s.Nil(storedOpen.EndDate)
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_PreviewReturnsCreditGrants() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-grants-preview")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	newEnd := oldEnd.AddDate(0, 6, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	grant := s.createSubscriptionCreditGrant(sub.ID, lo.ToPtr(oldEnd))
+
+	resp, err := s.service.Preview(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+	s.Require().Len(resp.ChangedResources.CreditGrants, 1)
+	s.Equal(grant.ID, resp.ChangedResources.CreditGrants[0].ID)
+
+	stored, err := s.GetStores().CreditGrantRepo.Get(ctx, grant.ID)
+	s.Require().NoError(err)
+	s.Equal(oldEnd, stored.EndDate.UTC(), "preview must not persist grant end")
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_UnwindScheduledCancellation() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-cancel")
+	now := s.GetNow().UTC()
+	oldEnd := now.AddDate(0, 6, 0).UTC()
+	cancelAt := now.AddDate(0, 2, 0).UTC()
+	newEnd := now.AddDate(0, 8, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	sub.CancelAt = lo.ToPtr(cancelAt)
+	sub.CancelAtPeriodEnd = true
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	// Line item bulk-terminated at cancel boundary.
+	li := s.createLineItemWithEnd(sub.ID, cust.ID, cancelAt, types.BILLING_PERIOD_MONTHLY)
+
+	resp, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	stored, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.Require().NoError(err)
+	s.Nil(stored.CancelAt)
+	s.False(stored.CancelAtPeriodEnd)
+	s.Equal(newEnd, stored.EndDate.UTC())
+
+	storedLI, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, li.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, storedLI.EndDate.UTC())
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_CancelAtNotPastRejects() {
+	ctx := s.GetContext()
+	cust := s.createCustomer("end-date-cancel-reject")
+	now := s.GetNow().UTC()
+	oldEnd := now.AddDate(0, 6, 0).UTC()
+	// Scheduled cancel after current end: extending past old end but not past cancel_at must reject.
+	cancelAt := now.AddDate(0, 8, 0).UTC()
+	sub := s.createFixedTermSub(cust.ID, oldEnd)
+	sub.CancelAt = lo.ToPtr(cancelAt)
+	sub.CancelAtPeriodEnd = true
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	_, err := s.service.Execute(ctx, sub.ID, endDateModifyReq(oldEnd.AddDate(0, 1, 0).UTC()))
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+}
+
+func (s *SubscriptionModificationServiceSuite) TestEndDate_CascadesToInheritedChildren() {
+	ctx := s.GetContext()
+	parentCust := s.createCustomer("end-date-cascade-parent")
+	childCust := s.createCustomer("end-date-cascade-child")
+	oldEnd := s.GetNow().AddDate(0, 6, 0).UTC()
+	newEnd := oldEnd.AddDate(0, 6, 0).UTC()
+
+	parentSub := s.createFixedTermSub(parentCust.ID, oldEnd)
+	parentLI := s.createLineItemWithEnd(parentSub.ID, parentCust.ID, oldEnd, types.BILLING_PERIOD_MONTHLY)
+
+	_, err := s.service.Execute(ctx, parentSub.ID, dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeInheritance,
+		InheritanceParams: &dto.SubModifyInheritanceRequest{
+			ExternalCustomerIDsToInheritSubscription: []string{childCust.ExternalID},
+		},
+	})
+	s.Require().NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.CustomerID = childCust.ID
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.Require().NoError(err)
+	s.Require().Len(children, 1)
+	childSub := children[0]
+	childSub.EndDate = lo.ToPtr(oldEnd)
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, childSub))
+	childLI := s.createLineItemWithEnd(childSub.ID, childCust.ID, oldEnd, types.BILLING_PERIOD_MONTHLY)
+
+	resp, err := s.service.Execute(ctx, parentSub.ID, endDateModifyReq(newEnd))
+	s.Require().NoError(err)
+
+	subIDs := map[string]bool{}
+	for _, cs := range resp.ChangedResources.Subscriptions {
+		subIDs[cs.ID] = true
+	}
+	s.True(subIDs[parentSub.ID])
+	s.True(subIDs[childSub.ID])
+
+	storedChild, err := s.GetStores().SubscriptionRepo.Get(ctx, childSub.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, storedChild.EndDate.UTC())
+
+	storedParentLI, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, parentLI.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, storedParentLI.EndDate.UTC())
+
+	storedChildLI, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, childLI.ID)
+	s.Require().NoError(err)
+	s.Equal(newEnd, storedChildLI.EndDate.UTC())
+}
+
+func TestSelectLineItemsToExtend(t *testing.T) {
+	oldEnd := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+	cancelAt := time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)
+
+	matching := &subscription.SubscriptionLineItem{
+		ID: "match", EndDate: oldEnd, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		BaseModel: types.BaseModel{Status: types.StatusPublished},
+	}
+	open := &subscription.SubscriptionLineItem{
+		ID: "open", EndDate: time.Time{}, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		BaseModel: types.BaseModel{Status: types.StatusPublished},
+	}
+	override := &subscription.SubscriptionLineItem{
+		ID: "override", EndDate: oldEnd.AddDate(0, -1, 0), BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		BaseModel: types.BaseModel{Status: types.StatusPublished},
+	}
+	oneTime := &subscription.SubscriptionLineItem{
+		ID: "onetime", EndDate: oldEnd, BillingPeriod: types.BILLING_PERIOD_ONETIME,
+		BaseModel: types.BaseModel{Status: types.StatusPublished},
+	}
+	deleted := &subscription.SubscriptionLineItem{
+		ID: "deleted", EndDate: oldEnd, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		BaseModel: types.BaseModel{Status: types.StatusDeleted},
+	}
+	cancelTerminated := &subscription.SubscriptionLineItem{
+		ID: "cancel", EndDate: cancelAt, BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+		BaseModel: types.BaseModel{Status: types.StatusPublished},
+	}
+
+	selected := selectLineItemsToExtend([]*subscription.SubscriptionLineItem{
+		matching, open, override, oneTime, deleted, cancelTerminated,
+	}, oldEnd, nil)
+	ids := map[string]bool{}
+	for _, li := range selected {
+		ids[li.ID] = true
+	}
+	require.True(t, ids["match"])
+	require.True(t, ids["open"])
+	require.False(t, ids["override"])
+	require.False(t, ids["onetime"])
+	require.False(t, ids["deleted"])
+	require.False(t, ids["cancel"])
+
+	selectedWithCancel := selectLineItemsToExtend([]*subscription.SubscriptionLineItem{
+		matching, override, cancelTerminated,
+	}, oldEnd, &cancelAt)
+	ids2 := map[string]bool{}
+	for _, li := range selectedWithCancel {
+		ids2[li.ID] = true
+	}
+	require.True(t, ids2["match"])
+	require.True(t, ids2["cancel"])
+	require.False(t, ids2["override"])
+}

--- a/internal/testutil/inmemory_subscription_schedule_store.go
+++ b/internal/testutil/inmemory_subscription_schedule_store.go
@@ -117,7 +117,7 @@ func (s *InMemorySubscriptionScheduleStore) GetPendingBySubscriptionAndType(ctx 
 	defer s.mu.RUnlock()
 	schedules, exists := s.schedulesBySubscription[subscriptionID]
 	if !exists {
-		return nil, ierr.NewError("subscription schedule not found").Mark(ierr.ErrNotFound)
+		return nil, nil // No pending schedule found is not an error (matches Ent repo)
 	}
 
 	for _, schedule := range schedules {
@@ -127,7 +127,7 @@ func (s *InMemorySubscriptionScheduleStore) GetPendingBySubscriptionAndType(ctx 
 		}
 	}
 
-	return nil, ierr.NewError("subscription schedule not found").Mark(ierr.ErrNotFound)
+	return nil, nil // No pending schedule found is not an error (matches Ent repo)
 }
 
 // List retrieves schedules with filters


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Implements **extend subscription `end_date`** via the existing subscription modifications APIs (`POST /v1/subscriptions/:id/modify/{preview,execute}`).

Also lands the design doc from the prior design PR and addresses the review note on credit grants.

## Why
Operators need a controlled way to push a fixed-term subscription (and matching line items) further into the future without cancel/recreate.

## How
- New modify type `end_date` with `end_date_params.new_end_date` (extend-only)
- Line-item selection: extend when end equals old sub end, or open-ended under a fixed term; skip earlier overrides, one-time items, soft-deleted
- Implicit credit-grant extension when grant `EndDate == old_end`, returned in `changed_resources.credit_grants` (preview + execute) per PR review feedback
- Unwind scheduled cancellation when `new_end > CancelAt`; re-extend LIs terminated at cancel boundary
- Recompute `CurrentPeriodEnd` when it was clipped to the old end
- Cascade to inherited children
- Docs: `docs/prds/extend_subscription_end_date.md`, flow note in `docs/FLOWS/subscription-lifecycle.md`

## Testing
- `go test ./internal/ee/service/ -run 'TestSubscriptionModificationServiceSuite/TestEndDate_|TestSelectLineItemsToExtend'` — pass
- Covers happy path, preview no-persist, overrides/onetime/open-ended, nil end, shorten reject, no-op equal, cancelled/inherited reject, trial bound, period recompute, credit grants in response, cancel unwind, inheritance cascade

## Follow-ups
- `make swagger` / SDK regen for public OpenAPI enum
- Optional e2e probe case

## Related
- Design PR: https://github.com/flexprice/flexprice/pull/2209
- Precedent: `subscription_modification_trial_end.go`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FLE-974](https://linear.app/flexprice/issue/FLE-974/extend-subscription-end-date)

<div><a href="https://cursor.com/agents/bc-547e0950-a3d1-4bbc-9f1f-9cb658677aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-547e0950-a3d1-4bbc-9f1f-9cb658677aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

