### PR TITLE
fix(tenant): reject cross-tenant reads on GET /v1/tenants/{id}

### DIFF
--- a/internal/api/v1/tenant.go
+++ b/internal/api/v1/tenant.go
@@ -41,6 +41,13 @@ func NewTenantHandler(
 func (h *TenantHandler) GetTenantByID(c *gin.Context) {
 	id := c.Param("id")
 
+	if id != types.GetTenantID(c.Request.Context()) {
+		c.Error(ierr.NewError("cannot access another tenant's details").
+			WithHint("You can only access your own tenant's details").
+			Mark(ierr.ErrPermissionDenied))
+		return
+	}
+
 	resp, err := h.service.GetTenantByID(c.Request.Context(), id)
 	if err != nil {
 		c.Error(err)

--- a/internal/ee/service/raw_event_consumption_test.go
+++ b/internal/ee/service/raw_event_consumption_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -194,7 +195,7 @@ func (s *RawEventConsumptionSuite) TestProcessMessage_FilterBehavior() {
 				Data:          data,
 			}
 
-			err := s.svc.processMessage(buildBatchMsg(batch))
+			err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 
 			if tc.wantErr {
 				s.Error(err)
@@ -233,7 +234,7 @@ func (s *RawEventConsumptionSuite) TestInvalidBentoEvent_SkippedBeforeFilterChec
 		},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
+	err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 	s.NoError(err)
 	s.Equal([]string{"org_001"}, s.publishedExternalIDs())
 }
@@ -242,7 +243,7 @@ func (s *RawEventConsumptionSuite) TestInvalidBentoEvent_SkippedBeforeFilterChec
 // returns an immediate non-retriable error (no retries would help).
 func (s *RawEventConsumptionSuite) TestMalformedBatchPayload_ReturnsNonRetriableError() {
 	msg := message.NewMessage("test-uuid", []byte("not-json"))
-	err := s.svc.processMessage(msg)
+	err := s.svc.processMessage(context.Background(), msg)
 	s.Error(err)
 	s.Contains(err.Error(), "non-retriable unmarshal error")
 }
@@ -272,7 +273,7 @@ func (s *RawEventConsumptionSuite) TestSettingsRepoError_FailsBatchForRetry() {
 		Data:          []json.RawMessage{json.RawMessage(validBentoPayload("org_001", "evt_001"))},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
+	err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 	s.Error(err, "corrupt setting value should fail the batch for retry")
 	s.Equal(0, len(s.outputPubSub.GetMessages(testOutputTopic)),
 		"no events should be forwarded when filter config is unreadable")
@@ -293,7 +294,7 @@ func (s *RawEventConsumptionSuite) TestTenantFallbackFromConfig() {
 		},
 	}
 
-	err := s.svc.processMessage(buildBatchMsg(batch))
+	err := s.svc.processMessage(context.Background(), buildBatchMsg(batch))
 	s.NoError(err)
 	s.Equal([]string{"org_001"}, s.publishedExternalIDs())
 }

--- a/internal/integration/events/handler_test.go
+++ b/internal/integration/events/handler_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -32,7 +33,7 @@ func TestProcessMessage_IgnoresUnknownEvent(t *testing.T) {
 	b, _ := json.Marshal(ev)
 	msg := message.NewMessage("msg-1", b)
 
-	if err := h.processMessage(msg); err != nil {
+	if err := h.processMessage(context.Background(), msg); err != nil {
 		t.Fatalf("expected nil error for unknown event, got %v", err)
 	}
 }
@@ -58,7 +59,7 @@ func TestProcessMessage_CustomerCreatedDispatchError(t *testing.T) {
 	b, _ := json.Marshal(ev)
 	msg := message.NewMessage("msg-2", b)
 
-	if err := h.processMessage(msg); err == nil {
+	if err := h.processMessage(context.Background(), msg); err == nil {
 		t.Fatalf("expected error when temporal service is unavailable")
 	}
 }


### PR DESCRIPTION
## Summary
- `TenantHandler.GetTenantByID` forwarded the `id` path param straight to `TenantService.GetTenantByID` with no check that it matched the caller's own tenant context — any authenticated caller of any tenant could read another tenant's name, billing details, status, and metadata by supplying its ID.
- Added a check that rejects the request with 403 (`ierr.ErrPermissionDenied`) when the requested `id` doesn't match `types.GetTenantID(ctx)`.
- Fix is handler-level rather than repo-level: `tenantRepository.GetByID` is also used internally (e.g. auth middleware resolving the caller's own tenant before request-scoped tenant context exists), so scoping the repo query itself would risk breaking those legitimate self-lookups.

Fixes GHSA-mf7c-j7p3-r434.

## Test plan
- [x] `go build ./internal/api/v1/...`
- [ ] Integration test / manual repro against a two-tenant local deployment (not run in this session — recommend before merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant data isolation by preventing access to tenant details belonging to another tenant.
  * Requests for unauthorized tenant details are now denied with a clear permission error.
* **Tests**
  * Updated event and raw event consumption tests to pass explicit context objects, aligning with the latest handler processing signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->