### PR TITLE
feat(tracing): storage-span sampling + app-level DB metrics (FLE-1003)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,12 +56,15 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.17.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/log v0.19.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.temporal.io/api v1.44.1
 	go.temporal.io/sdk v1.32.1
 	go.uber.org/fx v1.23.0
@@ -206,7 +209,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/Shopify/sarama/otelsarama v0.31.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,10 @@ go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.17.0 h1:6SRrIZrFL
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.17.0/go.mod h1:Nx2rIwEusIh/KFV8UrjjB87BfVn+daJ/lWCA0CkxAtY=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0 h1:HIBTQ3VO5aupLKjC90JgMqpezVXwFuq6Ryjn0/izoag=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0/go.mod h1:ji9vId85hMxqfvICA0Jt8JqEdrXaAkcpkI9HPXya0ro=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 h1:8UQVDcZxOJLtX6gxtDt3vY2WTgvZqMQRzjsqiIHQdkc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0/go.mod h1:2lmweYCiHYpEjQ/lSJBYhj9jP1zvCvQW4BqL9dnT7FQ=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 h1:w1K+pCJoPpQifuVpsKamUdn9U0zM3xUziVOqsGksUrY=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0/go.mod h1:HBy4BjzgVE8139ieRI75oXm3EcDN+6GhD88JT1Kjvxg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.41.0 h1:mq/Qcf28TWz719lE3/hMB4KkyDuLJIvgJnFGcd0kEUI=
@@ -522,6 +526,8 @@ go.opentelemetry.io/otel/log/logtest v0.17.0 h1:ljXJYD22KOc+h+vfv9IM1ppPjFSNndkp
 go.opentelemetry.io/otel/log/logtest v0.17.0/go.mod h1:MwJw0jkhvkZP8+qIQsVduBM660V0cMht4V1GUjuwLLE=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
+go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=
+go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/log v0.19.0 h1:scYVLqT22D2gqXItnWiocLUKGH9yvkkeql5dBDiXyko=

--- a/internal/cache/helper.go
+++ b/internal/cache/helper.go
@@ -96,8 +96,7 @@ func SetSpanSuccess(span *tracing.Span) {
 // No-op on nil spans; Set/Delete paths should not call this (the concept
 // doesn't apply).
 func SetCacheHit(span *tracing.Span, hit bool) {
-	if span == nil {
-		return
-	}
-	span.SetData("cache.hit", hit)
+	// SetCacheHit is nil-safe; it tags the span (if any) and stashes hit/miss
+	// for the cache.requests metric emitted on Finish.
+	span.SetCacheHit(hit)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -261,8 +261,9 @@ type OtelConfig struct {
 	Insecure    bool              `mapstructure:"insecure" default:"false"`          // true for local collector without TLS
 	Headers     map[string]string `mapstructure:"headers" validate:"omitempty"`      // applied to every signal unless that signal supplies its own non-empty map
 
-	Traces OtelTracesConfig `mapstructure:"traces"`
-	Logs   OtelLogsConfig   `mapstructure:"logs"`
+	Traces  OtelTracesConfig  `mapstructure:"traces"`
+	Logs    OtelLogsConfig    `mapstructure:"logs"`
+	Metrics OtelMetricsConfig `mapstructure:"metrics"`
 }
 
 // OtelTracesConfig configures OTLP span export.
@@ -280,6 +281,10 @@ type OtelTracesConfig struct {
 	Headers             map[string]string `mapstructure:"headers" validate:"omitempty"`          // overrides otel.headers when non-empty
 	SampleRate          float64           `mapstructure:"sample_rate" default:"1.0"`             // 0.0 - 1.0
 	StorageSpansEnabled bool              `mapstructure:"storage_spans_enabled" default:"false"` // enable per-query DB/cache/ClickHouse child spans (can be noisy)
+	// Per-trace throttle on storage spans (0.0-1.0), applied when StorageSpansEnabled
+	// is true. Independent of SampleRate (which thins whole traces incl. server spans);
+	// this thins only the DB/cache/ClickHouse fan-out. Default 0.2; set 1.0 to debug.
+	StorageSpansSampleRate float64 `mapstructure:"storage_spans_sample_rate" default:"0.2"`
 	// CaptureExceptions records errors (CaptureException calls, error-level logs,
 	// recovered panics) as OTel "exception" span events for SigNoz's Exceptions
 	// tab. Keep sample_rate at 1.0 so error-bearing traces are not sampled away.
@@ -306,6 +311,25 @@ func (c OtelTracesConfig) MergedHeaders() map[string]string {
 
 // MergedHeaders — see OtelTracesConfig.MergedHeaders.
 func (c OtelLogsConfig) MergedHeaders() map[string]string {
+	return mergeAuthHeader(c.Headers, c.AuthHeader, c.AuthValue)
+}
+
+// OtelMetricsConfig configures OTLP metric export (app-level DB/cache metrics).
+// Independent of Traces: metrics are always-on aggregate signal, cheap and
+// unsampled, so they carry steady-state monitoring while spans stay for debug.
+type OtelMetricsConfig struct {
+	Enabled    bool              `mapstructure:"enabled" default:"false"`
+	Endpoint   string            `mapstructure:"endpoint" validate:"omitempty"`
+	Protocol   string            `mapstructure:"protocol" validate:"omitempty"`
+	AuthHeader string            `mapstructure:"auth_header" validate:"omitempty"`
+	AuthValue  string            `mapstructure:"auth_value" validate:"omitempty"`
+	Headers    map[string]string `mapstructure:"headers" validate:"omitempty"`
+	// Export interval in seconds (PeriodicReader). Longer = cheaper (fewer samples).
+	IntervalSeconds int `mapstructure:"interval_seconds" default:"60"`
+}
+
+// MergedHeaders — see OtelTracesConfig.MergedHeaders.
+func (c OtelMetricsConfig) MergedHeaders() map[string]string {
 	return mergeAuthHeader(c.Headers, c.AuthHeader, c.AuthValue)
 }
 

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -151,6 +151,11 @@ otel:
     auth_header: "signoz-ingestion-key" # Set auth_value via FLEXPRICE_OTEL_TRACES_AUTH_VALUE
     auth_value: ""
     sample_rate: 1.0
+    # Per-query DB/cache/ClickHouse child spans. Off by default; when on, throttled
+    # per-trace by storage_spans_sample_rate (independent of sample_rate, so server
+    # spans stay 100%). 0.2 caps the fan-out; set 1.0 for full debug fidelity.
+    storage_spans_enabled: false
+    storage_spans_sample_rate: 0.2
     # Record errors/panics as OTel "exception" span events (SigNoz Exceptions tab).
     # Replaces Sentry. Keep sample_rate at 1.0 so error traces aren't sampled away.
     capture_exceptions: true
@@ -161,6 +166,16 @@ otel:
     protocol: "" # Empty = inherit top-level grpc.
     auth_header: "signoz-ingestion-key" # Set auth_value via FLEXPRICE_OTEL_LOGS_AUTH_VALUE
     auth_value: ""
+
+  # App-level DB/cache metrics (always-on aggregate signal, unsampled). Service-level
+  # resource only (no per-pod host attrs) to keep metric cardinality — and cost — flat.
+  metrics:
+    enabled: false
+    endpoint: "" # Set via FLEXPRICE_OTEL_METRICS_ENDPOINT
+    protocol: "" # Empty = inherit top-level grpc.
+    auth_header: "signoz-ingestion-key" # Set auth_value via FLEXPRICE_OTEL_METRICS_AUTH_VALUE
+    auth_value: ""
+    interval_seconds: 60
 
 pyroscope:
   enabled: false # Set to true to enable continuous profiling

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -451,6 +451,9 @@ func (s *Service) IsStorageSpansEnabled() bool {
 // kept trace retains its whole DB waterfall and, at equal rates, the kept set is
 // a subset of the head sampler's. Spans with no trace context are always emitted.
 func (s *Service) storageSpanSampled(ctx context.Context) bool {
+	if s == nil {
+		return false
+	}
 	rate := s.cfg.Otel.Traces.StorageSpansSampleRate
 	if rate >= 1.0 {
 		return true
@@ -702,6 +705,9 @@ func (s *Service) startSpan(ctx context.Context, name, op string, params map[str
 // storage_spans_sample_rate (per-trace), so every storage span — DB, ClickHouse,
 // repository — obeys both regardless of call path.
 func (s *Service) startStorageSpan(ctx context.Context, name, op, dbSystem string, params map[string]interface{}) (*Span, context.Context) {
+	if s == nil { // a nil tracing service is a valid no-op (tracing not wired)
+		return nil, ctx
+	}
 	spanOn := s.IsStorageSpansEnabled() && s.storageSpanSampled(ctx)
 	if !spanOn && !s.metricsEnabled {
 		return nil, ctx

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -15,6 +15,7 @@ package tracing
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -28,10 +29,14 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
@@ -51,6 +56,12 @@ type Service struct {
 	tracer         trace.Tracer
 	sentryEnabled  bool
 	tracingEnabled bool
+
+	// App-level metrics (independent of span export; see initMeter).
+	meterProvider  *sdkmetric.MeterProvider
+	metricsEnabled bool
+	dbDuration     metric.Float64Histogram // db.client.duration (ms) — {operation, db_system, status}
+	cacheRequests  metric.Int64Counter     // cache.requests — {operation, result}
 }
 
 // Module wires the Service into fx and registers OnStart / OnStop hooks.
@@ -79,6 +90,9 @@ func RegisterHooks(lc fx.Lifecycle, s *Service) {
 				return err
 			}
 			if err := s.initTracer(ctx); err != nil {
+				return err
+			}
+			if err := s.initMeter(ctx); err != nil {
 				return err
 			}
 			return nil
@@ -218,7 +232,10 @@ func (s *Service) newTraceExporter(ctx context.Context) (sdktrace.SpanExporter, 
 	return otlptrace.New(ctx, otlptracegrpc.NewClient(opts...))
 }
 
-func (s *Service) newResource(ctx context.Context) (*resource.Resource, error) {
+// baseResourceAttrs returns the service-level resource attributes shared by the
+// trace and metric resources (service name/version, environment, region,
+// component). No per-host/process attributes — those are added only for traces.
+func (s *Service) baseResourceAttrs() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(s.cfg.Otel.ResolveServiceName(s.cfg)),
 	}
@@ -251,9 +268,12 @@ func (s *Service) newResource(ctx context.Context) (*resource.Resource, error) {
 	if mode := string(s.cfg.Deployment.Mode); mode != "" {
 		attrs = append(attrs, attribute.String("app.component", mode))
 	}
+	return attrs
+}
 
+func (s *Service) newResource(ctx context.Context) (*resource.Resource, error) {
 	return resource.New(ctx,
-		resource.WithAttributes(attrs...),
+		resource.WithAttributes(s.baseResourceAttrs()...),
 		// Auto-detect host.name (container hostname on ECS), process.pid,
 		// process.executable.name, and os.type. These populate the "Infrastructure"
 		// section in SigNoz Span Details and enable host-level filtering.
@@ -266,11 +286,119 @@ func (s *Service) newResource(ctx context.Context) (*resource.Resource, error) {
 	)
 }
 
+// newMetricResource builds a SERVICE-LEVEL resource (no host.name/process attrs).
+// Metric series cardinality = label combinations × resource series; per-pod
+// host attributes would multiply every series by the running pod count, so they
+// are deliberately omitted to keep metric cost flat.
+func (s *Service) newMetricResource(ctx context.Context) (*resource.Resource, error) {
+	return resource.New(ctx,
+		resource.WithAttributes(s.baseResourceAttrs()...),
+		resource.WithFromEnv(),
+	)
+}
+
+// initMeter wires the OTLP metric pipeline (PeriodicReader → exporter) and
+// creates the app-level DB/cache instruments. Independent of tracing: metrics
+// stay on even when storage spans are sampled down or off.
+func (s *Service) initMeter(ctx context.Context) error {
+	mc := s.cfg.Otel.Metrics
+	if !s.cfg.Otel.Enabled || !mc.Enabled || mc.Endpoint == "" {
+		s.logger.Info(ctx, "OTel metrics is disabled")
+		return nil
+	}
+
+	exporter, err := s.newMetricExporter(ctx)
+	if err != nil {
+		s.logger.Error(ctx, "Failed to initialize OTel metric exporter", "error", err)
+		return err
+	}
+
+	res, err := s.newMetricResource(ctx)
+	if err != nil {
+		if !errors.Is(err, resource.ErrPartialResource) {
+			return err
+		}
+		s.logger.Warn(ctx, "OTel metric resource: partial detection, some attributes may be missing", "error", err)
+	}
+
+	interval := time.Duration(mc.IntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(interval))),
+	)
+	otel.SetMeterProvider(mp)
+	s.meterProvider = mp
+
+	meter := mp.Meter(tracerName)
+	if s.dbDuration, err = meter.Float64Histogram("db.client.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Latency of a DB/cache/ClickHouse repository call")); err != nil {
+		return err
+	}
+	if s.cacheRequests, err = meter.Int64Counter("cache.requests",
+		metric.WithDescription("Cache lookups by result (hit/miss)")); err != nil {
+		return err
+	}
+
+	s.metricsEnabled = true
+	s.logger.Info(ctx, "OTel metrics initialized", "endpoint", mc.Endpoint, "interval", interval.String())
+	return nil
+}
+
+// newMetricExporter builds the OTLP metric exporter (gRPC or HTTP), mirroring
+// newTraceExporter's endpoint/protocol/header handling.
+func (s *Service) newMetricExporter(ctx context.Context) (sdkmetric.Exporter, error) {
+	mc := s.cfg.Otel.Metrics
+	protocol := s.cfg.Otel.ResolveProtocol(mc.Protocol)
+	headers := s.cfg.Otel.ResolveHeaders(mc.MergedHeaders())
+	endpointIsURL := strings.HasPrefix(mc.Endpoint, "http://") || strings.HasPrefix(mc.Endpoint, "https://")
+
+	if strings.HasPrefix(protocol, "http") {
+		opts := []otlpmetrichttp.Option{}
+		if endpointIsURL {
+			opts = append(opts, otlpmetrichttp.WithEndpointURL(mc.Endpoint))
+		} else {
+			opts = append(opts, otlpmetrichttp.WithEndpoint(mc.Endpoint))
+		}
+		if s.cfg.Otel.Insecure {
+			opts = append(opts, otlpmetrichttp.WithInsecure())
+		}
+		if len(headers) > 0 {
+			opts = append(opts, otlpmetrichttp.WithHeaders(headers))
+		}
+		opts = append(opts, otlpmetrichttp.WithCompression(otlpmetrichttp.GzipCompression))
+		return otlpmetrichttp.New(ctx, opts...)
+	}
+
+	opts := []otlpmetricgrpc.Option{}
+	if endpointIsURL {
+		opts = append(opts, otlpmetricgrpc.WithEndpointURL(mc.Endpoint))
+	} else {
+		opts = append(opts, otlpmetricgrpc.WithEndpoint(mc.Endpoint))
+	}
+	if s.cfg.Otel.Insecure {
+		opts = append(opts, otlpmetricgrpc.WithInsecure())
+	}
+	if len(headers) > 0 {
+		opts = append(opts, otlpmetricgrpc.WithHeaders(headers))
+	}
+	return otlpmetricgrpc.New(ctx, opts...)
+}
+
 func (s *Service) shutdown(ctx context.Context) {
 	if s.tracerProvider != nil {
 		s.logger.Info(ctx, "Shutting down OTel tracer provider")
 		if err := s.tracerProvider.Shutdown(ctx); err != nil {
 			s.logger.Error(ctx, "OTel tracer provider shutdown error", "error", err)
+		}
+	}
+	if s.meterProvider != nil {
+		s.logger.Info(ctx, "Shutting down OTel meter provider")
+		if err := s.meterProvider.Shutdown(ctx); err != nil {
+			s.logger.Error(ctx, "OTel meter provider shutdown error", "error", err)
 		}
 	}
 	if s.sentryEnabled {
@@ -314,6 +442,57 @@ func (s *Service) IsStorageSpansEnabled() bool {
 		return false
 	}
 	return s.tracingEnabled && s.cfg.Otel.Traces.StorageSpansEnabled
+}
+
+// storageSpanSampled applies otel.traces.storage_spans_sample_rate as a per-trace
+// throttle on storage spans, independent of the global trace sampler — so the
+// noisy DB/cache/ClickHouse fan-out can be thinned while HTTP server spans stay
+// at 100%. Deterministic on the trace ID (mirrors OTel TraceIDRatioBased), so a
+// kept trace retains its whole DB waterfall and, at equal rates, the kept set is
+// a subset of the head sampler's. Spans with no trace context are always emitted.
+func (s *Service) storageSpanSampled(ctx context.Context) bool {
+	rate := s.cfg.Otel.Traces.StorageSpansSampleRate
+	if rate >= 1.0 {
+		return true
+	}
+	if rate <= 0 {
+		return false
+	}
+	tid := trace.SpanContextFromContext(ctx).TraceID()
+	if !tid.IsValid() {
+		return true
+	}
+	val := binary.BigEndian.Uint64(tid[8:16]) >> 1
+	return val < uint64(rate*float64(uint64(1)<<63))
+}
+
+// recordStorageMetric emits db.client.duration (+ cache.requests for cache ops)
+// for a finished storage span. Labels are bounded (operation, db_system, status)
+// — never tenant/pod/query — to keep metric cardinality flat.
+func (s *Service) recordStorageMetric(sp *Span) {
+	if s.dbDuration == nil {
+		return
+	}
+	status := "ok"
+	if sp.hadError {
+		status = "error"
+	}
+	ms := float64(time.Since(sp.metricStart).Microseconds()) / 1000.0
+	s.dbDuration.Record(sp.ctx, ms, metric.WithAttributes(
+		attribute.String("operation", sp.metricOp),
+		attribute.String("db_system", sp.dbSystem),
+		attribute.String("status", status),
+	))
+	if sp.cacheHit != nil && s.cacheRequests != nil {
+		result := "miss"
+		if *sp.cacheHit {
+			result = "hit"
+		}
+		s.cacheRequests.Add(sp.ctx, 1, metric.WithAttributes(
+			attribute.String("operation", sp.metricOp),
+			attribute.String("result", result),
+		))
+	}
 }
 
 // Tracer returns the underlying OTel tracer (for callers that prefer the raw API).
@@ -393,14 +572,41 @@ func (s *Service) AddBreadcrumb(ctx context.Context, category, message string, d
 type Span struct {
 	span trace.Span
 	ctx  context.Context
+
+	// Metric fields — populated when metrics are enabled, recorded on Finish.
+	// Present even when span is nil (storage spans sampled out / disabled).
+	svc         *Service
+	metricStart time.Time
+	metricOp    string
+	dbSystem    string
+	hadError    bool
+	cacheHit    *bool
 }
 
-// Finish ends the span. Safe to call on nil.
+// Finish records the storage metric (if metrics are enabled) and ends the span.
+// Safe to call on nil.
 func (s *Span) Finish() {
-	if s == nil || s.span == nil {
+	if s == nil {
 		return
 	}
-	s.span.End()
+	if s.svc != nil && !s.metricStart.IsZero() {
+		s.svc.recordStorageMetric(s)
+	}
+	if s.span != nil {
+		s.span.End()
+	}
+}
+
+// SetCacheHit records hit/miss on the span (attribute) and stashes it for the
+// cache.requests metric emitted on Finish. No-op on nil.
+func (s *Span) SetCacheHit(hit bool) {
+	if s == nil {
+		return
+	}
+	s.cacheHit = &hit
+	if s.span != nil {
+		s.span.SetAttributes(attribute.Bool("cache.hit", hit))
+	}
 }
 
 // SetData attaches a typed attribute to the span. Mirrors sentry.Span.SetData.
@@ -424,7 +630,11 @@ func (s *Span) SetTag(key, value string) {
 // through spanerr for a stacktrace and per-scope dedup; falls back to the raw
 // OTel RecordError if the span isn't reachable via context.
 func (s *Span) SetStatusError(err error) {
-	if s == nil || s.span == nil || err == nil {
+	if s == nil || err == nil {
+		return
+	}
+	s.hadError = true // drives the metric status label even when the span is nil
+	if s.span == nil {
 		return
 	}
 	if s.ctx != nil && spanerr.Record(s.ctx, err) {
@@ -488,21 +698,37 @@ func (s *Service) startSpan(ctx context.Context, name, op string, params map[str
 // spanKind=Client AND a non-empty db.system); a plain internal span renders
 // as an anonymous child in the waterfall and never reaches that tab.
 //
-// Gated on otel.traces.storage_spans_enabled so every storage span — DB,
-// ClickHouse, repository — obeys the one flag regardless of call path.
+// Gated on otel.traces.storage_spans_enabled (master switch) and throttled by
+// storage_spans_sample_rate (per-trace), so every storage span — DB, ClickHouse,
+// repository — obeys both regardless of call path.
 func (s *Service) startStorageSpan(ctx context.Context, name, op, dbSystem string, params map[string]interface{}) (*Span, context.Context) {
-	if !s.IsStorageSpansEnabled() {
+	spanOn := s.IsStorageSpansEnabled() && s.storageSpanSampled(ctx)
+	if !spanOn && !s.metricsEnabled {
 		return nil, ctx
 	}
-	newCtx, sp := s.tracer.Start(ctx, name, trace.WithSpanKind(trace.SpanKindClient))
-	sp.SetAttributes(
-		attribute.String("span.op", op),
-		attribute.String("db.system", dbSystem),
-	)
-	for k, v := range params {
-		sp.SetAttributes(toAttr(k, v))
+	out := &Span{ctx: ctx}
+	newCtx := ctx
+	if spanOn {
+		var sp trace.Span
+		newCtx, sp = s.tracer.Start(ctx, name, trace.WithSpanKind(trace.SpanKindClient))
+		sp.SetAttributes(
+			attribute.String("span.op", op),
+			attribute.String("db.system", dbSystem),
+		)
+		for k, v := range params {
+			sp.SetAttributes(toAttr(k, v))
+		}
+		out.span = sp
+		out.ctx = newCtx
 	}
-	return &Span{span: sp, ctx: newCtx}, newCtx
+	// Metrics are always-on (independent of span sampling): record on Finish.
+	if s.metricsEnabled {
+		out.svc = s
+		out.metricStart = time.Now()
+		out.metricOp = name
+		out.dbSystem = dbSystem
+	}
+	return out, newCtx
 }
 
 // StartDBSpan starts a span representing a Postgres operation.

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -180,3 +180,15 @@ func TestNoMetricsWhenDisabled(t *testing.T) {
 		t.Errorf("expected no data points when metrics disabled; got %v", got)
 	}
 }
+
+// A nil *Service must be a safe no-op — StartRepositorySpan is called on a nil
+// tracing service when tracing isn't wired (regression: the metrics change
+// added a direct s.metricsEnabled deref that panicked on nil, FLE-1003 CI).
+func TestNilServiceStorageSpanNoPanic(t *testing.T) {
+	var s *Service // nil
+	span, _ := s.StartRepositorySpan(context.Background(), "postgresql", "price", "list", nil)
+	span.Finish() // must also be nil-safe
+	if span != nil {
+		t.Errorf("expected nil span from nil service, got %v", span)
+	}
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,182 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// ctxWithTraceID returns a context carrying a span with the given low-8-byte
+// trace ID value (the bytes storageSpanSampled hashes on).
+func ctxWithTraceID(low uint64) context.Context {
+	var tid trace.TraceID
+	tid[0] = 1 // keep the ID valid (not all-zero)
+	for i := 0; i < 8; i++ {
+		tid[15-i] = byte(low >> (8 * i))
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid})
+	return trace.ContextWithSpanContext(context.Background(), sc)
+}
+
+func svcWithRate(rate float64) *Service {
+	return &Service{cfg: &config.Configuration{
+		Otel: config.OtelConfig{Traces: config.OtelTracesConfig{StorageSpansSampleRate: rate}},
+	}}
+}
+
+func TestStorageSpanSampled(t *testing.T) {
+	// low 8 bytes = 0 -> val 0 (smallest); all-ones -> val ~max.
+	lowCtx := ctxWithTraceID(0)
+	highCtx := ctxWithTraceID(^uint64(0))
+
+	tests := []struct {
+		name string
+		rate float64
+		ctx  context.Context
+		want bool
+	}{
+		{"rate 1.0 always samples", 1.0, highCtx, true},
+		{"rate 0.0 never samples", 0.0, lowCtx, false},
+		{"below threshold sampled", 0.5, lowCtx, true},
+		{"above threshold dropped", 0.5, highCtx, false},
+		{"no trace context always sampled", 0.5, context.Background(), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := svcWithRate(tt.rate).storageSpanSampled(tt.ctx); got != tt.want {
+				t.Fatalf("storageSpanSampled(rate=%v) = %v, want %v", tt.rate, got, tt.want)
+			}
+		})
+	}
+}
+
+// A kept/dropped decision must be identical for every span in the same trace.
+func TestStorageSpanSampledDeterministic(t *testing.T) {
+	s := svcWithRate(0.3)
+	ctx := ctxWithTraceID(12345)
+	first := s.storageSpanSampled(ctx)
+	for i := 0; i < 100; i++ {
+		if s.storageSpanSampled(ctx) != first {
+			t.Fatal("decision not stable within a trace")
+		}
+	}
+}
+
+// svcWithManualMeter builds a Service wired to a manual metric reader so the
+// full recording path (startStorageSpan → Finish → recordStorageMetric) can be
+// exercised in-process, without an OTLP endpoint. Storage spans stay disabled
+// (default cfg) to prove metrics record independently of span emission.
+func svcWithManualMeter(t *testing.T) (*Service, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meter := mp.Meter("test")
+	s := &Service{cfg: &config.Configuration{}, metricsEnabled: true}
+	var err error
+	if s.dbDuration, err = meter.Float64Histogram("db.client.duration"); err != nil {
+		t.Fatal(err)
+	}
+	if s.cacheRequests, err = meter.Int64Counter("cache.requests"); err != nil {
+		t.Fatal(err)
+	}
+	return s, reader
+}
+
+// collect gathers metrics and returns, per metric name, the list of data-point
+// attribute sets (as maps) so tests can assert labels without wrestling generics.
+func collect(t *testing.T, reader *sdkmetric.ManualReader) map[string][]map[string]string {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
+	}
+	out := map[string][]map[string]string{}
+	attrsOf := func(set attribute.Set) map[string]string {
+		m := map[string]string{}
+		for _, kv := range set.ToSlice() {
+			m[string(kv.Key)] = kv.Value.Emit()
+		}
+		return m
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, mtr := range sm.Metrics {
+			switch d := mtr.Data.(type) {
+			case metricdata.Histogram[float64]:
+				for _, dp := range d.DataPoints {
+					out[mtr.Name] = append(out[mtr.Name], attrsOf(dp.Attributes))
+				}
+			case metricdata.Sum[int64]:
+				for _, dp := range d.DataPoints {
+					out[mtr.Name] = append(out[mtr.Name], attrsOf(dp.Attributes))
+				}
+			}
+		}
+	}
+	return out
+}
+
+func hasDP(dps []map[string]string, want map[string]string) bool {
+	for _, dp := range dps {
+		match := true
+		for k, v := range want {
+			if dp[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func TestStorageMetricsRecorded(t *testing.T) {
+	s, reader := svcWithManualMeter(t)
+	ctx := context.Background()
+
+	// 1) Successful Postgres repository call.
+	sp, _ := s.startStorageSpan(ctx, "repository.price.list", "db.repository", "postgresql", nil)
+	sp.Finish()
+
+	// 2) Failed ClickHouse call → status=error.
+	sp, _ = s.startStorageSpan(ctx, "clickhouse.query", "db.clickhouse", "clickhouse", nil)
+	sp.SetStatusError(context.DeadlineExceeded)
+	sp.Finish()
+
+	// 3) Redis cache hit → db.client.duration + cache.requests{result=hit}.
+	sp, _ = s.startStorageSpan(ctx, "cache.secret.get", "cache.get", "redis", nil)
+	sp.SetCacheHit(true)
+	sp.Finish()
+
+	got := collect(t, reader)
+
+	dur := got["db.client.duration"]
+	if !hasDP(dur, map[string]string{"operation": "repository.price.list", "db_system": "postgresql", "status": "ok"}) {
+		t.Errorf("missing ok postgres duration point; got %v", dur)
+	}
+	if !hasDP(dur, map[string]string{"operation": "clickhouse.query", "db_system": "clickhouse", "status": "error"}) {
+		t.Errorf("missing error clickhouse duration point; got %v", dur)
+	}
+	if !hasDP(got["cache.requests"], map[string]string{"operation": "cache.secret.get", "result": "hit"}) {
+		t.Errorf("missing cache hit point; got %v", got["cache.requests"])
+	}
+}
+
+// Metrics must NOT record when the service has metrics disabled.
+func TestNoMetricsWhenDisabled(t *testing.T) {
+	s, reader := svcWithManualMeter(t)
+	s.metricsEnabled = false // startStorageSpan must not stamp metric metadata
+
+	sp, _ := s.startStorageSpan(context.Background(), "repository.price.list", "db.repository", "postgresql", nil)
+	sp.Finish() // sp is nil here (spans off + metrics off) — must be a safe no-op
+
+	if got := collect(t, reader); len(got["db.client.duration"]) != 0 {
+		t.Errorf("expected no data points when metrics disabled; got %v", got)
+	}
+}


### PR DESCRIPTION
## What & why
SigNoz trace **cost control** ([FLE-1003](https://linear.app/flexprice/issue/FLE-1003)). Jul 3–9, per-query storage-span instrumentation on prod `flexprice-api` drove traces to ~120M spans/day (~16× baseline, ~$300 of the SigNoz bill) while request volume was flat. This keeps the signal without the cost via two independent, config-gated levers.

## Changes

### 1. Storage-span sampling — the cost-stopper
- `otel.traces.storage_spans_sample_rate` (default **0.2**): a per-**trace** deterministic gate in `startStorageSpan` that throttles the DB/cache/ClickHouse child-span fan-out **independently of the global trace sampler**.
- HTTP **server spans stay at 100%** — API rate/error/latency are span-derived (no API metrics), so they must not be sampled.
- Mirrors OTel `TraceIDRatioBased`, so a kept trace retains its **whole** DB waterfall (no orphaned children).

### 2. App-level DB metrics — always-on aggregate signal
- New `otel.metrics` OTLP pipeline (MeterProvider + 60s PeriodicReader, push-based), default **off**.
- `db.client.duration` histogram `{operation, db_system, status}` — latency / call-rate / error-rate per repository operation.
- `cache.requests` counter `{operation, result}` — cache hit/miss.
- Recording rides the **existing** `StartRepositorySpan`/`FinishSpan` call sites (zero per-method edits) and is **independent of storage-span sampling** (metrics stay 100% even when spans are sampled to 0).
- **Service-level metric resource** (drops `WithHost()`/`WithProcess()`) → flat metric cardinality, no per-pod series multiplication.

## Not in this PR (by design)
- **Enabling** either lever per environment → separate **infra-repo PR** (`otel.metrics.enabled` + endpoint/auth; `storage_spans_sample_rate` per env; codify prod `storage_spans_enabled`).
- N+1 `db.calls_per_request` metric (needs request-scoped counting) — follow-up.

## Testing
- **Unit:** sampler decision (threshold / off / full / no-trace-context / determinism).
- **Unit:** metrics recording via `ManualReader` — asserts `db.client.duration` `{ok,error}` + `cache.requests{hit}`, and **no** emission when disabled.
- `go build ./cmd/... ./internal/...`, `go vet`, `go test ./internal/tracing ./internal/config` all pass.
- **Not** verified: OTLP push to SigNoz over the wire — deploy-time check. Enable in **staging** and confirm `db.client.duration` appears in SigNoz before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added application-level OTLP metrics export with configurable protocol/endpoint, auth, headers, and export interval.
  * Added storage metrics (DB operation duration and cache request metrics with cache hit/miss).
  * Added configurable throttling for storage child spans, sampled deterministically per trace.
* **Bug Fixes**
  * Improved cache-hit and error state handling so metrics are recorded reliably even when storage spans aren’t created.
  * Ensured storage span start is safe when the service is nil.
* **Tests**
  * Added tests for deterministic sampling, metrics recording (success/failure/cache hit), disabled-metrics behavior, and nil-safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->