### PR TITLE
fix(paddle): invoice payment update, skip only txn linked to sub creation in paddle

### DIFF
--- a/internal/integration/factory.go
+++ b/internal/integration/factory.go
@@ -488,6 +488,7 @@ func (f *Factory) GetPaddleIntegration(ctx context.Context) (*PaddleIntegration,
 	webhookHandler := paddlewebhook.NewHandler(
 		paymentSvc,
 		syncSvc,
+		f.subscriptionRepo,
 		f.logger,
 	)
 

--- a/internal/integration/paddle/webhook/handler.go
+++ b/internal/integration/paddle/webhook/handler.go
@@ -92,7 +92,7 @@ func (h *Handler) handleTransactionCompleted(ctx context.Context, payload []byte
 // Such transactions have no linked invoice — the subscription is activated by the
 // subscription.activated webhook instead.
 func (h *Handler) isSubscriptionBootstrapTransaction(ctx context.Context, customData map[string]any, paddleTransactionID string) bool {
-	if customData == nil || h.subscriptionRepo == nil {
+	if customData == nil {
 		return false
 	}
 

--- a/internal/integration/paddle/webhook/handler.go
+++ b/internal/integration/paddle/webhook/handler.go
@@ -6,6 +6,7 @@ import (
 
 	paddlesdk "github.com/PaddleHQ/paddle-go-sdk/v4"
 	"github.com/PaddleHQ/paddle-go-sdk/v4/pkg/paddlenotification"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/integration/paddle"
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -13,21 +14,24 @@ import (
 
 // Handler handles Paddle webhook events
 type Handler struct {
-	paymentSvc *paddle.PaymentService
-	syncSvc    *paddle.PaddleSyncService
-	logger     *logger.Logger
+	paymentSvc       *paddle.PaymentService
+	syncSvc          *paddle.PaddleSyncService
+	subscriptionRepo subscription.Repository
+	logger           *logger.Logger
 }
 
 // NewHandler creates a new Paddle webhook handler
 func NewHandler(
 	paymentSvc *paddle.PaymentService,
 	syncSvc *paddle.PaddleSyncService,
+	subscriptionRepo subscription.Repository,
 	logger *logger.Logger,
 ) *Handler {
 	return &Handler{
-		paymentSvc: paymentSvc,
-		syncSvc:    syncSvc,
-		logger:     logger,
+		paymentSvc:       paymentSvc,
+		syncSvc:          syncSvc,
+		subscriptionRepo: subscriptionRepo,
+		logger:           logger,
 	}
 }
 
@@ -64,17 +68,15 @@ func (h *Handler) handleTransactionCompleted(ctx context.Context, payload []byte
 			"error", err, "event_type", EventTransactionCompleted)
 		return nil
 	}
-	customData := event.Data.CustomData
 	// temp fix
 	// todo: handle using payment
-	// if txn is linked to internal subscription, meaning a 0$ txn
+	// if txn is the bootstrap txn of an internal subscription, meaning a 0$ txn
 	// no invoice linked to this payment
 	// skip this webhook( subscription gets activated using subscription.activated webhook event)
-	if customData != nil {
-		subID := h.syncSvc.ExtractFlexSubIDFromCustomData(event.Data.CustomData)
-		if subID != "" {
-			return nil
-		}
+	if h.isSubscriptionBootstrapTransaction(ctx, event.Data.CustomData, event.Data.ID) {
+		h.logger.Info(ctx, "skipping transaction.completed for subscription bootstrap transaction",
+			"paddle_transaction_id", event.Data.ID)
+		return nil
 	}
 	err := h.syncSvc.ProcessTransactionCompletedWebhook(ctx, event.Data.ID, services.PaymentService, services.InvoiceService)
 	if err != nil {
@@ -83,6 +85,33 @@ func (h *Handler) handleTransactionCompleted(ctx context.Context, payload []byte
 		return err
 	}
 	return nil
+}
+
+// isSubscriptionBootstrapTransaction reports whether the completed transaction is the
+// bootstrap transaction stored on the FlexPrice subscription referenced in custom_data.
+// Such transactions have no linked invoice — the subscription is activated by the
+// subscription.activated webhook instead.
+func (h *Handler) isSubscriptionBootstrapTransaction(ctx context.Context, customData map[string]any, paddleTransactionID string) bool {
+	if customData == nil || h.subscriptionRepo == nil {
+		return false
+	}
+
+	subID := h.syncSvc.ExtractFlexSubIDFromCustomData(customData)
+	if subID == "" {
+		return false
+	}
+
+	sub, err := h.subscriptionRepo.Get(ctx, subID)
+	if err != nil {
+		h.logger.Error(ctx, "failed to lookup subscription for transaction.completed webhook",
+			"error", err, "subscription_id", subID, "paddle_transaction_id", paddleTransactionID)
+		return false
+	}
+	if sub == nil || sub.Metadata == nil {
+		return false
+	}
+
+	return sub.Metadata[paddle.MetaKeyPaddleTransactionID] == paddleTransactionID
 }
 
 func (h *Handler) handleCustomerCreated(ctx context.Context, payload []byte, services *ServiceDependencies) error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of completed payment notifications.
  * Prevents duplicate processing of a subscription’s initial transaction while continuing to process unrelated completed transactions.
  * Added safeguards for missing subscription information and lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->