### PR TITLE
chore(subscription): Add meter expand support

### DIFF
--- a/internal/domain/subscription/line_item.go
+++ b/internal/domain/subscription/line_item.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/ent"
+	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
@@ -48,6 +49,11 @@ type SubscriptionLineItem struct {
 	CommitmentTimeBuckets   types.TimeOfDayBuckets `db:"commitment_time_buckets" json:"commitment_time_buckets,omitempty"`
 
 	Price *price.Price `json:"price,omitempty"`
+
+	// Meter is populated when the caller adds "meters" to a subscription-scoped
+	// expand string alongside "subscription_line_items". Only usage line items
+	// (PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.
+	Meter *meter.Meter `json:"meter,omitempty"`
 
 	types.BaseModel
 }

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entitlement"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	domainMeter "github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/interfaces"
 
@@ -2338,6 +2339,50 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 	}
 
 	s.Logger.Debug(ctx, "built subscription responses", "response_count", len(response.Items))
+
+	// Attach meters to subscription line items when the caller asks for both
+	// "subscription_line_items" and "meters" (either top-level or nested as
+	// "subscription_line_items.meters"). Bulk-fetch across all usage line items.
+	shouldExpandLineItemMeters := expand.Has(types.ExpandSubscriptionLineItems) &&
+		(expand.Has(types.ExpandMeters) || expand.GetNested(types.ExpandSubscriptionLineItems).Has(types.ExpandMeters))
+	if shouldExpandLineItemMeters && len(response.Items) > 0 {
+		meterIDSet := make(map[string]struct{})
+		for _, item := range response.Items {
+			if item.Subscription == nil {
+				continue
+			}
+			for _, li := range item.Subscription.LineItems {
+				if li.MeterID != "" {
+					meterIDSet[li.MeterID] = struct{}{}
+				}
+			}
+		}
+
+		if len(meterIDSet) > 0 {
+			meterIDs := lo.Keys(meterIDSet)
+			meterFilter := types.NewNoLimitMeterFilter()
+			meterFilter.MeterIDs = meterIDs
+			meters, err := s.MeterRepo.List(ctx, meterFilter)
+			if err != nil {
+				return nil, err
+			}
+			meterMap := make(map[string]*domainMeter.Meter, len(meters))
+			for _, m := range meters {
+				meterMap[m.ID] = m
+			}
+
+			for _, item := range response.Items {
+				if item.Subscription == nil {
+					continue
+				}
+				for _, li := range item.Subscription.LineItems {
+					if m, ok := meterMap[li.MeterID]; ok {
+						li.Meter = m
+					}
+				}
+			}
+		}
+	}
 
 	if expand.Has(types.ExpandEntitlements) && len(response.Items) > 0 {
 		// TODO(perf): serial per-customer fetch is fine for the typical

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2375,9 +2375,9 @@ func (s *subscriptionService) ListSubscriptions(ctx context.Context, filter *typ
 				if item.Subscription == nil {
 					continue
 				}
-				for _, li := range item.Subscription.LineItems {
+				for i, li := range item.Subscription.LineItems {
 					if m, ok := meterMap[li.MeterID]; ok {
-						li.Meter = m
+						item.Subscription.LineItems[i].Meter = m
 					}
 				}
 			}

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -83,7 +83,7 @@ var (
 			ExpandPrices:                {ExpandMeters},
 			ExpandSchedule:              {},
 			ExpandCouponAssociations:    {ExpandCoupon},
-			ExpandSubscriptionLineItems: {ExpandPrices},
+			ExpandSubscriptionLineItems: {ExpandPrices, ExpandMeters},
 			ExpandEntitlements:          {},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription responses can now include meter details alongside usage-based line items.
  * Meter details are automatically attached when the appropriate meter expansions are requested.
  * Nested expansion for subscription line items now supports both prices and meters.
  * Meter information is omitted when unavailable, not applicable, or not requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->