### PR TITLE
feat(auth): update Supabase token claims to include environment_id

### DIFF
--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -64,7 +64,7 @@ type Provider interface {
 	// GenerateDevToken creates a short-lived JWT for internal developer testing.
 	// The claim schema is provider-specific:
 	//   flexprice → { user_id, tenant_id, environment_id }   (email ignored)
-	//   supabase  → { sub, email, app_metadata.tenant_id }   (environmentID ignored; pass X-Environment-ID header)
+	//   supabase  → { sub, email, app_metadata.tenant_id, environment_id }
 	GenerateDevToken(tenantID, environmentID, userID, email string, expiryHours int) (string, time.Time, error)
 
 	// GenerateCheckoutToken creates a short-lived JWT for frontend payment checkout flows.

--- a/internal/auth/supabase.go
+++ b/internal/auth/supabase.go
@@ -142,10 +142,13 @@ func (s *supabaseAuth) ValidateToken(ctx context.Context, token string) (*auth.C
 			Mark(ierr.ErrPermissionDenied)
 	}
 
+	environmentID, _ := claims["environment_id"].(string)
+
 	return &auth.Claims{
-		UserID:   userID,
-		TenantID: tenantID,
-		Email:    email,
+		UserID:        userID,
+		TenantID:      tenantID,
+		Email:         email,
+		EnvironmentID: environmentID,
 	}, nil
 }
 
@@ -174,9 +177,8 @@ func (s *supabaseAuth) AssignUserToTenant(ctx context.Context, userID string, te
 }
 
 // GenerateDevToken creates a short-lived JWT that matches the Supabase claim schema so it
-// passes supabaseAuth.ValidateToken: { sub, email, app_metadata.tenant_id }.
-// environmentID is accepted for interface compatibility but not embedded — pass X-Environment-ID header instead.
-func (s *supabaseAuth) GenerateDevToken(tenantID, _, userID, email string, expiryHours int) (string, time.Time, error) {
+// passes supabaseAuth.ValidateToken: { sub, email, app_metadata.tenant_id, environment_id }.
+func (s *supabaseAuth) GenerateDevToken(tenantID, environmentID, userID, email string, expiryHours int) (string, time.Time, error) {
 	if tenantID == "" {
 		return "", time.Time{}, ierr.NewError("tenantID is required").
 			WithHint("Provide a tenant ID to generate a dev token").
@@ -198,6 +200,9 @@ func (s *supabaseAuth) GenerateDevToken(tenantID, _, userID, email string, expir
 		},
 		"exp": expiresAt.Unix(),
 		"iat": time.Now().Unix(),
+	}
+	if environmentID != "" {
+		claims["environment_id"] = environmentID
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/internal/auth/supabase_test.go
+++ b/internal/auth/supabase_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSupabaseAuth() *supabaseAuth {
+	return &supabaseAuth{
+		AuthConfig: config.AuthConfig{
+			Secret: "test-secret-key-32-bytes-minimum!",
+		},
+	}
+}
+
+func TestSupabaseDevTokenEnvironmentID(t *testing.T) {
+	a := newTestSupabaseAuth()
+
+	t.Run("extracts top-level environment_id", func(t *testing.T) {
+		token, _, err := a.GenerateDevToken("tenant_123", "env_123", "user_123", "dev@example.com", 1)
+		require.NoError(t, err)
+
+		claims, err := a.ValidateToken(context.Background(), token)
+		require.NoError(t, err)
+		assert.Equal(t, "env_123", claims.EnvironmentID)
+	})
+
+	t.Run("allows an omitted environment_id", func(t *testing.T) {
+		token, _, err := a.GenerateDevToken("tenant_123", "", "user_123", "dev@example.com", 1)
+		require.NoError(t, err)
+
+		claims, err := a.ValidateToken(context.Background(), token)
+		require.NoError(t, err)
+		assert.Empty(t, claims.EnvironmentID)
+	})
+
+	t.Run("ignores a non-string environment_id", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"sub":            "user_123",
+			"email":          "dev@example.com",
+			"environment_id": 123,
+			"app_metadata": map[string]interface{}{
+				"tenant_id": "tenant_123",
+			},
+		})
+		signed, err := token.SignedString([]byte(a.AuthConfig.Secret))
+		require.NoError(t, err)
+
+		claims, err := a.ValidateToken(context.Background(), signed)
+		require.NoError(t, err)
+		assert.Empty(t, claims.EnvironmentID)
+	})
+}

--- a/scripts/internal/generate_dev_token.go
+++ b/scripts/internal/generate_dev_token.go
@@ -17,7 +17,7 @@ import (
 // Environment variables:
 //
 //	TENANT_ID       required
-//	ENVIRONMENT_ID  optional (flexprice provider embeds it; supabase provider ignores it — pass X-Environment-ID header)
+//	ENVIRONMENT_ID  optional (embedded as environment_id when provided)
 //	USER_ID         optional, defaults to types.DefaultUserID
 //	USER_EMAIL      required when auth.provider=supabase, defaults to "dev@flexprice.io"
 //	EXPIRY_HOURS    optional, defaults to 1
@@ -25,7 +25,7 @@ import (
 // The claim schema is chosen automatically based on auth.provider in config:
 //
 //	flexprice → { user_id, tenant_id, environment_id, exp, iat }
-//	supabase  → { sub, email, app_metadata.tenant_id, exp, iat }
+//	supabase  → { sub, email, app_metadata.tenant_id, environment_id, exp, iat }
 func GenerateDevToken() error {
 	tenantID := os.Getenv("TENANT_ID")
 	environmentID := os.Getenv("ENVIRONMENT_ID")
@@ -72,7 +72,11 @@ func GenerateDevToken() error {
 	if cfg.Auth.Provider == types.AuthProviderSupabase {
 		fmt.Printf("User ID (sub):  %s\n", userID)
 		fmt.Printf("Email:          %s\n", userEmail)
-		fmt.Printf("Environment ID: (not in token — pass X-Environment-ID header)\n")
+		if environmentID != "" {
+			fmt.Printf("Environment ID: %s\n", environmentID)
+		} else {
+			fmt.Printf("Environment ID: (not set — use X-Environment-ID header)\n")
+		}
 	} else {
 		fmt.Printf("User ID:        %s\n", userID)
 		if environmentID != "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supabase authentication tokens now support an optional `environment_id` claim.
  * Environment IDs are automatically extracted during token validation when provided.

* **Documentation**
  * Updated development token guidance and command output to clarify environment ID handling for Supabase authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->