### PR TITLE
bug(subscription): Idempotency key support for proration invoices

### DIFF
--- a/docs/design/2026-07-22-proration-charge-invoice-idempotency.md
+++ b/docs/design/2026-07-22-proration-charge-invoice-idempotency.md
@@ -98,7 +98,7 @@ erDiagram
         string billing_reason "SUBSCRIPTION_UPDATE"
         datetime period_start "effective_date for charges"
         datetime period_end "CurrentPeriodEnd"
-        string idempotency_key UK "explicit for charges; auto for cycle"
+        string idempotency_key "tenant+env UK when published and not voided; explicit for charges"
         int billing_sequence "from billing_sequences"
         string invoice_status
     }

--- a/docs/design/2026-07-22-proration-charge-invoice-idempotency.md
+++ b/docs/design/2026-07-22-proration-charge-invoice-idempotency.md
@@ -1,0 +1,200 @@
+# Proration Charge Invoice Idempotency — Design ERD
+
+Status: **Implemented** — mid-cycle quantity-change / line-item proration charges use operation-scoped keys  
+Date: 2026-07-22  
+Related: [Payment-Gated Quantity Change](./2026-07-17-payment-gated-quantity-change.md), `CreateEmptyDraftInvoice` in `internal/ee/service/invoice.go`
+
+---
+
+## 1. Problem Statement
+
+Mid-cycle proration **charge** invoices set `SubscriptionID`, `BillingReason = SUBSCRIPTION_UPDATE`, and `PeriodStart = effective_date`, but historically omitted `IdempotencyKey`.
+
+They therefore inherited **period-invoice** uniqueness:
+
+1. Auto key = hash(`sub` + `billing_reason` + period)
+2. `GetForPeriod(sub, period_start, period_end, billing_reason)`
+
+So upgrading **distinct** line items at the **same** `effective_date` collided after the first invoice was finalized/paid (`invoice already exists`), even though each change is a separate ONE_OFF charge.
+
+Wallet **credits** for the same flow already used an explicit key (`proration_credit_{sub}_{lineItem}_{effectiveDate}`) and were fine.
+
+**Goal:** operation-scoped uniqueness for proration charges (mirror credits), without changing cycle / opening invoice period uniqueness.
+
+---
+
+
+
+## 2. Approach
+
+
+
+### 2.1 Explicit charge keys (caller owns uniqueness)
+
+
+| Path                               | Key |
+| ---------------------------------- | --- |
+| Pay-later per-item charge          | `idempotency.Generator` with `ScopeProrationCharge` |
+| Pay-first aggregated DRAFT         | same scope; `line_item_changes` covers **all** `(lineItemID, effectiveDate)` pairs |
+
+Key shape: `proration_charge-{16hex}` from `GenerateKey` (SHA-256, first 8 bytes). Params: `subscription_id`, `line_item_changes` (sorted `"liID|RFC3339"` lines joined by `\n`).
+
+Helper: `prorationChargeIdempotencyKey` in `subscription_modification_quantity.go` (wraps the generator).  
+DTO already copies `IdempotencyKey` via `CreateInvoiceRequest.ToDraftRequest()`.
+
+Out of scope: add/delete line-item proration via `line_item_proration.settleCharge` (not on the modification execute path).
+
+### 2.2 Skip period uniqueness when a key is supplied
+
+In `CreateEmptyDraftInvoice`:
+
+- `GetForPeriod` runs **only** when `req.IdempotencyKey == nil` (cycle / opening / auto-keyed path).
+- `GetNextBillingSequence` still runs for every subscription-scoped create (counter only — not a uniqueness gate).
+
+
+
+### 2.3 What did **not** change
+
+- Auto-key formula for subscription invoices when no caller key is passed
+- Wallet credit key shape
+- Add/delete line-item proration charge path (`line_item_proration.settleCharge`)
+- Schema / unique indexes (period uniqueness remains app-enforced; real unique index is on `(tenant, environment, idempotency_key)` for published non-voided invoices)
+
+---
+
+
+
+## 3. ERD
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ SUBSCRIPTION : owns
+    SUBSCRIPTION ||--o{ SUBSCRIPTION_LINE_ITEM : has
+    SUBSCRIPTION ||--o{ INVOICE : generates
+    SUBSCRIPTION ||--|| BILLING_SEQUENCE : sequences
+    INVOICE ||--o{ INVOICE_LINE_ITEM : contains
+    SUBSCRIPTION_LINE_ITEM ||..o{ INVOICE : "charge fingerprint input"
+    CUSTOMER ||--o{ WALLET_TRANSACTION : "downgrade credits"
+
+    SUBSCRIPTION {
+        string id PK
+        string customer_id FK
+        datetime current_period_start
+        datetime current_period_end
+    }
+
+    SUBSCRIPTION_LINE_ITEM {
+        string id PK
+        string subscription_id FK
+        decimal quantity
+        datetime start_date
+        datetime end_date "set on apply"
+    }
+
+    INVOICE {
+        string id PK
+        string subscription_id FK
+        string invoice_type "ONE_OFF for proration charges"
+        string billing_reason "SUBSCRIPTION_UPDATE"
+        datetime period_start "effective_date for charges"
+        datetime period_end "CurrentPeriodEnd"
+        string idempotency_key UK "explicit for charges; auto for cycle"
+        int billing_sequence "from billing_sequences"
+        string invoice_status
+    }
+
+    INVOICE_LINE_ITEM {
+        string id PK
+        string invoice_id FK
+        decimal amount
+        datetime period_start
+        datetime period_end
+    }
+
+    BILLING_SEQUENCE {
+        string tenant_id PK
+        string subscription_id PK
+        int last_sequence
+    }
+
+    WALLET_TRANSACTION {
+        string id PK
+        string customer_id FK
+        string idempotency_key UK "proration_credit_sub_li_date"
+        string transaction_reason "SUBSCRIPTION_CREDIT"
+    }
+```
+
+
+
+**No new tables.** Behavior delta only:
+
+
+| Piece                      | Change                                                    |
+| -------------------------- | --------------------------------------------------------- |
+| `invoices.idempotency_key` | Set by modification / LI-proration charge builders        |
+| `CreateEmptyDraftInvoice`  | Skip `GetForPeriod` when caller supplies `IdempotencyKey` |
+| `billing_sequences`        | Unchanged (still incremented)                             |
+
+
+---
+
+
+
+## 4. Uniqueness model
+
+```mermaid
+flowchart TD
+  create[CreateEmptyDraftInvoice]
+  hasKey{IdempotencyKey set?}
+  autoKey[Auto-hash sub + reason + period]
+  byKey[GetByIdempotencyKey]
+  period{GetForPeriod}
+  seq[GetNextBillingSequence]
+  persist[Create draft invoice]
+
+  create --> hasKey
+  hasKey -->|no| autoKey --> byKey
+  hasKey -->|yes| byKey
+  byKey --> periodGate{IdempotencyKey nil?}
+  periodGate -->|yes cycle path| period --> seq
+  periodGate -->|no caller-keyed| seq
+  seq --> persist
+```
+
+
+
+
+| Invoice kind                                     | Key source                        | `GetForPeriod` |
+| ------------------------------------------------ | --------------------------------- | -------------- |
+| `SUBSCRIPTION_CYCLE` / create / trial opening    | Auto                              | Yes            |
+| Proration ONE_OFF charge (`SUBSCRIPTION_UPDATE`) | Explicit `proration_charge-…` (generator) | No             |
+| Proration wallet credit                          | Explicit on `wallet_transactions` | N/A            |
+
+
+---
+
+
+
+## 5. Code map
+
+
+| File                                                        | Role                                                                       |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `internal/ee/service/invoice.go`                            | Gate `GetForPeriod` on nil caller key                                      |
+| `internal/idempotency/generator.go`                         | `ScopeProrationCharge`                                                     |
+| `internal/ee/service/subscription_modification_quantity.go` | `prorationChargeIdempotencyKey` via generator; set key on builders         |
+| `internal/ee/service/subscription_modification_test.go`     | Distinct LIs, same `effective_date`                                        |
+
+
+---
+
+
+
+## 6. Multi-effective-date note
+
+One `quantity_change` request may include multiple line items with **different** `effective_date`s.
+
+- **Pay-later:** one charge invoice (or wallet credit) per item → per-item fingerprint.
+- **Pay-first:** one aggregated DRAFT; invoice `period_start` is the earliest date, but the idempotency fingerprint hashes **all** `(liID, effectiveDate)` pairs so mixed-date batches do not collide.
+

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -230,29 +230,33 @@ func (s *invoiceService) CreateEmptyDraftInvoice(ctx context.Context, req dto.Cr
 			return ierr.NewError("invoice already exists").WithHint("invoice already exists").Mark(ierr.ErrAlreadyExists)
 		}
 
-		// 3. For subscription invoices, check period uniqueness and get billing sequence
+		// 3. For subscription invoices, check period uniqueness (when no caller key) and get billing sequence.
+		// Callers that supply IdempotencyKey own uniqueness (e.g. mid-cycle one-off proration charges).
+		// Period uniqueness remains for cycle/opening invoices that rely on the auto-generated key.
 		var billingSeq *int
 		if req.SubscriptionID != nil {
-			existingForPeriod, err := s.InvoiceRepo.GetForPeriod(txCtx, *req.SubscriptionID, *req.PeriodStart, *req.PeriodEnd, string(req.BillingReason))
-			if err != nil && !ierr.IsNotFound(err) {
-				return err
-			}
-			if existingForPeriod != nil {
-				if existingForPeriod.InvoiceStatus == types.InvoiceStatusDraft || existingForPeriod.InvoiceStatus == types.InvoiceStatusSkipped {
-					s.Logger.Info(ctx, "draft/skipped invoice already exists for period, returning existing",
+			if req.IdempotencyKey == nil {
+				existingForPeriod, err := s.InvoiceRepo.GetForPeriod(txCtx, *req.SubscriptionID, *req.PeriodStart, *req.PeriodEnd, string(req.BillingReason))
+				if err != nil && !ierr.IsNotFound(err) {
+					return err
+				}
+				if existingForPeriod != nil {
+					if existingForPeriod.InvoiceStatus == types.InvoiceStatusDraft || existingForPeriod.InvoiceStatus == types.InvoiceStatusSkipped {
+						s.Logger.Info(ctx, "draft/skipped invoice already exists for period, returning existing",
+							"invoice_id", existingForPeriod.ID,
+							"subscription_id", *req.SubscriptionID,
+							"period_start", *req.PeriodStart,
+							"period_end", *req.PeriodEnd)
+						resp = dto.NewInvoiceResponse(existingForPeriod)
+						return nil
+					}
+					s.Logger.Debug(ctx, "invoice already exists for subscription period",
 						"invoice_id", existingForPeriod.ID,
 						"subscription_id", *req.SubscriptionID,
 						"period_start", *req.PeriodStart,
 						"period_end", *req.PeriodEnd)
-					resp = dto.NewInvoiceResponse(existingForPeriod)
-					return nil
+					return ierr.NewError("invoice already exists").WithHint("invoice already exists for this period").Mark(ierr.ErrAlreadyExists)
 				}
-				s.Logger.Debug(ctx, "invoice already exists for subscription period",
-					"invoice_id", existingForPeriod.ID,
-					"subscription_id", *req.SubscriptionID,
-					"period_start", *req.PeriodStart,
-					"period_end", *req.PeriodEnd)
-				return ierr.NewError("invoice already exists").WithHint("invoice already exists for this period").Mark(ierr.ErrAlreadyExists)
 			}
 
 			// Get billing sequence

--- a/internal/ee/service/subscription_modification_quantity.go
+++ b/internal/ee/service/subscription_modification_quantity.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/idempotency"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 )
@@ -994,6 +996,7 @@ func buildAggregatedProrationChargeInvoiceRequest(
 	var periodStart *time.Time
 	periodEnd := sub.CurrentPeriodEnd
 	billingPeriod := string(sub.BillingPeriod)
+	keyParts := make([]prorationChargeKeyPart, 0, len(items))
 
 	for _, item := range items {
 		single := buildProrationChargeInvoiceRequest(sub, item)
@@ -1002,8 +1005,17 @@ func buildAggregatedProrationChargeInvoiceRequest(
 		if single.PeriodStart != nil && (periodStart == nil || single.PeriodStart.Before(*periodStart)) {
 			periodStart = single.PeriodStart
 		}
+		if mod := item.getMod(); mod != nil {
+			if oldItem := mod.getOldLineItem(); oldItem != nil {
+				keyParts = append(keyParts, prorationChargeKeyPart{
+					lineItemID:    oldItem.ID,
+					effectiveDate: mod.getEffectiveDate(),
+				})
+			}
+		}
 	}
 
+	idempKey := prorationChargeIdempotencyKey(sub.ID, keyParts)
 	return dto.CreateInvoiceRequest{
 		CustomerID:     sub.GetInvoicingCustomerID(),
 		SubscriptionID: &sub.ID,
@@ -1017,6 +1029,7 @@ func buildAggregatedProrationChargeInvoiceRequest(
 		PeriodEnd:      &periodEnd,
 		BillingPeriod:  &billingPeriod,
 		LineItems:      lineItems,
+		IdempotencyKey: &idempKey,
 	}
 }
 
@@ -1153,6 +1166,10 @@ func buildProrationChargeInvoiceRequest(
 		strings.ToUpper(sub.Currency), price.Price.Amount.String(),
 		effectiveDate.Format("2 Jan 2006"), periodEnd.Format("2 Jan 2006"))
 
+	idempKey := prorationChargeIdempotencyKey(sub.ID, []prorationChargeKeyPart{{
+		lineItemID:    oldItem.ID,
+		effectiveDate: effectiveDate,
+	}})
 	return dto.CreateInvoiceRequest{
 		CustomerID:     billingCustomer,
 		SubscriptionID: &sub.ID,
@@ -1165,6 +1182,7 @@ func buildProrationChargeInvoiceRequest(
 		PeriodStart:    &effectiveDate,
 		PeriodEnd:      &periodEnd,
 		BillingPeriod:  &billingPeriod,
+		IdempotencyKey: &idempKey,
 		LineItems: []dto.CreateInvoiceLineItemRequest{
 			{
 				PriceID:         &priceID,
@@ -1179,6 +1197,28 @@ func buildProrationChargeInvoiceRequest(
 			},
 		},
 	}
+}
+
+// prorationChargeKeyPart identifies one line-item change for charge invoice idempotency.
+type prorationChargeKeyPart struct {
+	lineItemID    string
+	effectiveDate time.Time
+}
+
+// prorationChargeIdempotencyKey builds a stable key via idempotency.Generator.
+// Params include subscription_id and a sorted "lineItemID|RFC3339" payload so
+// per-item and batch keys share one format and mixed effective dates stay unique.
+func prorationChargeIdempotencyKey(subID string, parts []prorationChargeKeyPart) string {
+	lines := make([]string, 0, len(parts))
+	for _, p := range parts {
+		lines = append(lines, p.lineItemID+"|"+p.effectiveDate.UTC().Format(time.RFC3339))
+	}
+	sort.Strings(lines)
+	
+	return idempotency.NewGenerator().GenerateKey(idempotency.ScopeProrationCharge, map[string]interface{}{
+		"subscription_id":   subID,
+		"line_item_changes": strings.Join(lines, "\n"),
+	})
 }
 
 // validateQuantityChangeEffectiveDateWithinLineItemWindow ensures effectiveDate lies in

--- a/internal/ee/service/subscription_modification_quantity.go
+++ b/internal/ee/service/subscription_modification_quantity.go
@@ -1007,10 +1007,7 @@ func buildAggregatedProrationChargeInvoiceRequest(
 		}
 		if mod := item.getMod(); mod != nil {
 			if oldItem := mod.getOldLineItem(); oldItem != nil {
-				keyParts = append(keyParts, prorationChargeKeyPart{
-					lineItemID:    oldItem.ID,
-					effectiveDate: mod.getEffectiveDate(),
-				})
+				keyParts = append(keyParts, newProrationChargeKeyPart(oldItem.ID, mod.getEffectiveDate()))
 			}
 		}
 	}
@@ -1166,10 +1163,9 @@ func buildProrationChargeInvoiceRequest(
 		strings.ToUpper(sub.Currency), price.Price.Amount.String(),
 		effectiveDate.Format("2 Jan 2006"), periodEnd.Format("2 Jan 2006"))
 
-	idempKey := prorationChargeIdempotencyKey(sub.ID, []prorationChargeKeyPart{{
-		lineItemID:    oldItem.ID,
-		effectiveDate: effectiveDate,
-	}})
+	idempKey := prorationChargeIdempotencyKey(sub.ID, []prorationChargeKeyPart{
+		newProrationChargeKeyPart(oldItem.ID, effectiveDate),
+	})
 	return dto.CreateInvoiceRequest{
 		CustomerID:     billingCustomer,
 		SubscriptionID: &sub.ID,
@@ -1205,16 +1201,38 @@ type prorationChargeKeyPart struct {
 	effectiveDate time.Time
 }
 
+func newProrationChargeKeyPart(lineItemID string, effectiveDate time.Time) prorationChargeKeyPart {
+	return prorationChargeKeyPart{
+		lineItemID:    lineItemID,
+		effectiveDate: effectiveDate,
+	}
+}
+
+func (p *prorationChargeKeyPart) getLineItemID() string {
+	if p == nil {
+		return ""
+	}
+	return p.lineItemID
+}
+
+func (p *prorationChargeKeyPart) getEffectiveDate() time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return p.effectiveDate
+}
+
 // prorationChargeIdempotencyKey builds a stable key via idempotency.Generator.
 // Params include subscription_id and a sorted "lineItemID|RFC3339" payload so
 // per-item and batch keys share one format and mixed effective dates stay unique.
 func prorationChargeIdempotencyKey(subID string, parts []prorationChargeKeyPart) string {
 	lines := make([]string, 0, len(parts))
-	for _, p := range parts {
-		lines = append(lines, p.lineItemID+"|"+p.effectiveDate.UTC().Format(time.RFC3339))
+	for i := range parts {
+		p := &parts[i]
+		lines = append(lines, p.getLineItemID()+"|"+p.getEffectiveDate().UTC().Format(time.RFC3339))
 	}
 	sort.Strings(lines)
-	
+
 	return idempotency.NewGenerator().GenerateKey(idempotency.ScopeProrationCharge, map[string]interface{}{
 		"subscription_id":   subID,
 		"line_item_changes": strings.Join(lines, "\n"),

--- a/internal/ee/service/subscription_modification_test.go
+++ b/internal/ee/service/subscription_modification_test.go
@@ -509,21 +509,21 @@ func (s *SubscriptionModificationServiceSuite) TestProrationChargeIdempotencyKey
 	t1 := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
 	t2 := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
 
-	k1 := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{{lineItemID: "li_a", effectiveDate: t1}})
-	k1Again := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{{lineItemID: "li_a", effectiveDate: t1}})
-	k2 := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{{lineItemID: "li_b", effectiveDate: t1}})
+	k1 := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{newProrationChargeKeyPart("li_a", t1)})
+	k1Again := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{newProrationChargeKeyPart("li_a", t1)})
+	k2 := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{newProrationChargeKeyPart("li_b", t1)})
 	s.Equal(k1, k1Again)
 	s.NotEqual(k1, k2)
 	s.True(strings.HasPrefix(k1, "proration_charge-"))
 	s.LessOrEqual(len(k1), 100)
 
 	batchAB := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{
-		{lineItemID: "li_a", effectiveDate: t1},
-		{lineItemID: "li_b", effectiveDate: t2},
+		newProrationChargeKeyPart("li_a", t1),
+		newProrationChargeKeyPart("li_b", t2),
 	})
 	batchBA := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{
-		{lineItemID: "li_b", effectiveDate: t2},
-		{lineItemID: "li_a", effectiveDate: t1},
+		newProrationChargeKeyPart("li_b", t2),
+		newProrationChargeKeyPart("li_a", t1),
 	})
 	s.Equal(batchAB, batchBA, "batch fingerprint must be order-independent")
 	s.NotEqual(k1, batchAB)

--- a/internal/ee/service/subscription_modification_test.go
+++ b/internal/ee/service/subscription_modification_test.go
@@ -451,6 +451,84 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Advance
 	}
 }
 
+// TestExecuteQuantityChange_DistinctLineItems_SameEffectiveDate verifies that upgrading
+// two different ADVANCE line items at the same effective_date each creates its own
+// proration charge invoice (operation-scoped idempotency keys; not one-per-period).
+func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_DistinctLineItems_SameEffectiveDate() {
+	ctx := s.GetContext()
+	periodStart := s.GetNow()
+	periodEnd := periodStart.AddDate(0, 1, 0)
+	effectiveDate := periodStart.AddDate(0, 0, 15)
+
+	cust := s.createCustomer("distinct-li-same-eff")
+	sub := s.createActiveSub(cust.ID)
+	s.setSubPeriod(sub.ID, periodStart, periodEnd)
+
+	priceA := s.createFixedPrice(decimal.NewFromInt(50), types.InvoiceCadenceAdvance)
+	priceB := s.createFixedPrice(decimal.NewFromInt(40), types.InvoiceCadenceAdvance)
+	liA := s.createFixedLineItemWithPrice(sub.ID, cust.ID, decimal.NewFromInt(1), types.InvoiceCadenceAdvance, priceA.ID)
+	liB := s.createFixedLineItemWithPrice(sub.ID, cust.ID, decimal.NewFromInt(1), types.InvoiceCadenceAdvance, priceB.ID)
+
+	respA, err := s.service.Execute(ctx, sub.ID, dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeQuantityChange,
+		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
+			LineItems: []dto.LineItemQuantityChange{
+				{ID: liA.ID, Quantity: decimal.NewFromInt(3), EffectiveDate: &effectiveDate},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(respA.ChangedResources.Invoices, 1)
+	s.Equal(dto.ChangedInvoiceActionCreated, respA.ChangedResources.Invoices[0].Action)
+	invA, err := s.GetStores().InvoiceRepo.Get(ctx, respA.ChangedResources.Invoices[0].ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(invA.IdempotencyKey)
+	s.NotEqual(types.InvoiceStatusDraft, invA.InvoiceStatus)
+
+	respB, err := s.service.Execute(ctx, sub.ID, dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeQuantityChange,
+		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
+			LineItems: []dto.LineItemQuantityChange{
+				{ID: liB.ID, Quantity: decimal.NewFromInt(2), EffectiveDate: &effectiveDate},
+			},
+		},
+	})
+	s.Require().NoError(err, "second distinct line-item upgrade at same effective_date must succeed")
+	s.Require().Len(respB.ChangedResources.Invoices, 1)
+	s.Equal(dto.ChangedInvoiceActionCreated, respB.ChangedResources.Invoices[0].Action)
+	invB, err := s.GetStores().InvoiceRepo.Get(ctx, respB.ChangedResources.Invoices[0].ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(invB.IdempotencyKey)
+	s.NotEqual(*invA.IdempotencyKey, *invB.IdempotencyKey)
+	s.NotEqual(invA.ID, invB.ID)
+}
+
+// TestProrationChargeIdempotencyKey_StableAndDistinct covers the hashed charge key helper.
+func (s *SubscriptionModificationServiceSuite) TestProrationChargeIdempotencyKey_StableAndDistinct() {
+	subID := "sub_test"
+	t1 := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+
+	k1 := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{{lineItemID: "li_a", effectiveDate: t1}})
+	k1Again := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{{lineItemID: "li_a", effectiveDate: t1}})
+	k2 := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{{lineItemID: "li_b", effectiveDate: t1}})
+	s.Equal(k1, k1Again)
+	s.NotEqual(k1, k2)
+	s.True(strings.HasPrefix(k1, "proration_charge-"))
+	s.LessOrEqual(len(k1), 100)
+
+	batchAB := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{
+		{lineItemID: "li_a", effectiveDate: t1},
+		{lineItemID: "li_b", effectiveDate: t2},
+	})
+	batchBA := prorationChargeIdempotencyKey(subID, []prorationChargeKeyPart{
+		{lineItemID: "li_b", effectiveDate: t2},
+		{lineItemID: "li_a", effectiveDate: t1},
+	})
+	s.Equal(batchAB, batchBA, "batch fingerprint must be order-independent")
+	s.NotEqual(k1, batchAB)
+}
+
 // ─────────────────────────────────────────────
 // Arrear tests
 // ─────────────────────────────────────────────

--- a/internal/idempotency/generator.go
+++ b/internal/idempotency/generator.go
@@ -32,6 +32,9 @@ const (
 
 	// Wallet Credit Adjustment
 	ScopeWalletCreditAdjustment Scope = "wallet_credit_adjustment"
+
+	// Mid-cycle proration charge invoices (subscription quantity-change modify)
+	ScopeProrationCharge Scope = "proration_charge"
 )
 
 // Generator generates idempotency keys


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proration charge invoices during subscription quantity changes now use operation-specific idempotency keys.
  * Proration charges for separate line items with the same effective date can produce distinct invoices with different idempotency keys.
* **Bug Fixes**
  * Period-based duplicate prevention is now applied only when an idempotency key isn’t provided, reducing unintended collisions when keys are supplied.
* **Documentation**
  * Added a design document detailing proration charge idempotency behavior and invoice creation flow.
* **Tests**
  * Added tests for stable, order-independent, and distinct proration charge idempotency keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->