### PR TITLE
feat(meter-usage): Handle group_by for commitments for exports

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -362,6 +362,11 @@ type GetUsageAnalyticsRequest struct {
 	// and the item to be linked to a subscription line item that has CommitmentTimeBuckets.
 	// Default: false (opt-in, backward compatible).
 	BreakdownBucket bool `json:"breakdown_bucket,omitempty" form:"breakdown_bucket"`
+	// ForceApplyCommitment is an INTERNAL toggle set by the CSV export pipeline
+	// to keep commitment / true-up cost on fanned-out (group_by=source) rows.
+	// json:"-" so it can never be set from an HTTP body — user-facing callers
+	// must not read or write this field.
+	ForceApplyCommitment bool `json:"-" form:"-"`
 }
 
 // GetUsageAnalyticsResponse represents the response for the usage analytics API

--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -103,6 +103,12 @@ type MeterUsageDetailedAnalyticsParams struct {
 	// true, each point is stamped with its BucketID/PriceID and per-bucket
 	// summaries are appended. Requires WindowSize to be set.
 	BreakdownBucket bool
+	// ForceApplyCommitment overrides the per-item skip that calculateCosts
+	// normally applies to fanned-out analytics (Source or Properties set).
+	// Internal-only — set by the CSV export pipeline so bucketed commitment
+	// line items keep their true-up / overage cost even when the export
+	// requests group_by=source. NEVER wire this into a user-facing DTO field.
+	ForceApplyCommitment bool
 }
 
 // MeterUsageDetailedResult holds aggregated analytics for a single group combination

--- a/internal/domain/events/models.go
+++ b/internal/domain/events/models.go
@@ -43,6 +43,10 @@ type UsageAnalyticsParams struct {
 	// - Subscription billing periods (e.g., customer signed up on 15th)
 	// - Custom business cycles (e.g., fiscal months starting on 5th)
 	BillingAnchor *time.Time
+	// ForceApplyCommitment mirrors MeterUsageDetailedAnalyticsParams.ForceApplyCommitment.
+	// Internal-only. Set by the CSV export pipeline to override the per-item
+	// commitment-skip that calculateCosts applies to fanned-out analytics.
+	ForceApplyCommitment bool
 }
 
 // DetailedUsageAnalytic represents detailed usage and cost data for analytics

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -164,19 +164,20 @@ type lineItemWithMeter struct {
 // usage-analytics CSV exporter).
 func (s *meterUsageService) GetDetailedUsageAnalytics(ctx context.Context, req *dto.GetUsageAnalyticsRequest) (*dto.GetUsageAnalyticsResponse, error) {
 	return s.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
-		TenantID:            types.GetTenantID(ctx),
-		EnvironmentID:       types.GetEnvironmentID(ctx),
-		ExternalCustomerID:  req.ExternalCustomerID,
-		ExternalCustomerIDs: req.ExternalCustomerIDs,
-		FeatureIDs:          req.FeatureIDs,
-		StartTime:           req.StartTime,
-		EndTime:             req.EndTime,
-		GroupBy:             req.GroupBy,
-		PropertyFilters:     req.PropertyFilters,
-		Sources:             req.Sources,
-		WindowSize:          req.WindowSize,
-		Expand:              req.Expand,
-		IncludeChildren:     req.IncludeChildren,
+		TenantID:             types.GetTenantID(ctx),
+		EnvironmentID:        types.GetEnvironmentID(ctx),
+		ExternalCustomerID:   req.ExternalCustomerID,
+		ExternalCustomerIDs:  req.ExternalCustomerIDs,
+		FeatureIDs:           req.FeatureIDs,
+		StartTime:            req.StartTime,
+		EndTime:              req.EndTime,
+		GroupBy:              req.GroupBy,
+		PropertyFilters:      req.PropertyFilters,
+		Sources:              req.Sources,
+		WindowSize:           req.WindowSize,
+		Expand:               req.Expand,
+		IncludeChildren:      req.IncludeChildren,
+		ForceApplyCommitment: req.ForceApplyCommitment,
 	})
 }
 
@@ -507,7 +508,7 @@ func (s *meterUsageService) GetSubscriptionMeterUsage(
 			// with the full group_by (per-group breakdown in the response).
 			hasExtraGroupBy := false
 			for _, g := range req.GroupBy {
-				if g != "" && g != "meter_id" {
+				if g != "" && g != "meter_id" && g != "feature_id" {
 					hasExtraGroupBy = true
 					break
 				}
@@ -769,7 +770,7 @@ func (s *meterUsageService) queryAndAppendAnalyticsEntries(
 	groupBy := []string{"meter_id"}
 	if useUserGroupBy {
 		for _, g := range req.GroupBy {
-			if g != "" && g != "meter_id" {
+			if g != "" && g != "meter_id" && g != "feature_id" {
 				groupBy = append(groupBy, g)
 			}
 		}
@@ -1188,13 +1189,10 @@ func (s *meterUsageService) GetDetailedAnalytics(ctx context.Context, params *ev
 	// Merge into AnalyticsData
 	data := s.mergeSubscriptionUsagesToAnalyticsData(cust, subscriptions, allUsages, params)
 
-	// Calculate costs inline (no dependency on featureUsageTrackingService)
-	if len(data.Analytics) > 0 {
-		if err := s.calculateCosts(ctx, data); err != nil {
-			s.logger.Info(ctx, "failed to calculate costs for meter usage analytics, costs will be zero",
-				"error", err,
-			)
-		}
+	// Calculate costs inline
+	err = s.calculateCosts(ctx, data)
+	if err != nil {
+		s.logger.Error(ctx, "failed to calculate costs for meter usage analytics, costs will be zero", "error", err)
 	}
 
 	// Set currency on all analytics items
@@ -1235,17 +1233,18 @@ func (s *meterUsageService) mergeSubscriptionUsagesToAnalyticsData(
 		Groups:                make(map[string]*group.Group),
 		Analytics:             make([]*events.DetailedUsageAnalytic, 0),
 		Params: &events.UsageAnalyticsParams{
-			TenantID:           params.TenantID,
-			EnvironmentID:      params.EnvironmentID,
-			ExternalCustomerID: params.ExternalCustomerID,
-			StartTime:          params.StartTime,
-			EndTime:            params.EndTime,
-			GroupBy:            params.GroupBy,
-			WindowSize:         params.WindowSize,
-			PropertyFilters:    params.PropertyFilters,
-			Sources:            params.Sources,
-			AggregationTypes:   params.AggregationTypes,
-			BillingAnchor:      params.BillingAnchor,
+			TenantID:             params.TenantID,
+			EnvironmentID:        params.EnvironmentID,
+			ExternalCustomerID:   params.ExternalCustomerID,
+			StartTime:            params.StartTime,
+			EndTime:              params.EndTime,
+			GroupBy:              params.GroupBy,
+			WindowSize:           params.WindowSize,
+			PropertyFilters:      params.PropertyFilters,
+			Sources:              params.Sources,
+			AggregationTypes:     params.AggregationTypes,
+			BillingAnchor:        params.BillingAnchor,
+			ForceApplyCommitment: params.ForceApplyCommitment,
 		},
 	}
 
@@ -1572,17 +1571,18 @@ func (s *meterUsageService) getDetailedAnalyticsWithoutSubscriptionContext(
 		Groups:                make(map[string]*group.Group),
 		Analytics:             make([]*events.DetailedUsageAnalytic, 0, len(allResults)),
 		Params: &events.UsageAnalyticsParams{
-			TenantID:           params.TenantID,
-			EnvironmentID:      params.EnvironmentID,
-			ExternalCustomerID: params.ExternalCustomerID,
-			StartTime:          params.StartTime,
-			EndTime:            params.EndTime,
-			GroupBy:            params.GroupBy,
-			WindowSize:         params.WindowSize,
-			PropertyFilters:    params.PropertyFilters,
-			Sources:            params.Sources,
-			AggregationTypes:   params.AggregationTypes,
-			BillingAnchor:      params.BillingAnchor,
+			TenantID:             params.TenantID,
+			EnvironmentID:        params.EnvironmentID,
+			ExternalCustomerID:   params.ExternalCustomerID,
+			StartTime:            params.StartTime,
+			EndTime:              params.EndTime,
+			GroupBy:              params.GroupBy,
+			WindowSize:           params.WindowSize,
+			PropertyFilters:      params.PropertyFilters,
+			Sources:              params.Sources,
+			AggregationTypes:     params.AggregationTypes,
+			BillingAnchor:        params.BillingAnchor,
+			ForceApplyCommitment: params.ForceApplyCommitment,
 		},
 	}
 
@@ -2255,6 +2255,10 @@ func loadAnalyticsCoupons(ctx context.Context, sp ServiceParams, data *Analytics
 
 // calculateCosts calculates costs for all analytics items in the data.
 func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsData) error {
+	if len(data.Analytics) == 0 {
+		return nil
+	}
+
 	priceService := NewPriceService(s.ServiceParams)
 
 	// Analytics filters (property_filters, sources) restrict the SQL result set
@@ -2264,8 +2268,20 @@ func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsD
 	// zero matching events would otherwise show the full commitment as unutilized
 	// and report it as cost). When any analytics-only filter is active, skip
 	// commitment application and report the raw filtered cost.
-	filterSkipCommitment := len(data.Params.PropertyFilters) > 0 ||
-		len(data.Params.Sources) > 0
+	//
+	// User group_by also triggers skip: each fanned-out (source, properties)
+	// combo analytic carries its own per-combo Usage and Points, and applying
+	// commitment math per combo would over-charge — the line item's commitment
+	// would fire once per combo instead of once across the whole line item.
+	//
+	// ForceApplyCommitment (internal-only, set by the CSV export path)
+	// overrides the group_by skip so bucketed commitment line items keep their
+	// true-up / overage cost even when the export requests group_by=source.
+	// Filter-based skip is NOT overridden — a filter subset is genuinely
+	// partial data and commitment math on it would still be misleading.
+	skipCommitment := len(data.Params.PropertyFilters) > 0 ||
+		len(data.Params.Sources) > 0 ||
+		(hasUserBucketedGroupBy(data.Params.GroupBy) && !data.Params.ForceApplyCommitment)
 
 	for _, item := range data.Analytics {
 		// Resolve meter: prefer via feature, fall back to direct MeterID lookup.
@@ -2284,17 +2300,6 @@ func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsD
 		if !hasPricing {
 			continue
 		}
-
-		// Per-item skip for source/properties fan-out: when this specific
-		// analytic represents one combo of a fanned-out result set, its Usage
-		// / Points cover only that slice — applying commitment here would fire
-		// the line item's commitment once per combo. An unfanned analytic
-		// (Source="" and no Properties), including the step-12 synthetic
-		// zero-fill entries created for zero-usage commitment line items,
-		// represents the whole line item and MUST apply commitment so the
-		// true-up amount is surfaced (this is where the export-vs-analytics
-		// $0-cost regression came from).
-		skipCommitment := filterSkipCommitment || item.Source != "" || len(item.Properties) > 0
 
 		if m.IsBucketedMaxMeter() || m.IsBucketedSumMeter() {
 			s.calculateBucketedCost(ctx, priceService, item, p, m, data, skipCommitment)

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -2264,14 +2264,8 @@ func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsD
 	// zero matching events would otherwise show the full commitment as unutilized
 	// and report it as cost). When any analytics-only filter is active, skip
 	// commitment application and report the raw filtered cost.
-	//
-	// User group_by also triggers skip: each fanned-out (source, properties)
-	// combo analytic carries its own per-combo Usage and Points, and applying
-	// commitment math per combo would over-charge — the line item's commitment
-	// would fire once per combo instead of once across the whole line item.
-	skipCommitment := len(data.Params.PropertyFilters) > 0 ||
-		len(data.Params.Sources) > 0 ||
-		hasUserBucketedGroupBy(data.Params.GroupBy)
+	filterSkipCommitment := len(data.Params.PropertyFilters) > 0 ||
+		len(data.Params.Sources) > 0
 
 	for _, item := range data.Analytics {
 		// Resolve meter: prefer via feature, fall back to direct MeterID lookup.
@@ -2290,6 +2284,17 @@ func (s *meterUsageService) calculateCosts(ctx context.Context, data *AnalyticsD
 		if !hasPricing {
 			continue
 		}
+
+		// Per-item skip for source/properties fan-out: when this specific
+		// analytic represents one combo of a fanned-out result set, its Usage
+		// / Points cover only that slice — applying commitment here would fire
+		// the line item's commitment once per combo. An unfanned analytic
+		// (Source="" and no Properties), including the step-12 synthetic
+		// zero-fill entries created for zero-usage commitment line items,
+		// represents the whole line item and MUST apply commitment so the
+		// true-up amount is surfaced (this is where the export-vs-analytics
+		// $0-cost regression came from).
+		skipCommitment := filterSkipCommitment || item.Source != "" || len(item.Properties) > 0
 
 		if m.IsBucketedMaxMeter() || m.IsBucketedSumMeter() {
 			s.calculateBucketedCost(ctx, priceService, item, p, m, data, skipCommitment)

--- a/internal/ee/service/meter_usage_test.go
+++ b/internal/ee/service/meter_usage_test.go
@@ -4697,27 +4697,40 @@ func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ParentCustomer_Include
 		s.totalUsageForMeter(resp, s.meterAPI.ID))
 }
 
-// TestGetDetailedAnalytics_ZeroUsageCommitment_WithGroupBySource: an unfanned
-// analytic (Source="", no Properties) must apply commitment even when the
-// request carries group_by=source. The synthetic zero-fill created by step 12
-// for a zero-usage commitment line item represents the whole line item, not a
-// per-source slice — skipping commitment there hides the true-up cost, which
-// is how the CSV export path was reporting $0 for reserved-capacity line items
-// with no usage in the window.
-func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ZeroUsageCommitment_WithGroupBySource() {
+// TestGetDetailedAnalytics_ForceApplyCommitment_KeepsCostOnFannedSources: the
+// CSV export sets ForceApplyCommitment=true so bucketed commitment line items
+// keep their true-up / overage cost even though the bucketed path fans the
+// analytics per source (Source populated on each row). Without the flag the
+// per-source rows zero out and the export totals drift from the analytics API.
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ForceApplyCommitment_KeepsCostOnFannedSources() {
 	ctx := s.GetContext()
 
-	// $100 committed, 1.5x overage, true-up on. Zero usage → true-up bills the
-	// entire commitment.
+	// Bucketed SUM meter — commitment items on bucketed meters go through
+	// queryBucketedMeterAnalyticsDetailed under group_by=source (no
+	// commitment/non-commitment split in that path), so the analytic ends up
+	// with Source set. That's the scenario the flag exists to unblock.
+	m := &meter.Meter{
+		ID:        "mtr_bkt_commit_fanned",
+		Name:      "Bucketed SUM w/ commitment",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+	p := s.createPriceForMeter(ctx, "pr_bkt_commit_fanned", m.ID, decimal.NewFromFloat(0.01))
+
 	commitmentAmount := decimal.NewFromInt(100)
 	overageFactor := decimal.NewFromFloat(1.5)
 	li := &subscription.SubscriptionLineItem{
-		ID:                      "li_commit_no_usage",
+		ID:                      "li_bkt_commit_fanned",
 		SubscriptionID:          s.sub.ID,
 		CustomerID:              s.customer.ID,
-		PriceID:                 s.priceAPI.ID,
+		PriceID:                 p.ID,
 		PriceType:               types.PRICE_TYPE_USAGE,
-		MeterID:                 s.meterAPI.ID,
+		MeterID:                 m.ID,
 		Currency:                "usd",
 		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
 		InvoiceCadence:          types.InvoiceCadenceArrear,
@@ -4732,31 +4745,153 @@ func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ZeroUsageCommitment_Wi
 	}
 	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
 
-	// No usage inserted.
+	// 10 units under a specific source — below the $100 commitment, so
+	// true-up would bill the full commitment if applied.
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "prod-api",
+		time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC), 10, nil)
 
-	// Same shape the export pipeline uses: GroupBy: ["source", "feature_id"].
-	// Previously this pinned skipCommitment=true globally and zeroed the cost.
-	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+	// Default behaviour — Source is set on the fanned analytic → skip commitment.
+	respDefault, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
 		TenantID:           types.GetTenantID(ctx),
 		EnvironmentID:      types.GetEnvironmentID(ctx),
 		ExternalCustomerID: s.customer.ExternalID,
 		StartTime:          s.periodStart,
 		EndTime:            s.periodEnd,
-		GroupBy:            []string{"source", "meter_id"},
+		GroupBy:            []string{"source", "feature_id"},
 	})
 	s.NoError(err)
-
-	var item *dto.UsageAnalyticItem
-	for i := range resp.Items {
-		if resp.Items[i].SubLineItemID == "li_commit_no_usage" {
-			item = &resp.Items[i]
+	var defaultItem *dto.UsageAnalyticItem
+	for i := range respDefault.Items {
+		if respDefault.Items[i].SubLineItemID == "li_bkt_commit_fanned" {
+			defaultItem = &respDefault.Items[i]
 			break
 		}
 	}
-	s.Require().NotNil(item, "expected an analytic entry for the zero-usage commitment line item")
-	s.True(item.TotalUsage.IsZero(), "zero-usage assertion: %s", item.TotalUsage)
-	s.True(item.TotalCost.Equal(commitmentAmount),
-		"zero-usage commitment must surface true-up cost (%s); got %s",
-		commitmentAmount, item.TotalCost)
-	s.Require().NotNil(item.CommitmentInfo, "commitment_info must be populated for zero-usage commitment items")
+	s.Require().NotNil(defaultItem, "expected fanned analytic for the bucketed commitment line item")
+	s.True(defaultItem.TotalCost.Equal(decimal.NewFromFloat(0.10)),
+		"without ForceApplyCommitment, bucketed commitment fanned by source must NOT apply commitment; got %s",
+		defaultItem.TotalCost)
+
+	// Export behaviour — same request plus ForceApplyCommitment. Commitment fires
+	// and the true-up bills the full $100.
+	respForced, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:             types.GetTenantID(ctx),
+		EnvironmentID:        types.GetEnvironmentID(ctx),
+		ExternalCustomerID:   s.customer.ExternalID,
+		StartTime:            s.periodStart,
+		EndTime:              s.periodEnd,
+		GroupBy:              []string{"source", "feature_id"},
+		ForceApplyCommitment: true,
+	})
+	s.NoError(err)
+	var forcedItem *dto.UsageAnalyticItem
+	for i := range respForced.Items {
+		if respForced.Items[i].SubLineItemID == "li_bkt_commit_fanned" {
+			forcedItem = &respForced.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(forcedItem)
+	s.True(forcedItem.TotalCost.Equal(commitmentAmount),
+		"with ForceApplyCommitment, fanned analytic must surface true-up cost (%s); got %s",
+		commitmentAmount, forcedItem.TotalCost)
+	s.Require().NotNil(forcedItem.CommitmentInfo,
+		"commitment_info must be populated when ForceApplyCommitment is set")
+}
+
+// TestGetDetailedAnalytics_ForceApplyCommitment_ParityWithAnalyticsAPI pins the
+// contract the CSV export relies on: an export-style call (group_by=source +
+// ForceApplyCommitment=true) must yield the same total cost as the plain
+// analytics-widget call (no group_by, no flag) for a bucketed commitment line
+// item. Otherwise the CSV totals drift from what the UI shows.
+//
+// Setup uses a single source of usage so the commitment / true-up math is not
+// split across per-source rows (that's a separate concern — commitment fired
+// per fanned combo would multi-count, and the export doesn't try to solve it).
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ForceApplyCommitment_ParityWithAnalyticsAPI() {
+	ctx := s.GetContext()
+
+	m := &meter.Meter{
+		ID:        "mtr_bkt_commit_parity",
+		Name:      "Bucketed SUM parity",
+		EventName: "api_call",
+		Aggregation: meter.Aggregation{
+			Type:       types.AggregationSum,
+			BucketSize: types.WindowSizeHour,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+	p := s.createPriceForMeter(ctx, "pr_bkt_commit_parity", m.ID, decimal.NewFromFloat(0.01))
+
+	commitmentAmount := decimal.NewFromInt(100)
+	overageFactor := decimal.NewFromFloat(1.5)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_bkt_commit_parity",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 p.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 m.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		BaseModel:               types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// Single source, below the $100 commitment → true-up bills the shortfall.
+	s.insertMeterUsageWithProps(ctx, m.ID, s.customer.ExternalID, "prod-api",
+		time.Date(2026, 1, 10, 12, 0, 0, 0, time.UTC), 10, nil)
+
+	// Analytics widget: no group_by, no flag.
+	widgetResp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+	})
+	s.NoError(err)
+
+	// Export shape: group_by=source, ForceApplyCommitment=true.
+	exportResp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:             types.GetTenantID(ctx),
+		EnvironmentID:        types.GetEnvironmentID(ctx),
+		ExternalCustomerID:   s.customer.ExternalID,
+		StartTime:            s.periodStart,
+		EndTime:              s.periodEnd,
+		GroupBy:              []string{"source", "meter_id"},
+		ForceApplyCommitment: true,
+	})
+	s.NoError(err)
+
+	widgetTotal := s.totalCostForLineItem(widgetResp, li.ID)
+	exportTotal := s.totalCostForLineItem(exportResp, li.ID)
+
+	s.True(widgetTotal.Equal(exportTotal),
+		"export (group_by=source + ForceApplyCommitment) must produce the same total cost as the analytics widget; widget=%s, export=%s",
+		widgetTotal, exportTotal)
+	s.True(widgetTotal.GreaterThan(decimal.Zero),
+		"parity is only meaningful when the commitment actually fires; got %s", widgetTotal)
+}
+
+// totalCostForLineItem sums TotalCost across every response item that belongs
+// to the given subscription line item — the export slices one line item into
+// N per-source rows, so parity checks must sum across them.
+func (s *MeterUsageServiceSuite) totalCostForLineItem(resp *dto.GetUsageAnalyticsResponse, subLineItemID string) decimal.Decimal {
+	total := decimal.Zero
+	for _, item := range resp.Items {
+		if item.SubLineItemID == subLineItemID {
+			total = total.Add(item.TotalCost)
+		}
+	}
+	return total
 }

--- a/internal/ee/service/meter_usage_test.go
+++ b/internal/ee/service/meter_usage_test.go
@@ -4696,3 +4696,67 @@ func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ParentCustomer_Include
 		"parent analytics with include_children must roll up parent+child (125); got %s",
 		s.totalUsageForMeter(resp, s.meterAPI.ID))
 }
+
+// TestGetDetailedAnalytics_ZeroUsageCommitment_WithGroupBySource: an unfanned
+// analytic (Source="", no Properties) must apply commitment even when the
+// request carries group_by=source. The synthetic zero-fill created by step 12
+// for a zero-usage commitment line item represents the whole line item, not a
+// per-source slice — skipping commitment there hides the true-up cost, which
+// is how the CSV export path was reporting $0 for reserved-capacity line items
+// with no usage in the window.
+func (s *MeterUsageServiceSuite) TestGetDetailedAnalytics_ZeroUsageCommitment_WithGroupBySource() {
+	ctx := s.GetContext()
+
+	// $100 committed, 1.5x overage, true-up on. Zero usage → true-up bills the
+	// entire commitment.
+	commitmentAmount := decimal.NewFromInt(100)
+	overageFactor := decimal.NewFromFloat(1.5)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "li_commit_no_usage",
+		SubscriptionID:          s.sub.ID,
+		CustomerID:              s.customer.ID,
+		PriceID:                 s.priceAPI.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 s.meterAPI.ID,
+		Currency:                "usd",
+		BillingPeriod:           types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.periodStart,
+		EndDate:                 s.periodEnd,
+		Quantity:                decimal.NewFromInt(1),
+		CommitmentAmount:        &commitmentAmount,
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentOverageFactor: &overageFactor,
+		CommitmentTrueUpEnabled: true,
+		BaseModel:               types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	// No usage inserted.
+
+	// Same shape the export pipeline uses: GroupBy: ["source", "feature_id"].
+	// Previously this pinned skipCommitment=true globally and zeroed the cost.
+	resp, err := s.svc.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
+		ExternalCustomerID: s.customer.ExternalID,
+		StartTime:          s.periodStart,
+		EndTime:            s.periodEnd,
+		GroupBy:            []string{"source", "meter_id"},
+	})
+	s.NoError(err)
+
+	var item *dto.UsageAnalyticItem
+	for i := range resp.Items {
+		if resp.Items[i].SubLineItemID == "li_commit_no_usage" {
+			item = &resp.Items[i]
+			break
+		}
+	}
+	s.Require().NotNil(item, "expected an analytic entry for the zero-usage commitment line item")
+	s.True(item.TotalUsage.IsZero(), "zero-usage assertion: %s", item.TotalUsage)
+	s.True(item.TotalCost.Equal(commitmentAmount),
+		"zero-usage commitment must surface true-up cost (%s); got %s",
+		commitmentAmount, item.TotalCost)
+	s.Require().NotNil(item.CommitmentInfo, "commitment_info must be populated for zero-usage commitment items")
+}

--- a/internal/ee/service/sync/export/usage_analytics_export.go
+++ b/internal/ee/service/sync/export/usage_analytics_export.go
@@ -166,7 +166,12 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 			ExternalCustomerID: c.ExternalID,
 			StartTime:          request.StartTime,
 			EndTime:            request.EndTime,
-			GroupBy:            []string{"source", "feature_id"},
+			GroupBy:            []string{"source", "feature_id"}, // TODO: remove feature_id from group by, we groupBy meter_id by default
+			// Internal flag: keep commitment / true-up cost on bucketed
+			// commitment line items even when they fan out per source.
+			// Without this the per-source rows would carry only raw usage
+			// cost and the export totals would drift from the analytics API.
+			ForceApplyCommitment: true,
 		})
 		if err != nil {
 			failedCount++


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed commitment/true-up cost calculation for detailed usage analytics when results are fanned out by `source` and when analytics-only filters are applied.
  * Ensured commitment costs and commitment details are handled consistently, including in zero-usage and “no analytics items” scenarios.
  * Adjusted commitment vs non-commitment analytics grouping to exclude `feature_id`, changing how commitment line items are queried versus non-commitment ones.
  * Improved CSV export analytics so exported totals and per-row costs match the analytics API when commitment overrides are enabled.
* **Tests**
  * Added regression coverage for commitment behavior with `source` fan-out and CSV-export parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->