### PR TITLE
feat(entitlements): Add entitlements in subscription search

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -738,10 +738,10 @@ type SubscriptionResponse struct {
 	// Latest invoice information for incomplete subscriptions
 	LatestInvoice *InvoiceResponse `json:"latest_invoice,omitempty"`
 
-	// Features is populated only when the caller adds "entitlements" to the
-	// search filter's expand string. Each entry is a feature with its
+	// Entitlements is populated only when the caller adds "entitlements" to
+	// the search filter's expand string. Each entry is a feature with its
 	// aggregated entitlement info (same shape as CustomerEntitlementsResponse.Features).
-	Features []*AggregatedFeature `json:"features,omitempty"`
+	Entitlements []*AggregatedFeature `json:"entitlements,omitempty"`
 }
 
 // ListSubscriptionsResponse represents the response for listing subscriptions

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -738,9 +738,10 @@ type SubscriptionResponse struct {
 	// Latest invoice information for incomplete subscriptions
 	LatestInvoice *InvoiceResponse `json:"latest_invoice,omitempty"`
 
-	// Entitlements is populated only when the caller sets with_entitlements=true
-	// on the search filter. Aggregated across all of the customer's subscriptions.
-	Entitlements *CustomerEntitlementsResponse `json:"entitlements,omitempty"`
+	// Features is populated only when the caller adds "entitlements" to the
+	// search filter's expand string. Each entry is a feature with its
+	// aggregated entitlement info (same shape as CustomerEntitlementsResponse.Features).
+	Features []*AggregatedFeature `json:"features,omitempty"`
 }
 
 // ListSubscriptionsResponse represents the response for listing subscriptions

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -737,6 +737,10 @@ type SubscriptionResponse struct {
 
 	// Latest invoice information for incomplete subscriptions
 	LatestInvoice *InvoiceResponse `json:"latest_invoice,omitempty"`
+
+	// Entitlements is populated only when the caller sets with_entitlements=true
+	// on the search filter. Aggregated across all of the customer's subscriptions.
+	Entitlements *CustomerEntitlementsResponse `json:"entitlements,omitempty"`
 }
 
 // ListSubscriptionsResponse represents the response for listing subscriptions

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2332,6 +2332,35 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 
 	s.Logger.Debug(ctx, "built subscription responses", "response_count", len(response.Items))
 
+	if filter.WithEntitlements && len(response.Items) > 0 {
+		billingService := NewBillingService(s.ServiceParams)
+		entitlementsByCustomer := make(map[string]*dto.CustomerEntitlementsResponse)
+		for _, item := range response.Items {
+			cid := item.CustomerID
+			if cid == "" {
+				continue
+			}
+			if _, ok := entitlementsByCustomer[cid]; ok {
+				continue
+			}
+
+			ents, err := billingService.GetCustomerEntitlements(ctx, cid, &dto.GetCustomerEntitlementsRequest{})
+			if err != nil {
+				// ponytail: don't fail the search if entitlement lookup fails for one customer; log and skip.
+				s.Logger.Error(ctx, "failed to load entitlements for customer", "error", err, "customer_id", cid)
+				entitlementsByCustomer[cid] = nil
+				continue
+			}
+			entitlementsByCustomer[cid] = ents
+		}
+
+		for _, item := range response.Items {
+			if ents, ok := entitlementsByCustomer[item.CustomerID]; ok {
+				item.Entitlements = ents
+			}
+		}
+	}
+
 	s.Logger.Debug(ctx, "completed ListSubscriptions successfully",
 		"total_items", len(response.Items),
 		"total_count", count,

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2340,14 +2340,18 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 	s.Logger.Debug(ctx, "built subscription responses", "response_count", len(response.Items))
 
 	if expand.Has(types.ExpandEntitlements) && len(response.Items) > 0 {
+		// TODO(perf): serial per-customer fetch is fine for the typical
+		// external_customer_id search (1 unique customer). For wide pages with
+		// many unique customers, consider either a bulk BillingService method
+		// or a bounded errgroup here.
 		billingService := NewBillingService(s.ServiceParams)
-		featuresByCustomer := make(map[string][]*dto.AggregatedFeature)
+		entitlementsByCustomer := make(map[string][]*dto.AggregatedFeature)
 		for _, item := range response.Items {
 			cid := item.CustomerID
 			if cid == "" {
 				continue
 			}
-			if _, ok := featuresByCustomer[cid]; ok {
+			if _, ok := entitlementsByCustomer[cid]; ok {
 				continue
 			}
 
@@ -2355,15 +2359,15 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 			if err != nil {
 				// ponytail: don't fail the search if entitlement lookup fails for one customer; log and skip.
 				s.Logger.Error(ctx, "failed to load entitlements for customer", "error", err, "customer_id", cid)
-				featuresByCustomer[cid] = nil
+				entitlementsByCustomer[cid] = nil
 				continue
 			}
-			featuresByCustomer[cid] = ents.Features
+			entitlementsByCustomer[cid] = ents.Features
 		}
 
 		for _, item := range response.Items {
-			if features, ok := featuresByCustomer[item.CustomerID]; ok {
-				item.Features = features
+			if features, ok := entitlementsByCustomer[item.CustomerID]; ok {
+				item.Entitlements = features
 			}
 		}
 	}

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2163,8 +2163,15 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 	}
 
 	// Validate expand fields
-	if err := filter.GetExpand().Validate(types.SubscriptionExpandConfig); err != nil {
+	expand := filter.GetExpand()
+	if err := expand.Validate(types.SubscriptionExpandConfig); err != nil {
 		return nil, err
+	}
+
+	// Back-fill deprecated WithLineItems from expand so both request styles
+	// eager-load line items in the repository query.
+	if expand.Has(types.ExpandSubscriptionLineItems) {
+		filter.WithLineItems = true
 	}
 
 	// Resolve external customer ID to internal customer ID if provided
@@ -2332,15 +2339,15 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 
 	s.Logger.Debug(ctx, "built subscription responses", "response_count", len(response.Items))
 
-	if filter.WithEntitlements && len(response.Items) > 0 {
+	if expand.Has(types.ExpandEntitlements) && len(response.Items) > 0 {
 		billingService := NewBillingService(s.ServiceParams)
-		entitlementsByCustomer := make(map[string]*dto.CustomerEntitlementsResponse)
+		featuresByCustomer := make(map[string][]*dto.AggregatedFeature)
 		for _, item := range response.Items {
 			cid := item.CustomerID
 			if cid == "" {
 				continue
 			}
-			if _, ok := entitlementsByCustomer[cid]; ok {
+			if _, ok := featuresByCustomer[cid]; ok {
 				continue
 			}
 
@@ -2348,15 +2355,15 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 			if err != nil {
 				// ponytail: don't fail the search if entitlement lookup fails for one customer; log and skip.
 				s.Logger.Error(ctx, "failed to load entitlements for customer", "error", err, "customer_id", cid)
-				entitlementsByCustomer[cid] = nil
+				featuresByCustomer[cid] = nil
 				continue
 			}
-			entitlementsByCustomer[cid] = ents
+			featuresByCustomer[cid] = ents.Features
 		}
 
 		for _, item := range response.Items {
-			if ents, ok := entitlementsByCustomer[item.CustomerID]; ok {
-				item.Entitlements = ents
+			if features, ok := featuresByCustomer[item.CustomerID]; ok {
+				item.Features = features
 			}
 		}
 	}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -5005,9 +5005,9 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions_ExpandEntitlements() {
 	s.NotEmpty(subs.Items, "seed data must contain at least one subscription for the test customer")
 
 	for _, sub := range subs.Items {
-		// Features slice may be empty if the customer has no entitlements, but
-		// it must be non-nil once the caller opts in via expand.
-		s.NotNil(sub.Features, "expand=entitlements should populate Features (possibly empty slice)")
+		// Entitlements slice may be empty if the customer has no entitlements,
+		// but it must be non-nil once the caller opts in via expand.
+		s.NotNil(sub.Entitlements, "expand=entitlements should populate Entitlements (possibly empty slice)")
 	}
 
 	// No expand → field must stay nil (default behavior preserved).
@@ -5015,7 +5015,7 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions_ExpandEntitlements() {
 	subs, err = s.service.ListSubscriptions(s.GetContext(), filter)
 	s.NoError(err)
 	for _, sub := range subs.Items {
-		s.Nil(sub.Features, "without expand=entitlements, Features must be nil")
+		s.Nil(sub.Entitlements, "without expand=entitlements, Entitlements must be nil")
 	}
 }
 

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -4989,6 +4989,34 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions() {
 	}
 }
 
+// TestListSubscriptions_WithEntitlements exercises the with_entitlements flag on
+// POST /subscriptions/search: entitlements should be attached per item, and
+// only fetched once per unique customer.
+func (s *SubscriptionServiceSuite) TestListSubscriptions_WithEntitlements() {
+	filter := &types.SubscriptionFilter{
+		QueryFilter:      types.NewDefaultQueryFilter(),
+		CustomerID:       s.testData.customer.ID,
+		WithEntitlements: true,
+	}
+
+	subs, err := s.service.ListSubscriptions(s.GetContext(), filter)
+	s.NoError(err)
+	s.NotEmpty(subs.Items, "seed data must contain at least one subscription for the test customer")
+
+	for _, sub := range subs.Items {
+		s.NotNil(sub.Entitlements, "with_entitlements=true should populate Entitlements")
+		s.Equal(s.testData.customer.ID, sub.Entitlements.CustomerID)
+	}
+
+	// Flag off → field must stay nil (default behavior preserved).
+	filter.WithEntitlements = false
+	subs, err = s.service.ListSubscriptions(s.GetContext(), filter)
+	s.NoError(err)
+	for _, sub := range subs.Items {
+		s.Nil(sub.Entitlements, "with_entitlements=false must not populate Entitlements")
+	}
+}
+
 func (s *SubscriptionServiceSuite) TestProcessSubscriptionPeriod() {
 	// Create a test subscription that's ready for period transition
 	now := time.Now().UTC()

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -4989,14 +4989,15 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions() {
 	}
 }
 
-// TestListSubscriptions_WithEntitlements exercises the with_entitlements flag on
-// POST /subscriptions/search: entitlements should be attached per item, and
-// only fetched once per unique customer.
-func (s *SubscriptionServiceSuite) TestListSubscriptions_WithEntitlements() {
+// TestListSubscriptions_ExpandEntitlements exercises expand="entitlements" on
+// POST /subscriptions/search: the aggregated features list should be attached
+// per item, and only fetched once per unique customer.
+func (s *SubscriptionServiceSuite) TestListSubscriptions_ExpandEntitlements() {
+	qf := types.NewDefaultQueryFilter()
+	qf.Expand = lo.ToPtr(string(types.ExpandEntitlements))
 	filter := &types.SubscriptionFilter{
-		QueryFilter:      types.NewDefaultQueryFilter(),
-		CustomerID:       s.testData.customer.ID,
-		WithEntitlements: true,
+		QueryFilter: qf,
+		CustomerID:  s.testData.customer.ID,
 	}
 
 	subs, err := s.service.ListSubscriptions(s.GetContext(), filter)
@@ -5004,16 +5005,17 @@ func (s *SubscriptionServiceSuite) TestListSubscriptions_WithEntitlements() {
 	s.NotEmpty(subs.Items, "seed data must contain at least one subscription for the test customer")
 
 	for _, sub := range subs.Items {
-		s.NotNil(sub.Entitlements, "with_entitlements=true should populate Entitlements")
-		s.Equal(s.testData.customer.ID, sub.Entitlements.CustomerID)
+		// Features slice may be empty if the customer has no entitlements, but
+		// it must be non-nil once the caller opts in via expand.
+		s.NotNil(sub.Features, "expand=entitlements should populate Features (possibly empty slice)")
 	}
 
-	// Flag off → field must stay nil (default behavior preserved).
-	filter.WithEntitlements = false
+	// No expand → field must stay nil (default behavior preserved).
+	qf.Expand = nil
 	subs, err = s.service.ListSubscriptions(s.GetContext(), filter)
 	s.NoError(err)
 	for _, sub := range subs.Items {
-		s.Nil(sub.Entitlements, "with_entitlements=false must not populate Entitlements")
+		s.Nil(sub.Features, "without expand=entitlements, Features must be nil")
 	}
 }
 

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -76,7 +76,7 @@ var (
 
 	// SubscriptionExpandConfig defines what can be expanded on a subscription
 	SubscriptionExpandConfig = ExpandConfig{
-		AllowedFields: []ExpandableField{ExpandPlan, ExpandCustomer, ExpandPrices, ExpandMeters, ExpandSchedule, ExpandCouponAssociations, ExpandCoupon, ExpandSubscriptionLineItems},
+		AllowedFields: []ExpandableField{ExpandPlan, ExpandCustomer, ExpandPrices, ExpandMeters, ExpandSchedule, ExpandCouponAssociations, ExpandCoupon, ExpandSubscriptionLineItems, ExpandEntitlements},
 		NestedExpands: map[ExpandableField][]ExpandableField{
 			ExpandPlan:                  {ExpandPrices},
 			ExpandCustomer:              {},
@@ -84,6 +84,7 @@ var (
 			ExpandSchedule:              {},
 			ExpandCouponAssociations:    {ExpandCoupon},
 			ExpandSubscriptionLineItems: {ExpandPrices},
+			ExpandEntitlements:          {},
 		},
 	}
 

--- a/internal/types/subscription.go
+++ b/internal/types/subscription.go
@@ -346,6 +346,11 @@ type SubscriptionFilter struct {
 
 	// WithLineItems includes line items in the response
 	WithLineItems bool `json:"with_line_items,omitempty" form:"with_line_items"`
+
+	// WithEntitlements, when true, includes the customer's aggregated entitlements
+	// (same shape as GET /customers/:id/entitlements) on each SubscriptionResponse.
+	// Entitlements are fetched once per unique customer in the result set.
+	WithEntitlements bool `json:"with_entitlements,omitempty" form:"with_entitlements"`
 }
 
 // NewSubscriptionFilter creates a new SubscriptionFilter with default values

--- a/internal/types/subscription.go
+++ b/internal/types/subscription.go
@@ -344,13 +344,13 @@ type SubscriptionFilter struct {
 	// SubscriptionType filters by subscription type
 	SubscriptionTypes []SubscriptionType `json:"subscription_type,omitempty" form:"subscription_type"`
 
-	// WithLineItems includes line items in the response
+	// WithLineItems includes line items in the response.
+	//
+	// Deprecated: use expand="subscription_line_items" instead. Retained for
+	// backwards compatibility and for internal callers that need to force-disable
+	// line item loading (set to false). The service layer ORs this with the
+	// expand check before invoking the repository.
 	WithLineItems bool `json:"with_line_items,omitempty" form:"with_line_items"`
-
-	// WithEntitlements, when true, includes the customer's aggregated entitlements
-	// (same shape as GET /customers/:id/entitlements) on each SubscriptionResponse.
-	// Entitlements are fetched once per unique customer in the result set.
-	WithEntitlements bool `json:"with_entitlements,omitempty" form:"with_entitlements"`
 }
 
 // NewSubscriptionFilter creates a new SubscriptionFilter with default values


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription results can now optionally include each customer’s aggregated entitlements.
  * Entitlements are returned in a new optional `entitlements` field when the `entitlements` expand option is requested.
  * The `entitlements` option is now an accepted expand value.
* **Bug Fixes**
  * If an entitlement lookup fails for a specific customer, other subscriptions are still returned; only that customer’s entitlements are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->