### PR TITLE
Fix/seat based pricing

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1526,16 +1526,8 @@ func (r *OverrideLineItemRequest) Validate(
 	}
 
 	// Validate quantity if provided
-	if r.Quantity != nil {
-		if r.Quantity.IsNegative() {
-			return ierr.NewError("quantity must be non-negative").
-				WithHint("Override quantity cannot be negative").
-				WithReportableDetails(map[string]interface{}{
-					"quantity": r.Quantity.String(),
-				}).
-				Mark(ierr.ErrValidation)
-		}
-
+	if err := price.ValidateQuantityNonNegative(r.Quantity); err != nil {
+		return err
 	}
 
 	// Get original price - it must be available for validation
@@ -1556,6 +1548,14 @@ func (r *OverrideLineItemRequest) Validate(
 				"price_id": r.PriceID,
 			}).
 			Mark(ierr.ErrValidation)
+	}
+
+	// Explicit override quantity (including 0) must respect the original price's min_quantity floor.
+	// Not meaningful for usage-based prices, which don't accept a quantity override at all (checked below).
+	if originalPrice.Type == types.PRICE_TYPE_FIXED {
+		if err := price.ValidateQuantityFloor(r.Quantity, originalPrice.MinQuantity); err != nil {
+			return err
+		}
 	}
 
 	// Quantity can only be set for fixed prices, not usage-based prices

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -85,7 +85,7 @@ type CreateSubscriptionLineItemRequest struct {
 	PriceID string `json:"price_id,omitempty"`
 	// Price defines a new price inline; server creates a subscription-scoped price and adds the line item. Exactly one of price_id or price must be set. Entity/currency are set from the subscription.
 	Price                *SubscriptionPriceCreateRequest `json:"price,omitempty"`
-	Quantity             decimal.Decimal                 `json:"quantity,omitempty"`
+	Quantity             *decimal.Decimal                `json:"quantity,omitempty" swaggertype:"string"`
 	StartDate            *time.Time                      `json:"start_date,omitempty"`
 	EndDate              *time.Time                      `json:"end_date,omitempty"`
 	Metadata             map[string]string               `json:"metadata,omitempty"`
@@ -172,9 +172,9 @@ func (r *UpdateSubscriptionLineItemRequest) HasCommitment() bool {
 }
 
 // Validate validates the create subscription line item request.
-// price is optional and can be provided for MinQuantity validation when using price_id.
+// linePrice is optional and can be provided for MinQuantity validation when using price_id.
 // sub is optional; when provided, line item and inline price start/end dates are validated to fall within subscription bounds.
-func (r *CreateSubscriptionLineItemRequest) Validate(price *price.Price, sub *subscription.Subscription) error {
+func (r *CreateSubscriptionLineItemRequest) Validate(linePrice *price.Price, sub *subscription.Subscription) error {
 	// Exactly one of price_id or price must be set
 	hasPriceID := r.PriceID != ""
 	hasPrice := r.Price != nil
@@ -189,7 +189,7 @@ func (r *CreateSubscriptionLineItemRequest) Validate(price *price.Price, sub *su
 			Mark(ierr.ErrValidation)
 	}
 
-	onetimeIgnoresRequestEndDate := (price != nil && price.BillingPeriod == types.BILLING_PERIOD_ONETIME) ||
+	onetimeIgnoresRequestEndDate := (linePrice != nil && linePrice.BillingPeriod == types.BILLING_PERIOD_ONETIME) ||
 		(r.Price != nil && r.Price.BillingPeriod == types.BILLING_PERIOD_ONETIME)
 
 	// Validate start date is not after end date if both are provided
@@ -261,19 +261,17 @@ func (r *CreateSubscriptionLineItemRequest) Validate(price *price.Price, sub *su
 	// Note: inline price path (r.Price) is nil here; ONETIME billing period is validated
 	// downstream in CreatePriceRequest.Validate() for that path.
 	// ONETIME charges must use ADVANCE invoice cadence
-	if price != nil && price.BillingPeriod == types.BILLING_PERIOD_ONETIME {
-		if price.InvoiceCadence != "" && price.InvoiceCadence != types.InvoiceCadenceAdvance {
+	if linePrice != nil && linePrice.BillingPeriod == types.BILLING_PERIOD_ONETIME {
+		if linePrice.InvoiceCadence != "" && linePrice.InvoiceCadence != types.InvoiceCadenceAdvance {
 			return ierr.NewError("ONETIME charges must have invoice_cadence ADVANCE").
 				WithHint("One-time charges are always billed in advance").
 				Mark(ierr.ErrValidation)
 		}
 	}
 
-	// Validate quantity is positive if provided
-	if !r.Quantity.IsZero() && r.Quantity.IsNegative() {
-		return ierr.NewError("quantity must be positive").
-			WithHint("Quantity must be positive").
-			Mark(ierr.ErrValidation)
+	// Validate quantity is non-negative if provided (nil/omitted is allowed and defaults downstream)
+	if err := price.ValidateQuantityNonNegative(r.Quantity); err != nil {
+		return err
 	}
 
 	// Validate commitment fields if provided
@@ -289,21 +287,12 @@ func (r *CreateSubscriptionLineItemRequest) Validate(price *price.Price, sub *su
 		}
 	}
 
-	// price_id path: validate against price when provided (e.g. MinQuantity)
-	if price != nil && price.Type == types.PRICE_TYPE_FIXED && price.MinQuantity != nil {
-		finalQuantity := r.Quantity
-		if finalQuantity.IsZero() {
-			// Will be set to MinQuantity in ToSubscriptionLineItem, so validation passes
-			finalQuantity = *price.MinQuantity
-		}
-		if finalQuantity.LessThan(lo.FromPtr(price.MinQuantity)) {
-			return ierr.NewError("quantity must be greater than or equal to min_quantity").
-				WithHint("Quantity must be at least the minimum quantity specified for this price").
-				WithReportableDetails(map[string]interface{}{
-					"quantity":     finalQuantity.String(),
-					"min_quantity": price.MinQuantity.String(),
-				}).
-				Mark(ierr.ErrValidation)
+	// price_id path: validate against price when provided (e.g. MinQuantity).
+	// Explicit quantity (including 0) is checked as-is; omitted quantity (nil) defaults
+	// downstream in ToSubscriptionLineItem and is not checked here.
+	if linePrice != nil && linePrice.Type == types.PRICE_TYPE_FIXED {
+		if err := price.ValidateQuantityFloor(r.Quantity, linePrice.MinQuantity); err != nil {
+			return err
 		}
 	}
 
@@ -503,9 +492,10 @@ func (r *CreateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 			}
 			lineItem.Quantity = decimal.Zero
 		} else {
-			// For fixed prices, use MinQuantity if quantity not provided and MinQuantity exists
-			if !r.Quantity.IsZero() {
-				lineItem.Quantity = r.Quantity
+			// For fixed prices: an explicit quantity (already floor-checked in Validate) is used
+			// as-is; an omitted quantity defaults to MinQuantity, else the price's default.
+			if r.Quantity != nil {
+				lineItem.Quantity = *r.Quantity
 			} else if params.Price.MinQuantity != nil {
 				lineItem.Quantity = lo.FromPtr(params.Price.MinQuantity)
 			} else {

--- a/internal/api/dto/subscription_line_item_test.go
+++ b/internal/api/dto/subscription_line_item_test.go
@@ -1,9 +1,12 @@
 package dto
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
@@ -256,6 +259,80 @@ func TestCreateSubscriptionLineItemRequest_Validate_Quantity(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestCreateSubscriptionLineItemRequest_ToSubscriptionLineItem_QuantityDefaulting(t *testing.T) {
+	ctx := context.Background()
+
+	sub := &SubscriptionResponse{
+		Subscription: &subscription.Subscription{
+			ID:         "sub_test",
+			CustomerID: "cust_test",
+			Currency:   "usd",
+			StartDate:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	basePrice := func(minQuantity *decimal.Decimal) *PriceResponse {
+		return &PriceResponse{
+			Price: &price.Price{
+				Type:           types.PRICE_TYPE_FIXED,
+				BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+				InvoiceCadence: types.InvoiceCadenceAdvance,
+				MinQuantity:    minQuantity,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		quantity    *decimal.Decimal
+		minQuantity *decimal.Decimal
+		wantQty     decimal.Decimal
+	}{
+		{
+			name:        "omitted quantity, min quantity set: defaults to min quantity",
+			quantity:    nil,
+			minQuantity: lo.ToPtr(decimal.NewFromInt(5)),
+			wantQty:     decimal.NewFromInt(5),
+		},
+		{
+			name:        "omitted quantity, no min quantity: defaults to price default quantity",
+			quantity:    nil,
+			minQuantity: nil,
+			wantQty:     decimal.NewFromInt(1), // fixed price default quantity
+		},
+		{
+			name:        "explicit zero quantity, min quantity set: honored as-is, not substituted",
+			quantity:    lo.ToPtr(decimal.Zero),
+			minQuantity: lo.ToPtr(decimal.NewFromInt(5)),
+			wantQty:     decimal.Zero,
+		},
+		{
+			name:        "explicit quantity, min quantity set: passes through as-is",
+			quantity:    lo.ToPtr(decimal.NewFromInt(3)),
+			minQuantity: lo.ToPtr(decimal.NewFromInt(5)),
+			wantQty:     decimal.NewFromInt(3),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &CreateSubscriptionLineItemRequest{
+				PriceID:  "price_test",
+				Quantity: tt.quantity,
+			}
+			params := LineItemParams{
+				Subscription: sub,
+				Price:        basePrice(tt.minQuantity),
+				EntityType:   types.SubscriptionLineItemEntityTypeSubscription,
+			}
+
+			lineItem := req.ToSubscriptionLineItem(ctx, params)
+
+			assert.True(t, tt.wantQty.Equal(lineItem.Quantity), "expected quantity %s, got %s", tt.wantQty.String(), lineItem.Quantity.String())
 		})
 	}
 }

--- a/internal/api/dto/subscription_line_item_test.go
+++ b/internal/api/dto/subscription_line_item_test.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"testing"
 
+	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
@@ -155,6 +156,100 @@ func TestCommitmentBucketRequest_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.req.Validate(0)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSub)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateSubscriptionLineItemRequest_Validate_Quantity(t *testing.T) {
+	fixedPriceNoMin := &price.Price{
+		Type:        types.PRICE_TYPE_FIXED,
+		MinQuantity: nil,
+	}
+	fixedPriceMin5 := &price.Price{
+		Type:        types.PRICE_TYPE_FIXED,
+		MinQuantity: lo.ToPtr(decimal.NewFromInt(5)),
+	}
+
+	tests := []struct {
+		name      string
+		quantity  *decimal.Decimal
+		linePrice *price.Price
+		wantErr   bool
+		errSub    string
+	}{
+		{
+			name:      "nil quantity, no min quantity set: no error",
+			quantity:  nil,
+			linePrice: fixedPriceNoMin,
+		},
+		{
+			name:      "nil quantity, min quantity set: no error (nil is never checked against floor)",
+			quantity:  nil,
+			linePrice: fixedPriceMin5,
+		},
+		{
+			name:      "explicit zero quantity, no min quantity: no error",
+			quantity:  lo.ToPtr(decimal.Zero),
+			linePrice: fixedPriceNoMin,
+		},
+		{
+			name:      "explicit zero quantity, min quantity set: error below floor",
+			quantity:  lo.ToPtr(decimal.Zero),
+			linePrice: fixedPriceMin5,
+			wantErr:   true,
+			errSub:    "quantity must be greater than or equal to min_quantity",
+		},
+		{
+			name:      "explicit quantity below min quantity: error",
+			quantity:  lo.ToPtr(decimal.NewFromInt(2)),
+			linePrice: fixedPriceMin5,
+			wantErr:   true,
+			errSub:    "quantity must be greater than or equal to min_quantity",
+		},
+		{
+			name:      "explicit quantity at min quantity: no error",
+			quantity:  lo.ToPtr(decimal.NewFromInt(5)),
+			linePrice: fixedPriceMin5,
+		},
+		{
+			name:      "explicit quantity above min quantity: no error",
+			quantity:  lo.ToPtr(decimal.NewFromInt(10)),
+			linePrice: fixedPriceMin5,
+		},
+		{
+			name:      "negative quantity: error regardless of min quantity",
+			quantity:  lo.ToPtr(decimal.NewFromInt(-1)),
+			linePrice: fixedPriceMin5,
+			wantErr:   true,
+			errSub:    "quantity must be non-negative",
+		},
+		{
+			name:      "nil linePrice, negative quantity: error not dependent on linePrice",
+			quantity:  lo.ToPtr(decimal.NewFromInt(-1)),
+			linePrice: nil,
+			wantErr:   true,
+			errSub:    "quantity must be non-negative",
+		},
+		{
+			name:      "nil linePrice, explicit quantity (including 0): no floor check applies",
+			quantity:  lo.ToPtr(decimal.Zero),
+			linePrice: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &CreateSubscriptionLineItemRequest{
+				PriceID:  "price_test",
+				Quantity: tt.quantity,
+			}
+			err := req.Validate(tt.linePrice, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSub)

--- a/internal/api/dto/subscription_modification.go
+++ b/internal/api/dto/subscription_modification.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/domain/price"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
@@ -59,8 +60,8 @@ func (r *SubModifyInheritanceRequest) Validate() error {
 
 // LineItemQuantityChange describes a quantity change for a single line item.
 type LineItemQuantityChange struct {
-	ID       string          `json:"id" binding:"required"`
-	Quantity decimal.Decimal `json:"quantity" swaggertype:"string" binding:"required"`
+	ID       string           `json:"id" binding:"required"`
+	Quantity *decimal.Decimal `json:"quantity" swaggertype:"string"`
 	// EffectiveDate is when the quantity change takes effect.
 	// If omitted, the change is effective immediately (now).
 	EffectiveDate *time.Time `json:"effective_date,omitempty"`
@@ -83,10 +84,13 @@ func (r *SubModifyQuantityChangeRequest) Validate() error {
 				WithHint("Each line_item entry must have a non-empty id").
 				Mark(ierr.ErrValidation)
 		}
-		if li.Quantity.LessThanOrEqual(decimal.Zero) {
-			return ierr.NewError("quantity must be positive").
-				WithHint("Each line_item quantity must be greater than zero").
+		if li.Quantity == nil {
+			return ierr.NewError("quantity is required").
+				WithHint("Each line_item entry must specify a quantity").
 				Mark(ierr.ErrValidation)
+		}
+		if err := price.ValidateQuantityNonNegative(li.Quantity); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/domain/price/model.go
+++ b/internal/domain/price/model.go
@@ -601,6 +601,16 @@ func (p *Price) ValidateEntityType() error {
 	return p.EntityType.Validate()
 }
 
+// ValidateMinQuantity checks that min_quantity, when set, is non-negative
+func (p *Price) ValidateMinQuantity() error {
+	if p.MinQuantity != nil && p.MinQuantity.IsNegative() {
+		return ierr.NewError("min_quantity must be non-negative").
+			WithHint("min_quantity cannot be negative").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
 // Validate performs all validations on the price
 func (p *Price) Validate() error {
 	if err := p.ValidateAmount(); err != nil {
@@ -619,6 +629,10 @@ func (p *Price) Validate() error {
 		return err
 	}
 
+	if err := p.ValidateMinQuantity(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -630,6 +644,34 @@ func (p *Price) GetDefaultQuantity() decimal.Decimal {
 		return decimal.Zero
 	}
 	return decimal.NewFromInt(1)
+}
+
+// ValidateQuantityNonNegative rejects a negative quantity. nil (omitted) is allowed.
+func ValidateQuantityNonNegative(qty *decimal.Decimal) error {
+	if qty == nil || !qty.IsNegative() {
+		return nil
+	}
+	return ierr.NewError("quantity must be non-negative").
+		WithHint("Quantity cannot be negative").
+		Mark(ierr.ErrValidation)
+}
+
+// ValidateQuantityFloor rejects an explicit quantity below minQuantity.
+// No-op if either qty or minQuantity is nil.
+func ValidateQuantityFloor(qty *decimal.Decimal, minQuantity *decimal.Decimal) error {
+	if qty == nil || minQuantity == nil {
+		return nil
+	}
+	if qty.LessThan(*minQuantity) {
+		return ierr.NewError("quantity must be greater than or equal to min_quantity").
+			WithHint("Quantity must be at least the minimum quantity specified for this price").
+			WithReportableDetails(map[string]interface{}{
+				"quantity":     qty.String(),
+				"min_quantity": minQuantity.String(),
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
 }
 
 // GetDisplayName returns the display name for a price

--- a/internal/domain/price/model_test.go
+++ b/internal/domain/price/model_test.go
@@ -1,0 +1,102 @@
+package price
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrice_Validate_MinQuantity(t *testing.T) {
+	base := func() *Price {
+		return &Price{
+			Amount:         decimal.NewFromInt(10),
+			Currency:       "usd",
+			BillingModel:   types.BILLING_MODEL_FLAT_FEE,
+			BillingCadence: types.BILLING_CADENCE_RECURRING,
+			BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+			InvoiceCadence: types.InvoiceCadenceAdvance,
+			EntityType:     types.PRICE_ENTITY_TYPE_PLAN,
+		}
+	}
+
+	t.Run("nil min_quantity is valid", func(t *testing.T) {
+		p := base()
+		p.MinQuantity = nil
+		assert.NoError(t, p.Validate())
+	})
+
+	t.Run("zero min_quantity is valid", func(t *testing.T) {
+		p := base()
+		p.MinQuantity = lo.ToPtr(decimal.Zero)
+		assert.NoError(t, p.Validate())
+	})
+
+	t.Run("positive min_quantity is valid", func(t *testing.T) {
+		p := base()
+		p.MinQuantity = lo.ToPtr(decimal.NewFromInt(5))
+		assert.NoError(t, p.Validate())
+	})
+
+	t.Run("negative min_quantity is rejected", func(t *testing.T) {
+		p := base()
+		p.MinQuantity = lo.ToPtr(decimal.NewFromInt(-1))
+		err := p.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "min_quantity must be non-negative")
+	})
+}
+
+func TestValidateQuantityNonNegative(t *testing.T) {
+	tests := []struct {
+		name    string
+		qty     *decimal.Decimal
+		wantErr bool
+	}{
+		{name: "nil is allowed (omitted)", qty: nil, wantErr: false},
+		{name: "zero is allowed", qty: lo.ToPtr(decimal.Zero), wantErr: false},
+		{name: "positive is allowed", qty: lo.ToPtr(decimal.NewFromInt(3)), wantErr: false},
+		{name: "negative is rejected", qty: lo.ToPtr(decimal.NewFromInt(-1)), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateQuantityNonNegative(tt.qty)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "quantity must be non-negative")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateQuantityFloor(t *testing.T) {
+	tests := []struct {
+		name        string
+		qty         *decimal.Decimal
+		minQuantity *decimal.Decimal
+		wantErr     bool
+	}{
+		{name: "nil qty is no-op", qty: nil, minQuantity: lo.ToPtr(decimal.NewFromInt(5)), wantErr: false},
+		{name: "nil min_quantity is no-op", qty: lo.ToPtr(decimal.Zero), minQuantity: nil, wantErr: false},
+		{name: "zero qty below positive floor is rejected", qty: lo.ToPtr(decimal.Zero), minQuantity: lo.ToPtr(decimal.NewFromInt(5)), wantErr: true},
+		{name: "qty at floor is allowed", qty: lo.ToPtr(decimal.NewFromInt(5)), minQuantity: lo.ToPtr(decimal.NewFromInt(5)), wantErr: false},
+		{name: "qty above floor is allowed", qty: lo.ToPtr(decimal.NewFromInt(6)), minQuantity: lo.ToPtr(decimal.NewFromInt(5)), wantErr: false},
+		{name: "qty below floor is rejected", qty: lo.ToPtr(decimal.NewFromInt(4)), minQuantity: lo.ToPtr(decimal.NewFromInt(5)), wantErr: true},
+		{name: "zero qty with zero floor is allowed", qty: lo.ToPtr(decimal.Zero), minQuantity: lo.ToPtr(decimal.Zero), wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateQuantityFloor(tt.qty, tt.minQuantity)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "quantity must be greater than or equal to min_quantity")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -16,7 +16,6 @@ import (
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
-	"github.com/shopspring/decimal"
 )
 
 type PlanService = interfaces.PlanService
@@ -772,7 +771,6 @@ func createPlanLineItem(
 
 	req := dto.CreateSubscriptionLineItemRequest{
 		PriceID:     price.ID,
-		Quantity:    decimal.Zero,
 		Metadata:    metadata,
 		DisplayName: price.DisplayName,
 		StartDate:   price.StartDate,

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -194,10 +194,8 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		if priceResponse.Price.Type == types.PRICE_TYPE_USAGE && priceResponse.Meter != nil {
 			item.MeterID = priceResponse.Meter.ID
 			item.MeterDisplayName = priceResponse.Meter.Name
-			item.DisplayName = priceResponse.Meter.Name
 			item.Quantity = decimal.Zero
 		} else {
-			item.DisplayName = plan.Name
 			if item.Quantity.IsZero() {
 				item.Quantity = decimal.NewFromInt(1)
 			}
@@ -1415,9 +1413,7 @@ func (s *subscriptionService) ProcessSubscriptionPriceOverrides(
 		// Update the line item to reference the new subscription-scoped price
 		// Also update display name to match the new price (which preserves the original display name)
 		lineItem.PriceID = overriddenPriceResp.ID
-		if overriddenPriceResp.DisplayName != "" {
-			lineItem.DisplayName = overriddenPriceResp.DisplayName
-		}
+		lineItem.DisplayName = overriddenPriceResp.DisplayName
 
 		s.Logger.Info(ctx, "created subscription-scoped price override",
 			"subscription_id", sub.ID,
@@ -5095,13 +5091,7 @@ func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, price
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
 
-	// Set display name from price (always use price display name)
-	if price.DisplayName != "" {
-		lineItem.DisplayName = price.DisplayName
-	} else {
-		// Fallback to addon name if price display name is not set
-		lineItem.DisplayName = addonName
-	}
+	lineItem.DisplayName = price.DisplayName
 
 	// Set price-related fields
 	if price.Type == types.PRICE_TYPE_USAGE && price.MeterID != "" && priceResponse.Meter != nil {

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	pricevalidation "github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
@@ -51,6 +52,9 @@ func (s *subscriptionService) AddSubscriptionLineItem(ctx context.Context, subsc
 			createdPrice, createErr := NewPriceService(s.ServiceParams).CreatePrice(txCtx, *inlineCreatePriceReq)
 			if createErr != nil {
 				return createErr
+			}
+			if err := pricevalidation.ValidateQuantityFloor(resolvedReq.Quantity, createdPrice.MinQuantity); err != nil {
+				return err
 			}
 			price = createdPrice
 			params.Price = createdPrice

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -272,7 +272,7 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_Success()
 
 	req := dto.CreateSubscriptionLineItemRequest{
 		PriceID:              price2.ID,
-		Quantity:             decimal.NewFromInt(2),
+		Quantity:             lo.ToPtr(decimal.NewFromInt(2)),
 		SkipEntitlementCheck: true,
 	}
 
@@ -363,7 +363,7 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_WithCreat
 
 	req := dto.CreateSubscriptionLineItemRequest{
 		PriceID:              secondPrice.ID,
-		Quantity:             decimal.NewFromInt(1),
+		Quantity:             lo.ToPtr(decimal.NewFromInt(1)),
 		SkipEntitlementCheck: true,
 		ProrationBehavior:    types.ProrationBehaviorCreateProrations,
 	}
@@ -414,7 +414,7 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_NoneProra
 
 	req := dto.CreateSubscriptionLineItemRequest{
 		PriceID:              thirdPrice.ID,
-		Quantity:             decimal.NewFromInt(1),
+		Quantity:             lo.ToPtr(decimal.NewFromInt(1)),
 		SkipEntitlementCheck: true,
 		ProrationBehavior:    types.ProrationBehaviorNone,
 	}
@@ -718,10 +718,10 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_Validatio
 			subID: s.testData.subscription.ID,
 			req: dto.CreateSubscriptionLineItemRequest{
 				PriceID:              s.testData.price.ID,
-				Quantity:             decimal.NewFromInt(-1),
+				Quantity:             lo.ToPtr(decimal.NewFromInt(-1)),
 				SkipEntitlementCheck: true,
 			},
-			wantErrCont: "quantity must be positive",
+			wantErrCont: "quantity must be non-negative",
 		},
 	}
 

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -288,6 +288,32 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_Success()
 	s.NoError(err)
 }
 
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_InlinePriceMinQuantityFloor() {
+	ctx := s.GetContext()
+
+	inlinePrice := &dto.SubscriptionPriceCreateRequest{
+		Type:               types.PRICE_TYPE_FIXED,
+		PriceUnitType:      types.PRICE_UNIT_TYPE_FIAT,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		Amount:             lo.ToPtr(decimal.NewFromInt(1)),
+		LookupKey:          "inline_min_quantity_floor",
+		MinQuantity:        lo.ToPtr(int64(5)),
+	}
+
+	req := dto.CreateSubscriptionLineItemRequest{
+		Price:                inlinePrice,
+		Quantity:             lo.ToPtr(decimal.NewFromInt(2)), // below the inline price's min_quantity of 5
+		SkipEntitlementCheck: true,
+	}
+
+	_, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, req)
+	s.Error(err, "quantity below the inline price's min_quantity should be rejected")
+	s.Contains(err.Error(), "quantity must be greater than or equal to min_quantity")
+}
+
 // TestAddSubscriptionLineItem_DateBoundsValidation asserts that when sub is passed, date-bounds validation runs:
 // line item start_date cannot be before subscription start date; line item end_date cannot be after subscription end date.
 func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_DateBoundsValidation() {

--- a/internal/ee/service/subscription_modification.go
+++ b/internal/ee/service/subscription_modification.go
@@ -479,7 +479,7 @@ func (s *subscriptionModificationService) executeQuantityChange(
 				PriceUnitID:             lineItem.PriceUnitID,
 				PriceUnit:               lineItem.PriceUnit,
 				DisplayName:             lineItem.DisplayName,
-				Quantity:                change.Quantity,
+				Quantity:                *change.Quantity,
 				Currency:                lineItem.Currency,
 				BillingPeriod:           lineItem.BillingPeriod,
 				BillingPeriodCount:      lineItem.BillingPeriodCount,
@@ -676,7 +676,7 @@ func (s *subscriptionModificationService) previewQuantityChange(
 			dto.ChangedLineItem{
 				ID:           "(preview-created)",
 				PriceID:      lineItem.PriceID,
-				Quantity:     change.Quantity,
+				Quantity:     *change.Quantity,
 				StartDate:    &startDate,
 				EndDate:      &newEndDate,
 				ChangeAction: dto.ChangedLineItemActionCreated,
@@ -688,7 +688,7 @@ func (s *subscriptionModificationService) previewQuantityChange(
 		if lineItem.InvoiceCadence == types.InvoiceCadenceAdvance {
 			previewNewItem := &subscription.SubscriptionLineItem{
 				PriceID:  lineItem.PriceID,
-				Quantity: change.Quantity,
+				Quantity: *change.Quantity,
 			}
 			inv, err := s.previewQuantityChangeProration(ctx, sub, lineItem, previewNewItem, effectiveDate)
 			if err != nil {

--- a/internal/ee/service/subscription_modification_test.go
+++ b/internal/ee/service/subscription_modification_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/suite"
 )
@@ -173,12 +174,13 @@ func (s *SubscriptionModificationServiceSuite) createParentSubWithChild(parentEx
 func (s *SubscriptionModificationServiceSuite) createFixedLineItem(subID, customerID string, qty decimal.Decimal, cadence types.InvoiceCadence) *subscription.SubscriptionLineItem {
 	ctx := s.GetContext()
 	now := s.GetNow()
+	p := s.createFixedPrice(decimal.NewFromInt(10), cadence)
 	li := &subscription.SubscriptionLineItem{
 		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
 		BaseModel:      types.GetDefaultBaseModel(ctx),
 		SubscriptionID: subID,
 		CustomerID:     customerID,
-		PriceID:        types.GenerateUUID(),
+		PriceID:        p.ID,
 		PriceType:      types.PRICE_TYPE_FIXED,
 		Quantity:       qty,
 		Currency:       "USD",
@@ -338,7 +340,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 				Type: dto.SubscriptionModifyTypeQuantityChange,
 				QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 					LineItems: []dto.LineItemQuantityChange{
-						{ID: li.ID, Quantity: tc.newQty, EffectiveDate: &effectiveDate},
+						{ID: li.ID, Quantity: lo.ToPtr(tc.newQty), EffectiveDate: &effectiveDate},
 					},
 				},
 			}
@@ -444,7 +446,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Arrear(
 				Type: dto.SubscriptionModifyTypeQuantityChange,
 				QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 					LineItems: []dto.LineItemQuantityChange{
-						{ID: li.ID, Quantity: tc.newQty, EffectiveDate: &effectiveDate},
+						{ID: li.ID, Quantity: lo.ToPtr(tc.newQty), EffectiveDate: &effectiveDate},
 					},
 				},
 			}
@@ -544,7 +546,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Effecti
 				Type: dto.SubscriptionModifyTypeQuantityChange,
 				QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 					LineItems: []dto.LineItemQuantityChange{
-						{ID: li.ID, Quantity: newQty, EffectiveDate: &effectiveDate},
+						{ID: li.ID, Quantity: lo.ToPtr(newQty), EffectiveDate: &effectiveDate},
 					},
 				},
 			}
@@ -954,7 +956,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Version
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: newQty},
+				{ID: li.ID, Quantity: lo.ToPtr(newQty)},
 			},
 		},
 	}
@@ -1008,7 +1010,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_WrongSu
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(7)},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(7))},
 			},
 		},
 	}
@@ -1030,7 +1032,7 @@ func (s *SubscriptionModificationServiceSuite) TestPreviewQuantityChange_DoesNot
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(10)},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(10))},
 			},
 		},
 	}
@@ -1045,8 +1047,8 @@ func (s *SubscriptionModificationServiceSuite) TestPreviewQuantityChange_DoesNot
 	s.True(origLI.EndDate.IsZero(), "Preview must not persist changes; EndDate should still be zero")
 }
 
-// TestExecuteQuantityChange_InvalidRequestRejected verifies that empty LineItems or zero
-// quantity are rejected with validation errors.
+// TestExecuteQuantityChange_InvalidRequestRejected verifies that empty LineItems or a
+// negative quantity are rejected with validation errors.
 func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_InvalidRequestRejected() {
 	ctx := s.GetContext()
 
@@ -1063,16 +1065,73 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Invalid
 	})
 	s.Require().Error(err, "empty LineItems should be rejected")
 
-	// Zero quantity
+	// Missing quantity
 	_, err = s.service.Execute(ctx, sub.ID, dto.ExecuteSubscriptionModifyRequest{
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.Zero},
+				{ID: li.ID},
 			},
 		},
 	})
-	s.Require().Error(err, "zero quantity should be rejected")
+	s.Require().Error(err, "missing quantity should be rejected")
+	s.Contains(err.Error(), "quantity is required")
+
+	// Negative quantity
+	_, err = s.service.Execute(ctx, sub.ID, dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeQuantityChange,
+		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
+			LineItems: []dto.LineItemQuantityChange{
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(-1))},
+			},
+		},
+	})
+	s.Require().Error(err, "negative quantity should be rejected")
+	s.Contains(err.Error(), "quantity must be non-negative")
+}
+
+// TestExecuteQuantityChange_ZeroQuantityAllowed verifies that quantity=0 is accepted when
+// the line item's price has no min_quantity floor.
+func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_ZeroQuantityAllowed() {
+	ctx := s.GetContext()
+
+	cust := s.createCustomer("ext-qty-005")
+	sub := s.createActiveSub(cust.ID)
+	li := s.createFixedLineItem(sub.ID, cust.ID, decimal.NewFromInt(5), types.InvoiceCadenceArrear)
+
+	_, err := s.service.Execute(ctx, sub.ID, dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeQuantityChange,
+		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
+			LineItems: []dto.LineItemQuantityChange{
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.Zero)},
+			},
+		},
+	})
+	s.Require().NoError(err, "zero quantity should be allowed when there is no min_quantity floor")
+}
+
+// TestExecuteQuantityChange_ZeroQuantityBelowMinQuantityRejected verifies that quantity=0 is
+// rejected when the line item's price has a positive min_quantity floor.
+func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_ZeroQuantityBelowMinQuantityRejected() {
+	ctx := s.GetContext()
+
+	cust := s.createCustomer("ext-qty-006")
+	sub := s.createActiveSub(cust.ID)
+	p := s.createFixedPrice(decimal.NewFromInt(10), types.InvoiceCadenceArrear)
+	p.MinQuantity = lo.ToPtr(decimal.NewFromInt(3))
+	s.Require().NoError(s.GetStores().PriceRepo.Update(ctx, p, false))
+	li := s.createFixedLineItemWithPrice(sub.ID, cust.ID, decimal.NewFromInt(5), types.InvoiceCadenceArrear, p.ID)
+
+	_, err := s.service.Execute(ctx, sub.ID, dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeQuantityChange,
+		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
+			LineItems: []dto.LineItemQuantityChange{
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.Zero)},
+			},
+		},
+	})
+	s.Require().Error(err, "zero quantity should be rejected below a positive min_quantity floor")
+	s.Contains(err.Error(), "quantity must be greater than or equal to min_quantity")
 }
 
 // TestExecuteQuantityChange_EffectiveDateOutsideLineItemWindowRejected verifies that
@@ -1099,7 +1158,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Effecti
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(8), EffectiveDate: &effectiveBeforeLine},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(8)), EffectiveDate: &effectiveBeforeLine},
 			},
 		},
 	})
@@ -1116,7 +1175,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Effecti
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(9), EffectiveDate: &effectiveAfterLineEnd},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(9)), EffectiveDate: &effectiveAfterLineEnd},
 			},
 		},
 	})
@@ -1146,7 +1205,7 @@ func (s *SubscriptionModificationServiceSuite) TestPreviewQuantityChange_Effecti
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(8), EffectiveDate: &effectiveBeforeLine},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(8)), EffectiveDate: &effectiveBeforeLine},
 			},
 		},
 	})
@@ -1163,7 +1222,7 @@ func (s *SubscriptionModificationServiceSuite) TestPreviewQuantityChange_Effecti
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(9), EffectiveDate: &effectiveAfterLineEnd},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(9)), EffectiveDate: &effectiveAfterLineEnd},
 			},
 		},
 	})
@@ -1194,8 +1253,8 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_MultiLi
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: advLI.ID, Quantity: decimal.NewFromInt(3), EffectiveDate: &effectiveDate},
-				{ID: arrLI.ID, Quantity: decimal.NewFromInt(5), EffectiveDate: &effectiveDate},
+				{ID: advLI.ID, Quantity: lo.ToPtr(decimal.NewFromInt(3)), EffectiveDate: &effectiveDate},
+				{ID: arrLI.ID, Quantity: lo.ToPtr(decimal.NewFromInt(5)), EffectiveDate: &effectiveDate},
 			},
 		},
 	}
@@ -1230,8 +1289,8 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_MultiLi
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: "nonexistent-id-xyz", Quantity: decimal.NewFromInt(3), EffectiveDate: &effectiveDate},
-				{ID: li.ID, Quantity: decimal.NewFromInt(5), EffectiveDate: &effectiveDate},
+				{ID: "nonexistent-id-xyz", Quantity: lo.ToPtr(decimal.NewFromInt(3)), EffectiveDate: &effectiveDate},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(5)), EffectiveDate: &effectiveDate},
 			},
 		},
 	}
@@ -1316,7 +1375,7 @@ func (s *SubscriptionModificationServiceSuite) TestPreviewQuantityChange() {
 				Type: dto.SubscriptionModifyTypeQuantityChange,
 				QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 					LineItems: []dto.LineItemQuantityChange{
-						{ID: li.ID, Quantity: tc.newQty, EffectiveDate: &effectiveDate},
+						{ID: li.ID, Quantity: lo.ToPtr(tc.newQty), EffectiveDate: &effectiveDate},
 					},
 				},
 			}
@@ -1438,7 +1497,7 @@ func (s *SubscriptionModificationServiceSuite) TestProrationMath_Upgrade() {
 				Type: dto.SubscriptionModifyTypeQuantityChange,
 				QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 					LineItems: []dto.LineItemQuantityChange{
-						{ID: li.ID, Quantity: tc.newQty, EffectiveDate: &tc.effectiveDate},
+						{ID: li.ID, Quantity: lo.ToPtr(tc.newQty), EffectiveDate: &tc.effectiveDate},
 					},
 				},
 			}
@@ -1497,7 +1556,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_NonFixe
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(3), EffectiveDate: &effectiveDate},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(3)), EffectiveDate: &effectiveDate},
 			},
 		},
 	}
@@ -1538,7 +1597,7 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Inactiv
 		Type: dto.SubscriptionModifyTypeQuantityChange,
 		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
 			LineItems: []dto.LineItemQuantityChange{
-				{ID: li.ID, Quantity: decimal.NewFromInt(5), EffectiveDate: &effectiveDate},
+				{ID: li.ID, Quantity: lo.ToPtr(decimal.NewFromInt(5)), EffectiveDate: &effectiveDate},
 			},
 		},
 	}

--- a/internal/ee/service/subscription_price_override_test.go
+++ b/internal/ee/service/subscription_price_override_test.go
@@ -97,6 +97,48 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 		assert.Contains(t, err.Error(), "at least one override field")
 	})
 
+	t.Run("should reject override quantity below min_quantity", func(t *testing.T) {
+		qty := decimal.NewFromInt(2)
+		priceMap := map[string]*dto.PriceResponse{
+			"test_price_min_qty": {
+				Price: &price.Price{
+					ID:            "test_price_min_qty",
+					Type:          types.PRICE_TYPE_FIXED,
+					BillingModel:  types.BILLING_MODEL_FLAT_FEE,
+					PriceUnitType: types.PRICE_UNIT_TYPE_FIAT,
+					MinQuantity:   lo.ToPtr(decimal.NewFromInt(5)),
+				},
+			},
+		}
+		override := dto.OverrideLineItemRequest{
+			PriceID:  "test_price_min_qty",
+			Quantity: &qty,
+		}
+		err := override.Validate(priceMap, nil, "test_plan_456")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "quantity must be greater than or equal to min_quantity")
+	})
+
+	t.Run("should allow zero override quantity when no min_quantity floor", func(t *testing.T) {
+		qty := decimal.Zero
+		priceMap := map[string]*dto.PriceResponse{
+			"test_price_no_floor": {
+				Price: &price.Price{
+					ID:            "test_price_no_floor",
+					Type:          types.PRICE_TYPE_FIXED,
+					BillingModel:  types.BILLING_MODEL_FLAT_FEE,
+					PriceUnitType: types.PRICE_UNIT_TYPE_FIAT,
+				},
+			},
+		}
+		override := dto.OverrideLineItemRequest{
+			PriceID:  "test_price_no_floor",
+			Quantity: &qty,
+		}
+		err := override.Validate(priceMap, nil, "test_plan_456")
+		assert.NoError(t, err)
+	})
+
 	t.Run("should reject duplicate price IDs in overrides", func(t *testing.T) {
 		amount1 := decimal.NewFromFloat(10.00)
 		amount2 := decimal.NewFromFloat(20.00)

--- a/internal/temporal/activities/prepareprocessedevents/prepare_processed_events_activities.go
+++ b/internal/temporal/activities/prepareprocessedevents/prepare_processed_events_activities.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
-	"github.com/shopspring/decimal"
 )
 
 // PrepareProcessedEventsActivities contains Temporal activities used by PrepareProcessedEventsWorkflow.
@@ -192,7 +191,6 @@ func (a *PrepareProcessedEventsActivities) RolloutToSubscriptionsActivity(
 		createReq := dto.CreateSubscriptionLineItemRequest{
 			PriceID:              input.PriceID,
 			StartDate:            &input.EventTimestamp, // Use event timestamp as StartDate
-			Quantity:             decimal.Zero,          // Usage prices have zero quantity
 			SkipEntitlementCheck: true,                  // Skip entitlement check for workflow-created line items
 			Metadata: map[string]string{
 				"added_by":      "prepare_processed_events_workflow",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription line-item `quantity` is now optional; omitting it uses the applicable `min_quantity` or the price’s default.
  * Explicit `quantity: 0` is preserved.
* **Bug Fixes**
  * Quantity validation now consistently rejects negative values and enforces `min_quantity` floors for inline pricing and price overrides.
  * Subscription line-item display name and quantity initialization behavior was corrected for certain price/override flows.
* **Tests**
  * Added/updated unit and integration coverage for nil vs zero quantities, defaulting behavior, and `min_quantity` validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->