### PR TITLE
fix(checkout): for tax not being applied on create subs via checkout

### DIFF
--- a/internal/ee/service/checkout_session.go
+++ b/internal/ee/service/checkout_session.go
@@ -370,7 +370,17 @@ func (s *checkoutSessionService) createDraftSubscription(ctx context.Context, se
 			Mark(ierr.ErrValidation)
 	}
 
-	// Re-fetch after compute so invoice amounts are populated on the returned struct.
+	// Apply subscription taxes so AmountDue includes tax before payment link creation.
+	// FinalizeInvoice will recalculate taxes idempotently (safe if credits adjust the base).
+	inv, err := s.InvoiceRepo.Get(ctx, invResp.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := invSvc.RecalculateTaxesOnInvoice(ctx, inv); err != nil {
+		return nil, nil, err
+	}
+
+	// Re-fetch after compute + tax so invoice amounts are populated on the returned struct.
 	invResp, err = invSvc.GetInvoice(ctx, invResp.ID)
 	if err != nil {
 		return nil, nil, err

--- a/internal/ee/service/checkout_session.go
+++ b/internal/ee/service/checkout_session.go
@@ -372,11 +372,7 @@ func (s *checkoutSessionService) createDraftSubscription(ctx context.Context, se
 
 	// Apply subscription taxes so AmountDue includes tax before payment link creation.
 	// FinalizeInvoice will recalculate taxes idempotently (safe if credits adjust the base).
-	inv, err := s.InvoiceRepo.Get(ctx, invResp.ID)
-	if err != nil {
-		return nil, nil, err
-	}
-	if err := invSvc.RecalculateTaxesOnInvoice(ctx, inv); err != nil {
+	if err := invSvc.RecalculateTaxesOnInvoice(ctx, &invResp.Invoice); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -74,6 +74,10 @@ type InvoiceService interface {
 	ListAllTenantDraftInvoices(ctx context.Context, batchSize, offset int) ([]*invoice.Invoice, error)
 
 	DistributeInvoiceLevelDiscount(ctx context.Context, lineItems []*invoice.InvoiceLineItem, invoiceDiscountAmount decimal.Decimal) error
+
+	// RecalculateTaxesOnInvoice applies subscription auto-apply taxes and updates
+	// total_tax / total / amount_due. Idempotent via tax-applied records.
+	RecalculateTaxesOnInvoice(ctx context.Context, inv *invoice.Invoice) error
 }
 
 type invoiceService struct {

--- a/internal/ee/service/invoice_apply_taxes_draft_test.go
+++ b/internal/ee/service/invoice_apply_taxes_draft_test.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
+	taxassociation "github.com/flexprice/flexprice/internal/domain/taxassociation"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+func (s *InvoiceServiceSuite) createPercentageTaxRate(pct int64) *taxrate.TaxRate {
+	ctx := s.GetContext()
+	pctDec := decimal.NewFromInt(pct)
+	tr := &taxrate.TaxRate{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_TAX_RATE),
+		Name:            "Checkout Draft Tax",
+		Code:            "checkout_draft_tax_" + types.GenerateUUIDWithPrefix("code"),
+		TaxRateStatus:   types.TaxRateStatusActive,
+		TaxRateType:     types.TaxRateTypePercentage,
+		PercentageValue: &pctDec,
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().TaxRateRepo.Create(ctx, tr))
+	return tr
+}
+
+func (s *InvoiceServiceSuite) createSubscriptionTaxAssociation(taxRateID, subscriptionID string) *taxassociation.TaxAssociation {
+	ctx := s.GetContext()
+	assoc := &taxassociation.TaxAssociation{
+		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_TAX_ASSOCIATION),
+		TaxRateID:     taxRateID,
+		EntityType:    types.TaxRateEntityTypeSubscription,
+		EntityID:      subscriptionID,
+		Priority:      100,
+		AutoApply:     true,
+		Currency:      "usd",
+		StartDate:     time.Now().UTC().Add(-24 * time.Hour),
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		BaseModel:     types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().TaxAssociationRepo.Create(ctx, assoc))
+	return assoc
+}
+
+func (s *InvoiceServiceSuite) buildDraftSubscriptionInvoice(id string, subtotal decimal.Decimal, withLineItem bool) *invoice.Invoice {
+	ctx := s.GetContext()
+	periodStart := s.testData.subscription.CurrentPeriodStart
+	periodEnd := s.testData.subscription.CurrentPeriodEnd
+	bp := string(types.BILLING_PERIOD_MONTHLY)
+	now := time.Now().UTC()
+
+	inv := &invoice.Invoice{
+		ID:              id,
+		CustomerID:      s.testData.customer.ID,
+		SubscriptionID:  lo.ToPtr(s.testData.subscription.ID),
+		InvoiceType:     types.InvoiceTypeSubscription,
+		InvoiceStatus:   types.InvoiceStatusDraft,
+		PaymentStatus:   types.PaymentStatusPending,
+		Currency:        "usd",
+		Subtotal:        subtotal,
+		Total:           subtotal,
+		AmountDue:       subtotal,
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: subtotal,
+		TotalTax:        decimal.Zero,
+		BillingPeriod:   &bp,
+		PeriodStart:     &periodStart,
+		PeriodEnd:       &periodEnd,
+		LastComputedAt:  &now,
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+
+	if withLineItem {
+		inv.LineItems = []*invoice.InvoiceLineItem{
+			{
+				ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE_LINE_ITEM),
+				InvoiceID:      id,
+				CustomerID:     s.testData.customer.ID,
+				SubscriptionID: lo.ToPtr(s.testData.subscription.ID),
+				PriceID:        lo.ToPtr(s.testData.prices.storage.ID),
+				PriceType:      lo.ToPtr(string(types.PRICE_TYPE_FIXED)),
+				DisplayName:    lo.ToPtr("Fixed Plan Fee"),
+				Amount:         subtotal,
+				Quantity:       decimal.NewFromInt(1),
+				Currency:       "usd",
+				PeriodStart:    &periodStart,
+				PeriodEnd:      &periodEnd,
+				BaseModel:      types.GetDefaultBaseModel(ctx),
+			},
+		}
+	}
+
+	s.Require().NoError(s.invoiceRepo.CreateWithLineItems(ctx, inv))
+	return inv
+}
+
+func (s *InvoiceServiceSuite) TestRecalculateTaxesOnInvoice_WithSubscriptionTax() {
+	ctx := s.GetContext()
+	subtotal := decimal.NewFromInt(100)
+	inv := s.buildDraftSubscriptionInvoice("inv_draft_tax_apply", subtotal, false)
+
+	tr := s.createPercentageTaxRate(10)
+	s.createSubscriptionTaxAssociation(tr.ID, s.testData.subscription.ID)
+
+	fresh, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+	err = s.service.RecalculateTaxesOnInvoice(ctx, fresh)
+	s.Require().NoError(err)
+
+	got, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+
+	expectedTax := decimal.NewFromInt(10)
+	expectedDue := subtotal.Add(expectedTax)
+	s.True(expectedTax.Equal(got.TotalTax), "expected total_tax %s, got %s", expectedTax, got.TotalTax)
+	s.True(expectedDue.Equal(got.AmountDue), "expected amount_due %s, got %s", expectedDue, got.AmountDue)
+	s.True(expectedDue.Equal(got.Total), "expected total %s, got %s", expectedDue, got.Total)
+}
+
+func (s *InvoiceServiceSuite) TestRecalculateTaxesOnInvoice_NoTaxUnchanged() {
+	ctx := s.GetContext()
+	subtotal := decimal.NewFromInt(100)
+	inv := s.buildDraftSubscriptionInvoice("inv_draft_tax_none", subtotal, false)
+
+	fresh, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+	err = s.service.RecalculateTaxesOnInvoice(ctx, fresh)
+	s.Require().NoError(err)
+
+	got, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+
+	s.True(got.TotalTax.IsZero(), "expected zero total_tax, got %s", got.TotalTax)
+	s.True(subtotal.Equal(got.AmountDue), "expected amount_due unchanged at %s, got %s", subtotal, got.AmountDue)
+	s.True(subtotal.Equal(got.Total), "expected total unchanged at %s, got %s", subtotal, got.Total)
+}
+
+func (s *InvoiceServiceSuite) TestRecalculateTaxesOnInvoice_FinalizeNoDoubleTax() {
+	ctx := s.GetContext()
+	subtotal := decimal.NewFromInt(100)
+	inv := s.buildDraftSubscriptionInvoice("inv_draft_tax_finalize", subtotal, true)
+
+	tr := s.createPercentageTaxRate(10)
+	s.createSubscriptionTaxAssociation(tr.ID, s.testData.subscription.ID)
+
+	fresh, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+	err = s.service.RecalculateTaxesOnInvoice(ctx, fresh)
+	s.Require().NoError(err)
+
+	afterApply, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+	taxAfterApply := afterApply.TotalTax
+	s.True(decimal.NewFromInt(10).Equal(taxAfterApply), "expected tax 10 after apply, got %s", taxAfterApply)
+
+	err = s.service.FinalizeInvoice(ctx, inv.ID)
+	s.Require().NoError(err)
+
+	afterFinalize, err := s.invoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+	s.Equal(types.InvoiceStatusFinalized, afterFinalize.InvoiceStatus)
+	s.True(taxAfterApply.Equal(afterFinalize.TotalTax),
+		"finalize must not double-tax: apply=%s finalize=%s", taxAfterApply, afterFinalize.TotalTax)
+	s.True(subtotal.Add(taxAfterApply).Equal(afterFinalize.AmountDue),
+		"expected amount_due %s after finalize, got %s", subtotal.Add(taxAfterApply), afterFinalize.AmountDue)
+}

--- a/internal/testutil/inmemory_invoice_store.go
+++ b/internal/testutil/inmemory_invoice_store.go
@@ -88,6 +88,7 @@ func copyInvoice(inv *invoice.Invoice) *invoice.Invoice {
 		AmountPaid:                 inv.AmountPaid,
 		Subtotal:                   inv.Subtotal,
 		Total:                      inv.Total,
+		TotalTax:                   inv.TotalTax,
 		TotalDiscount:              inv.TotalDiscount,
 		AmountRemaining:            inv.AmountRemaining,
 		AdjustmentAmount:           inv.AdjustmentAmount,


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkout invoices now recalculate subscription taxes before computing the amount due, ensuring payment and checkout-link amounts reflect tax accurately.
  * Finalizing an invoice no longer duplicates taxes that were already applied.
  * Tax totals are preserved correctly when draft invoices are copied and processed.

* **Tests**
  * Added coverage for recalculating taxes on draft invoices with subscription tax rates, handling invoices without taxes, and verifying finalization does not double-count taxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->