### PR TITLE
fix(subscription): defer resource termination to cancellation effective date

### DIFF
--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -905,6 +905,10 @@ func (s *creditGrantService) processScheduledApplication(
 		// Cancel every application scheduled after this one — the grant's EndDate isn't
 		// necessarily set at this point (this path runs during scheduled processing, not
 		// deletion), so use the current application's scheduled date as the cutoff instead.
+		// cga.ScheduledFor is a safe cutoff here because at most one Pending/Failed
+		// application is ever open per grant at a time — if that invariant changes (e.g. we
+		// start pre-generating multiple future scheduled applications instead of one at a
+		// time), this cutoff must be revisited.
 		err := s.cancelFutureGrantApplications(ctx, creditGrant.CreditGrant, cga.ScheduledFor)
 		if err != nil {
 			s.Logger.Error(ctx, "Failed to cancel future credit grant applications", "application_id", cga.ID, "error", err)

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -1206,11 +1206,12 @@ func (s *creditGrantService) cancelFutureGrantApplications(ctx context.Context, 
 		return err
 	}
 
-	// Cancel each application
+	// Cancel each application. Propagate failures so the caller's transaction rolls back —
+	// letting one fail silently would let grant.EndDate commit while a post-cutoff application
+	// stays pending and later grants credits the cancellation was supposed to prevent.
 	for _, app := range applications {
 		if err := s.cancelCreditGrantApplication(ctx, app); err != nil {
-			// Log error already done in helper, continue processing remaining applications
-			continue
+			return err
 		}
 	}
 

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -411,16 +411,20 @@ func (s *creditGrantService) DeleteCreditGrant(ctx context.Context, req dto.Dele
 
 	// For subscription-scoped grants, cancel future CGAs and set end date (do not delete or archive)
 	if err := s.DB.WithTx(ctx, func(ctx context.Context) error {
-		// Cancel all future applications for this specific grant
-		if err := s.cancelFutureGrantApplications(ctx, grant); err != nil {
-			return err
-		}
-
-		// Set end date to effective date or now
+		// Determine the effective date before mutating grant.EndDate, and use it explicitly as
+		// the cutoff for cancelling future applications. Previously cancelFutureGrantApplications
+		// read grant.EndDate directly, but that field wasn't assigned until after the call, so the
+		// cutoff was always nil and every pending/failed application got cancelled regardless of
+		// whether it was scheduled before or after the actual effective date.
 		endDate := time.Now().UTC()
 		if req.EffectiveDate != nil && !req.EffectiveDate.IsZero() {
 			endDate = lo.FromPtr(req.EffectiveDate)
 		}
+
+		if err := s.cancelFutureGrantApplications(ctx, grant, endDate); err != nil {
+			return err
+		}
+
 		grant.EndDate = &endDate
 		_, err = s.CreditGrantRepo.Update(ctx, grant)
 		if err != nil {
@@ -898,7 +902,10 @@ func (s *creditGrantService) processScheduledApplication(
 		if err := s.cancelCreditGrantApplication(ctx, cga); err != nil {
 			return nil, err
 		}
-		err := s.cancelFutureGrantApplications(ctx, creditGrant.CreditGrant)
+		// Cancel every application scheduled after this one — the grant's EndDate isn't
+		// necessarily set at this point (this path runs during scheduled processing, not
+		// deletion), so use the current application's scheduled date as the cutoff instead.
+		err := s.cancelFutureGrantApplications(ctx, creditGrant.CreditGrant, cga.ScheduledFor)
 		if err != nil {
 			s.Logger.Error(ctx, "Failed to cancel future credit grant applications", "application_id", cga.ID, "error", err)
 			return nil, err
@@ -1172,8 +1179,8 @@ func (s *creditGrantService) cancelCreditGrantApplication(ctx context.Context, c
 	return nil
 }
 
-// cancelFutureGrantApplications cancels all future applications for a specific grant
-func (s *creditGrantService) cancelFutureGrantApplications(ctx context.Context, grant *creditgrant.CreditGrant) error {
+// cancelFutureGrantApplications cancels all applications scheduled after effectiveDate for a specific grant
+func (s *creditGrantService) cancelFutureGrantApplications(ctx context.Context, grant *creditgrant.CreditGrant, effectiveDate time.Time) error {
 	if grant.Scope != types.CreditGrantScopeSubscription || grant.SubscriptionID == nil {
 		return nil
 	}
@@ -1186,7 +1193,7 @@ func (s *creditGrantService) cancelFutureGrantApplications(ctx context.Context, 
 			types.ApplicationStatusPending,
 			types.ApplicationStatusFailed,
 		},
-		ScheduledAfter: grant.EndDate,
+		ScheduledAfter: &effectiveDate,
 		QueryFilter:    types.NewNoLimitQueryFilter(),
 	}
 

--- a/internal/ee/service/creditgrant_test.go
+++ b/internal/ee/service/creditgrant_test.go
@@ -864,6 +864,26 @@ func (s *CreditGrantServiceTestSuite) TestDeleteCreditGrant_OnlyCancelsApplicati
 	}
 	s.NoError(s.GetStores().CreditGrantApplicationRepo.Create(s.GetContext(), afterApp))
 
+	// Scheduled exactly at the cutoff — must stay pending. This pins the filter as strictly
+	// "after" (ScheduledForGT), not "at or after"; if that ever changed to >=, this app would be
+	// wrongly cancelled and only this boundary case would catch it.
+	atCutoffApp := &creditgrantapplication.CreditGrantApplication{
+		ID:                              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT_APPLICATION),
+		CreditGrantID:                   creditGrantResp.CreditGrant.ID,
+		SubscriptionID:                  s.testData.subscription.ID,
+		ScheduledFor:                    effectiveDate,
+		PeriodStart:                     effectiveDate,
+		ApplicationStatus:               types.ApplicationStatusPending,
+		ApplicationReason:               types.ApplicationReasonRecurringCreditGrant,
+		SubscriptionStatusAtApplication: s.testData.subscription.SubscriptionStatus,
+		Credits:                         decimal.NewFromInt(100),
+		Metadata:                        types.Metadata{},
+		IdempotencyKey:                  "at_effective_date",
+		EnvironmentID:                   types.GetEnvironmentID(s.GetContext()),
+		BaseModel:                       types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CreditGrantApplicationRepo.Create(s.GetContext(), atCutoffApp))
+
 	err = s.creditGrantService.DeleteCreditGrant(s.GetContext(), dto.DeleteCreditGrantRequest{
 		CreditGrantID: creditGrantResp.CreditGrant.ID,
 		EffectiveDate: &effectiveDate,
@@ -873,6 +893,10 @@ func (s *CreditGrantServiceTestSuite) TestDeleteCreditGrant_OnlyCancelsApplicati
 	gotBefore, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), beforeApp.ID)
 	s.NoError(err)
 	s.Equal(types.ApplicationStatusPending, gotBefore.ApplicationStatus, "application scheduled before the effective date must remain untouched")
+
+	gotAtCutoff, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), atCutoffApp.ID)
+	s.NoError(err)
+	s.Equal(types.ApplicationStatusPending, gotAtCutoff.ApplicationStatus, "application scheduled exactly at the effective date must remain untouched (strictly-after cutoff)")
 
 	gotAfter, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), afterApp.ID)
 	s.NoError(err)

--- a/internal/ee/service/creditgrant_test.go
+++ b/internal/ee/service/creditgrant_test.go
@@ -811,6 +811,74 @@ func (s *CreditGrantServiceTestSuite) TestDeleteCreditGrant() {
 	s.True(gotGrant.EndDate.Equal(s.testData.now) || (gotGrant.EndDate.After(s.testData.now.Add(-time.Second)) && gotGrant.EndDate.Before(s.testData.now.Add(time.Second))))
 }
 
+func (s *CreditGrantServiceTestSuite) TestDeleteCreditGrant_OnlyCancelsApplicationsAfterEffectiveDate() {
+	creditGrantReq := dto.CreateCreditGrantRequest{
+		Name:           "Ordering Bug Grant",
+		Scope:          types.CreditGrantScopeSubscription,
+		SubscriptionID: &s.testData.subscription.ID,
+		Credits:        decimal.NewFromInt(100),
+		Cadence:        types.CreditGrantCadenceRecurring,
+		Period:         lo.ToPtr(types.CREDIT_GRANT_PERIOD_MONTHLY),
+		PeriodCount:    lo.ToPtr(1),
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		Priority:       lo.ToPtr(1),
+		PlanID:         &s.testData.plan.ID,
+		StartDate:      &s.testData.now,
+	}
+	creditGrantResp, err := s.creditGrantService.CreateCreditGrant(s.GetContext(), creditGrantReq)
+	s.NoError(err)
+
+	effectiveDate := s.testData.now.Add(15 * 24 * time.Hour)
+
+	beforeApp := &creditgrantapplication.CreditGrantApplication{
+		ID:                              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT_APPLICATION),
+		CreditGrantID:                   creditGrantResp.CreditGrant.ID,
+		SubscriptionID:                  s.testData.subscription.ID,
+		ScheduledFor:                    effectiveDate.Add(-5 * 24 * time.Hour), // still within the active window
+		PeriodStart:                     effectiveDate.Add(-5 * 24 * time.Hour),
+		ApplicationStatus:               types.ApplicationStatusPending,
+		ApplicationReason:               types.ApplicationReasonRecurringCreditGrant,
+		SubscriptionStatusAtApplication: s.testData.subscription.SubscriptionStatus,
+		Credits:                         decimal.NewFromInt(100),
+		Metadata:                        types.Metadata{},
+		IdempotencyKey:                  "before_effective_date",
+		EnvironmentID:                   types.GetEnvironmentID(s.GetContext()),
+		BaseModel:                       types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CreditGrantApplicationRepo.Create(s.GetContext(), beforeApp))
+
+	afterApp := &creditgrantapplication.CreditGrantApplication{
+		ID:                              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT_APPLICATION),
+		CreditGrantID:                   creditGrantResp.CreditGrant.ID,
+		SubscriptionID:                  s.testData.subscription.ID,
+		ScheduledFor:                    effectiveDate.Add(5 * 24 * time.Hour), // after cancellation takes effect
+		PeriodStart:                     effectiveDate.Add(5 * 24 * time.Hour),
+		ApplicationStatus:               types.ApplicationStatusPending,
+		ApplicationReason:               types.ApplicationReasonRecurringCreditGrant,
+		SubscriptionStatusAtApplication: s.testData.subscription.SubscriptionStatus,
+		Credits:                         decimal.NewFromInt(100),
+		Metadata:                        types.Metadata{},
+		IdempotencyKey:                  "after_effective_date",
+		EnvironmentID:                   types.GetEnvironmentID(s.GetContext()),
+		BaseModel:                       types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CreditGrantApplicationRepo.Create(s.GetContext(), afterApp))
+
+	err = s.creditGrantService.DeleteCreditGrant(s.GetContext(), dto.DeleteCreditGrantRequest{
+		CreditGrantID: creditGrantResp.CreditGrant.ID,
+		EffectiveDate: &effectiveDate,
+	})
+	s.NoError(err)
+
+	gotBefore, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), beforeApp.ID)
+	s.NoError(err)
+	s.Equal(types.ApplicationStatusPending, gotBefore.ApplicationStatus, "application scheduled before the effective date must remain untouched")
+
+	gotAfter, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), afterApp.ID)
+	s.NoError(err)
+	s.Equal(types.ApplicationStatusCancelled, gotAfter.ApplicationStatus, "application scheduled after the effective date must be cancelled")
+}
+
 // Test Case 13: Test period start and end dates for weekly credit grant
 func (s *CreditGrantServiceTestSuite) TestWeeklyCreditGrantPeriodDates() {
 	// Create weekly recurring credit grant

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2058,15 +2058,15 @@ func (s *subscriptionService) CancelSubscription(
 			return err
 		}
 
-		// Step 7a: Cancel all addons on the subscription (mark associations cancelled, terminate addon line items)
-		if err := s.cancelAddonsForSubscription(ctx, subscription.ID, effectiveDate, req.Reason); err != nil {
-			return err
-		}
-
-		// Step 7b: Terminate plan and subscription-scoped line items (set EndDate = effectiveDate).
-		// Addon line items are already terminated by cancelAddonsForSubscription above.
-		if err := s.cancelAllLineItemsForSubscription(ctx, subscription.ID, effectiveDate); err != nil {
-			return err
+		// Step 7a/7b/8: Terminate addon associations, addon/plan line items, and credit grants.
+		// Only done here for immediate cancellations. For end_of_period/scheduled_date, this is
+		// deferred to the point where the cancellation actually fires (processSubscriptionPeriod's
+		// period-rollover loop) so that reverting a pending schedule never leaves these resources
+		// terminated while the subscription itself is active again.
+		if req.CancellationType == types.CancellationTypeImmediate {
+			if err := s.terminateSubscriptionResourcesAt(ctx, subscription.ID, effectiveDate, req.Reason); err != nil {
+				return err
+			}
 		}
 
 		// Step 7c: Handle scheduling for future cancellations (end_of_period and scheduled_date)
@@ -2081,17 +2081,6 @@ func (s *subscriptionService) CancelSubscription(
 			if err := s.createCancellationSchedule(ctx, subscription, req, effectiveDate, originalState); err != nil {
 				logger.Error(ctx, "failed to create cancellation schedule", "error", err)
 			}
-		}
-
-		// Step 8: Void future credit grants
-		// Step 8: Set credit grant end dates to effective cancellation date, then archive grants
-		creditGrantService := NewCreditGrantService(s.ServiceParams)
-		err = creditGrantService.CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
-			SubscriptionID: subscription.ID,
-			EffectiveDate:  &effectiveDate,
-		})
-		if err != nil {
-			return err
 		}
 
 		// Step 9: Top up wallet for proration credit (only if there's a credit amount)
@@ -4651,6 +4640,38 @@ func (s *subscriptionService) validateEntitlementCompatibility(ctx context.Conte
 				}).
 				Mark(ierr.ErrValidation)
 		}
+	}
+
+	return nil
+}
+
+// terminateSubscriptionResourcesAt terminates all line items, addon associations, and credit
+// grants tied to a subscription as of effectiveDate. Called either synchronously (immediate
+// cancellation, from CancelSubscription) or from processSubscriptionPeriod's period-rollover
+// loop when a previously-scheduled cancellation actually fires. Never called at scheduling
+// time for end_of_period/scheduled_date cancellations — that's the whole point: a pending
+// schedule can then be reverted via the Cancel Subscription Schedule API without leaving
+// these resources terminated while the subscription itself goes back to active.
+func (s *subscriptionService) terminateSubscriptionResourcesAt(
+	ctx context.Context,
+	subscriptionID string,
+	effectiveDate time.Time,
+	reason string,
+) error {
+	if err := s.cancelAddonsForSubscription(ctx, subscriptionID, effectiveDate, reason); err != nil {
+		return err
+	}
+
+	if err := s.cancelAllLineItemsForSubscription(ctx, subscriptionID, effectiveDate); err != nil {
+		return err
+	}
+
+	creditGrantService := NewCreditGrantService(s.ServiceParams)
+	if err := creditGrantService.CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
+		SubscriptionID: subscriptionID,
+		EffectiveDate:  &effectiveDate,
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3205,6 +3205,20 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 				"end_date", *sub.EndDate)
 		}
 
+		// Terminate line items, addon associations, and credit grants now that the previously
+		// scheduled cancellation has actually fired. Gated on CancelAtPeriodEnd+CancelAt, which is
+		// set only by CancelSubscription's end_of_period/scheduled_date path (see
+		// updateSubscriptionForCancellation) — this never fires for a bare EndDate set through some
+		// other path (e.g. the generic subscription-update endpoint), which never had termination
+		// deferred in the first place and must be left alone.
+		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled &&
+			sub.CancelAtPeriodEnd && sub.CancelAt != nil {
+			reason := sub.Metadata["cancellation_reason"]
+			if err := s.terminateSubscriptionResourcesAt(ctx, sub.ID, *sub.CancelAt, reason); err != nil {
+				return err
+			}
+		}
+
 		// Update the subscription
 		if err := s.SubRepo.Update(ctx, sub); err != nil {
 			return err

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2064,7 +2064,7 @@ func (s *subscriptionService) CancelSubscription(
 		// period-rollover loop) so that reverting a pending schedule never leaves these resources
 		// terminated while the subscription itself is active again.
 		if req.CancellationType == types.CancellationTypeImmediate {
-			if err := s.terminateSubscriptionResourcesAt(ctx, subscription.ID, effectiveDate, req.Reason); err != nil {
+			if err := s.TerminateSubscriptionResourcesAt(ctx, subscription.ID, effectiveDate, req.Reason); err != nil {
 				return err
 			}
 		}
@@ -3214,7 +3214,7 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled &&
 			sub.CancelAtPeriodEnd && sub.CancelAt != nil {
 			reason := sub.Metadata["cancellation_reason"]
-			if err := s.terminateSubscriptionResourcesAt(ctx, sub.ID, *sub.CancelAt, reason); err != nil {
+			if err := s.TerminateSubscriptionResourcesAt(ctx, sub.ID, *sub.CancelAt, reason); err != nil {
 				return err
 			}
 		}
@@ -4659,14 +4659,14 @@ func (s *subscriptionService) validateEntitlementCompatibility(ctx context.Conte
 	return nil
 }
 
-// terminateSubscriptionResourcesAt terminates all line items, addon associations, and credit
+// TerminateSubscriptionResourcesAt terminates all line items, addon associations, and credit
 // grants tied to a subscription as of effectiveDate. Called either synchronously (immediate
 // cancellation, from CancelSubscription) or from processSubscriptionPeriod's period-rollover
 // loop when a previously-scheduled cancellation actually fires. Never called at scheduling
 // time for end_of_period/scheduled_date cancellations — that's the whole point: a pending
 // schedule can then be reverted via the Cancel Subscription Schedule API without leaving
 // these resources terminated while the subscription itself goes back to active.
-func (s *subscriptionService) terminateSubscriptionResourcesAt(
+func (s *subscriptionService) TerminateSubscriptionResourcesAt(
 	ctx context.Context,
 	subscriptionID string,
 	effectiveDate time.Time,

--- a/internal/ee/service/subscription_schedule.go
+++ b/internal/ee/service/subscription_schedule.go
@@ -509,5 +509,19 @@ func (s *subscriptionScheduleService) restoreCancellationState(
 		"restored_cancel_at_period_end", sub.CancelAtPeriodEnd,
 	)
 
+	// Cascade the reverted state to any inherited (child) subscriptions. CancelSubscription
+	// unconditionally cascades cancellation fields to children at scheduling time
+	// (CascadeCancelToInheritedSubscriptions), so a revert must undo that too — otherwise
+	// children stay stuck with stale CancelAtPeriodEnd/CancelAt/CancelledAt/EndDate and get
+	// wrongly cancelled on their own later. Reuses the same cascade function, called with the
+	// now-reverted parent struct; it's a no-op for non-parent subscriptions.
+	subService, ok := NewSubscriptionService(s.ServiceParams).(*subscriptionService)
+	if !ok {
+		return fmt.Errorf("failed to obtain subscriptionService for cascade")
+	}
+	if err := subService.CascadeCancelToInheritedSubscriptions(ctx, sub); err != nil {
+		return fmt.Errorf("failed to cascade reverted state to inherited subscriptions: %w", err)
+	}
+
 	return nil
 }

--- a/internal/ee/service/subscription_schedule.go
+++ b/internal/ee/service/subscription_schedule.go
@@ -515,10 +515,7 @@ func (s *subscriptionScheduleService) restoreCancellationState(
 	// children stay stuck with stale CancelAtPeriodEnd/CancelAt/CancelledAt/EndDate and get
 	// wrongly cancelled on their own later. Reuses the same cascade function, called with the
 	// now-reverted parent struct; it's a no-op for non-parent subscriptions.
-	subService, ok := NewSubscriptionService(s.ServiceParams).(*subscriptionService)
-	if !ok {
-		return fmt.Errorf("failed to obtain subscriptionService for cascade")
-	}
+	subService := NewSubscriptionService(s.ServiceParams).(*subscriptionService)
 	if err := subService.CascadeCancelToInheritedSubscriptions(ctx, sub); err != nil {
 		return fmt.Errorf("failed to cascade reverted state to inherited subscriptions: %w", err)
 	}

--- a/internal/ee/service/subscription_schedule.go
+++ b/internal/ee/service/subscription_schedule.go
@@ -486,6 +486,12 @@ func (s *subscriptionScheduleService) restoreCancellationState(
 	sub.CancelAtPeriodEnd = config.OriginalCancelAtPeriodEnd
 	sub.CancelAt = config.OriginalCancelAt
 	sub.EndDate = config.OriginalEndDate
+	// A subscription can't already have a pending cancellation when a new one is scheduled
+	// (cancelAllPendingSchedules/CancelSubscription's own validation prevent that), so nil is
+	// always the correct prior value here. Without this, CancelledAt (set unconditionally by
+	// updateSubscriptionForCancellation at scheduling time) stays permanently non-nil after a
+	// revert, which later spuriously blocks executePlanChange's cancellation guard.
+	sub.CancelledAt = nil
 	// Restore CurrentPeriodEnd if it was shortened at scheduling time (scheduled_date with effectiveDate < period end).
 	// Nil-safe: old schedule records without this field are handled gracefully.
 	if config.OriginalCurrentPeriodEnd != nil {

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7900,3 +7900,60 @@ func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod_FiresScheduledC
 	s.Require().Len(schedules, 1)
 	s.Equal(types.ScheduleStatusExecuted, schedules[0].Status)
 }
+
+func (s *SubscriptionServiceSuite) TestCancelSchedule_RevertRestoresCancelledAtAndLeavesResourcesUntouched() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_revert_cancelled_at",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems:          []*subscription.SubscriptionLineItem{},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeEndOfPeriod,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_revert",
+	})
+	s.NoError(err)
+
+	scheduledSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.NoError(err)
+	s.True(scheduledSub.CancelAtPeriodEnd)
+	s.NotNil(scheduledSub.CancelAt)
+	s.NotNil(scheduledSub.CancelledAt)
+
+	changeService := NewSubscriptionChangeService(subService.ServiceParams)
+	scheduleService := NewSubscriptionScheduleService(subService.ServiceParams, changeService)
+	err = scheduleService.CancelBySubscriptionAndType(ctx, sub.ID, types.SubscriptionScheduleChangeTypeCancellation)
+	s.NoError(err)
+
+	revertedSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.NoError(err)
+	s.Equal(types.SubscriptionStatusActive, revertedSub.SubscriptionStatus)
+	s.False(revertedSub.CancelAtPeriodEnd)
+	s.Nil(revertedSub.CancelAt)
+	s.Nil(revertedSub.EndDate)
+	s.Nil(revertedSub.CancelledAt, "cancelled_at must be cleared on revert, otherwise it permanently blocks future plan-change schedules")
+
+	// Line items were never touched to begin with (fixed in Task 1), so there's
+	// nothing left to restore here — this just confirms they're still fine post-revert.
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{sub.ID}
+	lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+	for _, li := range lineItems {
+		s.True(li.EndDate.IsZero())
+	}
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7792,3 +7792,111 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_OnetimeAddon_En
 	s.Require().NotNil(associations[0].EndDate)
 	s.True(associations[0].EndDate.Equal(expectedEnd), "one-time addon association EndDate should be recomputed from activation start date")
 }
+
+func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod_FiresScheduledCancellationTermination() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_fire_scheduled_cancellation",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   s.testData.now.Add(24 * time.Hour),
+		BillingAnchor:      s.testData.now.Add(-24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems:          []*subscription.SubscriptionLineItem{},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	// Attach an addon so we can verify it gets terminated at fire time, not before.
+	addonID := "addon_fire_scheduled_cancellation"
+	priceID := "price_addon_fire_scheduled_cancellation"
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(subService.AddonRepo.Create(ctx, a))
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meters.apiCalls.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	addAddonNow := time.Now().UTC()
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:   addonID,
+		StartDate: &addAddonNow,
+	})
+	s.NoError(err)
+
+	// Schedule an end-of-period cancellation effective at CurrentPeriodEnd.
+	_, err = s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeEndOfPeriod,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_fire_scheduled_cancellation",
+	})
+	s.NoError(err)
+
+	scheduledSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.NoError(err)
+	s.True(scheduledSub.CancelAtPeriodEnd)
+	s.Require().NotNil(scheduledSub.CancelAt)
+
+	// Sanity check: still untouched immediately after scheduling.
+	aaFilter := types.NewNoLimitAddonAssociationFilter()
+	aaFilter.EntityIDs = []string{sub.ID}
+	aaFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	associationsBefore, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+	s.NoError(err)
+	s.Require().NotEmpty(associationsBefore)
+	s.Equal(types.AddonStatusActive, associationsBefore[0].AddonStatus)
+
+	// Drive period processing past the effective cancellation date.
+	processAt := scheduledSub.CancelAt.Add(time.Hour)
+	err = subService.processSubscriptionPeriod(ctx, scheduledSub, processAt)
+	s.NoError(err)
+
+	firedSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.NoError(err)
+	s.Equal(types.SubscriptionStatusCancelled, firedSub.SubscriptionStatus)
+
+	// Line items must now be terminated.
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{sub.ID}
+	lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+	s.NotEmpty(lineItems)
+	for _, li := range lineItems {
+		s.False(li.EndDate.IsZero(), "line item %s should be terminated once the cancellation has fired", li.ID)
+	}
+
+	// Addon association must now be cancelled.
+	associationsAfter, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+	s.NoError(err)
+	s.Require().NotEmpty(associationsAfter)
+	s.Equal(types.AddonStatusCancelled, associationsAfter[0].AddonStatus)
+	s.NotNil(associationsAfter[0].EndDate)
+
+	// The cancellation schedule must be marked executed.
+	schedules, err := s.GetStores().SubscriptionScheduleRepo.GetBySubscriptionID(ctx, sub.ID)
+	s.NoError(err)
+	s.Require().Len(schedules, 1)
+	s.Equal(types.ScheduleStatusExecuted, schedules[0].Status)
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -7957,3 +7957,81 @@ func (s *SubscriptionServiceSuite) TestCancelSchedule_RevertRestoresCancelledAtA
 		s.True(li.EndDate.IsZero())
 	}
 }
+
+func (s *SubscriptionServiceSuite) TestCancelSchedule_RevertCascadesToInheritedSubscriptions() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	parentSub := *s.testData.subscription
+	parentSub.SubscriptionType = types.SubscriptionTypeParent
+	s.NoError(s.GetStores().SubscriptionRepo.Update(ctx, &parentSub))
+
+	child := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: "ext_child_revert_cascade",
+		Name:       "Child Revert Cascade",
+		Email:      "child-revert-cascade@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, child))
+
+	inherited := &subscription.Subscription{
+		ID:                   types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		CustomerID:           child.ID,
+		PlanID:               parentSub.PlanID,
+		Currency:             parentSub.Currency,
+		SubscriptionStatus:   parentSub.SubscriptionStatus,
+		BillingAnchor:        parentSub.BillingAnchor,
+		BillingCycle:         parentSub.BillingCycle,
+		StartDate:            parentSub.StartDate,
+		CurrentPeriodStart:   parentSub.CurrentPeriodStart,
+		CurrentPeriodEnd:     parentSub.CurrentPeriodEnd,
+		BillingPeriod:        parentSub.BillingPeriod,
+		BillingPeriodCount:   parentSub.BillingPeriodCount,
+		Version:              1,
+		EnvironmentID:        parentSub.EnvironmentID,
+		ParentSubscriptionID: &parentSub.ID,
+		SubscriptionType:     types.SubscriptionTypeInherited,
+		BaseModel:            types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, inherited))
+
+	// Schedule a scheduled_date cancellation on the parent — this type sets EndDate
+	// immediately too, giving us a non-nil field to assert cascaded and reverted on the child.
+	effectiveDate := parentSub.CurrentPeriodStart.Add(15 * 24 * time.Hour)
+	_, err := s.service.CancelSubscription(ctx, parentSub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeScheduledDate,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_revert_cascade",
+		CancelAt:          &effectiveDate,
+	})
+	s.NoError(err)
+
+	// The cascade must have already propagated to the child at scheduling time.
+	scheduledChild, err := s.GetStores().SubscriptionRepo.Get(ctx, inherited.ID)
+	s.NoError(err)
+	s.True(scheduledChild.CancelAtPeriodEnd)
+	s.NotNil(scheduledChild.CancelAt)
+	s.NotNil(scheduledChild.CancelledAt)
+	s.NotNil(scheduledChild.EndDate)
+
+	// Revert the parent's schedule.
+	changeService := NewSubscriptionChangeService(subService.ServiceParams)
+	scheduleService := NewSubscriptionScheduleService(subService.ServiceParams, changeService)
+	err = scheduleService.CancelBySubscriptionAndType(ctx, parentSub.ID, types.SubscriptionScheduleChangeTypeCancellation)
+	s.NoError(err)
+
+	// The child must be reverted too, not just the parent.
+	revertedChild, err := s.GetStores().SubscriptionRepo.Get(ctx, inherited.ID)
+	s.NoError(err)
+	s.False(revertedChild.CancelAtPeriodEnd, "inherited subscription's CancelAtPeriodEnd should be cleared when the parent's schedule is reverted")
+	s.Nil(revertedChild.CancelAt, "inherited subscription's CancelAt should be cleared when the parent's schedule is reverted")
+	s.Nil(revertedChild.CancelledAt, "inherited subscription's CancelledAt should be cleared when the parent's schedule is reverted")
+	s.Nil(revertedChild.EndDate, "inherited subscription's EndDate should be cleared when the parent's schedule is reverted")
+
+	revertedParent, err := s.GetStores().SubscriptionRepo.Get(ctx, parentSub.ID)
+	s.NoError(err)
+	s.False(revertedParent.CancelAtPeriodEnd)
+	s.Nil(revertedParent.CancelAt)
+	s.Nil(revertedParent.CancelledAt)
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -4481,10 +4481,10 @@ func (s *SubscriptionServiceSuite) TestTerminateSubscriptionResourcesAt_Idempote
 
 	effectiveDate := s.testData.now.Add(3 * 24 * time.Hour)
 
-	s.NoError(subService.terminateSubscriptionResourcesAt(ctx, sub.ID, effectiveDate, "idempotency_test"))
+	s.NoError(subService.TerminateSubscriptionResourcesAt(ctx, sub.ID, effectiveDate, "idempotency_test"))
 	// Calling it again with the same effectiveDate must not error, even though every
 	// resource is already terminated (repo-level guards make this a no-op the second time).
-	s.NoError(subService.terminateSubscriptionResourcesAt(ctx, sub.ID, effectiveDate, "idempotency_test"))
+	s.NoError(subService.TerminateSubscriptionResourcesAt(ctx, sub.ID, effectiveDate, "idempotency_test"))
 
 	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
 	liFilter.SubscriptionIDs = []string{sub.ID}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -4466,7 +4466,7 @@ func (s *SubscriptionServiceSuite) TestTerminateSubscriptionResourcesAt_Idempote
 	s.NoError(err)
 
 	creditGrantService := NewCreditGrantService(subService.ServiceParams)
-	_, err = creditGrantService.CreateCreditGrant(ctx, dto.CreateCreditGrantRequest{
+	creditGrantResp, err := creditGrantService.CreateCreditGrant(ctx, dto.CreateCreditGrantRequest{
 		Name:           "Idempotency Test Grant",
 		Scope:          types.CreditGrantScopeSubscription,
 		SubscriptionID: &sub.ID,
@@ -4494,6 +4494,20 @@ func (s *SubscriptionServiceSuite) TestTerminateSubscriptionResourcesAt_Idempote
 		s.False(li.EndDate.IsZero())
 		s.True(li.EndDate.Equal(effectiveDate))
 	}
+
+	aaFilter := types.NewNoLimitAddonAssociationFilter()
+	aaFilter.EntityIDs = []string{sub.ID}
+	aaFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+	s.NoError(err)
+	s.Require().NotEmpty(associations)
+	s.Require().NotNil(associations[0].EndDate)
+	s.True(associations[0].EndDate.Equal(effectiveDate), "addon association EndDate must equal the exact effective date, not just be non-nil")
+
+	gotGrant, err := creditGrantService.GetCreditGrant(ctx, creditGrantResp.CreditGrant.ID)
+	s.NoError(err)
+	s.Require().NotNil(gotGrant.EndDate)
+	s.True(gotGrant.EndDate.Equal(effectiveDate), "credit grant EndDate must equal the exact effective date, not just be non-nil")
 }
 
 func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {
@@ -7877,7 +7891,7 @@ func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod_FiresScheduledC
 	s.NoError(err)
 	s.Equal(types.SubscriptionStatusCancelled, firedSub.SubscriptionStatus)
 
-	// Line items must now be terminated.
+	// Line items must now be terminated, at the exact effective date.
 	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
 	liFilter.SubscriptionIDs = []string{sub.ID}
 	lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
@@ -7885,14 +7899,16 @@ func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod_FiresScheduledC
 	s.NotEmpty(lineItems)
 	for _, li := range lineItems {
 		s.False(li.EndDate.IsZero(), "line item %s should be terminated once the cancellation has fired", li.ID)
+		s.True(li.EndDate.Equal(*scheduledSub.CancelAt), "line item %s EndDate should equal the exact effective date", li.ID)
 	}
 
-	// Addon association must now be cancelled.
+	// Addon association must now be cancelled, at the exact effective date.
 	associationsAfter, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
 	s.NoError(err)
 	s.Require().NotEmpty(associationsAfter)
 	s.Equal(types.AddonStatusCancelled, associationsAfter[0].AddonStatus)
-	s.NotNil(associationsAfter[0].EndDate)
+	s.Require().NotNil(associationsAfter[0].EndDate)
+	s.True(associationsAfter[0].EndDate.Equal(*scheduledSub.CancelAt), "addon association EndDate should equal the exact effective date")
 
 	// The cancellation schedule must be marked executed.
 	schedules, err := s.GetStores().SubscriptionScheduleRepo.GetBySubscriptionID(ctx, sub.ID)

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -284,6 +284,7 @@ func (s *SubscriptionServiceSuite) setupService() {
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
 		ConnectionRepo:             s.GetStores().ConnectionRepo,
 		SettingsRepo:               s.GetStores().SettingsRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
 		EventPublisher:             s.GetPublisher(),
 		WebhookPublisher:           s.GetWebhookPublisher(),
 		ProrationCalculator:        s.GetCalculator(),
@@ -4316,6 +4317,183 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 
 		s.T().Logf("✅ Backdated cancellation boundary rejection completed successfully")
 	})
+}
+
+func (s *SubscriptionServiceSuite) TestCancelSubscription_ScheduledDoesNotEagerlyTerminateResources() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_scheduled_defer_termination",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems:          []*subscription.SubscriptionLineItem{},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	// Attach an addon so we can verify its association/line item survive scheduling.
+	addonID := "addon_defer_termination"
+	priceID := "price_addon_defer_termination"
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Addon for defer test",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(subService.AddonRepo.Create(ctx, a))
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meters.apiCalls.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	addAddonNow := time.Now().UTC()
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:   addonID,
+		StartDate: &addAddonNow,
+	})
+	s.NoError(err)
+
+	// Attach a subscription-scoped credit grant so we can verify it survives scheduling too.
+	creditGrantService := NewCreditGrantService(subService.ServiceParams)
+	creditGrantResp, err := creditGrantService.CreateCreditGrant(ctx, dto.CreateCreditGrantRequest{
+		Name:           "Defer Termination Grant",
+		Scope:          types.CreditGrantScopeSubscription,
+		SubscriptionID: &sub.ID,
+		Credits:        decimal.NewFromInt(50),
+		Cadence:        types.CreditGrantCadenceOneTime,
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		Priority:       lo.ToPtr(1),
+		PlanID:         &s.testData.plan.ID,
+		StartDate:      &s.testData.now,
+	})
+	s.NoError(err)
+
+	// Schedule an end-of-period cancellation.
+	_, err = s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeEndOfPeriod,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_defer_termination",
+	})
+	s.NoError(err)
+
+	// Plan/subscription-scoped line items must remain untouched.
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{sub.ID}
+	lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+	s.NotEmpty(lineItems)
+	for _, li := range lineItems {
+		s.True(li.EndDate.IsZero(), "line item %s should not be terminated while cancellation is only scheduled", li.ID)
+	}
+
+	// Addon association must remain active.
+	aaFilter := types.NewNoLimitAddonAssociationFilter()
+	aaFilter.EntityIDs = []string{sub.ID}
+	aaFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+	s.NoError(err)
+	s.NotEmpty(associations)
+	for _, aa := range associations {
+		s.Equal(types.AddonStatusActive, aa.AddonStatus, "addon association should remain active while cancellation is only scheduled")
+		s.Nil(aa.EndDate)
+	}
+
+	// Credit grant must remain un-terminated.
+	gotGrant, err := creditGrantService.GetCreditGrant(ctx, creditGrantResp.CreditGrant.ID)
+	s.NoError(err)
+	s.Nil(gotGrant.EndDate, "credit grant should not be terminated while cancellation is only scheduled")
+}
+
+func (s *SubscriptionServiceSuite) TestTerminateSubscriptionResourcesAt_IdempotentOnRetry() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_terminate_idempotent",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems:          []*subscription.SubscriptionLineItem{},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	addonID := "addon_terminate_idempotent"
+	priceID := "price_addon_terminate_idempotent"
+	a := &addon.Addon{ID: addonID, LookupKey: addonID, Name: "Addon", BaseModel: types.GetDefaultBaseModel(ctx)}
+	s.NoError(subService.AddonRepo.Create(ctx, a))
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meters.apiCalls.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	addAddonNow := time.Now().UTC()
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{AddonID: addonID, StartDate: &addAddonNow})
+	s.NoError(err)
+
+	creditGrantService := NewCreditGrantService(subService.ServiceParams)
+	_, err = creditGrantService.CreateCreditGrant(ctx, dto.CreateCreditGrantRequest{
+		Name:           "Idempotency Test Grant",
+		Scope:          types.CreditGrantScopeSubscription,
+		SubscriptionID: &sub.ID,
+		Credits:        decimal.NewFromInt(25),
+		Cadence:        types.CreditGrantCadenceOneTime,
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		Priority:       lo.ToPtr(1),
+		PlanID:         &s.testData.plan.ID,
+		StartDate:      &s.testData.now,
+	})
+	s.NoError(err)
+
+	effectiveDate := s.testData.now.Add(3 * 24 * time.Hour)
+
+	s.NoError(subService.terminateSubscriptionResourcesAt(ctx, sub.ID, effectiveDate, "idempotency_test"))
+	// Calling it again with the same effectiveDate must not error, even though every
+	// resource is already terminated (repo-level guards make this a no-op the second time).
+	s.NoError(subService.terminateSubscriptionResourcesAt(ctx, sub.ID, effectiveDate, "idempotency_test"))
+
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{sub.ID}
+	lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+	for _, li := range lineItems {
+		s.False(li.EndDate.IsZero())
+		s.True(li.EndDate.Equal(effectiveDate))
+	}
 }
 
 func (s *SubscriptionServiceSuite) TestCancelSubscriptionScheduledDate() {

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -1001,6 +1001,9 @@ func (m *mockSubscriptionService) ExternalCustomerIDsForSubscription(ctx context
 }
 func (m *mockSubscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription) {
 }
+func (m *mockSubscriptionService) TerminateSubscriptionResourcesAt(ctx context.Context, subscriptionID string, effectiveDate time.Time, reason string) error {
+	return nil
+}
 
 // --- ProcessSubscriptionActivatedWebhook tests ---
 

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -171,6 +171,12 @@ type SubscriptionService interface {
 	// CascadeCancelToInheritedSubscriptions mirrors the parent's cancellation fields onto INHERITED child subscriptions (no-op if not a parent). Used by Temporal update-billing-period cancellation and aligned with CancelSubscription / cron processing.
 	CascadeCancelToInheritedSubscriptions(ctx context.Context, parentSub *subscription.Subscription) error
 
+	// TerminateSubscriptionResourcesAt terminates line items, addon associations, and credit
+	// grants for a subscription as of effectiveDate. Used by both processSubscriptionPeriod's
+	// period-rollover loop and the Temporal CheckCancellationActivity, so a previously scheduled
+	// cancellation's resources are terminated exactly once, at the point it actually fires.
+	TerminateSubscriptionResourcesAt(ctx context.Context, subscriptionID string, effectiveDate time.Time, reason string) error
+
 	// PublishCancellationEvents publishes a update and cancel webhook event for a subscription and its inherited subs.
 	// Used by Temporal activities and other callers that need to fire subscription lifecycle events.
 	PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription)

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -172,9 +172,10 @@ type SubscriptionService interface {
 	CascadeCancelToInheritedSubscriptions(ctx context.Context, parentSub *subscription.Subscription) error
 
 	// TerminateSubscriptionResourcesAt terminates line items, addon associations, and credit
-	// grants for a subscription as of effectiveDate. Used by both processSubscriptionPeriod's
-	// period-rollover loop and the Temporal CheckCancellationActivity, so a previously scheduled
-	// cancellation's resources are terminated exactly once, at the point it actually fires.
+	// grants for a subscription as of effectiveDate. Called eagerly by CancelSubscription for
+	// immediate cancellations, and by both processSubscriptionPeriod's period-rollover loop and
+	// the Temporal CheckCancellationActivity when a previously scheduled cancellation fires, so
+	// resources are terminated exactly once, at the point cancellation actually takes effect.
 	TerminateSubscriptionResourcesAt(ctx context.Context, subscriptionID string, effectiveDate time.Time, reason string) error
 
 	// PublishCancellationEvents publishes a update and cancel webhook event for a subscription and its inherited subs.

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -312,6 +312,19 @@ func (s *BillingActivities) CheckCancellationActivity(
 				return err
 			}
 
+			// Terminate line items, addon associations, and credit grants now that the
+			// previously scheduled cancellation has actually fired. Gated on
+			// CancelAtPeriodEnd+CancelAt (set only by CancelSubscription's end_of_period/
+			// scheduled_date path), matching processSubscriptionPeriod's equivalent hook in
+			// internal/ee/service/subscription.go — never fires for a bare EndDate set through
+			// some other path that never had termination deferred in the first place.
+			if sub.CancelAtPeriodEnd && sub.CancelAt != nil {
+				reason := sub.Metadata["cancellation_reason"]
+				if err := subscriptionService.TerminateSubscriptionResourcesAt(ctx, sub.ID, *sub.CancelAt, reason); err != nil {
+					return err
+				}
+			}
+
 			// Update the cancellation schedule status to executed
 			if err := subscriptionService.MarkCancellationScheduleAsExecuted(ctx, sub.ID); err != nil {
 				s.logger.Error(ctx, "failed to mark cancellation schedule as executed",

--- a/internal/temporal/activities/subscription/update_billing_period_activities_test.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities_test.go
@@ -1,0 +1,234 @@
+package subscription
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/addon"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/meter"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/ee/service"
+	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+type BillingActivitiesSuite struct {
+	testutil.BaseServiceTestSuite
+	activities *BillingActivities
+	testData   struct {
+		customer *customer.Customer
+		plan     *plan.Plan
+		meter    *meter.Meter
+		now      time.Time
+	}
+}
+
+func TestBillingActivities(t *testing.T) {
+	suite.Run(t, new(BillingActivitiesSuite))
+}
+
+func (s *BillingActivitiesSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.ClearStores()
+	s.setupTestData()
+}
+
+func (s *BillingActivitiesSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+	s.ClearStores()
+}
+
+func (s *BillingActivitiesSuite) setupTestData() {
+	ctx := s.GetContext()
+	s.testData.now = time.Now().UTC()
+
+	s.testData.customer = &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: "ext_billing_activities_test",
+		Name:       "Billing Activities Test Customer",
+		Email:      "billing-activities-test@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, s.testData.customer))
+
+	s.testData.plan = &plan.Plan{
+		ID:          types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:        "Billing Activities Test Plan",
+		Description: "Test plan",
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, s.testData.plan))
+
+	s.testData.meter = &meter.Meter{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_METER),
+		Name:      "API Calls",
+		EventName: "api_call_billing_activities",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationCount,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, s.testData.meter))
+
+	serviceParams := s.newServiceParams()
+	subscriptionService := service.NewSubscriptionService(serviceParams)
+	s.activities = NewBillingActivities(subscriptionService, serviceParams, s.GetLogger())
+}
+
+// newServiceParams builds a service.ServiceParams wired to this suite's test stores,
+// mirroring the setupService() pattern used by internal/ee/service's test suites.
+func (s *BillingActivitiesSuite) newServiceParams() service.ServiceParams {
+	return service.ServiceParams{
+		Logger:                     s.GetLogger(),
+		Config:                     s.GetConfig(),
+		DB:                         s.GetDB(),
+		TaxAssociationRepo:         s.GetStores().TaxAssociationRepo,
+		TaxRateRepo:                s.GetStores().TaxRateRepo,
+		SubRepo:                    s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo:   s.GetStores().SubscriptionLineItemRepo,
+		SubscriptionPhaseRepo:      s.GetStores().SubscriptionPhaseRepo,
+		SubScheduleRepo:            s.GetStores().SubscriptionScheduleRepo,
+		PlanRepo:                   s.GetStores().PlanRepo,
+		PriceRepo:                  s.GetStores().PriceRepo,
+		PriceUnitRepo:              s.GetStores().PriceUnitRepo,
+		EventRepo:                  s.GetStores().EventRepo,
+		MeterRepo:                  s.GetStores().MeterRepo,
+		CustomerRepo:               s.GetStores().CustomerRepo,
+		InvoiceRepo:                s.GetStores().InvoiceRepo,
+		InvoiceLineItemRepo:        s.GetStores().InvoiceLineItemRepo,
+		EntitlementRepo:            s.GetStores().EntitlementRepo,
+		EnvironmentRepo:            s.GetStores().EnvironmentRepo,
+		FeatureRepo:                s.GetStores().FeatureRepo,
+		TenantRepo:                 s.GetStores().TenantRepo,
+		UserRepo:                   s.GetStores().UserRepo,
+		AuthRepo:                   s.GetStores().AuthRepo,
+		WalletRepo:                 s.GetStores().WalletRepo,
+		PaymentRepo:                s.GetStores().PaymentRepo,
+		CreditGrantRepo:            s.GetStores().CreditGrantRepo,
+		CreditGrantApplicationRepo: s.GetStores().CreditGrantApplicationRepo,
+		CouponRepo:                 s.GetStores().CouponRepo,
+		CouponAssociationRepo:      s.GetStores().CouponAssociationRepo,
+		CouponApplicationRepo:      s.GetStores().CouponApplicationRepo,
+		AddonRepo:                  s.GetStores().AddonRepo,
+		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
+		ConnectionRepo:             s.GetStores().ConnectionRepo,
+		SettingsRepo:               s.GetStores().SettingsRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
+		EventPublisher:             s.GetPublisher(),
+		WebhookPublisher:           s.GetWebhookPublisher(),
+		ProrationCalculator:        s.GetCalculator(),
+		FeatureUsageRepo:           s.GetStores().FeatureUsageRepo,
+		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
+		IntegrationFactory:         s.GetIntegrationFactory(),
+		PlanPriceSyncRepo:          s.GetStores().PlanPriceSyncRepo,
+	}
+}
+
+func (s *BillingActivitiesSuite) TestCheckCancellationActivity_TerminatesResourcesWhenCancellationFires() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "env_billing_activities_test")
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_check_cancellation_activity",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   s.testData.now.Add(24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems:          []*subscription.SubscriptionLineItem{},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	// Attach an addon so we can verify it gets terminated when the activity fires the cancellation.
+	addonID := "addon_check_cancellation_activity"
+	priceID := "price_addon_check_cancellation_activity"
+	a := &addon.Addon{ID: addonID, LookupKey: addonID, Name: "Addon", BaseModel: types.GetDefaultBaseModel(ctx)}
+	s.NoError(s.GetStores().AddonRepo.Create(ctx, a))
+	p := &price.Price{
+		ID:                 priceID,
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meter.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	addAddonNow := time.Now().UTC()
+	subscriptionService := service.NewSubscriptionService(s.newServiceParams())
+	_, err := subscriptionService.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:   addonID,
+		StartDate: &addAddonNow,
+	})
+	s.NoError(err)
+
+	// Schedule an end-of-period cancellation via the real service (creates the schedule row
+	// and sets CancelAtPeriodEnd/CancelAt, but must NOT terminate anything yet — earlier fix).
+	_, err = subscriptionService.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeEndOfPeriod,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_check_cancellation_activity",
+	})
+	s.NoError(err)
+
+	scheduledSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.NoError(err)
+	s.Require().NotNil(scheduledSub.CancelAt)
+
+	// Drive the Temporal activity directly, as ProcessSubscriptionBillingWorkflow would,
+	// with a period whose End is at/after CancelAt so it decides to cancel.
+	input := subscriptionModels.CheckSubscriptionCancellationActivityInput{
+		SubscriptionID: sub.ID,
+		TenantID:       types.GetTenantID(ctx),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		UserID:         types.GetUserID(ctx),
+		Period: dto.Period{
+			Start: scheduledSub.CurrentPeriodStart,
+			End:   *scheduledSub.CancelAt,
+		},
+	}
+	output, err := s.activities.CheckCancellationActivity(ctx, input)
+	s.NoError(err)
+	s.Require().NotNil(output)
+	s.True(output.IsCancelled)
+
+	firedSub, err := s.GetStores().SubscriptionRepo.Get(ctx, sub.ID)
+	s.NoError(err)
+	s.Equal(types.SubscriptionStatusCancelled, firedSub.SubscriptionStatus)
+
+	// Addon association must now be terminated — this is the assertion that fails without the fix.
+	aaFilter := types.NewNoLimitAddonAssociationFilter()
+	aaFilter.EntityIDs = []string{sub.ID}
+	aaFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+	s.NoError(err)
+	s.Require().NotEmpty(associations)
+	s.Equal(types.AddonStatusCancelled, associations[0].AddonStatus, "addon association must be terminated when CheckCancellationActivity fires the cancellation")
+	s.NotNil(associations[0].EndDate)
+
+	// Line items must now be terminated too.
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{sub.ID}
+	lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+	for _, li := range lineItems {
+		s.False(li.EndDate.IsZero(), "line item %s must be terminated when CheckCancellationActivity fires the cancellation", li.ID)
+	}
+}

--- a/internal/temporal/activities/subscription/update_billing_period_activities_test.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities_test.go
@@ -192,6 +192,15 @@ func (s *BillingActivitiesSuite) TestCheckCancellationActivity_TerminatesResourc
 	s.NoError(err)
 	s.Require().NotNil(scheduledSub.CancelAt)
 
+	// Sanity check: still untouched immediately after scheduling.
+	aaFilterBefore := types.NewNoLimitAddonAssociationFilter()
+	aaFilterBefore.EntityIDs = []string{sub.ID}
+	aaFilterBefore.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	associationsBefore, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilterBefore)
+	s.NoError(err)
+	s.Require().NotEmpty(associationsBefore)
+	s.Equal(types.AddonStatusActive, associationsBefore[0].AddonStatus)
+
 	// Drive the Temporal activity directly, as ProcessSubscriptionBillingWorkflow would,
 	// with a period whose End is at/after CancelAt so it decides to cancel.
 	input := subscriptionModels.CheckSubscriptionCancellationActivityInput{

--- a/internal/testutil/inmemory_creditgrantapplication_store.go
+++ b/internal/testutil/inmemory_creditgrantapplication_store.go
@@ -196,6 +196,11 @@ func creditGrantApplicationFilterFn(ctx context.Context, cga *creditgrantapplica
 		return false
 	}
 
+	// Check scheduled after filter (strictly after, matching the Ent repository's ScheduledForGT)
+	if f.ScheduledAfter != nil && !cga.ScheduledFor.After(*f.ScheduledAfter) {
+		return false
+	}
+
 	// Check applied at filter
 	if f.AppliedAt != nil {
 		if cga.AppliedAt == nil || !cga.AppliedAt.Equal(*f.AppliedAt) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription cancellations now terminate related resources exactly when the cancellation actually takes effect (immediate and end-of-period).
  * Scheduled cancellations preserve resources until the effective timestamp; credit grants are cancelled only for applications scheduled strictly after that time.
  * Reverting a cancellation schedule correctly restores cancellation state, including cascading to inherited subscriptions.
  * Resource termination is now safely repeatable without duplicate effects.
* **Tests**
  * Added/extended coverage for scheduled cancellation timing, cancellation reverts (including inheritance), termination idempotency, and credit-grant cutoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->