### PR TITLE
feat(developer): Service Account linked API keys revoke

### DIFF
--- a/internal/api/dto/secret.go
+++ b/internal/api/dto/secret.go
@@ -67,6 +67,8 @@ type SecretResponse struct {
 	Type               types.SecretType     `json:"type"`
 	Provider           types.SecretProvider `json:"provider"`
 	DisplayID          string               `json:"display_id"`
+	EnvironmentID      string               `json:"environment_id,omitempty"`
+	EnvironmentName    string               `json:"environment_name,omitempty"`
 	Roles              []string             `json:"roles,omitempty"`                // RBAC roles
 	UserType           types.UserType       `json:"user_type,omitempty"`            // "user" or "service_account"
 	UserID             string               `json:"user_id,omitempty"`              // user or service account this key belongs to
@@ -95,19 +97,20 @@ func ToSecretResponse(s *secret.Secret) *SecretResponse {
 	}
 
 	return &SecretResponse{
-		ID:         s.ID,
-		Name:       s.Name,
-		Type:       s.Type,
-		Provider:   s.Provider,
-		DisplayID:  s.DisplayID,
-		Roles:      s.Roles,
-		UserType:   types.UserType(s.UserType),
-		UserID:     s.UserID,
-		ExpiresAt:  s.ExpiresAt,
-		LastUsedAt: s.LastUsedAt,
-		Status:     s.Status,
-		CreatedAt:  s.CreatedAt,
-		UpdatedAt:  s.UpdatedAt,
+		ID:            s.ID,
+		Name:          s.Name,
+		Type:          s.Type,
+		Provider:      s.Provider,
+		DisplayID:     s.DisplayID,
+		EnvironmentID: s.EnvironmentID,
+		Roles:         s.Roles,
+		UserType:      types.UserType(s.UserType),
+		UserID:        s.UserID,
+		ExpiresAt:     s.ExpiresAt,
+		LastUsedAt:    s.LastUsedAt,
+		Status:        s.Status,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
 	}
 }
 

--- a/internal/api/dto/user.go
+++ b/internal/api/dto/user.go
@@ -61,6 +61,7 @@ type UserResponse struct {
 	Roles    []string          `json:"roles,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`
 	Tenant   *TenantResponse   `json:"tenant"`
+	APIKeys  []*SecretResponse `json:"api_keys,omitempty"`
 }
 
 // CreateUserResponse is the response for POST /users: same shape for both types; password only when type=user.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -156,6 +156,7 @@ func NewRouter(
 			user.GET("/me", handlers.User.GetUserInfo)
 			user.POST("", write(types.EntityUser, types.ActionWrite), handlers.User.CreateUser)
 			user.PUT("/me", write(types.EntityUser, types.ActionWrite), handlers.User.UpdateUser)
+			user.GET("/:id", handlers.User.GetUser)
 			user.PUT("/:id", write(types.EntityUser, types.ActionWrite), handlers.User.UpdateServiceAccount)
 			user.DELETE("/:id", write(types.EntityUser, types.ActionWrite), handlers.User.DeleteUser)
 			user.POST("/search", handlers.User.QueryUsers)

--- a/internal/api/v1/user.go
+++ b/internal/api/v1/user.go
@@ -147,6 +147,30 @@ func (h *UserHandler) QueryUsers(c *gin.Context) {
 	c.JSON(http.StatusOK, users)
 }
 
+// @Summary Get user or service account by ID
+// @ID getUser
+// @Description Get a user or service account by ID.
+// @Tags Users
+// @Produce json
+// @Security ApiKeyAuth
+// @Param id path string true "User or Service Account ID"
+// @Success 200 {object} dto.UserResponse
+// @Failure 400 {object} ierr.ErrorResponse "Invalid request"
+// @Failure 404 {object} ierr.ErrorResponse "Not found"
+// @Failure 500 {object} ierr.ErrorResponse "Server error"
+// @x-scope "read"
+// @Router /users/{id} [get]
+func (h *UserHandler) GetUser(c *gin.Context) {
+	id := c.Param("id")
+	resp, err := h.userService.GetUser(c.Request.Context(), id)
+	if err != nil {
+		h.logger.Error(c.Request.Context(), "failed to get user", "error", err)
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
 // @Summary Update service account
 // @ID updateServiceAccount
 // @Description Update a service account by ID (name only).
@@ -184,7 +208,7 @@ func (h *UserHandler) UpdateServiceAccount(c *gin.Context) {
 
 // @Summary Delete service account
 // @ID deleteServiceAccount
-// @Description Soft-delete (archive) a service account by ID.
+// @Description Soft-delete (archive) a service account by ID and revoke all of its published API keys across environments.
 // @Tags Users
 // @Produce json
 // @Security ApiKeyAuth

--- a/internal/domain/secret/repository.go
+++ b/internal/domain/secret/repository.go
@@ -26,6 +26,9 @@ type Repository interface {
 	// Delete deletes a secret by ID
 	Delete(ctx context.Context, id string) error
 
+	// DeletePublishedByUserID soft-deletes all published secrets for userID (tenant-scoped), including expired keys.
+	DeletePublishedByUserID(ctx context.Context, userID string) (int, error)
+
 	// GetAPIKeyByValue retrieves an API key by value
 	GetAPIKeyByValue(ctx context.Context, value string) (*Secret, error)
 

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -2,17 +2,18 @@ package service
 
 import (
 	"context"
-	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	authProvider "github.com/flexprice/flexprice/internal/auth"
 	"github.com/flexprice/flexprice/internal/config"
 	domainAuth "github.com/flexprice/flexprice/internal/domain/auth"
+	"github.com/flexprice/flexprice/internal/domain/environment"
 	domainSecret "github.com/flexprice/flexprice/internal/domain/secret"
 	"github.com/flexprice/flexprice/internal/domain/tenant"
 	"github.com/flexprice/flexprice/internal/domain/user"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/nedpals/supabase-go"
@@ -21,6 +22,7 @@ import (
 
 type UserService interface {
 	GetUserInfo(ctx context.Context) (*dto.UserResponse, error)
+	GetUser(ctx context.Context, id string) (*dto.UserResponse, error)
 	CreateUser(ctx context.Context, req *dto.CreateUserRequest) (*dto.CreateUserResponse, error)
 	UpdateUser(ctx context.Context, req *dto.UpdateUserRequest) (*dto.UpdateUserResponse, error)
 	UpdateServiceAccount(ctx context.Context, id string, req *dto.UpdateServiceAccountRequest) (*dto.UpdateServiceAccountResponse, error)
@@ -33,10 +35,12 @@ type userService struct {
 	tenantRepo      tenant.Repository
 	authRepo        domainAuth.Repository
 	secretRepo      domainSecret.Repository
+	environmentRepo environment.Repository
 	cfg             *config.Configuration
 	rbacService     *rbac.RBACService
 	supabaseAuth    *supabase.Client
 	settingsService SettingsService
+	db              postgres.IClient
 	logger          *logger.Logger
 }
 
@@ -45,10 +49,12 @@ func NewUserService(
 	tenantRepo tenant.Repository,
 	authRepo domainAuth.Repository,
 	secretRepo domainSecret.Repository,
+	environmentRepo environment.Repository,
 	cfg *config.Configuration,
 	rbacService *rbac.RBACService,
 	supabaseAuth *supabase.Client,
 	settingsService SettingsService,
+	db postgres.IClient,
 	logger *logger.Logger,
 ) UserService {
 	return &userService{
@@ -56,10 +62,12 @@ func NewUserService(
 		tenantRepo:      tenantRepo,
 		authRepo:        authRepo,
 		secretRepo:      secretRepo,
+		environmentRepo: environmentRepo,
 		cfg:             cfg,
 		rbacService:     rbacService,
 		supabaseAuth:    supabaseAuth,
 		settingsService: settingsService,
+		db:              db,
 		logger:          logger,
 	}
 }
@@ -90,6 +98,77 @@ func (s *userService) GetUserInfo(ctx context.Context) (*dto.UserResponse, error
 	}
 
 	return dto.NewUserResponse(user, tenant), nil
+}
+
+func (s *userService) GetUser(ctx context.Context, id string) (*dto.UserResponse, error) {
+	if id == "" {
+		return nil, ierr.NewError("user ID is required").
+			WithHint("Provide a valid user ID").
+			Mark(ierr.ErrValidation)
+	}
+
+	tenantID := types.GetTenantID(ctx)
+	if tenantID == "" {
+		return nil, ierr.NewError("tenant ID is required").
+			WithHint("Tenant ID is required").
+			Mark(ierr.ErrValidation)
+	}
+
+	u, err := s.userRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	tenant, err := s.tenantRepo.GetByID(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := dto.NewUserResponse(u, tenant)
+	if u.Type != types.UserTypeServiceAccount {
+		return resp, nil
+	}
+
+	tenantCtx := types.SetEnvironmentID(ctx, "")
+	secrets, err := s.secretRepo.ListAll(tenantCtx, &types.SecretFilter{
+		QueryFilter: &types.QueryFilter{
+			Status: lo.ToPtr(types.StatusPublished),
+		},
+		UserID: &id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	items := dto.ToSecretResponseList(secrets)
+	s.enrichSecretEnvironmentNames(tenantCtx, items)
+	resp.APIKeys = items
+
+	return resp, nil
+}
+
+func (s *userService) enrichSecretEnvironmentNames(ctx context.Context, items []*dto.SecretResponse) {
+	if s.environmentRepo == nil || len(items) == 0 {
+		return
+	}
+
+	envs, err := s.environmentRepo.List(ctx, types.Filter{
+		Limit:  100,
+		Status: types.StatusPublished,
+	})
+	if err != nil || len(envs) == 0 {
+		return
+	}
+
+	nameByID := lo.SliceToMap(envs, func(env *environment.Environment) (string, string) {
+		return env.ID, env.Name
+	})
+
+	for _, item := range items {
+		if name, ok := nameByID[item.EnvironmentID]; ok {
+			item.EnvironmentName = name
+		}
+	}
 }
 
 func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest) (*dto.CreateUserResponse, error) {
@@ -422,25 +501,11 @@ func (s *userService) DeleteUser(ctx context.Context, id string) error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Block archive if the service account has active (published, non-expired) API keys.
-	// Service accounts are tenant-scoped, so check across all environments.
-	now := time.Now().UTC()
-	tenantCtx := types.SetEnvironmentID(ctx, "")
-	activeCount, err := s.secretRepo.Count(tenantCtx, &types.SecretFilter{
-		QueryFilter: &types.QueryFilter{
-			Status: lo.ToPtr(types.StatusPublished),
-		},
-		UserID:       &id,
-		NotExpiredAt: &now,
+	return s.db.WithTx(ctx, func(txCtx context.Context) error {
+		tenantCtx := types.SetEnvironmentID(txCtx, "")
+		if _, err := s.secretRepo.DeletePublishedByUserID(tenantCtx, id); err != nil {
+			return err
+		}
+		return s.userRepo.Delete(txCtx, id)
 	})
-	if err != nil {
-		return err
-	}
-	if activeCount > 0 {
-		return ierr.NewError("service account has active API keys").
-			WithHint("Revoke all API keys before archiving this service account").
-			Mark(ierr.ErrValidation)
-	}
-
-	return s.userRepo.Delete(ctx, id)
 }

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/environment"
 	domainSecret "github.com/flexprice/flexprice/internal/domain/secret"
 	"github.com/flexprice/flexprice/internal/domain/tenant"
 	"github.com/flexprice/flexprice/internal/domain/user"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
@@ -18,11 +21,13 @@ import (
 
 type UserServiceSuite struct {
 	suite.Suite
-	ctx         context.Context
-	userService *userService
-	userRepo    *testutil.InMemoryUserStore
-	tenantRepo  *testutil.InMemoryTenantStore
-	secretRepo  *testutil.InMemorySecretStore
+	ctx             context.Context
+	userService     *userService
+	userRepo        *testutil.InMemoryUserStore
+	tenantRepo      *testutil.InMemoryTenantStore
+	secretRepo      *testutil.InMemorySecretStore
+	environmentRepo *testutil.InMemoryEnvironmentStore
+	db              postgres.IClient
 }
 
 func TestUserService(t *testing.T) {
@@ -34,19 +39,24 @@ func (s *UserServiceSuite) SetupTest() {
 	s.userRepo = testutil.NewInMemoryUserStore()
 	s.tenantRepo = testutil.NewInMemoryTenantStore()
 	s.secretRepo = testutil.NewInMemorySecretStore()
+	s.environmentRepo = testutil.NewInMemoryEnvironmentStore()
+	s.db = testutil.NewMockPostgresClient(logger.NewNoopLogger())
 	s.userService = &userService{
 		userRepo:        s.userRepo,
 		tenantRepo:      s.tenantRepo,
 		secretRepo:      s.secretRepo,
+		environmentRepo: s.environmentRepo,
+		db:              s.db,
 		rbacService:     nil,
 		supabaseAuth:    nil,
 		settingsService: nil,
 	}
 
-	s.tenantRepo.Create(s.ctx, &tenant.Tenant{
+	err := s.tenantRepo.Create(s.ctx, &tenant.Tenant{
 		ID:   types.DefaultTenantID,
 		Name: "Test Tenant",
 	})
+	s.NoError(err)
 }
 
 func (s *UserServiceSuite) TestGetUserInfo() {
@@ -282,7 +292,12 @@ func (s *UserServiceSuite) TestUpdateServiceAccount() {
 			Type:      types.UserTypeUser,
 			BaseModel: baseModel,
 		})
-		s.userService = &userService{userRepo: s.userRepo, tenantRepo: s.tenantRepo, secretRepo: s.secretRepo}
+		s.userService = &userService{
+			userRepo:   s.userRepo,
+			tenantRepo: s.tenantRepo,
+			secretRepo: s.secretRepo,
+			db:         s.db,
+		}
 	}
 
 	s.Run("success_name_updated", func() {
@@ -363,7 +378,12 @@ func (s *UserServiceSuite) TestDeleteUser() {
 			Type:      types.UserTypeUser,
 			BaseModel: baseModel,
 		})
-		s.userService = &userService{userRepo: s.userRepo, tenantRepo: s.tenantRepo, secretRepo: s.secretRepo}
+		s.userService = &userService{
+			userRepo:   s.userRepo,
+			tenantRepo: s.tenantRepo,
+			secretRepo: s.secretRepo,
+			db:         s.db,
+		}
 	}
 
 	s.Run("success_service_account_archived", func() {
@@ -400,30 +420,23 @@ func (s *UserServiceSuite) TestDeleteUser() {
 		s.Error(err)
 	})
 
-	s.Run("active_api_key_blocks_archive", func() {
+	s.Run("published_api_keys_across_envs_are_revoked", func() {
 		seedStore()
 		_ = s.secretRepo.Create(ctx, &domainSecret.Secret{
-			ID:       "key-1",
-			UserID:   "sa-1",
-			UserType: string(types.UserTypeServiceAccount),
+			ID:            "key-sandbox",
+			UserID:        "sa-1",
+			UserType:      string(types.UserTypeServiceAccount),
+			EnvironmentID: "env-sandbox",
 			BaseModel: types.BaseModel{
 				TenantID: types.DefaultTenantID,
 				Status:   types.StatusPublished,
 			},
 		})
-		err := s.userService.DeleteUser(ctx, "sa-1")
-		s.Error(err)
-		s.Contains(err.Error(), "active API keys")
-	})
-
-	s.Run("expired_api_key_allows_archive", func() {
-		seedStore()
-		past := time.Now().Add(-24 * time.Hour)
 		_ = s.secretRepo.Create(ctx, &domainSecret.Secret{
-			ID:        "key-2",
-			UserID:    "sa-1",
-			UserType:  string(types.UserTypeServiceAccount),
-			ExpiresAt: &past,
+			ID:            "key-prod",
+			UserID:        "sa-1",
+			UserType:      string(types.UserTypeServiceAccount),
+			EnvironmentID: "env-prod",
 			BaseModel: types.BaseModel{
 				TenantID: types.DefaultTenantID,
 				Status:   types.StatusPublished,
@@ -431,6 +444,156 @@ func (s *UserServiceSuite) TestDeleteUser() {
 		})
 		err := s.userService.DeleteUser(ctx, "sa-1")
 		s.NoError(err)
+
+		archived, err := s.userRepo.GetByID(ctx, "sa-1")
+		s.NoError(err)
+		s.Equal(types.StatusArchived, archived.Status)
+
+		keySandbox, err := s.secretRepo.Get(ctx, "key-sandbox")
+		s.NoError(err)
+		s.Equal(types.StatusDeleted, keySandbox.Status)
+
+		keyProd, err := s.secretRepo.Get(ctx, "key-prod")
+		s.NoError(err)
+		s.Equal(types.StatusDeleted, keyProd.Status)
+	})
+
+	s.Run("expired_published_api_key_is_also_revoked", func() {
+		seedStore()
+		past := time.Now().Add(-24 * time.Hour)
+		_ = s.secretRepo.Create(ctx, &domainSecret.Secret{
+			ID:            "key-expired",
+			UserID:        "sa-1",
+			UserType:      string(types.UserTypeServiceAccount),
+			EnvironmentID: "env-sandbox",
+			ExpiresAt:     &past,
+			BaseModel: types.BaseModel{
+				TenantID: types.DefaultTenantID,
+				Status:   types.StatusPublished,
+			},
+		})
+		err := s.userService.DeleteUser(ctx, "sa-1")
+		s.NoError(err)
+
+		key, err := s.secretRepo.Get(ctx, "key-expired")
+		s.NoError(err)
+		s.Equal(types.StatusDeleted, key.Status)
+	})
+}
+
+func (s *UserServiceSuite) TestGetUser() {
+	ctx := testutil.SetupContext()
+	ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
+	ctx = context.WithValue(ctx, types.CtxUserID, "actor-1")
+	// Request may be env-scoped; GetUser must still return keys across envs.
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, "env-sandbox")
+
+	baseModel := types.GetDefaultBaseModel(ctx)
+	baseModel.TenantID = types.DefaultTenantID
+
+	s.userRepo = testutil.NewInMemoryUserStore()
+	s.secretRepo = testutil.NewInMemorySecretStore()
+	s.environmentRepo = testutil.NewInMemoryEnvironmentStore()
+	_ = s.environmentRepo.Create(ctx, &environment.Environment{
+		ID:   "env-sandbox",
+		Name: "Sandbox",
+		Type: types.EnvironmentDevelopment,
+		BaseModel: types.BaseModel{
+			TenantID: types.DefaultTenantID,
+			Status:   types.StatusPublished,
+		},
+	})
+	_ = s.environmentRepo.Create(ctx, &environment.Environment{
+		ID:   "env-prod",
+		Name: "Production",
+		Type: types.EnvironmentProduction,
+		BaseModel: types.BaseModel{
+			TenantID: types.DefaultTenantID,
+			Status:   types.StatusPublished,
+		},
+	})
+	_ = s.userRepo.Create(ctx, &user.User{
+		ID:        "sa-1",
+		Name:      "Recon service",
+		Type:      types.UserTypeServiceAccount,
+		BaseModel: baseModel,
+	})
+	_ = s.userRepo.Create(ctx, &user.User{
+		ID:        "user-1",
+		Email:     "u@example.com",
+		Type:      types.UserTypeUser,
+		BaseModel: baseModel,
+	})
+	past := time.Now().Add(-24 * time.Hour)
+	_ = s.secretRepo.Create(ctx, &domainSecret.Secret{
+		ID:            "key-sandbox",
+		Name:          "sandbox-key",
+		UserID:        "sa-1",
+		UserType:      string(types.UserTypeServiceAccount),
+		EnvironmentID: "env-sandbox",
+		DisplayID:     "sk_****SB",
+		BaseModel: types.BaseModel{
+			TenantID: types.DefaultTenantID,
+			Status:   types.StatusPublished,
+		},
+	})
+	_ = s.secretRepo.Create(ctx, &domainSecret.Secret{
+		ID:            "key-prod-expired",
+		Name:          "prod-key",
+		UserID:        "sa-1",
+		UserType:      string(types.UserTypeServiceAccount),
+		EnvironmentID: "env-prod",
+		ExpiresAt:     &past,
+		DisplayID:     "sk_****PR",
+		BaseModel: types.BaseModel{
+			TenantID: types.DefaultTenantID,
+			Status:   types.StatusPublished,
+		},
+	})
+	s.userService = &userService{
+		userRepo:        s.userRepo,
+		tenantRepo:      s.tenantRepo,
+		secretRepo:      s.secretRepo,
+		environmentRepo: s.environmentRepo,
+		db:              s.db,
+	}
+
+	s.Run("human_user_has_no_api_keys", func() {
+		resp, err := s.userService.GetUser(ctx, "user-1")
+		s.NoError(err)
+		s.NotNil(resp)
+		s.Equal("user-1", resp.ID)
+		s.Nil(resp.APIKeys)
+	})
+
+	s.Run("service_account_includes_published_keys_across_envs", func() {
+		resp, err := s.userService.GetUser(ctx, "sa-1")
+		s.NoError(err)
+		s.NotNil(resp)
+		s.Equal("sa-1", resp.ID)
+		s.Require().NotNil(resp.APIKeys)
+		s.Equal(2, len(resp.APIKeys))
+
+		byID := map[string]*dto.SecretResponse{}
+		for _, key := range resp.APIKeys {
+			byID[key.ID] = key
+		}
+		s.Equal("Sandbox", byID["key-sandbox"].EnvironmentName)
+		s.Equal("env-sandbox", byID["key-sandbox"].EnvironmentID)
+		s.Equal("Production", byID["key-prod-expired"].EnvironmentName)
+		s.Equal("env-prod", byID["key-prod-expired"].EnvironmentID)
+	})
+
+	s.Run("empty_id_returns_validation_error", func() {
+		resp, err := s.userService.GetUser(ctx, "")
+		s.Error(err)
+		s.Nil(resp)
+	})
+
+	s.Run("unknown_id_returns_not_found", func() {
+		resp, err := s.userService.GetUser(ctx, "missing")
+		s.Error(err)
+		s.Nil(resp)
 	})
 }
 

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -502,7 +502,7 @@ func (s *walletService) loadUsersForExpansion(ctx context.Context, expand types.
 	}
 
 	// Fetch users in bulk
-	userService := NewUserService(s.UserRepo, s.TenantRepo, nil, nil, nil, nil, nil, nil, s.Logger)
+	userService := NewUserService(s.UserRepo, s.TenantRepo, nil, nil, s.EnvironmentRepo, nil, nil, nil, nil, s.DB, s.Logger)
 	userFilter := &types.UserFilter{
 		QueryFilter: types.NewNoLimitQueryFilter(),
 		UserIDs:     userIDs,

--- a/internal/repository/ent/secret.go
+++ b/internal/repository/ent/secret.go
@@ -310,6 +310,71 @@ func (r *secretRepository) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+func (r *secretRepository) DeletePublishedByUserID(ctx context.Context, userID string) (int, error) {
+	if userID == "" {
+		return 0, ierr.NewError("user ID is required").
+			WithHint("Provide a valid user ID").
+			Mark(ierr.ErrValidation)
+	}
+
+	tenantID := types.GetTenantID(ctx)
+	if tenantID == "" {
+		return 0, ierr.NewError("tenant ID is required").
+			WithHint("Tenant ID is required").
+			Mark(ierr.ErrValidation)
+	}
+
+	client := r.client.Writer(ctx)
+	r.log.Debug(ctx, "deleting published secrets by user_id", "user_id", userID)
+
+	query := client.Secret.Query().
+		Where(
+			secret.TenantID(tenantID),
+			secret.UserID(userID),
+			secret.Status(string(types.StatusPublished)),
+		)
+	query = r.queryOpts.ApplyEnvironmentFilter(ctx, query)
+
+	secrets, err := query.All(ctx)
+	if err != nil {
+		return 0, ierr.WithError(err).
+			WithHint("Failed to list secrets for user").
+			WithReportableDetails(map[string]interface{}{
+				"user_id": userID,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+	if len(secrets) == 0 {
+		return 0, nil
+	}
+
+	ids := make([]string, len(secrets))
+	values := make([]string, len(secrets))
+	for i, s := range secrets {
+		ids[i] = s.ID
+		values[i] = s.Value
+	}
+
+	n, err := client.Secret.Update().
+		Where(secret.IDIn(ids...)).
+		SetStatus(string(types.StatusDeleted)).
+		Save(ctx)
+	if err != nil {
+		return 0, ierr.WithError(err).
+			WithHint("Failed to delete secrets for user").
+			WithReportableDetails(map[string]interface{}{
+				"user_id": userID,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+
+	for _, value := range values {
+		r.DeleteCache(ctx, value)
+	}
+
+	return n, nil
+}
+
 type SecretQuery = *ent.SecretQuery
 
 type SecretQueryOptions struct{}

--- a/internal/testutil/inmemory_secret_store.go
+++ b/internal/testutil/inmemory_secret_store.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/secret"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
 
 // InMemorySecretStore implements secret.Repository
@@ -120,12 +121,21 @@ func (s *InMemorySecretStore) Count(ctx context.Context, filter *types.SecretFil
 }
 
 func (s *InMemorySecretStore) ListAll(ctx context.Context, filter *types.SecretFilter) ([]*secret.Secret, error) {
-	// Create an unlimited filter
+	if filter == nil {
+		filter = types.NewNoLimitSecretFilter()
+	}
+
 	unlimitedFilter := &types.SecretFilter{
 		QueryFilter:     types.NewNoLimitQueryFilter(),
 		TimeRangeFilter: filter.TimeRangeFilter,
 		Type:            filter.Type,
 		Provider:        filter.Provider,
+		Prefix:          filter.Prefix,
+		UserID:          filter.UserID,
+		NotExpiredAt:    filter.NotExpiredAt,
+	}
+	if filter.QueryFilter != nil && filter.QueryFilter.Status != nil {
+		unlimitedFilter.QueryFilter.Status = filter.QueryFilter.Status
 	}
 
 	return s.List(ctx, unlimitedFilter)
@@ -133,6 +143,33 @@ func (s *InMemorySecretStore) ListAll(ctx context.Context, filter *types.SecretF
 
 func (s *InMemorySecretStore) Delete(ctx context.Context, id string) error {
 	return s.InMemoryStore.Delete(ctx, id)
+}
+
+func (s *InMemorySecretStore) DeletePublishedByUserID(ctx context.Context, userID string) (int, error) {
+	if userID == "" {
+		return 0, ierr.NewError("user ID is required").
+			WithHint("Provide a valid user ID").
+			Mark(ierr.ErrValidation)
+	}
+
+	filter := &types.SecretFilter{
+		QueryFilter: &types.QueryFilter{
+			Status: lo.ToPtr(types.StatusPublished),
+		},
+		UserID: &userID,
+	}
+	secrets, err := s.ListAll(ctx, filter)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, sec := range secrets {
+		sec.Status = types.StatusDeleted
+		if err := s.InMemoryStore.Update(ctx, sec.ID, sec); err != nil {
+			return 0, err
+		}
+	}
+	return len(secrets), nil
 }
 
 func (s *InMemorySecretStore) GetAPIKeyByValue(ctx context.Context, value string) (*secret.Secret, error) {


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an endpoint to retrieve user details by ID.
  - Service-account details now include published API keys with environment information.
  - API keys can be listed across environments with their environment names and IDs.

- **Bug Fixes**
  - Deleting a user now archives all published API keys across environments, including expired keys, before removing the user.
  - User deletion and API key archival are handled together to prevent partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->