### PR TITLE
feat(marketplace): add support for currency, assume role validation before establishing connection

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flexprice/flexprice/internal/dynamodb"
 	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/httpclient"
+	"github.com/flexprice/flexprice/internal/integration/awsmarketplace"
 	integrationevents "github.com/flexprice/flexprice/internal/integration/events"
 	"github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -88,6 +89,10 @@ func main() {
 
 			// Security
 			security.NewEncryptionService,
+
+			// AWS Marketplace client (also used directly by internal/temporal/registration.go for
+			// the cron activities, which construct it manually rather than via this FX container)
+			awsmarketplace.NewClient,
 
 			// RBAC
 			rbac.NewRBACService,
@@ -701,4 +706,3 @@ func provideWalletBalanceAlertPubSub(
 	}
 	return types.WalletBalanceAlertPubSub{PubSub: pubSub}
 }
-

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -2436,6 +2436,7 @@ var (
 		{Name: "plan_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric(20,8)"}},
 		{Name: "amount", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric(20,8)"}},
+		{Name: "currency", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(10)"}},
 		{Name: "period_start", Type: field.TypeTime},
 		{Name: "period_end", Type: field.TypeTime},
 		{Name: "syncs", Type: field.TypeJSON, Nullable: true},
@@ -2450,7 +2451,7 @@ var (
 			{
 				Name:    "usagerecord_tenant_id_environment_id_all_providers_synced",
 				Unique:  false,
-				Columns: []*schema.Column{UsageRecordsColumns[1], UsageRecordsColumns[7], UsageRecordsColumns[17]},
+				Columns: []*schema.Column{UsageRecordsColumns[1], UsageRecordsColumns[7], UsageRecordsColumns[18]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -72055,6 +72055,7 @@ type UsageRecordMutation struct {
 	plan_id              *string
 	quantity             *decimal.Decimal
 	amount               *decimal.Decimal
+	currency             *string
 	period_start         *time.Time
 	period_end           *time.Time
 	syncs                *map[string]interface{}
@@ -72689,6 +72690,42 @@ func (m *UsageRecordMutation) ResetAmount() {
 	m.amount = nil
 }
 
+// SetCurrency sets the "currency" field.
+func (m *UsageRecordMutation) SetCurrency(s string) {
+	m.currency = &s
+}
+
+// Currency returns the value of the "currency" field in the mutation.
+func (m *UsageRecordMutation) Currency() (r string, exists bool) {
+	v := m.currency
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCurrency returns the old "currency" field's value of the UsageRecord entity.
+// If the UsageRecord object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UsageRecordMutation) OldCurrency(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCurrency is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCurrency requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCurrency: %w", err)
+	}
+	return oldValue.Currency, nil
+}
+
+// ResetCurrency resets all changes to the "currency" field.
+func (m *UsageRecordMutation) ResetCurrency() {
+	m.currency = nil
+}
+
 // SetPeriodStart sets the "period_start" field.
 func (m *UsageRecordMutation) SetPeriodStart(t time.Time) {
 	m.period_start = &t
@@ -72880,7 +72917,7 @@ func (m *UsageRecordMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UsageRecordMutation) Fields() []string {
-	fields := make([]string, 0, 17)
+	fields := make([]string, 0, 18)
 	if m.tenant_id != nil {
 		fields = append(fields, usagerecord.FieldTenantID)
 	}
@@ -72919,6 +72956,9 @@ func (m *UsageRecordMutation) Fields() []string {
 	}
 	if m.amount != nil {
 		fields = append(fields, usagerecord.FieldAmount)
+	}
+	if m.currency != nil {
+		fields = append(fields, usagerecord.FieldCurrency)
 	}
 	if m.period_start != nil {
 		fields = append(fields, usagerecord.FieldPeriodStart)
@@ -72966,6 +73006,8 @@ func (m *UsageRecordMutation) Field(name string) (ent.Value, bool) {
 		return m.Quantity()
 	case usagerecord.FieldAmount:
 		return m.Amount()
+	case usagerecord.FieldCurrency:
+		return m.Currency()
 	case usagerecord.FieldPeriodStart:
 		return m.PeriodStart()
 	case usagerecord.FieldPeriodEnd:
@@ -73009,6 +73051,8 @@ func (m *UsageRecordMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldQuantity(ctx)
 	case usagerecord.FieldAmount:
 		return m.OldAmount(ctx)
+	case usagerecord.FieldCurrency:
+		return m.OldCurrency(ctx)
 	case usagerecord.FieldPeriodStart:
 		return m.OldPeriodStart(ctx)
 	case usagerecord.FieldPeriodEnd:
@@ -73116,6 +73160,13 @@ func (m *UsageRecordMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAmount(v)
+		return nil
+	case usagerecord.FieldCurrency:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCurrency(v)
 		return nil
 	case usagerecord.FieldPeriodStart:
 		v, ok := value.(time.Time)
@@ -73265,6 +73316,9 @@ func (m *UsageRecordMutation) ResetField(name string) error {
 		return nil
 	case usagerecord.FieldAmount:
 		m.ResetAmount()
+		return nil
+	case usagerecord.FieldCurrency:
+		m.ResetCurrency()
 		return nil
 	case usagerecord.FieldPeriodStart:
 		m.ResetPeriodStart()

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -2466,8 +2466,12 @@ func init() {
 	usagerecordDescAmount := usagerecordFields[6].Descriptor()
 	// usagerecord.DefaultAmount holds the default value on creation for the amount field.
 	usagerecord.DefaultAmount = usagerecordDescAmount.Default.(decimal.Decimal)
+	// usagerecordDescCurrency is the schema descriptor for currency field.
+	usagerecordDescCurrency := usagerecordFields[7].Descriptor()
+	// usagerecord.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
+	usagerecord.CurrencyValidator = usagerecordDescCurrency.Validators[0].(func(string) error)
 	// usagerecordDescAllProvidersSynced is the schema descriptor for all_providers_synced field.
-	usagerecordDescAllProvidersSynced := usagerecordFields[10].Descriptor()
+	usagerecordDescAllProvidersSynced := usagerecordFields[11].Descriptor()
 	// usagerecord.DefaultAllProvidersSynced holds the default value on creation for the all_providers_synced field.
 	usagerecord.DefaultAllProvidersSynced = usagerecordDescAllProvidersSynced.Default.(bool)
 	userMixin := schema.User{}.Mixin()

--- a/ent/schema/usagerecord.go
+++ b/ent/schema/usagerecord.go
@@ -64,13 +64,17 @@ func (UsageRecord) Fields() []ent.Field {
 			}).
 			Default(decimal.Zero),
 
-		// Amount is the dollar total for [PeriodStart, PeriodEnd), from CalculateMeterUsageCharges —
-		// this is what's sent to AWS as BatchMeterUsage's "Quantity" field.
 		field.Other("amount", decimal.Decimal{}).
 			SchemaType(map[string]string{
 				"postgres": "numeric(20,8)",
 			}).
 			Default(decimal.Zero),
+
+		field.String("currency").
+			SchemaType(map[string]string{
+				"postgres": "varchar(10)",
+			}).
+			NotEmpty(),
 
 		field.Time("period_start"),
 

--- a/ent/usagerecord.go
+++ b/ent/usagerecord.go
@@ -45,6 +45,8 @@ type UsageRecord struct {
 	Quantity decimal.Decimal `json:"quantity,omitempty"`
 	// Amount holds the value of the "amount" field.
 	Amount decimal.Decimal `json:"amount,omitempty"`
+	// Currency holds the value of the "currency" field.
+	Currency string `json:"currency,omitempty"`
 	// PeriodStart holds the value of the "period_start" field.
 	PeriodStart time.Time `json:"period_start,omitempty"`
 	// PeriodEnd holds the value of the "period_end" field.
@@ -67,7 +69,7 @@ func (*UsageRecord) scanValues(columns []string) ([]any, error) {
 			values[i] = new(decimal.Decimal)
 		case usagerecord.FieldAllProvidersSynced:
 			values[i] = new(sql.NullBool)
-		case usagerecord.FieldID, usagerecord.FieldTenantID, usagerecord.FieldStatus, usagerecord.FieldCreatedBy, usagerecord.FieldUpdatedBy, usagerecord.FieldEnvironmentID, usagerecord.FieldCustomerID, usagerecord.FieldCustomerExternalID, usagerecord.FieldSubscriptionID, usagerecord.FieldPlanID:
+		case usagerecord.FieldID, usagerecord.FieldTenantID, usagerecord.FieldStatus, usagerecord.FieldCreatedBy, usagerecord.FieldUpdatedBy, usagerecord.FieldEnvironmentID, usagerecord.FieldCustomerID, usagerecord.FieldCustomerExternalID, usagerecord.FieldSubscriptionID, usagerecord.FieldPlanID, usagerecord.FieldCurrency:
 			values[i] = new(sql.NullString)
 		case usagerecord.FieldCreatedAt, usagerecord.FieldUpdatedAt, usagerecord.FieldPeriodStart, usagerecord.FieldPeriodEnd:
 			values[i] = new(sql.NullTime)
@@ -170,6 +172,12 @@ func (ur *UsageRecord) assignValues(columns []string, values []any) error {
 			} else if value != nil {
 				ur.Amount = *value
 			}
+		case usagerecord.FieldCurrency:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field currency", values[i])
+			} else if value.Valid {
+				ur.Currency = value.String
+			}
 		case usagerecord.FieldPeriodStart:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field period_start", values[i])
@@ -270,6 +278,9 @@ func (ur *UsageRecord) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("amount=")
 	builder.WriteString(fmt.Sprintf("%v", ur.Amount))
+	builder.WriteString(", ")
+	builder.WriteString("currency=")
+	builder.WriteString(ur.Currency)
 	builder.WriteString(", ")
 	builder.WriteString("period_start=")
 	builder.WriteString(ur.PeriodStart.Format(time.ANSIC))

--- a/ent/usagerecord/usagerecord.go
+++ b/ent/usagerecord/usagerecord.go
@@ -40,6 +40,8 @@ const (
 	FieldQuantity = "quantity"
 	// FieldAmount holds the string denoting the amount field in the database.
 	FieldAmount = "amount"
+	// FieldCurrency holds the string denoting the currency field in the database.
+	FieldCurrency = "currency"
 	// FieldPeriodStart holds the string denoting the period_start field in the database.
 	FieldPeriodStart = "period_start"
 	// FieldPeriodEnd holds the string denoting the period_end field in the database.
@@ -68,6 +70,7 @@ var Columns = []string{
 	FieldPlanID,
 	FieldQuantity,
 	FieldAmount,
+	FieldCurrency,
 	FieldPeriodStart,
 	FieldPeriodEnd,
 	FieldSyncs,
@@ -107,6 +110,8 @@ var (
 	DefaultQuantity decimal.Decimal
 	// DefaultAmount holds the default value on creation for the "amount" field.
 	DefaultAmount decimal.Decimal
+	// CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
+	CurrencyValidator func(string) error
 	// DefaultAllProvidersSynced holds the default value on creation for the "all_providers_synced" field.
 	DefaultAllProvidersSynced bool
 )
@@ -182,6 +187,11 @@ func ByQuantity(opts ...sql.OrderTermOption) OrderOption {
 // ByAmount orders the results by the amount field.
 func ByAmount(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAmount, opts...).ToFunc()
+}
+
+// ByCurrency orders the results by the currency field.
+func ByCurrency(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCurrency, opts...).ToFunc()
 }
 
 // ByPeriodStart orders the results by the period_start field.

--- a/ent/usagerecord/where.go
+++ b/ent/usagerecord/where.go
@@ -130,6 +130,11 @@ func Amount(v decimal.Decimal) predicate.UsageRecord {
 	return predicate.UsageRecord(sql.FieldEQ(FieldAmount, v))
 }
 
+// Currency applies equality check predicate on the "currency" field. It's identical to CurrencyEQ.
+func Currency(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldEQ(FieldCurrency, v))
+}
+
 // PeriodStart applies equality check predicate on the "period_start" field. It's identical to PeriodStartEQ.
 func PeriodStart(v time.Time) predicate.UsageRecord {
 	return predicate.UsageRecord(sql.FieldEQ(FieldPeriodStart, v))
@@ -928,6 +933,71 @@ func AmountLT(v decimal.Decimal) predicate.UsageRecord {
 // AmountLTE applies the LTE predicate on the "amount" field.
 func AmountLTE(v decimal.Decimal) predicate.UsageRecord {
 	return predicate.UsageRecord(sql.FieldLTE(FieldAmount, v))
+}
+
+// CurrencyEQ applies the EQ predicate on the "currency" field.
+func CurrencyEQ(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldEQ(FieldCurrency, v))
+}
+
+// CurrencyNEQ applies the NEQ predicate on the "currency" field.
+func CurrencyNEQ(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldNEQ(FieldCurrency, v))
+}
+
+// CurrencyIn applies the In predicate on the "currency" field.
+func CurrencyIn(vs ...string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldIn(FieldCurrency, vs...))
+}
+
+// CurrencyNotIn applies the NotIn predicate on the "currency" field.
+func CurrencyNotIn(vs ...string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldNotIn(FieldCurrency, vs...))
+}
+
+// CurrencyGT applies the GT predicate on the "currency" field.
+func CurrencyGT(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldGT(FieldCurrency, v))
+}
+
+// CurrencyGTE applies the GTE predicate on the "currency" field.
+func CurrencyGTE(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldGTE(FieldCurrency, v))
+}
+
+// CurrencyLT applies the LT predicate on the "currency" field.
+func CurrencyLT(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldLT(FieldCurrency, v))
+}
+
+// CurrencyLTE applies the LTE predicate on the "currency" field.
+func CurrencyLTE(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldLTE(FieldCurrency, v))
+}
+
+// CurrencyContains applies the Contains predicate on the "currency" field.
+func CurrencyContains(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldContains(FieldCurrency, v))
+}
+
+// CurrencyHasPrefix applies the HasPrefix predicate on the "currency" field.
+func CurrencyHasPrefix(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldHasPrefix(FieldCurrency, v))
+}
+
+// CurrencyHasSuffix applies the HasSuffix predicate on the "currency" field.
+func CurrencyHasSuffix(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldHasSuffix(FieldCurrency, v))
+}
+
+// CurrencyEqualFold applies the EqualFold predicate on the "currency" field.
+func CurrencyEqualFold(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldEqualFold(FieldCurrency, v))
+}
+
+// CurrencyContainsFold applies the ContainsFold predicate on the "currency" field.
+func CurrencyContainsFold(v string) predicate.UsageRecord {
+	return predicate.UsageRecord(sql.FieldContainsFold(FieldCurrency, v))
 }
 
 // PeriodStartEQ applies the EQ predicate on the "period_start" field.

--- a/ent/usagerecord_create.go
+++ b/ent/usagerecord_create.go
@@ -171,6 +171,12 @@ func (urc *UsageRecordCreate) SetNillableAmount(d *decimal.Decimal) *UsageRecord
 	return urc
 }
 
+// SetCurrency sets the "currency" field.
+func (urc *UsageRecordCreate) SetCurrency(s string) *UsageRecordCreate {
+	urc.mutation.SetCurrency(s)
+	return urc
+}
+
 // SetPeriodStart sets the "period_start" field.
 func (urc *UsageRecordCreate) SetPeriodStart(t time.Time) *UsageRecordCreate {
 	urc.mutation.SetPeriodStart(t)
@@ -323,6 +329,14 @@ func (urc *UsageRecordCreate) check() error {
 	if _, ok := urc.mutation.Amount(); !ok {
 		return &ValidationError{Name: "amount", err: errors.New(`ent: missing required field "UsageRecord.amount"`)}
 	}
+	if _, ok := urc.mutation.Currency(); !ok {
+		return &ValidationError{Name: "currency", err: errors.New(`ent: missing required field "UsageRecord.currency"`)}
+	}
+	if v, ok := urc.mutation.Currency(); ok {
+		if err := usagerecord.CurrencyValidator(v); err != nil {
+			return &ValidationError{Name: "currency", err: fmt.Errorf(`ent: validator failed for field "UsageRecord.currency": %w`, err)}
+		}
+	}
 	if _, ok := urc.mutation.PeriodStart(); !ok {
 		return &ValidationError{Name: "period_start", err: errors.New(`ent: missing required field "UsageRecord.period_start"`)}
 	}
@@ -418,6 +432,10 @@ func (urc *UsageRecordCreate) createSpec() (*UsageRecord, *sqlgraph.CreateSpec) 
 	if value, ok := urc.mutation.Amount(); ok {
 		_spec.SetField(usagerecord.FieldAmount, field.TypeOther, value)
 		_node.Amount = value
+	}
+	if value, ok := urc.mutation.Currency(); ok {
+		_spec.SetField(usagerecord.FieldCurrency, field.TypeString, value)
+		_node.Currency = value
 	}
 	if value, ok := urc.mutation.PeriodStart(); ok {
 		_spec.SetField(usagerecord.FieldPeriodStart, field.TypeTime, value)

--- a/ent/usagerecord_update.go
+++ b/ent/usagerecord_update.go
@@ -159,6 +159,20 @@ func (uru *UsageRecordUpdate) SetNillableAmount(d *decimal.Decimal) *UsageRecord
 	return uru
 }
 
+// SetCurrency sets the "currency" field.
+func (uru *UsageRecordUpdate) SetCurrency(s string) *UsageRecordUpdate {
+	uru.mutation.SetCurrency(s)
+	return uru
+}
+
+// SetNillableCurrency sets the "currency" field if the given value is not nil.
+func (uru *UsageRecordUpdate) SetNillableCurrency(s *string) *UsageRecordUpdate {
+	if s != nil {
+		uru.SetCurrency(*s)
+	}
+	return uru
+}
+
 // SetPeriodStart sets the "period_start" field.
 func (uru *UsageRecordUpdate) SetPeriodStart(t time.Time) *UsageRecordUpdate {
 	uru.mutation.SetPeriodStart(t)
@@ -271,6 +285,11 @@ func (uru *UsageRecordUpdate) check() error {
 			return &ValidationError{Name: "plan_id", err: fmt.Errorf(`ent: validator failed for field "UsageRecord.plan_id": %w`, err)}
 		}
 	}
+	if v, ok := uru.mutation.Currency(); ok {
+		if err := usagerecord.CurrencyValidator(v); err != nil {
+			return &ValidationError{Name: "currency", err: fmt.Errorf(`ent: validator failed for field "UsageRecord.currency": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -324,6 +343,9 @@ func (uru *UsageRecordUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := uru.mutation.Amount(); ok {
 		_spec.SetField(usagerecord.FieldAmount, field.TypeOther, value)
+	}
+	if value, ok := uru.mutation.Currency(); ok {
+		_spec.SetField(usagerecord.FieldCurrency, field.TypeString, value)
 	}
 	if value, ok := uru.mutation.PeriodStart(); ok {
 		_spec.SetField(usagerecord.FieldPeriodStart, field.TypeTime, value)
@@ -490,6 +512,20 @@ func (uruo *UsageRecordUpdateOne) SetNillableAmount(d *decimal.Decimal) *UsageRe
 	return uruo
 }
 
+// SetCurrency sets the "currency" field.
+func (uruo *UsageRecordUpdateOne) SetCurrency(s string) *UsageRecordUpdateOne {
+	uruo.mutation.SetCurrency(s)
+	return uruo
+}
+
+// SetNillableCurrency sets the "currency" field if the given value is not nil.
+func (uruo *UsageRecordUpdateOne) SetNillableCurrency(s *string) *UsageRecordUpdateOne {
+	if s != nil {
+		uruo.SetCurrency(*s)
+	}
+	return uruo
+}
+
 // SetPeriodStart sets the "period_start" field.
 func (uruo *UsageRecordUpdateOne) SetPeriodStart(t time.Time) *UsageRecordUpdateOne {
 	uruo.mutation.SetPeriodStart(t)
@@ -615,6 +651,11 @@ func (uruo *UsageRecordUpdateOne) check() error {
 			return &ValidationError{Name: "plan_id", err: fmt.Errorf(`ent: validator failed for field "UsageRecord.plan_id": %w`, err)}
 		}
 	}
+	if v, ok := uruo.mutation.Currency(); ok {
+		if err := usagerecord.CurrencyValidator(v); err != nil {
+			return &ValidationError{Name: "currency", err: fmt.Errorf(`ent: validator failed for field "UsageRecord.currency": %w`, err)}
+		}
+	}
 	return nil
 }
 
@@ -685,6 +726,9 @@ func (uruo *UsageRecordUpdateOne) sqlSave(ctx context.Context) (_node *UsageReco
 	}
 	if value, ok := uruo.mutation.Amount(); ok {
 		_spec.SetField(usagerecord.FieldAmount, field.TypeOther, value)
+	}
+	if value, ok := uruo.mutation.Currency(); ok {
+		_spec.SetField(usagerecord.FieldCurrency, field.TypeString, value)
 	}
 	if value, ok := uruo.mutation.PeriodStart(); ok {
 		_spec.SetField(usagerecord.FieldPeriodStart, field.TypeTime, value)

--- a/internal/api/dto/marketplace.go
+++ b/internal/api/dto/marketplace.go
@@ -2,27 +2,42 @@ package dto
 
 import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
+
+// allowedMarketplaceProviders are the SecretProvider values this endpoint accepts. AWS is the only
+// marketplace wired up today; adding a marketplace later (Azure/GCP) means adding its
+// SecretProvider constant in internal/types/secret.go and listing it here — nothing else about
+// this validation changes.
+var allowedMarketplaceProviders = []types.SecretProvider{
+	types.SecretProviderAWSMarketplace,
+}
 
 // RegisterMarketplaceAgreementRequest is the request body for POST /v1/marketplace/agreements,
 // sent once per buyer purchase to link a Flexprice subscription to its AWS agreement.
 type RegisterMarketplaceAgreementRequest struct {
-	Provider             string `json:"provider" validate:"required"` // e.g. "aws"
-	SubscriptionID       string `json:"subscription_id" validate:"required"`
-	CustomerID           string `json:"customer_id" validate:"required"`
-	CustomerAWSAccountID string `json:"customer_aws_account_id" validate:"required"`
-	LicenseArn           string `json:"license_arn" validate:"required"`
-	PlanID               string `json:"plan_id" validate:"required"`
-	ProductCode          string `json:"product_code" validate:"required"`
-	ConcurrentAgreements bool   `json:"concurrent_agreements"`
-	Dimension            string `json:"dimension" validate:"required"`
+	Provider             types.SecretProvider `json:"provider" validate:"required"` // e.g. "aws_marketplace"
+	SubscriptionID       string               `json:"subscription_id" validate:"required"`
+	CustomerID           string               `json:"customer_id" validate:"required"`
+	CustomerAWSAccountID string               `json:"customer_aws_account_id" validate:"required"`
+	LicenseArn           string               `json:"license_arn" validate:"required"`
+	PlanID               string               `json:"plan_id" validate:"required"`
+	ProductCode          string               `json:"product_code" validate:"required"`
+	ConcurrentAgreements bool                 `json:"concurrent_agreements"`
+	Dimension            string               `json:"dimension" validate:"required"`
 }
 
 // Validate checks the request shape only; subscription existence and uniqueness are validated in the service layer
 func (r *RegisterMarketplaceAgreementRequest) Validate() error {
 	if r.Provider == "" {
 		return ierr.NewError("provider is required").
-			WithHint("provider is required (e.g. \"aws\")").
+			WithHint("provider is required (e.g. \"aws_marketplace\")").
+			Mark(ierr.ErrValidation)
+	}
+	if !lo.Contains(allowedMarketplaceProviders, r.Provider) {
+		return ierr.NewErrorf("unsupported marketplace provider %q", r.Provider).
+			WithHint("Only \"aws_marketplace\" is supported for marketplace agreement registration").
 			Mark(ierr.ErrValidation)
 	}
 	if r.SubscriptionID == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Configuration struct {
 	Billing                    BillingConfig                    `validate:"omitempty"`
 	S3                         S3Config                         `validate:"required"`
 	FlexpriceS3Exports         FlexpriceS3ExportsConfig         `mapstructure:"flexprice_s3_exports" validate:"omitempty"`
+	Marketplace                MarketplaceConfig                `mapstructure:"marketplace" validate:"omitempty"`
 	Cache                      CacheConfig                      `validate:"required"`
 	EventProcessing            EventProcessingConfig            `mapstructure:"event_processing" validate:"required"`
 	EventProcessingLazy        EventProcessingLazyConfig        `mapstructure:"event_processing_lazy" validate:"required"`
@@ -116,6 +117,31 @@ type FlexpriceS3ExportsConfig struct {
 	AWSAccessKeyID     string `mapstructure:"aws_access_key_id" validate:"required"`
 	AWSSecretAccessKey string `mapstructure:"aws_secret_access_key" validate:"required"`
 	AWSSessionToken    string `mapstructure:"aws_session_token,omitempty"`
+}
+
+// MarketplaceConfig groups Flexprice's own credentials for each marketplace it reports usage to.
+// AWS is the only one implemented today; Azure and GCP would be added as sibling fields.
+type MarketplaceConfig struct {
+	AWS AWSMarketplaceConfig `mapstructure:"aws" validate:"omitempty"`
+}
+
+// AWSMarketplaceConfig holds Flexprice's OWN AWS identity — the caller that assumes each tenant's
+// role. sts:AssumeRole is an authenticated API: the tenant's trust policy names this principal, so
+// these credentials are what signs the AssumeRole request. They are unrelated to the tenant's
+// role_arn/external_id, which are the assume *target*, stored per-connection.
+//
+// These are set explicitly rather than resolved from the ambient AWS credential chain: the chain
+// ends at the EC2 instance-metadata endpoint, which is unreachable off EC2 and stalls for seconds
+// before failing — turning connection creation into a hang on any non-EC2 host.
+//
+// SessionToken is only set when the credentials are temporary (an ASIA... key from STS/SSO). A
+// long-lived AKIA... IAM user key has no session token, and sending a non-empty one with it makes
+// AWS reject the request.
+type AWSMarketplaceConfig struct {
+	Region          string `mapstructure:"region" validate:"omitempty"`
+	AccessKeyID     string `mapstructure:"access_key_id" validate:"omitempty"`
+	SecretAccessKey string `mapstructure:"secret_access_key" validate:"omitempty"`
+	SessionToken    string `mapstructure:"session_token" validate:"omitempty"`
 }
 
 type DeploymentConfig struct {
@@ -432,6 +458,7 @@ type EventProcessingReplayConfig struct {
 	RateLimit     int64  `mapstructure:"rate_limit" default:"1"`
 	ConsumerGroup string `mapstructure:"consumer_group" default:"v1_event_processing_replay"`
 }
+
 // MeterUsageTrackingConfig configures the meter_usage pipeline consumer
 type MeterUsageTrackingConfig struct {
 	Enabled                   bool   `mapstructure:"enabled" default:"true"`

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -283,6 +283,17 @@ flexprice_s3_exports:
   aws_secret_access_key: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_SECRET_ACCESS_KEY env var
   aws_session_token: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_SESSION_TOKEN env var
 
+# Flexprice's own AWS identity — the principal that assumes each tenant's marketplace IAM role.
+# This is the caller named in the tenant's trust policy, NOT the tenant's role (that lives per
+# connection). Required for the AWS Marketplace integration; leave unset to disable it.
+marketplace:
+  aws:
+    region: "" # Set via FLEXPRICE_MARKETPLACE_AWS_REGION env var
+    access_key_id: "" # Set via FLEXPRICE_MARKETPLACE_AWS_ACCESS_KEY_ID env var
+    secret_access_key: "" # Set via FLEXPRICE_MARKETPLACE_AWS_SECRET_ACCESS_KEY env var
+    # session_token only for temporary (ASIA...) keys; leave unset for a long-lived AKIA... key.
+    session_token: "" # Set via FLEXPRICE_MARKETPLACE_AWS_SESSION_TOKEN env var
+
 cache:
   enabled: false
   inmemory:

--- a/internal/domain/usagerecord/model.go
+++ b/internal/domain/usagerecord/model.go
@@ -42,6 +42,7 @@ type UsageRecord struct {
 	PlanID             string                               `db:"plan_id" json:"plan_id"`
 	Quantity           decimal.Decimal                      `db:"quantity" json:"quantity"`
 	Amount             decimal.Decimal                      `db:"amount" json:"amount"`
+	Currency           string                               `db:"currency" json:"currency"`
 	PeriodStart        time.Time                            `db:"period_start" json:"period_start"`
 	PeriodEnd          time.Time                            `db:"period_end" json:"period_end"`
 	Syncs              map[Marketplace]MarketplaceSyncEntry `db:"syncs" json:"syncs"`
@@ -63,6 +64,7 @@ func FromEnt(e *ent.UsageRecord) *UsageRecord {
 		PlanID:             e.PlanID,
 		Quantity:           e.Quantity,
 		Amount:             e.Amount,
+		Currency:           e.Currency,
 		PeriodStart:        e.PeriodStart,
 		PeriodEnd:          e.PeriodEnd,
 		Syncs:              syncsFromMap(e.Syncs),

--- a/internal/domain/usagerecord/repository.go
+++ b/internal/domain/usagerecord/repository.go
@@ -2,12 +2,19 @@ package usagerecord
 
 import (
 	"context"
+	"time"
 )
 
 // Repository provides persistence for usage records.
 type Repository interface {
 	// Create inserts a new usage record.
 	Create(ctx context.Context, record *UsageRecord) error
+
+	// ExistsForPeriod reports whether a usage record already exists for this subscription and
+	// exact reporting window. Used to make the snapshot activity idempotent under Temporal
+	// retries: the window is deterministic per scheduled run, so a matching row means this
+	// subscription was already processed by an earlier attempt.
+	ExistsForPeriod(ctx context.Context, subscriptionID string, periodStart, periodEnd time.Time) (bool, error)
 
 	// ListUnsynced returns the tenant/environment's usage records that are not yet fully synced.
 	ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*UsageRecord, error)

--- a/internal/ee/service/connection.go
+++ b/internal/ee/service/connection.go
@@ -7,10 +7,17 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/integration/awsmarketplace"
 	"github.com/flexprice/flexprice/internal/security"
 	temporalService "github.com/flexprice/flexprice/internal/temporal/service"
 	"github.com/flexprice/flexprice/internal/types"
 )
+
+// awsMarketplaceRoleVerificationDuration is how long the STS session used to verify a role ARN at
+// connection-creation time is valid for. It's short because these credentials are used once
+// (AssumeRole succeeding is itself the check) and immediately discarded — unlike the credentials
+// Cron B assumes to actually report usage, which need to live for the length of a reporting run.
+const awsMarketplaceRoleVerificationDuration = 5 * time.Minute
 
 // ConnectionService defines the interface for connection operations
 type ConnectionService interface {
@@ -23,14 +30,16 @@ type ConnectionService interface {
 
 type connectionService struct {
 	ServiceParams
-	encryptionService security.EncryptionService
+	encryptionService    security.EncryptionService
+	awsMarketplaceClient awsmarketplace.Client
 }
 
 // NewConnectionService creates a new connection service
-func NewConnectionService(params ServiceParams, encryptionService security.EncryptionService) ConnectionService {
+func NewConnectionService(params ServiceParams, encryptionService security.EncryptionService, awsMarketplaceClient awsmarketplace.Client) ConnectionService {
 	return &connectionService{
-		ServiceParams:     params,
-		encryptionService: encryptionService,
+		ServiceParams:        params,
+		encryptionService:    encryptionService,
+		awsMarketplaceClient: awsMarketplaceClient,
 	}
 }
 
@@ -533,6 +542,33 @@ func (s *connectionService) CreateConnection(ctx context.Context, req dto.Create
 	conn.UpdatedAt = time.Now()
 	conn.CreatedBy = types.GetUserID(ctx)
 	conn.UpdatedBy = types.GetUserID(ctx)
+
+	// AWS Marketplace: verify the tenant's role_arn/external_id actually work before the
+	// connection is ever persisted. AssumeRole succeeding is the whole check — the credentials
+	// themselves are discarded immediately after, using a short verification-only session
+	// (awsMarketplaceRoleVerificationDuration) rather than the longer duration Cron B uses to
+	// actually report usage.
+	if conn.ProviderType == types.SecretProviderAWSMarketplace {
+		if conn.EncryptedSecretData.AWSMarketplace == nil {
+			return nil, ierr.NewError("aws_marketplace connection requires role_arn and external_id").
+				WithHint("encrypted_secret_data.aws_marketplace with role_arn and external_id is required").
+				Mark(ierr.ErrValidation)
+		}
+		if err := conn.EncryptedSecretData.AWSMarketplace.Validate(); err != nil {
+			return nil, err
+		}
+		if _, err := s.awsMarketplaceClient.AssumeRole(
+			ctx,
+			conn.EncryptedSecretData.AWSMarketplace.RoleArn,
+			conn.EncryptedSecretData.AWSMarketplace.ExternalID,
+			awsMarketplaceRoleVerificationDuration,
+		); err != nil {
+			s.Logger.Error(ctx, "aws marketplace connection verification failed", "tenant_id", tenantID, "environment_id", environmentID)
+			return nil, ierr.WithError(err).
+				WithHint("Could not assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID before creating this connection.").
+				Mark(ierr.ErrValidation)
+		}
+	}
 
 	// Check if this is a Flexprice-managed S3 connection
 	if conn.ProviderType == types.SecretProviderS3 && conn.SyncConfig != nil && conn.SyncConfig.S3 != nil && conn.SyncConfig.S3.IsFlexpriceManaged {

--- a/internal/ee/service/connection.go
+++ b/internal/ee/service/connection.go
@@ -14,10 +14,10 @@ import (
 )
 
 // awsMarketplaceRoleVerificationDuration is how long the STS session used to verify a role ARN at
-// connection-creation time is valid for. It's short because these credentials are used once
-// (AssumeRole succeeding is itself the check) and immediately discarded — unlike the credentials
-// Cron B assumes to actually report usage, which need to live for the length of a reporting run.
-const awsMarketplaceRoleVerificationDuration = 5 * time.Minute
+// connection-creation time is valid for. These credentials are used once (AssumeRole succeeding is
+// itself the check) and discarded immediately, so this is the shortest session AWS permits: STS
+// rejects any durationSeconds below 900 with a ValidationError, so 15m is the floor, not a choice.
+const awsMarketplaceRoleVerificationDuration = 15 * time.Minute
 
 // ConnectionService defines the interface for connection operations
 type ConnectionService interface {
@@ -557,12 +557,19 @@ func (s *connectionService) CreateConnection(ctx context.Context, req dto.Create
 		if err := conn.EncryptedSecretData.AWSMarketplace.Validate(); err != nil {
 			return nil, err
 		}
-		if _, err := s.awsMarketplaceClient.AssumeRole(
-			ctx,
+		// Bounded so a slow/unreachable AWS credential chain (e.g. the SDK falling through to an
+		// unreachable EC2 instance-metadata endpoint when Flexprice's own AWS credentials aren't
+		// configured via env vars) can't hang this request indefinitely — there's no other timeout
+		// anywhere in this path otherwise.
+		verifyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		_, err := s.awsMarketplaceClient.AssumeRole(
+			verifyCtx,
 			conn.EncryptedSecretData.AWSMarketplace.RoleArn,
 			conn.EncryptedSecretData.AWSMarketplace.ExternalID,
 			awsMarketplaceRoleVerificationDuration,
-		); err != nil {
+		)
+		cancel()
+		if err != nil {
 			s.Logger.Error(ctx, "aws marketplace connection verification failed", "tenant_id", tenantID, "environment_id", environmentID)
 			return nil, ierr.WithError(err).
 				WithHint("Could not assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID before creating this connection.").

--- a/internal/ee/service/connection.go
+++ b/internal/ee/service/connection.go
@@ -570,7 +570,11 @@ func (s *connectionService) CreateConnection(ctx context.Context, req dto.Create
 		)
 		cancel()
 		if err != nil {
-			s.Logger.Error(ctx, "aws marketplace connection verification failed", "tenant_id", tenantID, "environment_id", environmentID)
+			// Deliberately not logger.Err(err): AssumeRole's underlying AWS error can embed the
+			// role ARN. See internal/integration/awsmarketplace/client.go's AssumeRole.
+			s.Logger.Error(ctx, "aws marketplace connection verification failed",
+				"tenant_id", tenantID, "environment_id", environmentID,
+				"error", "redacted: aws error message may embed the role arn")
 			return nil, ierr.WithError(err).
 				WithHint("Could not assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID before creating this connection.").
 				Mark(ierr.ErrValidation)

--- a/internal/ee/service/marketplace.go
+++ b/internal/ee/service/marketplace.go
@@ -33,7 +33,8 @@ func (s *marketplaceService) RegisterAgreement(ctx context.Context, req dto.Regi
 		return nil, err
 	}
 
-	providerType := string(types.SecretProviderAWSMarketplace)
+	// req.Provider is already validated against allowedMarketplaceProviders in Validate() above.
+	providerType := string(req.Provider)
 
 	// The subscription must already exist and be active; this endpoint never creates subscriptions.
 	sub, err := s.SubRepo.Get(ctx, req.SubscriptionID)

--- a/internal/integration/awsmarketplace/client.go
+++ b/internal/integration/awsmarketplace/client.go
@@ -120,7 +120,10 @@ func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string, dur
 
 	creds, err := provider.Retrieve(ctx)
 	if err != nil {
-		c.logger.Error(ctx, "aws marketplace assume role failed")
+		// Deliberately not logger.Err(err): AWS's AccessDenied message for a bad trust policy
+		// embeds the role ARN in its text. The redacted placeholder still satisfies loglint's
+		// "every Error() log carries an error field" invariant without leaking it into logs.
+		c.logger.Error(ctx, "aws marketplace assume role failed", "error", "redacted: aws error message may embed the role arn")
 		return aws.Credentials{}, ierr.WithError(err).
 			WithHint("Failed to assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID.").
 			Mark(ierr.ErrValidation)

--- a/internal/integration/awsmarketplace/client.go
+++ b/internal/integration/awsmarketplace/client.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/marketplacemetering"
 	mmtypes "github.com/aws/aws-sdk-go-v2/service/marketplacemetering/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/flexprice/flexprice/internal/config"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 )
@@ -57,10 +57,10 @@ type BatchMeterUsageResult struct {
 // Client is the set of AWS Marketplace operations the integration uses.
 type Client interface {
 	// AssumeRole exchanges the tenant's role ARN and external ID for short-lived credentials.
-	// duration controls how long the assumed session is valid for; pass 0 to use the SDK default
-	// (15 minutes, see stscreds.DefaultDuration) for normal reporting use, or a short explicit
-	// value (e.g. 5 minutes) when the call is only to verify the role/trust policy at connection
-	// setup time and the credentials are discarded immediately after.
+	// duration controls how long the assumed session is valid for. AWS rejects anything below 15
+	// minutes (STS: durationSeconds must be >= 900) and anything above the role's own
+	// MaxSessionDuration, so valid values are 15m up to that ceiling. Pass 0 to use the SDK default
+	// (15 minutes, see stscreds.DefaultDuration).
 	AssumeRole(ctx context.Context, roleArn, externalID string, duration time.Duration) (aws.Credentials, error)
 
 	// BatchMeterUsage reports a single usage record. It returns the result for any record present
@@ -71,35 +71,47 @@ type Client interface {
 }
 
 type client struct {
+	cfg    config.AWSMarketplaceConfig
 	logger *logger.Logger
 }
 
-// NewClient builds a stateless AWS Marketplace client. Credentials are passed per call, never held.
-func NewClient(log *logger.Logger) Client {
-	return &client{logger: log}
+// NewClient builds a stateless AWS Marketplace client. cfg carries Flexprice's own AWS identity —
+// the principal that assumes each tenant's role. Tenant credentials are passed per call, never held.
+func NewClient(conf *config.Configuration, log *logger.Logger) Client {
+	return &client{cfg: conf.Marketplace.AWS, logger: log}
 }
 
-// AssumeRole obtains short-lived credentials for the tenant's IAM role. It uses the process's
-// ambient AWS credentials (Flexprice's own account) as the caller identity, and the tenant's role
-// ARN + external ID as the assume target. The role session name identifies this session in the
-// tenant's AWS CloudTrail. On failure, the AWS SDK error is not logged or returned — a bad trust
-// policy's AccessDenied message embeds the role ARN in its text, so nothing derived from it is
-// surfaced anywhere. The role ARN and external ID are never logged.
+// AssumeRole obtains short-lived credentials for the tenant's IAM role. Flexprice's own configured
+// credentials (config: aws_marketplace.*) are the caller identity — sts:AssumeRole is an
+// authenticated API and the tenant's trust policy names this principal — and the tenant's role ARN
+// + external ID are the assume target. The role session name identifies this session in the
+// tenant's AWS CloudTrail.
+//
+// Everything is built explicitly: no LoadDefaultConfig, no ambient credential chain. The chain's
+// last step probes the EC2 instance-metadata endpoint, which is unreachable off EC2 and stalls for
+// seconds before failing — that must never be in the path of a user-facing connection request.
+//
+// On failure, the AWS SDK error is not logged or returned — a bad trust policy's AccessDenied
+// message embeds the role ARN in its text, so nothing derived from it is surfaced anywhere. The
+// role ARN and external ID are never logged.
 func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string, duration time.Duration) (aws.Credentials, error) {
 	if roleArn == "" || externalID == "" {
 		return aws.Credentials{}, ierr.NewError("role_arn and external_id are required").
 			WithHint("AWS Marketplace connection requires both role_arn and external_id").
 			Mark(ierr.ErrValidation)
 	}
-
-	cfg, err := awsconfig.LoadDefaultConfig(ctx)
-	if err != nil {
-		return aws.Credentials{}, ierr.WithError(err).
-			WithHint("Failed to load AWS SDK configuration").
+	if c.cfg.AccessKeyID == "" || c.cfg.SecretAccessKey == "" || c.cfg.Region == "" {
+		return aws.Credentials{}, ierr.NewError("aws marketplace credentials are not configured").
+			WithHint("Flexprice's own AWS credentials are missing. Set marketplace.aws.region, marketplace.aws.access_key_id and marketplace.aws.secret_access_key.").
 			Mark(ierr.ErrSystem)
 	}
 
-	stsClient := sts.NewFromConfig(cfg)
+	stsClient := sts.NewFromConfig(aws.Config{
+		Region: c.cfg.Region,
+		Credentials: credentials.NewStaticCredentialsProvider(
+			c.cfg.AccessKeyID, c.cfg.SecretAccessKey, c.cfg.SessionToken,
+		),
+	})
 	provider := stscreds.NewAssumeRoleProvider(stsClient, roleArn, func(o *stscreds.AssumeRoleOptions) {
 		o.ExternalID = &externalID
 		o.RoleSessionName = "flexprice-marketplace-metering"
@@ -109,7 +121,7 @@ func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string, dur
 	creds, err := provider.Retrieve(ctx)
 	if err != nil {
 		c.logger.Error(ctx, "aws marketplace assume role failed")
-		return aws.Credentials{}, ierr.NewError("failed to assume aws iam role").
+		return aws.Credentials{}, ierr.WithError(err).
 			WithHint("Failed to assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID.").
 			Mark(ierr.ErrValidation)
 	}

--- a/internal/integration/awsmarketplace/client.go
+++ b/internal/integration/awsmarketplace/client.go
@@ -31,7 +31,24 @@ type UsageRecordInput struct {
 	Timestamp            time.Time
 }
 
-// BatchMeterUsageResult is the outcome AWS reports for an accepted usage record.
+// AWS's three possible per-record outcomes (marketplacemetering/types.UsageRecordResultStatus).
+// A present entry in Results is NOT the same as the record being honored — Status must be checked.
+// Only StatusSuccess means AWS actually billed the record:
+//   - StatusCustomerNotSubscribed: the buyer has no active agreement (or was suspended); not
+//     honored.
+//   - StatusDuplicateRecord: AWS already has a DIFFERENT usage record for the same customer,
+//     dimension, and timestamp — the existing one, not this one, is what's on file. Also not
+//     honored. (This is not "AWS already recorded this exact record, safe to skip" — that case is
+//     just a second StatusSuccess, since AWS's own idempotency is on customer+dimension+time+
+//     quantity together.)
+const (
+	StatusSuccess               = string(mmtypes.UsageRecordResultStatusSuccess)
+	StatusCustomerNotSubscribed = string(mmtypes.UsageRecordResultStatusCustomerNotSubscribed)
+	StatusDuplicateRecord       = string(mmtypes.UsageRecordResultStatusDuplicateRecord)
+)
+
+// BatchMeterUsageResult is AWS's outcome for a record present in Results. Status must be checked —
+// only StatusSuccess means the record is recorded (billed) on AWS's side.
 type BatchMeterUsageResult struct {
 	MeteringRecordID string
 	Status           string
@@ -40,11 +57,16 @@ type BatchMeterUsageResult struct {
 // Client is the set of AWS Marketplace operations the integration uses.
 type Client interface {
 	// AssumeRole exchanges the tenant's role ARN and external ID for short-lived credentials.
-	AssumeRole(ctx context.Context, roleArn, externalID string) (aws.Credentials, error)
+	// duration controls how long the assumed session is valid for; pass 0 to use the SDK default
+	// (15 minutes, see stscreds.DefaultDuration) for normal reporting use, or a short explicit
+	// value (e.g. 5 minutes) when the call is only to verify the role/trust policy at connection
+	// setup time and the credentials are discarded immediately after.
+	AssumeRole(ctx context.Context, roleArn, externalID string, duration time.Duration) (aws.Credentials, error)
 
-	// BatchMeterUsage reports a single usage record. It returns the result when AWS accepts the
-	// record, nil when AWS returns it as unprocessed (the caller should retry it later), or an
-	// error when the call itself fails.
+	// BatchMeterUsage reports a single usage record. It returns the result for any record present
+	// in Results — whose Status the caller must check, since presence alone does not mean AWS
+	// accepted it — nil when AWS returns it as unprocessed (the caller should retry it later), or
+	// an error when the call itself fails.
 	BatchMeterUsage(ctx context.Context, creds aws.Credentials, region string, record UsageRecordInput) (*BatchMeterUsageResult, error)
 }
 
@@ -60,9 +82,10 @@ func NewClient(log *logger.Logger) Client {
 // AssumeRole obtains short-lived credentials for the tenant's IAM role. It uses the process's
 // ambient AWS credentials (Flexprice's own account) as the caller identity, and the tenant's role
 // ARN + external ID as the assume target. The role session name identifies this session in the
-// tenant's AWS CloudTrail. Errors are returned verbatim so the caller can surface AWS's message;
-// the role ARN and external ID are never logged.
-func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string) (aws.Credentials, error) {
+// tenant's AWS CloudTrail. On failure, the AWS SDK error is not logged or returned — a bad trust
+// policy's AccessDenied message embeds the role ARN in its text, so nothing derived from it is
+// surfaced anywhere. The role ARN and external ID are never logged.
+func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string, duration time.Duration) (aws.Credentials, error) {
 	if roleArn == "" || externalID == "" {
 		return aws.Credentials{}, ierr.NewError("role_arn and external_id are required").
 			WithHint("AWS Marketplace connection requires both role_arn and external_id").
@@ -80,12 +103,13 @@ func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string) (aw
 	provider := stscreds.NewAssumeRoleProvider(stsClient, roleArn, func(o *stscreds.AssumeRoleOptions) {
 		o.ExternalID = &externalID
 		o.RoleSessionName = "flexprice-marketplace-metering"
+		o.Duration = duration // 0 falls through to the SDK's own default (stscreds.DefaultDuration)
 	})
 
 	creds, err := provider.Retrieve(ctx)
 	if err != nil {
-		c.logger.Error(ctx, "aws marketplace assume role failed", "error", err)
-		return aws.Credentials{}, ierr.WithError(err).
+		c.logger.Error(ctx, "aws marketplace assume role failed")
+		return aws.Credentials{}, ierr.NewError("failed to assume aws iam role").
 			WithHint("Failed to assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID.").
 			Mark(ierr.ErrValidation)
 	}
@@ -97,9 +121,9 @@ func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string) (aw
 // built directly from the assumed-role credentials and the connection's region so no ambient
 // environment or instance-profile configuration is picked up.
 //
-// AWS returns an accepted record in Results (with a metering record id) or, if it could not be
-// processed, in UnprocessedRecords. An accepted record returns a result; an unprocessed record
-// returns nil so the caller retries it on the next run.
+// AWS returns a processed record in Results (with a Status the caller must check — a present
+// result is not the same as an accepted one) or, if it could not be processed at all, in
+// UnprocessedRecords, for which this returns nil so the caller retries it on the next run.
 func (c *client) BatchMeterUsage(ctx context.Context, creds aws.Credentials, region string, record UsageRecordInput) (*BatchMeterUsageResult, error) {
 	cfg := aws.Config{
 		Region:      region,

--- a/internal/integration/awsmarketplace/client.go
+++ b/internal/integration/awsmarketplace/client.go
@@ -120,11 +120,12 @@ func (c *client) AssumeRole(ctx context.Context, roleArn, externalID string, dur
 
 	creds, err := provider.Retrieve(ctx)
 	if err != nil {
-		// Deliberately not logger.Err(err): AWS's AccessDenied message for a bad trust policy
-		// embeds the role ARN in its text. The redacted placeholder still satisfies loglint's
-		// "every Error() log carries an error field" invariant without leaking it into logs.
+		// Deliberately not logger.Err(err) and not ierr.WithError(err): AWS's AccessDenied
+		// message for a bad trust policy embeds the role ARN in its text. The redacted
+		// placeholder still satisfies loglint's "every Error() log carries an error field"
+		// invariant without leaking it into logs or API responses.
 		c.logger.Error(ctx, "aws marketplace assume role failed", "error", "redacted: aws error message may embed the role arn")
-		return aws.Credentials{}, ierr.WithError(err).
+		return aws.Credentials{}, ierr.NewError("aws marketplace assume role failed").
 			WithHint("Failed to assume the provided AWS IAM role. Verify the role ARN, trust policy, and external ID.").
 			Mark(ierr.ErrValidation)
 	}

--- a/internal/repository/ent/usagerecord.go
+++ b/internal/repository/ent/usagerecord.go
@@ -59,6 +59,7 @@ func (r *usageRecordRepository) Create(ctx context.Context, rec *domainUsageReco
 		SetPlanID(rec.PlanID).
 		SetQuantity(rec.Quantity).
 		SetAmount(rec.Amount).
+		SetCurrency(rec.Currency).
 		SetPeriodStart(rec.PeriodStart).
 		SetPeriodEnd(rec.PeriodEnd).
 		SetSyncs(domainUsageRecord.SyncsToMap(rec.Syncs)).

--- a/internal/repository/ent/usagerecord.go
+++ b/internal/repository/ent/usagerecord.go
@@ -93,6 +93,38 @@ func (r *usageRecordRepository) Create(ctx context.Context, rec *domainUsageReco
 	return nil
 }
 
+func (r *usageRecordRepository) ExistsForPeriod(ctx context.Context, subscriptionID string, periodStart, periodEnd time.Time) (bool, error) {
+	client := r.client.Reader(ctx)
+
+	span := StartRepositorySpan(ctx, "usage_record", "exists_for_period", map[string]interface{}{
+		"subscription_id": subscriptionID,
+		"period_start":    periodStart,
+		"period_end":      periodEnd,
+	})
+	defer FinishSpan(span)
+
+	exists, err := client.UsageRecord.Query().
+		Where(
+			usagerecord.TenantID(types.GetTenantID(ctx)),
+			usagerecord.EnvironmentID(types.GetEnvironmentID(ctx)),
+			usagerecord.SubscriptionID(subscriptionID),
+			usagerecord.PeriodStart(periodStart),
+			usagerecord.PeriodEnd(periodEnd),
+			usagerecord.StatusEQ(string(types.StatusPublished)),
+		).
+		Exist(ctx)
+
+	if err != nil {
+		SetSpanError(span, err)
+		return false, ierr.WithError(err).
+			WithHint("Failed to check for an existing usage record").
+			Mark(ierr.ErrDatabase)
+	}
+
+	SetSpanSuccess(span)
+	return exists, nil
+}
+
 func (r *usageRecordRepository) ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*domainUsageRecord.UsageRecord, error) {
 	client := r.client.Reader(ctx)
 
@@ -122,6 +154,17 @@ func (r *usageRecordRepository) ListUnsynced(ctx context.Context, tenantID, envi
 	return domainUsageRecord.FromEntList(records), nil
 }
 
+// maxSyncResultRetries bounds the optimistic-locking retry loop in UpdateSyncResult. Syncs holds
+// one entry per marketplace and today only AWS reports, so real contention on a single row is rare;
+// this only guards against genuinely concurrent writers (e.g. an overlapping manual run) rather than
+// expected load.
+const maxSyncResultRetries = 5
+
+// UpdateSyncResult merges a marketplace's sync outcome into the record's Syncs map. This is a
+// read-modify-write on a JSON column, so it uses optimistic locking (UpdatedAtEQ as the version
+// check) with a bounded retry: if another writer updated the row between the read and the write,
+// the row count comes back 0, and the read+merge+write is retried against the new row instead of
+// silently overwriting the other writer's change and losing it.
 func (r *usageRecordRepository) UpdateSyncResult(
 	ctx context.Context,
 	id string,
@@ -137,53 +180,60 @@ func (r *usageRecordRepository) UpdateSyncResult(
 	})
 	defer FinishSpan(span)
 
-	existing, err := client.UsageRecord.Query().
-		Where(
-			usagerecord.ID(id),
-			usagerecord.TenantID(types.GetTenantID(ctx)),
-			usagerecord.EnvironmentID(types.GetEnvironmentID(ctx)),
-		).
-		Only(ctx)
-	if err != nil {
-		SetSpanError(span, err)
-		if ent.IsNotFound(err) {
+	for attempt := 0; attempt < maxSyncResultRetries; attempt++ {
+		existing, err := client.UsageRecord.Query().
+			Where(
+				usagerecord.ID(id),
+				usagerecord.TenantID(types.GetTenantID(ctx)),
+				usagerecord.EnvironmentID(types.GetEnvironmentID(ctx)),
+			).
+			Only(ctx)
+		if err != nil {
+			SetSpanError(span, err)
+			if ent.IsNotFound(err) {
+				return ierr.WithError(err).
+					WithHintf("Usage record with ID %s was not found", id).
+					Mark(ierr.ErrNotFound)
+			}
 			return ierr.WithError(err).
-				WithHintf("Usage record with ID %s was not found", id).
-				Mark(ierr.ErrNotFound)
+				WithHint("Failed to get usage record for sync update").
+				Mark(ierr.ErrDatabase)
 		}
-		return ierr.WithError(err).
-			WithHint("Failed to get usage record for sync update").
-			Mark(ierr.ErrDatabase)
-	}
 
-	syncs := domainUsageRecord.FromEnt(existing).Syncs
-	if syncs == nil {
-		syncs = make(map[domainUsageRecord.Marketplace]domainUsageRecord.MarketplaceSyncEntry)
-	}
-	syncs[marketplace] = entry
+		syncs := domainUsageRecord.FromEnt(existing).Syncs
+		if syncs == nil {
+			syncs = make(map[domainUsageRecord.Marketplace]domainUsageRecord.MarketplaceSyncEntry)
+		}
+		syncs[marketplace] = entry
 
-	_, err = client.UsageRecord.UpdateOneID(id).
-		Where(
-			usagerecord.TenantID(types.GetTenantID(ctx)),
-			usagerecord.EnvironmentID(types.GetEnvironmentID(ctx)),
-		).
-		SetSyncs(domainUsageRecord.SyncsToMap(syncs)).
-		SetAllProvidersSynced(allProvidersSynced).
-		SetUpdatedAt(time.Now().UTC()).
-		Save(ctx)
+		affected, err := client.UsageRecord.Update().
+			Where(
+				usagerecord.ID(id),
+				usagerecord.TenantID(types.GetTenantID(ctx)),
+				usagerecord.EnvironmentID(types.GetEnvironmentID(ctx)),
+				usagerecord.UpdatedAtEQ(existing.UpdatedAt),
+			).
+			SetSyncs(domainUsageRecord.SyncsToMap(syncs)).
+			SetAllProvidersSynced(allProvidersSynced).
+			SetUpdatedAt(time.Now().UTC()).
+			Save(ctx)
 
-	if err != nil {
-		SetSpanError(span, err)
-		if ent.IsNotFound(err) {
+		if err != nil {
+			SetSpanError(span, err)
 			return ierr.WithError(err).
-				WithHintf("Usage record with ID %s was not found", id).
-				Mark(ierr.ErrNotFound)
+				WithHint("Failed to update usage record sync result").
+				Mark(ierr.ErrDatabase)
 		}
-		return ierr.WithError(err).
-			WithHint("Failed to update usage record sync result").
-			Mark(ierr.ErrDatabase)
+		if affected == 0 {
+			// The row changed between the read and the write; retry against the new version.
+			continue
+		}
+
+		SetSpanSuccess(span)
+		return nil
 	}
 
-	SetSpanSuccess(span)
-	return nil
+	return ierr.NewErrorf("usage record %s was concurrently modified too many times", id).
+		WithHint("Another process kept updating this usage record's sync status. It will be retried on the next run.").
+		Mark(ierr.ErrVersionConflict)
 }

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"context"
+	"math"
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -17,11 +18,18 @@ import (
 	"go.temporal.io/sdk/activity"
 )
 
+// awsReportingCurrency is the currency AWS Marketplace bills in. AWS Marketplace dimension rates
+// are always denominated in USD — there is no seller-facing currency selection — so every usage
+// record reported here must already be in USD. This is an AWS-specific fact; usage_records itself
+// stores each record's native subscription currency, since the table is shared across marketplaces
+// and Azure/GCP may not require USD.
+const awsReportingCurrency = "usd"
+
 // ReportActivities reports usage records that have not yet been synced to their marketplace. For
 // every published aws_marketplace connection it reads the connection's unsynced usage records,
-// reports them to AWS in batches, and records the returned metering id on each record AWS accepts.
-// Records AWS does not accept are left unsynced so the next run retries them; there is no terminal
-// failure state.
+// skips any not already in USD (currency conversion isn't supported yet), reports the rest to AWS
+// in batches, and records the returned metering id on each record AWS accepts. Records AWS does not
+// accept are left unsynced so the next run retries them; there is no terminal failure state.
 type ReportActivities struct {
 	connectionRepo               connection.Repository
 	entityIntegrationMappingRepo entityintegrationmapping.Repository
@@ -143,6 +151,14 @@ func (a *ReportActivities) reportConnectionUsage(envCtx context.Context, conn *c
 	}
 
 	for _, rec := range records {
+		// AWS Marketplace only accepts USD; a non-USD record stays unsynced (not failed) until
+		// currency conversion is supported, so it's retried automatically once that lands.
+		if !types.IsMatchingCurrency(rec.Currency, awsReportingCurrency) {
+			a.logger.Debug(envCtx, "skipping marketplace usage record, currency not usd",
+				"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+				"usage_record_id", rec.ID, "currency", rec.Currency)
+			continue
+		}
 		result.Total++
 		a.reportRecord(envCtx, conn.ID, rec, mappings, creds, region, result)
 	}
@@ -180,15 +196,28 @@ func (a *ReportActivities) reportRecord(
 		productCode = ""
 	}
 
+	// Only called for records already filtered to currency == usd (see reportConnectionUsage), so
+	// rec.Amount is used as-is. AWS only accepts a whole number, so it's sent in USD cents rather
+	// than dollars — the tenant prices their dimension per cent (see setup docs), which keeps
+	// sub-dollar amounts from rounding away. Turning cents into a charge is AWS's job: it bills
+	// quantity x the dimension's rate.
+	quantity := types.ToSmallestUnit(rec.Amount, awsReportingCurrency)
+	if quantity > math.MaxInt32 {
+		a.logger.Error(envCtx, "marketplace usage report failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
+			"error", "quantity exceeds the maximum aws accepts", "stage", "convert_quantity")
+		result.Failed++
+		return
+	}
+
 	res, err := a.awsClient.BatchMeterUsage(envCtx, creds, region, awsmarketplace.UsageRecordInput{
 		CustomerAWSAccountID: customerAWSAccountID,
 		LicenseArn:           licenseArn,
 		ProductCode:          productCode,
 		Dimension:            plan.dimension,
-		// AWS Quantity is an integer, so the dollar amount is reported as whole units (rate is one
-		// unit per dollar). PeriodEnd is the timestamp so a retry sends an identical record and AWS
-		// de-duplicates it.
-		Quantity:  int32(rec.Amount.Round(0).IntPart()),
+		Quantity:             int32(quantity),
+		// PeriodEnd is the timestamp so a retry sends an identical record and AWS de-duplicates it.
 		Timestamp: rec.PeriodEnd,
 	})
 	if err != nil {

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -142,8 +142,12 @@ func (a *ReportActivities) reportConnectionUsage(envCtx context.Context, conn *c
 		return
 	}
 
-	// Assume the tenant's role once; the short-lived credentials cover one run's records.
-	creds, err := a.awsClient.AssumeRole(envCtx, roleArn, externalID)
+	// Assume the tenant's role once; the same static credentials are reused for every record in
+	// this connection's loop below (they are a one-time snapshot, not a live auto-refreshing
+	// provider). A busy connection's loop can run close to the activity's 30-minute
+	// StartToCloseTimeout, so the session must outlive that — 1 hour is requested because every IAM
+	// role supports it without the tenant needing to raise MaxSessionDuration on their side.
+	creds, err := a.awsClient.AssumeRole(envCtx, roleArn, externalID, time.Hour)
 	if err != nil {
 		a.logger.Error(envCtx, "marketplace usage report failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "error", err, "stage", "assume_role")
@@ -232,6 +236,42 @@ func (a *ReportActivities) reportRecord(
 		a.logger.Warn(envCtx, "marketplace usage record not processed by aws, will retry next run",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
+		result.Failed++
+		return
+	}
+
+	// A present result is not the same as an accepted record — AWS's Status must be checked. Per
+	// AWS's docs, only StatusSuccess means the record was honored; the other two statuses are
+	// distinct failure modes with different causes, so each gets its own log line rather than one
+	// generic "rejected" message.
+	switch res.Status {
+	case awsmarketplace.StatusSuccess:
+		// falls through to the sync below
+	case awsmarketplace.StatusCustomerNotSubscribed:
+		// The buyer (identified by customer_aws_account_id + license_arn — we don't use AWS's
+		// separate CustomerIdentifier field) has no active agreement for this product, or their AWS
+		// account was suspended. This resolves itself once the buyer (re)subscribes, so it's
+		// expected to keep retrying until then rather than needing manual action.
+		a.logger.Error(envCtx, "marketplace usage report rejected by aws: customer not subscribed, will retry next run",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"customer_id", rec.CustomerID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
+		result.Failed++
+		return
+	case awsmarketplace.StatusDuplicateRecord:
+		// NOT "AWS already has this exact record, safe to skip" — AWS has a DIFFERENT record for
+		// the same customer+dimension+timestamp already on file, and rejected this one. Retrying
+		// with the same (unchanged) amount will hit the same rejection every time; this does not
+		// self-heal and needs a human to find and fix the source of the mismatch.
+		a.logger.Error(envCtx, "marketplace usage report rejected by aws: conflicts with a different record already on file, needs manual investigation",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"customer_id", rec.CustomerID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"period_end", rec.PeriodEnd)
+		result.Failed++
+		return
+	default:
+		a.logger.Error(envCtx, "marketplace usage report rejected by aws: unrecognized status, will retry next run",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount, "aws_status", res.Status)
 		result.Failed++
 		return
 	}

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -254,7 +254,8 @@ func (a *ReportActivities) reportRecord(
 		// expected to keep retrying until then rather than needing manual action.
 		a.logger.Error(envCtx, "marketplace usage report rejected by aws: customer not subscribed, will retry next run",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"customer_id", rec.CustomerID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
+			"customer_id", rec.CustomerID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"error", "customer_not_subscribed")
 		result.Failed++
 		return
 	case awsmarketplace.StatusDuplicateRecord:
@@ -265,13 +266,14 @@ func (a *ReportActivities) reportRecord(
 		a.logger.Error(envCtx, "marketplace usage report rejected by aws: conflicts with a different record already on file, needs manual investigation",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"customer_id", rec.CustomerID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
-			"period_end", rec.PeriodEnd)
+			"period_end", rec.PeriodEnd, "error", "duplicate_record")
 		result.Failed++
 		return
 	default:
 		a.logger.Error(envCtx, "marketplace usage report rejected by aws: unrecognized status, will retry next run",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount, "aws_status", res.Status)
+			"license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"aws_status", res.Status, "error", "unrecognized_aws_status")
 		result.Failed++
 		return
 	}

--- a/internal/temporal/activities/marketplace/snapshot_activities.go
+++ b/internal/temporal/activities/marketplace/snapshot_activities.go
@@ -19,7 +19,9 @@ import (
 // SnapshotActivities creates the usage records that will later be reported to a marketplace. For
 // every published aws_marketplace connection it computes each mapped subscription's usage for the
 // reporting window, using the same commitment- and overage-aware computation as real invoicing,
-// and writes one usage record per subscription.
+// and writes one usage record per subscription in the subscription's own billing currency —
+// marketplace-mandated currency conversion (e.g. AWS requires USD) happens per-marketplace at
+// report time, not here, since this table is shared across marketplaces.
 type SnapshotActivities struct {
 	subscriptionService          service.SubscriptionService
 	billingService               service.BillingService
@@ -175,6 +177,9 @@ func (a *SnapshotActivities) snapshotSubscription(
 		return
 	}
 
+	// UsageRecord stores the subscription's native currency as the source of truth — this table is
+	// shared across marketplaces (AWS/Azure/GCP), so any marketplace-mandated currency conversion
+	// (AWS requires USD; Azure/GCP may not) happens per-marketplace at report time, not here.
 	customerExternalID := ""
 	if cust, custErr := a.customerRepo.Get(envCtx, sub.CustomerID); custErr == nil && cust != nil {
 		customerExternalID = cust.ExternalID
@@ -187,6 +192,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		SubscriptionID:     sub.ID,
 		PlanID:             sub.PlanID,
 		Amount:             totalAmount,
+		Currency:           usageResp.Currency,
 		PeriodStart:        input.PeriodStart,
 		PeriodEnd:          input.PeriodEnd,
 		Syncs:              map[usagerecord.Marketplace]usagerecord.MarketplaceSyncEntry{},

--- a/internal/temporal/activities/marketplace/snapshot_activities.go
+++ b/internal/temporal/activities/marketplace/snapshot_activities.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/domain/usagerecord"
 	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	temporalModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
@@ -152,6 +153,23 @@ func (a *SnapshotActivities) snapshotSubscription(
 
 	result.Total++
 
+	// The reporting window is deterministic per scheduled run, so a matching row means an earlier
+	// Temporal attempt for this exact activity call already wrote it (activity retries re-run the
+	// whole loop, including subscriptions a prior attempt already finished). Skip re-computing and
+	// re-inserting it — this is what makes the activity safe to retry.
+	alreadyExists, err := a.usageRecordRepo.ExistsForPeriod(envCtx, sub.ID, input.PeriodStart, input.PeriodEnd)
+	if err != nil {
+		a.logger.Error(envCtx, "marketplace usage snapshot failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
+			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "check_existing")
+		result.Failed++
+		return
+	}
+	if alreadyExists {
+		result.Succeeded++
+		return
+	}
+
 	usageResp, err := a.subscriptionService.GetMeterUsageBySubscription(envCtx, &dto.GetUsageBySubscriptionRequest{
 		SubscriptionID: sub.ID,
 		StartTime:      input.PeriodStart,
@@ -202,6 +220,14 @@ func (a *SnapshotActivities) snapshotSubscription(
 	}
 
 	if err := a.usageRecordRepo.Create(envCtx, rec); err != nil {
+		// The ExistsForPeriod check above is a fast pre-check, not the source of truth — the unique
+		// index on (subscription_id, period_start, period_end) is. A concurrent execution can still
+		// win the race between the check and this insert; that shows up here as ErrAlreadyExists,
+		// and means the record is already written, so it's a success, not a failure.
+		if ierr.IsAlreadyExists(err) {
+			result.Succeeded++
+			return
+		}
 		a.logger.Error(envCtx, "marketplace usage snapshot failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "create_usage_record")

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -279,7 +279,7 @@ func RegisterWorkflowsAndActivities(
 	environmentService := service.NewEnvironmentService(params.EnvironmentRepo, envAccessService, settingsService, params)
 	// Marketplace activities
 	billingService := service.NewBillingService(params)
-	awsMarketplaceClient := awsmarketplace.NewClient(params.Logger)
+	awsMarketplaceClient := awsmarketplace.NewClient(params.Config, params.Logger)
 	marketplaceSnapshotActivities := marketplaceActivities.NewSnapshotActivities(
 		subscriptionService,
 		billingService,

--- a/internal/testutil/base_service_suite.go
+++ b/internal/testutil/base_service_suite.go
@@ -42,6 +42,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/taxapplied"
 	"github.com/flexprice/flexprice/internal/domain/taxassociation"
 	"github.com/flexprice/flexprice/internal/domain/tenant"
+	"github.com/flexprice/flexprice/internal/domain/usagerecord"
 	"github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	"github.com/flexprice/flexprice/internal/integration"
@@ -101,6 +102,7 @@ type Stores struct {
 	MeterUsageRepo               events.MeterUsageRepository
 	PlanPriceSyncRepo            planpricesync.Repository
 	CheckoutSessionRepo          domainCheckout.Repository
+	UsageRecordRepo              usagerecord.Repository
 }
 
 // BaseServiceTestSuite provides common functionality for all service test suites
@@ -252,6 +254,7 @@ func (s *BaseServiceTestSuite) setupStores() {
 		MeterUsageRepo:               NewInMemoryMeterUsageStore(),
 		PlanPriceSyncRepo:            planPriceSyncStore,
 		CheckoutSessionRepo:          NewInMemoryCheckoutSessionStore(),
+		UsageRecordRepo:              NewInMemoryUsageRecordStore(),
 	}
 
 	// Cache stores
@@ -311,6 +314,7 @@ func (s *BaseServiceTestSuite) clearStores() {
 	s.stores.MeterUsageRepo.(*InMemoryMeterUsageStore).Clear()
 	s.stores.PlanPriceSyncRepo.(*InMemoryPlanPriceSyncStore).Clear()
 	s.stores.CheckoutSessionRepo.(*InMemoryCheckoutSessionStore).Clear()
+	s.stores.UsageRecordRepo.(*InMemoryUsageRecordStore).Clear()
 }
 
 func (s *BaseServiceTestSuite) ClearStores() {

--- a/internal/testutil/inmemory_usagerecord_store.go
+++ b/internal/testutil/inmemory_usagerecord_store.go
@@ -1,0 +1,141 @@
+package testutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/usagerecord"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// InMemoryUsageRecordStore is an in-memory implementation of usagerecord.Repository for tests.
+type InMemoryUsageRecordStore struct {
+	store *InMemoryStore[*usagerecord.UsageRecord]
+}
+
+func NewInMemoryUsageRecordStore() *InMemoryUsageRecordStore {
+	return &InMemoryUsageRecordStore{
+		store: NewInMemoryStore[*usagerecord.UsageRecord](),
+	}
+}
+
+func (s *InMemoryUsageRecordStore) Create(ctx context.Context, rec *usagerecord.UsageRecord) error {
+	if rec.EnvironmentID == "" {
+		rec.EnvironmentID = types.GetEnvironmentID(ctx)
+	}
+	if rec.TenantID == "" {
+		rec.TenantID = types.GetTenantID(ctx)
+	}
+
+	// Mirrors the unique index on (tenant_id, environment_id, subscription_id, period_start,
+	// period_end) the ent schema no longer has (dropped per the "every sub has its own agreement,
+	// concurrent overlap is prevented by SCHEDULE_OVERLAP_POLICY_SKIP" call) — kept here anyway
+	// since it costs nothing in-memory and exercises snapshotSubscription's ErrAlreadyExists path.
+	exists, _ := s.ExistsForPeriod(ctx, rec.SubscriptionID, rec.PeriodStart, rec.PeriodEnd)
+	if exists {
+		return ierr.NewError("usage record already exists for this subscription and period").
+			WithReportableDetails(map[string]any{
+				"subscription_id": rec.SubscriptionID,
+				"period_start":    rec.PeriodStart,
+				"period_end":      rec.PeriodEnd,
+			}).
+			Mark(ierr.ErrAlreadyExists)
+	}
+
+	return s.store.Create(ctx, rec.ID, copyUsageRecord(rec))
+}
+
+func (s *InMemoryUsageRecordStore) ExistsForPeriod(ctx context.Context, subscriptionID string, periodStart, periodEnd time.Time) (bool, error) {
+	filterFn := func(ctx context.Context, r *usagerecord.UsageRecord, _ interface{}) bool {
+		return r.SubscriptionID == subscriptionID &&
+			r.PeriodStart.Equal(periodStart) &&
+			r.PeriodEnd.Equal(periodEnd) &&
+			CheckTenantFilter(ctx, r.TenantID) &&
+			CheckEnvironmentFilter(ctx, r.EnvironmentID) &&
+			r.Status == types.StatusPublished
+	}
+	items, err := s.store.List(ctx, nil, filterFn, nil)
+	if err != nil {
+		return false, err
+	}
+	return len(items) > 0, nil
+}
+
+func (s *InMemoryUsageRecordStore) ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*usagerecord.UsageRecord, error) {
+	filterFn := func(_ context.Context, r *usagerecord.UsageRecord, _ interface{}) bool {
+		return r.TenantID == tenantID &&
+			r.EnvironmentID == environmentID &&
+			!r.AllProvidersSynced &&
+			r.Status == types.StatusPublished
+	}
+	items, err := s.store.List(ctx, nil, filterFn, nil)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*usagerecord.UsageRecord, len(items))
+	for i, item := range items {
+		result[i] = copyUsageRecord(item)
+	}
+	return result, nil
+}
+
+func (s *InMemoryUsageRecordStore) UpdateSyncResult(
+	ctx context.Context,
+	id string,
+	marketplace usagerecord.Marketplace,
+	entry usagerecord.MarketplaceSyncEntry,
+	allProvidersSynced bool,
+) error {
+	existing, err := s.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	updated := copyUsageRecord(existing)
+	if updated.Syncs == nil {
+		updated.Syncs = make(map[usagerecord.Marketplace]usagerecord.MarketplaceSyncEntry)
+	}
+	updated.Syncs[marketplace] = entry
+	updated.AllProvidersSynced = allProvidersSynced
+	updated.UpdatedAt = time.Now().UTC()
+
+	return s.store.Update(ctx, id, updated)
+}
+
+func (s *InMemoryUsageRecordStore) Clear() {
+	s.store.Clear()
+}
+
+func copyUsageRecord(r *usagerecord.UsageRecord) *usagerecord.UsageRecord {
+	if r == nil {
+		return nil
+	}
+	syncs := make(map[usagerecord.Marketplace]usagerecord.MarketplaceSyncEntry, len(r.Syncs))
+	for k, v := range r.Syncs {
+		syncs[k] = v
+	}
+	return &usagerecord.UsageRecord{
+		ID:                 r.ID,
+		CustomerID:         r.CustomerID,
+		CustomerExternalID: r.CustomerExternalID,
+		SubscriptionID:     r.SubscriptionID,
+		PlanID:             r.PlanID,
+		Quantity:           r.Quantity,
+		Amount:             r.Amount,
+		Currency:           r.Currency,
+		PeriodStart:        r.PeriodStart,
+		PeriodEnd:          r.PeriodEnd,
+		Syncs:              syncs,
+		AllProvidersSynced: r.AllProvidersSynced,
+		EnvironmentID:      r.EnvironmentID,
+		BaseModel: types.BaseModel{
+			TenantID:  r.TenantID,
+			Status:    r.Status,
+			CreatedAt: r.CreatedAt,
+			UpdatedAt: r.UpdatedAt,
+			CreatedBy: r.CreatedBy,
+			UpdatedBy: r.UpdatedBy,
+		},
+	}
+}

--- a/internal/testutil/inmemory_usagerecord_store_test.go
+++ b/internal/testutil/inmemory_usagerecord_store_test.go
@@ -1,0 +1,71 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/usagerecord"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryUsageRecordStore(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.CtxTenantID, "tenant_1")
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, "env_1")
+
+	store := NewInMemoryUsageRecordStore()
+	periodStart := time.Now().UTC().Add(-10 * time.Hour)
+	periodEnd := time.Now().UTC().Add(-4 * time.Hour)
+
+	rec := &usagerecord.UsageRecord{
+		ID:             "ur_1",
+		CustomerID:     "cust_1",
+		SubscriptionID: "sub_1",
+		PlanID:         "plan_1",
+		Amount:         decimal.NewFromInt(10),
+		Currency:       "usd",
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+		Syncs:          map[usagerecord.Marketplace]usagerecord.MarketplaceSyncEntry{},
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+
+	// Create + duplicate-period guard
+	require.NoError(t, store.Create(ctx, rec))
+	dup := *rec
+	dup.ID = "ur_2"
+	require.Error(t, store.Create(ctx, &dup), "same subscription+period should be rejected")
+
+	// ExistsForPeriod
+	exists, err := store.ExistsForPeriod(ctx, "sub_1", periodStart, periodEnd)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	notExists, err := store.ExistsForPeriod(ctx, "sub_1", periodStart, periodEnd.Add(time.Hour))
+	require.NoError(t, err)
+	require.False(t, notExists)
+
+	// ListUnsynced
+	unsynced, err := store.ListUnsynced(ctx, "tenant_1", "env_1")
+	require.NoError(t, err)
+	require.Len(t, unsynced, 1)
+	require.Equal(t, "ur_1", unsynced[0].ID)
+
+	// UpdateSyncResult
+	err = store.UpdateSyncResult(ctx, "ur_1", usagerecord.MarketplaceAWS, usagerecord.MarketplaceSyncEntry{
+		ConnectionID: "conn_1",
+	}, true)
+	require.NoError(t, err)
+
+	unsynced, err = store.ListUnsynced(ctx, "tenant_1", "env_1")
+	require.NoError(t, err)
+	require.Len(t, unsynced, 0, "record should no longer be unsynced")
+
+	store.Clear()
+	unsynced, err = store.ListUnsynced(ctx, "tenant_1", "env_1")
+	require.NoError(t, err)
+	require.Len(t, unsynced, 0)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage records now include and require a currency value, with full support across APIs, querying, ordering, and updates.
  * Added AWS Marketplace configuration and optional connection pre-validation.
  * Marketplace agreement provider selection now uses a validated allow-list.

* **Bug Fixes**
  * AWS Marketplace reporting is USD-only; non-USD records are skipped and metering outcomes are handled per status.
  * Marketplace snapshotting and sync processing are now idempotent and more resilient to retries/concurrent updates.

* **Tests**
  * Added in-memory usage-record repository coverage for the new currency and idempotency behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->