### PR TITLE
fix(meters): Index with status and meter repo level fix

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1375,6 +1375,14 @@ var (
 				Unique:  false,
 				Columns: []*schema.Column{MetersColumns[1], MetersColumns[7]},
 			},
+			{
+				Name:    "idx_meter_tenant_env_status",
+				Unique:  false,
+				Columns: []*schema.Column{MetersColumns[1], MetersColumns[7], MetersColumns[2]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "((status)::text = ANY (ARRAY['published'::text, 'archived'::text]))",
+				},
+			},
 		},
 	}
 	// PaymentsColumns holds the columns for the "payments" table.

--- a/ent/schema/meter.go
+++ b/ent/schema/meter.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	baseMixin "github.com/flexprice/flexprice/ent/schema/mixin"
@@ -60,6 +61,11 @@ func (Meter) Fields() []ent.Field {
 func (Meter) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id"),
+		index.Fields("tenant_id", "environment_id", "status").
+			StorageKey("idx_meter_tenant_env_status").
+			Annotations(entsql.IndexWhere(
+				"((status)::text = ANY (ARRAY['published'::text, 'archived'::text]))",
+			)),
 	}
 }
 

--- a/go.sum
+++ b/go.sum
@@ -334,6 +334,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -354,6 +356,8 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
-github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -356,8 +354,6 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/internal/ee/service/meter_test.go
+++ b/internal/ee/service/meter_test.go
@@ -203,6 +203,43 @@ func (s *MeterServiceSuite) TestGetAllMeters() {
 	}
 }
 
+// TestListIncludesArchivedMeters ensures empty-status List returns published+archived
+// (billing looks up meters by ID without an explicit status) and excludes deleted.
+func (s *MeterServiceSuite) TestListIncludesArchivedMeters() {
+	seed := func(name string, status types.Status) *meter.Meter {
+		m := meter.NewMeter(name, types.GetTenantID(s.ctx), "test-user")
+		m.EventName = "api_request"
+		m.Aggregation = meter.Aggregation{Type: types.AggregationCount}
+		m.Filters = []meter.Filter{}
+		m.ResetUsage = types.ResetUsageBillingPeriod
+		m.BaseModel = types.GetDefaultBaseModel(s.ctx)
+		m.Status = status
+		s.NoError(s.store.CreateMeter(s.ctx, m))
+		return m
+	}
+
+	published := seed("Published Meter", types.StatusPublished)
+	archived := seed("Archived Meter", types.StatusArchived)
+	deleted := seed("Deleted Meter", types.StatusDeleted)
+
+	filter := types.NewNoLimitMeterFilter()
+	filter.MeterIDs = []string{published.ID, archived.ID, deleted.ID}
+
+	got, err := s.store.List(s.ctx, filter)
+	s.NoError(err)
+
+	ids := make(map[string]types.Status, len(got))
+	for _, m := range got {
+		ids[m.ID] = m.Status
+	}
+
+	s.Equal(types.StatusPublished, ids[published.ID])
+	s.Equal(types.StatusArchived, ids[archived.ID])
+	_, hasDeleted := ids[deleted.ID]
+	s.False(hasDeleted, "deleted meters must not appear in default List")
+	s.Len(got, 2)
+}
+
 // Helper function to sort meters by Name
 func sortMetersByName(meters []*meter.Meter) {
 	sort.Slice(meters, func(i, j int) bool {

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -334,7 +334,6 @@ func (o MeterQueryOptions) ApplyEnvironmentFilter(ctx context.Context, query Met
 
 func (o MeterQueryOptions) ApplyStatusFilter(query MeterQuery, status string) MeterQuery {
 	if status == "" {
-		// Billing and other List callers need archived meters (historical line items).
 		return query.Where(meter.StatusIn(
 			string(types.StatusPublished),
 			string(types.StatusArchived),

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -334,7 +334,11 @@ func (o MeterQueryOptions) ApplyEnvironmentFilter(ctx context.Context, query Met
 
 func (o MeterQueryOptions) ApplyStatusFilter(query MeterQuery, status string) MeterQuery {
 	if status == "" {
-		return query.Where(meter.StatusEQ(string(types.StatusPublished)))
+		// Billing and other List callers need archived meters (historical line items).
+		return query.Where(meter.StatusIn(
+			string(types.StatusPublished),
+			string(types.StatusArchived),
+		))
 	}
 	return query.Where(meter.Status(status))
 }

--- a/internal/testutil/inmemory_meter_store.go
+++ b/internal/testutil/inmemory_meter_store.go
@@ -219,8 +219,12 @@ func meterFilterFn(ctx context.Context, m *meter.Meter, filter interface{}) bool
 		return false
 	}
 
-	// Apply status filter
-	if f.Status != nil && m.Status != *f.Status {
+	// Apply status filter — empty status mirrors Ent ApplyStatusFilter (published + archived).
+	if f.GetStatus() == "" {
+		if m.Status != types.StatusPublished && m.Status != types.StatusArchived {
+			return false
+		}
+	} else if string(m.Status) != f.GetStatus() {
 		return false
 	}
 


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Meter listings now include both **published** and **archived** meters by default, while still excluding **deleted** meters.
  - Status filtering behavior is now consistent across storage implementations when no specific status is requested.
- **Performance**
  - Improved database indexing to speed up queries that filter by tenant, environment, and meter status.
- **Tests**
  - Added coverage to ensure archived meters appear in default listings and deleted meters do not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->