### PR TITLE
feat(wallet): Wallet auto topup cooloff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -664,3 +664,4 @@ the base toolchain on the box is older, so Go auto-downloads the required `1.25.
 
 1. Whenever creating new structs, keep them private, and expose their getters and constructors with proper nil handling and use those in code. Keep the structs and it's fields private and only expose them via getters with nil handlings.
 2. When updating entities, use their builders. If builder doesn't exist, create it and then use and set only the required fields. Builders should have always initiate by taking in input an existing entity and provide a builder instance of it.
+3. Only add comments when some logic or definition is complex to understand or there is an edge case. Don't write comments on generic logic and easy to understand structs and methods.

--- a/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
+++ b/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
@@ -129,7 +129,7 @@ erDiagram
 | `threshold` | yes | Trigger when ongoing balance ≤ this |
 | `amount` | yes | Credits/currency amount per auto-topup |
 | `invoicing` | yes | `true` → pending txn + invoice; `false` → direct credit |
-| `cooldown` | no | Omit = no cooloff. `unit`: `SECOND` \| `MINUTE` \| `HOUR` \| `DAY` |
+| `cooldown` | no | Omit = no cooloff. `unit`: `SECOND` \| `MINUTE` \| `HOUR` \| `DAY`. On **update**: omit/null = leave unchanged; `{ "value": 0, "unit": "<any>" }` = clear cooloff |
 
 ### 3.2 How rows relate for guards
 

--- a/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
+++ b/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
@@ -1,0 +1,196 @@
+# Wallet Auto Top-up — In-flight Guard & Optional Cooloff
+
+Status: **Implemented and QA’d via Postman (direct cooloff, direct burst, invoiced in-flight).**
+Date: 2026-07-22
+Postman: [`docs/postman/auto-topup-cooloff.postman_collection.json`](../postman/auto-topup-cooloff.postman_collection.json)
+
+---
+
+## 1. Problem Statement
+
+Auto top-up already fires when wallet ongoing balance ≤ threshold (`triggerAutoTopup`). Gaps:
+
+1. **Direct mode** nested re-eval could burst many completed credits in one evaluation chain until balance cleared the threshold.
+2. **In-flight** protection for invoiced mode was customer-scoped invoice payment status only; there was no wallet-scoped pending-txn guard for both modes.
+3. Product asked for an optional **cooloff** (minutes/days — now also seconds/hours) after a *successful* auto-topup before another may run. Evaluations during cooloff **skip** (no queue).
+
+Manual credit/debit/top-up must never be gated by these rules.
+
+---
+
+## 2. Approach (as implemented)
+
+### 2.1 Config
+
+- Extend `wallets.auto_topup` JSONB with optional `cooldown: { value, unit }`.
+- Generic `types.Duration` / `types.DurationUnit` (`SECOND` | `MINUTE` | `HOUR` | `DAY`) in [`internal/types/duration.go`](../../internal/types/duration.go). Optionality is `*Duration` at the call site.
+- No new table / migration — JSONB field already exists.
+
+### 2.2 Guards in `triggerAutoTopup`
+
+| Mode | Guards (in order) |
+|---|---|
+| Invoiced | Existing `hasPendingAutoTopupInvoice` (customer + `WALLET_AUTO_TOPUP`) **and** pending wallet txn matching auto-topup discriminator |
+| Direct | Pending wallet txn matching auto-topup discriminator only |
+| Both | Optional cooloff: last **completed** auto-topup txn `UpdatedAt`/`CreatedAt` + `cooldown` duration |
+
+Discriminator: `metadata.auto_topup = "true"` (`types.WalletMetadataKeyAutoTopup`). Manual purchased-credit txns lack this key.
+
+### 2.3 Generic ledger helpers
+
+Not auto-topup-named; reusable by reason and/or metadata:
+
+- `hasPendingWalletTransaction(ctx, walletID, lookup)`
+- `getLastCompletedWalletTransaction(ctx, walletID, lookup)`
+
+Lookup scans up to 50 recent rows for the wallet+status (index-friendly on `wallet_id`; metadata filtered in app). Cooloff/pending stay ledger-authoritative — no Redis TTL (pending invoices/txns have no natural expiry today).
+
+### 2.4 Cooloff semantics
+
+- Unset `cooldown` → previous behavior (direct can still burst).
+- Set → strict one successful auto-topup per window; nested re-eval and later debits skip until window ends.
+- No wake-up timer; next top-up needs a normal re-eval after cooloff (usage alert / debit / payment complete event).
+
+---
+
+## 3. ERD (as actually implemented)
+
+No new entities. Cooloff config lives inside existing `Wallet.auto_topup` JSONB. In-flight/cooloff state is derived from `WalletTransaction` (+ existing auto-topup `Invoice` for invoiced mode).
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ WALLET : "owns"
+    WALLET ||--o{ WALLET_TRANSACTION : "ledger"
+    CUSTOMER ||--o{ INVOICE : "billed"
+    WALLET_TRANSACTION }o--o| INVOICE : "purchased credit invoiced via metadata.wallet_transaction_id"
+
+    CUSTOMER {
+        string id PK
+        string tenant_id
+        string environment_id
+    }
+
+    WALLET {
+        string id PK
+        string customer_id FK
+        string currency
+        string wallet_type
+        numeric credit_balance
+        jsonb auto_topup "AutoTopup config — see nested shape"
+        string tenant_id
+        string environment_id
+    }
+
+    WALLET_TRANSACTION {
+        string id PK
+        string wallet_id FK
+        string customer_id
+        string type "credit | debit"
+        string transaction_status "pending | completed | failed"
+        string transaction_reason
+        jsonb metadata "auto_topup=true marks auto top-up rows"
+        numeric credit_amount
+        timestamp created_at
+        timestamp updated_at
+        string tenant_id
+        string environment_id
+    }
+
+    INVOICE {
+        string id PK
+        string customer_id FK
+        string billing_reason "WALLET_AUTO_TOPUP for invoiced auto top-up"
+        string invoice_status
+        string payment_status
+        jsonb metadata "wallet_id, wallet_transaction_id, auto_topup"
+        string tenant_id
+        string environment_id
+    }
+```
+
+### 3.1 `auto_topup` JSON shape (on `WALLET`)
+
+```json
+{
+  "enabled": true,
+  "threshold": "50",
+  "amount": "10",
+  "invoicing": false,
+  "cooldown": {
+    "value": 1,
+    "unit": "MINUTE"
+  }
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `enabled` | yes* | `*` when configuring AutoTopup |
+| `threshold` | yes | Trigger when ongoing balance ≤ this |
+| `amount` | yes | Credits/currency amount per auto-topup |
+| `invoicing` | yes | `true` → pending txn + invoice; `false` → direct credit |
+| `cooldown` | no | Omit = no cooloff. `unit`: `SECOND` \| `MINUTE` \| `HOUR` \| `DAY` |
+
+### 3.2 How rows relate for guards
+
+```mermaid
+flowchart LR
+  subgraph config [Config]
+    AT[Wallet.auto_topup.cooldown]
+  end
+  subgraph inflight [In-flight]
+    PT[WalletTransaction pending + metadata.auto_topup]
+    INV[Invoice WALLET_AUTO_TOPUP unpaid]
+  end
+  subgraph cooloff [Cooloff clock]
+    CT[WalletTransaction completed + metadata.auto_topup]
+  end
+  AT --> cooloff
+  PT --> triggerSkip[triggerAutoTopup skip]
+  INV --> triggerSkip
+  CT --> triggerSkip
+```
+
+---
+
+## 4. Decision flow
+
+```mermaid
+flowchart TD
+  start[triggerAutoTopup] --> en{enabled?}
+  en -->|no| out[skip]
+  en -->|yes| th{balance lessOrEqual threshold?}
+  th -->|no| out
+  th -->|yes| inv{invoicing?}
+  inv -->|yes| invPend{hasPendingAutoTopupInvoice}
+  invPend -->|yes| out
+  invPend -->|no| txnPend
+  inv -->|no| txnPend{hasPendingWalletTransaction auto_topup}
+  txnPend -->|yes| out
+  txnPend -->|no| cd{cooldown set?}
+  cd -->|no| topup[TopUpWallet metadata.auto_topup]
+  cd -->|yes| within{now less than lastCompleted plus cooldown}
+  within -->|yes| out
+  within -->|no| topup
+```
+
+---
+
+## 5. Key code
+
+| Piece | Location |
+|---|---|
+| `types.Duration` / `DurationUnit` | `internal/types/duration.go` |
+| `AutoTopup.Cooldown`, `WalletMetadataKeyAutoTopup` | `internal/types/wallet.go` |
+| Guards + helpers | `internal/ee/service/wallet.go` (`triggerAutoTopup`, `hasPendingWalletTransaction`, `getLastCompletedWalletTransaction`, `isWithinAutoTopupCooldown`) |
+| Legacy invoice guard (kept) | `hasPendingAutoTopupInvoice` |
+| Unit tests | `internal/types/duration_test.go`, `internal/ee/service/wallet_test.go` (`WalletAutoTopupInvoiceSuite`, `WalletAutoTopupDirectSuite`) |
+
+---
+
+## 6. Out of scope / known limits
+
+- No Redis cooloff/pending keys (ledger remains source of truth).
+- No natural expiry for pending wallet txns or unpaid auto-topup invoices — a stuck pending row blocks further auto-topups until paid/voided/completed.
+- Cooloff completed-txn lookup considers the latest 50 completed rows for the wallet; dense non-auto-topup traffic could theoretically miss an older auto-topup marker (acceptable for v1).
+- No scheduled wake-up when cooloff ends.

--- a/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
+++ b/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
@@ -38,7 +38,7 @@ Discriminator: `metadata.auto_topup = "true"` (`types.WalletMetadataKeyAutoTopup
 
 ### 2.3 Single ledger lookup
 
-`WalletRepo.GetLastWalletAutoTopupTransaction(ctx, walletID)` returns the most recent published txn with `metadata.auto_topup=true` (`created_at` desc), or nil.
+`WalletRepo.GetLastAutoTopupTransactionForWallet(ctx, walletID)` returns the most recent published txn with `metadata.auto_topup=true` (`created_at` desc), or nil.
 
 `triggerAutoTopup` uses that one row for both guards:
 1. pending → skip (in-flight)
@@ -166,7 +166,7 @@ flowchart TD
   inv -->|yes| invPend{hasPendingAutoTopupInvoice}
   invPend -->|yes| out
   invPend -->|no| lastTxn
-  inv -->|no| lastTxn[GetLastWalletAutoTopupTransaction]
+  inv -->|no| lastTxn[GetLastAutoTopupTransactionForWallet]
   lastTxn --> pending{last txn pending?}
   pending -->|yes| out
   pending -->|no| cd{cooldown set?}
@@ -184,7 +184,7 @@ flowchart TD
 |---|---|
 | `types.Duration` / `DurationUnit` | `internal/types/duration.go` |
 | `AutoTopup.Cooldown`, `WalletMetadataKeyAutoTopup` | `internal/types/wallet.go` |
-| Repo lookup | `WalletRepo.GetLastWalletAutoTopupTransaction` (`internal/domain/wallet`, ent + inmemory) |
+| Repo lookup | `WalletRepo.GetLastAutoTopupTransactionForWallet` (`internal/domain/wallet`, ent + inmemory) |
 | Guards | `internal/ee/service/wallet.go` (`triggerAutoTopup`, `isWithinAutoTopupCooldown`) |
 | Legacy invoice guard (kept) | `hasPendingAutoTopupInvoice` |
 | Unit tests | `internal/types/duration_test.go`, `internal/ee/service/wallet_test.go` (`WalletAutoTopupInvoiceSuite`, `WalletAutoTopupDirectSuite`) |

--- a/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
+++ b/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
@@ -32,7 +32,7 @@ Manual credit/debit/top-up must never be gated by these rules.
 |---|---|
 | Invoiced | Existing `hasPendingAutoTopupInvoice` (customer + `WALLET_AUTO_TOPUP`) **and** latest auto-topup wallet txn pending |
 | Direct | Latest auto-topup wallet txn pending |
-| Both | Optional cooloff from the same latest auto-topup txn (`UpdatedAt`/`CreatedAt` + `cooldown`) when it is not pending |
+| Both | Optional cooloff from the same latest auto-topup txn (`CreatedAt` + `cooldown`) when it is not pending. 
 
 Discriminator: `metadata.auto_topup = "true"` (`types.WalletMetadataKeyAutoTopup`). Manual purchased-credit txns lack this key.
 

--- a/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
+++ b/docs/design/2026-07-22-wallet-auto-topup-cooloff.md
@@ -30,20 +30,21 @@ Manual credit/debit/top-up must never be gated by these rules.
 
 | Mode | Guards (in order) |
 |---|---|
-| Invoiced | Existing `hasPendingAutoTopupInvoice` (customer + `WALLET_AUTO_TOPUP`) **and** pending wallet txn matching auto-topup discriminator |
-| Direct | Pending wallet txn matching auto-topup discriminator only |
-| Both | Optional cooloff: last **completed** auto-topup txn `UpdatedAt`/`CreatedAt` + `cooldown` duration |
+| Invoiced | Existing `hasPendingAutoTopupInvoice` (customer + `WALLET_AUTO_TOPUP`) **and** latest auto-topup wallet txn pending |
+| Direct | Latest auto-topup wallet txn pending |
+| Both | Optional cooloff from the same latest auto-topup txn (`UpdatedAt`/`CreatedAt` + `cooldown`) when it is not pending |
 
 Discriminator: `metadata.auto_topup = "true"` (`types.WalletMetadataKeyAutoTopup`). Manual purchased-credit txns lack this key.
 
-### 2.3 Generic ledger helpers
+### 2.3 Single ledger lookup
 
-Not auto-topup-named; reusable by reason and/or metadata:
+`WalletRepo.GetLastWalletAutoTopupTransaction(ctx, walletID)` returns the most recent published txn with `metadata.auto_topup=true` (`created_at` desc), or nil.
 
-- `hasPendingWalletTransaction(ctx, walletID, lookup)`
-- `getLastCompletedWalletTransaction(ctx, walletID, lookup)`
+`triggerAutoTopup` uses that one row for both guards:
+1. pending → skip (in-flight)
+2. otherwise → cooloff check from its timestamp (when `cooldown` is set)
 
-Lookup scans up to 50 recent rows for the wallet+status (index-friendly on `wallet_id`; metadata filtered in app). Cooloff/pending stay ledger-authoritative — no Redis TTL (pending invoices/txns have no natural expiry today).
+Cooloff/pending stay ledger-authoritative — no Redis TTL (pending invoices/txns have no natural expiry today).
 
 ### 2.4 Cooloff semantics
 
@@ -164,12 +165,13 @@ flowchart TD
   th -->|yes| inv{invoicing?}
   inv -->|yes| invPend{hasPendingAutoTopupInvoice}
   invPend -->|yes| out
-  invPend -->|no| txnPend
-  inv -->|no| txnPend{hasPendingWalletTransaction auto_topup}
-  txnPend -->|yes| out
-  txnPend -->|no| cd{cooldown set?}
+  invPend -->|no| lastTxn
+  inv -->|no| lastTxn[GetLastWalletAutoTopupTransaction]
+  lastTxn --> pending{last txn pending?}
+  pending -->|yes| out
+  pending -->|no| cd{cooldown set?}
   cd -->|no| topup[TopUpWallet metadata.auto_topup]
-  cd -->|yes| within{now less than lastCompleted plus cooldown}
+  cd -->|yes| within{now less than lastTxn plus cooldown}
   within -->|yes| out
   within -->|no| topup
 ```
@@ -182,7 +184,8 @@ flowchart TD
 |---|---|
 | `types.Duration` / `DurationUnit` | `internal/types/duration.go` |
 | `AutoTopup.Cooldown`, `WalletMetadataKeyAutoTopup` | `internal/types/wallet.go` |
-| Guards + helpers | `internal/ee/service/wallet.go` (`triggerAutoTopup`, `hasPendingWalletTransaction`, `getLastCompletedWalletTransaction`, `isWithinAutoTopupCooldown`) |
+| Repo lookup | `WalletRepo.GetLastWalletAutoTopupTransaction` (`internal/domain/wallet`, ent + inmemory) |
+| Guards | `internal/ee/service/wallet.go` (`triggerAutoTopup`, `isWithinAutoTopupCooldown`) |
 | Legacy invoice guard (kept) | `hasPendingAutoTopupInvoice` |
 | Unit tests | `internal/types/duration_test.go`, `internal/ee/service/wallet_test.go` (`WalletAutoTopupInvoiceSuite`, `WalletAutoTopupDirectSuite`) |
 

--- a/internal/domain/wallet/repository.go
+++ b/internal/domain/wallet/repository.go
@@ -27,8 +27,6 @@ type Repository interface {
 	ListWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	ListAllWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	CountWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) (int, error)
-	// GetLastWalletAutoTopupTransaction returns the most recent wallet transaction
-	// with metadata.auto_topup=true (created_at desc), or nil if none exists.
 	GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*Transaction, error)
 	UpdateTransactionStatus(ctx context.Context, id string, status types.TransactionStatus) error
 	UpdateTransaction(ctx context.Context, tx *Transaction) error

--- a/internal/domain/wallet/repository.go
+++ b/internal/domain/wallet/repository.go
@@ -27,7 +27,7 @@ type Repository interface {
 	ListWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	ListAllWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	CountWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) (int, error)
-	GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*Transaction, error)
+	GetLastAutoTopupTransactionForWallet(ctx context.Context, walletID string) (*Transaction, error)
 	UpdateTransactionStatus(ctx context.Context, id string, status types.TransactionStatus) error
 	UpdateTransaction(ctx context.Context, tx *Transaction) error
 

--- a/internal/domain/wallet/repository.go
+++ b/internal/domain/wallet/repository.go
@@ -27,6 +27,9 @@ type Repository interface {
 	ListWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	ListAllWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*Transaction, error)
 	CountWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) (int, error)
+	// GetLastWalletAutoTopupTransaction returns the most recent wallet transaction
+	// with metadata.auto_topup=true (created_at desc), or nil if none exists.
+	GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*Transaction, error)
 	UpdateTransactionStatus(ctx context.Context, id string, status types.TransactionStatus) error
 	UpdateTransaction(ctx context.Context, tx *Transaction) error
 

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -1556,7 +1556,7 @@ func (s *walletService) UpdateWallet(ctx context.Context, id string, req *dto.Up
 			current.Invoicing = req.AutoTopup.Invoicing
 		}
 		if req.AutoTopup.Cooldown != nil {
-			if req.AutoTopup.Cooldown.ShouldClearCooldown() {
+			if req.AutoTopup.Cooldown.IsEmpty() {
 				current.Cooldown = nil
 			} else {
 				current.Cooldown = req.AutoTopup.Cooldown
@@ -3686,8 +3686,6 @@ func (s *walletService) hasPendingAutoTopupInvoice(ctx context.Context, customer
 	return len(invoices) > 0, nil
 }
 
-// isWithinAutoTopupCooldown reports whether last auto-topup txn still falls inside
-// the wallet's configured cooldown window. last may be nil (no prior auto-topup).
 func (s *walletService) isWithinAutoTopupCooldown(w *wallet.Wallet, last *wallet.Transaction) (bool, error) {
 	if w.AutoTopup == nil || !w.AutoTopup.Cooldown.IsSet() || last == nil {
 		return false, nil
@@ -3698,12 +3696,7 @@ func (s *walletService) isWithinAutoTopupCooldown(w *wallet.Wallet, last *wallet
 		return false, err
 	}
 
-	anchor := last.UpdatedAt
-	if anchor.IsZero() {
-		anchor = last.CreatedAt
-	}
-
-	return time.Now().UTC().Before(anchor.Add(cooldown)), nil
+	return time.Now().UTC().Before(last.CreatedAt.Add(cooldown)), nil
 }
 
 // triggerAutoTopup checks if auto top-up is enabled and triggers it if needed.
@@ -3750,7 +3743,6 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 			}
 		}
 
-		// Single lookup: latest auto-topup txn drives both in-flight + cooloff.
 		lastAutoTopup, err := s.WalletRepo.GetLastWalletAutoTopupTransaction(ctx, w.ID)
 		if err != nil {
 			s.Logger.Error(ctx, "failed to get last auto-topup wallet transaction",

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -3743,7 +3743,7 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 			}
 		}
 
-		lastAutoTopup, err := s.WalletRepo.GetLastWalletAutoTopupTransaction(ctx, w.ID)
+		lastAutoTopup, err := s.WalletRepo.GetLastAutoTopupTransactionForWallet(ctx, w.ID)
 		if err != nil {
 			s.Logger.Error(ctx, "failed to get last auto-topup wallet transaction",
 				"error", err,

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -1556,8 +1556,7 @@ func (s *walletService) UpdateWallet(ctx context.Context, id string, req *dto.Up
 			current.Invoicing = req.AutoTopup.Invoicing
 		}
 		if req.AutoTopup.Cooldown != nil {
-			// value == 0 clears; omit/null leaves unchanged (partial update).
-			if req.AutoTopup.Cooldown.IsClearSentinel() {
+			if req.AutoTopup.Cooldown.ShouldClearCooldown() {
 				current.Cooldown = nil
 			} else {
 				current.Cooldown = req.AutoTopup.Cooldown
@@ -3687,103 +3686,16 @@ func (s *walletService) hasPendingAutoTopupInvoice(ctx context.Context, customer
 	return len(invoices) > 0, nil
 }
 
-// walletTransactionLookup discriminates wallet transactions for generic pending /
-// last-completed lookups (reason and/or metadata key match).
-type walletTransactionLookup struct {
-	transactionReason *types.TransactionReason
-	metadata          types.Metadata
-}
-
-func autoTopupWalletTransactionLookup() walletTransactionLookup {
-	return walletTransactionLookup{
-		metadata: types.Metadata{types.WalletMetadataKeyAutoTopup: "true"},
-	}
-}
-
-func metadataMatches(txMeta, want types.Metadata) bool {
-	if len(want) == 0 {
-		return true
-	}
-	if txMeta == nil {
-		return false
-	}
-	for k, v := range want {
-		if txMeta[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
-func (l walletTransactionLookup) matches(tx *wallet.Transaction) bool {
-	if tx == nil {
-		return false
-	}
-	if l.transactionReason != nil && tx.TransactionReason != *l.transactionReason {
-		return false
-	}
-	return metadataMatches(tx.Metadata, l.metadata)
-}
-
-// hasPendingWalletTransaction reports whether the wallet has a pending transaction
-// matching the lookup discriminator.
-func (s *walletService) hasPendingWalletTransaction(ctx context.Context, walletID string, lookup walletTransactionLookup) (bool, error) {
-	status := types.TransactionStatusPending
-	filter := types.NewWalletTransactionFilter()
-	filter.WalletID = &walletID
-	filter.TransactionStatus = &status
-	filter.Limit = lo.ToPtr(50)
-
-	txs, err := s.WalletRepo.ListWalletTransactions(ctx, filter)
-	if err != nil {
-		return false, err
-	}
-	for _, tx := range txs {
-		if lookup.matches(tx) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// getLastCompletedWalletTransaction returns the most recent completed transaction
-// for the wallet matching the lookup discriminator (created_at desc), or nil if none.
-func (s *walletService) getLastCompletedWalletTransaction(ctx context.Context, walletID string, lookup walletTransactionLookup) (*wallet.Transaction, error) {
-	status := types.TransactionStatusCompleted
-	filter := types.NewWalletTransactionFilter()
-	filter.WalletID = &walletID
-	filter.TransactionStatus = &status
-	filter.Limit = lo.ToPtr(50)
-	// QueryFilter defaults already sort created_at desc.
-
-	txs, err := s.WalletRepo.ListWalletTransactions(ctx, filter)
-	if err != nil {
-		return nil, err
-	}
-	for _, tx := range txs {
-		if lookup.matches(tx) {
-			return tx, nil
-		}
-	}
-	return nil, nil
-}
-
-func (s *walletService) isWithinAutoTopupCooldown(ctx context.Context, w *wallet.Wallet) (bool, error) {
-	if w.AutoTopup == nil || !w.AutoTopup.Cooldown.IsSet() {
+// isWithinAutoTopupCooldown reports whether last auto-topup txn still falls inside
+// the wallet's configured cooldown window. last may be nil (no prior auto-topup).
+func (s *walletService) isWithinAutoTopupCooldown(w *wallet.Wallet, last *wallet.Transaction) (bool, error) {
+	if w.AutoTopup == nil || !w.AutoTopup.Cooldown.IsSet() || last == nil {
 		return false, nil
 	}
 
 	cooldown, err := w.AutoTopup.Cooldown.ToDuration()
 	if err != nil {
 		return false, err
-	}
-
-	last, err := s.getLastCompletedWalletTransaction(ctx, w.ID, autoTopupWalletTransactionLookup())
-	if err != nil {
-		return false, err
-	}
-	if last == nil {
-		return false, nil
 	}
 
 	anchor := last.UpdatedAt
@@ -3838,17 +3750,16 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 			}
 		}
 
-		// Wallet-scoped pending txn guard: do not open another auto-topup
-		// while a matching pending wallet transaction exists.
-		hasPendingTxn, err := s.hasPendingWalletTransaction(ctx, w.ID, autoTopupWalletTransactionLookup())
+		// Single lookup: latest auto-topup txn drives both in-flight + cooloff.
+		lastAutoTopup, err := s.WalletRepo.GetLastWalletAutoTopupTransaction(ctx, w.ID)
 		if err != nil {
-			s.Logger.Error(ctx, "failed to check for pending auto-topup wallet transaction",
+			s.Logger.Error(ctx, "failed to get last auto-topup wallet transaction",
 				"error", err,
 				"wallet_id", w.ID,
 			)
 			return err
 		}
-		if hasPendingTxn {
+		if lastAutoTopup != nil && lastAutoTopup.TxStatus == types.TransactionStatusPending {
 			s.Logger.Info(ctx, "pending auto-topup wallet transaction exists, skipping",
 				"wallet_id", w.ID,
 				"auto_topup_threshold", *w.AutoTopup.Threshold,
@@ -3856,8 +3767,7 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 			return nil
 		}
 
-		// Optional cooloff after a successful auto-topup
-		withinCooldown, err := s.isWithinAutoTopupCooldown(ctx, w)
+		withinCooldown, err := s.isWithinAutoTopupCooldown(w, lastAutoTopup)
 		if err != nil {
 			s.Logger.Error(ctx, "failed to check auto-topup cooloff",
 				"error", err,

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -1556,7 +1556,12 @@ func (s *walletService) UpdateWallet(ctx context.Context, id string, req *dto.Up
 			current.Invoicing = req.AutoTopup.Invoicing
 		}
 		if req.AutoTopup.Cooldown != nil {
-			current.Cooldown = req.AutoTopup.Cooldown
+			// value == 0 clears; omit/null leaves unchanged (partial update).
+			if req.AutoTopup.Cooldown.IsClearSentinel() {
+				current.Cooldown = nil
+			} else {
+				current.Cooldown = req.AutoTopup.Cooldown
+			}
 		}
 		existing.AutoTopup = current
 	}

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -1555,6 +1555,9 @@ func (s *walletService) UpdateWallet(ctx context.Context, id string, req *dto.Up
 		if req.AutoTopup.Invoicing != nil {
 			current.Invoicing = req.AutoTopup.Invoicing
 		}
+		if req.AutoTopup.Cooldown != nil {
+			current.Cooldown = req.AutoTopup.Cooldown
+		}
 		existing.AutoTopup = current
 	}
 	if req.Config != nil {
@@ -3679,6 +3682,113 @@ func (s *walletService) hasPendingAutoTopupInvoice(ctx context.Context, customer
 	return len(invoices) > 0, nil
 }
 
+// walletTransactionLookup discriminates wallet transactions for generic pending /
+// last-completed lookups (reason and/or metadata key match).
+type walletTransactionLookup struct {
+	transactionReason *types.TransactionReason
+	metadata          types.Metadata
+}
+
+func autoTopupWalletTransactionLookup() walletTransactionLookup {
+	return walletTransactionLookup{
+		metadata: types.Metadata{types.WalletMetadataKeyAutoTopup: "true"},
+	}
+}
+
+func metadataMatches(txMeta, want types.Metadata) bool {
+	if len(want) == 0 {
+		return true
+	}
+	if txMeta == nil {
+		return false
+	}
+	for k, v := range want {
+		if txMeta[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (l walletTransactionLookup) matches(tx *wallet.Transaction) bool {
+	if tx == nil {
+		return false
+	}
+	if l.transactionReason != nil && tx.TransactionReason != *l.transactionReason {
+		return false
+	}
+	return metadataMatches(tx.Metadata, l.metadata)
+}
+
+// hasPendingWalletTransaction reports whether the wallet has a pending transaction
+// matching the lookup discriminator.
+func (s *walletService) hasPendingWalletTransaction(ctx context.Context, walletID string, lookup walletTransactionLookup) (bool, error) {
+	status := types.TransactionStatusPending
+	filter := types.NewWalletTransactionFilter()
+	filter.WalletID = &walletID
+	filter.TransactionStatus = &status
+	filter.Limit = lo.ToPtr(50)
+
+	txs, err := s.WalletRepo.ListWalletTransactions(ctx, filter)
+	if err != nil {
+		return false, err
+	}
+	for _, tx := range txs {
+		if lookup.matches(tx) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getLastCompletedWalletTransaction returns the most recent completed transaction
+// for the wallet matching the lookup discriminator (created_at desc), or nil if none.
+func (s *walletService) getLastCompletedWalletTransaction(ctx context.Context, walletID string, lookup walletTransactionLookup) (*wallet.Transaction, error) {
+	status := types.TransactionStatusCompleted
+	filter := types.NewWalletTransactionFilter()
+	filter.WalletID = &walletID
+	filter.TransactionStatus = &status
+	filter.Limit = lo.ToPtr(50)
+	// QueryFilter defaults already sort created_at desc.
+
+	txs, err := s.WalletRepo.ListWalletTransactions(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	for _, tx := range txs {
+		if lookup.matches(tx) {
+			return tx, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *walletService) isWithinAutoTopupCooldown(ctx context.Context, w *wallet.Wallet) (bool, error) {
+	if w.AutoTopup == nil || !w.AutoTopup.Cooldown.IsSet() {
+		return false, nil
+	}
+
+	cooldown, err := w.AutoTopup.Cooldown.ToDuration()
+	if err != nil {
+		return false, err
+	}
+
+	last, err := s.getLastCompletedWalletTransaction(ctx, w.ID, autoTopupWalletTransactionLookup())
+	if err != nil {
+		return false, err
+	}
+	if last == nil {
+		return false, nil
+	}
+
+	anchor := last.UpdatedAt
+	if anchor.IsZero() {
+		anchor = last.CreatedAt
+	}
+
+	return time.Now().UTC().Before(anchor.Add(cooldown)), nil
+}
+
 // triggerAutoTopup checks if auto top-up is enabled and triggers it if needed.
 //
 // autoTopupIdempotencyKey, when non-empty, is used verbatim as the TopUpWallet
@@ -3723,6 +3833,41 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 			}
 		}
 
+		// Wallet-scoped pending txn guard: do not open another auto-topup
+		// while a matching pending wallet transaction exists.
+		hasPendingTxn, err := s.hasPendingWalletTransaction(ctx, w.ID, autoTopupWalletTransactionLookup())
+		if err != nil {
+			s.Logger.Error(ctx, "failed to check for pending auto-topup wallet transaction",
+				"error", err,
+				"wallet_id", w.ID,
+			)
+			return err
+		}
+		if hasPendingTxn {
+			s.Logger.Info(ctx, "pending auto-topup wallet transaction exists, skipping",
+				"wallet_id", w.ID,
+				"auto_topup_threshold", *w.AutoTopup.Threshold,
+			)
+			return nil
+		}
+
+		// Optional cooloff after a successful auto-topup
+		withinCooldown, err := s.isWithinAutoTopupCooldown(ctx, w)
+		if err != nil {
+			s.Logger.Error(ctx, "failed to check auto-topup cooloff",
+				"error", err,
+				"wallet_id", w.ID,
+			)
+			return err
+		}
+		if withinCooldown {
+			s.Logger.Info(ctx, "auto-topup cooloff active, skipping",
+				"wallet_id", w.ID,
+				"auto_topup_threshold", *w.AutoTopup.Threshold,
+			)
+			return nil
+		}
+
 		transactionReason := lo.Ternary(isInvoiced,
 			types.TransactionReasonPurchasedCreditInvoiced,
 			types.TransactionReasonPurchasedCreditDirect,
@@ -3736,14 +3881,14 @@ func (s *walletService) triggerAutoTopup(ctx context.Context, w *wallet.Wallet, 
 		if idempotencyKey == "" {
 			idempotencyKey = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION)
 		}
-		_, err := s.TopUpWallet(ctx, w.ID, &dto.TopUpWalletRequest{
+		_, err = s.TopUpWallet(ctx, w.ID, &dto.TopUpWalletRequest{
 			CreditsToAdd:      *w.AutoTopup.Amount,
 			Amount:            *w.AutoTopup.Amount,
 			TransactionReason: transactionReason,
 			BillingReason:     billingReason,
 			IdempotencyKey:    lo.ToPtr(idempotencyKey),
 			Description:       "Auto top-up triggered for low ongoing balance",
-			Metadata:          types.Metadata{"auto_topup": "true"},
+			Metadata:          types.Metadata{types.WalletMetadataKeyAutoTopup: "true"},
 		})
 		if err != nil {
 			s.Logger.Error(ctx, "failed to top up wallet for auto top-up",

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -2493,6 +2493,41 @@ func (s *WalletAutoTopupInvoiceSuite) countAutoTopupInvoices() int {
 	return len(invoices)
 }
 
+func (s *WalletAutoTopupInvoiceSuite) countAutoTopupWalletTxns(status *types.TransactionStatus) int {
+	ctx := s.GetContext()
+	filter := types.NewNoLimitWalletTransactionFilter()
+	filter.WalletID = &s.wallet.ID
+	if status != nil {
+		filter.TransactionStatus = status
+	}
+	txs, err := s.GetStores().WalletRepo.ListWalletTransactions(ctx, filter)
+	s.NoError(err)
+	count := 0
+	for _, tx := range txs {
+		if tx.Metadata != nil && tx.Metadata[types.WalletMetadataKeyAutoTopup] == "true" {
+			if status == nil || tx.TxStatus == *status {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func (s *WalletAutoTopupInvoiceSuite) completePendingAutoTopupWalletTxns() {
+	ctx := s.GetContext()
+	pending := types.TransactionStatusPending
+	filter := types.NewNoLimitWalletTransactionFilter()
+	filter.WalletID = &s.wallet.ID
+	filter.TransactionStatus = &pending
+	txs, err := s.GetStores().WalletRepo.ListWalletTransactions(ctx, filter)
+	s.NoError(err)
+	for _, tx := range txs {
+		if tx.Metadata != nil && tx.Metadata[types.WalletMetadataKeyAutoTopup] == "true" {
+			s.NoError(s.GetStores().WalletRepo.UpdateTransactionStatus(ctx, tx.ID, types.TransactionStatusCompleted))
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Test 1 – no invoices exist → hasPendingAutoTopupInvoice returns false.
 // ---------------------------------------------------------------------------
@@ -2579,12 +2614,14 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_AllowsNewInvoiceAfter
 	ctx := s.GetContext()
 	balance := decimal.NewFromInt(3) // below threshold of 5
 
-	// First trigger – creates one pending invoice.
+	// First trigger – creates one pending invoice + pending wallet txn.
 	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
 	s.NoError(err)
 	s.Equal(1, s.countAutoTopupInvoices(), "expected 1 auto-topup invoice after first trigger")
+	pending := types.TransactionStatusPending
+	s.Equal(1, s.countAutoTopupWalletTxns(&pending), "expected 1 pending auto-topup wallet txn")
 
-	// Fetch the invoice and mark it as paid.
+	// Fetch the invoice and mark it as paid; complete the wallet txn (mirrors reconcile).
 	filter := types.NewNoLimitInvoiceFilter()
 	filter.CustomerID = s.customer.ID
 	filter.BillingReason = types.InvoiceBillingReasonWalletAutoTopup
@@ -2594,12 +2631,232 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_AllowsNewInvoiceAfter
 
 	invoices[0].PaymentStatus = types.PaymentStatusSucceeded
 	s.NoError(s.GetStores().InvoiceRepo.Update(ctx, invoices[0]))
+	s.completePendingAutoTopupWalletTxns()
 
-	// Second trigger – guard no longer blocks because invoice is paid.
-	// Re-read wallet to get fresh state (balance still low since no actual credit was added).
+	// Second trigger – invoice + pending-txn guards cleared; no cooloff configured.
 	err = s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
 	s.NoError(err)
 	s.Equal(2, s.countAutoTopupInvoices(), "expected 2 auto-topup invoices after payment cleared the guard")
+}
+
+func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_PendingWalletTxnBlocksEvenWithoutInvoice() {
+	ctx := s.GetContext()
+	balance := decimal.NewFromInt(3)
+
+	// Seed a pending auto-topup wallet txn without an invoice row.
+	pendingTx := &wallet.Transaction{
+		ID:                "txn_pending_autotopup",
+		WalletID:          s.wallet.ID,
+		CustomerID:        s.customer.ID,
+		Type:              types.TransactionTypeCredit,
+		CreditAmount:      decimal.NewFromInt(10),
+		Amount:            decimal.NewFromInt(10),
+		TxStatus:          types.TransactionStatusPending,
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		Metadata:          types.Metadata{types.WalletMetadataKeyAutoTopup: "true"},
+		Currency:          "usd",
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(ctx, pendingTx))
+
+	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
+	s.NoError(err)
+	s.Equal(0, s.countAutoTopupInvoices(), "pending wallet txn alone must block a new auto-topup invoice")
+}
+
+func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_CooldownBlocksAfterCompletedTxn() {
+	ctx := s.GetContext()
+	balance := decimal.NewFromInt(3)
+	s.wallet.AutoTopup.Cooldown = &types.Duration{Value: 1, Unit: types.DurationUnitDay}
+	s.NoError(s.GetStores().WalletRepo.UpdateWallet(ctx, s.wallet.ID, s.wallet))
+
+	completed := &wallet.Transaction{
+		ID:                "txn_completed_autotopup",
+		WalletID:          s.wallet.ID,
+		CustomerID:        s.customer.ID,
+		Type:              types.TransactionTypeCredit,
+		CreditAmount:      decimal.NewFromInt(10),
+		Amount:            decimal.NewFromInt(10),
+		TxStatus:          types.TransactionStatusCompleted,
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		Metadata:          types.Metadata{types.WalletMetadataKeyAutoTopup: "true"},
+		Currency:          "usd",
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(ctx, completed))
+
+	err := s.svc().triggerAutoTopup(ctx, s.wallet, balance, "")
+	s.NoError(err)
+	s.Equal(0, s.countAutoTopupInvoices(), "cooloff after completed auto-topup must block a new invoice")
+}
+
+func (s *WalletAutoTopupInvoiceSuite) TestHasPendingWalletTransaction_IgnoresManualPending() {
+	ctx := s.GetContext()
+	manual := &wallet.Transaction{
+		ID:                "txn_manual_pending",
+		WalletID:          s.wallet.ID,
+		CustomerID:        s.customer.ID,
+		Type:              types.TransactionTypeCredit,
+		CreditAmount:      decimal.NewFromInt(10),
+		Amount:            decimal.NewFromInt(10),
+		TxStatus:          types.TransactionStatusPending,
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		Metadata:          types.Metadata{},
+		Currency:          "usd",
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().WalletRepo.CreateTransaction(ctx, manual))
+
+	has, err := s.svc().hasPendingWalletTransaction(ctx, s.wallet.ID, autoTopupWalletTransactionLookup())
+	s.NoError(err)
+	s.False(has, "manual pending txn without auto_topup metadata must not match")
+}
+
+// ---------------------------------------------------------------------------
+// WalletAutoTopupDirectSuite – direct (non-invoiced) cooloff / burst behavior
+// ---------------------------------------------------------------------------
+
+type WalletAutoTopupDirectSuite struct {
+	testutil.BaseServiceTestSuite
+	service  WalletService
+	customer *customer.Customer
+	wallet   *wallet.Wallet
+}
+
+func TestWalletAutoTopupDirect(t *testing.T) {
+	suite.Run(t, new(WalletAutoTopupDirectSuite))
+}
+
+func (s *WalletAutoTopupDirectSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	stores := s.GetStores()
+	pubsub := testutil.NewInMemoryPubSub()
+	s.service = NewWalletService(ServiceParams{
+		Logger:                   s.GetLogger(),
+		Config:                   s.GetConfig(),
+		DB:                       s.GetDB(),
+		WalletRepo:               stores.WalletRepo,
+		SubRepo:                  stores.SubscriptionRepo,
+		SubscriptionLineItemRepo: stores.SubscriptionLineItemRepo,
+		PlanRepo:                 stores.PlanRepo,
+		PriceRepo:                stores.PriceRepo,
+		EventRepo:                stores.EventRepo,
+		MeterUsageRepo:           stores.MeterUsageRepo,
+		MeterRepo:                stores.MeterRepo,
+		CustomerRepo:             stores.CustomerRepo,
+		InvoiceRepo:              stores.InvoiceRepo,
+		EntitlementRepo:          stores.EntitlementRepo,
+		FeatureRepo:              stores.FeatureRepo,
+		AddonAssociationRepo:     stores.AddonAssociationRepo,
+		SettingsRepo:             stores.SettingsRepo,
+		AlertLogsRepo:            stores.AlertLogsRepo,
+		EventPublisher:           s.GetPublisher(),
+		WebhookPublisher:         s.GetWebhookPublisher(),
+		WalletBalanceAlertPubSub: types.WalletBalanceAlertPubSub{PubSub: pubsub},
+		TaxAssociationRepo:       stores.TaxAssociationRepo,
+		TaxRateRepo:              stores.TaxRateRepo,
+		TaxAppliedRepo:           stores.TaxAppliedRepo,
+	})
+
+	ctx := s.GetContext()
+	s.customer = &customer.Customer{
+		ID:         "cust_autotopup_direct",
+		ExternalID: "ext_cust_autotopup_direct",
+		Name:       "AutoTopup Direct Customer",
+		Email:      "autotopup-direct@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(stores.CustomerRepo.Create(ctx, s.customer))
+
+	threshold := decimal.NewFromInt(50)
+	amount := decimal.NewFromInt(10)
+	enabled := true
+	invoicing := false
+	s.wallet = &wallet.Wallet{
+		ID:                  "wallet_autotopup_direct",
+		CustomerID:          s.customer.ID,
+		Currency:            "usd",
+		WalletType:          types.WalletTypePrePaid,
+		WalletStatus:        types.WalletStatusActive,
+		Balance:             decimal.NewFromInt(5),
+		CreditBalance:       decimal.NewFromInt(5),
+		ConversionRate:      decimal.NewFromFloat(1.0),
+		TopupConversionRate: decimal.NewFromFloat(1.0),
+		AutoTopup: &types.AutoTopup{
+			Enabled:   &enabled,
+			Threshold: &threshold,
+			Amount:    &amount,
+			Invoicing: &invoicing,
+		},
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(stores.WalletRepo.CreateWallet(ctx, s.wallet))
+}
+
+func (s *WalletAutoTopupDirectSuite) GetContext() context.Context {
+	return types.SetEnvironmentID(s.BaseServiceTestSuite.GetContext(), "env_test")
+}
+
+func (s *WalletAutoTopupDirectSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+	s.BaseServiceTestSuite.ClearStores()
+}
+
+func (s *WalletAutoTopupDirectSuite) svc() *walletService {
+	return s.service.(*walletService)
+}
+
+func (s *WalletAutoTopupDirectSuite) countCompletedAutoTopupTxns() int {
+	ctx := s.GetContext()
+	completed := types.TransactionStatusCompleted
+	filter := types.NewNoLimitWalletTransactionFilter()
+	filter.WalletID = &s.wallet.ID
+	filter.TransactionStatus = &completed
+	txs, err := s.GetStores().WalletRepo.ListWalletTransactions(ctx, filter)
+	s.NoError(err)
+	count := 0
+	for _, tx := range txs {
+		if tx.Metadata != nil && tx.Metadata[types.WalletMetadataKeyAutoTopup] == "true" {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *WalletAutoTopupDirectSuite) TestDirect_NoCooldown_BurstsUntilAboveThreshold() {
+	ctx := s.GetContext()
+	// balance 5, threshold 50, amount 10 → nested re-eval should credit until > 50
+	err := s.svc().EvaluateAlertsForWallet(ctx, s.wallet, NewAlertLogsService(ServiceParams{
+		Logger:        s.GetLogger(),
+		AlertLogsRepo: s.GetStores().AlertLogsRepo,
+		SettingsRepo:  s.GetStores().SettingsRepo,
+	}), "")
+	s.NoError(err)
+
+	w, err := s.GetStores().WalletRepo.GetWalletByID(ctx, s.wallet.ID)
+	s.NoError(err)
+	s.True(w.CreditBalance.GreaterThan(decimal.NewFromInt(50)),
+		"expected burst to push balance above threshold, got %s", w.CreditBalance)
+	s.GreaterOrEqual(s.countCompletedAutoTopupTxns(), 5, "expected multiple direct auto-topup credits without cooloff")
+}
+
+func (s *WalletAutoTopupDirectSuite) TestDirect_WithCooldown_OneShotPerWindow() {
+	ctx := s.GetContext()
+	s.wallet.AutoTopup.Cooldown = &types.Duration{Value: 1, Unit: types.DurationUnitDay}
+	s.NoError(s.GetStores().WalletRepo.UpdateWallet(ctx, s.wallet.ID, s.wallet))
+
+	err := s.svc().EvaluateAlertsForWallet(ctx, s.wallet, NewAlertLogsService(ServiceParams{
+		Logger:        s.GetLogger(),
+		AlertLogsRepo: s.GetStores().AlertLogsRepo,
+		SettingsRepo:  s.GetStores().SettingsRepo,
+	}), "")
+	s.NoError(err)
+
+	s.Equal(1, s.countCompletedAutoTopupTxns(), "cooloff must suppress direct-mode burst to a single top-up")
+	w, err := s.GetStores().WalletRepo.GetWalletByID(ctx, s.wallet.ID)
+	s.NoError(err)
+	s.True(w.CreditBalance.Equal(decimal.NewFromInt(15)),
+		"expected balance 5+10=15 after one top-up, got %s", w.CreditBalance)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -2690,7 +2690,7 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_CooldownBlocksAfterCo
 	s.Equal(0, s.countAutoTopupInvoices(), "cooloff after completed auto-topup must block a new invoice")
 }
 
-func (s *WalletAutoTopupInvoiceSuite) TestGetLastWalletAutoTopupTransaction_IgnoresManualPending() {
+func (s *WalletAutoTopupInvoiceSuite) TestGetLastAutoTopupTransactionForWallet_IgnoresManualPending() {
 	ctx := s.GetContext()
 	manual := &wallet.Transaction{
 		ID:                "txn_manual_pending",
@@ -2707,7 +2707,7 @@ func (s *WalletAutoTopupInvoiceSuite) TestGetLastWalletAutoTopupTransaction_Igno
 	}
 	s.NoError(s.GetStores().WalletRepo.CreateTransaction(ctx, manual))
 
-	last, err := s.GetStores().WalletRepo.GetLastWalletAutoTopupTransaction(ctx, s.wallet.ID)
+	last, err := s.GetStores().WalletRepo.GetLastAutoTopupTransactionForWallet(ctx, s.wallet.ID)
 	s.NoError(err)
 	s.Nil(last, "manual pending txn without auto_topup metadata must not match")
 }

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -2840,6 +2840,30 @@ func (s *WalletAutoTopupDirectSuite) TestDirect_NoCooldown_BurstsUntilAboveThres
 	s.GreaterOrEqual(s.countCompletedAutoTopupTxns(), 5, "expected multiple direct auto-topup credits without cooloff")
 }
 
+func (s *WalletAutoTopupDirectSuite) TestUpdateWallet_CooldownZeroClears() {
+	ctx := s.GetContext()
+	s.wallet.AutoTopup.Cooldown = &types.Duration{Value: 1, Unit: types.DurationUnitDay}
+	s.NoError(s.GetStores().WalletRepo.UpdateWallet(ctx, s.wallet.ID, s.wallet))
+
+	updated, err := s.svc().UpdateWallet(ctx, s.wallet.ID, &dto.UpdateWalletRequest{
+		AutoTopup: &types.AutoTopup{
+			Cooldown: &types.Duration{Value: 0, Unit: types.DurationUnitSecond},
+		},
+	})
+	s.NoError(err)
+	s.Require().NotNil(updated.AutoTopup)
+	s.Nil(updated.AutoTopup.Cooldown, "value 0 must clear persisted cooldown")
+
+	// Omit cooldown on a later update must leave it cleared (not resurrect).
+	updated, err = s.svc().UpdateWallet(ctx, s.wallet.ID, &dto.UpdateWalletRequest{
+		AutoTopup: &types.AutoTopup{
+			Enabled: lo.ToPtr(true),
+		},
+	})
+	s.NoError(err)
+	s.Nil(updated.AutoTopup.Cooldown, "omitting cooldown must not restore a cleared cooldown")
+}
+
 func (s *WalletAutoTopupDirectSuite) TestDirect_WithCooldown_OneShotPerWindow() {
 	ctx := s.GetContext()
 	s.wallet.AutoTopup.Cooldown = &types.Duration{Value: 1, Unit: types.DurationUnitDay}

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -2690,7 +2690,7 @@ func (s *WalletAutoTopupInvoiceSuite) TestTriggerAutoTopup_CooldownBlocksAfterCo
 	s.Equal(0, s.countAutoTopupInvoices(), "cooloff after completed auto-topup must block a new invoice")
 }
 
-func (s *WalletAutoTopupInvoiceSuite) TestHasPendingWalletTransaction_IgnoresManualPending() {
+func (s *WalletAutoTopupInvoiceSuite) TestGetLastWalletAutoTopupTransaction_IgnoresManualPending() {
 	ctx := s.GetContext()
 	manual := &wallet.Transaction{
 		ID:                "txn_manual_pending",
@@ -2707,9 +2707,9 @@ func (s *WalletAutoTopupInvoiceSuite) TestHasPendingWalletTransaction_IgnoresMan
 	}
 	s.NoError(s.GetStores().WalletRepo.CreateTransaction(ctx, manual))
 
-	has, err := s.svc().hasPendingWalletTransaction(ctx, s.wallet.ID, autoTopupWalletTransactionLookup())
+	last, err := s.GetStores().WalletRepo.GetLastWalletAutoTopupTransaction(ctx, s.wallet.ID)
 	s.NoError(err)
-	s.False(has, "manual pending txn without auto_topup metadata must not match")
+	s.Nil(last, "manual pending txn without auto_topup metadata must not match")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/predicate"
 	"github.com/flexprice/flexprice/ent/wallet"
@@ -581,6 +583,48 @@ func (r *walletRepository) GetPendingTransactionByParent(ctx context.Context, pa
 			WithHint("Failed to retrieve pending bonus transaction").
 			WithReportableDetails(map[string]interface{}{
 				"parent_transaction_id": parentTransactionID,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+
+	return walletdomain.TransactionFromEnt(t), nil
+}
+
+// GetLastWalletAutoTopupTransaction returns the most recent published wallet
+// transaction with metadata.auto_topup=true for the wallet, or nil if none.
+func (r *walletRepository) GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*walletdomain.Transaction, error) {
+	span := StartRepositorySpan(ctx, "wallet", "get_last_wallet_auto_topup_transaction", map[string]interface{}{
+		"wallet_id": walletID,
+	})
+	defer FinishSpan(span)
+
+	client := r.client.Reader(ctx)
+	t, err := client.WalletTransaction.Query().
+		Where(
+			wallettransaction.WalletID(walletID),
+			wallettransaction.TenantID(types.GetTenantID(ctx)),
+			wallettransaction.StatusEQ(string(types.StatusPublished)),
+			wallettransaction.EnvironmentID(types.GetEnvironmentID(ctx)),
+			predicate.WalletTransaction(func(s *sql.Selector) {
+				s.Where(sqljson.ValueEQ(
+					wallettransaction.FieldMetadata,
+					"true",
+					sqljson.Path(types.WalletMetadataKeyAutoTopup),
+				))
+			}),
+		).
+		Order(wallettransaction.ByCreatedAt(sql.OrderDesc())).
+		First(ctx)
+
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, nil
+		}
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to retrieve last auto-topup wallet transaction").
+			WithReportableDetails(map[string]interface{}{
+				"wallet_id": walletID,
 			}).
 			Mark(ierr.ErrDatabase)
 	}

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -590,10 +590,10 @@ func (r *walletRepository) GetPendingTransactionByParent(ctx context.Context, pa
 	return walletdomain.TransactionFromEnt(t), nil
 }
 
-// GetLastWalletAutoTopupTransaction returns the most recent published wallet
+// GetLastAutoTopupTransactionForWallet returns the most recent published wallet
 // transaction with metadata.auto_topup=true for the wallet, or nil if none.
-func (r *walletRepository) GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*walletdomain.Transaction, error) {
-	span := StartRepositorySpan(ctx, "wallet", "get_last_wallet_auto_topup_transaction", map[string]interface{}{
+func (r *walletRepository) GetLastAutoTopupTransactionForWallet(ctx context.Context, walletID string) (*walletdomain.Transaction, error) {
+	span := StartRepositorySpan(ctx, "wallet", "get_last_auto_topup_transaction_for_wallet", map[string]interface{}{
 		"wallet_id": walletID,
 	})
 	defer FinishSpan(span)

--- a/internal/testutil/inmemory_wallet_store.go
+++ b/internal/testutil/inmemory_wallet_store.go
@@ -490,6 +490,38 @@ func (s *InMemoryWalletStore) GetPendingTransactionByParent(ctx context.Context,
 	return transactions[0], nil
 }
 
+func (s *InMemoryWalletStore) GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*wallet.Transaction, error) {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	filterFn := func(ctx context.Context, tx *wallet.Transaction, _ interface{}) bool {
+		if tx == nil {
+			return false
+		}
+		if tx.WalletID != walletID ||
+			tx.TenantID != tenantID ||
+			tx.EnvironmentID != environmentID ||
+			tx.Status != types.StatusPublished {
+			return false
+		}
+		return tx.Metadata != nil && tx.Metadata[types.WalletMetadataKeyAutoTopup] == "true"
+	}
+
+	transactions, err := s.transactions.List(ctx, nil, filterFn, transactionSortFn)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to retrieve last auto-topup wallet transaction").
+			WithReportableDetails(map[string]interface{}{
+				"wallet_id": walletID,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+	if len(transactions) == 0 {
+		return nil, nil
+	}
+	return transactions[0], nil
+}
+
 func (s *InMemoryWalletStore) ListWalletTransactions(ctx context.Context, f *types.WalletTransactionFilter) ([]*wallet.Transaction, error) {
 	transactions, err := s.transactions.List(ctx, f, transactionFilterFn, transactionSortFn)
 	if err != nil {

--- a/internal/testutil/inmemory_wallet_store.go
+++ b/internal/testutil/inmemory_wallet_store.go
@@ -490,7 +490,7 @@ func (s *InMemoryWalletStore) GetPendingTransactionByParent(ctx context.Context,
 	return transactions[0], nil
 }
 
-func (s *InMemoryWalletStore) GetLastWalletAutoTopupTransaction(ctx context.Context, walletID string) (*wallet.Transaction, error) {
+func (s *InMemoryWalletStore) GetLastAutoTopupTransactionForWallet(ctx context.Context, walletID string) (*wallet.Transaction, error) {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
 

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -35,13 +35,11 @@ func (u DurationUnit) Validate() error {
 }
 
 // Duration is a generic value+unit time span.
-// Optionality is expressed by using *Duration at the call site (nil = unset).
 type Duration struct {
 	Value int          `json:"value"`
 	Unit  DurationUnit `json:"unit"`
 }
 
-// IsSet reports whether the duration pointer is non-nil with a positive value and unit.
 func (d *Duration) IsSet() bool {
 	return d != nil && d.Value > 0 && d.Unit != ""
 }
@@ -50,7 +48,6 @@ func (d *Duration) IsEmpty() bool {
 	return d == nil || d.Value == 0
 }
 
-// Validate checks bounds when Duration is present. Nil Duration is valid (unset).
 func (d *Duration) Validate() error {
 	if d == nil {
 		return nil
@@ -69,7 +66,6 @@ func (d *Duration) Validate() error {
 	return d.Unit.Validate()
 }
 
-// ToDuration converts to time.Duration. Returns an error if unset or invalid.
 func (d *Duration) ToDuration() (time.Duration, error) {
 	if err := d.Validate(); err != nil {
 		return 0, err

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -46,9 +46,9 @@ func (d *Duration) IsSet() bool {
 	return d != nil && d.Value > 0 && d.Unit != ""
 }
 
-// IsClearSentinel reports whether this duration is the explicit clear marker
+// ShouldClearCooldown reports whether this duration is the explicit clear marker
 // (value == 0). Used by partial updates where omit/null means "leave unchanged".
-func (d *Duration) IsClearSentinel() bool {
+func (d *Duration) ShouldClearCooldown() bool {
 	return d != nil && d.Value == 0
 }
 

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -1,0 +1,92 @@
+package types
+
+import (
+	"fmt"
+	"time"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/samber/lo"
+)
+
+// DurationUnit is a unit for value+unit duration configs (cooloff, etc.).
+type DurationUnit string
+
+const (
+	DurationUnitSecond DurationUnit = "SECOND"
+	DurationUnitMinute DurationUnit = "MINUTE"
+	DurationUnitHour   DurationUnit = "HOUR"
+	DurationUnitDay    DurationUnit = "DAY"
+)
+
+func (u DurationUnit) Validate() error {
+	allowed := []DurationUnit{
+		DurationUnitSecond,
+		DurationUnitMinute,
+		DurationUnitHour,
+		DurationUnitDay,
+	}
+	if !lo.Contains(allowed, u) {
+		return ierr.NewError("invalid duration unit").
+			WithHint(fmt.Sprintf("Duration unit must be one of: %v", allowed)).
+			WithReportableDetails(map[string]any{"allowed": allowed}).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+// Duration is a generic value+unit time span.
+// Optionality is expressed by using *Duration at the call site (nil = unset).
+type Duration struct {
+	Value int          `json:"value"`
+	Unit  DurationUnit `json:"unit"`
+}
+
+// IsSet reports whether the duration pointer is non-nil with a positive value and unit.
+func (d *Duration) IsSet() bool {
+	return d != nil && d.Value > 0 && d.Unit != ""
+}
+
+// Validate checks bounds when Duration is present. Nil Duration is valid (unset).
+func (d *Duration) Validate() error {
+	if d == nil {
+		return nil
+	}
+	if d.Value <= 0 {
+		return ierr.NewError("duration value must be greater than zero").
+			WithHint("Duration value must be greater than zero").
+			WithReportableDetails(map[string]any{"value": d.Value}).
+			Mark(ierr.ErrValidation)
+	}
+	if d.Unit == "" {
+		return ierr.NewError("duration unit is required").
+			WithHint("Duration unit is required").
+			Mark(ierr.ErrValidation)
+	}
+	return d.Unit.Validate()
+}
+
+// ToDuration converts to time.Duration. Returns an error if unset or invalid.
+func (d *Duration) ToDuration() (time.Duration, error) {
+	if err := d.Validate(); err != nil {
+		return 0, err
+	}
+	if !d.IsSet() {
+		return 0, ierr.NewError("duration is not set").
+			WithHint("Duration value and unit are required").
+			Mark(ierr.ErrValidation)
+	}
+	switch d.Unit {
+	case DurationUnitSecond:
+		return time.Duration(d.Value) * time.Second, nil
+	case DurationUnitMinute:
+		return time.Duration(d.Value) * time.Minute, nil
+	case DurationUnitHour:
+		return time.Duration(d.Value) * time.Hour, nil
+	case DurationUnitDay:
+		return time.Duration(d.Value) * 24 * time.Hour, nil
+	default:
+		return 0, ierr.NewError("invalid duration unit").
+			WithHint("Unsupported duration unit").
+			Mark(ierr.ErrValidation)
+	}
+}

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -46,6 +46,12 @@ func (d *Duration) IsSet() bool {
 	return d != nil && d.Value > 0 && d.Unit != ""
 }
 
+// IsClearSentinel reports whether this duration is the explicit clear marker
+// (value == 0). Used by partial updates where omit/null means "leave unchanged".
+func (d *Duration) IsClearSentinel() bool {
+	return d != nil && d.Value == 0
+}
+
 // Validate checks bounds when Duration is present. Nil Duration is valid (unset).
 func (d *Duration) Validate() error {
 	if d == nil {

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -12,10 +12,10 @@ import (
 type DurationUnit string
 
 const (
-	DurationUnitSecond DurationUnit = "SECOND"
-	DurationUnitMinute DurationUnit = "MINUTE"
-	DurationUnitHour   DurationUnit = "HOUR"
-	DurationUnitDay    DurationUnit = "DAY"
+	DurationUnitSecond DurationUnit = "second"
+	DurationUnitMinute DurationUnit = "minute"
+	DurationUnitHour   DurationUnit = "hour"
+	DurationUnitDay    DurationUnit = "day"
 )
 
 func (u DurationUnit) Validate() error {
@@ -46,10 +46,8 @@ func (d *Duration) IsSet() bool {
 	return d != nil && d.Value > 0 && d.Unit != ""
 }
 
-// ShouldClearCooldown reports whether this duration is the explicit clear marker
-// (value == 0). Used by partial updates where omit/null means "leave unchanged".
-func (d *Duration) ShouldClearCooldown() bool {
-	return d != nil && d.Value == 0
+func (d *Duration) IsEmpty() bool {
+	return d == nil || d.Value == 0
 }
 
 // Validate checks bounds when Duration is present. Nil Duration is valid (unset).

--- a/internal/types/duration_test.go
+++ b/internal/types/duration_test.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuration_Validate(t *testing.T) {
+	assert.NoError(t, (*Duration)(nil).Validate())
+
+	assert.Error(t, (&Duration{Value: 0, Unit: DurationUnitMinute}).Validate())
+	assert.Error(t, (&Duration{Value: 5, Unit: ""}).Validate())
+	assert.Error(t, (&Duration{Value: 5, Unit: DurationUnit("WEEK")}).Validate())
+
+	assert.NoError(t, (&Duration{Value: 5, Unit: DurationUnitSecond}).Validate())
+	assert.NoError(t, (&Duration{Value: 5, Unit: DurationUnitMinute}).Validate())
+	assert.NoError(t, (&Duration{Value: 5, Unit: DurationUnitHour}).Validate())
+	assert.NoError(t, (&Duration{Value: 5, Unit: DurationUnitDay}).Validate())
+}
+
+func TestDuration_ToDuration(t *testing.T) {
+	_, err := (*Duration)(nil).ToDuration()
+	assert.Error(t, err)
+
+	got, err := (&Duration{Value: 3, Unit: DurationUnitSecond}).ToDuration()
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Second, got)
+
+	got, err = (&Duration{Value: 3, Unit: DurationUnitMinute}).ToDuration()
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Minute, got)
+
+	got, err = (&Duration{Value: 3, Unit: DurationUnitHour}).ToDuration()
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Hour, got)
+
+	got, err = (&Duration{Value: 3, Unit: DurationUnitDay}).ToDuration()
+	require.NoError(t, err)
+	assert.Equal(t, 3*24*time.Hour, got)
+}
+
+func TestDuration_IsSet(t *testing.T) {
+	assert.False(t, (*Duration)(nil).IsSet())
+	assert.False(t, (&Duration{}).IsSet())
+	assert.False(t, (&Duration{Value: 1}).IsSet())
+	assert.True(t, (&Duration{Value: 1, Unit: DurationUnitMinute}).IsSet())
+}

--- a/internal/types/duration_test.go
+++ b/internal/types/duration_test.go
@@ -48,3 +48,10 @@ func TestDuration_IsSet(t *testing.T) {
 	assert.False(t, (&Duration{Value: 1}).IsSet())
 	assert.True(t, (&Duration{Value: 1, Unit: DurationUnitMinute}).IsSet())
 }
+
+func TestDuration_IsClearSentinel(t *testing.T) {
+	assert.False(t, (*Duration)(nil).IsClearSentinel())
+	assert.True(t, (&Duration{Value: 0, Unit: DurationUnitSecond}).IsClearSentinel())
+	assert.True(t, (&Duration{Value: 0}).IsClearSentinel())
+	assert.False(t, (&Duration{Value: 1, Unit: DurationUnitMinute}).IsClearSentinel())
+}

--- a/internal/types/duration_test.go
+++ b/internal/types/duration_test.go
@@ -41,17 +41,3 @@ func TestDuration_ToDuration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3*24*time.Hour, got)
 }
-
-func TestDuration_IsSet(t *testing.T) {
-	assert.False(t, (*Duration)(nil).IsSet())
-	assert.False(t, (&Duration{}).IsSet())
-	assert.False(t, (&Duration{Value: 1}).IsSet())
-	assert.True(t, (&Duration{Value: 1, Unit: DurationUnitMinute}).IsSet())
-}
-
-func TestDuration_IsClearSentinel(t *testing.T) {
-	assert.False(t, (*Duration)(nil).IsClearSentinel())
-	assert.True(t, (&Duration{Value: 0, Unit: DurationUnitSecond}).IsClearSentinel())
-	assert.True(t, (&Duration{Value: 0}).IsClearSentinel())
-	assert.False(t, (&Duration{Value: 1, Unit: DurationUnitMinute}).IsClearSentinel())
-}

--- a/internal/types/wallet.go
+++ b/internal/types/wallet.go
@@ -352,12 +352,17 @@ func (f *WalletFilter) Validate() error {
 	return f.QueryFilter.Validate()
 }
 
+// WalletMetadataKeyAutoTopup marks wallet transactions / invoices created by auto top-up.
+const WalletMetadataKeyAutoTopup = "auto_topup"
+
 // AutoTopup represents the auto top-up configuration for a wallet
 type AutoTopup struct {
 	Enabled   *bool            `json:"enabled"`
 	Threshold *decimal.Decimal `json:"threshold"`
 	Amount    *decimal.Decimal `json:"amount"`
 	Invoicing *bool            `json:"invoicing"`
+	// Cooldown is an optional cooloff after a successful auto top-up before another may run.
+	Cooldown *Duration `json:"cooldown,omitempty"`
 }
 
 func (a *AutoTopup) Validate() error {
@@ -375,6 +380,9 @@ func (a *AutoTopup) Validate() error {
 		return ierr.NewError("invoicing boolean is required").
 			WithHint("Invoicing boolean is required").
 			Mark(ierr.ErrValidation)
+	}
+	if err := a.Cooldown.Validate(); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional cooldown for wallet auto top-ups (seconds, minutes, hours, days).
  - Auto top-ups now pause during the cooldown window after the most recent completed auto top-up, and won’t create a new credit while an auto top-up is pending.

- **Bug Fixes**
  - Strengthened in-flight protection for both invoiced and direct modes, including better handling to ignore unrelated manually pending transactions.

- **Documentation**
  - Added a design spec for the updated “in-flight guard & optional cooldown” behavior.

- **Tests**
  - Expanded coverage for cooldown enforcement, pending-wallet blocking, and cooldown clearing on update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->