### PR TITLE
fix(ci): update stale helm chart paths after ee/infrastructure move

### DIFF
--- a/.github/workflows/helm-validate.yml
+++ b/.github/workflows/helm-validate.yml
@@ -7,12 +7,12 @@ name: Helm Chart Validate
 on:
   pull_request:
     paths:
-      - 'helm/**'
+      - 'internal/ee/infrastructure/helm/**'
       - '.github/workflows/helm-validate.yml'
   push:
     branches: [main]
     paths:
-      - 'helm/**'
+      - 'internal/ee/infrastructure/helm/**'
       - '.github/workflows/helm-validate.yml'
 
 permissions:
@@ -43,18 +43,18 @@ jobs:
           helm repo update
 
       - name: helm dependency build
-        run: helm dependency build helm/flexprice
+        run: helm dependency build internal/ee/infrastructure/helm/flexprice
 
       - name: helm lint (default values)
-        run: helm lint helm/flexprice
+        run: helm lint internal/ee/infrastructure/helm/flexprice
 
       - name: helm lint (values-local)
-        run: helm lint helm/flexprice -f helm/values-local.yaml
+        run: helm lint internal/ee/infrastructure/helm/flexprice -f internal/ee/infrastructure/helm/values-local.yaml
 
       - name: helm lint (values-prod.example)
         run: |
-          helm lint helm/flexprice \
-            -f helm/values-prod.example.yaml \
+          helm lint internal/ee/infrastructure/helm/flexprice \
+            -f internal/ee/infrastructure/helm/values-prod.example.yaml \
             --set secrets.existingSecret=flexprice-secrets
 
       - name: Install kubeconform
@@ -67,19 +67,19 @@ jobs:
 
       - name: helm template + kubeconform (default)
         run: |
-          helm template flexprice helm/flexprice \
+          helm template flexprice internal/ee/infrastructure/helm/flexprice \
             --set secrets.existingSecret=test \
             | kubeconform -strict -ignore-missing-schemas -skip "$SKIP_KINDS" -summary -
 
       - name: helm template + kubeconform (values-local)
         run: |
-          helm template flexprice helm/flexprice -f helm/values-local.yaml \
+          helm template flexprice internal/ee/infrastructure/helm/flexprice -f internal/ee/infrastructure/helm/values-local.yaml \
             | kubeconform -strict -ignore-missing-schemas -skip "$SKIP_KINDS" -summary -
 
       - name: helm template + kubeconform (values-prod.example)
         run: |
-          helm template flexprice helm/flexprice \
-            -f helm/values-prod.example.yaml \
+          helm template flexprice internal/ee/infrastructure/helm/flexprice \
+            -f internal/ee/infrastructure/helm/values-prod.example.yaml \
             --set secrets.existingSecret=flexprice-secrets \
             | kubeconform -strict -ignore-missing-schemas -skip "$SKIP_KINDS" -summary -
 
@@ -110,7 +110,7 @@ jobs:
           helm repo update
 
       - name: helm dependency build
-        run: helm dependency build helm/flexprice
+        run: helm dependency build internal/ee/infrastructure/helm/flexprice
 
       - name: helm install --dry-run (default profile with placeholder secret)
         run: |
@@ -124,7 +124,7 @@ jobs:
             --from-literal=redis-password=placeholder \
             --from-literal=temporal-api-key=placeholder \
             --from-literal=auth-secret=placeholder
-          helm install flexprice helm/flexprice \
+          helm install flexprice internal/ee/infrastructure/helm/flexprice \
             -n flexprice-rc \
             --set secrets.existingSecret=flexprice-secrets \
             --dry-run \

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'helm/flexprice/**'
+      - 'internal/ee/infrastructure/helm/flexprice/**'
       - '.github/workflows/publish-helm-chart.yml'
     tags:
       - 'chart-v*'
@@ -52,7 +52,7 @@ jobs:
         id: chart-version
         run: |
           set -euo pipefail
-          CHART_VERSION=$(grep -E '^version:' helm/flexprice/Chart.yaml | awk '{print $2}' | tr -d '"')
+          CHART_VERSION=$(grep -E '^version:' internal/ee/infrastructure/helm/flexprice/Chart.yaml | awk '{print $2}' | tr -d '"')
           if [[ "${GITHUB_REF:-}" == refs/tags/chart-v* ]]; then
             TAG_VERSION="${GITHUB_REF#refs/tags/chart-v}"
             if [[ "$TAG_VERSION" != "$CHART_VERSION" ]]; then
@@ -75,7 +75,7 @@ jobs:
       - name: Extract Chart Name
         id: chart-name
         run: |
-          CHART_NAME=$(helm show chart helm/flexprice | grep '^name:' | awk '{print $2}' | tr -d '"' || echo "flexprice")
+          CHART_NAME=$(helm show chart internal/ee/infrastructure/helm/flexprice | grep '^name:' | awk '{print $2}' | tr -d '"' || echo "flexprice")
           echo "name=$CHART_NAME" >> $GITHUB_OUTPUT
           echo "Chart name: $CHART_NAME"
 
@@ -91,7 +91,7 @@ jobs:
             exit 0
           fi
           if git rev-parse HEAD^ >/dev/null 2>&1; then
-            PREV=$(git show HEAD^:helm/flexprice/Chart.yaml 2>/dev/null | grep -E '^version:' | awk '{print $2}' | tr -d '"' || echo "")
+            PREV=$(git show HEAD^:internal/ee/infrastructure/helm/flexprice/Chart.yaml 2>/dev/null | grep -E '^version:' | awk '{print $2}' | tr -d '"' || echo "")
           else
             PREV=""
           fi
@@ -112,17 +112,17 @@ jobs:
 
       - name: Build Helm Dependencies
         run: |
-          helm dependency build helm/flexprice
+          helm dependency build internal/ee/infrastructure/helm/flexprice
 
       - name: Lint Helm Chart
         run: |
-          helm lint helm/flexprice --set secrets.existingSecret=test
-          helm template flexprice-test helm/flexprice --set secrets.existingSecret=test --debug
+          helm lint internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test
+          helm template flexprice-test internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test --debug
 
       - name: Package Helm Chart
         if: ${{ steps.changed.outputs.publish == 'true' }}
         run: |
-          helm package helm/flexprice --version ${{ steps.chart-version.outputs.version }}
+          helm package internal/ee/infrastructure/helm/flexprice --version ${{ steps.chart-version.outputs.version }}
 
       - name: Check if version already exists
         id: version-check


### PR DESCRIPTION
## Summary
- Chart moved to `internal/ee/infrastructure/helm/flexprice` in eaa1f9007 but `publish-helm-chart.yml` and `helm-validate.yml` still referenced the old `helm/flexprice` path.
- Every publish run since the move has failed at the `Chart.yaml` grep step (`grep: helm/flexprice/Chart.yaml: No such file or directory`) — confirmed via `gh run list`, every run v2.1.16 through v2.1.21 = failure.
- `oci://ghcr.io/flexprice/charts/flexprice` currently has zero published tags. Customer-reported bugs (Helm `first` on map error, missing `config/rbac/roles.json`) do not reproduce on current chart — the customer's copy predates or bypasses the ee/infrastructure move and was never a CI-validated artifact.

## Test plan
- [x] `helm dependency build internal/ee/infrastructure/helm/flexprice` succeeds locally
- [x] `helm lint internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test` passes
- [ ] CI green on this PR (helm-validate.yml)
- [ ] Trigger `publish-helm-chart.yml` (workflow_dispatch or version bump) post-merge to get first real chart onto GHCR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Helm validation workflows to monitor and validate the chart from its new location.
  * Updated chart publishing automation to build, verify, package, and version the chart from the new location.
  * Helm linting, template rendering, dependency building, and installation dry runs continue to run against the relocated chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->