### PR TITLE
feat(dev-token): add Makefile target for generating development token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,26 @@ run-server-local: run-server
 .PHONY: run
 run: run-server
 
+.PHONY: dev-token
+dev-token:
+	@tenant_id=''; \
+	while [ -z "$$tenant_id" ]; do \
+		printf 'Tenant ID: '; \
+		if ! IFS= read -r tenant_id; then \
+			printf '\nUnable to read tenant ID.\n'; \
+			exit 1; \
+		fi; \
+		if [ -z "$$tenant_id" ]; then \
+			echo 'Tenant ID is required.'; \
+		fi; \
+	done; \
+	printf 'Environment ID (optional): '; \
+	if ! IFS= read -r environment_id; then \
+		printf '\nUnable to read environment ID.\n'; \
+		exit 1; \
+	fi; \
+	go run ./scripts -cmd generate-dev-token -tenant-id "$$tenant_id" -environment-id "$$environment_id"
+
 # ---------------------------------------------------------------------------
 # Local development targets — load .env.local on top of .env so local Docker
 # infra overrides take effect without touching production config.

--- a/scripts/internal/generate_dev_token.go
+++ b/scripts/internal/generate_dev_token.go
@@ -34,7 +34,7 @@ func GenerateDevToken() error {
 	expiryHoursStr := os.Getenv("EXPIRY_HOURS")
 
 	if tenantID == "" {
-		return fmt.Errorf("TENANT_ID is required (pass -tenant-id flag or set TENANT_ID env var)")
+		return fmt.Errorf("TENANT_ID is required")
 	}
 	if userID == "" {
 		userID = types.DefaultUserID


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a developer helper command for interactively generating development tokens with a required Tenant ID and optional Environment ID.

* **Bug Fixes**
  * Improved the missing Tenant ID error message to clearly indicate that the value is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->