### PR TITLE
fix(subscription-schedule): scope Get/Update/Delete to tenant + environment

### DIFF
--- a/internal/repository/ent/subscription_schedule.go
+++ b/internal/repository/ent/subscription_schedule.go
@@ -99,7 +99,11 @@ func (r *subscriptionScheduleRepository) Get(ctx context.Context, id string) (*d
 
 	entity, err := client.SubscriptionSchedule.
 		Query().
-		Where(subscriptionschedule.IDEQ(id)).
+		Where(
+			subscriptionschedule.IDEQ(id),
+			subscriptionschedule.TenantID(types.GetTenantID(ctx)),
+			subscriptionschedule.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		Only(ctx)
 
 	if err != nil {
@@ -133,7 +137,12 @@ func (r *subscriptionScheduleRepository) Update(ctx context.Context, schedule *d
 	}
 
 	builder := client.SubscriptionSchedule.
-		UpdateOneID(schedule.ID).
+		Update().
+		Where(
+			subscriptionschedule.IDEQ(schedule.ID),
+			subscriptionschedule.TenantID(types.GetTenantID(ctx)),
+			subscriptionschedule.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		SetScheduleType(schedule.ScheduleType).
 		SetScheduledAt(schedule.ScheduledAt).
 		SetStatus(string(schedule.Status)).
@@ -172,13 +181,14 @@ func (r *subscriptionScheduleRepository) Update(ctx context.Context, schedule *d
 		builder.SetMetadata(schedule.Metadata)
 	}
 
-	_, err := builder.Save(ctx)
+	affected, err := builder.Save(ctx)
 	if err != nil {
 		SetSpanError(span, err)
-		if ent.IsNotFound(err) {
-			return fmt.Errorf("subscription schedule not found: %w", err)
-		}
 		return fmt.Errorf("failed to update subscription schedule: %w", err)
+	}
+	if affected == 0 {
+		SetSpanError(span, fmt.Errorf("not found"))
+		return fmt.Errorf("subscription schedule not found")
 	}
 
 	SetSpanSuccess(span)
@@ -196,17 +206,23 @@ func (r *subscriptionScheduleRepository) Delete(ctx context.Context, id string) 
 	defer FinishSpan(span)
 
 	// Soft delete by updating status to cancelled
-	err := client.SubscriptionSchedule.
-		UpdateOneID(id).
+	affected, err := client.SubscriptionSchedule.
+		Update().
+		Where(
+			subscriptionschedule.IDEQ(id),
+			subscriptionschedule.TenantID(types.GetTenantID(ctx)),
+			subscriptionschedule.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		SetStatus(string(types.ScheduleStatusCancelled)).
-		Exec(ctx)
+		Save(ctx)
 
 	if err != nil {
 		SetSpanError(span, err)
-		if ent.IsNotFound(err) {
-			return fmt.Errorf("subscription schedule not found: %w", err)
-		}
 		return fmt.Errorf("failed to delete subscription schedule: %w", err)
+	}
+	if affected == 0 {
+		SetSpanError(span, fmt.Errorf("not found"))
+		return fmt.Errorf("subscription schedule not found")
 	}
 
 	SetSpanSuccess(span)

--- a/internal/repository/ent/subscription_schedule.go
+++ b/internal/repository/ent/subscription_schedule.go
@@ -241,7 +241,11 @@ func (r *subscriptionScheduleRepository) GetBySubscriptionID(ctx context.Context
 
 	entities, err := client.SubscriptionSchedule.
 		Query().
-		Where(subscriptionschedule.SubscriptionIDEQ(subscriptionID)).
+		Where(
+			subscriptionschedule.SubscriptionIDEQ(subscriptionID),
+			subscriptionschedule.TenantID(types.GetTenantID(ctx)),
+			subscriptionschedule.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		Order(ent.Desc(subscriptionschedule.FieldCreatedAt)).
 		All(ctx)
 
@@ -275,6 +279,8 @@ func (r *subscriptionScheduleRepository) GetPendingBySubscriptionAndType(
 			subscriptionschedule.SubscriptionIDEQ(subscriptionID),
 			subscriptionschedule.ScheduleTypeEQ(scheduleType),
 			subscriptionschedule.StatusEQ(string(types.ScheduleStatusPending)),
+			subscriptionschedule.TenantID(types.GetTenantID(ctx)),
+			subscriptionschedule.EnvironmentID(types.GetEnvironmentID(ctx)),
 		).
 		Only(ctx)
 
@@ -304,7 +310,7 @@ func (r *subscriptionScheduleRepository) List(ctx context.Context, filter *types
 	query := client.SubscriptionSchedule.Query()
 
 	// Apply filters
-	query = r.applyFilters(query, filter)
+	query = r.applyFilters(ctx, query, filter)
 
 	// Apply pagination
 	if filter.QueryFilter != nil {
@@ -339,7 +345,7 @@ func (r *subscriptionScheduleRepository) Count(ctx context.Context, filter *type
 	query := client.SubscriptionSchedule.Query()
 
 	// Apply filters
-	query = r.applyFilters(query, filter)
+	query = r.applyFilters(ctx, query, filter)
 
 	count, err := query.Count(ctx)
 	if err != nil {
@@ -353,9 +359,15 @@ func (r *subscriptionScheduleRepository) Count(ctx context.Context, filter *type
 
 // applyFilters applies filter conditions to the query
 func (r *subscriptionScheduleRepository) applyFilters(
+	ctx context.Context,
 	query *ent.SubscriptionScheduleQuery,
 	filter *types.SubscriptionScheduleFilter,
 ) *ent.SubscriptionScheduleQuery {
+	query = query.Where(
+		subscriptionschedule.TenantID(types.GetTenantID(ctx)),
+		subscriptionschedule.EnvironmentID(types.GetEnvironmentID(ctx)),
+	)
+
 	if filter == nil {
 		return query
 	}


### PR DESCRIPTION
## Summary
- `subscriptionScheduleRepository.Get/Update/Delete` queried by ID alone, with no `tenant_id`/`environment_id` predicate — any authenticated user of any tenant could read or cancel another tenant's subscription schedule if they knew/guessed the ID.
- Scopes all three to `TenantID` + `EnvironmentID`, mirroring the existing pattern in `subscription.go` / `customer.go`.
- `Update`/`Delete` switched from `UpdateOneID` to `Update().Where(...)` since a filtered predicate requires the bulk-update builder; not-found is now detected via affected-row count instead of `ent.IsNotFound`.

Fixes GHSA-wwp6-359h-qmg9.

## Test plan
- [x] `go build ./internal/repository/ent/...`
- [x] `go vet ./internal/repository/ent/...`
- [ ] Integration test / manual repro against a two-tenant local deployment (not run in this session — recommend before merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription schedule isolation across tenants and environments.
  * Prevented updates, deletions, and lookups from affecting schedules outside the active tenant and environment.
  * Improved handling when a requested subscription schedule cannot be found.
  * Ensured list and count results consistently respect tenant, environment, and filter criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->