### PR TITLE
feat(payment): Add polling for tracking id

### DIFF
--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -579,9 +579,6 @@ func (s *paymentService) syncPaymentStatusFromGateway(ctx context.Context, p *pa
 	if p.PaymentStatus != types.PaymentStatusPending && p.PaymentStatus != types.PaymentStatusProcessing {
 		return p, nil
 	}
-	if p.GatewayPaymentID == nil || lo.FromPtr(p.GatewayPaymentID) == "" {
-		return p, nil
-	}
 	if p.PaymentGateway == nil {
 		return p, nil
 	}
@@ -590,32 +587,46 @@ func (s *paymentService) syncPaymentStatusFromGateway(ctx context.Context, p *pa
 	}
 
 	gatewayPaymentID := lo.FromPtr(p.GatewayPaymentID)
+	gatewayTrackingID := lo.FromPtr(p.GatewayTrackingID)
 	gateway := types.PaymentGatewayType(*p.PaymentGateway)
 
 	var newStatus types.PaymentStatus
 	var err error
-	switch gateway {
-	case types.PaymentGatewayTypeStripe:
-		newStatus, err = s.fetchStripePaymentStatus(ctx, gatewayPaymentID)
-	case types.PaymentGatewayTypeRazorpay:
-		newStatus, err = s.fetchRazorpayPaymentStatus(ctx, gatewayPaymentID)
-	case types.PaymentGatewayTypeMoyasar:
-		newStatus, err = s.fetchMoyasarPaymentStatus(ctx, gatewayPaymentID)
-	default:
-		return p, nil
+	var backfillGatewayPaymentID string
+
+	if gatewayPaymentID != "" {
+		switch gateway {
+		case types.PaymentGatewayTypeStripe:
+			newStatus, err = s.fetchStripePaymentStatus(ctx, gatewayPaymentID)
+		case types.PaymentGatewayTypeRazorpay:
+			newStatus, err = s.fetchRazorpayPaymentStatus(ctx, gatewayPaymentID)
+		case types.PaymentGatewayTypeMoyasar:
+			newStatus, err = s.fetchMoyasarPaymentStatus(ctx, gatewayPaymentID)
+		default:
+			return p, nil
+		}
+	} else if gatewayTrackingID != "" {
+		switch gateway {
+		case types.PaymentGatewayTypeRazorpay:
+			newStatus, backfillGatewayPaymentID, err = s.fetchRazorpayPaymentLinkStatus(ctx, gatewayTrackingID)
+		default:
+			return p, nil
+		}
 	}
+
 	if err != nil {
 		s.Logger.Error(ctx,
 			"failed to fetch payment status from gateway",
 			"payment_id", p.ID,
 			"gateway", gateway,
 			"gateway_payment_id", gatewayPaymentID,
+			"gateway_tracking_id", gatewayTrackingID,
 			"error", err,
 		)
 		return p, err
 	}
 
-	if newStatus == p.PaymentStatus {
+	if newStatus == "" || newStatus == p.PaymentStatus {
 		return p, nil
 	}
 
@@ -629,6 +640,9 @@ func (s *paymentService) syncPaymentStatusFromGateway(ctx context.Context, p *pa
 	now := time.Now().UTC()
 	updateReq := dto.UpdatePaymentRequest{
 		PaymentStatus: lo.ToPtr(string(newStatus)),
+	}
+	if backfillGatewayPaymentID != "" {
+		updateReq.GatewayPaymentID = lo.ToPtr(backfillGatewayPaymentID)
 	}
 	switch newStatus {
 	case types.PaymentStatusSucceeded:
@@ -677,6 +691,30 @@ func (s *paymentService) fetchRazorpayPaymentStatus(ctx context.Context, gateway
 		return "", err
 	}
 	return integrations.RazorpayPaymentStatus(rawStatus).ToFlexpricePaymentStatus()
+}
+
+// fetchRazorpayPaymentLinkStatus reconciles a payment record against a Razorpay
+// payment link when the direct pay_xxx isn't known yet. When the link exposes a
+// captured pay_xxx it is returned as backfillGatewayPaymentID for the caller to persist.
+func (s *paymentService) fetchRazorpayPaymentLinkStatus(
+	ctx context.Context,
+	paymentLinkID string,
+) (types.PaymentStatus, string, error) {
+	razorpayIntegration, err := s.IntegrationFactory.GetRazorpayIntegration(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	linkStatus, err := razorpayIntegration.PaymentSvc.GetPaymentLinkStatus(ctx, paymentLinkID)
+	if err != nil {
+		return "", "", err
+	}
+
+	fpPaymentStatus, err := integrations.RazorpayPaymentLinkStatus(linkStatus.Status).ToFlexpricePaymentStatus()
+	if err != nil {
+		return "", "", err
+	}
+	return fpPaymentStatus, linkStatus.RazorpayPaymentID, nil
 }
 
 func (s *paymentService) fetchMoyasarPaymentStatus(ctx context.Context, gatewayPaymentID string) (types.PaymentStatus, error) {

--- a/internal/integration/razorpay/client.go
+++ b/internal/integration/razorpay/client.go
@@ -44,6 +44,11 @@ type RazorpayClient interface {
 	// "amount_refunded" int in the smallest currency unit). There is no boolean
 	// "refunded" field on this entity.
 	FetchPayment(ctx context.Context, paymentID string) (map[string]interface{}, error)
+	// FetchPaymentLink retrieves a payment link's current state from Razorpay
+	// (GET /v1/payment_links/{id}). The response's "status" field takes values
+	// "created" | "partially_paid" | "paid" | "expired" | "cancelled", and its
+	// "payments" array carries the underlying pay_xxx attempts once any exist.
+	FetchPaymentLink(ctx context.Context, paymentLinkID string) (map[string]interface{}, error)
 }
 
 // Client handles Razorpay API client setup and configuration
@@ -590,6 +595,28 @@ func (c *Client) FetchPayment(ctx context.Context, paymentID string) (map[string
 			WithReportableDetails(map[string]interface{}{
 				"payment_id": paymentID,
 				"error":      err.Error(),
+			}).
+			Mark(ierr.ErrInternal)
+	}
+
+	return result, nil
+}
+
+// FetchPaymentLink retrieves a payment link's current state from Razorpay. SDK: PaymentLink.Fetch.
+func (c *Client) FetchPaymentLink(ctx context.Context, paymentLinkID string) (map[string]interface{}, error) {
+	rc, err := c.sdkClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := rc.PaymentLink.Fetch(paymentLinkID, nil, nil)
+	if err != nil {
+		c.logger.Error(ctx, "failed to fetch Razorpay payment link", "error", err, "payment_link_id", paymentLinkID)
+		return nil, ierr.NewError("failed to fetch Razorpay payment link").
+			WithHint("Unable to retrieve the payment link from Razorpay").
+			WithReportableDetails(map[string]interface{}{
+				"payment_link_id": paymentLinkID,
+				"error":           err.Error(),
 			}).
 			Mark(ierr.ErrInternal)
 	}

--- a/internal/integration/razorpay/payment.go
+++ b/internal/integration/razorpay/payment.go
@@ -35,6 +35,19 @@ type AutoChargeResult struct {
 	AlreadySubmitted  bool   // true = payment was previously submitted; webhook will reconcile
 }
 
+// PaymentLinkStatus captures the fields the FlexPrice sync path needs from a
+// Razorpay payment link fetch.
+type PaymentLinkStatus struct {
+	// Status is the Razorpay-native payment link status:
+	// "created" | "partially_paid" | "paid" | "expired" | "cancelled".
+	Status string
+	// RazorpayPaymentID is the pay_xxx of the first captured attempt on the link
+	// (empty when no attempt has been captured yet). Provided so the caller can
+	// backfill gateway_payment_id and cut over to the direct payment-status path
+	// on subsequent syncs.
+	RazorpayPaymentID string
+}
+
 // PaymentService handles Razorpay payment operations
 type PaymentService struct {
 	client         RazorpayClient
@@ -1026,4 +1039,46 @@ func (s *PaymentService) GetPaymentStatus(ctx context.Context, razorpayPaymentID
 			Mark(ierr.ErrSystem)
 	}
 	return status, nil
+}
+
+// GetPaymentLinkStatus fetches a Razorpay payment link and returns its status
+// plus the first captured pay_xxx from its payments array, if any.
+func (s *PaymentService) GetPaymentLinkStatus(ctx context.Context, paymentLinkID string) (*PaymentLinkStatus, error) {
+	if paymentLinkID == "" {
+		return nil, ierr.NewError("payment_link_id is required").Mark(ierr.ErrValidation)
+	}
+	result, err := s.client.FetchPaymentLink(ctx, paymentLinkID)
+	if err != nil {
+		s.logger.Error(ctx, "failed to fetch Razorpay payment link",
+			"payment_link_id", paymentLinkID, "error", err)
+		return nil, err
+	}
+	status, ok := result["status"].(string)
+	if !ok || status == "" {
+		return nil, ierr.NewError("razorpay payment link status missing or invalid").
+			WithHint("Expected a non-empty string status in Razorpay FetchPaymentLink response").
+			WithReportableDetails(map[string]interface{}{
+				"payment_link_id": paymentLinkID,
+				"status":          result["status"],
+			}).
+			Mark(ierr.ErrSystem)
+	}
+	out := &PaymentLinkStatus{Status: status}
+	if payments, ok := result["payments"].([]interface{}); ok {
+		for _, entry := range payments {
+			pm, ok := entry.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			pStatus, _ := pm["status"].(string)
+			if pStatus != "captured" {
+				continue
+			}
+			if id, ok := pm["payment_id"].(string); ok && id != "" {
+				out.RazorpayPaymentID = id
+				break
+			}
+		}
+	}
+	return out, nil
 }

--- a/internal/integration/razorpay/payment_link_status_test.go
+++ b/internal/integration/razorpay/payment_link_status_test.go
@@ -1,0 +1,84 @@
+package razorpay
+
+// Tests for PaymentService.GetPaymentLinkStatus — the payment-link fallback used
+// by the FlexPrice sync path when the direct pay_xxx isn't known yet.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// fakePaymentLinkClient stubs only FetchPaymentLink; other RazorpayClient methods
+// are inherited from the embedded (nil) interface and will panic if called.
+type fakePaymentLinkClient struct {
+	RazorpayClient
+	resp map[string]interface{}
+	err  error
+}
+
+func (c *fakePaymentLinkClient) FetchPaymentLink(_ context.Context, _ string) (map[string]interface{}, error) {
+	return c.resp, c.err
+}
+
+func TestGetPaymentLinkStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		resp        map[string]interface{}
+		wantStatus  string
+		wantPayment string
+	}{
+		{
+			name: "paid link exposes captured pay_xxx for backfill",
+			resp: map[string]interface{}{
+				"status": "paid",
+				"payments": []interface{}{
+					map[string]interface{}{"payment_id": "pay_cap001", "status": "captured"},
+				},
+			},
+			wantStatus:  "paid",
+			wantPayment: "pay_cap001",
+		},
+		{
+			name: "paid link skips non-captured attempts, picks first captured",
+			resp: map[string]interface{}{
+				"status": "paid",
+				"payments": []interface{}{
+					map[string]interface{}{"payment_id": "pay_fail001", "status": "failed"},
+					map[string]interface{}{"payment_id": "pay_cap002", "status": "captured"},
+				},
+			},
+			wantStatus:  "paid",
+			wantPayment: "pay_cap002",
+		},
+		{
+			name:        "created link has no payments — nothing to backfill",
+			resp:        map[string]interface{}{"status": "created", "payments": nil},
+			wantStatus:  "created",
+			wantPayment: "",
+		},
+		{
+			name:        "expired link — no captured payment expected",
+			resp:        map[string]interface{}{"status": "expired"},
+			wantStatus:  "expired",
+			wantPayment: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &PaymentService{
+				client: &fakePaymentLinkClient{resp: tt.resp},
+				logger: logger.NewNoopLogger(),
+			}
+			got, err := svc.GetPaymentLinkStatus(context.Background(), "plink_test")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Status != tt.wantStatus || got.RazorpayPaymentID != tt.wantPayment {
+				t.Fatalf("got %+v, want status=%s payment_id=%s", got, tt.wantStatus, tt.wantPayment)
+			}
+		})
+	}
+}

--- a/internal/types/integrations/razorpay.go
+++ b/internal/types/integrations/razorpay.go
@@ -30,3 +30,37 @@ func (s RazorpayPaymentStatus) ToFlexpricePaymentStatus() (types.PaymentStatus, 
 			Mark(ierr.ErrInvalidOperation)
 	}
 }
+
+// RazorpayPaymentLinkStatus is Razorpay's payment-link (plink_xxx) status enum,
+// which is a separate lifecycle from the payment (pay_xxx) enum above. A payment
+// link is created, may collect one or more attempts (partially_paid), and lands
+// in a terminal state of paid, expired, or cancelled.
+type RazorpayPaymentLinkStatus string
+
+const (
+	RazorpayPaymentLinkStatusCreated       RazorpayPaymentLinkStatus = "created"
+	RazorpayPaymentLinkStatusPartiallyPaid RazorpayPaymentLinkStatus = "partially_paid"
+	RazorpayPaymentLinkStatusPaid          RazorpayPaymentLinkStatus = "paid"
+	RazorpayPaymentLinkStatusExpired       RazorpayPaymentLinkStatus = "expired"
+	RazorpayPaymentLinkStatusCancelled     RazorpayPaymentLinkStatus = "cancelled"
+)
+
+// ToFlexpricePaymentStatus maps a Razorpay payment link status to a FlexPrice
+// PaymentStatus. Non-terminal states (created / partially_paid) return an empty
+// PaymentStatus with a nil error to signal "still pending, no transition".
+func (s RazorpayPaymentLinkStatus) ToFlexpricePaymentStatus() (types.PaymentStatus, error) {
+	switch s {
+	case RazorpayPaymentLinkStatusPaid:
+		return types.PaymentStatusSucceeded, nil
+	case RazorpayPaymentLinkStatusExpired, RazorpayPaymentLinkStatusCancelled:
+		return types.PaymentStatusFailed, nil
+	case RazorpayPaymentLinkStatusCreated, RazorpayPaymentLinkStatusPartiallyPaid:
+		return "", nil
+	default:
+		return "", ierr.NewError("unmapped razorpay payment link status").
+			WithReportableDetails(map[string]interface{}{
+				"razorpay_payment_link_status": s,
+			}).
+			Mark(ierr.ErrInvalidOperation)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved payment status synchronization for Razorpay payment links.
  - Payment links can now be checked using tracking IDs when a gateway payment ID is unavailable.
  - Captured Razorpay payment IDs are automatically saved when discovered.
  - Supports paid, expired, cancelled, created, and partially paid link statuses.

- **Bug Fixes**
  - Prevents unnecessary payment updates when no new status is available.
  - Improved sync failure details for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->