### PR TITLE
chore(meter-usage): Config driven spend alerts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -471,6 +471,7 @@ type MeterUsageTrackingConfig struct {
 	TopicDLQ                  string `mapstructure:"topic_dlq" default:""`
 	RedisDeduplicationEnabled bool   `mapstructure:"redis_deduplication_enabled" default:"false"`
 	WalletAlertPushEnabled    bool   `mapstructure:"wallet_alert_push_enabled" default:"false"`
+	SpendAlertWebhookEnabled  bool   `mapstructure:"spend_alert_webhook_enabled" default:"false"`
 
 	// event.rejected webhook (fired when an event produces no meter usage); opt-in.
 	RejectedEventWebhookEnabled bool `mapstructure:"rejected_event_webhook_enabled" default:"false"`

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -327,6 +327,7 @@ meter_usage_tracking:
   topic_dlq: "meter_usage_tracking_service_dlq"
   redis_deduplication_enabled: false
   wallet_alert_push_enabled: false
+  spend_alert_webhook_enabled: false
   rejected_event_webhook_enabled: false
   rejected_event_webhook_window: "10m"
 

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -391,7 +391,7 @@ func (s *meterUsageTrackingService) processEvent(ctx context.Context, event *eve
 	// 1. Resolving the customer for the event
 	// 2. Running the customer onboarding workflow
 	// 3. Checking for spend breaches and logging alerts
-	s.runMeterUsagePostInsertSideEffects(ctx, event)
+	s.runMeterUsagePostInsertSideEffects(ctx, event, records)
 
 	return nil
 }

--- a/internal/ee/service/meter_usage_tracking_post_insert.go
+++ b/internal/ee/service/meter_usage_tracking_post_insert.go
@@ -22,7 +22,7 @@ import (
 // runMeterUsagePostInsertSideEffects runs customer resolution/onboarding and wallet
 // balance alert publishing after meter_usage rows are written to ClickHouse.
 // Failures are logged only; the Kafka message is not retried for side-effect errors.
-func (s *meterUsageTrackingService) runMeterUsagePostInsertSideEffects(ctx context.Context, event *events.Event) {
+func (s *meterUsageTrackingService) runMeterUsagePostInsertSideEffects(ctx context.Context, event *events.Event, records []*events.MeterUsage) {
 	if event == nil || event.ExternalCustomerID == "" {
 		return
 	}
@@ -50,8 +50,11 @@ func (s *meterUsageTrackingService) runMeterUsagePostInsertSideEffects(ctx conte
 
 	if s.Config.MeterUsageTracking.WalletAlertPushEnabled {
 		s.publishWalletBalanceAlert(ctx, event, cust)
-	} else {
-		s.Logger.Debug(ctx, "wallet balance alert push disabled for meter usage tracking", "event_id", event.ID, "customer_id", cust.ID)
+	}
+
+	if s.Config.MeterUsageTracking.SpendAlertWebhookEnabled {
+		meterIDs := lo.Uniq(lo.Map(records, func(r *events.MeterUsage, _ int) string { return r.MeterID }))
+		s.checkSpendBreachForEvent(ctx, event, meterIDs, cust)
 	}
 }
 
@@ -115,11 +118,7 @@ func ResolveCustomerForUsageEvent(
 
 // executeCustomerOnboardingForEvent runs the synchronous CustomerOnboarding workflow
 // when the tenant has customer_onboarding_config with create_customer as the first action.
-func executeCustomerOnboardingForEvent(
-	ctx context.Context,
-	params ServiceParams,
-	event *events.Event,
-) (*customer.Customer, error) {
+func executeCustomerOnboardingForEvent(ctx context.Context, params ServiceParams, event *events.Event) (*customer.Customer, error) {
 	settingsService := &settingsService{ServiceParams: params}
 	workflowConfig, err := GetSetting[*workflowModels.WorkflowConfig](
 		settingsService,

--- a/internal/ee/service/meter_usage_tracking_test.go
+++ b/internal/ee/service/meter_usage_tracking_test.go
@@ -510,7 +510,7 @@ func TestRunMeterUsagePostInsertSideEffects(t *testing.T) {
 		ExternalCustomerID: "ext_1",
 	}
 
-	svc.runMeterUsagePostInsertSideEffects(ctx, event)
+	svc.runMeterUsagePostInsertSideEffects(ctx, event, []*events.MeterUsage{})
 	assert.Equal(t, existing.ID, event.CustomerID)
 }
 

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -386,7 +386,6 @@ func (s *SubscriptionServiceSuite) setupService() {
 		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
 		ConnectionRepo:             s.GetStores().ConnectionRepo,
 		SettingsRepo:               s.GetStores().SettingsRepo,
-		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
 		EventPublisher:             s.GetPublisher(),
 		WebhookPublisher:           s.GetWebhookPublisher(),
 		ProrationCalculator:        s.GetCalculator(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable spend-alert webhooks, disabled by default.
  * Spend alerts can now be evaluated after meter usage is recorded, based on affected meters.

* **Bug Fixes**
  * Improved post-usage processing by using the exact usage records that were successfully saved.

* **Tests**
  * Updated service tests to reflect the enhanced post-insert processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->