### PR TITLE
fix(meter-usage): Inhereted subscription revenue fix

### DIFF
--- a/internal/api/dto/costsheet_analytics.go
+++ b/internal/api/dto/costsheet_analytics.go
@@ -28,6 +28,12 @@ type GetCostAnalyticsRequest struct {
 	// Pagination
 	Limit  int `json:"limit,omitempty"`
 	Offset int `json:"offset,omitempty"`
+
+	// IncludeChildren, when true and ExternalCustomerID belongs to a parent
+	// customer, aggregates every inherited-child customer's usage into the
+	// revenue and cost totals. Default (false) restricts the query to the
+	// customer's own usage — mirrors the meter-usage analytics contract.
+	IncludeChildren bool `json:"include_children,omitempty"`
 }
 
 // Validate validates the cost analytics request and sets defaults

--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -1516,12 +1516,13 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 	// then re-cost using costsheet prices.
 	meterUsageService := NewMeterUsageService(s.ServiceParams)
 	analyticsParams := &events.MeterUsageDetailedAnalyticsParams{
-		TenantID:      types.GetTenantID(ctx),
-		EnvironmentID: types.GetEnvironmentID(ctx),
-		MeterIDs:      meterIDs,
-		FeatureIDs:    req.FeatureIDs,
-		StartTime:     req.StartTime,
-		EndTime:       req.EndTime,
+		TenantID:        types.GetTenantID(ctx),
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		MeterIDs:        meterIDs,
+		FeatureIDs:      req.FeatureIDs,
+		StartTime:       req.StartTime,
+		EndTime:         req.EndTime,
+		IncludeChildren: req.IncludeChildren,
 		// Group by meter_id so we get one row per meter (matches how the old
 		// costsheet_usage path keyed its results).
 		GroupBy: []string{"meter_id"},

--- a/internal/ee/service/revenue_analytics.go
+++ b/internal/ee/service/revenue_analytics.go
@@ -53,6 +53,7 @@ func (s *revenueAnalyticsService) GetDetailedCostAnalytics(
 		FeatureIDs:         req.FeatureIDs,
 		StartTime:          req.StartTime,
 		EndTime:            req.EndTime,
+		IncludeChildren:    req.IncludeChildren,
 	}
 	meterUsageService := NewMeterUsageService(s.ServiceParams)
 	revenueAnalytics, err = meterUsageService.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include usage inherited from child customers when viewing cost and revenue analytics.
  * Analytics can now be limited to a parent customer’s own usage when the option is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->