### PR TITLE
chore(dlq): add force-reprocess flag in msg header

### DIFF
--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -44,7 +44,7 @@ type Event struct {
 	// ExternalCustomerID is the identifier of the customer in the external system ex Customer DB or Stripe
 	ExternalCustomerID string `json:"external_customer_id" ch:"external_customer_id"`
 
-	ForceReprocess bool `json:"force_reprocess" ch:"-"` // if true, the event will be reprocessed even if it has already been processed
+	ForceReprocess bool `json:"-" ch:"-"` // if true, the event will be reprocessed even if it has already been processed
 }
 
 // ProcessedEvent represents an event that has been processed for billing

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -231,6 +231,11 @@ func (s *meterUsageTrackingService) processMessage(ctx context.Context, msg *mes
 		return nil // non-retriable
 	}
 
+	// if force reprocess is true, then we need to process the event even if it has already been processed
+	if msg.Metadata.Get("force_reprocess") == "true" {
+		event.ForceReprocess = true
+	}
+
 	if err := s.processEvent(ctx, &event); err != nil {
 		s.Logger.Error(ctx, "failed to process event for meter usage tracking",
 			"error", err,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for explicitly forcing eligible events to be processed again when requested through message metadata.

- **Bug Fixes**
  - Forced reprocessing requests are now honored consistently, preventing applicable events from being skipped during deduplication.
  - Internal processing controls are no longer included in serialized event data or external storage mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->