### PR TITLE
fix(clickhouse): batch singleton event inserts

### DIFF
--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -20,7 +21,7 @@ import (
 )
 
 type EventRepository struct {
-	store  *clickhouse.ClickHouseStore
+	store  interface{ GetConn() driver.Conn }
 	logger *logger.Logger
 }
 
@@ -97,7 +98,8 @@ func (r *EventRepository) InsertEvent(ctx context.Context, event *events.Event) 
 		)
 	`
 
-	err = r.store.GetConn().Exec(ctx, query,
+	// Wait for the server-side batch to flush before acknowledging the insert.
+	err = r.store.GetConn().AsyncInsert(ctx, query, true,
 		event.ID,
 		event.ExternalCustomerID,
 		event.CustomerID,
@@ -128,6 +130,9 @@ func (r *EventRepository) InsertEvent(ctx context.Context, event *events.Event) 
 func (r *EventRepository) BulkInsertEvents(ctx context.Context, events []*events.Event) error {
 	if len(events) == 0 {
 		return nil
+	}
+	if len(events) == 1 {
+		return r.InsertEvent(ctx, events[0])
 	}
 
 	// Start a span for this repository operation

--- a/internal/repository/clickhouse/event_test.go
+++ b/internal/repository/clickhouse/event_test.go
@@ -1,0 +1,67 @@
+package clickhouse
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/stretchr/testify/require"
+)
+
+type eventTestStore struct {
+	conn driver.Conn
+}
+
+func (s *eventTestStore) GetConn() driver.Conn {
+	return s.conn
+}
+
+type eventTestConn struct {
+	driver.Conn
+	asyncInsertCalls  int
+	prepareBatchCalls int
+	wait              bool
+	err               error
+}
+
+func (c *eventTestConn) AsyncInsert(_ context.Context, _ string, wait bool, _ ...any) error {
+	c.asyncInsertCalls++
+	c.wait = wait
+	return c.err
+}
+
+func (c *eventTestConn) PrepareBatch(context.Context, string, ...driver.PrepareBatchOption) (driver.Batch, error) {
+	c.prepareBatchCalls++
+	return nil, errors.New("unexpected batch insert")
+}
+
+func TestBulkInsertEventsUsesWaitingAsyncInsertForSingleton(t *testing.T) {
+	insertErr := errors.New("flush failed")
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "success"},
+		{name: "flush error", err: insertErr},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			conn := &eventTestConn{err: test.err}
+			repo := &EventRepository{store: &eventTestStore{conn: conn}}
+			event := events.NewEvent("api_call", "tenant-1", "customer-1", nil, time.Now(), "event-1", "", "test", "environment-1")
+
+			err := repo.BulkInsertEvents(context.Background(), []*events.Event{event})
+
+			if test.err == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.err.Error())
+			}
+			require.Equal(t, 1, conn.asyncInsertCalls)
+			require.True(t, conn.wait)
+			require.Zero(t, conn.prepareBatchCalls)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2398

Related to #736


## 📝 Description

You currently route Kafka events through BulkInsertEvents, but most deliveries contain only one event. The batch api still sends a one-row insert.

This creates a lot of background merge pressure, we've seen this result in 99k one-row parts withing ten minutes and CPU throttling during ~70% of scheduling periods.

This PR routes singleton bulk deliveries though ClcikHouse async inserts, then ClickHouse can combine compatible inserts server-side before creating a part.

`wait=true` makes sure the call succeeds after ClickHouse flushed the insert, so errors can propagate. Genuine multi-event deliveries continue using the existing batch implementation.

---

## 🔨 Changes Made
- [ ] Feature 1
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [x] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized event ingestion for single-event writes by using a faster insert path.
  * Improved overall event write handling for faster, more efficient ingestion.

* **Reliability Improvements**
  * Ensures event inserts wait for server-side batching to flush before reporting completion.

* **Tests**
  * Added coverage to verify singleton bulk inserts use the waiting async insert behavior and correctly propagate insert errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->