### PR TITLE
feat(webhook): Send only subscribed events to svix

### DIFF
--- a/ent/schema/meter.go
+++ b/ent/schema/meter.go
@@ -77,13 +77,13 @@ type MeterFilter struct {
 
 // MeterAggregation defines the aggregation configuration for a meter
 type MeterAggregation struct {
-	Type       types.AggregationType `json:"type"`
-	Field      string                `json:"field,omitempty"`
+	Type  types.AggregationType `json:"type"`
+	Field string                `json:"field,omitempty"`
 	// Expression is an optional CEL expression to compute per-event quantity from event.properties.
 	// When set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).
-	Expression string                `json:"expression,omitempty"`
-	Multiplier *decimal.Decimal      `json:"multiplier,omitempty"`
-	BucketSize types.WindowSize      `json:"bucket_size,omitempty"`
+	Expression string           `json:"expression,omitempty"`
+	Multiplier *decimal.Decimal `json:"multiplier,omitempty"`
+	BucketSize types.WindowSize `json:"bucket_size,omitempty"`
 	// GroupBy is the property name in event.properties to group by before aggregating.
 	// Currently only supported for MAX aggregation with bucket_size.
 	// When set, aggregation is applied per unique value of this property within each bucket,

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -264,6 +264,7 @@ func (s *meterUsageTrackingService) getMetersForEvent(ctx context.Context, event
 
 		meterFilter := types.NewNoLimitMeterFilter()
 		meterFilter.EventName = eventName
+		meterFilter.Status = lo.ToPtr(types.StatusPublished)
 
 		meters, err := s.MeterRepo.List(ctx, meterFilter)
 		if err != nil {

--- a/internal/repository/ent/creditgrant.go
+++ b/internal/repository/ent/creditgrant.go
@@ -553,7 +553,10 @@ func (o CreditGrantQueryOptions) ApplyEnvironmentFilter(ctx context.Context, que
 
 func (o CreditGrantQueryOptions) ApplyStatusFilter(query CreditGrantQuery, status string) CreditGrantQuery {
 	if status == "" {
-		return query.Where(creditgrant.StatusEQ(string(types.StatusPublished)))
+		return query.Where(creditgrant.StatusIn(
+			string(types.StatusPublished),
+			string(types.StatusArchived),
+		))
 	}
 	return query.Where(creditgrant.Status(status))
 }

--- a/internal/repository/ent/feature.go
+++ b/internal/repository/ent/feature.go
@@ -484,7 +484,10 @@ func (o FeatureQueryOptions) ApplyEnvironmentFilter(ctx context.Context, query F
 
 func (o FeatureQueryOptions) ApplyStatusFilter(query FeatureQuery, status string) FeatureQuery {
 	if status == "" {
-		return query.Where(feature.StatusEQ(string(types.StatusPublished)))
+		return query.Where(feature.StatusIn(
+			string(types.StatusPublished),
+			string(types.StatusArchived),
+		))
 	}
 	return query.Where(feature.Status(status))
 }

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -800,7 +800,10 @@ func (o WalletTransactionQueryOptions) ApplyEnvironmentFilter(ctx context.Contex
 
 func (o WalletTransactionQueryOptions) ApplyStatusFilter(query WalletTransactionQuery, status string) WalletTransactionQuery {
 	if status == "" {
-		return query.Where(wallettransaction.StatusEQ(string(types.StatusPublished)))
+		return query.Where(wallettransaction.StatusIn(
+			string(types.StatusPublished),
+			string(types.StatusArchived),
+		))
 	}
 	return query.Where(wallettransaction.Status(status))
 }

--- a/internal/svix/client.go
+++ b/internal/svix/client.go
@@ -5,13 +5,41 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 
+	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/httpclient"
 	"github.com/flexprice/flexprice/internal/tracing"
 	svix "github.com/svix/svix-webhooks/go"
 	"github.com/svix/svix-webhooks/go/models"
 )
+
+// subscriptionCacheTTL bounds how long a tenant's Svix endpoint subscription
+// map is trusted before we re-list. 1m matches typical UI-driven change latency.
+const subscriptionCacheTTL = 1 * time.Minute
+
+// subscriptionCachePrefix namespaces the cache entries for endpoint subscriptions.
+const subscriptionCachePrefix = "svix_subs:v1:"
+
+// appSubscriptions is the cached result of listing an app's endpoints.
+// subscribeAll=true when at least one endpoint has no filterTypes (Svix treats
+// an empty filterTypes list as "receive every event type").
+type appSubscriptions struct {
+	subscribeAll bool
+	types        map[string]struct{}
+}
+
+func (s *appSubscriptions) has(eventType string) bool {
+	if s == nil {
+		return false
+	}
+	if s.subscribeAll {
+		return true
+	}
+	_, ok := s.types[eventType]
+	return ok
+}
 
 // Client wraps the Svix SDK client
 type Client struct {
@@ -115,6 +143,77 @@ func (c *Client) GetDashboardURL(ctx context.Context, applicationID string) (url
 	}
 
 	return dashboard.Url, dashboard.Token, nil
+}
+
+// IsEventSubscribed returns true if the tenant's Svix application has at least
+// one endpoint subscribed to eventType. An endpoint without filterTypes counts
+// as subscribed to every event. Results are cached per app for
+// subscriptionCacheTTL. When Svix is disabled the check is a no-op (returns
+// true) so callers keep their existing behaviour.
+//
+// Fail-open on transient list errors: callers should not silently drop webhooks
+// because Svix's control-plane is momentarily unhappy — the message send itself
+// will retry via the caller's existing error path.
+func (c *Client) IsEventSubscribed(ctx context.Context, applicationID, eventType string) (bool, error) {
+	if !c.enabled || c.client == nil {
+		return true, nil
+	}
+
+	cacheKey := subscriptionCachePrefix + applicationID
+	cacheClient := cache.GetInMemoryCache()
+	if cacheClient != nil {
+		if cached, found := cacheClient.ForceCacheGet(ctx, cacheKey); found {
+			if subs, ok := cached.(*appSubscriptions); ok {
+				return subs.has(eventType), nil
+			}
+		}
+	}
+
+	subs, err := c.listSubscribedEvents(ctx, applicationID)
+	if err != nil {
+		return true, err
+	}
+
+	if cacheClient != nil {
+		cacheClient.ForceCacheSet(ctx, cacheKey, subs, subscriptionCacheTTL)
+	}
+	return subs.has(eventType), nil
+}
+
+// listSubscribedEvents walks every endpoint on the app and folds their
+// filterTypes into a single appSubscriptions. ponytail: no pagination limit
+// guard; add a page cap if a tenant ever fans out past a few thousand endpoints.
+func (c *Client) listSubscribedEvents(ctx context.Context, applicationID string) (*appSubscriptions, error) {
+	subs := &appSubscriptions{types: map[string]struct{}{}}
+	var iterator *string
+	for {
+		page, err := c.client.Endpoint.List(ctx, applicationID, &svix.EndpointListOptions{
+			Iterator: iterator,
+		})
+		if err != nil {
+			if err.Error() == "application not found" {
+				return subs, nil
+			}
+			return nil, fmt.Errorf("failed to list endpoints: %w", err)
+		}
+		for _, ep := range page.Data {
+			if ep.Disabled != nil && *ep.Disabled {
+				continue
+			}
+			if len(ep.FilterTypes) == 0 {
+				subs.subscribeAll = true
+				continue
+			}
+			for _, t := range ep.FilterTypes {
+				subs.types[t] = struct{}{}
+			}
+		}
+		if page.Done || page.Iterator == nil || *page.Iterator == "" {
+			break
+		}
+		iterator = page.Iterator
+	}
+	return subs, nil
 }
 
 // SendMessage sends a webhook message to the given application.

--- a/internal/svix/subscriptions_test.go
+++ b/internal/svix/subscriptions_test.go
@@ -1,0 +1,25 @@
+package svix
+
+import "testing"
+
+func TestAppSubscriptions_Has(t *testing.T) {
+	all := &appSubscriptions{subscribeAll: true}
+	if !all.has("anything.happened") {
+		t.Fatalf("subscribeAll must match every event type")
+	}
+
+	filtered := &appSubscriptions{types: map[string]struct{}{
+		"invoice.created": {},
+	}}
+	if !filtered.has("invoice.created") {
+		t.Fatalf("filtered set must match listed type")
+	}
+	if filtered.has("invoice.voided") {
+		t.Fatalf("filtered set must not match unlisted type")
+	}
+
+	var nilSubs *appSubscriptions
+	if nilSubs.has("x") {
+		t.Fatalf("nil subscriptions must not match")
+	}
+}

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -245,6 +245,33 @@ func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, me
 		return err
 	}
 
+	subscribed, subErr := h.svixClient.IsEventSubscribed(ctx, appID, event.EventName)
+	if subErr != nil {
+		// Fail-open: if we can't confirm subscription state, fall through to send.
+		h.logger.Info(ctx, "svix subscription lookup failed, sending anyway",
+			"error", subErr,
+			"event_name", event.EventName,
+			"tenant_id", event.TenantID,
+		)
+	} else if !subscribed {
+		h.logger.Debug(ctx, "svix skipping unsubscribed event",
+			"event_name", event.EventName,
+			"tenant_id", event.TenantID,
+			"environment_id", event.EnvironmentID,
+		)
+		if h.systemEventRepo != nil && event.ID != "" {
+			if err := h.systemEventRepo.OnDelivered(ctx, event.ID, nil); err != nil {
+				h.logger.Info(ctx, "system_events OnDelivered failed for unsubscribed event",
+					"error", err,
+					"event_id", event.ID,
+					"event_name", event.EventName,
+				)
+				return err
+			}
+		}
+		return nil
+	}
+
 	builder, err := h.factory.GetBuilder(event.EventName)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook delivery now checks event subscriptions before sending, preventing delivery of events that are not subscribed.
  - Added subscription status caching to improve repeated webhook checks and support subscription-wide endpoints.
  - Subscription lookup failures fail open to avoid unintentionally dropping webhooks.

- **Bug Fixes**
  - Default queries now include both published and archived credit grants, features, and wallet transactions.
  - Meter usage tracking now considers only published meters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->