### PR TITLE
fix: context cancel in watermill router

### DIFF
--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -43,6 +43,8 @@ type Event struct {
 
 	// ExternalCustomerID is the identifier of the customer in the external system ex Customer DB or Stripe
 	ExternalCustomerID string `json:"external_customer_id" ch:"external_customer_id"`
+
+	ForceReprocess bool `json:"force_reprocess" ch:"-"` // if true, the event will be reprocessed even if it has already been processed
 }
 
 // ProcessedEvent represents an event that has been processed for billing

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -289,6 +289,7 @@ func (s *meterUsageTrackingService) getMetersForEvent(ctx context.Context, event
 func (s *meterUsageTrackingService) processEvent(ctx context.Context, event *events.Event) (err error) {
 	// Step 0: Check if the event is already processed
 	if event.ID != "" &&
+		!event.ForceReprocess &&
 		s.Config.MeterUsageTracking.RedisDeduplicationEnabled &&
 		s.ServiceParams.Locker != nil {
 		eventId := event.ID

--- a/internal/pubsub/router/router.go
+++ b/internal/pubsub/router/router.go
@@ -149,7 +149,13 @@ func (r *Router) AddNoPublishHandler(
 			tenantID := msg.Metadata.Get("tenant_id")
 			environmentID := msg.Metadata.Get("environment_id")
 
-			ctx, cancel := context.WithTimeout(msg.Context(), 600*time.Second)
+			// Detach from msg.Context() cancellation so a consumer-group rebalance
+			// or subscriber shutdown doesn't kill an in-flight handler mid-write.
+			// WithoutCancel keeps values (tracing span, writer pin, handler name)
+			// but strips cancellation, so the 600s below is a real floor, not just
+			// a ceiling under whichever cancels first. Safe because unacked messages
+			// are redelivered on the next session and handlers are idempotent.
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(msg.Context()), 600*time.Second)
 			defer cancel()
 			ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 			ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to force reprocessing of meter usage events, bypassing duplicate-event prevention.

* **Bug Fixes**
  * Improved processing reliability by allowing in-progress message handlers to finish when subscriber or consumer cancellation occurs, while retaining a maximum execution timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->