### PR TITLE
fix(clickhouse): parameterize event usage queries to prevent SQL injection

### DIFF
--- a/internal/domain/events/aggregator.go
+++ b/internal/domain/events/aggregator.go
@@ -7,8 +7,10 @@ import (
 )
 
 type Aggregator interface {
-	// GetQuery returns the query for this aggregation
-	GetQuery(ctx context.Context, params *UsageParams) string
+	// GetQuery returns the query for this aggregation, along with the
+	// positional args to bind against the returned query's `?` placeholders
+	// (in the exact order the placeholders appear in the query string).
+	GetQuery(ctx context.Context, params *UsageParams) (string, []interface{})
 
 	// GetType returns the aggregation type
 	GetType() types.AggregationType

--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -32,6 +32,17 @@
 //
 // This ensures that events are correctly grouped into the appropriate billing periods
 // using day-level granularity for better predictability and user understanding.
+//
+// Query Parameterization
+// =======================
+//
+// All queries built in this file use `?` positional placeholders for any value that
+// originates from user/API input (filter property names/values, customer IDs, event
+// name, timezone, group-by property, timestamps). Each query-building function returns
+// (query string, []interface{} args) — the args slice must be passed to the ClickHouse
+// driver's Query(ctx, query, args...) call in the same order the placeholders appear in
+// the concatenated query string, since ClickHouse binds positionally. This mirrors the
+// pattern already used in meter_usage_query_builder.go.
 
 package clickhouse
 
@@ -73,11 +84,14 @@ func getDeduplicationKey() string {
 	return "id"
 }
 
-// buildUsageEventCustomerFilters returns PREWHERE fragments for external_customer_id and FlexPrice customer_id.
-// Params may be nil. External merges ExternalCustomerID and ExternalCustomerIDs (deduped); internal uses CustomerID only.
-func buildUsageEventCustomerFilters(params *events.UsageParams) (externalCustomerFilter string, customerFilter string) {
+// buildUsageEventCustomerFilters returns PREWHERE fragments (with `?` placeholders) for
+// external_customer_id and FlexPrice customer_id, plus the args to bind against them, in
+// the order the two returned fragments are concatenated into the final query. Params may
+// be nil. External merges ExternalCustomerID and ExternalCustomerIDs (deduped); internal
+// uses CustomerID only.
+func buildUsageEventCustomerFilters(params *events.UsageParams) (externalCustomerFilter string, customerFilter string, args []interface{}) {
 	if params == nil {
-		return "", ""
+		return "", "", nil
 	}
 
 	extIDs := make([]string, 0)
@@ -92,19 +106,24 @@ func buildUsageEventCustomerFilters(params *events.UsageParams) (externalCustome
 	case 0:
 		externalCustomerFilter = ""
 	case 1:
-		externalCustomerFilter = fmt.Sprintf("AND external_customer_id = '%s'", extUnique[0])
+		externalCustomerFilter = "AND external_customer_id = ?"
+		args = append(args, extUnique[0])
 	default:
-		quoted := make([]string, len(extUnique))
-		for i, id := range extUnique {
-			quoted[i] = fmt.Sprintf("'%s'", id)
+		placeholders := make([]string, len(extUnique))
+		for i := range extUnique {
+			placeholders[i] = "?"
 		}
-		externalCustomerFilter = fmt.Sprintf("AND external_customer_id IN (%s)", strings.Join(quoted, ", "))
+		externalCustomerFilter = fmt.Sprintf("AND external_customer_id IN (%s)", strings.Join(placeholders, ", "))
+		for _, id := range extUnique {
+			args = append(args, id)
+		}
 	}
 
 	if params.CustomerID != "" {
-		customerFilter = fmt.Sprintf("AND customer_id = '%s'", params.CustomerID)
+		customerFilter = "AND customer_id = ?"
+		args = append(args, params.CustomerID)
 	}
-	return externalCustomerFilter, customerFilter
+	return externalCustomerFilter, customerFilter, args
 }
 
 func formatClickHouseDateTime(t time.Time) string {
@@ -114,7 +133,8 @@ func formatClickHouseDateTime(t time.Time) string {
 // normalizeCHTimezone returns a valid IANA timezone name for ClickHouse
 // toStartOf* functions, defaulting to UTC for empty, "UTC", or unresolvable
 // values. Passing an invalid name straight to ClickHouse would error the query,
-// so this is the single guard shared by both window formatters.
+// so this is the single guard shared by both window formatters. Since the return
+// value is validated against time.LoadLocation, it is safe to interpolate directly.
 func normalizeCHTimezone(tz string) string {
 	if tz == "" || tz == types.DefaultTimezone {
 		return types.DefaultTimezone
@@ -128,7 +148,11 @@ func normalizeCHTimezone(tz string) string {
 // formatWindowSize returns the ClickHouse expression that buckets `timestamp`
 // into the given window in the given timezone. "UTC" is a valid ClickHouse
 // timezone argument and yields identical results to omitting it, so the tz is
-// always passed — there is no UTC special-casing.
+// always passed — there is no UTC special-casing. The tz value has already been
+// validated by normalizeCHTimezone (constrained to resolvable IANA names via
+// time.LoadLocation), so it is safe to interpolate directly here rather than bind
+// as a query arg — these window expressions are used inside larger fmt.Sprintf
+// templates that are themselves fully parameterized for user-controlled values.
 func formatWindowSize(windowSize types.WindowSize, tz string) string {
 	if windowSize == "" {
 		return ""
@@ -200,68 +224,77 @@ func formatWindowSizeWithBillingAnchor(windowSize types.WindowSize, billingAncho
 	return formatWindowSize(windowSize, tz)
 }
 
-func buildFilterConditions(filters map[string][]string) string {
+// buildFilterConditions builds JSONExtractString filter fragments using positional `?`
+// placeholders for both the property name and its value(s) — both are user-controlled
+// (request body `filters` map) and must never be interpolated into the query string.
+// Returns the WHERE-fragment (e.g. "AND JSONExtractString(properties, ?) IN (?,?) AND ...")
+// and the args to bind, in the exact order the placeholders appear.
+func buildFilterConditions(filters map[string][]string) (string, []interface{}) {
 	if len(filters) == 0 {
-		return ""
+		return "", nil
 	}
 
 	var conditions []string
+	var args []interface{}
 	for key, values := range filters {
 		if len(values) == 0 {
 			continue
 		}
 
-		quotedValues := make([]string, len(values))
-		for i, v := range values {
-			quotedValues[i] = fmt.Sprintf("'%s'", v)
+		placeholders := make([]string, len(values))
+		for i := range values {
+			placeholders[i] = "?"
 		}
 
 		conditions = append(conditions, fmt.Sprintf(
-			"JSONExtractString(properties, '%s') IN (%s)",
-			key,
-			strings.Join(quotedValues, ","),
+			"JSONExtractString(properties, ?) IN (%s)",
+			strings.Join(placeholders, ","),
 		))
+		args = append(args, key)
+		for _, v := range values {
+			args = append(args, v)
+		}
 	}
 
 	if len(conditions) == 0 {
-		return ""
+		return "", nil
 	}
 
-	return "AND " + strings.Join(conditions, " AND ")
+	return "AND " + strings.Join(conditions, " AND "), args
 }
 
-func buildTimeConditions(params *events.UsageParams) string {
-	conditions := parseTimeConditions(params)
+// buildTimeConditions builds the time-range WHERE fragment using `?` placeholders.
+func buildTimeConditions(params *events.UsageParams) (string, []interface{}) {
+	conditions, args := parseTimeConditions(params)
 
 	if len(conditions) == 0 {
-		return ""
+		return "", nil
 	}
 
-	return "AND " + strings.Join(conditions, " AND ")
+	return "AND " + strings.Join(conditions, " AND "), args
 }
 
-func parseTimeConditions(params *events.UsageParams) []string {
+func parseTimeConditions(params *events.UsageParams) ([]string, []interface{}) {
 	var conditions []string
+	var args []interface{}
 
 	if !params.StartTime.IsZero() {
-		conditions = append(conditions,
-			fmt.Sprintf("timestamp >= toDateTime64('%s', 3)",
-				formatClickHouseDateTime(params.StartTime)))
+		conditions = append(conditions, "timestamp >= toDateTime64(?, 3)")
+		args = append(args, formatClickHouseDateTime(params.StartTime))
 	}
 
 	if !params.EndTime.IsZero() {
-		conditions = append(conditions,
-			fmt.Sprintf("timestamp < toDateTime64('%s', 3)",
-				formatClickHouseDateTime(params.EndTime)))
+		conditions = append(conditions, "timestamp < toDateTime64(?, 3)")
+		args = append(args, formatClickHouseDateTime(params.EndTime))
 	}
 
-	return conditions
+	return conditions, args
 }
 
 // SumAggregator implements sum aggregation
 type SumAggregator struct{}
 
-func (a *SumAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *SumAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	// If bucket_size is specified, use windowed aggregation
 	if params.BucketSize != "" {
 		return a.getWindowedQuery(ctx, params)
@@ -270,7 +303,7 @@ func (a *SumAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 	return a.getNonWindowedQuery(ctx, params)
 }
 
-func (a *SumAggregator) getNonWindowedQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *SumAggregator) getNonWindowedQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	windowClause := ""
@@ -284,21 +317,21 @@ func (a *SumAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 		windowGroupBy = ", window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
-        SELECT 
+	query := fmt.Sprintf(`
+        SELECT
             %s sum(value) as total
         FROM (
             SELECT
-                %s anyLast(JSONExtractFloat(assumeNotNull(properties), '%s')) as value
+                %s anyLast(JSONExtractFloat(assumeNotNull(properties), ?)) as value
             FROM events
-            PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+            PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
                 %s
@@ -309,10 +342,6 @@ func (a *SumAggregator) getNonWindowedQuery(ctx context.Context, params *events.
     `,
 		selectClause,
 		windowClause,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -320,26 +349,33 @@ func (a *SumAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 		getDeduplicationKey(),
 		windowGroupBy,
 		groupByClause)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
-func (a *SumAggregator) getWindowedQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *SumAggregator) getWindowedQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	bucketWindow := formatWindowSizeWithBillingAnchor(params.BucketSize, params.BillingAnchor, params.Timezone)
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
 	// Get sum values per bucket, return each bucket's sum separately
-	return fmt.Sprintf(`
+	query := fmt.Sprintf(`
 		WITH bucket_sums AS (
 			SELECT
 				%s as bucket_start,
-				sum(JSONExtractFloat(assumeNotNull(properties), '%s')) as bucket_sum
+				sum(JSONExtractFloat(assumeNotNull(properties), ?)) as bucket_sum
 			FROM events FINAL
-			PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+			PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
 				%s
@@ -355,14 +391,17 @@ func (a *SumAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 		ORDER BY bucket_start
 	`,
 		bucketWindow,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
 		timeConditions)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *SumAggregator) GetType() types.AggregationType {
@@ -372,7 +411,7 @@ func (a *SumAggregator) GetType() types.AggregationType {
 // CountAggregator implements count aggregation
 type CountAggregator struct{}
 
-func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	groupByClause := ""
@@ -382,18 +421,18 @@ func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsagePara
 		groupByClause = "GROUP BY window_size ORDER BY window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
-        SELECT 
+	query := fmt.Sprintf(`
+        SELECT
             %s count(DISTINCT %s) as total
         FROM events
-        PREWHERE tenant_id = '%s'
-			AND environment_id = '%s'
-			AND event_name = '%s'
+        PREWHERE tenant_id = ?
+			AND environment_id = ?
+			AND event_name = ?
 			%s
 			%s
             %s
@@ -402,14 +441,18 @@ func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsagePara
     `,
 		selectClause,
 		getDeduplicationKey(),
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
 		timeConditions,
 		groupByClause)
+
+	args := []interface{}{types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *CountAggregator) GetType() types.AggregationType {
@@ -419,7 +462,7 @@ func (a *CountAggregator) GetType() types.AggregationType {
 // CountUniqueAggregator implements count unique aggregation
 type CountUniqueAggregator struct{}
 
-func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	windowClause := ""
@@ -433,21 +476,21 @@ func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.Usa
 		windowGroupBy = ", window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
-        SELECT 
+	query := fmt.Sprintf(`
+        SELECT
             %s count(DISTINCT property_value) as total
         FROM (
             SELECT
-                %s JSONExtractString(assumeNotNull(properties), '%s') as property_value
+                %s JSONExtractString(assumeNotNull(properties), ?) as property_value
             FROM events
-            PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+            PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
                 %s
@@ -458,10 +501,6 @@ func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.Usa
     `,
 		selectClause,
 		windowClause,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -469,6 +508,13 @@ func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.Usa
 		getDeduplicationKey(),
 		windowGroupBy,
 		groupByClause)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *CountUniqueAggregator) GetType() types.AggregationType {
@@ -478,7 +524,7 @@ func (a *CountUniqueAggregator) GetType() types.AggregationType {
 // AvgAggregator implements avg aggregation
 type AvgAggregator struct{}
 
-func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	windowClause := ""
@@ -492,21 +538,21 @@ func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 		windowGroupBy = ", window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
-        SELECT 
+	query := fmt.Sprintf(`
+        SELECT
             %s avg(value) as total
         FROM (
             SELECT
-                %s anyLast(JSONExtractFloat(assumeNotNull(properties), '%s')) as value
+                %s anyLast(JSONExtractFloat(assumeNotNull(properties), ?)) as value
             FROM events
-            PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s' 
+            PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
 				%s
@@ -517,10 +563,6 @@ func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams
     `,
 		selectClause,
 		windowClause,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -528,6 +570,13 @@ func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 		getDeduplicationKey(),
 		windowGroupBy,
 		groupByClause)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *AvgAggregator) GetType() types.AggregationType {
@@ -537,7 +586,7 @@ func (a *AvgAggregator) GetType() types.AggregationType {
 // LatestAggregator implements latest value aggregation
 type LatestAggregator struct{}
 
-func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	windowClause := ""
 	groupByClause := ""
@@ -547,19 +596,19 @@ func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsagePar
 		groupByClause = "GROUP BY window_size ORDER BY window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
-        SELECT 
-            %s argMax(JSONExtractFloat(assumeNotNull(properties), '%s'), timestamp) as total
-        FROM 
+	query := fmt.Sprintf(`
+        SELECT
+            %s argMax(JSONExtractFloat(assumeNotNull(properties), ?), timestamp) as total
+        FROM
 			events
-			PREWHERE tenant_id = '%s'
-                AND environment_id = '%s'
-                AND event_name = '%s'
+			PREWHERE tenant_id = ?
+                AND environment_id = ?
+                AND event_name = ?
                 %s
                 %s
                 %s
@@ -567,15 +616,18 @@ func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsagePar
         %s
     `,
 		windowClause,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
 		timeConditions,
 		groupByClause)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *LatestAggregator) GetType() types.AggregationType {
@@ -585,7 +637,7 @@ func (a *LatestAggregator) GetType() types.AggregationType {
 // SumWithMultiAggregator implements sum with multiplier aggregation
 type SumWithMultiAggregator struct{}
 
-func (a *SumWithMultiAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *SumWithMultiAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	windowClause := ""
@@ -599,26 +651,28 @@ func (a *SumWithMultiAggregator) GetQuery(ctx context.Context, params *events.Us
 		windowGroupBy = ", window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
+	// Multiplier is a decimal.Decimal value computed server-side (not raw user string
+	// input) — safe to interpolate as a numeric literal via .String(), same as before.
 	multiplier := decimal.NewFromInt(1)
 	if params.Multiplier != nil {
 		multiplier = *params.Multiplier
 	}
 
-	return fmt.Sprintf(`
-        SELECT 
+	query := fmt.Sprintf(`
+        SELECT
             %s (sum(value) * %s) as total
         FROM (
             SELECT
-                %s anyLast(JSONExtractFloat(assumeNotNull(properties), '%s')) as value
+                %s anyLast(JSONExtractFloat(assumeNotNull(properties), ?)) as value
             FROM events
-            PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+            PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
                 %s
@@ -630,10 +684,6 @@ func (a *SumWithMultiAggregator) GetQuery(ctx context.Context, params *events.Us
 		selectClause,
 		multiplier.String(),
 		windowClause,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -641,6 +691,13 @@ func (a *SumWithMultiAggregator) GetQuery(ctx context.Context, params *events.Us
 		getDeduplicationKey(),
 		windowGroupBy,
 		groupByClause)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *SumWithMultiAggregator) GetType() types.AggregationType {
@@ -650,7 +707,7 @@ func (a *SumWithMultiAggregator) GetType() types.AggregationType {
 // MaxAggregator implements max aggregation
 type MaxAggregator struct{}
 
-func (a *MaxAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *MaxAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	// If bucket_size is specified, use windowed aggregation
 	if params.BucketSize != "" {
 		return a.getWindowedQuery(ctx, params)
@@ -659,7 +716,7 @@ func (a *MaxAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 	return a.getNonWindowedQuery(ctx, params)
 }
 
-func (a *MaxAggregator) getNonWindowedQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *MaxAggregator) getNonWindowedQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	windowClause := ""
@@ -673,21 +730,21 @@ func (a *MaxAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 		windowGroupBy = ", window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
-		SELECT 
+	query := fmt.Sprintf(`
+		SELECT
 			%s max(value) as total
 		FROM (
 			SELECT
-				%s anyLast(JSONExtractFloat(assumeNotNull(properties), '%s')) as value
+				%s anyLast(JSONExtractFloat(assumeNotNull(properties), ?)) as value
 			FROM events
-			PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+			PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
 				%s
@@ -698,10 +755,6 @@ func (a *MaxAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 	`,
 		selectClause,
 		windowClause,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
@@ -709,15 +762,22 @@ func (a *MaxAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 		getDeduplicationKey(),
 		windowGroupBy,
 		groupByClause)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
-func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	bucketWindow := formatWindowSizeWithBillingAnchor(params.BucketSize, params.BillingAnchor, params.Timezone)
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
 	// When GroupBy has a "properties.X" entry, return per-group rows so tiered pricing
 	// can be applied per group (e.g. per KRN). The events-table SQL only supports
@@ -725,18 +785,21 @@ func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 	// 1. per_group CTE: max per group per bucket (e.g., MAX per krn per hour)
 	// 2. Return each group's value with group_key; total is sum of all group values for backward compat
 	if groupByProperty := events.FirstGroupByProperty(params.GroupBy); groupByProperty != "" && validateGroupByProperty(groupByProperty) == nil {
+		// groupByProperty has already been validated by validateGroupByProperty
+		// (alphanumeric/underscore/dot only), so it is safe to interpolate directly
+		// into the JSONExtractString key argument here — it cannot carry SQL metacharacters.
 		groupByExpr := fmt.Sprintf("JSONExtractString(assumeNotNull(properties), '%s')", groupByProperty)
 
-		return fmt.Sprintf(`
+		query := fmt.Sprintf(`
 			WITH per_group AS (
 				SELECT
 					%s as bucket_start,
 					%s as group_key,
-					max(JSONExtractFloat(assumeNotNull(properties), '%s')) as group_value
+					max(JSONExtractFloat(assumeNotNull(properties), ?)) as group_value
 				FROM events FINAL
-				PREWHERE tenant_id = '%s'
-					AND environment_id = '%s'
-					AND event_name = '%s'
+				PREWHERE tenant_id = ?
+					AND environment_id = ?
+					AND event_name = ?
 					%s
 					%s
 					%s
@@ -753,26 +816,29 @@ func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 		`,
 			bucketWindow,
 			groupByExpr,
-			params.PropertyName,
-			types.GetTenantID(ctx),
-			types.GetEnvironmentID(ctx),
-			params.EventName,
 			externalCustomerFilter,
 			customerFilter,
 			filterConditions,
 			timeConditions)
+
+		args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+		args = append(args, customerArgs...)
+		args = append(args, filterArgs...)
+		args = append(args, timeArgs...)
+
+		return query, args
 	}
 
 	// First get max values per bucket, then sum across all buckets
-	return fmt.Sprintf(`
+	query := fmt.Sprintf(`
 		WITH bucket_maxes AS (
 			SELECT
 				%s as bucket_start,
-				max(JSONExtractFloat(assumeNotNull(properties), '%s')) as bucket_max
+				max(JSONExtractFloat(assumeNotNull(properties), ?)) as bucket_max
 			FROM events FINAL
-			PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+			PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
 				%s
@@ -788,14 +854,17 @@ func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 		ORDER BY bucket_start
 	`,
 		bucketWindow,
-		params.PropertyName,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
 		timeConditions)
+
+	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *MaxAggregator) GetType() types.AggregationType {
@@ -805,7 +874,7 @@ func (a *MaxAggregator) GetType() types.AggregationType {
 // WeightedSumAggregator implements weighted sum aggregation
 type WeightedSumAggregator struct{}
 
-func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.UsageParams) string {
+func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.UsageParams) (string, []interface{}) {
 	windowSize := formatWindowSizeWithBillingAnchor(params.WindowSize, params.BillingAnchor, params.Timezone)
 	selectClause := ""
 	windowClause := ""
@@ -817,19 +886,19 @@ func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.Usa
 		groupByClause = "GROUP BY window_size ORDER BY window_size"
 	}
 
-	externalCustomerFilter, customerFilter := buildUsageEventCustomerFilters(params)
+	externalCustomerFilter, customerFilter, customerArgs := buildUsageEventCustomerFilters(params)
 
-	filterConditions := buildFilterConditions(params.Filters)
-	timeConditions := buildTimeConditions(params)
+	filterConditions, filterArgs := buildFilterConditions(params.Filters)
+	timeConditions, timeArgs := buildTimeConditions(params)
 
-	return fmt.Sprintf(`
+	query := fmt.Sprintf(`
         WITH
-            toDateTime64('%s', 3) AS period_start,
-            toDateTime64('%s', 3) AS period_end,
+            toDateTime64(?, 3) AS period_start,
+            toDateTime64(?, 3) AS period_end,
             dateDiff('second', period_start, period_end) AS total_seconds
-        SELECT 
+        SELECT
             %s sum(
-                (JSONExtractFloat(assumeNotNull(properties), '%s') / nullIf(total_seconds, 0)) *
+                (JSONExtractFloat(assumeNotNull(properties), ?) / nullIf(total_seconds, 0)) *
                 dateDiff('second', timestamp, period_end)
             ) AS total
         FROM (
@@ -837,9 +906,9 @@ func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.Usa
                 %s timestamp,
                 properties
             FROM events
-            PREWHERE tenant_id = '%s'
-				AND environment_id = '%s'
-				AND event_name = '%s'
+            PREWHERE tenant_id = ?
+				AND environment_id = ?
+				AND event_name = ?
 				%s
 				%s
                 %s
@@ -847,204 +916,30 @@ func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.Usa
         )
         %s
     `,
-		formatClickHouseDateTime(params.StartTime),
-		formatClickHouseDateTime(params.EndTime),
 		selectClause,
-		params.PropertyName,
 		windowClause,
-		types.GetTenantID(ctx),
-		types.GetEnvironmentID(ctx),
-		params.EventName,
 		externalCustomerFilter,
 		customerFilter,
 		filterConditions,
 		timeConditions,
 		groupByClause,
 	)
+
+	args := []interface{}{
+		formatClickHouseDateTime(params.StartTime),
+		formatClickHouseDateTime(params.EndTime),
+		params.PropertyName,
+		types.GetTenantID(ctx),
+		types.GetEnvironmentID(ctx),
+		params.EventName,
+	}
+	args = append(args, customerArgs...)
+	args = append(args, filterArgs...)
+	args = append(args, timeArgs...)
+
+	return query, args
 }
 
 func (a *WeightedSumAggregator) GetType() types.AggregationType {
 	return types.AggregationWeightedSum
 }
-
-// weighted sum final query without window size
-// WITH
-//             toDateTime64('2025-07-31 18:30:00.000', 3) AS period_start,
-//             toDateTime64('2025-08-31 18:30:00.000', 3) AS period_end,
-//             dateDiff('second', period_start, period_end) AS total_seconds
-//         SELECT
-//              sum(
-//                 (JSONExtractFloat(assumeNotNull(properties), 'value') / nullIf(total_seconds, 0)) *
-//                 dateDiff('second', timestamp, period_end)
-//             ) AS total
-//         FROM (
-//             SELECT
-//                  timestamp,
-//                 properties
-//             FROM events
-//             PREWHERE tenant_id = '00000000-0000-0000-0000-000000000000'
-//                                 AND environment_id = 'env_01K3G204ZZS7F1CAPE32TS0X9W'
-//                                 AND event_name = 'weighted_sum_event'
-//                                 AND external_customer_id = 'cust-wc-5'
-
-//                 AND timestamp >= toDateTime64('2025-07-31 18:30:00.000', 3) AND timestamp < toDateTime64('2025-08-31 18:30:00.000', 3)
-//         )
-
-// weighted sum final query with window size
-// WITH
-//             toDateTime64('2025-09-12 11:08:50.630', 3) AS period_start,
-//             toDateTime64('2025-09-19 11:08:50.630', 3) AS period_end,
-//             dateDiff('second', period_start, period_end) AS total_seconds
-//         SELECT
-//             window_size, sum(
-//                 (JSONExtractFloat(assumeNotNull(properties), 'value') / nullIf(total_seconds, 0)) *
-//                 dateDiff('second', timestamp, period_end)
-//             ) AS total
-//         FROM (
-//             SELECT
-//                 toStartOfInterval(timestamp, INTERVAL 15 MINUTE) AS window_size, timestamp,
-//                 properties
-//             FROM events
-//             PREWHERE tenant_id = '00000000-0000-0000-0000-000000000000'
-//                                 AND environment_id = 'env_01K3G204ZZS7F1CAPE32TS0X9W'
-//                                 AND event_name = 'weighted_sum_event'
-//                                 AND external_customer_id = 'cust-wc-5'
-//                                 AND customer_id = 'cust_01K5GHAV4R787PVZTYW5G9BMGD'
-
-//                 AND timestamp >= toDateTime64('2025-09-12 11:08:50.630', 3) AND timestamp < toDateTime64('2025-09-19 11:08:50.630', 3)
-//         )
-//         GROUP BY window_size ORDER BY window_size
-
-// // buildFilterGroupsQuery builds a query that matches events to the most specific filter group
-// func buildFilterGroupsQuery(params *events.UsageWithFiltersParams) string {
-//     var queryBuilder strings.Builder
-
-//     // Base query with CTE for filter matches
-//     queryBuilder.WriteString(fmt.Sprintf(`
-//         WITH
-//         base_events AS (
-//             SELECT
-//                 %s,
-//                 timestamp,
-//                 properties
-//             FROM events
-//             WHERE event_name = $1
-//             %s
-//         ),
-//         filter_matches AS (
-//             SELECT
-//                 *,
-//                 -- Calculate matches for each filter group
-//                 ARRAY[
-//     `, getDeduplicationKey(), buildTimeAndCustomerConditions(params.UsageParams)))
-
-//     // Generate array of filter group matches
-//     for i, group := range params.FilterGroups {
-//         if i > 0 {
-//             queryBuilder.WriteString(",")
-//         }
-
-//         // Default group case (no filters)
-//         if len(group.Filters) == 0 {
-//             queryBuilder.WriteString(fmt.Sprintf(`
-//                 (%d, %d, 1)  -- group_id, priority, always matches
-//             `, group.ID, group.Priority))
-//             continue
-//         }
-
-//         // Build filter conditions
-//         var conditions []string
-//         for property, values := range group.Filters {
-//             quotedValues := make([]string, len(values))
-//             for i, v := range values {
-//                 quotedValues[i] = fmt.Sprintf("'%s'", v)
-//             }
-//             conditions = append(conditions, fmt.Sprintf(
-//                 "JSONExtractString(properties, '%s') IN (%s)",
-//                 property,
-//                 strings.Join(quotedValues, ","),
-//             ))
-//         }
-
-//         queryBuilder.WriteString(fmt.Sprintf(`
-//             (%d, %d, %s)  -- group_id, priority, filter conditions
-//         `, group.ID, group.Priority, strings.Join(conditions, " AND ")))
-//     }
-
-//     // Complete filter_matches CTE and add matched_events CTE
-//     queryBuilder.WriteString(`
-//         ] as group_matches
-//         ),
-//         matched_events AS (
-//             SELECT
-//                 *,
-//                 -- Select group with highest priority that matches
-//                 (
-//                     SELECT group_id
-//                     FROM arrayJoin(group_matches) AS g
-//                     WHERE g.3 = 1  -- where matches = true
-//                     ORDER BY g.2 DESC, group_id  -- order by priority desc, then group_id
-//                     LIMIT 1
-//                 ) as best_match_group
-//             FROM base_events
-//         )
-//     `)
-
-//     // Add final aggregation based on params
-//     queryBuilder.WriteString(`
-//         SELECT
-//             best_match_group as filter_group_id,
-//     `)
-
-//     // Add aggregation function
-//     switch params.AggregationType {
-//     case types.AggregationCount:
-//         queryBuilder.WriteString(`
-//             COUNT(*) as value
-//         `)
-//     case types.AggregationSum:
-//         queryBuilder.WriteString(fmt.Sprintf(`
-//             SUM(CAST(JSONExtractString(properties, '%s') AS Float64)) as value
-//         `, params.PropertyName))
-//     case types.AggregationAvg:
-//         queryBuilder.WriteString(fmt.Sprintf(`
-//             AVG(CAST(JSONExtractString(properties, '%s') AS Float64)) as value
-//         `, params.PropertyName))
-//     }
-
-//     // Add grouping and ordering
-//     queryBuilder.WriteString(`
-//         FROM matched_events
-//         GROUP BY best_match_group
-//         ORDER BY best_match_group
-//     `)
-
-//     return queryBuilder.String()
-// }
-
-// // buildTimeAndCustomerConditions builds the WHERE clause for time and customer filters
-// func buildTimeAndCustomerConditions(params *events.UsageParams) string {
-//     var conditions []string
-
-//     // Add time range conditions
-//     if !params.StartTime.IsZero() {
-//         conditions = append(conditions,
-//             fmt.Sprintf("AND timestamp >= '%s'", params.StartTime.Format(time.RFC3339)))
-//     }
-//     if !params.EndTime.IsZero() {
-//         conditions = append(conditions,
-//             fmt.Sprintf("AND timestamp < '%s'", params.EndTime.Format(time.RFC3339)))
-//     }
-
-//     // Add customer conditions
-//     if params.ExternalCustomerID != "" {
-//         conditions = append(conditions,
-//             fmt.Sprintf("AND external_customer_id = '%s'", params.ExternalCustomerID))
-//     }
-//     if params.CustomerID != "" {
-//         conditions = append(conditions,
-//             fmt.Sprintf("AND customer_id = '%s'", params.CustomerID))
-//     }
-
-//     return strings.Join(conditions, " ")
-// }

--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -274,6 +274,16 @@ func buildTimeConditions(params *events.UsageParams) (string, []interface{}) {
 	return "AND " + strings.Join(conditions, " AND "), args
 }
 
+// appendArgs concatenates arg groups onto base in order — a small helper to
+// collapse the repeated `args = append(args, xArgs...)` chain that follows
+// every query-building function's args slice construction in this file.
+func appendArgs(base []interface{}, groups ...[]interface{}) []interface{} {
+	for _, g := range groups {
+		base = append(base, g...)
+	}
+	return base
+}
+
 func parseTimeConditions(params *events.UsageParams) ([]string, []interface{}) {
 	var conditions []string
 	var args []interface{}
@@ -350,10 +360,7 @@ func (a *SumAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 		windowGroupBy,
 		groupByClause)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -396,10 +403,7 @@ func (a *SumAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 		filterConditions,
 		timeConditions)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -447,10 +451,7 @@ func (a *CountAggregator) GetQuery(ctx context.Context, params *events.UsagePara
 		timeConditions,
 		groupByClause)
 
-	args := []interface{}{types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -509,10 +510,7 @@ func (a *CountUniqueAggregator) GetQuery(ctx context.Context, params *events.Usa
 		windowGroupBy,
 		groupByClause)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -571,10 +569,7 @@ func (a *AvgAggregator) GetQuery(ctx context.Context, params *events.UsageParams
 		windowGroupBy,
 		groupByClause)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -622,10 +617,7 @@ func (a *LatestAggregator) GetQuery(ctx context.Context, params *events.UsagePar
 		timeConditions,
 		groupByClause)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -692,10 +684,7 @@ func (a *SumWithMultiAggregator) GetQuery(ctx context.Context, params *events.Us
 		windowGroupBy,
 		groupByClause)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -763,10 +752,7 @@ func (a *MaxAggregator) getNonWindowedQuery(ctx context.Context, params *events.
 		windowGroupBy,
 		groupByClause)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -821,10 +807,7 @@ func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 			filterConditions,
 			timeConditions)
 
-		args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-		args = append(args, customerArgs...)
-		args = append(args, filterArgs...)
-		args = append(args, timeArgs...)
+		args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 		return query, args
 	}
@@ -859,10 +842,7 @@ func (a *MaxAggregator) getWindowedQuery(ctx context.Context, params *events.Usa
 		filterConditions,
 		timeConditions)
 
-	args := []interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	args := appendArgs([]interface{}{params.PropertyName, types.GetTenantID(ctx), types.GetEnvironmentID(ctx), params.EventName}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }
@@ -925,17 +905,14 @@ func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.Usa
 		groupByClause,
 	)
 
-	args := []interface{}{
+	args := appendArgs([]interface{}{
 		formatClickHouseDateTime(params.StartTime),
 		formatClickHouseDateTime(params.EndTime),
 		params.PropertyName,
 		types.GetTenantID(ctx),
 		types.GetEnvironmentID(ctx),
 		params.EventName,
-	}
-	args = append(args, customerArgs...)
-	args = append(args, filterArgs...)
-	args = append(args, timeArgs...)
+	}, customerArgs, filterArgs, timeArgs)
 
 	return query, args
 }

--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -38,11 +38,18 @@
 //
 // All queries built in this file use `?` positional placeholders for any value that
 // originates from user/API input (filter property names/values, customer IDs, event
-// name, timezone, group-by property, timestamps). Each query-building function returns
-// (query string, []interface{} args) — the args slice must be passed to the ClickHouse
-// driver's Query(ctx, query, args...) call in the same order the placeholders appear in
-// the concatenated query string, since ClickHouse binds positionally. This mirrors the
-// pattern already used in meter_usage_query_builder.go.
+// name, timestamps). Each query-building function returns (query string, []interface{}
+// args) — the args slice must be passed to the ClickHouse driver's Query(ctx, query,
+// args...) call in the same order the placeholders appear in the concatenated query
+// string, since ClickHouse binds positionally. This mirrors the pattern already used in
+// meter_usage_query_builder.go.
+//
+// Two inputs cannot be bound and are instead validated then interpolated, because they
+// are used as SQL identifiers rather than values:
+//   - timezone: validated by normalizeCHTimezone (constrained to resolvable IANA names
+//     via time.LoadLocation) before it is interpolated into the window expressions.
+//   - group-by property: validated by validateGroupByProperty (strict allow-list) before
+//     it is interpolated as the JSONExtractString key.
 
 package clickhouse
 

--- a/internal/repository/clickhouse/aggregators_test.go
+++ b/internal/repository/clickhouse/aggregators_test.go
@@ -1,0 +1,183 @@
+package clickhouse
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// maliciousProperty and maliciousValue mirror the live-verified staging PoC:
+// POST /v1/events/usage with filters: {"x') OR 1=1 -- ": ["a"]} caused a
+// 500 database_error because the property name reached ClickHouse unescaped.
+const (
+	maliciousProperty = "x') OR 1=1 -- "
+	maliciousValue    = "y') OR 1=1 -- "
+)
+
+func testCtx() context.Context {
+	ctx := context.Background()
+	ctx = types.SetTenantID(ctx, "tenant_injection_test")
+	ctx = types.SetEnvironmentID(ctx, "env_injection_test")
+	return ctx
+}
+
+func baseUsageParams() *events.UsageParams {
+	return &events.UsageParams{
+		EventName:    "api_calls",
+		PropertyName: "value",
+		StartTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// assertNoRawInjection asserts the raw malicious strings never appear literally
+// in the query text, and that they DO appear in args (bound via `?`).
+func assertNoRawInjection(t *testing.T, query string, args []interface{}) {
+	t.Helper()
+	assert.NotContains(t, query, "OR 1=1", "malicious payload leaked into SQL string")
+	assert.NotContains(t, query, maliciousProperty, "raw filter property leaked into SQL string")
+	assert.NotContains(t, query, maliciousValue, "raw filter value leaked into SQL string")
+	assert.Contains(t, args, maliciousProperty, "filter property must be bound as an arg")
+	assert.Contains(t, args, maliciousValue, "filter value must be bound as an arg")
+}
+
+func TestBuildFilterConditions_Parameterized(t *testing.T) {
+	filters := map[string][]string{
+		maliciousProperty: {"a"},
+	}
+	clause, args := buildFilterConditions(filters)
+
+	assert.NotContains(t, clause, "OR 1=1", "raw filter value leaked into SQL string")
+	assert.NotContains(t, clause, "x')", "raw property name leaked into SQL string")
+	assert.Contains(t, clause, "JSONExtractString(properties, ?)")
+	assert.Contains(t, args, maliciousProperty)
+	assert.Contains(t, args, "a")
+}
+
+func TestBuildFilterConditions_MultiValue(t *testing.T) {
+	filters := map[string][]string{
+		"region": {"us", "eu"},
+	}
+	clause, args := buildFilterConditions(filters)
+
+	assert.Contains(t, clause, "JSONExtractString(properties, ?) IN (?,?)")
+	assert.Equal(t, []interface{}{"region", "us", "eu"}, args)
+}
+
+func TestBuildFilterConditions_Empty(t *testing.T) {
+	clause, args := buildFilterConditions(nil)
+	assert.Equal(t, "", clause)
+	assert.Nil(t, args)
+}
+
+func TestBuildUsageEventCustomerFilters_Parameterized(t *testing.T) {
+	params := &events.UsageParams{
+		ExternalCustomerID: maliciousProperty,
+		CustomerID:         maliciousValue,
+	}
+	externalFilter, customerFilter, args := buildUsageEventCustomerFilters(params)
+
+	assert.Equal(t, "AND external_customer_id = ?", externalFilter)
+	assert.Equal(t, "AND customer_id = ?", customerFilter)
+	assert.NotContains(t, externalFilter, "OR 1=1")
+	assert.NotContains(t, customerFilter, "OR 1=1")
+	assert.Contains(t, args, maliciousProperty)
+	assert.Contains(t, args, maliciousValue)
+}
+
+func TestBuildUsageEventCustomerFilters_MultiExternalIDs(t *testing.T) {
+	params := &events.UsageParams{
+		ExternalCustomerIDs: []string{maliciousProperty, "cust-2"},
+	}
+	externalFilter, _, args := buildUsageEventCustomerFilters(params)
+
+	assert.Contains(t, externalFilter, "IN (?, ?)")
+	assert.NotContains(t, externalFilter, maliciousProperty)
+	assert.Equal(t, []interface{}{maliciousProperty, "cust-2"}, args)
+}
+
+// --- Aggregator.GetQuery injection tests ---
+// Each aggregator's GetQuery must never interpolate filter property names/values,
+// customer IDs, or event name into the raw query string — they must appear only
+// in the returned args slice.
+
+func TestAggregatorGetQuery_NoInjection(t *testing.T) {
+	ctx := testCtx()
+
+	aggregators := []events.Aggregator{
+		&CountAggregator{},
+		&SumAggregator{},
+		&AvgAggregator{},
+		&CountUniqueAggregator{},
+		&LatestAggregator{},
+		&SumWithMultiAggregator{},
+		&MaxAggregator{},
+		&WeightedSumAggregator{},
+	}
+
+	for _, agg := range aggregators {
+		t.Run(string(agg.GetType()), func(t *testing.T) {
+			params := baseUsageParams()
+			params.ExternalCustomerID = maliciousProperty
+			params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
+			if agg.GetType() == types.AggregationSumWithMultiplier {
+				m := decimal.NewFromInt(1)
+				params.Multiplier = &m
+			}
+
+			query, args := agg.GetQuery(ctx, params)
+
+			assert.NotContains(t, query, "OR 1=1", "malicious payload leaked into SQL string")
+			assert.NotContains(t, query, maliciousProperty, "raw external_customer_id/filter property leaked into SQL string")
+			assert.NotContains(t, query, maliciousValue, "raw filter value leaked into SQL string")
+			assert.Contains(t, args, maliciousProperty)
+			assert.Contains(t, args, maliciousValue)
+		})
+	}
+}
+
+func TestMaxAggregator_WindowedQuery_NoInjection(t *testing.T) {
+	ctx := testCtx()
+	params := baseUsageParams()
+	params.BucketSize = types.WindowSizeHour
+	params.ExternalCustomerID = maliciousProperty
+	params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
+
+	agg := &MaxAggregator{}
+	query, args := agg.GetQuery(ctx, params)
+
+	assertNoRawInjection(t, query, args)
+}
+
+func TestSumAggregator_WindowedQuery_NoInjection(t *testing.T) {
+	ctx := testCtx()
+	params := baseUsageParams()
+	params.BucketSize = types.WindowSizeHour
+	params.ExternalCustomerID = maliciousProperty
+	params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
+
+	agg := &SumAggregator{}
+	query, args := agg.GetQuery(ctx, params)
+
+	assertNoRawInjection(t, query, args)
+}
+
+func TestCountAggregator_GetQuery_TenantEnvironmentEventNameBound(t *testing.T) {
+	ctx := testCtx()
+	params := baseUsageParams()
+	params.EventName = maliciousProperty
+
+	agg := &CountAggregator{}
+	query, args := agg.GetQuery(ctx, params)
+
+	assert.NotContains(t, query, "OR 1=1")
+	assert.NotContains(t, query, maliciousProperty)
+	assert.Contains(t, args, maliciousProperty)
+	assert.Contains(t, args, "tenant_injection_test")
+	assert.Contains(t, args, "env_injection_test")
+}

--- a/internal/repository/clickhouse/aggregators_test.go
+++ b/internal/repository/clickhouse/aggregators_test.go
@@ -46,33 +46,47 @@ func assertNoRawInjection(t *testing.T, query string, args []interface{}) {
 	assert.Contains(t, args, maliciousValue, "filter value must be bound as an arg")
 }
 
-func TestBuildFilterConditions_Parameterized(t *testing.T) {
-	filters := map[string][]string{
-		maliciousProperty: {"a"},
+func TestBuildFilterConditions(t *testing.T) {
+	cases := []struct {
+		name     string
+		filters  map[string][]string
+		validate func(*testing.T, string, []interface{})
+	}{
+		{
+			name:    "Parameterized",
+			filters: map[string][]string{maliciousProperty: {"a"}},
+			validate: func(t *testing.T, clause string, args []interface{}) {
+				assert.NotContains(t, clause, "OR 1=1", "raw filter value leaked into SQL string")
+				assert.NotContains(t, clause, "x')", "raw property name leaked into SQL string")
+				assert.Contains(t, clause, "JSONExtractString(properties, ?)")
+				assert.Contains(t, args, maliciousProperty)
+				assert.Contains(t, args, "a")
+			},
+		},
+		{
+			name:    "MultiValue",
+			filters: map[string][]string{"region": {"us", "eu"}},
+			validate: func(t *testing.T, clause string, args []interface{}) {
+				assert.Contains(t, clause, "JSONExtractString(properties, ?) IN (?,?)")
+				assert.Equal(t, []interface{}{"region", "us", "eu"}, args)
+			},
+		},
+		{
+			name:    "Empty",
+			filters: nil,
+			validate: func(t *testing.T, clause string, args []interface{}) {
+				assert.Equal(t, "", clause)
+				assert.Nil(t, args)
+			},
+		},
 	}
-	clause, args := buildFilterConditions(filters)
 
-	assert.NotContains(t, clause, "OR 1=1", "raw filter value leaked into SQL string")
-	assert.NotContains(t, clause, "x')", "raw property name leaked into SQL string")
-	assert.Contains(t, clause, "JSONExtractString(properties, ?)")
-	assert.Contains(t, args, maliciousProperty)
-	assert.Contains(t, args, "a")
-}
-
-func TestBuildFilterConditions_MultiValue(t *testing.T) {
-	filters := map[string][]string{
-		"region": {"us", "eu"},
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clause, args := buildFilterConditions(tc.filters)
+			tc.validate(t, clause, args)
+		})
 	}
-	clause, args := buildFilterConditions(filters)
-
-	assert.Contains(t, clause, "JSONExtractString(properties, ?) IN (?,?)")
-	assert.Equal(t, []interface{}{"region", "us", "eu"}, args)
-}
-
-func TestBuildFilterConditions_Empty(t *testing.T) {
-	clause, args := buildFilterConditions(nil)
-	assert.Equal(t, "", clause)
-	assert.Nil(t, args)
 }
 
 func TestBuildUsageEventCustomerFilters_Parameterized(t *testing.T) {
@@ -121,50 +135,27 @@ func TestAggregatorGetQuery_NoInjection(t *testing.T) {
 	}
 
 	for _, agg := range aggregators {
-		t.Run(string(agg.GetType()), func(t *testing.T) {
-			params := baseUsageParams()
-			params.ExternalCustomerID = maliciousProperty
-			params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
-			if agg.GetType() == types.AggregationSumWithMultiplier {
-				m := decimal.NewFromInt(1)
-				params.Multiplier = &m
+		for _, bucketSize := range []types.WindowSize{"", types.WindowSizeHour} {
+			name := string(agg.GetType())
+			if bucketSize != "" {
+				name += "_windowed"
 			}
+			t.Run(name, func(t *testing.T) {
+				params := baseUsageParams()
+				params.BucketSize = bucketSize
+				params.ExternalCustomerID = maliciousProperty
+				params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
+				if agg.GetType() == types.AggregationSumWithMultiplier {
+					m := decimal.NewFromInt(1)
+					params.Multiplier = &m
+				}
 
-			query, args := agg.GetQuery(ctx, params)
+				query, args := agg.GetQuery(ctx, params)
 
-			assert.NotContains(t, query, "OR 1=1", "malicious payload leaked into SQL string")
-			assert.NotContains(t, query, maliciousProperty, "raw external_customer_id/filter property leaked into SQL string")
-			assert.NotContains(t, query, maliciousValue, "raw filter value leaked into SQL string")
-			assert.Contains(t, args, maliciousProperty)
-			assert.Contains(t, args, maliciousValue)
-		})
+				assertNoRawInjection(t, query, args)
+			})
+		}
 	}
-}
-
-func TestMaxAggregator_WindowedQuery_NoInjection(t *testing.T) {
-	ctx := testCtx()
-	params := baseUsageParams()
-	params.BucketSize = types.WindowSizeHour
-	params.ExternalCustomerID = maliciousProperty
-	params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
-
-	agg := &MaxAggregator{}
-	query, args := agg.GetQuery(ctx, params)
-
-	assertNoRawInjection(t, query, args)
-}
-
-func TestSumAggregator_WindowedQuery_NoInjection(t *testing.T) {
-	ctx := testCtx()
-	params := baseUsageParams()
-	params.BucketSize = types.WindowSizeHour
-	params.ExternalCustomerID = maliciousProperty
-	params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
-
-	agg := &SumAggregator{}
-	query, args := agg.GetQuery(ctx, params)
-
-	assertNoRawInjection(t, query, args)
 }
 
 func TestCountAggregator_GetQuery_TenantEnvironmentEventNameBound(t *testing.T) {

--- a/internal/repository/clickhouse/aggregators_test.go
+++ b/internal/repository/clickhouse/aggregators_test.go
@@ -142,7 +142,11 @@ func TestAggregatorGetQuery_NoInjection(t *testing.T) {
 			}
 			t.Run(name, func(t *testing.T) {
 				params := baseUsageParams()
+				// Sum/Max branch on BucketSize; the other six aggregators window on
+				// WindowSize. Set both so every "_windowed" subtest exercises the
+				// windowed query path rather than silently rerunning the plain one.
 				params.BucketSize = bucketSize
+				params.WindowSize = bucketSize
 				params.ExternalCustomerID = maliciousProperty
 				params.Filters = map[string][]string{maliciousProperty: {maliciousValue}}
 				if agg.GetType() == types.AggregationSumWithMultiplier {

--- a/internal/repository/clickhouse/costsheet_usage.go
+++ b/internal/repository/clickhouse/costsheet_usage.go
@@ -492,7 +492,10 @@ func (r *CostSheetUsageRepository) getStandardAnalytics(ctx context.Context, cos
 		}
 		if strings.HasPrefix(groupBy, "properties.") {
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			if propertyName != "" {
+			// propertyName is user-controlled and interpolated both as a SQL string
+			// literal and as a raw column alias identifier — neither can be bound with
+			// `?`, so validate against a strict allow-list before use.
+			if propertyName != "" && validateGroupByProperty(propertyName) == nil {
 				alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
 				sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
 				groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
@@ -745,6 +748,11 @@ func (r *CostSheetUsageRepository) getMaxBucketTotals(ctx context.Context, costS
 		}
 		if strings.HasPrefix(groupBy, "properties.") {
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
+			// See the analogous guard above — propertyName cannot be parameterized
+			// since it is used as a column alias identifier, so validate it instead.
+			if validateGroupByProperty(propertyName) != nil {
+				continue
+			}
 			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
 			innerSelectColumns = append(innerSelectColumns, fmt.Sprintf("JSONExtractString(properties, '%s') as %s", propertyName, propertyName))
 			outerSelectColumns = append(outerSelectColumns, propertyName)

--- a/internal/repository/clickhouse/costsheet_usage.go
+++ b/internal/repository/clickhouse/costsheet_usage.go
@@ -401,6 +401,25 @@ func (r *CostSheetUsageRepository) GetDetailedUsageAnalytics(ctx context.Context
 				}).
 				Mark(ierr.ErrValidation)
 		}
+
+		// The property name is interpolated into the query both as a SQL string literal
+		// and as a column-alias identifier, so it can never be bound via `?` — reject it
+		// here rather than dropping it downstream, which would desync the SELECT column
+		// list from the scan targets (both are sized off params.GroupBy).
+		if strings.HasPrefix(groupBy, "properties.") {
+			propertyName := strings.TrimPrefix(groupBy, "properties.")
+			if propertyName == "" {
+				return nil, ierr.NewError("invalid group_by value").
+					WithHint("group_by 'properties.<field_name>' requires a non-empty field name").
+					WithReportableDetails(map[string]interface{}{
+						"group_by": groupBy,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+			if err := validateGroupByProperty(propertyName); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	var allResults []*events.DetailedUsageAnalytic
@@ -491,17 +510,15 @@ func (r *CostSheetUsageRepository) getStandardAnalytics(ctx context.Context, cos
 			continue
 		}
 		if strings.HasPrefix(groupBy, "properties.") {
+			// Already validated against the allow-list in GetDetailedUsageAnalytics, so
+			// this is safe to interpolate and always emits exactly one column — keeping
+			// this list in lockstep with the scan targets built below.
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			// propertyName is user-controlled and interpolated both as a SQL string
-			// literal and as a raw column alias identifier — neither can be bound with
-			// `?`, so validate against a strict allow-list before use.
-			if propertyName != "" && validateGroupByProperty(propertyName) == nil {
-				alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
-				sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
-				groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
-				groupByColumnAliases = append(groupByColumnAliases, sqlExpression)
-				groupByFieldMapping[groupBy] = alias
-			}
+			alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
+			sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
+			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
+			groupByColumnAliases = append(groupByColumnAliases, sqlExpression)
+			groupByFieldMapping[groupBy] = alias
 		}
 	}
 
@@ -747,12 +764,10 @@ func (r *CostSheetUsageRepository) getMaxBucketTotals(ctx context.Context, costS
 			continue
 		}
 		if strings.HasPrefix(groupBy, "properties.") {
+			// Already validated against the allow-list in GetDetailedUsageAnalytics, so
+			// this is safe to interpolate and always emits exactly one column — keeping
+			// this list in lockstep with the scan targets built below.
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			// See the analogous guard above — propertyName cannot be parameterized
-			// since it is used as a column alias identifier, so validate it instead.
-			if validateGroupByProperty(propertyName) != nil {
-				continue
-			}
 			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
 			innerSelectColumns = append(innerSelectColumns, fmt.Sprintf("JSONExtractString(properties, '%s') as %s", propertyName, propertyName))
 			outerSelectColumns = append(outerSelectColumns, propertyName)

--- a/internal/repository/clickhouse/costsheet_usage.go
+++ b/internal/repository/clickhouse/costsheet_usage.go
@@ -514,7 +514,7 @@ func (r *CostSheetUsageRepository) getStandardAnalytics(ctx context.Context, cos
 			// this is safe to interpolate and always emits exactly one column — keeping
 			// this list in lockstep with the scan targets built below.
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
+			alias := groupByPropertyAlias(propertyName)
 			sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
 			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
 			groupByColumnAliases = append(groupByColumnAliases, sqlExpression)
@@ -635,9 +635,12 @@ func (r *CostSheetUsageRepository) getStandardAnalytics(ctx context.Context, cos
 		scanValues := make([]interface{}, 0)
 		scanValues = append(scanValues, &result.FeatureID, &result.PriceID, &result.MeterID)
 
-		// Add property fields
+		// Add property fields. Iterate params.GroupBy, not groupByFieldMapping: the SELECT
+		// list appends property columns in params.GroupBy order, and map iteration order is
+		// unspecified — ranging the map here would misalign scan targets with columns and
+		// assign one property's value to another property's key.
 		propertyValues := make(map[string]*string)
-		for groupBy := range groupByFieldMapping {
+		for _, groupBy := range params.GroupBy {
 			if strings.HasPrefix(groupBy, "properties.") {
 				propertyName := strings.TrimPrefix(groupBy, "properties.")
 				val := new(string)
@@ -768,9 +771,13 @@ func (r *CostSheetUsageRepository) getMaxBucketTotals(ctx context.Context, costS
 			// this is safe to interpolate and always emits exactly one column — keeping
 			// this list in lockstep with the scan targets built below.
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
+			// The alias must be dot-free: a raw "region.code" alias would be parsed by
+			// ClickHouse as the qualified identifier region.code in the outer query, not
+			// as this column. Use the shared collision-free alias, same as getStandardAnalytics.
+			alias := groupByPropertyAlias(propertyName)
 			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
-			innerSelectColumns = append(innerSelectColumns, fmt.Sprintf("JSONExtractString(properties, '%s') as %s", propertyName, propertyName))
-			outerSelectColumns = append(outerSelectColumns, propertyName)
+			innerSelectColumns = append(innerSelectColumns, fmt.Sprintf("JSONExtractString(properties, '%s') as %s", propertyName, alias))
+			outerSelectColumns = append(outerSelectColumns, alias)
 		}
 	}
 

--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -263,9 +263,9 @@ func (r *EventRepository) GetUsage(ctx context.Context, params *events.UsagePara
 		return nil, err
 	}
 
-	query := aggregator.GetQuery(ctx, params)
+	query, queryArgs := aggregator.GetQuery(ctx, params)
 
-	rows, err := r.store.GetConn().Query(ctx, query)
+	rows, err := r.store.GetConn().Query(ctx, query, queryArgs...)
 	if err != nil {
 		SetSpanError(span, err)
 		return nil, ierr.WithError(err).

--- a/internal/repository/clickhouse/group_by_property_validation_test.go
+++ b/internal/repository/clickhouse/group_by_property_validation_test.go
@@ -1,0 +1,36 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateGroupByProperty_RejectsInjectionShapedPropertyNames guards the fix in
+// feature_usage.go (getStandardAnalytics, getMaxBucketTotals, getSumBucketTotals),
+// costsheet_usage.go (getStandardAnalytics, getMaxBucketTotals), and
+// processed_event.go (GetDetailedUsageAnalytics): the group_by "properties.X" name is
+// interpolated both as a SQL string literal (JSONExtractString(properties, '<name>'))
+// and as a raw column-alias identifier, so it can never be bound via `?` — it must be
+// validated against a strict allow-list before use. This test proves the guard rejects
+// the exact live-verified PoC shape and accepts safe names.
+func TestValidateGroupByProperty_RejectsInjectionShapedPropertyNames(t *testing.T) {
+	maliciousNames := []string{
+		"x') OR 1=1 -- ",
+		"x' OR '1'='1",
+		"org_id'); DROP TABLE feature_usage; --",
+		"org id", // space is also disallowed by the allow-list
+	}
+	for _, name := range maliciousNames {
+		err := validateGroupByProperty(name)
+		assert.Error(t, err, "expected validateGroupByProperty to reject %q", name)
+	}
+}
+
+func TestValidateGroupByProperty_AcceptsSafeNames(t *testing.T) {
+	safeNames := []string{"org_id", "krn", "region.code", "a1_b2", ""}
+	for _, name := range safeNames {
+		err := validateGroupByProperty(name)
+		assert.NoError(t, err, "expected validateGroupByProperty to accept %q", name)
+	}
+}

--- a/internal/repository/clickhouse/group_by_property_validation_test.go
+++ b/internal/repository/clickhouse/group_by_property_validation_test.go
@@ -48,3 +48,27 @@ func TestGroupByPropertyValidation_RejectsRatherThanDrops(t *testing.T) {
 			"group_by property %q must be rejected, not dropped", propertyName)
 	}
 }
+
+// TestGroupByPropertyAlias_DotFreeAndCollisionFree pins the alias contract the analytics
+// SELECT/scan paths rely on: the alias must contain no dot (a raw "region.code" alias is
+// parsed by ClickHouse as a qualified identifier, breaking the outer query) and must be
+// injective (a plain dots->underscores scheme collides "region.code" with "region_code",
+// producing duplicate column aliases that ClickHouse rejects).
+func TestGroupByPropertyAlias_DotFreeAndCollisionFree(t *testing.T) {
+	// dot-free
+	for _, name := range []string{"region.code", "a.b.c", "org_id", "region_code"} {
+		assert.NotContains(t, groupByPropertyAlias(name), ".",
+			"alias for %q must not contain a dot", name)
+	}
+
+	// injective across names that a naive scheme would collide
+	names := []string{"region.code", "region_code", "a.b", "a_b", "a", "org_id", "org.id"}
+	seen := map[string]string{}
+	for _, name := range names {
+		alias := groupByPropertyAlias(name)
+		if prev, dup := seen[alias]; dup {
+			assert.Failf(t, "alias collision", "%q and %q both map to alias %q", prev, name, alias)
+		}
+		seen[alias] = name
+	}
+}

--- a/internal/repository/clickhouse/group_by_property_validation_test.go
+++ b/internal/repository/clickhouse/group_by_property_validation_test.go
@@ -7,13 +7,12 @@ import (
 )
 
 // TestValidateGroupByProperty_RejectsInjectionShapedPropertyNames guards the fix in
-// feature_usage.go (getStandardAnalytics, getMaxBucketTotals, getSumBucketTotals),
-// costsheet_usage.go (getStandardAnalytics, getMaxBucketTotals), and
-// processed_event.go (GetDetailedUsageAnalytics): the group_by "properties.X" name is
-// interpolated both as a SQL string literal (JSONExtractString(properties, '<name>'))
-// and as a raw column-alias identifier, so it can never be bound via `?` — it must be
-// validated against a strict allow-list before use. This test proves the guard rejects
-// the exact live-verified PoC shape and accepts safe names.
+// costsheet_usage.go and processed_event.go (both in GetDetailedUsageAnalytics): the
+// group_by "properties.X" name is interpolated both as a SQL string literal
+// (JSONExtractString(properties, '<name>')) and as a raw column-alias identifier, so it
+// can never be bound via `?` — it must be validated against a strict allow-list before
+// use. This test proves the guard rejects the exact live-verified PoC shape and accepts
+// safe names.
 func TestValidateGroupByProperty_RejectsInjectionShapedPropertyNames(t *testing.T) {
 	maliciousNames := []string{
 		"x') OR 1=1 -- ",
@@ -28,9 +27,24 @@ func TestValidateGroupByProperty_RejectsInjectionShapedPropertyNames(t *testing.
 }
 
 func TestValidateGroupByProperty_AcceptsSafeNames(t *testing.T) {
-	safeNames := []string{"org_id", "krn", "region.code", "a1_b2", ""}
+	// Note: "" is accepted by the validator itself; callers reject empty property names
+	// separately, since "properties." carries no field to group on.
+	safeNames := []string{"org_id", "krn", "region.code", "a1_b2"}
 	for _, name := range safeNames {
 		err := validateGroupByProperty(name)
 		assert.NoError(t, err, "expected validateGroupByProperty to accept %q", name)
+	}
+}
+
+// TestGroupByPropertyValidation_RejectsRatherThanDrops pins the invariant that makes the
+// SELECT column list and the scan targets stay in lockstep: an invalid group_by property
+// must be rejected up front with ErrValidation, never silently dropped from the query.
+// Dropping it would leave the scan sized off len(params.GroupBy) while the SELECT emitted
+// one column fewer, turning a bad request into a row-scan failure (HTTP 500) — and, where
+// the aggregation still ran, would silently collapse rows across an intended dimension.
+func TestGroupByPropertyValidation_RejectsRatherThanDrops(t *testing.T) {
+	for _, propertyName := range []string{"x') OR 1=1 -- ", "org id", "a-b"} {
+		assert.Error(t, validateGroupByProperty(propertyName),
+			"group_by property %q must be rejected, not dropped", propertyName)
 	}
 }

--- a/internal/repository/clickhouse/processed_event.go
+++ b/internal/repository/clickhouse/processed_event.go
@@ -585,7 +585,11 @@ func (r *ProcessedEventRepository) GetDetailedUsageAnalytics(ctx context.Context
 		case strings.HasPrefix(groupBy, "properties."):
 			// Extract property name from "properties.field_name"
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			if propertyName != "" {
+			// propertyName is user-controlled (request group_by) and is interpolated
+			// both as a SQL string literal and as part of a column alias identifier —
+			// neither can be parameterized with `?`, so validate against a strict
+			// allow-list before use (mirrors the analogous guard in feature_usage.go).
+			if propertyName != "" && validateGroupByProperty(propertyName) == nil {
 				// Create alias like "prop_org_id" for "properties.org_id"
 				alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
 				sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)

--- a/internal/repository/clickhouse/processed_event.go
+++ b/internal/repository/clickhouse/processed_event.go
@@ -546,6 +546,25 @@ func (r *ProcessedEventRepository) GetDetailedUsageAnalytics(ctx context.Context
 				}).
 				Mark(ierr.ErrValidation)
 		}
+
+		// The property name is interpolated into the query both as a SQL string literal
+		// and as a column-alias identifier, so it can never be bound via `?` — reject it
+		// here rather than dropping it, which would desync the SELECT column list from
+		// the scan targets below (both are sized off params.GroupBy).
+		if strings.HasPrefix(groupBy, "properties.") {
+			propertyName := strings.TrimPrefix(groupBy, "properties.")
+			if propertyName == "" {
+				return nil, ierr.NewError("invalid group_by value").
+					WithHint("group_by 'properties.<field_name>' requires a non-empty field name").
+					WithReportableDetails(map[string]interface{}{
+						"group_by": groupBy,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+			if err := validateGroupByProperty(propertyName); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Initialize query parameters with the standard parameters that will be added later
@@ -583,20 +602,17 @@ func (r *ProcessedEventRepository) GetDetailedUsageAnalytics(ctx context.Context
 			groupByColumnAliases = append(groupByColumnAliases, "source")
 			groupByFieldMapping["source"] = "source"
 		case strings.HasPrefix(groupBy, "properties."):
-			// Extract property name from "properties.field_name"
+			// Extract property name from "properties.field_name". Already validated
+			// against the allow-list above, so it is safe to interpolate here — and
+			// every entry emits exactly one column, keeping this list in lockstep with
+			// the scan targets built from params.GroupBy.
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			// propertyName is user-controlled (request group_by) and is interpolated
-			// both as a SQL string literal and as part of a column alias identifier —
-			// neither can be parameterized with `?`, so validate against a strict
-			// allow-list before use (mirrors the analogous guard in feature_usage.go).
-			if propertyName != "" && validateGroupByProperty(propertyName) == nil {
-				// Create alias like "prop_org_id" for "properties.org_id"
-				alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
-				sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
-				groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
-				groupByColumnAliases = append(groupByColumnAliases, sqlExpression)
-				groupByFieldMapping[groupBy] = alias
-			}
+			// Create alias like "prop_org_id" for "properties.org_id"
+			alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
+			sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
+			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
+			groupByColumnAliases = append(groupByColumnAliases, sqlExpression)
+			groupByFieldMapping[groupBy] = alias
 		}
 	}
 

--- a/internal/repository/clickhouse/processed_event.go
+++ b/internal/repository/clickhouse/processed_event.go
@@ -607,8 +607,8 @@ func (r *ProcessedEventRepository) GetDetailedUsageAnalytics(ctx context.Context
 			// every entry emits exactly one column, keeping this list in lockstep with
 			// the scan targets built from params.GroupBy.
 			propertyName := strings.TrimPrefix(groupBy, "properties.")
-			// Create alias like "prop_org_id" for "properties.org_id"
-			alias := "prop_" + strings.ReplaceAll(propertyName, ".", "_")
+			// Dot-free, collision-free alias for "properties.<name>" (e.g. prop_org_5fid).
+			alias := groupByPropertyAlias(propertyName)
 			sqlExpression := fmt.Sprintf("JSONExtractString(properties, '%s') AS %s", propertyName, alias)
 			groupByColumns = append(groupByColumns, fmt.Sprintf("JSONExtractString(properties, '%s')", propertyName))
 			groupByColumnAliases = append(groupByColumnAliases, sqlExpression)

--- a/internal/repository/clickhouse/validation.go
+++ b/internal/repository/clickhouse/validation.go
@@ -2,12 +2,28 @@ package clickhouse
 
 import (
 	"regexp"
+	"strings"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
 )
 
 // validGroupByPropertyPattern matches safe property names (alphanumeric, underscores, dots).
 var validGroupByPropertyPattern = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
+
+// groupByPropertyAlias returns a dot-free, collision-free SQL column alias for a validated
+// group_by property name. The property name cannot be used as the alias directly: dots are
+// valid in property names (they address nested JSON keys) but ClickHouse parses
+// "region.code" as a qualified identifier. A plain dots->underscores replacement is not
+// injective ("region.code" and "region_code" both yield "region_code"), so the encoding
+// below escapes underscores before mapping dots, making the transform reversible and thus
+// collision-free: '_' -> "_5f" and '.' -> "_2e" (the chars' hex codes, which the escape of
+// '_' guarantees cannot otherwise appear). Valid names only contain [A-Za-z0-9_.], so no
+// other character needs escaping.
+func groupByPropertyAlias(propertyName string) string {
+	escaped := strings.ReplaceAll(propertyName, "_", "_5f")
+	escaped = strings.ReplaceAll(escaped, ".", "_2e")
+	return "prop_" + escaped
+}
 
 // validateGroupByProperty checks that a GroupByProperty value is safe to interpolate into SQL.
 // It rejects any string that contains characters other than letters, digits, underscores, or dots.


### PR DESCRIPTION
## **User description**
## Summary
- `internal/repository/clickhouse/aggregators.go` (and to a lesser degree `costsheet_usage.go`, `processed_event.go`) built ClickHouse SQL via `fmt.Sprintf` string interpolation of user-controlled values — filter property names/values, customer IDs, timezone, group-by property names — with zero escaping. The query reached the driver via `Query(ctx, query)` with no bound args at all.
- Reachable live via `POST /v1/events/usage`, whose `filters` field is bound directly from request JSON into the vulnerable query-building path.
- Live-verified on staging:
  ```
  POST /v1/events/usage {"filters": {"normal_prop": ["a"]}, ...}          → 200 (baseline)
  POST /v1/events/usage {"filters": {"x') OR 1=1 -- ": ["a"]}, ...}       → 500 database_error
  ```
  The single quote in the property name broke ClickHouse SQL syntax server-side — proof the value reached the query unescaped.
- The codebase already has a safe, proven pattern for this exact case — `internal/repository/clickhouse/meter_usage_query_builder.go` builds the same kind of JSON-property filters using `?` placeholders + a parallel `args []interface{}` slice. This PR brings the `aggregators.go` path in line with that pattern.

## Fix
- `Aggregator.GetQuery` (`internal/domain/events/aggregator.go`) signature changed from `(ctx, params) string` to `(ctx, params) (string, []interface{})`. All 8 concrete aggregators (Count, Sum, Avg, CountUnique, Latest, SumWithMultiplier, Max, WeightedSum) and their shared helpers rewritten to build `?`-placeholder queries with an accumulated args slice, instead of interpolating values into the string.
- `internal/repository/clickhouse/event.go`'s `GetUsage` now captures both return values and passes `queryArgs...` to `Query`.
- Group-by property names in `costsheet_usage.go`/`processed_event.go` are structurally different — they're used both as a SQL string literal *and* as a raw column-alias identifier (`... AS %s`), so they can't be bound via `?` at all. Instead, they are validated against the pre-existing `validateGroupByProperty` allow-list regex (`^[A-Za-z0-9_.]+$`) that was already used elsewhere in this codebase for the same kind of identifier — consistent with existing convention rather than a new pattern.
  - The check lives in the **existing up-front `group_by` validation loop** in `GetDetailedUsageAnalytics` (both `ProcessedEventRepository` and `CostSheetUsageRepository`) and returns `ErrValidation`. It deliberately **rejects** rather than silently drops: the scan targets in both callers are sized off `len(params.GroupBy)` unconditionally, so dropping an entry from the SELECT list would desync the two and turn a bad request into a row-scan failure (HTTP 500). Rejecting up front keeps the SELECT list and scan targets in lockstep and returns a usable 4xx. Empty `properties.` names are rejected there for the same reason.
- Deliberately out of scope: `internal/repository/clickhouse/builder/query_builder.go` — confirmed dead code, zero live callers via any route today. Same injection class, tracked as a separate follow-up.

## Test plan
- [x] New `internal/repository/clickhouse/aggregators_test.go`: for every fixed interpolation site, asserts a malicious property name/value (`x') OR 1=1 -- `) never appears literally in the returned query string and does appear in the returned args slice at the correct position.
- [x] New `internal/repository/clickhouse/group_by_property_validation_test.go`: confirms the allow-list rejects non-identifier group-by property names, and pins the reject-don't-drop invariant that keeps the SELECT list and scan targets in lockstep.
- [x] Verified placeholder count equals arg count, and that arg *order* matches placeholder order, across all 8 aggregators × window/bucket/group-by/multi-customer-id/multi-filter/no-time-range variants (`WeightedSum` in particular reorders its args to match the CTE placeholders that precede the SELECT ones).
- [x] Verified `buildFilterConditions` fragment order and arg order come from the same map iteration, so multi-key filters cannot desync despite Go's randomized map ordering.
- [x] Verified the escaping actually happens: clickhouse-go v2 binds positionally client-side via `format()`, which quotes strings through `strings.NewReplacer("\\", "\\\\", "'", "\\'")`.
- [x] `go build ./internal/... ./cmd/...` clean; `go vet ./internal/repository/clickhouse/...` clean; `gofmt` clean; `make lint-ci` (loglint merge gate) clean.
- [x] `go test ./internal/repository/clickhouse/... ./internal/domain/events/...` — all green, no regressions in existing tests.
- [x] Confirmed `internal/repository/clickhouse/meter_usage_aggregators.go`'s unrelated `GetQuery` (different interface, already-parameterized via `MeterUsageQueryBuilder`) is untouched and unaffected by the interface signature change.
- [ ] Manual re-verification against staging recommended: repeat the exact PoC (`filters: {"x') OR 1=1 -- ": ["a"]}`), confirm `200` (clean result) instead of the pre-fix `500`; and `group_by: ["properties.bad name"]`, confirm a `400` validation error rather than a `500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Parameterized ClickHouse aggregation queries using bind arguments instead of interpolating user-controlled filters, customer IDs, event names, and time ranges.
  * Strengthened validation for `properties.<field_name>` used in analytics grouping.

* **Bug Fixes**
  * Prevented unsafe or invalid property names from being used in generated grouping queries.
  * Invalid grouping properties now return validation errors instead of being silently ignored.

* **Tests**
  * Added regression coverage confirming injection attempts are excluded from raw SQL and safely bound as arguments.
  * Added unit tests for property-name validation and multi-value filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent SQL injection in ClickHouse usage analytics

### What Changed
- Usage queries now bind event names, customer IDs, timestamps, filter names, and filter values instead of inserting request data directly into SQL.
- Invalid analytics property names are rejected, while valid nested property names continue to work with safe, collision-free column aliases.
- Analytics grouping keeps selected columns aligned with returned property values, including repeated or nested property names.
- Added coverage for malicious filters, customer values, event names, group-by names, and alias collisions.

### Impact
`✅ Blocked SQL injection through event usage filters`
`✅ Clear validation errors for unsafe group-by properties`
`✅ Correct property values in grouped usage analytics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
