### PR TITLE
Feat/moyasar sync

### DIFF
--- a/internal/api/dto/connection.go
+++ b/internal/api/dto/connection.go
@@ -12,9 +12,12 @@ type CreateConnectionRequest struct {
 	Name                string                   `json:"name" validate:"required,max=255"`
 	ProviderType        types.SecretProvider     `json:"provider_type" validate:"required"`
 	EncryptedSecretData types.ConnectionMetadata `json:"encrypted_secret_data,omitempty"`
-	// Metadata holds provider-specific non-secret settings. For Paddle: use {"redirect_url": "https://..."}
-	// as the success URL where customers are redirected after payment. Backend appends &_success=<redirect_url>
-	// to Paddle checkout URLs before storing/sending them.
+	// Metadata holds provider-specific non-secret settings.
+	// For Paddle: use {"redirect_url": "https://..."} as the success URL where customers
+	// are redirected after payment. Backend appends &_success=<redirect_url> to Paddle
+	// checkout URLs before storing/sending them.
+	// For Moyasar: use {"success_url": "...", "cancel_url": "..."} to control where
+	// customers land after paying or cancelling on Moyasar's hosted invoice page.
 	Metadata   map[string]interface{} `json:"metadata,omitempty"`
 	SyncConfig *types.SyncConfig      `json:"sync_config,omitempty" validate:"omitempty,dive"`
 }

--- a/internal/api/dto/wallet.go
+++ b/internal/api/dto/wallet.go
@@ -345,6 +345,12 @@ type TopUpWalletRequest struct {
 	// bonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is
 	// used as-is, skipping slab resolution. To grant no bonus, omit this field entirely.
 	BonusCreditsToAdd *decimal.Decimal `json:"bonus_credits_to_add,omitempty" swaggertype:"string"`
+	// force_sync_invoice, when true and transaction_reason is PURCHASED_CREDIT_INVOICED,
+	// attempts to synchronously sync the purchased-credit invoice to Moyasar (if enabled)
+	// after this call's wallet transaction commits, instead of relying solely on the async
+	// Kafka + Temporal vendor-sync pipeline. Best-effort: sync failures are logged but never
+	// fail the top-up.
+	ForceSyncInvoice bool `json:"force_sync_invoice,omitempty"`
 }
 
 func (r *TopUpWalletRequest) Validate() error {

--- a/internal/api/dto/wallet.go
+++ b/internal/api/dto/wallet.go
@@ -268,7 +268,6 @@ func FromWallet(w *wallet.Wallet) *WalletResponse {
 	}
 }
 
-
 // WalletResponseFromBalance maps a computed balance into a WalletResponse with real-time fields.
 func WalletResponseFromBalance(b *WalletBalanceResponse) *WalletResponse {
 	if b == nil || b.Wallet == nil {
@@ -345,11 +344,7 @@ type TopUpWalletRequest struct {
 	// bonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is
 	// used as-is, skipping slab resolution. To grant no bonus, omit this field entirely.
 	BonusCreditsToAdd *decimal.Decimal `json:"bonus_credits_to_add,omitempty" swaggertype:"string"`
-	// force_sync_invoice, when true and transaction_reason is PURCHASED_CREDIT_INVOICED,
-	// attempts to synchronously sync the purchased-credit invoice to Moyasar (if enabled)
-	// after this call's wallet transaction commits, instead of relying solely on the async
-	// Kafka + Temporal vendor-sync pipeline. Best-effort: sync failures are logged but never
-	// fail the top-up.
+
 	ForceSyncInvoice bool `json:"force_sync_invoice,omitempty"`
 }
 

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -948,10 +948,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			Metadata:      invoiceMetadata,
 			BillingReason: req.BillingReason,
 		}
-		// Use CreateOneOffInvoice which handles draft-first flow: create draft, compute,
-		// finalize, webhook. ForceSyncInvoice is intentionally NOT set here — this call runs
-		// inside the enclosing DB transaction, and the Moyasar sync involves real network
-		// calls; it's triggered separately below, after the transaction commits.
+		// ForceSyncInvoice is omitted
 		inv, err := invoiceService.CreateOneOffInvoice(ctx, invReq)
 		if err != nil {
 			return ierr.WithError(err).

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -948,8 +948,11 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			Metadata:      invoiceMetadata,
 			BillingReason: req.BillingReason,
 		}
-		// Use CreateInvoice which handles draft-first flow: create draft, compute, finalize, webhook
-		inv, err := invoiceService.CreateInvoice(ctx, invReq)
+		// Use CreateOneOffInvoice which handles draft-first flow: create draft, compute,
+		// finalize, webhook. ForceSyncInvoice is intentionally NOT set here — this call runs
+		// inside the enclosing DB transaction, and the Moyasar sync involves real network
+		// calls; it's triggered separately below, after the transaction commits.
+		inv, err := invoiceService.CreateOneOffInvoice(ctx, invReq)
 		if err != nil {
 			return ierr.WithError(err).
 				WithHint("Failed to create invoice for purchased credits").
@@ -982,6 +985,16 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 
 	if err != nil {
 		return "", "", err
+	}
+
+	// Synchronous Moyasar sync (if requested) runs here, outside the DB transaction above,
+	// since it involves real network calls (invoice creation + optional token charge).
+	// Best-effort: never fails the top-up.
+	if req.ForceSyncInvoice {
+		if err := invoiceService.SyncInvoiceToMoyasarIfEnabled(ctx, invoiceID); err != nil {
+			s.Logger.Error(ctx, "force sync to Moyasar failed",
+				"error", err, "invoice_id", invoiceID, "wallet_id", walletID)
+		}
 	}
 
 	// If auto-completed, publish webhook event immediately

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -944,11 +944,11 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 					DisplayName: lo.ToPtr(fmt.Sprintf("Purchase %s Credits", req.CreditsToAdd.String())),
 				},
 			},
-			PaymentStatus: lo.ToPtr(paymentStatus),
-			Metadata:      invoiceMetadata,
-			BillingReason: req.BillingReason,
+			PaymentStatus:    lo.ToPtr(paymentStatus),
+			Metadata:         invoiceMetadata,
+			BillingReason:    req.BillingReason,
+			ForceSyncInvoice: req.ForceSyncInvoice,
 		}
-		// ForceSyncInvoice is omitted
 		inv, err := invoiceService.CreateOneOffInvoice(ctx, invReq)
 		if err != nil {
 			return ierr.WithError(err).
@@ -982,16 +982,6 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 
 	if err != nil {
 		return "", "", err
-	}
-
-	// Synchronous Moyasar sync (if requested) runs here, outside the DB transaction above,
-	// since it involves real network calls (invoice creation + optional token charge).
-	// Best-effort: never fails the top-up.
-	if req.ForceSyncInvoice {
-		if err := invoiceService.SyncInvoiceToMoyasarIfEnabled(ctx, invoiceID); err != nil {
-			s.Logger.Error(ctx, "force sync to Moyasar failed",
-				"error", err, "invoice_id", invoiceID, "wallet_id", walletID)
-		}
 	}
 
 	// If auto-completed, publish webhook event immediately

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/cache"
+	"github.com/flexprice/flexprice/internal/domain/connection"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entitlement"
 	"github.com/flexprice/flexprice/internal/domain/events"
@@ -77,28 +78,31 @@ func (s *WalletServiceSuite) setupService() {
 	stores := s.GetStores()
 	pubsub := testutil.NewInMemoryPubSub()
 	s.service = NewWalletService(ServiceParams{
-		Logger:                   s.GetLogger(),
-		Config:                   s.GetConfig(),
-		DB:                       s.GetDB(),
-		RedisCache:               testutil.NewInMemoryRedis(),
-		WalletRepo:               stores.WalletRepo,
-		SubRepo:                  stores.SubscriptionRepo,
-		SubscriptionLineItemRepo: stores.SubscriptionLineItemRepo,
-		PlanRepo:                 stores.PlanRepo,
-		PriceRepo:                stores.PriceRepo,
-		EventRepo:                stores.EventRepo,
-		MeterUsageRepo:           stores.MeterUsageRepo,
-		MeterRepo:                stores.MeterRepo,
-		CustomerRepo:             stores.CustomerRepo,
-		InvoiceRepo:              stores.InvoiceRepo,
-		EntitlementRepo:          stores.EntitlementRepo,
-		FeatureRepo:              stores.FeatureRepo,
-		AddonAssociationRepo:     stores.AddonAssociationRepo,
-		SettingsRepo:             stores.SettingsRepo,
-		AlertLogsRepo:            s.GetStores().AlertLogsRepo,
-		EventPublisher:           s.GetPublisher(),
-		WebhookPublisher:         s.GetWebhookPublisher(),
-		WalletBalanceAlertPubSub: types.WalletBalanceAlertPubSub{PubSub: pubsub},
+		Logger:                       s.GetLogger(),
+		Config:                       s.GetConfig(),
+		DB:                           s.GetDB(),
+		RedisCache:                   testutil.NewInMemoryRedis(),
+		WalletRepo:                   stores.WalletRepo,
+		SubRepo:                      stores.SubscriptionRepo,
+		SubscriptionLineItemRepo:     stores.SubscriptionLineItemRepo,
+		PlanRepo:                     stores.PlanRepo,
+		PriceRepo:                    stores.PriceRepo,
+		EventRepo:                    stores.EventRepo,
+		MeterUsageRepo:               stores.MeterUsageRepo,
+		MeterRepo:                    stores.MeterRepo,
+		CustomerRepo:                 stores.CustomerRepo,
+		InvoiceRepo:                  stores.InvoiceRepo,
+		EntitlementRepo:              stores.EntitlementRepo,
+		FeatureRepo:                  stores.FeatureRepo,
+		AddonAssociationRepo:         stores.AddonAssociationRepo,
+		SettingsRepo:                 stores.SettingsRepo,
+		AlertLogsRepo:                s.GetStores().AlertLogsRepo,
+		EventPublisher:               s.GetPublisher(),
+		WebhookPublisher:             s.GetWebhookPublisher(),
+		WalletBalanceAlertPubSub:     types.WalletBalanceAlertPubSub{PubSub: pubsub},
+		IntegrationFactory:           s.GetIntegrationFactory(),
+		ConnectionRepo:               stores.ConnectionRepo,
+		EntityIntegrationMappingRepo: stores.EntityIntegrationMappingRepo,
 	})
 	s.subsService = NewSubscriptionService(ServiceParams{
 		Logger:                   s.GetLogger(),
@@ -716,6 +720,78 @@ func (s *WalletServiceSuite) TestTopUpWallet() {
 	s.NotNil(foundTx, "Transaction with matching idempotency key not found")
 	s.NotNil(foundTx.Priority, "Transaction priority should not be nil")
 	s.Equal(2, *foundTx.Priority, "Transaction priority mismatch")
+}
+
+func (s *WalletServiceSuite) TestTopUpWallet_ForceSyncInvoice_AttemptsMoyasarSyncAfterCommit() {
+	ctx := s.GetContext()
+
+	s.Require().NoError(s.GetStores().ConnectionRepo.Create(ctx, &connection.Connection{
+		ID:            "conn_moyasar_wallet_enabled",
+		Name:          "moyasar enabled",
+		ProviderType:  types.SecretProviderMoyasar,
+		EnvironmentID: "env_test",
+		SyncConfig: &types.SyncConfig{
+			Invoice: &types.EntitySyncConfig{Outbound: true},
+		},
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedBy: types.DefaultUserID,
+			UpdatedBy: types.DefaultUserID,
+		},
+	}))
+
+	rec := &recordingConnectionRepo{Repository: s.GetStores().ConnectionRepo}
+	s.service.(*walletService).ConnectionRepo = rec
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("force_sync_wallet_topup_1"),
+		ForceSyncInvoice:  true,
+	}
+
+	resp, err := s.service.TopUpWallet(ctx, s.testData.wallet.ID, req)
+	s.Require().NoError(err, "top-up must succeed even though the Moyasar sync will fail (unconfigured credentials)")
+	s.Require().NotNil(resp)
+	s.Contains(rec.getByProviderCalls, types.SecretProviderMoyasar,
+		"ForceSyncInvoice=true must attempt a Moyasar sync after the transaction commits")
+}
+
+func (s *WalletServiceSuite) TestTopUpWallet_ForceSyncInvoiceFalse_NoSyncAttempted() {
+	ctx := s.GetContext()
+
+	s.Require().NoError(s.GetStores().ConnectionRepo.Create(ctx, &connection.Connection{
+		ID:            "conn_moyasar_wallet_default_false",
+		Name:          "moyasar enabled",
+		ProviderType:  types.SecretProviderMoyasar,
+		EnvironmentID: "env_test",
+		SyncConfig: &types.SyncConfig{
+			Invoice: &types.EntitySyncConfig{Outbound: true},
+		},
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedBy: types.DefaultUserID,
+			UpdatedBy: types.DefaultUserID,
+		},
+	}))
+
+	rec := &recordingConnectionRepo{Repository: s.GetStores().ConnectionRepo}
+	s.service.(*walletService).ConnectionRepo = rec
+
+	req := &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("force_sync_wallet_topup_2"),
+		// ForceSyncInvoice omitted, defaults to false
+	}
+
+	resp, err := s.service.TopUpWallet(ctx, s.testData.wallet.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.NotContains(rec.getByProviderCalls, types.SecretProviderMoyasar,
+		"ForceSyncInvoice=false must never attempt a Moyasar sync")
 }
 
 func (s *WalletServiceSuite) TestTerminateWallet() {

--- a/internal/integration/moyasar/invoice.go
+++ b/internal/integration/moyasar/invoice.go
@@ -231,6 +231,20 @@ func (s *InvoiceSyncService) buildInvoiceRequest(
 		Metadata:    metadata,
 	}
 
+	// Carry the tenant-configured redirect URLs (set on the connection, not per-invoice)
+	// through to Moyasar's hosted invoice page. Mirrors how
+	// PaddleSyncService.appendCheckoutToken reads ConnKeyRedirectURL off the connection.
+	// Errors/missing metadata are non-fatal — the customer simply isn't redirected
+	// anywhere after paying.
+	if conn, connErr := s.client.GetConnection(ctx); connErr == nil && conn != nil && conn.Metadata != nil {
+		if successURL, ok := conn.Metadata[ConnKeySuccessURL].(string); ok && successURL != "" {
+			req.SuccessURL = successURL
+		}
+		if cancelURL, ok := conn.Metadata[ConnKeyCancelURL].(string); ok && cancelURL != "" {
+			req.BackURL = cancelURL
+		}
+	}
+
 	s.logger.Info(ctx, "built invoice request for Moyasar",
 		"invoice_id", flexInvoice.ID,
 		"amount", flexInvoice.Total.String(),

--- a/internal/integration/moyasar/invoice_test.go
+++ b/internal/integration/moyasar/invoice_test.go
@@ -1,0 +1,108 @@
+package moyasar
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/connection"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustTestLogger(t *testing.T) *logger.Logger {
+	t.Helper()
+	cfg := &config.Configuration{
+		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
+	}
+	log, err := logger.NewLogger(cfg)
+	require.NoError(t, err)
+	return log
+}
+
+// stubMoyasarClient overrides only GetConnection; buildInvoiceRequest never calls any
+// other MoyasarClient method, so the embedded nil interface is safe.
+type stubMoyasarClient struct {
+	MoyasarClient
+	conn *connection.Connection
+	err  error
+}
+
+func (s *stubMoyasarClient) GetConnection(ctx context.Context) (*connection.Connection, error) {
+	return s.conn, s.err
+}
+
+func TestBuildInvoiceRequest_SetsSuccessAndBackURLFromConnectionMetadata(t *testing.T) {
+	svc := &InvoiceSyncService{
+		client: &stubMoyasarClient{
+			conn: &connection.Connection{
+				Metadata: map[string]interface{}{
+					ConnKeySuccessURL: "https://example.com/success",
+					ConnKeyCancelURL:  "https://example.com/cancel",
+				},
+			},
+		},
+		logger: mustTestLogger(t),
+	}
+
+	inv := &invoice.Invoice{
+		ID:         "inv_test_1",
+		CustomerID: "cust_test_1",
+		Total:      decimal.NewFromInt(100),
+		Currency:   "usd",
+	}
+
+	req, err := svc.buildInvoiceRequest(context.Background(), inv)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/success", req.SuccessURL)
+	assert.Equal(t, "https://example.com/cancel", req.BackURL)
+	assert.Empty(t, req.CallbackURL)
+}
+
+func TestBuildInvoiceRequest_NoConnectionMetadata_URLsEmpty(t *testing.T) {
+	svc := &InvoiceSyncService{
+		client: &stubMoyasarClient{
+			conn: &connection.Connection{}, // Metadata is nil
+		},
+		logger: mustTestLogger(t),
+	}
+
+	inv := &invoice.Invoice{
+		ID:         "inv_test_2",
+		CustomerID: "cust_test_2",
+		Total:      decimal.NewFromInt(50),
+		Currency:   "usd",
+	}
+
+	req, err := svc.buildInvoiceRequest(context.Background(), inv)
+	require.NoError(t, err)
+	assert.Empty(t, req.SuccessURL)
+	assert.Empty(t, req.BackURL)
+	assert.Empty(t, req.CallbackURL)
+}
+
+func TestBuildInvoiceRequest_GetConnectionErrors_URLsEmpty(t *testing.T) {
+	svc := &InvoiceSyncService{
+		client: &stubMoyasarClient{
+			err: errors.New("connection lookup failed"),
+		},
+		logger: mustTestLogger(t),
+	}
+
+	inv := &invoice.Invoice{
+		ID:         "inv_test_3",
+		CustomerID: "cust_test_3",
+		Total:      decimal.NewFromInt(75),
+		Currency:   "usd",
+	}
+
+	req, err := svc.buildInvoiceRequest(context.Background(), inv)
+	require.NoError(t, err, "a connection lookup failure must not fail the whole invoice-request build")
+	assert.Empty(t, req.SuccessURL)
+	assert.Empty(t, req.BackURL)
+}

--- a/internal/integration/moyasar/keys.go
+++ b/internal/integration/moyasar/keys.go
@@ -1,0 +1,10 @@
+package moyasar
+
+// Connection metadata keys used across the Moyasar integration.
+// Always use these constants instead of raw string literals to prevent typos.
+const (
+	// Connection metadata keys, stored on the Moyasar connection record's non-encrypted
+	// Metadata field (set via POST/PUT /connections {"metadata": {...}}).
+	ConnKeySuccessURL = "success_url" // customer redirected here after a successful payment
+	ConnKeyCancelURL  = "cancel_url"  // customer redirected here if they cancel/go back
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to force a synchronous invoice sync after wallet top-ups with purchased credits.
  - Enhanced Moyasar hosted invoices to automatically use tenant connection metadata for success and cancel redirect URLs.

- **Behavior**
  - When the option is enabled, a post-commit sync is attempted; otherwise, it’s not triggered.
  - Sync/invoice creation remains non-blocking if redirect URL data is missing or connection lookup fails.

- **Tests**
  - Added unit and integration coverage for the forced sync behavior and Moyasar redirect URL population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->