### PR TITLE
feat(redis): Redis Sentinel support (HA / automatic failover)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -658,8 +658,21 @@ type RedisConfig struct {
 	// cluster-mode enabled). false → standalone *redis.Client. Default is
 	// true to preserve the pre-1.1 hardcoded behaviour; flip to false for
 	// single-node Redis. Baked default lives in config.yaml; env override:
-	// FLEXPRICE_REDIS_CLUSTER_MODE.
+	// FLEXPRICE_REDIS_CLUSTER_MODE. Ignored when SentinelMasterName is set.
 	ClusterMode bool `mapstructure:"cluster_mode"`
+
+	// Sentinel HA: a non-empty SentinelMasterName switches to Sentinel mode
+	// (ignores Host/Port/ClusterMode) and resolves the master via the quorum.
+	// SentinelAddrs are the sentinel endpoints, NOT the master. Password (above)
+	// auths the data nodes; SentinelUsername/Password auth the sentinels.
+	SentinelMasterName string   `mapstructure:"sentinel_master_name" default:""`
+	SentinelAddrs      []string `mapstructure:"sentinel_addrs"`
+	SentinelUsername   string   `mapstructure:"sentinel_username" default:""`
+	SentinelPassword   string   `mapstructure:"sentinel_password" default:""`
+
+	// RouteReadsToReplicas (Sentinel only) routes reads to the lowest-latency node
+	// among master+replicas; writes stay on master. Read scaling, not sharding.
+	RouteReadsToReplicas bool `mapstructure:"route_reads_to_replicas" default:"false"`
 }
 
 func NewConfig() (*Configuration, error) {

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -434,6 +434,12 @@ redis:
   # was always *redis.ClusterClient). Set to false when targeting a single-node
   # Redis (in-cluster bitnami/redis chart, single-node ElastiCache).
   cluster_mode: true
+  # Sentinel HA: set sentinel_master_name to enable (ignores host/port/cluster_mode).
+  sentinel_master_name: "" # e.g. "mymaster"; FLEXPRICE_REDIS_SENTINEL_MASTER_NAME
+  sentinel_addrs: [] # sentinel endpoints host:port, NOT the master; FLEXPRICE_REDIS_SENTINEL_ADDRS (comma-separated)
+  sentinel_username: "" # sentinel auth, optional; FLEXPRICE_REDIS_SENTINEL_USERNAME
+  sentinel_password: "" # sentinel auth, optional; FLEXPRICE_REDIS_SENTINEL_PASSWORD
+  route_reads_to_replicas: false # reads to lowest-latency master/replica (NOT sharding); FLEXPRICE_REDIS_ROUTE_READS_TO_REPLICAS
 
 # Raw events reprocessing configuration
 raw_events_reprocessing:

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -27,18 +27,27 @@ const (
 	modeSentinelReplicaRead redisMode = "sentinel-replica-read"
 )
 
-// resolveRedisMode maps config to a topology (Sentinel > Cluster > Standalone).
-// Pure function so precedence is unit-testable without a live Redis.
-func resolveRedisMode(c config.RedisConfig) redisMode {
+// resolveRedisMode maps config to a topology (Sentinel > Cluster > Standalone)
+// and validates Sentinel coherence: master name and addresses must be set
+// together, else HA is silently lost (addrs dropped) or go-redis defaults to a
+// phantom localhost sentinel. Pure (no I/O) so both precedence and the guards
+// are unit-testable without a live Redis.
+func resolveRedisMode(c config.RedisConfig) (redisMode, error) {
+	hasMaster := c.SentinelMasterName != ""
+	hasAddrs := len(c.SentinelAddrs) > 0
 	switch {
-	case c.SentinelMasterName != "" && c.RouteReadsToReplicas:
-		return modeSentinelReplicaRead
-	case c.SentinelMasterName != "":
-		return modeSentinel
+	case hasMaster && !hasAddrs:
+		return "", fmt.Errorf("redis: FLEXPRICE_REDIS_SENTINEL_MASTER_NAME is set but no sentinel addresses provided (FLEXPRICE_REDIS_SENTINEL_ADDRS)")
+	case hasAddrs && !hasMaster:
+		return "", fmt.Errorf("redis: sentinel addresses are set but FLEXPRICE_REDIS_SENTINEL_MASTER_NAME is empty — set the master name to enable Sentinel mode, or clear the addresses")
+	case hasMaster && c.RouteReadsToReplicas:
+		return modeSentinelReplicaRead, nil
+	case hasMaster:
+		return modeSentinel, nil
 	case c.ClusterMode:
-		return modeCluster
+		return modeCluster, nil
 	default:
-		return modeStandalone
+		return modeStandalone, nil
 	}
 }
 
@@ -66,15 +75,14 @@ func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error
 	}
 
 	var rdb redis.UniversalClient
-	mode := resolveRedisMode(config.Redis)
+	mode, err := resolveRedisMode(config.Redis)
+	if err != nil {
+		return nil, err
+	}
 	switch mode {
 	case modeSentinel, modeSentinelReplicaRead:
 		// Addrs are the sentinel endpoints; go-redis (via Failover()) discovers
-		// the master/replicas. Guard empty addrs: go-redis would otherwise default
-		// to 127.0.0.1:26379 and connect to a phantom local sentinel.
-		if len(config.Redis.SentinelAddrs) == 0 {
-			return nil, fmt.Errorf("redis sentinel mode requires at least one sentinel address (FLEXPRICE_REDIS_SENTINEL_ADDRS)")
-		}
+		// the master/replicas. resolveRedisMode has already ensured they're set.
 		opts.Addrs = config.Redis.SentinelAddrs
 		opts.MasterName = config.Redis.SentinelMasterName
 		opts.SentinelUsername = config.Redis.SentinelUsername

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -17,10 +17,33 @@ type Client struct {
 	log *logger.Logger
 }
 
-// NewClient creates a new Redis client. Set RedisConfig.ClusterMode=true for
-// Redis Cluster (e.g. AWS ElastiCache cluster mode enabled); leave false for
-// standalone Redis (single ElastiCache node, in-cluster redis, Redis sentinel
-// via the universal client's failover path).
+// redisMode is the connection topology NewClient selects from RedisConfig.
+type redisMode string
+
+const (
+	modeStandalone          redisMode = "standalone"
+	modeCluster             redisMode = "cluster"
+	modeSentinel            redisMode = "sentinel"
+	modeSentinelReplicaRead redisMode = "sentinel-replica-read"
+)
+
+// resolveRedisMode maps config to a topology (Sentinel > Cluster > Standalone).
+// Pure function so precedence is unit-testable without a live Redis.
+func resolveRedisMode(c config.RedisConfig) redisMode {
+	switch {
+	case c.SentinelMasterName != "" && c.RouteReadsToReplicas:
+		return modeSentinelReplicaRead
+	case c.SentinelMasterName != "":
+		return modeSentinel
+	case c.ClusterMode:
+		return modeCluster
+	default:
+		return modeStandalone
+	}
+}
+
+// NewClient creates a Redis client in one of three modes (see resolveRedisMode):
+// Sentinel (HA/automatic failover), Cluster (sharded), or Standalone (single node).
 func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), config.Redis.Timeout)
 	defer cancel()
@@ -34,7 +57,6 @@ func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error
 	}
 
 	opts := &redis.UniversalOptions{
-		Addrs:        []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)},
 		Password:     config.Redis.Password,
 		DB:           config.Redis.DB,
 		ReadTimeout:  config.Redis.Timeout,
@@ -44,20 +66,43 @@ func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error
 	}
 
 	var rdb redis.UniversalClient
-	if config.Redis.ClusterMode {
+	mode := resolveRedisMode(config.Redis)
+	switch mode {
+	case modeSentinel, modeSentinelReplicaRead:
+		// Addrs are the sentinel endpoints; go-redis (via Failover()) discovers
+		// the master/replicas. Guard empty addrs: go-redis would otherwise default
+		// to 127.0.0.1:26379 and connect to a phantom local sentinel.
+		if len(config.Redis.SentinelAddrs) == 0 {
+			return nil, fmt.Errorf("redis sentinel mode requires at least one sentinel address (FLEXPRICE_REDIS_SENTINEL_ADDRS)")
+		}
+		opts.Addrs = config.Redis.SentinelAddrs
+		opts.MasterName = config.Redis.SentinelMasterName
+		opts.SentinelUsername = config.Redis.SentinelUsername
+		opts.SentinelPassword = config.Redis.SentinelPassword
+		if mode == modeSentinelReplicaRead {
+			// RouteByLatency: reads go to the lowest-latency node among
+			// master+replicas, writes to master. Read scaling, not sharding.
+			opts.RouteByLatency = true
+			rdb = redis.NewFailoverClusterClient(opts.Failover())
+		} else {
+			rdb = redis.NewFailoverClient(opts.Failover())
+		}
+	case modeCluster:
+		opts.Addrs = []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)}
 		rdb = redis.NewClusterClient(opts.Cluster())
-	} else {
+	default: // modeStandalone
 		// UniversalOptions.Simple() routes to a standalone *redis.Client; DB index applies.
+		opts.Addrs = []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)}
 		rdb = redis.NewClient(opts.Simple())
 	}
 
 	result, err := rdb.Ping(ctx).Result()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create redis client: %w", err)
+		return nil, fmt.Errorf("failed to create redis client (mode=%s): %w", mode, err)
 	}
 
-	log.Info(ctx, "PING result", "result", result, "cluster_mode", config.Redis.ClusterMode)
-	log.Info(ctx, "Connected to Redis successfully", "addr", opts.Addrs, "cluster_mode", config.Redis.ClusterMode)
+	log.Info(ctx, "PING result", "result", result, "mode", string(mode))
+	log.Info(ctx, "Connected to Redis successfully", "addr", opts.Addrs, "mode", string(mode))
 
 	return &Client{
 		rdb: rdb,

--- a/internal/redis/client_sentinel_test.go
+++ b/internal/redis/client_sentinel_test.go
@@ -1,0 +1,229 @@
+package redis
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// sentinelCfgFromEnv builds a Sentinel client config from env vars so the same
+// tests exercise both the plain rig and the auth+TLS rig:
+//
+//	REDIS_SENTINEL_ADDRS       comma-separated sentinel endpoints (required)
+//	REDIS_SENTINEL_MASTER      master group name (default "mymaster")
+//	REDIS_PASSWORD             data-node password (auth rig)
+//	REDIS_SENTINEL_PASSWORD    password to auth to the sentinels (auth rig)
+//	REDIS_USE_TLS=1            connect over TLS (tls rig)
+func sentinelCfgFromEnv() *config.Configuration {
+	addrs := os.Getenv("REDIS_SENTINEL_ADDRS")
+	if addrs == "" {
+		addrs = "127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381"
+	}
+	master := os.Getenv("REDIS_SENTINEL_MASTER")
+	if master == "" {
+		master = "mymaster"
+	}
+
+	cfg := config.GetDefaultConfig()
+	cfg.Redis.Timeout = 3 * time.Second
+	cfg.Redis.SentinelMasterName = master
+	cfg.Redis.SentinelAddrs = strings.Split(addrs, ",")
+	cfg.Redis.Password = os.Getenv("REDIS_PASSWORD")
+	cfg.Redis.SentinelPassword = os.Getenv("REDIS_SENTINEL_PASSWORD")
+	cfg.Redis.UseTLS = os.Getenv("REDIS_USE_TLS") == "1"
+	cfg.Redis.RouteReadsToReplicas = os.Getenv("REDIS_SENTINEL_ROUTE_READS") == "1"
+	return cfg
+}
+
+// TestNewClient_SurvivesFailover is the production scenario: a long-lived client
+// holds a connection through a master failure. It connects via Sentinel, then
+// hammers SET/GET for RUN_SECONDS while an external driver kills the master
+// mid-run (see scripts/redis-sentinel-test/test-survive-failover.sh). It PASSES
+// if the client recovers on its own (no restart) — the final ops succeed — and
+// reports the longest stall so we can see how long the blip lasted.
+//
+// Gated behind REDIS_FAILOVER_TEST=1.
+func TestNewClient_SurvivesFailover(t *testing.T) {
+	if os.Getenv("REDIS_FAILOVER_TEST") != "1" {
+		t.Skip("set REDIS_FAILOVER_TEST=1 and run via test-survive-failover.sh")
+	}
+
+	runSecs := 45
+	if v := os.Getenv("RUN_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			runSecs = n
+		}
+	}
+
+	cfg := sentinelCfgFromEnv()
+
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	client, err := NewClient(cfg, log)
+	if err != nil {
+		t.Fatalf("initial NewClient failed: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	rdb := client.GetClient()
+	deadline := time.Now().Add(time.Duration(runSecs) * time.Second)
+
+	var ok, fail int
+	var curStall, maxStall int
+	sawFailure := false
+	tick := 0
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		key := "flexprice:failover:probe"
+		err := rdb.Set(ctx, key, "v", time.Minute).Err()
+		if err == nil {
+			_, err = rdb.Get(ctx, key).Result()
+		}
+		cancel()
+
+		tick++
+		if err != nil {
+			fail++
+			sawFailure = true
+			curStall++
+			if curStall > maxStall {
+				maxStall = curStall
+			}
+			if fail%3 == 1 {
+				t.Logf("tick %d: DOWN (%v)", tick, err)
+			}
+		} else {
+			if curStall > 0 {
+				t.Logf("tick %d: RECOVERED after %d failed ticks", tick, curStall)
+			}
+			ok++
+			curStall = 0
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Logf("summary: ok=%d fail=%d longest-stall=%d ticks (~%.1fs) sawFailure=%v",
+		ok, fail, maxStall, float64(maxStall)*0.5, sawFailure)
+
+	// Must be healthy at the end (recovered without a restart).
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("client did NOT recover — still failing after run: %v", err)
+	}
+	if ok == 0 {
+		t.Fatal("no successful operations at all — check the rig")
+	}
+	// Prove the final stretch is stable, not a lucky single ping.
+	for i := 0; i < 5; i++ {
+		if err := rdb.Set(ctx, "flexprice:failover:final", "ok", time.Minute).Err(); err != nil {
+			t.Fatalf("post-run stability check failed on op %d: %v", i, err)
+		}
+	}
+	t.Logf("PASS: client survived and recovered on its own (no restart)")
+}
+
+// TestNewClient_StandaloneMode is a backward-compat guard: with no Sentinel
+// config (the default), NewClient must still connect in standalone mode exactly
+// as before. Gated behind REDIS_STANDALONE_TEST=1 (needs a plain Redis).
+//
+//	docker run -d --name r -p 6379:6379 redis:7-alpine
+//	REDIS_STANDALONE_TEST=1 go test -v ./internal/redis -run TestNewClient_StandaloneMode
+func TestNewClient_StandaloneMode(t *testing.T) {
+	if os.Getenv("REDIS_STANDALONE_TEST") != "1" {
+		t.Skip("set REDIS_STANDALONE_TEST=1 (and start a plain redis) to run the standalone backward-compat test")
+	}
+
+	host := os.Getenv("REDIS_HOST")
+	if host == "" {
+		host = "127.0.0.1"
+	}
+
+	cfg := config.GetDefaultConfig()
+	cfg.Redis.Timeout = 5 * time.Second
+	cfg.Redis.Host = host
+	cfg.Redis.Port = 6379
+	// SentinelMasterName and ClusterMode left at their zero values → standalone.
+
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	client, err := NewClient(cfg, log)
+	if err != nil {
+		t.Fatalf("NewClient (standalone) failed: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("standalone ping failed: %v", err)
+	}
+	const key, want = "flexprice:standalone:probe", "ok"
+	if err := client.GetClient().Set(ctx, key, want, time.Minute).Err(); err != nil {
+		t.Fatalf("standalone set failed: %v", err)
+	}
+	if got, _ := client.GetClient().Get(ctx, key).Result(); got != want {
+		t.Fatalf("standalone round-trip mismatch: got %q want %q", got, want)
+	}
+}
+
+// TestNewClient_SentinelMode exercises the real NewClient Sentinel code path
+// against the rig in scripts/redis-sentinel-test. It is gated behind
+// REDIS_SENTINEL_TEST=1 so `make test` never requires a running Sentinel quorum.
+//
+// Run it (from a host that can route to the Sentinel-discovered node IPs — a
+// Linux box / CI, or from inside the compose network; see the rig README for the
+// Mac networking caveat):
+//
+//	docker compose -f scripts/redis-sentinel-test/docker-compose.sentinel.yml up -d
+//	REDIS_SENTINEL_TEST=1 \
+//	  REDIS_SENTINEL_ADDRS=127.0.0.1:26379,127.0.0.1:26380,127.0.0.1:26381 \
+//	  REDIS_SENTINEL_MASTER=mymaster \
+//	  go test -v -race ./internal/redis -run TestNewClient_SentinelMode
+func TestNewClient_SentinelMode(t *testing.T) {
+	if os.Getenv("REDIS_SENTINEL_TEST") != "1" {
+		t.Skip("set REDIS_SENTINEL_TEST=1 (and start the rig) to run the Sentinel integration test")
+	}
+
+	cfg := sentinelCfgFromEnv()
+
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+
+	client, err := NewClient(cfg, log)
+	if err != nil {
+		t.Fatalf("NewClient (sentinel) failed — is the rig up and reachable? %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("ping via sentinel-resolved master failed: %v", err)
+	}
+
+	const key, want = "flexprice:sentinel:probe", "ok"
+	if err := client.GetClient().Set(ctx, key, want, time.Minute).Err(); err != nil {
+		t.Fatalf("set via sentinel master failed: %v", err)
+	}
+	got, err := client.GetClient().Get(ctx, key).Result()
+	if err != nil {
+		t.Fatalf("get via sentinel failed: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, want)
+	}
+}

--- a/internal/redis/client_test.go
+++ b/internal/redis/client_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 )
 
-// TestResolveRedisMode locks the mode-selection precedence: Sentinel wins over
-// Cluster, RouteReadsToReplicas only refines Sentinel, and the zero config is
-// standalone (the backward-compatible default). No infra required.
+// TestResolveRedisMode locks mode-selection precedence (Sentinel > Cluster >
+// Standalone) and the Sentinel coherence guards: master name and addresses must
+// be set together. No infra required.
 func TestResolveRedisMode(t *testing.T) {
+	addrs := []string{"s1:26379", "s2:26379"}
 	tests := []struct {
-		name string
-		cfg  config.RedisConfig
-		want redisMode
+		name    string
+		cfg     config.RedisConfig
+		want    redisMode
+		wantErr bool
 	}{
 		{
 			name: "zero config -> standalone (backward compatible)",
@@ -28,18 +30,18 @@ func TestResolveRedisMode(t *testing.T) {
 			want: modeCluster,
 		},
 		{
-			name: "sentinel master set -> sentinel",
-			cfg:  config.RedisConfig{SentinelMasterName: "mymaster"},
+			name: "sentinel master + addrs -> sentinel",
+			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", SentinelAddrs: addrs},
 			want: modeSentinel,
 		},
 		{
 			name: "sentinel + route reads -> sentinel-replica-read",
-			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", RouteReadsToReplicas: true},
+			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", SentinelAddrs: addrs, RouteReadsToReplicas: true},
 			want: modeSentinelReplicaRead,
 		},
 		{
 			name: "sentinel AND cluster both set -> sentinel wins",
-			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", ClusterMode: true},
+			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", SentinelAddrs: addrs, ClusterMode: true},
 			want: modeSentinel,
 		},
 		{
@@ -47,10 +49,30 @@ func TestResolveRedisMode(t *testing.T) {
 			cfg:  config.RedisConfig{ClusterMode: true, RouteReadsToReplicas: true},
 			want: modeCluster,
 		},
+		{
+			name:    "master without addrs -> error",
+			cfg:     config.RedisConfig{SentinelMasterName: "mymaster"},
+			wantErr: true,
+		},
+		{
+			name:    "addrs without master -> error (silent HA loss)",
+			cfg:     config.RedisConfig{SentinelAddrs: addrs},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := resolveRedisMode(tt.cfg); got != tt.want {
+			got, err := resolveRedisMode(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveRedisMode() expected error, got mode %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveRedisMode() unexpected error: %v", err)
+			}
+			if got != tt.want {
 				t.Fatalf("resolveRedisMode() = %q, want %q", got, tt.want)
 			}
 		})
@@ -90,5 +112,27 @@ func TestNewClient_SentinelMissingAddrsErrors(t *testing.T) {
 				t.Fatal("expected an error, got nil")
 			}
 		})
+	}
+}
+
+// TestNewClient_SentinelAddrsWithoutMasterErrors guards the inverse misconfig:
+// sentinel addresses set but SentinelMasterName empty must fail fast rather than
+// silently dropping the addresses and running without HA.
+func TestNewClient_SentinelAddrsWithoutMasterErrors(t *testing.T) {
+	cfg := config.GetDefaultConfig()
+	cfg.Redis.Timeout = 500 * time.Millisecond
+	cfg.Redis.SentinelMasterName = "" // empty / typo'd
+	cfg.Redis.SentinelAddrs = []string{"10.0.0.1:26379"}
+
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	client, err := NewClient(cfg, log)
+	if err == nil {
+		if client != nil {
+			_ = client.Close()
+		}
+		t.Fatal("expected an error for sentinel addrs without master name, got nil")
 	}
 }

--- a/internal/redis/client_test.go
+++ b/internal/redis/client_test.go
@@ -1,0 +1,94 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// TestResolveRedisMode locks the mode-selection precedence: Sentinel wins over
+// Cluster, RouteReadsToReplicas only refines Sentinel, and the zero config is
+// standalone (the backward-compatible default). No infra required.
+func TestResolveRedisMode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.RedisConfig
+		want redisMode
+	}{
+		{
+			name: "zero config -> standalone (backward compatible)",
+			cfg:  config.RedisConfig{},
+			want: modeStandalone,
+		},
+		{
+			name: "cluster_mode set -> cluster",
+			cfg:  config.RedisConfig{ClusterMode: true},
+			want: modeCluster,
+		},
+		{
+			name: "sentinel master set -> sentinel",
+			cfg:  config.RedisConfig{SentinelMasterName: "mymaster"},
+			want: modeSentinel,
+		},
+		{
+			name: "sentinel + route reads -> sentinel-replica-read",
+			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", RouteReadsToReplicas: true},
+			want: modeSentinelReplicaRead,
+		},
+		{
+			name: "sentinel AND cluster both set -> sentinel wins",
+			cfg:  config.RedisConfig{SentinelMasterName: "mymaster", ClusterMode: true},
+			want: modeSentinel,
+		},
+		{
+			name: "route reads without sentinel is ignored -> cluster",
+			cfg:  config.RedisConfig{ClusterMode: true, RouteReadsToReplicas: true},
+			want: modeCluster,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveRedisMode(tt.cfg); got != tt.want {
+				t.Fatalf("resolveRedisMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewClient_SentinelMissingAddrsErrors verifies that a misconfigured Sentinel
+// setup fails loudly rather than panicking, hanging, or (worse) silently
+// connecting to go-redis's 127.0.0.1:26379 default when addrs are empty.
+func TestNewClient_SentinelMissingAddrsErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		addrs []string
+	}{
+		// Empty addrs must be rejected up front — go-redis would otherwise
+		// substitute 127.0.0.1:26379 and connect to a phantom local sentinel.
+		{name: "empty addrs", addrs: nil},
+		// Unreachable addrs must surface a connection error, not hang.
+		{name: "unreachable addr", addrs: []string{"127.0.0.1:1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.GetDefaultConfig()
+			cfg.Redis.Timeout = 500 * time.Millisecond
+			cfg.Redis.SentinelMasterName = "mymaster"
+			cfg.Redis.SentinelAddrs = tt.addrs
+
+			log, err := logger.NewLogger(cfg)
+			if err != nil {
+				t.Fatalf("logger: %v", err)
+			}
+			client, err := NewClient(cfg, log)
+			if err == nil {
+				if client != nil {
+					_ = client.Close()
+				}
+				t.Fatal("expected an error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a **Redis Sentinel** connection mode to the Redis client, alongside standalone and cluster — for self-hosted deployments needing Redis HA (automatic failover) **without** sharding. `NewClient` selects one of three mutually exclusive modes: **Sentinel** (precedence) → **Cluster** → **Standalone**.

## Config (env-driven; covered by the existing reflection auto-binder)

| Env var | Purpose |
|---|---|
| `FLEXPRICE_REDIS_SENTINEL_MASTER_NAME` | Enables Sentinel mode when set |
| `FLEXPRICE_REDIS_SENTINEL_ADDRS` | Sentinel endpoints `host:port` (comma-separated, not the master) |
| `FLEXPRICE_REDIS_SENTINEL_USERNAME` / `FLEXPRICE_REDIS_SENTINEL_PASSWORD` | Auth to the sentinels (optional) |
| `FLEXPRICE_REDIS_ROUTE_READS_TO_REPLICAS` | Route reads to lowest-latency master/replica (read scaling, not sharding) |

## Backward compatibility

Zero impact with no Sentinel config (the default) — non-Sentinel branches set the same options/constructors as before. Only observable change: startup log field `cluster_mode` → `mode`. Auth/TLS are config-based; the two-password model (data-node vs. sentinel password) is independent and composes with TLS. Empty sentinel addrs fail fast instead of silently connecting to localhost.

## Tests

- Unit (run in `make test`, no infra): `resolveRedisMode` precedence, bad-config → error.
- Gated integration (env-driven): standalone backward-compat, Sentinel connect, survive-failover; all pick up auth/TLS from env.

Verified locally against a 1-master/2-replica/3-sentinel quorum: replica promotion, client survives an abrupt master SIGKILL (recovers, no restart), and the full auth + TLS path incl. failover. Local test rig intentionally not committed.

> Clean companion to #2353 (which targets `main`). Cut directly from `develop`, so this diff is Sentinel-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Redis Sentinel high-availability configuration, including master discovery and optional Sentinel authentication.
  - Reads can optionally be routed to replicas for lower latency, while writes continue to go to the master.
  - Redis connection mode selection now supports standalone, cluster, and Sentinel (with optional replica-read) based on configuration.

- **Bug Fixes**
  - Misconfigured Sentinel settings now fail fast with clear errors instead of falling back silently.
  - Improved failover behavior so client operations recover after a master change without requiring a restart.

- **Tests**
  - Added coverage for Sentinel and failover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->