### PR TITLE
feat(wallet): add support for bonus credit grant backed by slab config

### DIFF
--- a/docs/design/2026-07-09-FLE-904-bonus-credit-topup.md
+++ b/docs/design/2026-07-09-FLE-904-bonus-credit-topup.md
@@ -1,0 +1,197 @@
+# Bonus Credit Top-Up — PERD (Post-implementation ERD)
+
+- **Author:** Tsage
+- **Date:** 2026-07-09
+- **Linear:** [FLE-904 — Add support for separate free credit top-up transactions](https://linear.app/flexprice/issue/FLE-904/add-support-for-separate-free-credit-top-up-transactions)
+- **Original ERD:** `ERDs/bonus_credits.md` (design doc, not checked into this repo)
+- **Status:** Implemented, tests passing, pending production migration run
+
+## Summary
+
+Adds a separate, independently-tracked bonus credit transaction that gets created automatically
+when a large **purchased** wallet top-up completes — e.g. buy 5,000 credits, get 750 bonus
+credits. The bonus is its own `wallet_transaction` row (`transaction_reason =
+PURCHASED_CREDIT_BONUS`), linked to the purchase via a new `parent_transaction_id` column. It
+shares the purchase's fate atomically: credited the moment the purchase completes (same request
+for direct/auto-complete top-ups, invoice-paid time for pending invoiced top-ups), never before.
+
+Two additions:
+- `bonus_credits_to_add` on the top-up request — explicit override, must be omitted or `> 0`.
+- A tenant × environment setting, `bonus_credits_topup_config`, holding slabs that map "credits
+  purchased" → "bonus credits granted", used only when the caller doesn't pass an explicit
+  override.
+
+---
+
+## 1. Original ERD (as designed)
+
+The full original design is preserved at `ERDs/bonus_credits.md`. Key points, for reference:
+
+- **Schema:** one new nullable, immutable column `parent_transaction_id` on `wallet_transaction`,
+  plus a composite index `(tenant_id, environment_id, parent_transaction_id, transaction_status)`.
+- **New enum value:** `TransactionReasonPurchasedCreditBonus = "PURCHASED_CREDIT_BONUS"`.
+- **New setting key:** `bonus_credits_topup_config`, tenant × environment scoped, default
+  `{enabled: false, slabs: []}`.
+- **New types:** `BonusCreditsTopupConfig`, `BonusCreditsSlab`, `BonusValueType`, `BonusValue`.
+- **New operator value:** `GREATER_THAN_EQUAL FilterOperatorType = "gte"`, added to the existing
+  `types.FilterOperatorType` enum and reused as `BonusCreditsSlab.Operator`'s type.
+- **Resolution flow:** in `TopUpWallet`, after `req.Validate()`, if `req.BonusCreditsToAdd` is nil
+  and the reason is a purchased-credit reason, resolve it from the tenant's slab config
+  (`findBonusSlab` + `resolveBonusValue`), mutating `req.BonusCreditsToAdd` in place.
+- **Creation:** the bonus tx is created in the **same DB transaction** as the purchase tx —
+  `completed` immediately if the purchase completes immediately (direct, or invoiced
+  auto-complete), `pending` otherwise.
+- **Completion:** for the pending-invoice case, `completePurchasedCreditTransaction`'s **existing**
+  `s.DB.WithTx` block (no new helper) looks up the pending bonus child via the new
+  `GetPendingTransactionByParent` repo method and completes it in the same transaction.
+- **Idempotency:** inherited for free from `completePurchasedCreditTransaction`'s existing
+  pending-check — a retry against an already-`completed` tx is a no-op.
+
+---
+
+## 2. Deviations from the original ERD
+
+All of these were discussed and explicitly approved during implementation — none are silent.
+
+| # | ERD said | Implementation does | Why |
+|---|---|---|---|
+| 1 | `BonusCreditsSlab.Operator` validated via `validate:"required,oneof=gte"` struct tag | Explicit `if slab.Operator != GREATER_THAN_EQUAL { ... }` check inside `BonusCreditsTopupConfig.Validate()` | This codebase's convention for enum validation is an explicit check with `ierr.NewError`, not go-playground `oneof` tags — no other enum in the codebase uses `oneof` this way (`TransactionReason.Validate()`, `WalletTxReferenceType.Validate()`, etc. are all explicit) |
+| 2 | `BonusValue.Type` validated via `oneof=flat percentage` | Explicit `if slab.Bonus.Type != BonusValueTypeFlat && slab.Bonus.Type != BonusValueTypePercentage { ... }` check, same location | Same reason as #1 |
+| 3 | `bonus_credits_to_add: 0` is a valid, deliberate "opt-out" override (§5.1, §8.3 "explicit zero (opt-out)") | `0` (and negative) is a **validation error**; the field must be omitted entirely, or a positive value | Product decision: there is no real caller for "explicitly opt out of a slab bonus for one purchase" — if no bonus is wanted, don't pass the field at all. Simpler contract, one less state to reason about |
+| 4 | `findBonusSlab` pseudocode has a `switch s.Operator { case GREATER_THAN_EQUAL: ... }` | Plain `if credits.GreaterThanOrEqual(slabs[i].Threshold)`, no switch | The operator is guaranteed to be `gte` by `BonusCreditsTopupConfig.Validate()` before any slab ever reaches this function — the switch was dead branching over an already-validated invariant |
+| 5 | Function named `resolveBonusValue` | Named `resolveBonusCredits` | Cosmetic naming only, no behavior change |
+| 6 | §5.2 completion pseudocode re-reads the wallet via a fresh `GetWalletByID` call for the bonus's before/after balance | Reuses the `finalBalance`/`newCreditBalance` local variables already computed for the purchase completion, two lines above, in the same DB transaction | Same value (nothing else can write in between, same tx), saves a redundant DB round-trip |
+| 7 | §5.1's "create the bonus tx directly as completed, in the same DB transaction as the purchase tx" for the direct-purchase branch | Bonus creation lives as a small, nil-gated block **inside `processWalletOperation`'s existing `s.DB.WithTx` closure** (guarded by a new optional `WalletOperation.BonusCreditAmount` field), not a separate duplicated function | First attempt duplicated ~150 lines of lock/create/balance/webhook/alert logic into a standalone method to avoid touching the shared `processWalletOperation`. That was overcomplicated and inconsistent with the ERD's own stated philosophy ("a few lines added inside the existing transaction block, no new helper") — which is exactly how the completion side (§5.2) already works. Reverted to the minimal in-place approach; `BonusCreditAmount` stays `nil` (no-op) for every caller except `TopUpWallet`'s credit path |
+
+---
+
+## 3. Bugs found and fixed during implementation
+
+These were not deviations from the ERD — they were mistakes introduced while implementing it,
+caught either by careful re-review against the ERD or by live end-to-end testing against a
+running server.
+
+1. **Missing `Comment(...)` on the `parent_transaction_id` ent schema field.** The ERD specifies
+   a doc comment on the column; it was dropped in an early pass and silently missing until a
+   full re-audit against the ERD caught it. Restored, `make generate-ent` re-run.
+
+2. **Bonus tx stuck at `pending` forever for invoiced auto-complete purchases.** In
+   `handlePurchasedCreditInvoicedTransaction`, the bonus transaction was created with
+   `TxStatus: types.TransactionStatusPending`, then the code mutated
+   `bonusTx.TxStatus = types.TransactionStatusCompleted` **after** `CreateTransaction` had already
+   persisted it — without ever calling `UpdateTransaction`. Against real Postgres this would leave
+   the bonus row permanently `pending` while the wallet balance already reflected its credit. It
+   passed the in-memory test suite because the test store keeps the same pointer on `Create`, so
+   the later in-process mutation leaked into the "stored" copy and masked the bug. Fixed by
+   setting `TxStatus: txStatus` (the same status the purchase tx got) directly in the struct
+   literal at creation time.
+
+3. **Missing hint on the slab sort-order validation error.** The "slabs must be sorted descending
+   by threshold" error was the only one of the four validation branches in
+   `BonusCreditsTopupConfig.Validate()` without a `.WithHint(...)`. The API's error middleware
+   (`getDisplayMessage` in `internal/rest/middleware/errhandler.go`) only surfaces a hint if one is
+   attached — otherwise it falls back to a generic "An unexpected error occurred", hiding the real
+   cause from the API caller. Fixed by adding the hint.
+
+4. **`bonus_credits_topup_config` was unreachable via the settings API entirely.** `GetSettingByKey`
+   and `UpdateSettingByKey` in `internal/ee/service/settings.go` — the functions actually called by
+   `GET`/`PUT /v1/settings/:key` — each have their own `switch key` dispatcher, separate from
+   `types.ValidateSettingValue`'s switch (which *was* updated). The new key was missing from both,
+   so every attempt to read or write the setting via the API failed with `"Unknown setting key:
+   bonus_credits_topup_config"`, regardless of restart or payload correctness. Fixed by adding the
+   missing case to both switches, and added `TestBonusCreditsTopupConfig_APIDispatch` (verified by
+   temporarily reverting the fix and confirming the test fails) to close the gap.
+
+5. **Bonus transaction's currency `Amount` field was never set on the direct-purchase path.**
+   Found via live testing against a running server: the bonus row showed `"amount":
+   0.000000000` next to a correct `"credit_amount": 50.000000000`. The bonus-creation block added
+   inside `processWalletOperation` set `CreditAmount` but never `Amount`. Fixed by computing it the
+   same way `validateWalletOperation` computes the purchase tx's own `Amount` —
+   `s.GetCurrencyAmountFromCredits(*req.BonusCreditAmount, w.TopupConversionRate)` — and added an
+   assertion to `TestBonusCreditsCreationAtomicity_Direct` to catch a regression.
+
+---
+
+## 4. Files touched
+
+- `ent/schema/wallettransaction.go` — `parent_transaction_id` field + composite index
+- `internal/types/wallet.go` — `TransactionReasonPurchasedCreditBonus`
+- `internal/types/search_filter.go` — `GREATER_THAN_EQUAL` operator
+- `internal/types/settings.go` — `BonusCreditsTopupConfig`, `BonusCreditsSlab`, `BonusValueType`,
+  `BonusValue`, default value, `SettingKey` allow-list, `ValidateSettingValue` case
+- `internal/api/dto/wallet.go` — `BonusCreditsToAdd` field + validation
+- `internal/domain/wallet/transaction.go` — `ParentTransactionID` field + Ent conversions
+- `internal/domain/wallet/repository.go` — `GetPendingTransactionByParent` interface method
+- `internal/domain/wallet/operation.go` — `BonusCreditAmount` field on `WalletOperation`
+- `internal/repository/ent/wallet.go` — `GetPendingTransactionByParent` Ent-backed implementation
+- `internal/testutil/inmemory_wallet_store.go` — `GetPendingTransactionByParent` in-memory
+  implementation
+- `internal/ee/service/wallet.go` — resolution logic in `TopUpWallet`; bonus creation inside
+  `processWalletOperation` (direct) and `handlePurchasedCreditInvoicedTransaction` (invoiced);
+  bonus completion inside `completePurchasedCreditTransaction`
+- `internal/ee/service/settings.go` — `GetSettingByKey`/`UpdateSettingByKey` dispatch cases
+- `internal/ee/service/wallet_test.go` — all new tests (see §5)
+- `docs/swagger/*` — regenerated via `make swagger`
+
+---
+
+## 5. Test coverage
+
+All added to the existing `internal/ee/service/wallet_test.go` (no new test files, per project
+convention — tests belong alongside the service they test, not in a parallel file):
+
+- `TestFindBonusSlab`, `TestResolveBonusCredits` — pure-function table tests
+- `TestBonusCreditsResolution_*` (6 cases) — explicit override, explicit-zero-rejected, disabled
+  config, slab match/no-match, no setting row seeded
+- `TestBonusCreditsCreationAtomicity_*` (4 cases) — direct, invoiced auto-complete, invoiced
+  pending, zero-bonus-no-row — including the `Amount` field regression check (bug #5 above)
+- `TestCompletePurchasedCreditTransaction_*` (4 cases) — happy path, no-bonus regression, retry
+  idempotency, partial-failure-propagates (documents the in-memory test harness's rollback
+  limitation inline)
+- `TestBonusCreditsTopupConfig_APIDispatch` — closes bug #4 above, verified against a deliberate
+  regression
+- `TestTopUpWallet` (pre-existing) — confirmed passing unmodified, proving the default-disabled
+  setting doesn't change behavior for any top-up that predates this feature
+
+**Known gap:** the ERD's §8.1 table-driven unit tests for `BonusCreditsTopupConfig.Validate()`
+(empty-slabs, non-descending, bad operator, bad bonus type, zero-threshold-catch-all, etc.) were
+written once as a standalone `internal/types/settings_test.go`, then deliberately dropped per
+review feedback ("service has test files, not types") without being re-homed anywhere. Validation
+correctness for that type is currently only exercised indirectly, through `seedBonusConfig`'s calls
+to `UpdateSetting` in the service-level tests above. The direct table-driven coverage from §8.1
+does not currently exist anywhere in the tree.
+
+All of build / `go vet` / `go test ./internal/...` pass clean at time of writing.
+
+---
+
+## 6. Migration
+
+No live Postgres was available during implementation to run `make generate-migration`, so the
+canonical migration file was never generated. Based on `ent/migrate/schema.go`, the expected diff
+is:
+
+```sql
+ALTER TABLE "wallet_transactions" ADD COLUMN "parent_transaction_id" character varying NULL;
+
+CREATE INDEX "idx_tenant_environment_parent_transaction_status"
+    ON "wallet_transactions" ("tenant_id", "environment_id", "parent_transaction_id", "transaction_status");
+```
+
+**Action item:** run `make generate-migration` against a live dev DB to produce the canonical,
+timestamped file under `migrations/ent/` before this ships to production.
+
+---
+
+## 7. Manual verification against a running server
+
+Confirmed end-to-end against `make run-server`:
+
+- `PUT /v1/settings/bonus_credits_topup_config` with slabs in descending threshold order —
+  succeeds, both `GetSettingByKey`/`UpdateSettingByKey` recognize the key (post bug #4 fix).
+- `POST /v1/wallets/{id}/top-up` with `transaction_reason: PURCHASED_CREDIT_DIRECT` and an
+  explicit `bonus_credits_to_add` — creates two `completed` rows atomically, wallet balance
+  reflects both, bonus row's `amount` correctly matches its `credit_amount` (post bug #5 fix).
+- `transaction_reason: PURCHASED_CREDIT_BONUS` is correctly rejected on a top-up request — it's a
+  system-only reason stamped on the auto-generated child row, never a caller-supplied top-level
+  reason.

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -2421,6 +2421,7 @@ var (
 		{Name: "idempotency_key", Type: field.TypeString, Nullable: true},
 		{Name: "transaction_reason", Type: field.TypeString, Default: "FREE_CREDIT_GRANT", SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "priority", Type: field.TypeInt, Nullable: true},
+		{Name: "parent_transaction_id", Type: field.TypeString, Nullable: true},
 	}
 	// WalletTransactionsTable holds the schema information for the "wallet_transactions" table.
 	WalletTransactionsTable = &schema.Table{
@@ -2463,6 +2464,11 @@ var (
 				Annotation: &entsql.IndexAnnotation{
 					Where: "idempotency_key IS NOT NULL AND idempotency_key <> '' AND status='published'",
 				},
+			},
+			{
+				Name:    "idx_tenant_environment_parent_transaction_status",
+				Unique:  false,
+				Columns: []*schema.Column{WalletTransactionsColumns[1], WalletTransactionsColumns[7], WalletTransactionsColumns[28], WalletTransactionsColumns[19]},
 			},
 		},
 	}

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -2421,7 +2421,7 @@ var (
 		{Name: "idempotency_key", Type: field.TypeString, Nullable: true},
 		{Name: "transaction_reason", Type: field.TypeString, Default: "FREE_CREDIT_GRANT", SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "priority", Type: field.TypeInt, Nullable: true},
-		{Name: "parent_transaction_id", Type: field.TypeString, Nullable: true},
+		{Name: "parent_transaction_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 	}
 	// WalletTransactionsTable holds the schema information for the "wallet_transactions" table.
 	WalletTransactionsTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -71444,6 +71444,7 @@ type WalletTransactionMutation struct {
 	transaction_reason    *types.TransactionReason
 	priority              *int
 	addpriority           *int
+	parent_transaction_id *string
 	clearedFields         map[string]struct{}
 	done                  bool
 	oldValue              func(context.Context) (*WalletTransaction, error)
@@ -72716,6 +72717,55 @@ func (m *WalletTransactionMutation) ResetPriority() {
 	delete(m.clearedFields, wallettransaction.FieldPriority)
 }
 
+// SetParentTransactionID sets the "parent_transaction_id" field.
+func (m *WalletTransactionMutation) SetParentTransactionID(s string) {
+	m.parent_transaction_id = &s
+}
+
+// ParentTransactionID returns the value of the "parent_transaction_id" field in the mutation.
+func (m *WalletTransactionMutation) ParentTransactionID() (r string, exists bool) {
+	v := m.parent_transaction_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldParentTransactionID returns the old "parent_transaction_id" field's value of the WalletTransaction entity.
+// If the WalletTransaction object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *WalletTransactionMutation) OldParentTransactionID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldParentTransactionID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldParentTransactionID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldParentTransactionID: %w", err)
+	}
+	return oldValue.ParentTransactionID, nil
+}
+
+// ClearParentTransactionID clears the value of the "parent_transaction_id" field.
+func (m *WalletTransactionMutation) ClearParentTransactionID() {
+	m.parent_transaction_id = nil
+	m.clearedFields[wallettransaction.FieldParentTransactionID] = struct{}{}
+}
+
+// ParentTransactionIDCleared returns if the "parent_transaction_id" field was cleared in this mutation.
+func (m *WalletTransactionMutation) ParentTransactionIDCleared() bool {
+	_, ok := m.clearedFields[wallettransaction.FieldParentTransactionID]
+	return ok
+}
+
+// ResetParentTransactionID resets all changes to the "parent_transaction_id" field.
+func (m *WalletTransactionMutation) ResetParentTransactionID() {
+	m.parent_transaction_id = nil
+	delete(m.clearedFields, wallettransaction.FieldParentTransactionID)
+}
+
 // Where appends a list predicates to the WalletTransactionMutation builder.
 func (m *WalletTransactionMutation) Where(ps ...predicate.WalletTransaction) {
 	m.predicates = append(m.predicates, ps...)
@@ -72750,7 +72800,7 @@ func (m *WalletTransactionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *WalletTransactionMutation) Fields() []string {
-	fields := make([]string, 0, 27)
+	fields := make([]string, 0, 28)
 	if m.tenant_id != nil {
 		fields = append(fields, wallettransaction.FieldTenantID)
 	}
@@ -72832,6 +72882,9 @@ func (m *WalletTransactionMutation) Fields() []string {
 	if m.priority != nil {
 		fields = append(fields, wallettransaction.FieldPriority)
 	}
+	if m.parent_transaction_id != nil {
+		fields = append(fields, wallettransaction.FieldParentTransactionID)
+	}
 	return fields
 }
 
@@ -72894,6 +72947,8 @@ func (m *WalletTransactionMutation) Field(name string) (ent.Value, bool) {
 		return m.TransactionReason()
 	case wallettransaction.FieldPriority:
 		return m.Priority()
+	case wallettransaction.FieldParentTransactionID:
+		return m.ParentTransactionID()
 	}
 	return nil, false
 }
@@ -72957,6 +73012,8 @@ func (m *WalletTransactionMutation) OldField(ctx context.Context, name string) (
 		return m.OldTransactionReason(ctx)
 	case wallettransaction.FieldPriority:
 		return m.OldPriority(ctx)
+	case wallettransaction.FieldParentTransactionID:
+		return m.OldParentTransactionID(ctx)
 	}
 	return nil, fmt.Errorf("unknown WalletTransaction field %s", name)
 }
@@ -73155,6 +73212,13 @@ func (m *WalletTransactionMutation) SetField(name string, value ent.Value) error
 		}
 		m.SetPriority(v)
 		return nil
+	case wallettransaction.FieldParentTransactionID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetParentTransactionID(v)
+		return nil
 	}
 	return fmt.Errorf("unknown WalletTransaction field %s", name)
 }
@@ -73239,6 +73303,9 @@ func (m *WalletTransactionMutation) ClearedFields() []string {
 	if m.FieldCleared(wallettransaction.FieldPriority) {
 		fields = append(fields, wallettransaction.FieldPriority)
 	}
+	if m.FieldCleared(wallettransaction.FieldParentTransactionID) {
+		fields = append(fields, wallettransaction.FieldParentTransactionID)
+	}
 	return fields
 }
 
@@ -73291,6 +73358,9 @@ func (m *WalletTransactionMutation) ClearField(name string) error {
 		return nil
 	case wallettransaction.FieldPriority:
 		m.ClearPriority()
+		return nil
+	case wallettransaction.FieldParentTransactionID:
+		m.ClearParentTransactionID()
 		return nil
 	}
 	return fmt.Errorf("unknown WalletTransaction nullable field %s", name)
@@ -73380,6 +73450,9 @@ func (m *WalletTransactionMutation) ResetField(name string) error {
 		return nil
 	case wallettransaction.FieldPriority:
 		m.ResetPriority()
+		return nil
+	case wallettransaction.FieldParentTransactionID:
+		m.ResetParentTransactionID()
 		return nil
 	}
 	return fmt.Errorf("unknown WalletTransaction field %s", name)

--- a/ent/schema/wallettransaction.go
+++ b/ent/schema/wallettransaction.go
@@ -146,6 +146,9 @@ func (WalletTransaction) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			Comment("Lower number indicates higher priority. Nil values are treated as lowest priority."),
+		field.String("parent_transaction_id").
+			Optional().
+			Immutable(),
 	}
 }
 
@@ -170,5 +173,7 @@ func (WalletTransaction) Indexes() []ent.Index {
 				entsql.IndexWhere("idempotency_key IS NOT NULL AND idempotency_key <> '' AND status='published'"),
 			).
 			StorageKey("idx_tenant_environment_idempotency_key"),
+		index.Fields("tenant_id", "environment_id", "parent_transaction_id", "transaction_status").
+			StorageKey("idx_tenant_environment_parent_transaction_status"),
 	}
 }

--- a/ent/schema/wallettransaction.go
+++ b/ent/schema/wallettransaction.go
@@ -147,6 +147,9 @@ func (WalletTransaction) Fields() []ent.Field {
 			Nillable().
 			Comment("Lower number indicates higher priority. Nil values are treated as lowest priority."),
 		field.String("parent_transaction_id").
+			SchemaType(map[string]string{
+				"postgres": "varchar(50)",
+			}).
 			Optional().
 			Immutable(),
 	}

--- a/ent/wallettransaction.go
+++ b/ent/wallettransaction.go
@@ -73,8 +73,10 @@ type WalletTransaction struct {
 	// TransactionReason holds the value of the "transaction_reason" field.
 	TransactionReason types.TransactionReason `json:"transaction_reason,omitempty"`
 	// Lower number indicates higher priority. Nil values are treated as lowest priority.
-	Priority     *int `json:"priority,omitempty"`
-	selectValues sql.SelectValues
+	Priority *int `json:"priority,omitempty"`
+	// ParentTransactionID holds the value of the "parent_transaction_id" field.
+	ParentTransactionID string `json:"parent_transaction_id,omitempty"`
+	selectValues        sql.SelectValues
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -90,7 +92,7 @@ func (*WalletTransaction) scanValues(columns []string) ([]any, error) {
 			values[i] = new(decimal.Decimal)
 		case wallettransaction.FieldPriority:
 			values[i] = new(sql.NullInt64)
-		case wallettransaction.FieldID, wallettransaction.FieldTenantID, wallettransaction.FieldStatus, wallettransaction.FieldCreatedBy, wallettransaction.FieldUpdatedBy, wallettransaction.FieldEnvironmentID, wallettransaction.FieldWalletID, wallettransaction.FieldCustomerID, wallettransaction.FieldType, wallettransaction.FieldReferenceType, wallettransaction.FieldReferenceID, wallettransaction.FieldDescription, wallettransaction.FieldTransactionStatus, wallettransaction.FieldCurrency, wallettransaction.FieldIdempotencyKey, wallettransaction.FieldTransactionReason:
+		case wallettransaction.FieldID, wallettransaction.FieldTenantID, wallettransaction.FieldStatus, wallettransaction.FieldCreatedBy, wallettransaction.FieldUpdatedBy, wallettransaction.FieldEnvironmentID, wallettransaction.FieldWalletID, wallettransaction.FieldCustomerID, wallettransaction.FieldType, wallettransaction.FieldReferenceType, wallettransaction.FieldReferenceID, wallettransaction.FieldDescription, wallettransaction.FieldTransactionStatus, wallettransaction.FieldCurrency, wallettransaction.FieldIdempotencyKey, wallettransaction.FieldTransactionReason, wallettransaction.FieldParentTransactionID:
 			values[i] = new(sql.NullString)
 		case wallettransaction.FieldCreatedAt, wallettransaction.FieldUpdatedAt, wallettransaction.FieldExpiryDate:
 			values[i] = new(sql.NullTime)
@@ -284,6 +286,12 @@ func (wt *WalletTransaction) assignValues(columns []string, values []any) error 
 				wt.Priority = new(int)
 				*wt.Priority = int(value.Int64)
 			}
+		case wallettransaction.FieldParentTransactionID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field parent_transaction_id", values[i])
+			} else if value.Valid {
+				wt.ParentTransactionID = value.String
+			}
 		default:
 			wt.selectValues.Set(columns[i], values[i])
 		}
@@ -410,6 +418,9 @@ func (wt *WalletTransaction) String() string {
 		builder.WriteString("priority=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
+	builder.WriteString(", ")
+	builder.WriteString("parent_transaction_id=")
+	builder.WriteString(wt.ParentTransactionID)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/ent/wallettransaction/wallettransaction.go
+++ b/ent/wallettransaction/wallettransaction.go
@@ -69,6 +69,8 @@ const (
 	FieldTransactionReason = "transaction_reason"
 	// FieldPriority holds the string denoting the priority field in the database.
 	FieldPriority = "priority"
+	// FieldParentTransactionID holds the string denoting the parent_transaction_id field in the database.
+	FieldParentTransactionID = "parent_transaction_id"
 	// Table holds the table name of the wallettransaction in the database.
 	Table = "wallet_transactions"
 )
@@ -103,6 +105,7 @@ var Columns = []string{
 	FieldIdempotencyKey,
 	FieldTransactionReason,
 	FieldPriority,
+	FieldParentTransactionID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -280,4 +283,9 @@ func ByTransactionReason(opts ...sql.OrderTermOption) OrderOption {
 // ByPriority orders the results by the priority field.
 func ByPriority(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPriority, opts...).ToFunc()
+}
+
+// ByParentTransactionID orders the results by the parent_transaction_id field.
+func ByParentTransactionID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldParentTransactionID, opts...).ToFunc()
 }

--- a/ent/wallettransaction/where.go
+++ b/ent/wallettransaction/where.go
@@ -200,6 +200,11 @@ func Priority(v int) predicate.WalletTransaction {
 	return predicate.WalletTransaction(sql.FieldEQ(FieldPriority, v))
 }
 
+// ParentTransactionID applies equality check predicate on the "parent_transaction_id" field. It's identical to ParentTransactionIDEQ.
+func ParentTransactionID(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldEQ(FieldParentTransactionID, v))
+}
+
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
 func TenantIDEQ(v string) predicate.WalletTransaction {
 	return predicate.WalletTransaction(sql.FieldEQ(FieldTenantID, v))
@@ -1819,6 +1824,81 @@ func PriorityIsNil() predicate.WalletTransaction {
 // PriorityNotNil applies the NotNil predicate on the "priority" field.
 func PriorityNotNil() predicate.WalletTransaction {
 	return predicate.WalletTransaction(sql.FieldNotNull(FieldPriority))
+}
+
+// ParentTransactionIDEQ applies the EQ predicate on the "parent_transaction_id" field.
+func ParentTransactionIDEQ(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldEQ(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDNEQ applies the NEQ predicate on the "parent_transaction_id" field.
+func ParentTransactionIDNEQ(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldNEQ(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDIn applies the In predicate on the "parent_transaction_id" field.
+func ParentTransactionIDIn(vs ...string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldIn(FieldParentTransactionID, vs...))
+}
+
+// ParentTransactionIDNotIn applies the NotIn predicate on the "parent_transaction_id" field.
+func ParentTransactionIDNotIn(vs ...string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldNotIn(FieldParentTransactionID, vs...))
+}
+
+// ParentTransactionIDGT applies the GT predicate on the "parent_transaction_id" field.
+func ParentTransactionIDGT(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldGT(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDGTE applies the GTE predicate on the "parent_transaction_id" field.
+func ParentTransactionIDGTE(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldGTE(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDLT applies the LT predicate on the "parent_transaction_id" field.
+func ParentTransactionIDLT(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldLT(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDLTE applies the LTE predicate on the "parent_transaction_id" field.
+func ParentTransactionIDLTE(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldLTE(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDContains applies the Contains predicate on the "parent_transaction_id" field.
+func ParentTransactionIDContains(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldContains(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDHasPrefix applies the HasPrefix predicate on the "parent_transaction_id" field.
+func ParentTransactionIDHasPrefix(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldHasPrefix(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDHasSuffix applies the HasSuffix predicate on the "parent_transaction_id" field.
+func ParentTransactionIDHasSuffix(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldHasSuffix(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDIsNil applies the IsNil predicate on the "parent_transaction_id" field.
+func ParentTransactionIDIsNil() predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldIsNull(FieldParentTransactionID))
+}
+
+// ParentTransactionIDNotNil applies the NotNil predicate on the "parent_transaction_id" field.
+func ParentTransactionIDNotNil() predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldNotNull(FieldParentTransactionID))
+}
+
+// ParentTransactionIDEqualFold applies the EqualFold predicate on the "parent_transaction_id" field.
+func ParentTransactionIDEqualFold(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldEqualFold(FieldParentTransactionID, v))
+}
+
+// ParentTransactionIDContainsFold applies the ContainsFold predicate on the "parent_transaction_id" field.
+func ParentTransactionIDContainsFold(v string) predicate.WalletTransaction {
+	return predicate.WalletTransaction(sql.FieldContainsFold(FieldParentTransactionID, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/ent/wallettransaction_create.go
+++ b/ent/wallettransaction_create.go
@@ -336,6 +336,20 @@ func (wtc *WalletTransactionCreate) SetNillablePriority(i *int) *WalletTransacti
 	return wtc
 }
 
+// SetParentTransactionID sets the "parent_transaction_id" field.
+func (wtc *WalletTransactionCreate) SetParentTransactionID(s string) *WalletTransactionCreate {
+	wtc.mutation.SetParentTransactionID(s)
+	return wtc
+}
+
+// SetNillableParentTransactionID sets the "parent_transaction_id" field if the given value is not nil.
+func (wtc *WalletTransactionCreate) SetNillableParentTransactionID(s *string) *WalletTransactionCreate {
+	if s != nil {
+		wtc.SetParentTransactionID(*s)
+	}
+	return wtc
+}
+
 // SetID sets the "id" field.
 func (wtc *WalletTransactionCreate) SetID(s string) *WalletTransactionCreate {
 	wtc.mutation.SetID(s)
@@ -632,6 +646,10 @@ func (wtc *WalletTransactionCreate) createSpec() (*WalletTransaction, *sqlgraph.
 	if value, ok := wtc.mutation.Priority(); ok {
 		_spec.SetField(wallettransaction.FieldPriority, field.TypeInt, value)
 		_node.Priority = &value
+	}
+	if value, ok := wtc.mutation.ParentTransactionID(); ok {
+		_spec.SetField(wallettransaction.FieldParentTransactionID, field.TypeString, value)
+		_node.ParentTransactionID = value
 	}
 	return _node, _spec
 }

--- a/ent/wallettransaction_update.go
+++ b/ent/wallettransaction_update.go
@@ -450,6 +450,9 @@ func (wtu *WalletTransactionUpdate) sqlSave(ctx context.Context) (n int, err err
 	if wtu.mutation.PriorityCleared() {
 		_spec.ClearField(wallettransaction.FieldPriority, field.TypeInt)
 	}
+	if wtu.mutation.ParentTransactionIDCleared() {
+		_spec.ClearField(wallettransaction.FieldParentTransactionID, field.TypeString)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, wtu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{wallettransaction.Label}
@@ -919,6 +922,9 @@ func (wtuo *WalletTransactionUpdateOne) sqlSave(ctx context.Context) (_node *Wal
 	}
 	if wtuo.mutation.PriorityCleared() {
 		_spec.ClearField(wallettransaction.FieldPriority, field.TypeInt)
+	}
+	if wtuo.mutation.ParentTransactionIDCleared() {
+		_spec.ClearField(wallettransaction.FieldParentTransactionID, field.TypeString)
 	}
 	_node = &WalletTransaction{config: wtuo.config}
 	_spec.Assign = _node.assignValues

--- a/internal/api/dto/wallet.go
+++ b/internal/api/dto/wallet.go
@@ -323,6 +323,11 @@ type TopUpWalletRequest struct {
 	// BillingReason indicates why this top-up was triggered (e.g. WALLET_AUTO_TOPUP).
 	// When set, it is stamped on the invoice created for PURCHASED_CREDIT_INVOICED transactions.
 	BillingReason types.InvoiceBillingReason `json:"-"`
+	// bonus_credits_to_add is an explicit override for the bonus credits granted alongside this
+	// purchase. When nil/omitted, the bonus is resolved from the tenant's
+	// bonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is
+	// used as-is, skipping slab resolution. To grant no bonus, omit this field entirely.
+	BonusCreditsToAdd *decimal.Decimal `json:"bonus_credits_to_add,omitempty" swaggertype:"string"`
 }
 
 func (r *TopUpWalletRequest) Validate() error {
@@ -366,6 +371,15 @@ func (r *TopUpWalletRequest) Validate() error {
 	if r.Priority != nil && *r.Priority < 0 {
 		return ierr.NewError("priority must be greater than or equal to 0").
 			WithHint("Priority must be a non-negative integer").
+			Mark(ierr.ErrValidation)
+	}
+
+	if r.BonusCreditsToAdd != nil && r.BonusCreditsToAdd.LessThanOrEqual(decimal.Zero) {
+		return ierr.NewError("bonus_credits_to_add must be greater than 0").
+			WithHint("To grant no bonus credits, omit bonus_credits_to_add entirely").
+			WithReportableDetails(map[string]interface{}{
+				"bonus_credits_to_add": r.BonusCreditsToAdd,
+			}).
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/domain/wallet/operation.go
+++ b/internal/domain/wallet/operation.go
@@ -44,6 +44,11 @@ type WalletOperation struct {
 	// For Expiry Credits, this is the ID of the parent credit transaction
 	// so that we can use the same credits for the expiry debit transaction
 	ParentCreditTxID string `json:"-"`
+	// BonusCreditAmount, when set and greater than zero on a credit operation, creates a second
+	// wallet_transaction row (reason PURCHASED_CREDIT_BONUS, parent_transaction_id = this
+	// operation's transaction ID) crediting this many bonus credits in the same DB transaction.
+	// nil for every caller except TopUpWallet's direct-purchase branch.
+	BonusCreditAmount *decimal.Decimal `json:"-"`
 }
 
 func (w *WalletOperation) Validate() error {

--- a/internal/domain/wallet/operation.go
+++ b/internal/domain/wallet/operation.go
@@ -87,6 +87,15 @@ func (w *WalletOperation) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	if w.BonusCreditAmount != nil && w.BonusCreditAmount.LessThan(decimal.Zero) {
+		return ierr.NewError("bonus_credit_amount cannot be negative").
+			WithHint("Bonus credit amount must be zero or positive").
+			WithReportableDetails(map[string]interface{}{
+				"bonus_credit_amount": w.BonusCreditAmount,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
 	if err := w.TransactionReason.Validate(); err != nil {
 		return err
 	}

--- a/internal/domain/wallet/repository.go
+++ b/internal/domain/wallet/repository.go
@@ -21,6 +21,9 @@ type Repository interface {
 	// Transaction operations
 	GetTransactionByID(ctx context.Context, id string) (*Transaction, error)
 	GetTransactionByIdempotencyKey(ctx context.Context, idempotencyKey string) (*Transaction, error)
+	// GetPendingTransactionByParent returns the pending bonus transaction whose
+	// parent_transaction_id is parentTransactionID, if one exists (ent.IsNotFound if not).
+	GetPendingTransactionByParent(ctx context.Context, parentTransactionID string) (*Transaction, error)
 	ListWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	ListAllWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	CountWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) (int, error)

--- a/internal/domain/wallet/transaction.go
+++ b/internal/domain/wallet/transaction.go
@@ -31,6 +31,10 @@ type Transaction struct {
 	Priority            *int                        `db:"priority" json:"priority"`
 	Currency            string                      `db:"currency" json:"currency"`
 
+	// ParentTransactionID is the ID of the parent wallet_transaction this row was earned from
+	// (the purchase tx, for a bonus grant). Empty for ordinary transactions.
+	ParentTransactionID string `db:"parent_transaction_id" json:"parent_transaction_id,omitempty"`
+
 	// conversion_rate is the conversion rate for the transaction to the currency
 	ConversionRate *decimal.Decimal `db:"conversion_rate" json:"conversion_rate,omitempty" swaggertype:"string"`
 
@@ -101,6 +105,7 @@ func (t *Transaction) ToEnt() *ent.WalletTransaction {
 		Currency:            t.Currency,
 		ConversionRate:      t.ConversionRate,
 		TopupConversionRate: t.TopupConversionRate,
+		ParentTransactionID: t.ParentTransactionID,
 		EnvironmentID:       t.EnvironmentID,
 		TenantID:            t.TenantID,
 		Status:              string(t.Status),
@@ -139,6 +144,7 @@ func TransactionFromEnt(e *ent.WalletTransaction) *Transaction {
 		Priority:            e.Priority,
 		ConversionRate:      e.ConversionRate,
 		TopupConversionRate: e.TopupConversionRate,
+		ParentTransactionID: e.ParentTransactionID,
 		EnvironmentID:       e.EnvironmentID,
 		BaseModel: types.BaseModel{
 			TenantID:  e.TenantID,

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -233,6 +233,8 @@ func (s *settingsService) GetSettingByKey(ctx context.Context, key types.Setting
 		return getSettingByKey[types.CustomerPortalConfig](s, ctx, key)
 	case types.SettingKeyEventIngestionFilter:
 		return getSettingByKey[types.EventIngestionFilterConfig](s, ctx, key)
+	case types.SettingKeyBonusCreditsTopupConfig:
+		return getSettingByKey[types.BonusCreditsTopupConfig](s, ctx, key)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).
@@ -277,6 +279,8 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 		return updateSettingByKey[types.CustomerPortalConfig](s, ctx, key, req)
 	case types.SettingKeyEventIngestionFilter:
 		return updateSettingByKey[types.EventIngestionFilterConfig](s, ctx, key, req)
+	case types.SettingKeyBonusCreditsTopupConfig:
+		return updateSettingByKey[types.BonusCreditsTopupConfig](s, ctx, key, req)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -695,8 +695,9 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 // descending by Threshold (enforced by BonusCreditsTopupConfig.Validate) — first match wins.
 func findBonusSlab(slabs []types.BonusCreditsSlab, credits decimal.Decimal) *types.BonusCreditsSlab {
 	for i := range slabs {
-		// Operator is always gte: BonusCreditsSlab.Operator is validated as
-		// `oneof=gte` wherever the setting is saved (BonusCreditsTopupConfig.Validate).
+		if slabs[i].Operator != types.GREATER_THAN_EQUAL {
+			continue
+		}
 		if credits.GreaterThanOrEqual(slabs[i].Threshold) {
 			return &slabs[i]
 		}

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -571,6 +571,24 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 			Mark(ierr.ErrValidation)
 	}
 
+	// Resolve bonus credits from the tenant's slab config when the caller didn't pass an
+	// explicit override. Only "purchased" (paid) top-up reasons trigger slab resolution;
+	// req.BonusCreditsToAdd is mutated in place so every downstream step just reads it.
+	if req.BonusCreditsToAdd == nil &&
+		(req.TransactionReason == types.TransactionReasonPurchasedCreditDirect ||
+			req.TransactionReason == types.TransactionReasonPurchasedCreditInvoiced) {
+		settingsSvc := &settingsService{ServiceParams: s.ServiceParams}
+		bonusCfg, err := GetSetting[types.BonusCreditsTopupConfig](settingsSvc, ctx, types.SettingKeyBonusCreditsTopupConfig)
+		if err != nil {
+			return nil, err
+		}
+		if bonusCfg.Enabled {
+			if slab := findBonusSlab(bonusCfg.Slabs, req.CreditsToAdd); slab != nil {
+				req.BonusCreditsToAdd = lo.ToPtr(resolveBonusCredits(slab, req.CreditsToAdd))
+			}
+		}
+	}
+
 	// Generate idempotency key
 	var idempotencyKey string
 	if lo.FromPtr(req.IdempotencyKey) != "" {
@@ -644,6 +662,7 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		ExpiryDateTime:    req.ExpiryDateUTC, // ExpiryDateUTC is the preferred input: a full-precision timestamp
 		IdempotencyKey:    idempotencyKey,
 		Priority:          req.Priority,
+		BonusCreditAmount: req.BonusCreditsToAdd,
 	}
 
 	// Process wallet credit immediately
@@ -670,6 +689,31 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		InvoiceID:         nil,
 		Wallet:            walletResp,
 	}, nil
+}
+
+// findBonusSlab returns the highest-threshold slab that credits clears. Requires slabs sorted
+// descending by Threshold (enforced by BonusCreditsTopupConfig.Validate) — first match wins.
+func findBonusSlab(slabs []types.BonusCreditsSlab, credits decimal.Decimal) *types.BonusCreditsSlab {
+	for i := range slabs {
+		// Operator is always gte: BonusCreditsSlab.Operator is validated as
+		// `oneof=gte` wherever the setting is saved (BonusCreditsTopupConfig.Validate).
+		if credits.GreaterThanOrEqual(slabs[i].Threshold) {
+			return &slabs[i]
+		}
+	}
+	return nil
+}
+
+// resolveBonusCredits turns a matched slab into an actual credit amount.
+func resolveBonusCredits(slab *types.BonusCreditsSlab, creditsToAdd decimal.Decimal) decimal.Decimal {
+	switch slab.Bonus.Type {
+	case types.BonusValueTypeFlat:
+		return slab.Bonus.Value
+	case types.BonusValueTypePercentage:
+		return creditsToAdd.Mul(slab.Bonus.Value).Div(decimal.NewFromInt(100))
+	default:
+		return decimal.Zero
+	}
 }
 
 func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Context, walletID string, idempotencyKey *string, req *dto.TopUpWalletRequest) (string, string, error) {
@@ -764,9 +808,61 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			return err
 		}
 
-		// If auto-complete is enabled, update wallet balance immediately
+		walletTransactionID = tx.ID
+
+		// Create the bonus grant, sharing the purchase tx's fate: same status (pending or
+		// completed), completed atomically with the purchase when the purchase completes here.
+		var bonusAmountInCurrency decimal.Decimal
+		if req.BonusCreditsToAdd != nil && req.BonusCreditsToAdd.GreaterThan(decimal.Zero) {
+			bonusCreditBalanceBefore := balanceAfter
+			bonusCreditBalanceAfter := balanceAfter
+			if autoCompleteEnabled {
+				bonusCreditBalanceAfter = balanceAfter.Add(*req.BonusCreditsToAdd)
+			}
+
+			bonusAmountInCurrency = s.GetCurrencyAmountFromCredits(*req.BonusCreditsToAdd, w.TopupConversionRate)
+
+			bonusTx := &wallet.Transaction{
+				ID:                  types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+				WalletID:            walletID,
+				CustomerID:          w.CustomerID,
+				Type:                types.TransactionTypeCredit,
+				CreditAmount:        *req.BonusCreditsToAdd,
+				Amount:              bonusAmountInCurrency,
+				TxStatus:            txStatus, // shares the purchase tx's status: pending or completed
+				ReferenceType:       types.WalletTxReferenceTypeExternal,
+				ReferenceID:         lo.FromPtr(idempotencyKey),
+				Description:         "Bonus credits for purchase",
+				Metadata:            txMetadata,
+				TransactionReason:   types.TransactionReasonPurchasedCreditBonus,
+				ParentTransactionID: tx.ID,
+				EnvironmentID:       w.EnvironmentID,
+				CreditBalanceBefore: bonusCreditBalanceBefore,
+				CreditBalanceAfter:  bonusCreditBalanceAfter,
+				Currency:            w.Currency,
+				TopupConversionRate: lo.ToPtr(w.TopupConversionRate),
+				BaseModel:           types.GetDefaultBaseModel(ctx),
+			}
+
+			bonusTx.CreditsAvailable, err = bonusTx.ComputeCreditsAvailable()
+			if err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to compute credits available for bonus transaction").
+					Mark(ierr.ErrInternal)
+			}
+
+			if err := s.WalletRepo.CreateTransaction(ctx, bonusTx); err != nil {
+				return err
+			}
+
+			if autoCompleteEnabled {
+				balanceAfter = bonusCreditBalanceAfter
+			}
+		}
+
+		// If auto-complete is enabled, update wallet balance immediately (purchase + bonus, if any)
 		if autoCompleteEnabled {
-			finalBalance := w.Balance.Add(tx.Amount)
+			finalBalance := w.Balance.Add(tx.Amount).Add(bonusAmountInCurrency)
 			if err := s.WalletRepo.UpdateWalletBalance(ctx, walletID, finalBalance, balanceAfter); err != nil {
 				return ierr.WithError(err).
 					WithHint("Failed to update wallet balance").
@@ -780,8 +876,6 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 				"new_credit_balance", balanceAfter.String(),
 			)
 		}
-
-		walletTransactionID = tx.ID
 
 		// Step 2: Create invoice for credit purchase with wallet_transaction_id in metadata
 		amount := s.GetCurrencyAmountFromCredits(req.CreditsToAdd, w.TopupConversionRate)
@@ -1020,6 +1114,43 @@ func (s *walletService) completePurchasedCreditTransaction(ctx context.Context, 
 			"credits_added", tx.CreditAmount.String(),
 			"new_balance", newCreditBalance.String(),
 		)
+
+		// Complete the pending bonus grant earned from this purchase, in the same transaction.
+		bonusTx, err := s.WalletRepo.GetPendingTransactionByParent(ctx, tx.ID)
+		if err != nil && !ierr.IsNotFound(err) {
+			return err
+		}
+		if bonusTx != nil {
+			bonusTx.TxStatus = types.TransactionStatusCompleted
+			bonusTx.CreditBalanceBefore = newCreditBalance
+			bonusTx.CreditBalanceAfter = newCreditBalance.Add(bonusTx.CreditAmount)
+			if bonusTx.CreditsAvailable, err = bonusTx.ComputeCreditsAvailable(); err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to compute credits available for bonus transaction").
+					Mark(ierr.ErrInternal)
+			}
+			bonusTx.UpdatedAt = time.Now().UTC()
+
+			if err := s.WalletRepo.UpdateTransaction(ctx, bonusTx); err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to update bonus wallet transaction").
+					Mark(ierr.ErrInternal)
+			}
+
+			bonusFinalBalance := finalBalance.Add(bonusTx.Amount)
+			if err := s.WalletRepo.UpdateWalletBalance(ctx, bonusTx.WalletID, bonusFinalBalance, bonusTx.CreditBalanceAfter); err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to update wallet balance for bonus transaction").
+					Mark(ierr.ErrInternal)
+			}
+
+			s.Logger.Info(ctx, "completed linked bonus credit transaction",
+				"wallet_transaction_id", bonusTx.ID,
+				"parent_transaction_id", tx.ID,
+				"wallet_id", bonusTx.WalletID,
+				"bonus_credits_added", bonusTx.CreditAmount.String(),
+			)
+		}
 
 		return nil
 	})
@@ -1872,6 +2003,44 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 		// Step 6: Create transaction record
 		if err := s.WalletRepo.CreateTransaction(ctx, tx); err != nil {
 			return err
+		}
+
+		// Create the bonus grant earned from this purchase, in the same transaction, already
+		// completed — no reason to round-trip through pending when the purchase completes here.
+		if req.BonusCreditAmount != nil && req.BonusCreditAmount.GreaterThan(decimal.Zero) {
+			bonusCreditBalanceBefore := newCreditBalance
+			newCreditBalance = newCreditBalance.Add(*req.BonusCreditAmount)
+
+			bonusTx := &wallet.Transaction{
+				ID:                  types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+				WalletID:            req.WalletID,
+				CustomerID:          w.CustomerID,
+				Type:                types.TransactionTypeCredit,
+				Amount:              s.GetCurrencyAmountFromCredits(*req.BonusCreditAmount, w.TopupConversionRate),
+				CreditAmount:        *req.BonusCreditAmount,
+				Description:         "Bonus credits for purchase",
+				Metadata:            metadata,
+				TxStatus:            types.TransactionStatusCompleted,
+				TransactionReason:   types.TransactionReasonPurchasedCreditBonus,
+				ParentTransactionID: tx.ID,
+				CreditBalanceBefore: bonusCreditBalanceBefore,
+				CreditBalanceAfter:  newCreditBalance,
+				Currency:            w.Currency,
+				EnvironmentID:       types.GetEnvironmentID(ctx),
+				TopupConversionRate: lo.ToPtr(w.TopupConversionRate),
+				BaseModel:           types.GetDefaultBaseModel(ctx),
+			}
+			bonusTx.CreditsAvailable, err = bonusTx.ComputeCreditsAvailable()
+			if err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to compute credits available for bonus transaction").
+					Mark(ierr.ErrInternal)
+			}
+			if err := s.WalletRepo.CreateTransaction(ctx, bonusTx); err != nil {
+				return err
+			}
+
+			finalBalance = s.GetCurrencyAmountFromCredits(newCreditBalance, w.ConversionRate)
 		}
 
 		// Step 7: Update wallet balance atomically

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -3036,4 +3037,453 @@ func (s *CheckWalletBalanceAlertSuite) TestAutoTopupNotBlockedByDisabledAlerts()
 	s.NoError(err)
 	s.Equal(0, s.countWalletAlertLogs(w.ID), "no alert logs when alerts not configured")
 	s.Equal(1, s.countAutoTopupInvoices(), "auto top-up must not be blocked by disabled alerts")
+}
+
+// ---------------------------------------------------------------------------
+// Bonus credit top-up (ERD: bonus_credits.md) — §8.2-8.5
+// ---------------------------------------------------------------------------
+
+// --- 8.2 Unit tests: findBonusSlab / resolveBonusValue (pure functions) ---
+
+func bonusSlabsForTest() []types.BonusCreditsSlab {
+	return []types.BonusCreditsSlab{
+		{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}},
+		{Threshold: decimal.NewFromInt(1000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypePercentage, Value: decimal.NewFromInt(10)}},
+		{Threshold: decimal.Zero, Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.Zero}},
+	}
+}
+
+func TestFindBonusSlab(t *testing.T) {
+	slabsNoZeroCatchAll := bonusSlabsForTest()[:2] // only 5000, 1000 — no 0 catch-all
+
+	tests := []struct {
+		name    string
+		slabs   []types.BonusCreditsSlab
+		credits decimal.Decimal
+		wantNil bool
+		wantThr decimal.Decimal
+	}{
+		{"below every threshold, no catch-all", slabsNoZeroCatchAll, decimal.NewFromInt(500), true, decimal.Decimal{}},
+		{"exact threshold match", bonusSlabsForTest(), decimal.NewFromInt(1000), false, decimal.NewFromInt(1000)},
+		{"falls in middle bracket", bonusSlabsForTest(), decimal.NewFromInt(3000), false, decimal.NewFromInt(1000)},
+		{"highest bracket", bonusSlabsForTest(), decimal.NewFromInt(10000), false, decimal.NewFromInt(5000)},
+		{"empty slabs", []types.BonusCreditsSlab{}, decimal.NewFromInt(100), true, decimal.Decimal{}},
+		{"zero credits with catch-all", bonusSlabsForTest(), decimal.Zero, false, decimal.Zero},
+		{"zero credits without catch-all", slabsNoZeroCatchAll, decimal.Zero, true, decimal.Decimal{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findBonusSlab(tt.slabs, tt.credits)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.True(t, tt.wantThr.Equal(got.Threshold), "expected threshold %s, got %s", tt.wantThr, got.Threshold)
+			}
+		})
+	}
+}
+
+func TestResolveBonusValue(t *testing.T) {
+	flatSlab := &types.BonusCreditsSlab{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}}
+	pctSlab := &types.BonusCreditsSlab{Threshold: decimal.NewFromInt(1000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypePercentage, Value: decimal.NewFromInt(10)}}
+
+	got := resolveBonusCredits(flatSlab, decimal.NewFromInt(6000))
+	assert.True(t, decimal.NewFromInt(750).Equal(got), "flat bonus should be 750, got %s", got)
+
+	got = resolveBonusCredits(pctSlab, decimal.NewFromInt(3000))
+	assert.True(t, decimal.NewFromInt(300).Equal(got), "percentage bonus should be 300, got %s", got)
+}
+
+// --- helpers shared by 8.3-8.5 ---
+
+func (s *WalletServiceSuite) seedBonusConfig(cfg types.BonusCreditsTopupConfig) {
+	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+	s.NoError(UpdateSetting(svc, s.GetContext(), types.SettingKeyBonusCreditsTopupConfig, cfg))
+}
+
+func (s *WalletServiceSuite) seedAutoComplete(enabled bool) {
+	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+	invCfg, err := GetSetting[types.InvoiceConfig](svc, s.GetContext(), types.SettingKeyInvoiceConfig)
+	s.NoError(err)
+	invCfg.AutoCompletePurchasedCreditTransaction = enabled
+	s.NoError(UpdateSetting(svc, s.GetContext(), types.SettingKeyInvoiceConfig, invCfg))
+}
+
+// TestBonusCreditsTopupConfig_APIDispatch exercises the actual GetSettingByKey/UpdateSettingByKey
+// switch dispatch used by the GET/PUT /v1/settings/:key API handlers — the seed helpers above
+// only exercise the generic GetSetting/UpdateSetting typed functions, which bypass this switch
+// entirely, so this is the only coverage for "is bonus_credits_topup_config wired into the API".
+func (s *WalletServiceSuite) TestBonusCreditsTopupConfig_APIDispatch() {
+	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+
+	updateResp, err := svc.UpdateSettingByKey(s.GetContext(), types.SettingKeyBonusCreditsTopupConfig, &dto.UpdateSettingRequest{
+		Value: map[string]interface{}{
+			"enabled": true,
+			"slabs": []map[string]interface{}{
+				{"threshold": "200", "operator": "gte", "bonus": map[string]interface{}{"type": "percentage", "value": "10"}},
+				{"threshold": "100", "operator": "gte", "bonus": map[string]interface{}{"type": "flat", "value": "50"}},
+			},
+		},
+	})
+	s.NoError(err, "UpdateSettingByKey must recognize bonus_credits_topup_config")
+	s.Equal(types.SettingKeyBonusCreditsTopupConfig, updateResp.Key)
+
+	getResp, err := svc.GetSettingByKey(s.GetContext(), types.SettingKeyBonusCreditsTopupConfig)
+	s.NoError(err, "GetSettingByKey must recognize bonus_credits_topup_config")
+	s.Equal(true, getResp.Value["enabled"])
+}
+
+func (s *WalletServiceSuite) bonusTxByParent(parentID string) *wallet.Transaction {
+	filter := types.NewNoLimitWalletTransactionFilter()
+	filter.WalletID = &s.testData.wallet.ID
+	txs, err := s.GetStores().WalletRepo.ListAllWalletTransactions(s.GetContext(), filter)
+	s.NoError(err)
+	for _, tx := range txs {
+		if tx.ParentTransactionID == parentID {
+			return tx
+		}
+	}
+	return nil
+}
+
+// --- 8.3 TopUpWallet resolution ---
+
+func (s *WalletServiceSuite) TestBonusCreditsResolution_ExplicitOverrideWins() {
+	s.seedBonusConfig(types.BonusCreditsTopupConfig{
+		Enabled: true,
+		Slabs:   []types.BonusCreditsSlab{{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}}},
+	})
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(6000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(500)),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_explicit_override"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	if s.NotNil(bonusTx, "expected a bonus transaction") {
+		s.True(decimal.NewFromInt(500).Equal(bonusTx.CreditAmount), "explicit override should win over slab-resolved 750")
+		s.Equal(types.TransactionReasonPurchasedCreditBonus, bonusTx.TransactionReason)
+	}
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsResolution_ExplicitZeroIsRejected() {
+	// bonus_credits_to_add must be omitted to grant no bonus; 0 (or negative) is now a
+	// validation error rather than an "opt out" signal.
+	s.seedBonusConfig(types.BonusCreditsTopupConfig{
+		Enabled: true,
+		Slabs:   []types.BonusCreditsSlab{{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}}},
+	})
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(6000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.Zero),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_explicit_zero"),
+	}
+	_, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.Error(err)
+	s.True(ierr.IsValidation(err), "expected a validation error, got %v", err)
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsResolution_NilConfigDisabled() {
+	s.seedBonusConfig(types.BonusCreditsTopupConfig{Enabled: false, Slabs: []types.BonusCreditsSlab{}})
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(6000),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_nil_disabled"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	s.Nil(bonusTx, "disabled config should not create a bonus transaction")
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsResolution_NilConfigEnabledSlabMatches() {
+	s.seedBonusConfig(types.BonusCreditsTopupConfig{
+		Enabled: true,
+		Slabs:   []types.BonusCreditsSlab{{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}}},
+	})
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(6000),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_slab_matches"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	if s.NotNil(bonusTx) {
+		s.True(decimal.NewFromInt(750).Equal(bonusTx.CreditAmount))
+	}
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsResolution_NilConfigEnabledNoSlabMatches() {
+	s.seedBonusConfig(types.BonusCreditsTopupConfig{
+		Enabled: true,
+		Slabs:   []types.BonusCreditsSlab{{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}}},
+	})
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_no_slab_matches"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	s.Nil(bonusTx, "no slab clears the purchase amount, so no bonus should be created")
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsResolution_NoSettingRowSeeded() {
+	// No seeding at all: GetSetting must fall back to the coded default (enabled:false).
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(6000),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_no_setting_row"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	s.Nil(bonusTx)
+}
+
+// --- 8.4 Creation-time status and atomicity ---
+
+func (s *WalletServiceSuite) TestBonusCreditsCreationAtomicity_Direct() {
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(100)),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_direct_atomic"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+	s.Equal(types.TransactionStatusCompleted, resp.WalletTransaction.TxStatus)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	if s.NotNil(bonusTx) {
+		s.Equal(types.TransactionStatusCompleted, bonusTx.TxStatus)
+		s.True(decimal.NewFromInt(100).Equal(bonusTx.Amount), "bonus tx currency amount must reflect its credit_amount at the topup conversion rate, got %s", bonusTx.Amount)
+	}
+
+	// wallet started at credit_balance=1000; both purchase (1000) and bonus (100) applied
+	w, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(2100).Equal(w.CreditBalance), "expected 1000 + 1000 + 100 = 2100, got %s", w.CreditBalance)
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsCreationAtomicity_InvoicedAutoComplete() {
+	s.seedAutoComplete(true)
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(100)),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("bonus_invoiced_auto_complete"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+	s.Equal(types.TransactionStatusCompleted, resp.WalletTransaction.TxStatus)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	if s.NotNil(bonusTx) {
+		s.Equal(types.TransactionStatusCompleted, bonusTx.TxStatus)
+	}
+
+	w, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(2100).Equal(w.CreditBalance), "expected 1000 + 1000 + 100 = 2100, got %s", w.CreditBalance)
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsCreationAtomicity_InvoicedNoAutoComplete() {
+	s.seedAutoComplete(false)
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(100)),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("bonus_invoiced_no_auto_complete"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+	s.Equal(types.TransactionStatusPending, resp.WalletTransaction.TxStatus)
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	if s.NotNil(bonusTx) {
+		s.Equal(types.TransactionStatusPending, bonusTx.TxStatus)
+	}
+
+	// balance must be unchanged since nothing has been paid/completed yet
+	w, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(1000).Equal(w.CreditBalance), "expected unchanged 1000, got %s", w.CreditBalance)
+}
+
+func (s *WalletServiceSuite) TestBonusCreditsCreationAtomicity_ZeroBonusNoRow() {
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100), // below any seeded slab, no override
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("bonus_zero_no_row"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitWalletTransactionFilter()
+	filter.WalletID = &s.testData.wallet.ID
+	txs, err := s.GetStores().WalletRepo.ListAllWalletTransactions(s.GetContext(), filter)
+	s.NoError(err)
+
+	count := 0
+	for _, tx := range txs {
+		if tx.ID == resp.WalletTransaction.ID || tx.ParentTransactionID == resp.WalletTransaction.ID {
+			count++
+		}
+	}
+	s.Equal(1, count, "only the purchase transaction should exist, no zero-amount bonus row")
+}
+
+// --- 8.5 completePurchasedCreditTransaction with a linked bonus ---
+
+func (s *WalletServiceSuite) TestCompletePurchasedCreditTransaction_WithLinkedBonus_HappyPath() {
+	s.seedAutoComplete(false)
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(100)),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("bonus_completion_happy_path"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+	s.Equal(types.TransactionStatusPending, resp.WalletTransaction.TxStatus)
+
+	balanceBefore, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(1000).Equal(balanceBefore.CreditBalance))
+
+	err = s.service.(*walletService).CompletePurchasedCreditTransactionWithRetry(s.GetContext(), resp.WalletTransaction.ID)
+	s.NoError(err)
+
+	purchaseTx, err := s.GetStores().WalletRepo.GetTransactionByID(s.GetContext(), resp.WalletTransaction.ID)
+	s.NoError(err)
+	s.Equal(types.TransactionStatusCompleted, purchaseTx.TxStatus)
+
+	bonusTx := s.bonusTxByParent(purchaseTx.ID)
+	if s.NotNil(bonusTx) {
+		s.Equal(types.TransactionStatusCompleted, bonusTx.TxStatus)
+	}
+
+	w, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(2100).Equal(w.CreditBalance), "expected 1000 + 1000 + 100 = 2100, got %s", w.CreditBalance)
+}
+
+func (s *WalletServiceSuite) TestCompletePurchasedCreditTransaction_NoLinkedBonus_Regression() {
+	s.seedAutoComplete(false)
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("no_bonus_regression"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	err = s.service.(*walletService).CompletePurchasedCreditTransactionWithRetry(s.GetContext(), resp.WalletTransaction.ID)
+	s.NoError(err, "completion must succeed even when GetPendingTransactionByParent finds nothing")
+
+	purchaseTx, err := s.GetStores().WalletRepo.GetTransactionByID(s.GetContext(), resp.WalletTransaction.ID)
+	s.NoError(err)
+	s.Equal(types.TransactionStatusCompleted, purchaseTx.TxStatus)
+}
+
+func (s *WalletServiceSuite) TestCompletePurchasedCreditTransaction_WithLinkedBonus_Idempotent() {
+	s.seedAutoComplete(false)
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(100)),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("bonus_completion_idempotent"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	err = s.service.(*walletService).CompletePurchasedCreditTransactionWithRetry(s.GetContext(), resp.WalletTransaction.ID)
+	s.NoError(err)
+
+	w1, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+
+	// second call must be a no-op: the top-of-function pending-check short-circuits
+	err = s.service.(*walletService).CompletePurchasedCreditTransactionWithRetry(s.GetContext(), resp.WalletTransaction.ID)
+	s.NoError(err)
+
+	w2, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallet.ID)
+	s.NoError(err)
+	s.True(w1.CreditBalance.Equal(w2.CreditBalance), "balance must not change on a repeat completion call")
+
+	bonusTx := s.bonusTxByParent(resp.WalletTransaction.ID)
+	if s.NotNil(bonusTx) {
+		s.Equal(types.TransactionStatusCompleted, bonusTx.TxStatus)
+	}
+}
+
+// failingBonusWalletRepo wraps the in-memory wallet repo and fails the Nth call to
+// UpdateWalletBalance, used to simulate a mid-transaction failure on the bonus half of
+// completePurchasedCreditTransaction. NOTE: the in-memory/mock DB client's WithTx does not
+// implement real rollback (see testutil.MockPostgresClient.WithTx), so this test can only
+// assert that the error propagates out of completePurchasedCreditTransaction — it cannot
+// assert that the purchase-side write is rolled back, since the test harness has no such
+// mechanism. Real atomicity is provided by Postgres's actual transaction in production.
+type failingBonusWalletRepo struct {
+	wallet.Repository
+	callCount int
+	failOnErr int
+}
+
+func (r *failingBonusWalletRepo) UpdateWalletBalance(ctx context.Context, walletID string, finalBalance, newCreditBalance decimal.Decimal) error {
+	r.callCount++
+	if r.callCount == r.failOnErr {
+		return ierr.NewError("injected failure on bonus balance update").Mark(ierr.ErrDatabase)
+	}
+	return r.Repository.UpdateWalletBalance(ctx, walletID, finalBalance, newCreditBalance)
+}
+
+func (s *WalletServiceSuite) TestCompletePurchasedCreditTransaction_WithLinkedBonus_PartialFailurePropagates() {
+	s.seedAutoComplete(false)
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(1000),
+		BonusCreditsToAdd: lo.ToPtr(decimal.NewFromInt(100)),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("bonus_completion_partial_failure"),
+	}
+	resp, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, req)
+	s.NoError(err)
+
+	realRepo := s.service.(*walletService).ServiceParams.WalletRepo
+	failingRepo := &failingBonusWalletRepo{Repository: realRepo, failOnErr: 2} // 1st call = purchase, 2nd = bonus
+
+	failingParams := s.service.(*walletService).ServiceParams
+	failingParams.WalletRepo = failingRepo
+	failingService := NewWalletService(failingParams).(*walletService)
+
+	// Call the non-retrying entrypoint directly: CompletePurchasedCreditTransactionWithRetry
+	// would retry and, since the mock has no rollback, find the purchase tx already marked
+	// completed from the first (failed) attempt and short-circuit as a false success.
+	err = failingService.completePurchasedCreditTransaction(s.GetContext(), resp.WalletTransaction.ID)
+	s.Error(err, "the injected failure on the bonus half must surface as an error")
 }

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -3055,6 +3055,14 @@ func bonusSlabsForTest() []types.BonusCreditsSlab {
 
 func TestFindBonusSlab(t *testing.T) {
 	slabsNoZeroCatchAll := bonusSlabsForTest()[:2] // only 5000, 1000 — no 0 catch-all
+	slabsWithNonGteHighest := []types.BonusCreditsSlab{
+		{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}},
+		{Threshold: decimal.NewFromInt(1000), Operator: types.GREATER_THAN_EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypePercentage, Value: decimal.NewFromInt(10)}},
+	}
+	slabsAllNonGte := []types.BonusCreditsSlab{
+		{Threshold: decimal.NewFromInt(5000), Operator: types.GREATER_THAN, Bonus: types.BonusValue{Type: types.BonusValueTypeFlat, Value: decimal.NewFromInt(750)}},
+		{Threshold: decimal.NewFromInt(1000), Operator: types.EQUAL, Bonus: types.BonusValue{Type: types.BonusValueTypePercentage, Value: decimal.NewFromInt(10)}},
+	}
 
 	tests := []struct {
 		name    string
@@ -3070,6 +3078,8 @@ func TestFindBonusSlab(t *testing.T) {
 		{"empty slabs", []types.BonusCreditsSlab{}, decimal.NewFromInt(100), true, decimal.Decimal{}},
 		{"zero credits with catch-all", bonusSlabsForTest(), decimal.Zero, false, decimal.Zero},
 		{"zero credits without catch-all", slabsNoZeroCatchAll, decimal.Zero, true, decimal.Decimal{}},
+		{"skips non-gte highest, matches next gte", slabsWithNonGteHighest, decimal.NewFromInt(10000), false, decimal.NewFromInt(1000)},
+		{"all non-gte slabs skipped", slabsAllNonGte, decimal.NewFromInt(10000), true, decimal.Decimal{}},
 	}
 
 	for _, tt := range tests {

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -376,6 +376,11 @@ func (r *walletRepository) CreateTransaction(ctx context.Context, tx *walletdoma
 		tx.EnvironmentID = types.GetEnvironmentID(ctx)
 	}
 
+	var parentTransactionID *string
+	if tx.ParentTransactionID != "" {
+		parentTransactionID = &tx.ParentTransactionID
+	}
+
 	transaction, err := client.WalletTransaction.Create().
 		SetID(tx.ID).
 		SetTenantID(tx.TenantID).
@@ -405,6 +410,7 @@ func (r *walletRepository) CreateTransaction(ctx context.Context, tx *walletdoma
 		SetEnvironmentID(tx.EnvironmentID).
 		SetIdempotencyKey(tx.IdempotencyKey).
 		SetNillablePriority(tx.Priority).
+		SetNillableParentTransactionID(parentTransactionID).
 		Save(ctx)
 
 	if err != nil {
@@ -534,6 +540,47 @@ func (r *walletRepository) GetTransactionByIdempotencyKey(ctx context.Context, i
 			WithHint("Failed to retrieve transaction by idempotency key").
 			WithReportableDetails(map[string]interface{}{
 				"idempotency_key": idempotencyKey,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+
+	return walletdomain.TransactionFromEnt(t), nil
+}
+
+// GetPendingTransactionByParent returns the pending bonus transaction whose
+// parent_transaction_id is parentTransactionID, if one exists.
+func (r *walletRepository) GetPendingTransactionByParent(ctx context.Context, parentTransactionID string) (*walletdomain.Transaction, error) {
+	// Start a span for this repository operation
+	span := StartRepositorySpan(ctx, "wallet", "get_pending_transaction_by_parent", map[string]interface{}{
+		"parent_transaction_id": parentTransactionID,
+	})
+	defer FinishSpan(span)
+
+	client := r.client.Reader(ctx)
+	t, err := client.WalletTransaction.Query().
+		Where(
+			wallettransaction.ParentTransactionID(parentTransactionID),
+			wallettransaction.TransactionStatusEQ(types.TransactionStatusPending),
+			wallettransaction.TenantID(types.GetTenantID(ctx)),
+			wallettransaction.StatusEQ(string(types.StatusPublished)),
+			wallettransaction.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
+		Only(ctx)
+
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, ierr.WithError(err).
+				WithHint("Pending bonus transaction not found").
+				WithReportableDetails(map[string]interface{}{
+					"parent_transaction_id": parentTransactionID,
+				}).
+				Mark(ierr.ErrNotFound)
+		}
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to retrieve pending bonus transaction").
+			WithReportableDetails(map[string]interface{}{
+				"parent_transaction_id": parentTransactionID,
 			}).
 			Mark(ierr.ErrDatabase)
 	}

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -568,6 +568,7 @@ func (r *walletRepository) GetPendingTransactionByParent(ctx context.Context, pa
 		Only(ctx)
 
 	if err != nil {
+		SetSpanError(span, err)
 		if ent.IsNotFound(err) {
 			return nil, ierr.WithError(err).
 				WithHint("Pending bonus transaction not found").
@@ -576,7 +577,6 @@ func (r *walletRepository) GetPendingTransactionByParent(ctx context.Context, pa
 				}).
 				Mark(ierr.ErrNotFound)
 		}
-		SetSpanError(span, err)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to retrieve pending bonus transaction").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/testutil/inmemory_wallet_store.go
+++ b/internal/testutil/inmemory_wallet_store.go
@@ -456,6 +456,40 @@ func (s *InMemoryWalletStore) GetTransactionByIdempotencyKey(ctx context.Context
 	return transactions[0], nil
 }
 
+func (s *InMemoryWalletStore) GetPendingTransactionByParent(ctx context.Context, parentTransactionID string) (*wallet.Transaction, error) {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	filterFn := func(ctx context.Context, tx *wallet.Transaction, _ interface{}) bool {
+		return tx.ParentTransactionID == parentTransactionID &&
+			tx.TxStatus == types.TransactionStatusPending &&
+			tx.TenantID == tenantID &&
+			tx.EnvironmentID == environmentID &&
+			tx.Status == types.StatusPublished
+	}
+
+	transactions, err := s.transactions.List(ctx, nil, filterFn, nil)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to retrieve pending bonus transaction").
+			WithReportableDetails(map[string]interface{}{
+				"parent_transaction_id": parentTransactionID,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+
+	if len(transactions) == 0 {
+		return nil, ierr.NewError("pending bonus transaction not found").
+			WithHint("Pending bonus transaction not found").
+			WithReportableDetails(map[string]interface{}{
+				"parent_transaction_id": parentTransactionID,
+			}).
+			Mark(ierr.ErrNotFound)
+	}
+
+	return transactions[0], nil
+}
+
 func (s *InMemoryWalletStore) ListWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*wallet.Transaction, error) {
 	transactions, err := s.transactions.List(ctx, f, transactionFilterFn, transactionSortFn)
 	if err != nil {

--- a/internal/types/search_filter.go
+++ b/internal/types/search_filter.go
@@ -40,8 +40,9 @@ const (
 	// ENDS_WITH    FilterOperatorType = "ENDS_WITH"
 
 	// number
-	GREATER_THAN FilterOperatorType = "gt"
-	LESS_THAN    FilterOperatorType = "lt"
+	GREATER_THAN       FilterOperatorType = "gt"
+	LESS_THAN          FilterOperatorType = "lt"
+	GREATER_THAN_EQUAL FilterOperatorType = "gte"
 
 	// array
 	IN     FilterOperatorType = "in"

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -414,11 +414,27 @@ func (c BonusCreditsTopupConfig) Validate() error {
 				}).
 				Mark(ierr.ErrValidation)
 		}
+		if slab.Threshold.LessThan(decimal.Zero) {
+			return ierr.NewError("bonus_credits_topup_config: slab threshold cannot be negative").
+				WithHint("Threshold must be zero or positive").
+				WithReportableDetails(map[string]any{
+					"threshold": slab.Threshold,
+				}).
+				Mark(ierr.ErrValidation)
+		}
 		if slab.Bonus.Type != BonusValueTypeFlat && slab.Bonus.Type != BonusValueTypePercentage {
 			return ierr.NewErrorf("bonus_credits_topup_config: bonus type must be %s or %s", BonusValueTypeFlat, BonusValueTypePercentage).
 				WithHint("Only flat or percentage bonus types are supported").
 				WithReportableDetails(map[string]any{
 					"bonus_type": slab.Bonus.Type,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		if slab.Bonus.Value.LessThan(decimal.Zero) {
+			return ierr.NewError("bonus_credits_topup_config: bonus value cannot be negative").
+				WithHint("Bonus value must be zero or positive").
+				WithReportableDetails(map[string]any{
+					"bonus_value": slab.Bonus.Value,
 				}).
 				Mark(ierr.ErrValidation)
 		}

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -29,6 +29,7 @@ const (
 	SettingKeyCustomAnalytics          SettingKey = "custom_analytics_config"
 	SettingKeyCustomerPortalConfig     SettingKey = "customer_portal_config"
 	SettingKeyEventIngestionFilter     SettingKey = "event_ingestion_filter"
+	SettingKeyBonusCreditsTopupConfig  SettingKey = "bonus_credits_topup_config"
 )
 
 func (s *SettingKey) Validate() error {
@@ -44,6 +45,7 @@ func (s *SettingKey) Validate() error {
 		SettingKeyCustomAnalytics,
 		SettingKeyCustomerPortalConfig,
 		SettingKeyEventIngestionFilter,
+		SettingKeyBonusCreditsTopupConfig,
 	}
 
 	if !lo.Contains(allowedKeys, *s) {
@@ -358,6 +360,81 @@ func (c EventIngestionFilterConfig) Validate() error {
 	return validator.ValidateRequest(c)
 }
 
+// BonusValueType controls whether a slab's bonus is a fixed credit amount or a percentage of
+// the credits being purchased.
+type BonusValueType string
+
+const (
+	BonusValueTypeFlat       BonusValueType = "flat"
+	BonusValueTypePercentage BonusValueType = "percentage"
+)
+
+// BonusValue is the bonus a matched slab grants.
+type BonusValue struct {
+	Type  BonusValueType  `json:"type" validate:"required"`
+	Value decimal.Decimal `json:"value" validate:"required"`
+}
+
+// BonusCreditsSlab: if credits_to_add <Operator> Threshold, grant Bonus. Slabs are evaluated in
+// list order and the FIRST match wins, so they must be stored sorted DESCENDING by Threshold —
+// the highest bracket a purchase clears is the one that applies.
+//
+// Operator reuses the existing FilterOperatorType instead of minting a new type. Only
+// GREATER_THAN_EQUAL is accepted for now, enforced in BonusCreditsTopupConfig.Validate against
+// the actual constant (not a duplicated string literal in a struct tag).
+type BonusCreditsSlab struct {
+	Threshold decimal.Decimal    `json:"threshold" validate:"required"`
+	Operator  FilterOperatorType `json:"operator" validate:"required"`
+	Bonus     BonusValue         `json:"bonus" validate:"required"`
+}
+
+// BonusCreditsTopupConfig defines slab-based bonus-credit rules applied to a purchased wallet top-up.
+type BonusCreditsTopupConfig struct {
+	Enabled bool               `json:"enabled"`
+	Slabs   []BonusCreditsSlab `json:"slabs" validate:"omitempty,dive"`
+}
+
+// Validate implements SettingConfig interface.
+// Mirrors EventIngestionFilterConfig: enabled=true with no slabs would silently grant zero bonus on
+// every purchase, which is almost certainly a misconfiguration. Also rejects slabs not sorted
+// strictly descending by threshold, since findBonusSlab depends on it, and rejects any operator
+// other than GREATER_THAN_EQUAL (the only one findBonusSlab knows how to evaluate).
+func (c BonusCreditsTopupConfig) Validate() error {
+	if c.Enabled && len(c.Slabs) == 0 {
+		return ierr.NewError("bonus_credits_topup_config: enabled is true but slabs is empty").
+			WithHint("Add at least one slab, or set enabled=false").
+			Mark(ierr.ErrValidation)
+	}
+	for i, slab := range c.Slabs {
+		if slab.Operator != GREATER_THAN_EQUAL {
+			return ierr.NewErrorf("bonus_credits_topup_config: slab operator must be %s", GREATER_THAN_EQUAL).
+				WithHint("Only the gte operator is supported for bonus credit slabs").
+				WithReportableDetails(map[string]any{
+					"operator": slab.Operator,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		if slab.Bonus.Type != BonusValueTypeFlat && slab.Bonus.Type != BonusValueTypePercentage {
+			return ierr.NewErrorf("bonus_credits_topup_config: bonus type must be %s or %s", BonusValueTypeFlat, BonusValueTypePercentage).
+				WithHint("Only flat or percentage bonus types are supported").
+				WithReportableDetails(map[string]any{
+					"bonus_type": slab.Bonus.Type,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		if i > 0 && !c.Slabs[i-1].Threshold.GreaterThan(slab.Threshold) {
+			return ierr.NewError("bonus_credits_topup_config: slabs must be sorted descending by threshold").
+				WithHint("Slabs must be sorted in strictly descending order by threshold, the highest bracket first").
+				WithReportableDetails(map[string]any{
+					"index":     i,
+					"threshold": slab.Threshold,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+	return validator.ValidateRequest(c)
+}
+
 // GetDefaultSettings returns the default settings configuration for all setting keys
 // Uses typed structs and converts them to maps using ToMap utility from conversion.go
 func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
@@ -513,6 +590,15 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 		return nil, err
 	}
 
+	defaultBonusCreditsTopupConfig := BonusCreditsTopupConfig{
+		Enabled: false,
+		Slabs:   []BonusCreditsSlab{},
+	}
+	defaultBonusCreditsTopupConfigMap, err := utils.ToMap(defaultBonusCreditsTopupConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[SettingKey]DefaultSettingValue{
 		SettingKeyInvoiceConfig: {
 			Key:          SettingKeyInvoiceConfig,
@@ -565,6 +651,11 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			Key:          SettingKeyEventIngestionFilter,
 			DefaultValue: defaultEventIngestionFilterConfigMap,
 			Description:  "Controls which external customer IDs are forwarded from raw events to the events pipeline (pilot allowlist)",
+		},
+		SettingKeyBonusCreditsTopupConfig: {
+			Key:          SettingKeyBonusCreditsTopupConfig,
+			DefaultValue: defaultBonusCreditsTopupConfigMap,
+			Description:  "Slab-based bonus credit rules applied automatically to purchased wallet top-ups",
 		},
 	}, nil
 }
@@ -667,6 +758,13 @@ func ValidateSettingValue(key SettingKey, value map[string]interface{}) error {
 
 	case SettingKeyEventIngestionFilter:
 		config, err := utils.ToStruct[EventIngestionFilterConfig](value)
+		if err != nil {
+			return err
+		}
+		return config.Validate()
+
+	case SettingKeyBonusCreditsTopupConfig:
+		config, err := utils.ToStruct[BonusCreditsTopupConfig](value)
 		if err != nil {
 			return err
 		}

--- a/internal/types/wallet.go
+++ b/internal/types/wallet.go
@@ -68,6 +68,7 @@ const (
 	TransactionReasonManualBalanceDebit      TransactionReason = "MANUAL_BALANCE_DEBIT"
 	TransactionReasonCreditAdjustment        TransactionReason = "CREDIT_ADJUSTMENT"
 	TransactionReasonInvoiceVoidRefund       TransactionReason = "INVOICE_VOID_REFUND"
+	TransactionReasonPurchasedCreditBonus    TransactionReason = "PURCHASED_CREDIT_BONUS"
 )
 
 func (t TransactionReason) Validate() error {
@@ -87,6 +88,7 @@ func (t TransactionReason) Validate() error {
 		string(TransactionReasonManualBalanceDebit),
 		string(TransactionReasonCreditAdjustment),
 		string(TransactionReasonInvoiceVoidRefund),
+		string(TransactionReasonPurchasedCreditBonus),
 	}
 	if !lo.Contains(allowedValues, string(t)) {
 		return ierr.NewError("invalid transaction reason").


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added slab-based bonus credits for wallet top-ups, including tenant-configured automatic resolution and an optional `bonus_credits_to_add` override.
  * Introduced linked bonus wallet transactions via a new `parent_transaction_id`, with added support for filtering and ordering by this field.
* **Bug Fixes**
  * Improved purchased-credit bonus flows to correctly create and complete linked bonus transactions for both invoiced and direct cases, including pending/completed behavior and atomic updates.
  * Prevents bonus transaction creation when the computed bonus is zero and supports safe, idempotent retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->