### PR TITLE
fix(checkout): add nil check for PaymentProviderConfig

### DIFF
--- a/internal/api/dto/checkout_session.go
+++ b/internal/api/dto/checkout_session.go
@@ -42,8 +42,10 @@ func (r *CreateCheckoutSessionRequest) Validate() error {
 		return err
 	}
 
-	if err := r.PaymentProviderConfig.Validate(); err != nil {
-		return err
+	if r.PaymentProviderConfig != nil {
+		if err := r.PaymentProviderConfig.Validate(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating a checkout session without optional payment provider settings no longer produces an unexpected validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->