### PR TITLE
feat(subscription): add inline child creation for grouped-invoicing

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -325,6 +325,12 @@ func (r *SubscriptionCouponInput) Validate() error {
 	return nil
 }
 
+type GroupedInvoicingChildRequest struct {
+	PlanID             string     `json:"plan_id" validate:"required"`
+	ExternalCustomerID string     `json:"external_customer_id" validate:"required"`
+	StartDate          *time.Time `json:"start_date,omitempty"`
+}
+
 // SubscriptionInheritanceConfig groups all hierarchy and invoicing-routing fields for
 // subscription creation.
 type SubscriptionInheritanceConfig struct {
@@ -343,6 +349,13 @@ type SubscriptionInheritanceConfig struct {
 	// SubscriptionsIDsForGroupedInvoicing: existing standalone subscription IDs to convert to
 	// grouped_invoicing under this parent at creation time. Only valid for parent behavior.
 	SubscriptionsIDsForGroupedInvoicing []string `json:"subscriptions_ids_for_grouped_invoicing,omitempty"`
+
+	// GroupedInvoicingChildrenToCreate: seat specs to create as brand-new grouped_invoicing
+	// children of this parent, in the same request. Each child is created with its own opening
+	// invoice suppressed; its period-1 charges are folded into this parent's single opening
+	// invoice instead. Only valid for parent behavior; mutually exclusive with
+	// SubscriptionsIDsForGroupedInvoicing.
+	GroupedInvoicingChildrenToCreate []GroupedInvoicingChildRequest `json:"grouped_invoicing_children_to_create,omitempty" validate:"omitempty,dive"`
 }
 
 // Validate enforces mutual-exclusivity constraints between inheritance fields.
@@ -383,6 +396,13 @@ func (c *SubscriptionInheritanceConfig) Validate() error {
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either grouped invoicing conversion or inherited child creation, not both").
+			Mark(ierr.ErrValidation)
+	}
+
+	// Grouped invoicing inline-child creation cannot be combined with existing-subscription conversion.
+	if len(c.GroupedInvoicingChildrenToCreate) > 0 && len(c.SubscriptionsIDsForGroupedInvoicing) > 0 {
+		return ierr.NewError("cannot set grouped_invoicing_children_to_create together with subscriptions_ids_for_grouped_invoicing").
+			WithHint("Use either inline child creation or existing-subscription conversion, not both").
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -351,11 +351,7 @@ type SubscriptionInheritanceConfig struct {
 	// grouped_invoicing under this parent at creation time. Only valid for parent behavior.
 	SubscriptionsIDsForGroupedInvoicing []string `json:"subscriptions_ids_for_grouped_invoicing,omitempty"`
 
-	// GroupedInvoicingChildrenToCreate: seat specs to create as brand-new grouped_invoicing
-	// children of this parent, in the same request. Each child is created with its own opening
-	// invoice suppressed; its period-1 charges are folded into this parent's single opening
-	// invoice instead. Only valid for parent behavior; mutually exclusive with
-	// SubscriptionsIDsForGroupedInvoicing.
+	// grouped_invoicing_children_to_create creates new grouped_invoicing children under this parent
 	GroupedInvoicingChildrenToCreate []GroupedInvoicingChildRequest `json:"grouped_invoicing_children_to_create,omitempty" validate:"omitempty,dive"`
 }
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -325,10 +325,11 @@ func (r *SubscriptionCouponInput) Validate() error {
 	return nil
 }
 
+// GroupedInvoicingChildRequest creates one grouped_invoicing child under the parent in the same request.
+// Billing period, cycle, anchor, currency, and start_date are inherited from the parent.
 type GroupedInvoicingChildRequest struct {
-	PlanID             string     `json:"plan_id" validate:"required"`
-	ExternalCustomerID string     `json:"external_customer_id" validate:"required"`
-	StartDate          *time.Time `json:"start_date,omitempty"`
+	PlanID             string `json:"plan_id" validate:"required"`
+	ExternalCustomerID string `json:"external_customer_id" validate:"required"`
 }
 
 // SubscriptionInheritanceConfig groups all hierarchy and invoicing-routing fields for

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -403,6 +403,14 @@ func (c *SubscriptionInheritanceConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	// Inline children require creating a parent, not attaching under an existing parent.
+	// InvoicingCustomerExternalID is allowed (delegated payer for seat fees).
+	if len(c.GroupedInvoicingChildrenToCreate) > 0 && c.ParentSubscriptionID != "" {
+		return ierr.NewError("cannot set grouped_invoicing_children_to_create together with parent_subscription_id").
+			WithHint("grouped_invoicing_children_to_create can only be used when creating a parent subscription").
+			Mark(ierr.ErrValidation)
+	}
+
 	// Validate that no element in SubscriptionsIDsForGroupedInvoicing is empty.
 	for i, id := range c.SubscriptionsIDsForGroupedInvoicing {
 		if id == "" {

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -191,3 +191,42 @@ func TestCreateSubscriptionRequestValidate_AutoInvoiceThreshold(t *testing.T) {
 		}
 	})
 }
+
+func TestSubscriptionInheritanceConfig_Validate_GroupedInvoicingChildrenToCreate(t *testing.T) {
+	t.Run("rejects combining with subscriptions_ids_for_grouped_invoicing", func(t *testing.T) {
+		c := &SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+				{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+			},
+			SubscriptionsIDsForGroupedInvoicing: []string{"sub_existing_1"},
+		}
+
+		err := c.Validate()
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "grouped_invoicing_children_to_create") {
+			t.Fatalf("expected error to mention grouped_invoicing_children_to_create, got: %v", err)
+		}
+	})
+
+	t.Run("passes with only grouped_invoicing_children_to_create set", func(t *testing.T) {
+		c := &SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+				{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+			},
+		}
+
+		err := c.Validate()
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("nil config still passes", func(t *testing.T) {
+		var c *SubscriptionInheritanceConfig
+		if err := c.Validate(); err != nil {
+			t.Fatalf("expected no error for nil config, got: %v", err)
+		}
+	})
+}

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -230,3 +230,46 @@ func TestSubscriptionInheritanceConfig_Validate_GroupedInvoicingChildrenToCreate
 		}
 	})
 }
+
+func TestCreateSubscriptionRequestValidate_GroupedInvoicingChildrenToCreate_RequiredFields(t *testing.T) {
+	t.Run("rejects a child missing plan_id", func(t *testing.T) {
+		req := baseCreateSubscriptionRequest()
+		req.Inheritance = &SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+				{ExternalCustomerID: "ext_seat_1"},
+			},
+		}
+
+		err := req.Validate()
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("rejects a child missing external_customer_id", func(t *testing.T) {
+		req := baseCreateSubscriptionRequest()
+		req.Inheritance = &SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+				{PlanID: "plan_seat"},
+			},
+		}
+
+		err := req.Validate()
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+	})
+
+	t.Run("passes with both fields set", func(t *testing.T) {
+		req := baseCreateSubscriptionRequest()
+		req.Inheritance = &SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+				{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+			},
+		}
+
+		if err := req.Validate(); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+}

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7444,9 +7444,6 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 ) error {
 	for _, c := range childRequests {
 		startDate := parent.StartDate
-		if c.StartDate != nil {
-			startDate = *c.StartDate
-		}
 		childReq := dto.CreateSubscriptionRequest{
 			ExternalCustomerID: c.ExternalCustomerID,
 			PlanID:             c.PlanID,
@@ -7461,14 +7458,7 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 			},
 		}
 		if _, err := s.createSubscription(ctx, childReq); err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to create grouped-invoicing child subscription").
-				WithReportableDetails(map[string]any{
-					"parent_subscription_id": parent.ID,
-					"external_customer_id":   c.ExternalCustomerID,
-					"plan_id":                c.PlanID,
-				}).
-				Mark(ierr.ErrDatabase)
+			return err
 		}
 	}
 	return nil

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -440,21 +440,17 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 		}
 	}
 
-	// Create opening invoice for eligible statuses (trial conversion invoice is created at trial end).
-	// Grouped_invoicing / inherited skip; charges for grouped children land on the parent.
-	eligibleStatusesForOpeningInvoice := []types.SubscriptionStatus{
-		types.SubscriptionStatusIncomplete,
-		types.SubscriptionStatusActive,
-	}
-
-	eligibleTypesForOpeningInvoice := []types.SubscriptionType{
-		types.SubscriptionTypeStandalone,
-		types.SubscriptionTypeParent,
-		types.SubscriptionTypeDelegatedInvoicing,
-	}
-
-	if lo.Contains(eligibleStatusesForOpeningInvoice, sub.SubscriptionStatus) &&
-		lo.Contains(eligibleTypesForOpeningInvoice, sub.SubscriptionType) {
+	// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
+	// Grouped-invoicing children created inline (SubscriptionType pre-set internally by
+	// createGroupedInvoicingChildren) skip their own opening invoice — their charges are
+	// folded into the parent's invoice via the existing Parent-type merge in
+	// PrepareSubscriptionInvoiceRequest. This condition is intentionally minimal: it only adds
+	// the GroupedInvoicing exclusion on top of the pre-existing status check, so every other
+	// subscription type (Standalone, Parent, Inherited, DelegatedInvoicing) keeps its existing
+	// invoicing behavior unchanged.
+	if sub.SubscriptionStatus != types.SubscriptionStatusDraft &&
+		sub.SubscriptionStatus != types.SubscriptionStatusTrialing &&
+		sub.SubscriptionType != types.SubscriptionTypeGroupedInvoicing {
 		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
 
 		createReq := &dto.CreateSubscriptionInvoiceRequest{

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -537,31 +537,30 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 	if err != nil {
 		return nil, err
 	}
-	sub, invoice, phases, plan, validPrices, customer := result.Sub, result.Invoice, result.Phases, result.Plan, result.ValidPrices, result.Customer
 
 	// Handle phases (post-transaction)
-	if req.SubscriptionStatus != types.SubscriptionStatusDraft && len(phases) > 0 {
-		if err = s.handleSubscriptionPhases(ctx, sub, phases, req.Phases, plan, validPrices); err != nil {
+	if req.SubscriptionStatus != types.SubscriptionStatusDraft && len(result.Phases) > 0 {
+		if err = s.handleSubscriptionPhases(ctx, result.Sub, result.Phases, req.Phases, result.Plan, result.ValidPrices); err != nil {
 			return nil, err
 		}
 	}
 
 	// Build response
-	response := &dto.SubscriptionResponse{Subscription: sub}
-	if invoice != nil {
-		response.LatestInvoice = invoice
+	response := &dto.SubscriptionResponse{Subscription: result.Sub}
+	if result.Invoice != nil {
+		response.LatestInvoice = result.Invoice
 	}
 
 	// Sync to HubSpot and publish webhooks
 	isDraft := req.SubscriptionStatus == types.SubscriptionStatusDraft
 	if isDraft {
-		s.triggerHubSpotQuoteSyncWorkflow(ctx, sub.ID, customer.ID)
-		s.runPaddleSubscriptionSync(ctx, sub)
-		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionDraftCreated, sub.ID)
+		s.triggerHubSpotQuoteSyncWorkflow(ctx, result.Sub.ID, result.Customer.ID)
+		s.runPaddleSubscriptionSync(ctx, result.Sub)
+		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionDraftCreated, result.Sub.ID)
 	} else {
-		s.triggerHubSpotDealSyncWorkflow(ctx, sub.ID, customer.ID)
-		s.runPaddleSubscriptionSync(ctx, sub)
-		s.publishSubscriptionCreatedEvent(ctx, sub)
+		s.triggerHubSpotDealSyncWorkflow(ctx, result.Sub.ID, result.Customer.ID)
+		s.runPaddleSubscriptionSync(ctx, result.Sub)
+		s.publishSubscriptionCreatedEvent(ctx, result.Sub)
 	}
 	return response, nil
 }

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -328,6 +328,12 @@ func (s *subscriptionService) createSubscriptionCore(ctx context.Context, req dt
 		return nil, err
 	}
 
+	if req.Inheritance != nil && len(req.Inheritance.GroupedInvoicingChildrenToCreate) > 0 {
+		if err := s.createGroupedInvoicingChildren(ctx, sub, req.Inheritance.GroupedInvoicingChildrenToCreate); err != nil {
+			return nil, err
+		}
+	}
+
 	if len(req.Addons) > 0 {
 		if err = s.handleSubscriptionAddons(ctx, sub, req.Addons); err != nil {
 			return nil, err
@@ -442,7 +448,13 @@ func (s *subscriptionService) createSubscriptionCore(ctx context.Context, req dt
 	}
 
 	// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
-	if sub.SubscriptionStatus != types.SubscriptionStatusDraft && sub.SubscriptionStatus != types.SubscriptionStatusTrialing {
+	// Grouped-invoicing children created inline (SubscriptionType pre-set internally by
+	// createGroupedInvoicingChildren) skip their own opening invoice — their charges are
+	// folded into the parent's invoice via the existing Parent-type merge in
+	// PrepareSubscriptionInvoiceRequest.
+	if sub.SubscriptionStatus != types.SubscriptionStatusDraft &&
+		sub.SubscriptionStatus != types.SubscriptionStatusTrialing &&
+		sub.SubscriptionType != types.SubscriptionTypeGroupedInvoicing {
 		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
 
 		createReq := &dto.CreateSubscriptionInvoiceRequest{
@@ -7311,8 +7323,14 @@ func (s *subscriptionService) prepareSubscriptionInheritanceForCreate(ctx contex
 				Mark(ierr.ErrValidation)
 		}
 		sub.InvoicingCustomerID = parentSub.InvoicingCustomerID
-		sub.SubscriptionType = types.SubscriptionTypeInherited
 		sub.ParentSubscriptionID = lo.ToPtr(inh.ParentSubscriptionID)
+		// Preserve a pre-set GroupedInvoicing type (set internally by
+		// createGroupedInvoicingChildren, never settable from external requests since
+		// CreateSubscriptionRequest.SubscriptionType is json:"-") instead of defaulting to
+		// Inherited.
+		if sub.SubscriptionType != types.SubscriptionTypeGroupedInvoicing {
+			sub.SubscriptionType = types.SubscriptionTypeInherited
+		}
 	}
 
 	if inh.InvoicingCustomerExternalID != nil {
@@ -7340,7 +7358,7 @@ func (s *subscriptionService) prepareSubscriptionInheritanceForCreate(ctx contex
 	// SubIDsForGroupedInvoicing are processed post-create (parent.ID not known yet at this point).
 	groupedInvoicingSubIDs = inh.SubscriptionsIDsForGroupedInvoicing
 
-	if len(childCustomerIDs) > 0 || len(groupedInvoicingSubIDs) > 0 {
+	if len(childCustomerIDs) > 0 || len(groupedInvoicingSubIDs) > 0 || len(inh.GroupedInvoicingChildrenToCreate) > 0 {
 		sub.SubscriptionType = types.SubscriptionTypeParent
 	} else if sub.SubscriptionType == "" {
 		sub.SubscriptionType = types.SubscriptionTypeStandalone
@@ -7424,6 +7442,51 @@ func (s *subscriptionService) createInheritedSubscriptions(ctx context.Context, 
 				"child_customer_id":      childCustomerID,
 			}).
 			Mark(ierr.ErrDatabase)
+	}
+	return nil
+}
+
+// createGroupedInvoicingChildren creates each child spec as a brand-new grouped_invoicing
+// subscription under parent, inside the caller's existing transaction. Each child's own opening
+// invoice is suppressed (see the invoice-generation gate in createSubscriptionCore); its period-1
+// charges are folded into the parent's own opening invoice instead. Calls createSubscriptionCore
+// directly (not the public CreateSubscription): it must reuse the caller's already-open
+// transaction and must not fire the child's own post-transaction side effects (webhook,
+// HubSpot/Paddle sync) — only the parent's single post-tx block should run, once, after
+// everything commits.
+func (s *subscriptionService) createGroupedInvoicingChildren(
+	ctx context.Context,
+	parent *subscription.Subscription,
+	childRequests []dto.GroupedInvoicingChildRequest,
+) error {
+	for _, c := range childRequests {
+		startDate := parent.StartDate
+		if c.StartDate != nil {
+			startDate = *c.StartDate
+		}
+		childReq := dto.CreateSubscriptionRequest{
+			ExternalCustomerID: c.ExternalCustomerID,
+			PlanID:             c.PlanID,
+			Currency:           parent.Currency,
+			StartDate:          &startDate,
+			BillingPeriod:      parent.BillingPeriod,
+			BillingPeriodCount: parent.BillingPeriodCount,
+			BillingCycle:       parent.BillingCycle,
+			SubscriptionType:   types.SubscriptionTypeGroupedInvoicing,
+			Inheritance: &dto.SubscriptionInheritanceConfig{
+				ParentSubscriptionID: parent.ID,
+			},
+		}
+		if _, err := s.createSubscriptionCore(ctx, childReq); err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to create grouped-invoicing child subscription").
+				WithReportableDetails(map[string]any{
+					"parent_subscription_id": parent.ID,
+					"external_customer_id":   c.ExternalCustomerID,
+					"plan_id":                c.PlanID,
+				}).
+				Mark(ierr.ErrDatabase)
+		}
 	}
 	return nil
 }

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -59,8 +59,7 @@ func (s *subscriptionService) listSubscriptionLineItemsForUsageWindow(ctx contex
 	return s.SubscriptionLineItemRepo.List(ctx, filter)
 }
 
-// subscriptionCoreResult carries everything CreateSubscription's post-transaction block
-// (phase handling, HubSpot/Paddle sync, webhook publish) needs, out of createSubscriptionCore.
+// subscriptionCoreResult is the output of createSubscription for CreateSubscription post-commit work.
 type subscriptionCoreResult struct {
 	Sub         *subscription.Subscription
 	Invoice     *dto.InvoiceResponse
@@ -70,9 +69,7 @@ type subscriptionCoreResult struct {
 	Customer    *customer.Customer
 }
 
-// createSubscription validates the request and creates the subscription through invoice
-// generation. Caller must already be inside a transaction. Post-commit side effects (phases,
-// syncs, webhooks) stay in CreateSubscription.
+// createSubscription creates the subscription through invoice generation. Caller must be in a transaction.
 func (s *subscriptionService) createSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*subscriptionCoreResult, error) {
 	if req.BillingCycle == "" {
 		req.BillingCycle = types.BillingCycleAnniversary
@@ -444,10 +441,7 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 	}
 
 	// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
-	// Grouped-invoicing children created inline (SubscriptionType pre-set internally by
-	// createGroupedInvoicingChildren) skip their own opening invoice — their charges are
-	// folded into the parent's invoice via the existing Parent-type merge in
-	// PrepareSubscriptionInvoiceRequest.
+	// Grouped_invoicing children skip their opening invoice; charges land on the parent instead.
 	if sub.SubscriptionStatus != types.SubscriptionStatusDraft &&
 		sub.SubscriptionStatus != types.SubscriptionStatusTrialing &&
 		sub.SubscriptionType != types.SubscriptionTypeGroupedInvoicing {

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -440,17 +440,23 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 		}
 	}
 
-	// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
-	// Grouped-invoicing children created inline (SubscriptionType pre-set internally by
-	// createGroupedInvoicingChildren) skip their own opening invoice — their charges are
-	// folded into the parent's invoice via the existing Parent-type merge in
-	// PrepareSubscriptionInvoiceRequest. This condition is intentionally minimal: it only adds
-	// the GroupedInvoicing exclusion on top of the pre-existing status check, so every other
-	// subscription type (Standalone, Parent, Inherited, DelegatedInvoicing) keeps its existing
-	// invoicing behavior unchanged.
-	if sub.SubscriptionStatus != types.SubscriptionStatusDraft &&
-		sub.SubscriptionStatus != types.SubscriptionStatusTrialing &&
-		sub.SubscriptionType != types.SubscriptionTypeGroupedInvoicing {
+	// Skip the opening invoice for draft/trialing subscriptions (trial conversion invoice is
+	// created at trial end) and for grouped-invoicing children created inline (SubscriptionType
+	// pre-set internally by createGroupedInvoicingChildren) — their charges are folded into the
+	// parent's invoice via the existing Parent-type merge in PrepareSubscriptionInvoiceRequest.
+	//
+	// Deliberately a skip-list, not an allow-list: any SubscriptionType/Status added in the
+	// future keeps getting invoiced by default, same as every existing type does today. Only add
+	// an entry here when that type/status must NOT get its own opening invoice.
+	skipOpeningInvoiceStatuses := []types.SubscriptionStatus{
+		types.SubscriptionStatusDraft,
+		types.SubscriptionStatusTrialing,
+	}
+	skipOpeningInvoiceTypes := []types.SubscriptionType{
+		types.SubscriptionTypeGroupedInvoicing,
+	}
+	if !lo.Contains(skipOpeningInvoiceStatuses, sub.SubscriptionStatus) &&
+		!lo.Contains(skipOpeningInvoiceTypes, sub.SubscriptionType) {
 		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
 
 		createReq := &dto.CreateSubscriptionInvoiceRequest{

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -70,14 +70,10 @@ type subscriptionCoreResult struct {
 	Customer    *customer.Customer
 }
 
-// createSubscriptionCore contains everything from customer/plan validation through the
-// invoice-generation gate. It opens no transaction of its own — the caller must already be
-// inside one (either createSubscriptionCoreTx for a top-level call, or a caller that's already
-// inside its own s.DB.WithTx, e.g. createGroupedInvoicingChildren). It runs no post-transaction
-// side effects (no phase handling, no HubSpot/Paddle sync, no webhook) — those stay in the
-// public CreateSubscription wrapper so they fire exactly once, only for a top-level call, only
-// after commit.
-func (s *subscriptionService) createSubscriptionCore(ctx context.Context, req dto.CreateSubscriptionRequest) (*subscriptionCoreResult, error) {
+// createSubscription validates the request and creates the subscription through invoice
+// generation. Caller must already be inside a transaction. Post-commit side effects (phases,
+// syncs, webhooks) stay in CreateSubscription.
+func (s *subscriptionService) createSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*subscriptionCoreResult, error) {
 	if req.BillingCycle == "" {
 		req.BillingCycle = types.BillingCycleAnniversary
 	}
@@ -530,26 +526,14 @@ func (s *subscriptionService) createSubscriptionCore(ctx context.Context, req dt
 	}, nil
 }
 
-// createSubscriptionCoreTx opens the transaction and runs createSubscriptionCore inside it.
-// Only the public CreateSubscription calls this — createGroupedInvoicingChildren calls
-// createSubscriptionCore directly, reusing the caller's already-open transaction instead.
-func (s *subscriptionService) createSubscriptionCoreTx(ctx context.Context, req dto.CreateSubscriptionRequest) (*subscriptionCoreResult, error) {
+// CreateSubscription creates a subscription and its opening invoice, then runs post-commit side effects.
+func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*dto.SubscriptionResponse, error) {
 	var result *subscriptionCoreResult
 	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
 		var txErr error
-		result, txErr = s.createSubscriptionCore(ctx, req)
+		result, txErr = s.createSubscription(ctx, req)
 		return txErr
 	})
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-
-// CreateSubscription validates and persists a new subscription, generating its opening invoice
-// (unless draft/trialing) and syncing/publishing side effects once the transaction has committed.
-func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*dto.SubscriptionResponse, error) {
-	result, err := s.createSubscriptionCoreTx(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -7477,7 +7461,7 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 				ParentSubscriptionID: parent.ID,
 			},
 		}
-		if _, err := s.createSubscriptionCore(ctx, childReq); err != nil {
+		if _, err := s.createSubscription(ctx, childReq); err != nil {
 			return ierr.WithError(err).
 				WithHint("Failed to create grouped-invoicing child subscription").
 				WithReportableDetails(map[string]any{

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -440,11 +440,21 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 		}
 	}
 
-	// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
-	// Grouped_invoicing children skip their opening invoice; charges land on the parent instead.
-	if sub.SubscriptionStatus != types.SubscriptionStatusDraft &&
-		sub.SubscriptionStatus != types.SubscriptionStatusTrialing &&
-		sub.SubscriptionType != types.SubscriptionTypeGroupedInvoicing {
+	// Create opening invoice for eligible statuses (trial conversion invoice is created at trial end).
+	// Grouped_invoicing / inherited skip; charges for grouped children land on the parent.
+	eligibleStatusesForOpeningInvoice := []types.SubscriptionStatus{
+		types.SubscriptionStatusIncomplete,
+		types.SubscriptionStatusActive,
+	}
+
+	eligibleTypesForOpeningInvoice := []types.SubscriptionType{
+		types.SubscriptionTypeStandalone,
+		types.SubscriptionTypeParent,
+		types.SubscriptionTypeDelegatedInvoicing,
+	}
+
+	if lo.Contains(eligibleStatusesForOpeningInvoice, sub.SubscriptionStatus) &&
+		lo.Contains(eligibleTypesForOpeningInvoice, sub.SubscriptionType) {
 		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
 
 		createReq := &dto.CreateSubscriptionInvoiceRequest{

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -440,14 +440,9 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 		}
 	}
 
-	// Skip the opening invoice for draft/trialing subscriptions (trial conversion invoice is
-	// created at trial end) and for grouped-invoicing children created inline (SubscriptionType
-	// pre-set internally by createGroupedInvoicingChildren) — their charges are folded into the
-	// parent's invoice via the existing Parent-type merge in PrepareSubscriptionInvoiceRequest.
-	//
-	// Deliberately a skip-list, not an allow-list: any SubscriptionType/Status added in the
-	// future keeps getting invoiced by default, same as every existing type does today. Only add
-	// an entry here when that type/status must NOT get its own opening invoice.
+	// Skip: draft/trialing (trial conversion invoice is created at trial end), and
+	// grouped-invoicing children (their charges land on the parent's invoice instead).
+	// Skip-list, not allow-list, so future types/statuses keep getting invoiced by default.
 	skipOpeningInvoiceStatuses := []types.SubscriptionStatus{
 		types.SubscriptionStatusDraft,
 		types.SubscriptionStatusTrialing,

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -59,7 +59,25 @@ func (s *subscriptionService) listSubscriptionLineItemsForUsageWindow(ctx contex
 	return s.SubscriptionLineItemRepo.List(ctx, filter)
 }
 
-func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*dto.SubscriptionResponse, error) {
+// subscriptionCoreResult carries everything CreateSubscription's post-transaction block
+// (phase handling, HubSpot/Paddle sync, webhook publish) needs, out of createSubscriptionCore.
+type subscriptionCoreResult struct {
+	Sub         *subscription.Subscription
+	Invoice     *dto.InvoiceResponse
+	Phases      []*subscription.SubscriptionPhase
+	Plan        *plan.Plan
+	ValidPrices []*dto.PriceResponse
+	Customer    *customer.Customer
+}
+
+// createSubscriptionCore contains everything from customer/plan validation through the
+// invoice-generation gate. It opens no transaction of its own — the caller must already be
+// inside one (either createSubscriptionCoreTx for a top-level call, or a caller that's already
+// inside its own s.DB.WithTx, e.g. createGroupedInvoicingChildren). It runs no post-transaction
+// side effects (no phase handling, no HubSpot/Paddle sync, no webhook) — those stay in the
+// public CreateSubscription wrapper so they fire exactly once, only for a top-level call, only
+// after commit.
+func (s *subscriptionService) createSubscriptionCore(ctx context.Context, req dto.CreateSubscriptionRequest) (*subscriptionCoreResult, error) {
 	if req.BillingCycle == "" {
 		req.BillingCycle = types.BillingCycleAnniversary
 	}
@@ -291,211 +309,239 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 	var updatedSub *subscription.Subscription
 	invoiceService := NewInvoiceService(s.ServiceParams)
 
-	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
-		groupedInvoicingSubIDs, childCustomerIDs, err := s.prepareSubscriptionInheritanceForCreate(ctx, &req, sub)
+	groupedInvoicingSubIDs, childCustomerIDs, err := s.prepareSubscriptionInheritanceForCreate(ctx, &req, sub)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.validateAutoInvoiceThresholdForCreate(sub); err != nil {
+		return nil, err
+	}
+
+	// Create bucket price rows for line items carrying commitment time
+	// buckets, inside this transaction so they roll back with the line items.
+	if err := s.createBucketPricesForLineItems(ctx, sub, sub.LineItems, lineItemBucketCfgs); err != nil {
+		return nil, err
+	}
+
+	if err := s.SubRepo.CreateWithLineItems(ctx, sub, sub.LineItems); err != nil {
+		return nil, err
+	}
+
+	if len(req.Addons) > 0 {
+		if err = s.handleSubscriptionAddons(ctx, sub, req.Addons); err != nil {
+			return nil, err
+		}
+	}
+	// Add extra line items (price_id or price) in the same transaction
+	for i := range req.LineItems {
+		itemReq := req.LineItems[i]
+		itemReq.SkipEntitlementCheck = true
+		if _, err = s.AddSubscriptionLineItem(ctx, sub.ID, itemReq); err != nil {
+			return nil, err
+		}
+	}
+	if len(req.OverrideEntitlements) > 0 {
+		if err = s.ProcessSubscriptionEntitlementOverrides(ctx, sub, req.OverrideEntitlements); err != nil {
+			return nil, err
+		}
+	}
+
+	// Prepare credit grants
+	var creditGrantRequests []dto.CreateCreditGrantRequest
+	if req.CreditGrants != nil {
+		creditGrantRequests = req.CreditGrants
+	} else {
+		creditGrantService := NewCreditGrantService(s.ServiceParams)
+		planCreditGrants, err := creditGrantService.GetCreditGrantsByPlan(ctx, plan.ID)
 		if err != nil {
-			return err
+			return nil, err
 		}
-
-		if err := s.validateAutoInvoiceThresholdForCreate(sub); err != nil {
-			return err
-		}
-
-		// Create bucket price rows for line items carrying commitment time
-		// buckets, inside this transaction so they roll back with the line items.
-		if err := s.createBucketPricesForLineItems(ctx, sub, sub.LineItems, lineItemBucketCfgs); err != nil {
-			return err
-		}
-
-		if err := s.SubRepo.CreateWithLineItems(ctx, sub, sub.LineItems); err != nil {
-			return err
-		}
-
-		if len(req.Addons) > 0 {
-			if err = s.handleSubscriptionAddons(ctx, sub, req.Addons); err != nil {
-				return err
+		if len(planCreditGrants.Items) > 0 {
+			s.Logger.Info(ctx, "plan has credit grants", "plan_id", plan.ID, "credit_grants_count", len(planCreditGrants.Items))
+			creditGrantRequests = make([]dto.CreateCreditGrantRequest, 0, len(planCreditGrants.Items))
+			for _, cg := range planCreditGrants.Items {
+				creditGrantRequests = append(creditGrantRequests, dto.CreateCreditGrantRequest{
+					Name:                   cg.Name,
+					Scope:                  types.CreditGrantScopeSubscription,
+					Credits:                cg.Credits,
+					Cadence:                cg.Cadence,
+					ExpirationType:         cg.ExpirationType,
+					Priority:               cg.Priority,
+					SubscriptionID:         lo.ToPtr(sub.ID),
+					Period:                 cg.Period,
+					PlanID:                 &plan.ID,
+					ExpirationDuration:     cg.ExpirationDuration,
+					ExpirationDurationUnit: cg.ExpirationDurationUnit,
+					Metadata:               cg.Metadata,
+					PeriodCount:            cg.PeriodCount,
+					ConversionRate:         cg.ConversionRate,
+					TopupConversionRate:    cg.TopupConversionRate,
+				})
 			}
 		}
-		// Add extra line items (price_id or price) in the same transaction
-		for i := range req.LineItems {
-			itemReq := req.LineItems[i]
-			itemReq.SkipEntitlementCheck = true
-			if _, err = s.AddSubscriptionLineItem(ctx, sub.ID, itemReq); err != nil {
-				return err
-			}
-		}
-		if len(req.OverrideEntitlements) > 0 {
-			if err = s.ProcessSubscriptionEntitlementOverrides(ctx, sub, req.OverrideEntitlements); err != nil {
-				return err
-			}
-		}
+	}
+	if err = s.handleCreditGrants(ctx, sub, creditGrantRequests); err != nil {
+		return nil, err
+	}
+	if err = s.handleTaxRateLinking(ctx, sub, req); err != nil {
+		return nil, err
+	}
+	if err = s.handleSubCoupons(ctx, sub, req, originalPriceToLineItemMap); err != nil {
+		return nil, err
+	}
 
-		// Prepare credit grants
-		var creditGrantRequests []dto.CreateCreditGrantRequest
-		if req.CreditGrants != nil {
-			creditGrantRequests = req.CreditGrants
-		} else {
-			creditGrantService := NewCreditGrantService(s.ServiceParams)
-			planCreditGrants, err := creditGrantService.GetCreditGrantsByPlan(ctx, plan.ID)
-			if err != nil {
-				return err
-			}
-			if len(planCreditGrants.Items) > 0 {
-				s.Logger.Info(ctx, "plan has credit grants", "plan_id", plan.ID, "credit_grants_count", len(planCreditGrants.Items))
-				creditGrantRequests = make([]dto.CreateCreditGrantRequest, 0, len(planCreditGrants.Items))
-				for _, cg := range planCreditGrants.Items {
-					creditGrantRequests = append(creditGrantRequests, dto.CreateCreditGrantRequest{
-						Name:                   cg.Name,
-						Scope:                  types.CreditGrantScopeSubscription,
-						Credits:                cg.Credits,
-						Cadence:                cg.Cadence,
-						ExpirationType:         cg.ExpirationType,
-						Priority:               cg.Priority,
-						SubscriptionID:         lo.ToPtr(sub.ID),
-						Period:                 cg.Period,
-						PlanID:                 &plan.ID,
-						ExpirationDuration:     cg.ExpirationDuration,
-						ExpirationDurationUnit: cg.ExpirationDurationUnit,
-						Metadata:               cg.Metadata,
-						PeriodCount:            cg.PeriodCount,
-						ConversionRate:         cg.ConversionRate,
-						TopupConversionRate:    cg.TopupConversionRate,
-					})
-				}
-			}
+	// Handle entitlement proration for calendar billing
+	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations &&
+		sub.BillingCycle == types.BillingCycleCalendar {
+		if err = s.handleEntitlementProration(ctx, sub); err != nil {
+			// Log error but don't fail subscription creation
+			s.Logger.Error(ctx, "failed to create prorated entitlements",
+				"error", err,
+				"subscription_id", sub.ID)
 		}
-		if err = s.handleCreditGrants(ctx, sub, creditGrantRequests); err != nil {
-			return err
-		}
-		if err = s.handleTaxRateLinking(ctx, sub, req); err != nil {
-			return err
-		}
-		if err = s.handleSubCoupons(ctx, sub, req, originalPriceToLineItemMap); err != nil {
-			return err
-		}
+	}
 
-		// Handle entitlement proration for calendar billing
-		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations &&
-			sub.BillingCycle == types.BillingCycleCalendar {
-			if err = s.handleEntitlementProration(ctx, sub); err != nil {
-				// Log error but don't fail subscription creation
-				s.Logger.Error(ctx, "failed to create prorated entitlements",
-					"error", err,
-					"subscription_id", sub.ID)
-			}
+	// Create phase 0 DB record and its extra line items (e.g. ADVANCE one-time charges) BEFORE
+	// invoice generation so they are included in the opening invoice.
+	// Subsequent phases are handled post-transaction in handleSubscriptionPhases.
+	if len(phases) > 0 {
+		if err = s.SubscriptionPhaseRepo.Create(ctx, phases[0]); err != nil {
+			return nil, err
 		}
-
-		// Create phase 0 DB record and its extra line items (e.g. ADVANCE one-time charges) BEFORE
-		// invoice generation so they are included in the opening invoice.
-		// Subsequent phases are handled post-transaction in handleSubscriptionPhases.
-		if len(phases) > 0 {
-			if err = s.SubscriptionPhaseRepo.Create(ctx, phases[0]); err != nil {
-				return err
+		if len(req.Phases) > 0 && len(req.Phases[0].LineItems) > 0 {
+			extraItems, extraErr := s.createPhaseExtraLineItems(ctx, sub, phases[0], req.Phases[0])
+			if extraErr != nil {
+				return nil, extraErr
 			}
-			if len(req.Phases) > 0 && len(req.Phases[0].LineItems) > 0 {
-				extraItems, extraErr := s.createPhaseExtraLineItems(ctx, sub, phases[0], req.Phases[0])
-				if extraErr != nil {
-					return extraErr
-				}
-				// Apply phase 0 coupons to the extra line items created above.
-				// handleSubCoupons runs before this block and only covers req.Coupons /
-				// req.LineItemCoupons; phase-level coupons (req.Phases[0].Coupons /
-				// req.Phases[0].LineItemCoupons) need to be resolved here using the
-				// just-created items.
-				phase0Req := req.Phases[0]
-				if len(phase0Req.Coupons) > 0 || len(phase0Req.LineItemCoupons) > 0 || len(phase0Req.SubscriptionCoupons) > 0 {
-					phase0PriceToLIMap := make(map[string]string)
-					for _, li := range extraItems {
-						if li.PriceID != "" && li.ID != "" {
-							phase0PriceToLIMap[li.PriceID] = li.ID
-						}
+			// Apply phase 0 coupons to the extra line items created above.
+			// handleSubCoupons runs before this block and only covers req.Coupons /
+			// req.LineItemCoupons; phase-level coupons (req.Phases[0].Coupons /
+			// req.Phases[0].LineItemCoupons) need to be resolved here using the
+			// just-created items.
+			phase0Req := req.Phases[0]
+			if len(phase0Req.Coupons) > 0 || len(phase0Req.LineItemCoupons) > 0 || len(phase0Req.SubscriptionCoupons) > 0 {
+				phase0PriceToLIMap := make(map[string]string)
+				for _, li := range extraItems {
+					if li.PriceID != "" && li.ID != "" {
+						phase0PriceToLIMap[li.PriceID] = li.ID
 					}
-					phase0Coupons, err := s.normalizePhaseCoupons(ctx, phase0Req, phases[0].ID, phase0PriceToLIMap)
-					if err != nil {
-						return err
-					}
-					if len(phase0Coupons) > 0 {
-						couponSvc := NewCouponAssociationService(s.ServiceParams)
-						if err = couponSvc.ApplyCouponsToSubscription(ctx, sub, phase0Coupons); err != nil {
-							return err
-						}
+				}
+				phase0Coupons, err := s.normalizePhaseCoupons(ctx, phase0Req, phases[0].ID, phase0PriceToLIMap)
+				if err != nil {
+					return nil, err
+				}
+				if len(phase0Coupons) > 0 {
+					couponSvc := NewCouponAssociationService(s.ServiceParams)
+					if err = couponSvc.ApplyCouponsToSubscription(ctx, sub, phase0Coupons); err != nil {
+						return nil, err
 					}
 				}
 			}
 		}
+	}
 
-		// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
-		if sub.SubscriptionStatus != types.SubscriptionStatusDraft && sub.SubscriptionStatus != types.SubscriptionStatusTrialing {
-			paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
+	// Create invoice for non-draft, non-trialing subscriptions (trial conversion invoice is created at trial end).
+	if sub.SubscriptionStatus != types.SubscriptionStatusDraft && sub.SubscriptionStatus != types.SubscriptionStatusTrialing {
+		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
 
-			createReq := &dto.CreateSubscriptionInvoiceRequest{
-				SubscriptionID: sub.ID,
-				PeriodStart:    sub.CurrentPeriodStart,
-				PeriodEnd:      sub.CurrentPeriodEnd,
-				ReferencePoint: types.ReferencePointPeriodStart,
-			}
-
-			if req.OpeningInvoiceAdjustmentAmount != nil {
-				createReq.OpeningInvoiceAdjustmentAmount = req.OpeningInvoiceAdjustmentAmount
-				createReq.BillingReason = types.InvoiceBillingReasonSubscriptionUpdate
-			}
-
-			invoice, updatedSub, err = invoiceService.CreateSubscriptionInvoice(ctx, createReq, paymentParams, types.InvoiceFlowSubscriptionCreation, false)
-			if err != nil {
-				return err
-			}
-			if updatedSub != nil {
-				sub = updatedSub
-			}
-			// Activate subscription if no invoice needed or already paid
-			if (req.Workflow == nil || *req.Workflow != types.TemporalStripeIntegrationWorkflow) &&
-				sub.SubscriptionStatus == types.SubscriptionStatusIncomplete &&
-				(invoice == nil || invoice.PaymentStatus == types.PaymentStatusSucceeded) {
-				sub.SubscriptionStatus = types.SubscriptionStatusActive
-				if err = s.SubRepo.Update(ctx, sub); err != nil {
-					return err
-				}
-			}
-		} else if sub.SubscriptionStatus == types.SubscriptionStatusTrialing {
-			// Create a $0 preview invoice at trial start so downstream integrations (Stripe,
-			// Paddle) can drive card capture via their $0 checkout flow.
-			// syncTrialingStateFromCreateRequest has already aligned:
-			//   CurrentPeriodStart = TrialStart
-			//   CurrentPeriodEnd   = TrialEnd
-			paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
-
-			invoice, _, err = invoiceService.CreateSubscriptionInvoice(ctx, &dto.CreateSubscriptionInvoiceRequest{
-				SubscriptionID: sub.ID,
-				PeriodStart:    sub.CurrentPeriodStart, // == TrialStart
-				PeriodEnd:      sub.CurrentPeriodEnd,   // == TrialEnd
-				ReferencePoint: types.ReferencePointPeriodStart,
-				BillingReason:  types.InvoiceBillingReasonSubscriptionTrialStart,
-			}, paymentParams, types.InvoiceFlowSubscriptionCreation, false)
-			if err != nil {
-				return err
-			}
-			// Subscription stays TRIALING — trial start invoice does not gate activation.
+		createReq := &dto.CreateSubscriptionInvoiceRequest{
+			SubscriptionID: sub.ID,
+			PeriodStart:    sub.CurrentPeriodStart,
+			PeriodEnd:      sub.CurrentPeriodEnd,
+			ReferencePoint: types.ReferencePointPeriodStart,
 		}
 
-		// Inherited children must see the parent's final status/period fields after invoice + activation.
-		for _, childID := range childCustomerIDs {
-			if err := s.createInheritedSubscriptions(ctx, sub, childID); err != nil {
-				return err
-			}
+		if req.OpeningInvoiceAdjustmentAmount != nil {
+			createReq.OpeningInvoiceAdjustmentAmount = req.OpeningInvoiceAdjustmentAmount
+			createReq.BillingReason = types.InvoiceBillingReasonSubscriptionUpdate
 		}
 
-		// Convert existing standalone subscriptions to grouped_invoicing under the newly created parent
-		for _, gSubID := range groupedInvoicingSubIDs {
-			if err := s.addToGroupedInvoicing(ctx, sub, gSubID); err != nil {
-				return err
+		invoice, updatedSub, err = invoiceService.CreateSubscriptionInvoice(ctx, createReq, paymentParams, types.InvoiceFlowSubscriptionCreation, false)
+		if err != nil {
+			return nil, err
+		}
+		if updatedSub != nil {
+			sub = updatedSub
+		}
+		// Activate subscription if no invoice needed or already paid
+		if (req.Workflow == nil || *req.Workflow != types.TemporalStripeIntegrationWorkflow) &&
+			sub.SubscriptionStatus == types.SubscriptionStatusIncomplete &&
+			(invoice == nil || invoice.PaymentStatus == types.PaymentStatusSucceeded) {
+			sub.SubscriptionStatus = types.SubscriptionStatusActive
+			if err = s.SubRepo.Update(ctx, sub); err != nil {
+				return nil, err
 			}
 		}
+	} else if sub.SubscriptionStatus == types.SubscriptionStatusTrialing {
+		// Create a $0 preview invoice at trial start so downstream integrations (Stripe,
+		// Paddle) can drive card capture via their $0 checkout flow.
+		// syncTrialingStateFromCreateRequest has already aligned:
+		//   CurrentPeriodStart = TrialStart
+		//   CurrentPeriodEnd   = TrialEnd
+		paymentParams := dto.NewPaymentParametersFromSubscription(sub.CollectionMethod, sub.PaymentBehavior, sub.GatewayPaymentMethodID).NormalizePaymentParameters()
 
-		return nil
+		invoice, _, err = invoiceService.CreateSubscriptionInvoice(ctx, &dto.CreateSubscriptionInvoiceRequest{
+			SubscriptionID: sub.ID,
+			PeriodStart:    sub.CurrentPeriodStart, // == TrialStart
+			PeriodEnd:      sub.CurrentPeriodEnd,   // == TrialEnd
+			ReferencePoint: types.ReferencePointPeriodStart,
+			BillingReason:  types.InvoiceBillingReasonSubscriptionTrialStart,
+		}, paymentParams, types.InvoiceFlowSubscriptionCreation, false)
+		if err != nil {
+			return nil, err
+		}
+		// Subscription stays TRIALING — trial start invoice does not gate activation.
+	}
+
+	// Inherited children must see the parent's final status/period fields after invoice + activation.
+	for _, childID := range childCustomerIDs {
+		if err := s.createInheritedSubscriptions(ctx, sub, childID); err != nil {
+			return nil, err
+		}
+	}
+
+	// Convert existing standalone subscriptions to grouped_invoicing under the newly created parent
+	for _, gSubID := range groupedInvoicingSubIDs {
+		if err := s.addToGroupedInvoicing(ctx, sub, gSubID); err != nil {
+			return nil, err
+		}
+	}
+
+	return &subscriptionCoreResult{
+		Sub:         sub,
+		Invoice:     invoice,
+		Phases:      phases,
+		Plan:        plan,
+		ValidPrices: validPrices,
+		Customer:    customer,
+	}, nil
+}
+
+// createSubscriptionCoreTx opens the transaction and runs createSubscriptionCore inside it.
+// Only the public CreateSubscription calls this — createGroupedInvoicingChildren calls
+// createSubscriptionCore directly, reusing the caller's already-open transaction instead.
+func (s *subscriptionService) createSubscriptionCoreTx(ctx context.Context, req dto.CreateSubscriptionRequest) (*subscriptionCoreResult, error) {
+	var result *subscriptionCoreResult
+	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
+		var txErr error
+		result, txErr = s.createSubscriptionCore(ctx, req)
+		return txErr
 	})
 	if err != nil {
 		return nil, err
 	}
+	return result, nil
+}
+
+// CreateSubscription validates and persists a new subscription, generating its opening invoice
+// (unless draft/trialing) and syncing/publishing side effects once the transaction has committed.
+func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.CreateSubscriptionRequest) (*dto.SubscriptionResponse, error) {
+	result, err := s.createSubscriptionCoreTx(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	sub, invoice, phases, plan, validPrices, customer := result.Sub, result.Invoice, result.Phases, result.Plan, result.ValidPrices, result.Customer
 
 	// Handle phases (post-transaction)
 	if req.SubscriptionStatus != types.SubscriptionStatusDraft && len(phases) > 0 {

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8298,3 +8298,110 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 		s.Empty(childInvoices, "expected no invoice for grouped-invoicing child %s", c.ID)
 	}
 }
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_CreditGrantsFundEachChildWallet() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	// Established idiom in this file for reaching the suite's already-built ServiceParams to
+	// construct a sibling service in a test.
+	subService := s.service.(*subscriptionService)
+	creditGrantService := NewCreditGrantService(subService.ServiceParams)
+	_, err := creditGrantService.CreateCreditGrant(ctx, dto.CreateCreditGrantRequest{
+		Name:           "Seat Monthly Credits",
+		Scope:          types.CreditGrantScopePlan,
+		PlanID:         &seatPlan.ID,
+		Credits:        decimal.NewFromInt(100),
+		Cadence:        types.CreditGrantCadenceRecurring,
+		Period:         lo.ToPtr(types.CREDIT_GRANT_PERIOD_MONTHLY),
+		PeriodCount:    lo.ToPtr(1),
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+	})
+	s.NoError(err)
+
+	seatExternal := "ext_seat_credit"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Credit",
+		Email:      "seatcredit@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seatExternal},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	wallets, err := s.GetStores().WalletRepo.GetWalletsByCustomerID(ctx, seat.ID)
+	s.NoError(err)
+	s.Require().Len(wallets, 1)
+	s.True(decimal.NewFromInt(100).Equal(wallets[0].Balance),
+		"expected seat wallet funded with 100 credits, got %s", wallets[0].Balance.String())
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_RollsBackOnChildFailure() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seat1External := "ext_seat_ok"
+	seat1 := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seat1External,
+		Name:       "Seat OK",
+		Email:      "seatok@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat1))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seat1External},
+				{PlanID: "plan_does_not_exist", ExternalCustomerID: "ext_seat_bad"},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.Error(err, "expected an error when a later child's plan_id doesn't exist")
+	s.Nil(resp)
+
+	// Note: this suite runs against testutil's MockPostgresClient (internal/testutil/mock_postgres_client.go),
+	// whose WithTx is a no-op pass-through with no real rollback — writes made before the error
+	// are not undone at this test layer. True atomicity (rollback on error) is a property of the
+	// real internal/postgres.Client.WithTx (confirmed by inspection during design: writer-pinned
+	// ent transaction, rolled back on any returned error or panic), not something this in-memory
+	// unit-test harness can exercise. This test therefore only asserts the error propagates —
+	// it does not assert on persisted row counts.
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8405,3 +8405,237 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	// unit-test harness can exercise. This test therefore only asserts the error propagates —
 	// it does not assert on persisted row counts.
 }
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_ChildInheritsParentStartDate confirms
+// a grouped-invoicing child always starts when the parent starts — start_date is not settable
+// per child (removed from GroupedInvoicingChildRequest by design). Uses a start date offset from
+// "now" so the assertion can't pass by coincidence.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ChildInheritsParentStartDate() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_start_date"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Start Date",
+		Email:      "seatstartdate@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	futureStart := s.testData.now.Add(10 * 24 * time.Hour)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(futureStart),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seatExternal},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+	s.Equal(resp.StartDate.Unix(), children[0].StartDate.Unix(),
+		"grouped-invoicing child must start exactly when the parent starts")
+}
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_SingleChild covers the minimal case
+// of exactly one seat, to make sure the mechanism isn't accidentally N>=2-only.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_SingleChild() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_single"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Single",
+		Email:      "seatsingle@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seatExternal},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+	s.Equal(types.SubscriptionTypeParent, resp.SubscriptionType)
+	s.NotNil(resp.LatestInvoice)
+	s.True(decimal.NewFromInt(100).Equal(resp.LatestInvoice.Total),
+		"expected consolidated invoice total 100 (parent 50 + 1 seat 50), got %s", resp.LatestInvoice.Total.String())
+}
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_EmptySliceIsNoop confirms an explicit
+// empty (non-nil) slice behaves exactly like the field being unset: the subscription stays
+// standalone, no children are created.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_EmptySliceIsNoop() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+	s.Equal(types.SubscriptionTypeStandalone, resp.SubscriptionType)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Empty(children)
+}
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_UnknownCustomerFails confirms a child
+// referencing an external_customer_id that doesn't resolve to any customer surfaces as an error
+// from CreateSubscription (a different failure mode than an invalid plan_id, covered by
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_RollsBackOnChildFailure).
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_UnknownCustomerFails() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: "ext_seat_does_not_exist"},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.Error(err)
+	s.Nil(resp)
+}
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_RejectsCombiningWithSubscriptionsIDsForGroupedInvoicing
+// confirms the DTO-level mutual-exclusivity guard is actually wired into the service call path
+// (not just unit-tested in isolation at the DTO layer).
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_RejectsCombiningWithSubscriptionsIDsForGroupedInvoicing() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: "ext_seat_x"},
+			},
+			SubscriptionsIDsForGroupedInvoicing: []string{"sub_some_existing_id"},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.Error(err)
+	s.Nil(resp)
+	s.Contains(err.Error(), "grouped_invoicing_children_to_create")
+}
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_DelegatedInvoicingCustomer covers the
+// real-world motivating scenario: an org payer distinct from the parent subscription's own
+// customer. The consolidated invoice must bill the delegated invoicing customer, not the parent
+// subscription's own customer.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_DelegatedInvoicingCustomer() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	payerExternal := "ext_payer_org"
+	payer := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: payerExternal,
+		Name:       "Payer Org",
+		Email:      "payer@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, payer))
+
+	seatExternal := "ext_seat_delegated"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Delegated",
+		Email:      "seatdelegated@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			InvoicingCustomerExternalID: lo.ToPtr(payerExternal),
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seatExternal},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp.LatestInvoice)
+
+	// The consolidated invoice bills the delegated payer, not the parent's own customer.
+	s.Equal(payer.ID, resp.LatestInvoice.CustomerID)
+	s.True(decimal.NewFromInt(100).Equal(resp.LatestInvoice.Total),
+		"expected consolidated invoice total 100 (parent 50 + 1 seat 50), got %s", resp.LatestInvoice.Total.String())
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8639,3 +8639,138 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	s.True(decimal.NewFromInt(100).Equal(resp.LatestInvoice.Total),
 		"expected consolidated invoice total 100 (parent 50 + 1 seat 50), got %s", resp.LatestInvoice.Total.String())
 }
+
+// setupParentPlatformFeePlan creates a plan with a single $30/month ADVANCE recurring fixed
+// price, deliberately distinct in amount from setupSeatFeePlan's $50 seat fee, so line-item-level
+// tests can't pass by coincidence of equal amounts.
+func (s *SubscriptionServiceSuite) setupParentPlatformFeePlan() *plan.Plan {
+	ctx := s.GetContext()
+	parentPlan := &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Org Platform Plan",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, parentPlan))
+
+	platformFee := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(30),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           parentPlan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, platformFee))
+	return parentPlan
+}
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_OpeningInvoiceLineItems verifies, at
+// the line-item level (not just the total), that the parent's opening invoice contains the
+// parent's own ADVANCE charge AND each child's ADVANCE charge — each correctly attributed to its
+// originating subscription via SubscriptionID and (for children) the child-customer metadata key
+// the grouped-invoicing merge in PrepareSubscriptionInvoiceRequest sets
+// (billing.go:1570-1577). Parent and children use different plans/amounts (30 vs 50 x 2) so the
+// assertions can't pass by coincidence of equal totals.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_OpeningInvoiceLineItems() {
+	ctx := s.GetContext()
+	parentPlan := s.setupParentPlatformFeePlan()
+	seatPlan := s.setupSeatFeePlan()
+
+	seat1External := "ext_seat_li_1"
+	seat1 := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seat1External,
+		Name:       "Seat LI 1",
+		Email:      "seatli1@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat1))
+
+	seat2External := "ext_seat_li_2"
+	seat2 := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seat2External,
+		Name:       "Seat LI 2",
+		Email:      "seatli2@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat2))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             parentPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seat1External},
+				{PlanID: seatPlan.ID, ExternalCustomerID: seat2External},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+	s.Require().NotNil(resp.LatestInvoice)
+
+	// Total = parent's 30 platform fee + 2 x 50 seat fee = 130.
+	s.True(decimal.NewFromInt(130).Equal(resp.LatestInvoice.Total),
+		"expected consolidated invoice total 130 (parent 30 + 2 seats x 50), got %s", resp.LatestInvoice.Total.String())
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 2)
+	childCustomerIDByChildID := map[string]string{
+		children[0].ID: children[0].CustomerID,
+		children[1].ID: children[1].CustomerID,
+	}
+
+	// Exactly one line item per subscription (parent + 2 children) — every ADVANCE charge shows
+	// up exactly once, none duplicated, none missing.
+	s.Require().Len(resp.LatestInvoice.LineItems, 3,
+		"expected exactly 3 line items: 1 from the parent, 1 from each of the 2 children")
+
+	var parentLineItemAmount decimal.Decimal
+	var parentLineItemFound bool
+	childLineItemAmounts := map[string]decimal.Decimal{}
+
+	for _, li := range resp.LatestInvoice.LineItems {
+		s.Require().NotNil(li.SubscriptionID, "every merged line item must carry a subscription_id")
+		switch *li.SubscriptionID {
+		case resp.ID:
+			parentLineItemFound = true
+			parentLineItemAmount = li.Amount
+		default:
+			childCustomerID, isChild := childCustomerIDByChildID[*li.SubscriptionID]
+			s.Require().True(isChild, "line item subscription_id %s is neither the parent nor a known child", *li.SubscriptionID)
+			childLineItemAmounts[*li.SubscriptionID] = li.Amount
+			// The grouped-invoicing merge tags each forwarded child line item with the
+			// child's customer ID under this metadata key (billing.go:1576).
+			s.Equal(childCustomerID, li.Metadata[types.InvoiceLineItemMetadataKeyChildCustomerID],
+				"child line item must be tagged with its own customer_id, not the parent's")
+		}
+	}
+
+	s.True(parentLineItemFound, "parent's own ADVANCE line item must be present in the opening invoice")
+	s.True(decimal.NewFromInt(30).Equal(parentLineItemAmount),
+		"expected parent's own line item amount 30, got %s", parentLineItemAmount.String())
+
+	s.Require().Len(childLineItemAmounts, 2, "expected one line item per child")
+	for childID, amount := range childLineItemAmounts {
+		s.True(decimal.NewFromInt(50).Equal(amount),
+			"expected child %s line item amount 50, got %s", childID, amount.String())
+	}
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8197,3 +8197,104 @@ func (s *SubscriptionServiceSuite) TestCancelSchedule_RevertCascadesToInheritedS
 	s.Nil(revertedParent.CancelAt)
 	s.Nil(revertedParent.CancelledAt)
 }
+
+// setupSeatFeePlan creates a plan with a single $50/month ADVANCE recurring fixed price,
+// for tests exercising grouped-invoicing inline child creation.
+func (s *SubscriptionServiceSuite) setupSeatFeePlan() *plan.Plan {
+	ctx := s.GetContext()
+	seatPlan := &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Seat Plan",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, seatPlan))
+
+	seatFee := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(50),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           seatPlan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, seatFee))
+	return seatPlan
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seat1External := "ext_seat_1"
+	seat1 := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seat1External,
+		Name:       "Seat 1",
+		Email:      "seat1@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat1))
+
+	seat2External := "ext_seat_2"
+	seat2 := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seat2External,
+		Name:       "Seat 2",
+		Email:      "seat2@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat2))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seat1External},
+				{PlanID: seatPlan.ID, ExternalCustomerID: seat2External},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(types.SubscriptionTypeParent, resp.SubscriptionType)
+
+	// Exactly one invoice, on the parent, covering parent + both seats' fees ($50 x 3 = $150).
+	s.NotNil(resp.LatestInvoice)
+	s.True(decimal.NewFromInt(150).Equal(resp.LatestInvoice.Total),
+		"expected consolidated invoice total 150, got %s", resp.LatestInvoice.Total.String())
+
+	// Both children exist as GROUPED_INVOICING, attached to the parent.
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Len(children, 2)
+
+	for _, c := range children {
+		s.NotNil(c.ParentSubscriptionID)
+		s.Equal(resp.ID, *c.ParentSubscriptionID)
+
+		// No opening invoice exists for this child.
+		invFilter := types.NewNoLimitInvoiceFilter()
+		invFilter.SubscriptionID = c.ID
+		childInvoices, err := s.GetStores().InvoiceRepo.List(ctx, invFilter)
+		s.NoError(err)
+		s.Empty(childInvoices, "expected no invoice for grouped-invoicing child %s", c.ID)
+	}
+}


### PR DESCRIPTION
## Summary

**Problem:** For a multi-seat org billing setup — one payer/org subscription + N seat subscriptions, recurring periods consolidated via `grouped_invoicing`, all seats purchased through a single checkout — there was no way to get a single consolidated invoice for the *first* billing period. `CreateSubscription` unconditionally generates an opening invoice for any non-draft, non-trialing subscription before `grouped_invoicing` conversion ever runs, and conversion itself only takes effect at the *next* billing period boundary (see the existing note in `subscription_grouped_invoicing.go`). So creating a parent + N seats always produced N individual opening invoices — defeating the single-checkout requirement, with no clean workaround short of manually voiding and regenerating invoices per seat.

**Approach:**
- Added `Inheritance.GroupedInvoicingChildrenToCreate` — a list of `{plan_id, external_customer_id}` seat specs. Setting it on a `CreateSubscription` call creates the parent **and** all its seats atomically, in one transaction, with **one** consolidated opening invoice.
- Extracted `CreateSubscription`'s transactional body into `createSubscriptionCore` (no transaction of its own, no post-commit side effects) plus a thin public wrapper. This let a new `createGroupedInvoicingChildren` orchestrator create each child by calling the same core logic directly inside the parent's already-open transaction — zero duplicated price/line-item/credit-grant logic, and children never fire their own webhooks/HubSpot/Paddle syncs (only the parent's post-commit block runs, once, after everything commits).
- Each child is built already typed `grouped_invoicing` (via the existing internal-only, non-API-settable `SubscriptionType` field) with `parent_subscription_id` pre-set, so by the time the parent's own opening-invoice step runs, the existing `Parent`-type merge logic in `PrepareSubscriptionInvoiceRequest` already picks up every child's line items — no new merge logic needed.
- Children always inherit the parent's `start_date`, `billing_period`, `billing_period_count`, `billing_cycle`, and `currency` — none of these are settable per seat, keeping the contract simple and consistent with how `subscriptions_ids_for_grouped_invoicing` already behaves.
- `subscriptions_ids_for_grouped_invoicing` (converting *existing* standalone subscriptions into children) is untouched — different use case, still works exactly as before.

**Backward compatibility:** every new code path is gated behind `SubscriptionType`, which is `json:"-"` — no external caller can ever set it, so the new branches are structurally unreachable from any existing request shape. The `CreateSubscription` extraction is a pure refactor (same transaction boundary, same post-commit side effects, same order) verified against the full existing test suite.

## Test scenarios covered

DTO validation (`internal/api/dto/subscription_test.go`):
- Rejects combining `grouped_invoicing_children_to_create` with `subscriptions_ids_for_grouped_invoicing`
- Rejects combining `grouped_invoicing_children_to_create` with `parent_subscription_id` (a sub can't be both a child of an existing parent and itself a parent creating new children)
- Required fields (`plan_id`, `external_customer_id`) enforced per child
- Nil config still passes

Service-level (`internal/ee/service/subscription_test.go`):
- Basic case — parent + N seats produce exactly one consolidated invoice, no per-child invoices
- Line-item-level verification — parent's own ADVANCE charge and each child's ADVANCE charge each appear exactly once in the opening invoice, correctly attributed via `subscription_id` / child-customer metadata (deliberately different amounts per subscription so the assertions can't pass by coincidence)
- Credit grants fire independently of invoicing — each child's wallet gets funded per its own plan's credit grant
- Single-child (minimal N=1) case
- Empty (non-nil) slice is a no-op — subscription stays standalone
- Unknown `external_customer_id` on a child surfaces as an error
- Child always inherits the parent's exact `start_date` (asserted with a non-"now" offset so it can't pass by coincidence)
- Delegated invoicing customer — the core real-world scenario: org payer distinct from the parent's own customer, consolidated invoice correctly bills the payer
- Mutual-exclusivity guard enforced through the actual `CreateSubscription` call path, not just at the DTO layer in isolation
- Rollback: a later child's failure propagates the error (full DB rollback is a property of the real Postgres `WithTx`, confirmed by inspection; the suite's `MockPostgresClient` has a no-op `WithTx` so it can't exercise rollback itself — documented inline where relevant)

Full existing `internal/ee/service` and `internal/api/dto` suites pass unchanged, confirming no regressions to existing subscription-creation behavior.
