### PR TITLE
chore(tracing): drop unused http.server/http.client OTel metrics (~31% metric ingestion)

### DIFF
--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -328,6 +328,20 @@ func (s *Service) initMeter(ctx context.Context) error {
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(interval))),
+		// Drop the framework's auto-emitted HTTP metrics (http.server.* / http.client.*).
+		// Turning on the MeterProvider auto-enabled these; they were ~31% of metric
+		// ingestion and are referenced by no dashboard or alert. Body-size histograms
+		// are unwanted, and request latency is already covered by APM (derived from
+		// traces). NOTE: if API traces are ever sampled below 100%, re-add a coarse
+		// http.server.request.duration here as the always-on latency source.
+		sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "http.server.*"},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+		)),
+		sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "http.client.*"},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+		)),
 	)
 	otel.SetMeterProvider(mp)
 	s.meterProvider = mp


### PR DESCRIPTION
## What
Drop the framework's auto-emitted `http.server.*` / `http.client.*` OTel metrics via two `AggregationDrop` Views in `initMeter`.

## Why (FLE-1003 SigNoz cost control)
These HTTP metrics turned on automatically with the MeterProvider and are **~31% of metric ingestion (~44M datapoints/day)** — the single largest metric category — but:
- **0 dashboards / 0 alerts** reference any of them (verified across all 8 names)
- request/response **latency + errors are already in traces**: APM per-route p99 (server spans) and outbound **client spans** (e.g. `POST api.razorpay.com`, `GET sandbox-api.paddle.com`)
- only unused payload-size histograms are forgone (spans don't carry byte sizes, and nothing uses them)

**Expected:** ~31% fewer metric samples, ~$40–50/mo, zero observability loss.

## Verification
- `go build` + `go vet` clean
- runtime test: after the Views, **only `db.client.duration` is emitted**; `http.server.*` and `http.client.*` are dropped

## Reversibility
Remove the two Views to restore. If API traces are ever sampled <100%, re-add a coarsened `http.server.request.duration` as the always-on latency source (noted in code comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)