### PR TITLE
feat(invoice): skip non-syncable line items in zoho

### DIFF
--- a/internal/integration/zoho/invoice.go
+++ b/internal/integration/zoho/invoice.go
@@ -188,9 +188,11 @@ func (s *InvoiceService) buildLineItems(ctx context.Context, flexInvoice *invoic
 	childCustomerIDs := make([]string, 0)
 	lineItemIDToChildCustomer := make(map[string]string)
 	for _, li := range flexInvoice.LineItems {
-		if li == nil || li.Amount.IsZero() {
+		// skip line items that are not syncable
+		if li == nil || li.Amount.IsZero() || li.PriceID == nil {
 			continue
 		}
+
 		inputs = append(inputs, ItemSyncInput{
 			PriceID: lo.FromPtr(li.PriceID),
 			Name:    lo.FromPtrOr(li.DisplayName, "Charge"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice synchronization by skipping line items with missing pricing information.
  * Prevented incomplete or invalid line items from being processed during invoice imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->