### PR TITLE
fix(deploy): authenticate crane directly for the :main promotion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -339,13 +339,6 @@ jobs:
     runs-on: self-hosted
     environment: gcp-prod-approval
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ vars.GHCR_USERNAME || github.actor }}
-          password: ${{ secrets.GHCR_PUBLISH_TOKEN }}
-
       - name: Install crane
         uses: imjasonh/setup-crane@v0.4
 
@@ -353,10 +346,17 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
           GITHUB_SHA: ${{ github.sha }}
+          GHCR_USER: ${{ vars.GHCR_USERNAME || github.actor }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PUBLISH_TOKEN }}
         run: |
-          # The build job pushed ${GHCR_IMAGE}:${GITHUB_SHA} to GHCR (required on main).
-          # `crane tag` copies the multi-arch manifest to :main — no Docker daemon,
-          # no rebuild. Auth comes from the docker config the login step wrote.
+          # Authenticate crane DIRECTLY — do not rely on docker/login-action's config.
+          # On the self-hosted runner crane's keychain does not pick up docker's creds
+          # (credsStore/path mismatch), so it hit GHCR anonymously and got DENIED on the
+          # manifest fetch. `crane auth login` writes to crane's own config, via stdin so
+          # the token never lands on the command line.
+          echo "$GHCR_TOKEN" | crane auth login ghcr.io -u "$GHCR_USER" --password-stdin
+          # The build job pushed ${GHCR_IMAGE}:${GITHUB_SHA} (required on main); copy that
+          # multi-arch manifest to :main — no daemon, no rebuild.
           crane tag "${GHCR_IMAGE}:${GITHUB_SHA}" main
 
   # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The `promote-main-ghcr` job (the GCP `:main` promotion added in #2264) failed on the first real prod run:
```
crane tag → DENIED: requested access to the resource is denied
GET https://ghcr.io/v2/flexprice/flexprice/manifests/<sha>
```
The image **exists** (the build job's required GHCR `:<sha>` push succeeded — otherwise this gated job wouldn't have run). The job did `docker/login-action` then `crane tag`, assuming crane reads Docker's config. On the self-hosted runner it **doesn't** — crane's keychain didn't pick up the docker creds (credsStore/path mismatch), so crane hit GHCR **anonymously** and got `DENIED` on the private manifest. (The green "Login" step only meant *Docker* logged in.)

## Fix
Authenticate crane directly:
```
echo "$GHCR_TOKEN" | crane auth login ghcr.io -u "$GHCR_USER" --password-stdin
crane tag "${GHCR_IMAGE}:${GITHUB_SHA}" main
```
`--password-stdin` keeps the token off the command line. Removed the now-redundant `docker/login-action` step from this job (nothing else in it uses Docker).

## Note
Because the promotion failed, the last main merge's image did **not** reach GCP prod (GCP is still on the previously-promoted `:main`, healthy). After this merges, re-run the failed workflow (or the next main merge) to promote — or someone with the GHCR token can manually `crane tag <sha> main` to unblock immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container image promotion authentication in the deployment workflow.
  * Main image tags are now updated more reliably without rebuilding multi-architecture images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->