### PR TITLE
fix(ci): publish helm chart on main push, isolate publish steps

### DIFF
--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -109,19 +109,16 @@ jobs:
           helm repo update
 
       - name: Build Helm Dependencies
-        continue-on-error: true
         run: |
           helm dependency build internal/ee/infrastructure/helm/flexprice
 
       - name: Lint Helm Chart
-        continue-on-error: true
         run: |
           helm lint internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test
           helm template flexprice-test internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test --debug
 
       - name: Package Helm Chart
         if: ${{ steps.changed.outputs.publish == 'true' }}
-        continue-on-error: true
         run: |
           helm package internal/ee/infrastructure/helm/flexprice --version ${{ steps.chart-version.outputs.version }}
 
@@ -146,7 +143,7 @@ jobs:
         continue-on-error: true
 
       - name: Login to GHCR
-        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/chart-v') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ steps.changed.outputs.publish == 'true' }}
         env:
           # PAT auth — see comment in publish-app-image.yml. Override the
           # username via vars.GHCR_USERNAME if the PAT owner differs from
@@ -154,13 +151,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GHCR_PUBLISH_TOKEN }}
           GH_USER: ${{ vars.GHCR_USERNAME || github.actor }}
           GHCR_HOST: ${{ env.GHCR_HOST }}
-        continue-on-error: true
         run: |
           echo "$GH_TOKEN" | helm registry login "$GHCR_HOST" -u "$GH_USER" --password-stdin
 
       - name: Push Helm Chart to GHCR
-        if: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/chart-v') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
-        continue-on-error: true
+        if: ${{ steps.changed.outputs.publish == 'true' && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
         env:
           CHART_NAME: ${{ steps.chart-name.outputs.name }}
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
@@ -176,8 +171,7 @@ jobs:
           echo "::notice::Published $CHART_NAME:$CHART_VERSION to $TARGET"
 
       - name: Verify Published Chart (GHCR)
-        if: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/chart-v') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
-        continue-on-error: true
+        if: ${{ steps.changed.outputs.publish == 'true' && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
         env:
           CHART_NAME: ${{ steps.chart-name.outputs.name }}
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
@@ -198,6 +192,7 @@ jobs:
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
           EXISTS: ${{ steps.version-check.outputs.exists }}
           FORCE: ${{ github.event.inputs.force }}
+          PUBLISH: ${{ steps.changed.outputs.publish }}
         run: |
           OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
           TARGET="oci://${GHCR_HOST}/${OWNER_LC}/${GHCR_REPOSITORY}/${CHART_NAME}"
@@ -206,9 +201,11 @@ jobs:
           echo "- **Chart Name**: $CHART_NAME" >> $GITHUB_STEP_SUMMARY
           echo "- **Chart Version**: $CHART_VERSION" >> $GITHUB_STEP_SUMMARY
           echo "- **Registry**: $TARGET" >> $GITHUB_STEP_SUMMARY
-          if [ "$EXISTS" == "true" ] && [ "$FORCE" != "true" ]; then
+          if [ "$PUBLISH" != "true" ]; then
+            echo "- **Status**: ℹ️ Chart version unchanged — nothing published" >> $GITHUB_STEP_SUMMARY
+          elif [ "$EXISTS" == "true" ] && [ "$FORCE" != "true" ]; then
             echo "- **Status**: ⚠️ Version already exists (skipped)" >> $GITHUB_STEP_SUMMARY
-          elif [ "$EXISTS" != "true" ] || [ "$FORCE" == "true" ]; then
+          else
             echo "- **Status**: ✅ Published successfully" >> $GITHUB_STEP_SUMMARY
             echo "- **Chart URL**: \`helm pull $TARGET --version $CHART_VERSION\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -122,26 +122,6 @@ jobs:
         run: |
           helm package internal/ee/infrastructure/helm/flexprice --version ${{ steps.chart-version.outputs.version }}
 
-      - name: Check if version already exists
-        id: version-check
-        if: ${{ steps.changed.outputs.publish == 'true' && github.event.inputs.force != 'true' }}
-        env:
-          CHART_NAME: ${{ steps.chart-name.outputs.name }}
-          CHART_VERSION: ${{ steps.chart-version.outputs.version }}
-          OWNER: ${{ github.repository_owner }}
-          GHCR_HOST: ${{ env.GHCR_HOST }}
-          GHCR_REPOSITORY: ${{ env.GHCR_REPOSITORY }}
-        run: |
-          OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
-          if helm show chart "oci://${GHCR_HOST}/${OWNER_LC}/${GHCR_REPOSITORY}/${CHART_NAME}" --version "$CHART_VERSION" 2>/dev/null | grep -q "version: $CHART_VERSION"; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "::warning::Chart version $CHART_VERSION already exists in registry"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Chart version $CHART_VERSION does not exist, proceeding with publish"
-          fi
-        continue-on-error: true
-
       - name: Login to GHCR
         if: ${{ steps.changed.outputs.publish == 'true' }}
         env:
@@ -154,8 +134,44 @@ jobs:
         run: |
           echo "$GH_TOKEN" | helm registry login "$GHCR_HOST" -u "$GH_USER" --password-stdin
 
+      - name: Check if version already exists
+        id: version-check
+        # Runs after login so the lookup is authenticated. Fails closed: only an
+        # explicit registry "not found" sets exists=false; any other lookup error
+        # (auth/network) fails the job rather than being treated as absence.
+        if: ${{ steps.changed.outputs.publish == 'true' && github.event.inputs.force != 'true' }}
+        env:
+          CHART_NAME: ${{ steps.chart-name.outputs.name }}
+          CHART_VERSION: ${{ steps.chart-version.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+          GHCR_HOST: ${{ env.GHCR_HOST }}
+          GHCR_REPOSITORY: ${{ env.GHCR_REPOSITORY }}
+        run: |
+          set -uo pipefail
+          OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
+          REF="oci://${GHCR_HOST}/${OWNER_LC}/${GHCR_REPOSITORY}/${CHART_NAME}"
+          set +e
+          OUT=$(helm show chart "$REF" --version "$CHART_VERSION" 2>&1)
+          RC=$?
+          set -e
+          if [ "$RC" -eq 0 ] && echo "$OUT" | grep -q "version: $CHART_VERSION"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Chart version $CHART_VERSION already exists in registry"
+          elif echo "$OUT" | grep -qiE 'not found|manifest unknown|no such|not exist'; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Chart version $CHART_VERSION does not exist, proceeding with publish"
+          else
+            echo "exists=unknown" >> "$GITHUB_OUTPUT"
+            echo "::error::Registry lookup for $REF@$CHART_VERSION failed (rc=$RC); refusing to publish. Output:"
+            echo "$OUT"
+            exit 1
+          fi
+
       - name: Push Helm Chart to GHCR
-        if: ${{ steps.changed.outputs.publish == 'true' && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
+        id: push
+        # force bypasses the existence check; otherwise require an explicit
+        # exists=false (a proven absence), never a failed/unknown lookup.
+        if: ${{ steps.changed.outputs.publish == 'true' && (github.event.inputs.force == 'true' || steps.version-check.outputs.exists == 'false') }}
         env:
           CHART_NAME: ${{ steps.chart-name.outputs.name }}
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
@@ -171,7 +187,7 @@ jobs:
           echo "::notice::Published $CHART_NAME:$CHART_VERSION to $TARGET"
 
       - name: Verify Published Chart (GHCR)
-        if: ${{ steps.changed.outputs.publish == 'true' && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
+        if: ${{ steps.push.outcome == 'success' }}
         env:
           CHART_NAME: ${{ steps.chart-name.outputs.name }}
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
@@ -193,6 +209,7 @@ jobs:
           EXISTS: ${{ steps.version-check.outputs.exists }}
           FORCE: ${{ github.event.inputs.force }}
           PUBLISH: ${{ steps.changed.outputs.publish }}
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
         run: |
           OWNER_LC=$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')
           TARGET="oci://${GHCR_HOST}/${OWNER_LC}/${GHCR_REPOSITORY}/${CHART_NAME}"
@@ -203,11 +220,13 @@ jobs:
           echo "- **Registry**: $TARGET" >> $GITHUB_STEP_SUMMARY
           if [ "$PUBLISH" != "true" ]; then
             echo "- **Status**: ℹ️ Chart version unchanged — nothing published" >> $GITHUB_STEP_SUMMARY
+          elif [ "$PUSH_OUTCOME" == "success" ]; then
+            echo "- **Status**: ✅ Published successfully" >> $GITHUB_STEP_SUMMARY
+            echo "- **Chart URL**: \`helm pull $TARGET --version $CHART_VERSION\`" >> $GITHUB_STEP_SUMMARY
           elif [ "$EXISTS" == "true" ] && [ "$FORCE" != "true" ]; then
             echo "- **Status**: ⚠️ Version already exists (skipped)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "- **Status**: ✅ Published successfully" >> $GITHUB_STEP_SUMMARY
-            echo "- **Chart URL**: \`helm pull $TARGET --version $CHART_VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **Status**: ❌ Publish did not complete — see failed steps above" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload Chart Artifact

--- a/.github/workflows/publish-helm-chart.yml
+++ b/.github/workflows/publish-helm-chart.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
     paths:
+      # Only run when the chart itself changes.
       - 'internal/ee/infrastructure/helm/flexprice/**'
-      - '.github/workflows/publish-helm-chart.yml'
     tags:
       - 'chart-v*'
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -111,16 +109,19 @@ jobs:
           helm repo update
 
       - name: Build Helm Dependencies
+        continue-on-error: true
         run: |
           helm dependency build internal/ee/infrastructure/helm/flexprice
 
       - name: Lint Helm Chart
+        continue-on-error: true
         run: |
           helm lint internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test
           helm template flexprice-test internal/ee/infrastructure/helm/flexprice --set secrets.existingSecret=test --debug
 
       - name: Package Helm Chart
         if: ${{ steps.changed.outputs.publish == 'true' }}
+        continue-on-error: true
         run: |
           helm package internal/ee/infrastructure/helm/flexprice --version ${{ steps.chart-version.outputs.version }}
 
@@ -145,7 +146,7 @@ jobs:
         continue-on-error: true
 
       - name: Login to GHCR
-        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/chart-v') }}
+        if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/chart-v') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         env:
           # PAT auth — see comment in publish-app-image.yml. Override the
           # username via vars.GHCR_USERNAME if the PAT owner differs from
@@ -153,11 +154,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GHCR_PUBLISH_TOKEN }}
           GH_USER: ${{ vars.GHCR_USERNAME || github.actor }}
           GHCR_HOST: ${{ env.GHCR_HOST }}
+        continue-on-error: true
         run: |
           echo "$GH_TOKEN" | helm registry login "$GHCR_HOST" -u "$GH_USER" --password-stdin
 
       - name: Push Helm Chart to GHCR
-        if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/chart-v')) && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
+        if: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/chart-v') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
+        continue-on-error: true
         env:
           CHART_NAME: ${{ steps.chart-name.outputs.name }}
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
@@ -173,7 +176,8 @@ jobs:
           echo "::notice::Published $CHART_NAME:$CHART_VERSION to $TARGET"
 
       - name: Verify Published Chart (GHCR)
-        if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/chart-v')) && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
+        if: ${{ (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/chart-v') || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && (steps.version-check.outputs.exists != 'true' || github.event.inputs.force == 'true') }}
+        continue-on-error: true
         env:
           CHART_NAME: ${{ steps.chart-name.outputs.name }}
           CHART_VERSION: ${{ steps.chart-version.outputs.version }}
@@ -210,7 +214,7 @@ jobs:
           fi
 
       - name: Upload Chart Artifact
-        if: always()
+        if: ${{ steps.changed.outputs.publish == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: helm-chart-${{ steps.chart-version.outputs.version }}


### PR DESCRIPTION
## Problem

The **Publish Helm Chart to GHCR** workflow was not publishing charts to `ghcr.io/flexprice/charts`. Two independent bugs:

1. **Main-push never published (silent green).** The workflow triggers on push→`main`, but the Login / Push / Verify steps were gated only on `release || workflow_dispatch || refs/tags/v* || refs/tags/chart-v*`. A push to `main` matches none of these, so the job ran green in ~39s and skipped the publish entirely (e.g. run for merge of #2269).
2. **`release` trigger crashed (exit 2).** On a `release` event the workflow checked out the **code** tag (e.g. `v2.1.21`), where `Chart.yaml` sat at a different path, so `grep '^version:'` returned empty → `CHART_VERSION` blank → "Extract Chart Version" failed. All recent release-triggered runs (`v2.1.21`, `v2.0.24`, `v2.0.23`, `v2.0.22`) failed here.

## Changes

- Gate Login / Push / Verify on **push→main** (plus `chart-v*` tag and manual dispatch).
- Drop the broken `release` trigger and the `refs/tags/v*` gate branch — the chart should not ride code-release tags.
- Narrow the push trigger to the **helm chart dir only** (`internal/ee/infrastructure/helm/flexprice/**`); dropped the workflow self-path so unrelated changes don't fire a publish.
- Mark build-deps / lint / package / login / push / verify as `continue-on-error` so a helm-step failure logs a warning without failing the job or blocking anything downstream.
- Upload the chart artifact only when a chart was actually packaged (was `always()`, which warned/failed when nothing was built).

## Publish paths after this change

- Merge to `main` touching the helm chart dir (requires a `Chart.yaml` version bump — the existing diff check guards against duplicates)
- `chart-v<version>` tag
- Manual `workflow_dispatch`

## Verification

YAML validated locally. GitHub Actions logic reasoned from the failing run history (`gh run list/view`). Not runnable locally — recommend confirming on the first post-merge run via `gh run watch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart publishing workflow to run only for `main` pushes that modify the Flexprice chart files (while keeping `chart-v*` tag filtering).
  * Publishing actions are now gated so they run only when a chart needs to be published.
  * The publishing summary now explicitly reports “nothing published,” and distinguishes between “version already exists (skipped)” and successful publishing.
  * Chart artifact uploads now occur only when publication is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->