### PR TITLE
feat(auto-topup): Idempotency on temporal run id

### DIFF
--- a/internal/ee/service/alert.go
+++ b/internal/ee/service/alert.go
@@ -38,7 +38,12 @@ type AlertService interface {
 	// fetches every wallet for the customer, computes real-time balance for each,
 	// and runs wallet-level + feature-level alert checks and auto-topup.
 	// Self-contained; one call drives everything.
-	EvaluateWalletAlertsForCustomer(ctx context.Context, cust *customer.Customer) error
+	//
+	// autoTopupIdempotencySeed is propagated to walletService for stable auto-topup
+	// idempotency keys — Temporal-driven callers should pass their workflow run id
+	// so retries do not create duplicate top-ups. Empty seed preserves the legacy
+	// fresh-UUID-per-call behavior.
+	EvaluateWalletAlertsForCustomer(ctx context.Context, cust *customer.Customer, autoTopupIdempotencySeed string) error
 
 	// EvaluateSpendBreachForEvent is the sync per-event entry used by the meter
 	// usage post-insert side effect when the debouncer is off. Delegates to

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -292,7 +292,7 @@ func (s *alertService) evaluateSpendForSubscription(
 // walletService.EvaluateAlertsForWallet. Per-wallet resolve / balance /
 // short-circuit / three-step handler dance lives entirely on walletService —
 // this coordinator only owns the tenant + customer scope.
-func (s *alertService) EvaluateWalletAlertsForCustomer(ctx context.Context, cust *customer.Customer) error {
+func (s *alertService) EvaluateWalletAlertsForCustomer(ctx context.Context, cust *customer.Customer, autoTopupIdempotencySeed string) error {
 	settingsSvc := &settingsService{ServiceParams: s.ServiceParams}
 	tenantCfg, err := GetSetting[types.AlertSettings](settingsSvc, ctx, types.SettingKeyWalletBalanceAlertConfig)
 	if err != nil {
@@ -319,7 +319,7 @@ func (s *alertService) EvaluateWalletAlertsForCustomer(ctx context.Context, cust
 	alertLogsSvc := NewAlertLogsService(s.ServiceParams)
 
 	for _, w := range wallets {
-		if err := walletSvc.EvaluateAlertsForWallet(ctx, w, alertLogsSvc); err != nil {
+		if err := walletSvc.EvaluateAlertsForWallet(ctx, w, alertLogsSvc, autoTopupIdempotencySeed); err != nil {
 			s.Logger.Error(ctx, "wallet alerts: EvaluateAlertsForWallet returned error", "error", err, "wallet_id", w.ID)
 		}
 	}

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -102,6 +102,7 @@ type WalletService interface {
 	// CompletePurchasedCreditTransaction completes a pending wallet transaction when payment succeeds
 	CompletePurchasedCreditTransactionWithRetry(ctx context.Context, walletTransactionID string) error
 
+	// TODO: Cleanup this method, moved to `EvaluateAlertsForWallet`
 	CheckWalletBalanceAlert(ctx context.Context, req *wallet.WalletBalanceAlertEvent) error
 
 	// PublishWalletBalanceAlertEvent publishes a wallet balance alert event
@@ -2075,20 +2076,6 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 	// Publish webhook event after transaction commits
 	s.publishInternalTransactionWebhookEvent(ctx, types.WebhookEventWalletTransactionCreated, tx.ID)
 
-	// CheckWalletBalanceAlert runs synchronously below for this event, so it is not
-	// published to Kafka — publishing it too would let the async consumer re-run the
-	// same check and double-fire auto top-up.
-	event := &wallet.WalletBalanceAlertEvent{
-		ID:                    types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_ALERT),
-		Timestamp:             time.Now().UTC(),
-		Source:                EventSourceWalletTransaction,
-		CustomerID:            w.CustomerID,
-		ForceCalculateBalance: true,
-		TenantID:              types.GetTenantID(ctx),
-		EnvironmentID:         types.GetEnvironmentID(ctx),
-		WalletID:              req.WalletID,
-	}
-
 	// Log credit balance alert after wallet operation
 	if err := s.logCreditBalanceAlert(ctx, w, newCreditBalance); err != nil {
 		// Don't fail the transaction if alert logging fails
@@ -2098,8 +2085,10 @@ func (s *walletService) processWalletOperation(ctx context.Context, req *wallet.
 		)
 	}
 
-	if err := s.CheckWalletBalanceAlert(ctx, event); err != nil {
-		s.Logger.Error(ctx, "failed to check wallet balance alert after wallet operation",
+	// Only the wallet we just changed can have moved its alert state, so drive
+	// the per-wallet path directly instead of fanning out to every customer wallet.
+	if err := s.EvaluateAlertsForWallet(ctx, w, NewAlertLogsService(s.ServiceParams), ""); err != nil {
+		s.Logger.Error(ctx, "failed to evaluate wallet alerts after wallet operation",
 			"error", err,
 			"wallet_id", req.WalletID,
 			"customer_id", w.CustomerID,
@@ -3216,6 +3205,10 @@ func (s *walletService) EvaluateAlertsForWallet(ctx context.Context, w *wallet.W
 		return nil
 	}
 
+	// Note: same cache key is being read & updated by `GetWalletBalanceV2`
+	// so if tenant called get wallet balance v2, then the cached balance will be updated
+	// and if there's no usage in-between, no balance updated webhook will be sent
+	// expecting that tenant already got the updated balance
 	cachedBalance := s.getWalletRealtimeBalanceFromCache(ctx, w.ID, nil)
 
 	balance, err := s.GetWalletBalanceV2(ctx, w.ID)
@@ -3224,13 +3217,14 @@ func (s *walletService) EvaluateAlertsForWallet(ctx context.Context, w *wallet.W
 		return nil
 	}
 	ongoingBalance := lo.FromPtr(balance.RealTimeCreditBalance)
-	eventID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_ALERT)
 
 	if hasWalletAlert {
+		eventID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_ALERT)
 		if err := s.processWalletBalanceAlert(ctx, w, ongoingBalance, alertSettings, alertLogs, eventID); err != nil {
 			s.Logger.Error(ctx, "failed to process wallet balance alert", "error", err, "wallet_id", w.ID)
 		}
 	}
+
 	if autoTopupEnabled {
 		autoTopupKey := ""
 		if autoTopupIdempotencySeed != "" {

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -118,7 +118,13 @@ type WalletService interface {
 	// (nil / empty is fine). Per-step failures are logged and skipped so a
 	// single bad wallet handler doesn't block the next; only fatal setup
 	// errors return.
-	EvaluateAlertsForWallet(ctx context.Context, w *wallet.Wallet, alertLogs AlertLogsService) error
+	//
+	// autoTopupIdempotencySeed, when non-empty, is combined with the wallet ID
+	// to form a stable idempotency key for the auto-topup call. Callers driving
+	// this from a retryable context (Temporal activity) must pass a seed that
+	// is constant across retries of the same logical evaluation. Empty seed
+	// preserves the legacy fresh-UUID-per-call behavior.
+	EvaluateAlertsForWallet(ctx context.Context, w *wallet.Wallet, alertLogs AlertLogsService, autoTopupIdempotencySeed string) error
 }
 
 // walletBalanceComputeTimeout bounds the realtime-balance computation in
@@ -3188,7 +3194,7 @@ func (s *walletService) ManualBalanceDebit(ctx context.Context, walletID string,
 // alert-evaluation coordinator (alert_evaluation.go). Bundles the three
 // steps (wallet-level, feature-level, auto-topup) with the balance fetch
 // and short-circuit so callers don't need access to the private helpers.
-func (s *walletService) EvaluateAlertsForWallet(ctx context.Context, w *wallet.Wallet, alertLogs AlertLogsService) error {
+func (s *walletService) EvaluateAlertsForWallet(ctx context.Context, w *wallet.Wallet, alertLogs AlertLogsService, autoTopupIdempotencySeed string) error {
 	if w == nil {
 		return nil
 	}
@@ -3226,7 +3232,11 @@ func (s *walletService) EvaluateAlertsForWallet(ctx context.Context, w *wallet.W
 		}
 	}
 	if autoTopupEnabled {
-		if err := s.triggerAutoTopup(ctx, w, ongoingBalance); err != nil {
+		autoTopupKey := ""
+		if autoTopupIdempotencySeed != "" {
+			autoTopupKey = autoTopupIdempotencySeed + "-topup-" + w.ID
+		}
+		if err := s.triggerAutoTopup(ctx, w, ongoingBalance, autoTopupKey); err != nil {
 			s.Logger.Error(ctx, "failed to trigger auto top-up", "error", err, "wallet_id", w.ID)
 		}
 	}
@@ -3592,7 +3602,10 @@ func (s *walletService) CheckWalletBalanceAlert(ctx context.Context, req *wallet
 		// CheckWalletBalanceAlert that fires inside processWalletOperation during
 		// the top-up credit will record the recovered (ok) state automatically.
 		if autoTopupEnabled {
-			if err := s.triggerAutoTopup(ctx, w, ongoingBalance); err != nil {
+			// Legacy Kafka path — retries are governed by Kafka delivery and
+			// each delivery has its own message identity, so keep the fresh-UUID
+			// behavior here rather than plumbing a Kafka-scoped stable key.
+			if err := s.triggerAutoTopup(ctx, w, ongoingBalance, ""); err != nil {
 				s.Logger.Error(ctx, "failed to trigger auto top-up",
 					"error", err,
 					"wallet_id", w.ID,
@@ -3661,8 +3674,15 @@ func (s *walletService) hasPendingAutoTopupInvoice(ctx context.Context, customer
 	return len(invoices) > 0, nil
 }
 
-// triggerAutoTopup checks if auto top-up is enabled and triggers it if needed
-func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, ongoingBalance decimal.Decimal) error {
+// triggerAutoTopup checks if auto top-up is enabled and triggers it if needed.
+//
+// autoTopupIdempotencyKey, when non-empty, is used verbatim as the TopUpWallet
+// idempotency key so retries of the same logical evaluation collapse into a
+// single top-up. Callers that own a stable per-evaluation identity (e.g. a
+// Temporal workflow run id) should pass it here. Empty string preserves the
+// legacy behavior of minting a fresh UUID per call — appropriate for callers
+// that already have their own retry/dedup barrier (Kafka consumers, tests).
+func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, ongoingBalance decimal.Decimal, autoTopupIdempotencyKey string) error {
 
 	if w.AutoTopup == nil || w.AutoTopup.Enabled == nil || !*w.AutoTopup.Enabled {
 		s.Logger.Debug(ctx, "auto top-up not enabled, skipping",
@@ -3707,12 +3727,16 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 			types.InvoiceBillingReason(""),
 		)
 
+		idempotencyKey := autoTopupIdempotencyKey
+		if idempotencyKey == "" {
+			idempotencyKey = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION)
+		}
 		_, err := s.TopUpWallet(ctx, w.ID, &dto.TopUpWalletRequest{
 			CreditsToAdd:      *w.AutoTopup.Amount,
 			Amount:            *w.AutoTopup.Amount,
 			TransactionReason: transactionReason,
 			BillingReason:     billingReason,
-			IdempotencyKey:    lo.ToPtr(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION)),
+			IdempotencyKey:    lo.ToPtr(idempotencyKey),
 			Description:       "Auto top-up triggered for low ongoing balance",
 			Metadata:          types.Metadata{"auto_topup": "true"},
 		})

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -2479,12 +2479,12 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_GuardPreventsSecondIn
 	balance := decimal.NewFromInt(3) // below threshold of 5
 
 	// First call – should create one invoice.
-	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance)
+	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
 	s.NoError(err)
 	s.Equal(1, s.countAutoTopupInvoices(), "expected 1 auto-topup invoice after first trigger")
 
 	// Second call – guard must detect the pending invoice and skip.
-	err = s.svc().triggerAutoTopup(ctx, s.wallet, balance)
+	err = s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
 	s.NoError(err)
 	s.Equal(1, s.countAutoTopupInvoices(), "expected still 1 auto-topup invoice after second trigger (guard blocked it)")
 }
@@ -2498,7 +2498,7 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_AllowsNewInvoiceAfter
 	balance := decimal.NewFromInt(3) // below threshold of 5
 
 	// First trigger – creates one pending invoice.
-	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance)
+	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
 	s.NoError(err)
 	s.Equal(1, s.countAutoTopupInvoices(), "expected 1 auto-topup invoice after first trigger")
 
@@ -2515,7 +2515,7 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_AllowsNewInvoiceAfter
 
 	// Second trigger – guard no longer blocks because invoice is paid.
 	// Re-read wallet to get fresh state (balance still low since no actual credit was added).
-	err = s.svc().triggerAutoTopup(ctx, s.wallet, balance)
+	err = s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
 	s.NoError(err)
 	s.Equal(2, s.countAutoTopupInvoices(), "expected 2 auto-topup invoices after payment cleared the guard")
 }

--- a/internal/temporal/activities/alerts/alerts.go
+++ b/internal/temporal/activities/alerts/alerts.go
@@ -88,5 +88,9 @@ func (a *AlertActivities) WalletAlertsActivity(ctx context.Context, input models
 		return nil
 	}
 
-	return service.NewAlertService(a.serviceParams).EvaluateWalletAlertsForCustomer(ctx, cust)
+	// Anchor the auto-topup idempotency key to the Temporal workflow run id so
+	// activity retries within the same debounce firing collapse into a single
+	// top-up per wallet (fresh UUIDs on each retry would double-topup).
+	autoTopupSeed := activity.GetInfo(ctx).WorkflowExecution.RunID
+	return service.NewAlertService(a.serviceParams).EvaluateWalletAlertsForCustomer(ctx, cust, autoTopupSeed)
 }

--- a/internal/temporal/workflows/usage_alert_workflow.go
+++ b/internal/temporal/workflows/usage_alert_workflow.go
@@ -12,9 +12,9 @@ import (
 const (
 	// Workflow and activity names — must match the registered function names in
 	// registration.go so the SDK can dispatch by string.
-	WorkflowUsageAlert     = "UsageAlertWorkflow"
-	ActivitySpendAlerts    = "SpendAlertsActivity"
-	ActivityWalletAlerts   = "WalletAlertsActivity"
+	WorkflowUsageAlert   = "UsageAlertWorkflow"
+	ActivitySpendAlerts  = "SpendAlertsActivity"
+	ActivityWalletAlerts = "WalletAlertsActivity"
 
 	usageAlertActivityBudget = 5 * time.Minute
 )
@@ -55,10 +55,10 @@ func UsageAlertWorkflow(ctx workflow.Context, input models.UsageAlertWorkflowInp
 	})
 
 	if err := workflow.ExecuteActivity(actCtx, ActivitySpendAlerts, activityInput).Get(actCtx, nil); err != nil {
-		logger.Warn("SpendAlertsActivity returned error", "error", err)
+		logger.Error("SpendAlertsActivity returned error", "error", err)
 	}
 	if err := workflow.ExecuteActivity(actCtx, ActivityWalletAlerts, activityInput).Get(actCtx, nil); err != nil {
-		logger.Warn("WalletAlertsActivity returned error", "error", err)
+		logger.Error("WalletAlertsActivity returned error", "error", err)
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved auto-top-up reliability by preventing duplicate charges when alert processing is retried.
  - Preserved existing auto-top-up behavior for standard alert processing.
  - Improved workflow failure visibility by recording activity failures at a higher severity while allowing remaining alert checks to continue.

- **Bug Fixes**
  - Fixed retry handling so repeated alert evaluations consistently use the same auto-top-up transaction reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->