### PR TITLE
feat(entitlements): Improve grants window

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -251,6 +251,7 @@ func main() {
 			service.NewInvoiceService,
 			service.NewFeatureService,
 			service.NewEntitlementService,
+			service.NewEntitlementGrantService,
 			service.NewPaymentService,
 			service.NewPaymentProcessorService,
 			service.NewTaskService,

--- a/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
+++ b/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
@@ -77,7 +77,8 @@ CREATE TABLE entitlement_grants (
     valid_from             timestamptz NOT NULL,
     valid_to               timestamptz NOT NULL,             -- <= sub.current_period_end
     grant_status           varchar(20) NOT NULL DEFAULT 'active',  -- active|exhausted; expiry derived from valid_to
-    last_computed_at       timestamptz                              -- >= valid_to marks a closed window finalized
+    last_computed_at       timestamptz,                             -- snapshot watermark; >= valid_to marks a closed window finalized
+    quota_crossed_at       timestamptz                              -- set once: the EVALUATION time that first saw usage > quota (see §5.3 note)
     -- + standard base columns (status, created_at, ...)
 );
 
@@ -264,10 +265,12 @@ Grants are immutable for their lifetime; EC/mode/quota changes take effect from 
 
 Per returned feature-scoped grant (open windows plus the finalize set), over `[valid_from, min(now, valid_to))`:
 
-- **quantity** — one raw `meter_usage` query (`dto.GrantWindowUsageRequest.ToParams()`, FINAL consistency).
+- **quantity** — one raw `meter_usage` query (`dto.UsageTotalRequest.ToParams()`, FINAL consistency).
 - **amount** — rides the billing path: `GetSubscriptionMeterUsageWithSub` + `ConvertToBillingCharges`, summing the charges for the grant's meter. The billing path splits the window into per-line-item date ranges, so a **mid-window price change produces a new segment priced at its own price** — no price pinning, no retroactive repricing.
 
-Snapshot write (`UpdateSnapshot`): `usage`, `last_computed_at`, and `active → exhausted` when `usage >= quota`.
+Snapshot write (`UpdateSnapshot`): `usage`, `last_computed_at`, `quota_crossed_at`, and `active → exhausted` when `usage >= quota`.
+
+**Quota-exhaustion recording (once per grant lifetime):** when a refresh first sees `usage > quota`, the evaluator sets `quota_crossed_at = evaluation time` — no extra queries. **Note (deliberate approximation):** this is the *detection* time, not the exact event-level crossing; billing only charges usage *after* it, so overage accrued between the true crossing and detection is never billed — pro-customer, bounded by the debounce delay. The exact alternative, if ever needed, is binary-searching the crossing second on the running measure and storing the usage total through it (see decisions log). That is ALL the evaluator does for overage; billing derives everything else (§6).
 
 **Alerts fire on exhaustion only** (`usage/quota >= 1`): one `alert_logs` row (`in_alarm`) per grant, deduped by state transition, delivered as the `entitlement.grant.exhausted` webhook (payload: subscription + grant id + usage ratio). Recovery is a new grant window, not a state flip.
 
@@ -277,7 +280,15 @@ Snapshot write (`UpdateSnapshot`): `usage`, `last_computed_at`, and `active → 
 
 Runs inside `CalculateMeterUsageCharges`. Grants for the cycle are loaded once per invoice build (`WithCycleOverlap` — purely time-based, so a grant whose window closed mid-cycle still owes its overage) and folded per line item, replacing the legacy entitlement adjustment for that feature.
 
-**Overage-sum model:** `Σ max(0, grant.usage − grant.quota)` across the cycle's grants. Each grant is an independent budget — combined-pool was rejected because it silently masks overage across parallel budgets. Additive groups are already one summed grant, so the same formula covers both modes.
+**Merged-overage-windows model:** overage usage bills **exactly once** no matter how many ECs were in overage. The evaluator records only *when* each grant exhausted (§5.3); billing derives everything else:
+
+- **Single EC** (common config): snapshot sum `Σ max(0, usage − quota)` — exact, zero queries.
+- **Multiple ECs** (`mergedOverage`): each quota-crossed EG contributes an overage window `[quota_crossed_at, valid_to)`; overlapping windows **merge**, and billable = usage/cost inside the merged windows. Quantity measure: **one** ClickHouse query over all windows (`TimeRanges` OR'd in `BuildWhereClause`); amount measure: one billing-path pricing per window. **Zero queries when nothing crossed** (the common case) — marginal next to the per-meter usage queries `CalculateMeterUsageCharges` already runs.
+- **Lag semantics:** an EG over quota whose exhaustion isn't recorded yet simply contributes no window — it bills on the next pass (slight lag, never wrong). A measurement error propagates: the charge calculation fails and retries rather than billing an approximation.
+- **Service boundaries:** window measurement lives on `MeterUsageService` (`GetUsageTotal`, `GetMeterWindowCost`); neither the evaluator nor the billing fold touches the meter-usage repo directly.
+- **Freshness:** wallet real-time balance accepts ≤ one debounce of staleness; invoice creation runs `RefreshEntitlementGrantsForCustomer` (grants-only pass, idempotent) before charges so snapshots are fresh at the money moment.
+
+`PerECOverage` reports per-EC violation totals (`usage − quota`) — overlapping across ECs by construction, NOT a bill decomposition. Combined-pool stays rejected (masks per-budget overage in alerts); additive groups are one summed grant, so a single EC covers that mode.
 
 - **Quantity lane** — the summed overage becomes the billable quantity for the pricer (commit / tier / true-up apply on top as usual).
 - **Amount lane** — the summed overage is already currency; it lands directly on the line item and the quantity zeroes so nothing double-counts. A runtime guard skips folding when the line item carries commitment or true-up, or the price is tiered (those need full-cycle pricing scope) — EC-write validation prevents the tiered case, the guard covers config drift and sub-line-level commitments invisible at EC-write time.
@@ -307,7 +318,7 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 
 **Runtime (billing fold):**
 
-12. Amount-lane folding skips line items with commitment / true-up / tiered pricing (belt-and-braces).
+12. Grant folding skips **tiered** prices in both lanes (overage is priced standalone / pre-priced per window — the marginal units would land in the wrong tier); the **amount lane** additionally skips commitment / true-up line items (they reconcile the whole cycle, which pre-priced overage bypasses). The quantity lane composes with commitments — its qty re-enters the normal pipeline.
 13. Only feature-scoped grants fold per meter.
 
 **Alerting:**
@@ -329,6 +340,8 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 | Backdated events | Usage is always recomputed from CH over the grant window, never incremented — late events inside a window are picked up on the next tick. |
 | Window closes between ticks | The closed grant stays in the finalize set (`last_computed_at < valid_to`) and gets one final refresh — the tick scheduled by the window's own last event performs it. |
 | Slot race (two workers opening) | Deterministic `valid_from` ⇒ collision on the unique `(slot, valid_from)` index; loser re-reads the winner. |
+| Exhaustion not yet recorded at read time (evaluator lagging) | The EG contributes no overage window — bills on the next pass. Slight lag, never a wrong number; invoice creation closes the gap by running a grants-only refresh first. |
+| Merged-window measurement failure at read time | The error propagates — charge calculation fails and the invoice/balance request retries. A knowingly wrong number is never billed. |
 | Workflow-task backlog | Late-firing runs yield once via `ContinueAsNew` to the back of the queue; newer customers evaluate first. |
 | Activity-queue backlog | `ScheduleToStartTimeout` bounds the wait; error logged, next event's workflow re-evaluates. |
 
@@ -341,7 +354,9 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 | No `grant_type` column | Fully derivable: an entitlement with a grant config *is* grant-based (`HasGrantConfig()`). Fewer knobs, no half-set states. |
 | `aggregation_mode` enum (`additive` default / `parallel`) instead of a `parallel` bool | Names the semantic; additive stays the legacy-compatible default. |
 | Additive = ONE summed grant on the primary EC slot | Single pool downstream — evaluation, alerts, billing need zero group-awareness. Splitting usage across same-feature buckets would need attribution machinery. |
-| Parallel = one grant per EC slot | Independent windows/budgets; per-grant overage summed for billing (combined-pool rejected — masks overage). |
+| Parallel = one grant per EC slot | Independent windows/budgets that each see the full usage stream; windows drift (usage-anchored per slot). Billing uses the excess-interval union — every unit that exceeded ≥1 budget bills exactly once — aligned violations merge, drifted ones both bill. Combined-pool rejected — masks per-budget overage in alerts. |
+| Record *when*, measure *where* (exhaustion timestamp at evaluator time, merged overage windows at read) | The debounced tick stores one fact per exhausted grant (`quota_crossed_at`); billing merges the overage windows and measures usage inside them — 0 queries when nothing crossed, ~1 when in overage. Replaced a full ownership ledger: same bill-once semantics, a fraction of the machinery. Invoice creation runs one idempotent refresh to close the debounce gap. |
+| `quota_crossed_at` = detection time, not the exact event-level crossing | Exact crossing needs extra ClickHouse queries (binary search on running usage) plus a stored usage-at-crossing for the straddling event. We skip both: billing only charges usage after detection — under-bills by the overage accrued before the tick (pro-customer, bounded by the debounce). Upgrade path if exactness is ever needed: binary-searched crossing second + usage-through-it. |
 | No price pinning on amount grants | The billing path already segments queries by line-item date ranges; a mid-window price change is priced per segment. Pinning would freeze the whole window at one price — worse. |
 | Usage-anchored windows (replaces butt-joint / delay-derived anchors) | Windows open at the first uncovered usage event and never at all when there is none — exact coverage with no idle-time windows and no delay-derived approximation. One extra indexed CH `min(timestamp)` scalar per window open. |
 | Skip `duration >= cycle length` at open | Cycle-scoped quotas already exist as `usage_reset_period`; avoids redundant rows/evaluation. Checked at open (not write) because cycle length is per-subscription. |

--- a/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
+++ b/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
@@ -224,8 +224,8 @@ flowchart TD
 
     Meta --> Open["openMissingGrants<br/>per sub → openableGrantECsByFeature"]
     Open --> Cand["grantCandidatesForFeature<br/>additive → one summed candidate on the primary EC<br/>parallel → one candidate per EC"]
-    Cand --> Occ{"slot's latest<br/>valid_to &gt; at?"}
-    Occ -->|"yes — window still open"| Skip["skip candidate"]
+    Cand --> Occ{"slot's latest valid_to &gt; at,<br/>or already &ge; cycle_end?"}
+    Occ -->|"yes — window open / cycle fully covered"| Skip["skip candidate<br/>(no usage query)"]
     Occ -->|"no — slot free"| Win["computeGrantWindow<br/>coveredUntil = max(last window end, cycle_start)<br/>firstUncoveredAt = min(timestamp) in [coveredUntil, min(at, cycle_end))"]
     Win -->|"no uncovered usage"| Skip
     Win -->|"window (boundary: cap at cycle_end, absorb sub-1h stubs; loops until slot caught up)"| Ins["INSERT grant<br/>unique (slot, valid_from) = race arbiter"]
@@ -324,7 +324,7 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 | Redis unavailable | Throttle fails open; Temporal `AlreadyStarted` dedup absorbs duplicates. |
 | Temporal unavailable | CH insert + Kafka ack unaffected; alerts delayed, not lost. |
 | Evaluation delayed / consumer down | Usage during the outage anchors each missed window exactly; one tick drains the whole backlog (per-slot catch-up loop) and recomputes usage from CH. |
-| Cycle-rollover lag (period fields updated late by the billing worker) | Ticks during the lag open nothing past the stale `cycle_end` (anchor query is clamped). The first tick after rollover drains all backlog windows at exact event timestamps. If no event ever arrives post-rollover, the backlog waits for the next tick — hardening option: trigger an evaluation from the rollover workflow itself. |
+| Cycle-rollover lag (period fields updated late by the billing worker) | Ticks during the lag open nothing past the stale `cycle_end`: once slot coverage reaches `cycle_end` the open loop skips without even issuing the usage query. The first tick after rollover drains all backlog windows at exact event timestamps. If no event ever arrives post-rollover, the backlog waits for the next tick — hardening option: trigger an evaluation from the rollover workflow itself. |
 | Outage spanning a cycle rollover | New cycle anchors at `cycle_start` (coverage continues); windows never open in a closed cycle, so an old-cycle uncovered tail stays unbilled (accepted — same class as any usage after the last window of a cycle). |
 | Backdated events | Usage is always recomputed from CH over the grant window, never incremented — late events inside a window are picked up on the next tick. |
 | Window closes between ticks | The closed grant stays in the finalize set (`last_computed_at < valid_to`) and gets one final refresh — the tick scheduled by the window's own last event performs it. |

--- a/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
+++ b/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
@@ -249,11 +249,11 @@ For each subscription, resolve its entitlements (`GetSubscriptionEntitlements` �
 
 Grant opening (`openOneGrant`): compute the window and INSERT — nothing else. The unique `(slot, valid_from)` index is the race arbiter: `valid_from` is deterministic (same covered-until bound + same events ⇒ same start), so a losing racer collides and re-reads the winner (`FindLastBySlot`).
 
-**Window math (`computeGrantWindow`) — windows are usage-anchored.** Every window opens at the first usage event past the covered range, so no event ever falls outside a window and idle periods open no windows at all:
+**Window math (`computeGrantWindow`) — windows are usage-anchored.** Every window opens at the first usage event past the covered range, so every event *visible at evaluation time* falls inside a window and idle periods open no windows at all (a backdated arrival into an already-passed gap is the accepted edge below):
 
 - **`coveredUntil`** = `max(prev.valid_to, cycle_start)` from the slot's latest grant — everything before it is covered by past windows (no grant, or one from an earlier cycle → `cycle_start`; last usage in the previous cycle followed by first usage in the new one is a normal idle gap, not an error).
 - **`firstUncoveredAt`** = `min(timestamp)` of `meter_usage` in `[coveredUntil, min(now, cycle_end))` for the grant's meter + external customer IDs (`GetEarliestUsageTimestamp`). The `cycle_end` clamp keeps next-cycle events out before the subscription object rolls; an empty range simply finds nothing. **No uncovered usage → no grant opens** (lazy opening — the next tick re-checks with the same covered-until bound, so an event still in the ingest pipeline is picked up later).
-- `valid_from = firstUncoveredAt` — exact: an event at 2:00 evaluated at 2:07 opens a window starting 2:00. Idle gaps between windows are legal by construction (no events there).
+- `valid_from = firstUncoveredAt` — exact for events visible in the uncovered query range: an event at 2:00 evaluated at 2:07 opens a window starting 2:00. Idle gaps between windows are legal by construction (no events there *when the window opened*; a later backdated arrival into such a gap stays uncovered — see the accepted edges).
 - `valid_to = valid_from + duration`; when the remainder to `cycle_end` would be sub-minimum the window **stretches to `cycle_end`** — cap and trailing-stub absorption in one rule. The **1h minimum is best-effort at the boundary**: a forced tail (first uncovered event inside the cycle's last hour) opens short `[event, cycle_end)` — coverage beats window-length aesthetics; the config-level minimum (`grant_duration >= 1h`) is structural (smallest unit is an hour).
 - **Catch-up drains in one pass**: after delayed evaluation or cycle-rollover lag, a single tick loops per slot — open window, advance the covered bound, re-anchor — until the latest window is open at `now` or no uncovered usage remains. Draining a backlog never depends on future events arriving. Usage recompute from CH keeps late accounting idempotent.
 
@@ -318,7 +318,7 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 
 **Runtime (billing fold):**
 
-12. Grant folding skips **tiered** prices in both lanes (overage is priced standalone / pre-priced per window — the marginal units would land in the wrong tier); the **amount lane** additionally skips commitment / true-up line items (they reconcile the whole cycle, which pre-priced overage bypasses). The quantity lane composes with commitments — its qty re-enters the normal pipeline.
+12. Grant folding requires an **additive, non-bucketed** meter aggregation (SUM / COUNT / SUM_WITH_MULTIPLIER without a bucket): snapshot sums and merged-window measurement assume usage decomposes over time windows, which MAX / LATEST / AVG / bucketed meters don't. Grant folding also skips **tiered** prices in both lanes (overage is priced standalone / pre-priced per window — the marginal units would land in the wrong tier); the **amount lane** additionally skips commitment / true-up line items (they reconcile the whole cycle, which pre-priced overage bypasses). The quantity lane composes with commitments — its qty re-enters the normal pipeline.
 13. Only feature-scoped grants fold per meter.
 
 **Alerting:**

--- a/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
+++ b/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
@@ -228,7 +228,7 @@ flowchart TD
     Occ -->|"yes — window still open"| Skip["skip candidate"]
     Occ -->|"no — slot free"| Win["computeGrantWindow<br/>coveredUntil = max(last window end, cycle_start)<br/>firstUncoveredAt = min(timestamp) in [coveredUntil, min(at, cycle_end))"]
     Win -->|"no uncovered usage"| Skip
-    Win -->|"window (boundary: backdate to last full duration / stretch to cycle_end)"| Ins["INSERT grant<br/>unique (slot, valid_from) = race arbiter"]
+    Win -->|"window (boundary: cap at cycle_end, absorb sub-1h stubs; loops until slot caught up)"| Ins["INSERT grant<br/>unique (slot, valid_from) = race arbiter"]
     Ins -->|"conflict"| ReRead["FindLastBySlot → return the winner"]
     Ins -->|"ok"| Opened["opened"]
     ReRead --> Opened
@@ -252,9 +252,9 @@ Grant opening (`openOneGrant`): compute the window and INSERT — nothing else. 
 
 - **`coveredUntil`** = `max(prev.valid_to, cycle_start)` from the slot's latest grant — everything before it is covered by past windows (no grant, or one from an earlier cycle → `cycle_start`; last usage in the previous cycle followed by first usage in the new one is a normal idle gap, not an error).
 - **`firstUncoveredAt`** = `min(timestamp)` of `meter_usage` in `[coveredUntil, min(now, cycle_end))` for the grant's meter + external customer IDs (`GetEarliestUsageTimestamp`). The `cycle_end` clamp keeps next-cycle events out before the subscription object rolls; an empty range simply finds nothing. **No uncovered usage → no grant opens** (lazy opening — the next tick re-checks with the same covered-until bound, so an event still in the ingest pipeline is picked up later).
-- `valid_from = firstUncoveredAt` — exact: an event at 2:00 evaluated at 2:07 opens a window starting 2:00. Idle gaps between windows are legal by construction (no events there). When the full duration no longer fits (`cycle_end − firstUncoveredAt < duration`), the start **backdates** to `max(coveredUntil, cycle_end − duration)` — the final window is the cycle's last `duration`, clamped at the covered range. Backdating is free: `[coveredUntil, firstUncoveredAt)` is event-free by definition.
-- `valid_to = valid_from + duration`; when the remainder to `cycle_end` would be sub-minimum the window **stretches to `cycle_end`** — cap and trailing-stub absorption in one rule (absorption also keeps `coveredUntil` out of the final hour, which is what guarantees backdated windows are ≥ 1h even when clamped). Every instantiated window is ≥ 1h, enforced by domain `Validate`.
-- Catch-up after delayed evaluation walks one usage-anchored window per tick; usage recompute from CH keeps late accounting idempotent.
+- `valid_from = firstUncoveredAt` — exact: an event at 2:00 evaluated at 2:07 opens a window starting 2:00. Idle gaps between windows are legal by construction (no events there).
+- `valid_to = valid_from + duration`; when the remainder to `cycle_end` would be sub-minimum the window **stretches to `cycle_end`** — cap and trailing-stub absorption in one rule. The **1h minimum is best-effort at the boundary**: a forced tail (first uncovered event inside the cycle's last hour) opens short `[event, cycle_end)` — coverage beats window-length aesthetics; the config-level minimum (`grant_duration >= 1h`) is structural (smallest unit is an hour).
+- **Catch-up drains in one pass**: after delayed evaluation or cycle-rollover lag, a single tick loops per slot — open window, advance the covered bound, re-anchor — until the latest window is open at `now` or no uncovered usage remains. Draining a backlog never depends on future events arriving. Usage recompute from CH keeps late accounting idempotent.
 
 Grants are immutable for their lifetime; EC/mode/quota changes take effect from the next window.
 
@@ -296,22 +296,23 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 4. `measure='amount'` rejects **tiered** prices on the meter — amount grants require linear/flat per-unit pricing.
 5. `aggregation_mode='parallel'` requires a grant config (legacy entitlements are always additive).
 6. **Cross-EC coherence per feature**: one aggregation mode, one measure; **additive** groups must also share `grant_duration` (their quotas sum into one window).
+7. **One published entitlement per (entity, feature)** — DB partial unique index `WHERE status='published' AND aggregation_mode <> 'parallel'`. Parallel ECs stack on one entity (that's the mode's purpose); additive duplicates on the same entity are a quota edit, not a second row — additive *groups* span entities (plan + addon + subscription override).
 
 **Grant open time:**
 
-7. `grant_duration < subscription cycle length` — cycle-spanning grants are skipped (use `usage_reset_period` instead).
-8. Cycle-boundary cap: `valid_to <= current_period_end`. The cycle's final window absorbs a sub-1h trailing remainder; an anchor within `duration` of `cycle_end` backdates the start to `max(frontier, cycle_end − duration)` (safe — the backdated zone is event-free). Every instantiated window is ≥ 1h (also enforced by domain `Validate`).
-9. One window at a time per (tenant, env, config, customer, subscription) slot — the unique `(slot, valid_from)` index arbitrates racing opens; occupancy itself is time-derived (`valid_to > now`).
-10. Grants are immutable; config changes apply from the next window.
+8. `grant_duration < subscription cycle length` — cycle-spanning grants are skipped (use `usage_reset_period` instead).
+9. Cycle-boundary cap: `valid_to <= current_period_end`. The cycle's final window absorbs a sub-1h trailing remainder; a forced-tail anchor opens a short window `[event, cycle_end)` — the 1h minimum is best-effort at the boundary (config-level minimum stays structural).
+10. One window at a time per (tenant, env, config, customer, subscription) slot — the unique `(slot, valid_from)` index arbitrates racing opens; occupancy itself is time-derived (`valid_to > now`).
+11. Grants are immutable; config changes apply from the next window.
 
 **Runtime (billing fold):**
 
-11. Amount-lane folding skips line items with commitment / true-up / tiered pricing (belt-and-braces).
-12. Only feature-scoped grants fold per meter.
+12. Amount-lane folding skips line items with commitment / true-up / tiered pricing (belt-and-braces).
+13. Only feature-scoped grants fold per meter.
 
 **Alerting:**
 
-13. Exhaustion-only (`usage/quota >= 1` → `in_alarm`), deduped by alert-log state transition; no intermediate thresholds, no recovery transitions.
+14. Exhaustion-only (`usage/quota >= 1` → `in_alarm`), deduped by alert-log state transition; no intermediate thresholds, no recovery transitions.
 
 ---
 
@@ -322,7 +323,8 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 | Activity crashes / retried | Alert dedup (state transition) + idempotent `UpdateSnapshot` + `EnsureGrants` convergence make retries safe. |
 | Redis unavailable | Throttle fails open; Temporal `AlreadyStarted` dedup absorbs duplicates. |
 | Temporal unavailable | CH insert + Kafka ack unaffected; alerts delayed, not lost. |
-| Evaluation delayed / consumer down | Usage during the outage anchors the next window exactly (no coverage gap); catch-up opens one window per tick and recomputes usage from CH. |
+| Evaluation delayed / consumer down | Usage during the outage anchors each missed window exactly; one tick drains the whole backlog (per-slot catch-up loop) and recomputes usage from CH. |
+| Cycle-rollover lag (period fields updated late by the billing worker) | Ticks during the lag open nothing past the stale `cycle_end` (anchor query is clamped). The first tick after rollover drains all backlog windows at exact event timestamps. If no event ever arrives post-rollover, the backlog waits for the next tick — hardening option: trigger an evaluation from the rollover workflow itself. |
 | Outage spanning a cycle rollover | New cycle anchors at `cycle_start` (coverage continues); windows never open in a closed cycle, so an old-cycle uncovered tail stays unbilled (accepted — same class as any usage after the last window of a cycle). |
 | Backdated events | Usage is always recomputed from CH over the grant window, never incremented — late events inside a window are picked up on the next tick. |
 | Window closes between ticks | The closed grant stays in the finalize set (`last_computed_at < valid_to`) and gets one final refresh — the tick scheduled by the window's own last event performs it. |
@@ -350,7 +352,8 @@ Only **feature-scoped** grants fold per meter. A future subscription- or group-s
 | Spend alerts subscription-level only | Line-item/group spend alerts dropped by design review; settings CRUD retained for now. |
 | `ContinueAsNew` for late-firing workflow runs | Temporal's native "replace myself with a fresh run": same workflow ID (no duplicate race), fresh task at the back of the queue, no in-workflow sleep. One yield per chain guards against livelock. |
 | `ScheduleToStartTimeout` for activity-queue waits | Temporal's out-of-the-box queue-wait bound; not retried by policy (a retry rejoins the same queue). Distinct from workflow-run staleness — different queues. Knobs ride the workflow input for replay determinism. |
-| Minimum grant duration 1 hour; hour/day/week units | Product rule — no noisy short buckets. A boundary anchor backdates the window start to the cycle's last full `duration` rather than opening short (the backdated zone is event-free by definition of the anchor). |
+| Minimum grant duration 1 hour; hour/day/week units | Product rule — no noisy short buckets. Enforced at config level (structural — smallest unit is an hour); instantiated windows honor it best-effort: cycle-boundary tails may be shorter, keeping window math a plain anchor + cap and never leaving boundary usage uncovered. |
+| Multi-window catch-up per tick | One evaluation pass loops per slot until caught up to `now`, so a rollover-lag or outage backlog drains on the first tick instead of needing one future event per missed window. Bounded: windows strictly advance the covered range within one cycle. |
 | Expiry derived, never written (`grant_status` = quota state only) | Closed windows need no UPDATE at all — `valid_to <= now` says it. The slot's uniqueness moved to `(slot, valid_from)`, sound because usage-anchored `valid_from` is deterministic. Two constant-size reads (slot-frontier aggregate + open-or-unfinalized working set) replace per-slot expire/find queries and stay flat as the cycle accumulates windows. |
 | Finalize via `last_computed_at >= valid_to` | A closed window still owes one usage refresh (its last events tick in after the close, debounce ≈ schedule delay). The marker is snapshot data the evaluator already writes — no status machinery, self-clearing, zero cost when idle. |
 

--- a/ent/entitlementgrant.go
+++ b/ent/entitlementgrant.go
@@ -57,6 +57,8 @@ type EntitlementGrant struct {
 	GrantStatus types.EntitlementGrantStatus `json:"grant_status,omitempty"`
 	// LastComputedAt holds the value of the "last_computed_at" field.
 	LastComputedAt *time.Time `json:"last_computed_at,omitempty"`
+	// QuotaCrossedAt holds the value of the "quota_crossed_at" field.
+	QuotaCrossedAt *time.Time `json:"quota_crossed_at,omitempty"`
 	selectValues   sql.SelectValues
 }
 
@@ -69,7 +71,7 @@ func (*EntitlementGrant) scanValues(columns []string) ([]any, error) {
 			values[i] = new(decimal.Decimal)
 		case entitlementgrant.FieldID, entitlementgrant.FieldTenantID, entitlementgrant.FieldStatus, entitlementgrant.FieldCreatedBy, entitlementgrant.FieldUpdatedBy, entitlementgrant.FieldEnvironmentID, entitlementgrant.FieldEntitlementConfigID, entitlementgrant.FieldCustomerID, entitlementgrant.FieldSubscriptionID, entitlementgrant.FieldScopeEntityType, entitlementgrant.FieldScopeEntityID, entitlementgrant.FieldMeasure, entitlementgrant.FieldGrantStatus:
 			values[i] = new(sql.NullString)
-		case entitlementgrant.FieldCreatedAt, entitlementgrant.FieldUpdatedAt, entitlementgrant.FieldValidFrom, entitlementgrant.FieldValidTo, entitlementgrant.FieldLastComputedAt:
+		case entitlementgrant.FieldCreatedAt, entitlementgrant.FieldUpdatedAt, entitlementgrant.FieldValidFrom, entitlementgrant.FieldValidTo, entitlementgrant.FieldLastComputedAt, entitlementgrant.FieldQuotaCrossedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -207,6 +209,13 @@ func (eg *EntitlementGrant) assignValues(columns []string, values []any) error {
 				eg.LastComputedAt = new(time.Time)
 				*eg.LastComputedAt = value.Time
 			}
+		case entitlementgrant.FieldQuotaCrossedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field quota_crossed_at", values[i])
+			} else if value.Valid {
+				eg.QuotaCrossedAt = new(time.Time)
+				*eg.QuotaCrossedAt = value.Time
+			}
 		default:
 			eg.selectValues.Set(columns[i], values[i])
 		}
@@ -299,6 +308,11 @@ func (eg *EntitlementGrant) String() string {
 	builder.WriteString(", ")
 	if v := eg.LastComputedAt; v != nil {
 		builder.WriteString("last_computed_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := eg.QuotaCrossedAt; v != nil {
+		builder.WriteString("quota_crossed_at=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteByte(')')

--- a/ent/entitlementgrant/entitlementgrant.go
+++ b/ent/entitlementgrant/entitlementgrant.go
@@ -53,6 +53,8 @@ const (
 	FieldGrantStatus = "grant_status"
 	// FieldLastComputedAt holds the string denoting the last_computed_at field in the database.
 	FieldLastComputedAt = "last_computed_at"
+	// FieldQuotaCrossedAt holds the string denoting the quota_crossed_at field in the database.
+	FieldQuotaCrossedAt = "quota_crossed_at"
 	// Table holds the table name of the entitlementgrant in the database.
 	Table = "entitlement_grants"
 )
@@ -79,6 +81,7 @@ var Columns = []string{
 	FieldValidTo,
 	FieldGrantStatus,
 	FieldLastComputedAt,
+	FieldQuotaCrossedAt,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -223,4 +226,9 @@ func ByGrantStatus(opts ...sql.OrderTermOption) OrderOption {
 // ByLastComputedAt orders the results by the last_computed_at field.
 func ByLastComputedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastComputedAt, opts...).ToFunc()
+}
+
+// ByQuotaCrossedAt orders the results by the quota_crossed_at field.
+func ByQuotaCrossedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldQuotaCrossedAt, opts...).ToFunc()
 }

--- a/ent/entitlementgrant/where.go
+++ b/ent/entitlementgrant/where.go
@@ -164,6 +164,11 @@ func LastComputedAt(v time.Time) predicate.EntitlementGrant {
 	return predicate.EntitlementGrant(sql.FieldEQ(FieldLastComputedAt, v))
 }
 
+// QuotaCrossedAt applies equality check predicate on the "quota_crossed_at" field. It's identical to QuotaCrossedAtEQ.
+func QuotaCrossedAt(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldEQ(FieldQuotaCrossedAt, v))
+}
+
 // TenantIDEQ applies the EQ predicate on the "tenant_id" field.
 func TenantIDEQ(v string) predicate.EntitlementGrant {
 	return predicate.EntitlementGrant(sql.FieldEQ(FieldTenantID, v))
@@ -1319,6 +1324,56 @@ func LastComputedAtIsNil() predicate.EntitlementGrant {
 // LastComputedAtNotNil applies the NotNil predicate on the "last_computed_at" field.
 func LastComputedAtNotNil() predicate.EntitlementGrant {
 	return predicate.EntitlementGrant(sql.FieldNotNull(FieldLastComputedAt))
+}
+
+// QuotaCrossedAtEQ applies the EQ predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtEQ(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldEQ(FieldQuotaCrossedAt, v))
+}
+
+// QuotaCrossedAtNEQ applies the NEQ predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtNEQ(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldNEQ(FieldQuotaCrossedAt, v))
+}
+
+// QuotaCrossedAtIn applies the In predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtIn(vs ...time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldIn(FieldQuotaCrossedAt, vs...))
+}
+
+// QuotaCrossedAtNotIn applies the NotIn predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtNotIn(vs ...time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldNotIn(FieldQuotaCrossedAt, vs...))
+}
+
+// QuotaCrossedAtGT applies the GT predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtGT(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldGT(FieldQuotaCrossedAt, v))
+}
+
+// QuotaCrossedAtGTE applies the GTE predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtGTE(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldGTE(FieldQuotaCrossedAt, v))
+}
+
+// QuotaCrossedAtLT applies the LT predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtLT(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldLT(FieldQuotaCrossedAt, v))
+}
+
+// QuotaCrossedAtLTE applies the LTE predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtLTE(v time.Time) predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldLTE(FieldQuotaCrossedAt, v))
+}
+
+// QuotaCrossedAtIsNil applies the IsNil predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtIsNil() predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldIsNull(FieldQuotaCrossedAt))
+}
+
+// QuotaCrossedAtNotNil applies the NotNil predicate on the "quota_crossed_at" field.
+func QuotaCrossedAtNotNil() predicate.EntitlementGrant {
+	return predicate.EntitlementGrant(sql.FieldNotNull(FieldQuotaCrossedAt))
 }
 
 // And groups predicates with the AND operator between them.

--- a/ent/entitlementgrant_create.go
+++ b/ent/entitlementgrant_create.go
@@ -216,6 +216,20 @@ func (egc *EntitlementGrantCreate) SetNillableLastComputedAt(t *time.Time) *Enti
 	return egc
 }
 
+// SetQuotaCrossedAt sets the "quota_crossed_at" field.
+func (egc *EntitlementGrantCreate) SetQuotaCrossedAt(t time.Time) *EntitlementGrantCreate {
+	egc.mutation.SetQuotaCrossedAt(t)
+	return egc
+}
+
+// SetNillableQuotaCrossedAt sets the "quota_crossed_at" field if the given value is not nil.
+func (egc *EntitlementGrantCreate) SetNillableQuotaCrossedAt(t *time.Time) *EntitlementGrantCreate {
+	if t != nil {
+		egc.SetQuotaCrossedAt(*t)
+	}
+	return egc
+}
+
 // SetID sets the "id" field.
 func (egc *EntitlementGrantCreate) SetID(s string) *EntitlementGrantCreate {
 	egc.mutation.SetID(s)
@@ -484,6 +498,10 @@ func (egc *EntitlementGrantCreate) createSpec() (*EntitlementGrant, *sqlgraph.Cr
 	if value, ok := egc.mutation.LastComputedAt(); ok {
 		_spec.SetField(entitlementgrant.FieldLastComputedAt, field.TypeTime, value)
 		_node.LastComputedAt = &value
+	}
+	if value, ok := egc.mutation.QuotaCrossedAt(); ok {
+		_spec.SetField(entitlementgrant.FieldQuotaCrossedAt, field.TypeTime, value)
+		_node.QuotaCrossedAt = &value
 	}
 	return _node, _spec
 }

--- a/ent/entitlementgrant_update.go
+++ b/ent/entitlementgrant_update.go
@@ -132,6 +132,26 @@ func (egu *EntitlementGrantUpdate) ClearLastComputedAt() *EntitlementGrantUpdate
 	return egu
 }
 
+// SetQuotaCrossedAt sets the "quota_crossed_at" field.
+func (egu *EntitlementGrantUpdate) SetQuotaCrossedAt(t time.Time) *EntitlementGrantUpdate {
+	egu.mutation.SetQuotaCrossedAt(t)
+	return egu
+}
+
+// SetNillableQuotaCrossedAt sets the "quota_crossed_at" field if the given value is not nil.
+func (egu *EntitlementGrantUpdate) SetNillableQuotaCrossedAt(t *time.Time) *EntitlementGrantUpdate {
+	if t != nil {
+		egu.SetQuotaCrossedAt(*t)
+	}
+	return egu
+}
+
+// ClearQuotaCrossedAt clears the value of the "quota_crossed_at" field.
+func (egu *EntitlementGrantUpdate) ClearQuotaCrossedAt() *EntitlementGrantUpdate {
+	egu.mutation.ClearQuotaCrossedAt()
+	return egu
+}
+
 // Mutation returns the EntitlementGrantMutation object of the builder.
 func (egu *EntitlementGrantUpdate) Mutation() *EntitlementGrantMutation {
 	return egu.mutation
@@ -214,6 +234,12 @@ func (egu *EntitlementGrantUpdate) sqlSave(ctx context.Context) (n int, err erro
 	}
 	if egu.mutation.LastComputedAtCleared() {
 		_spec.ClearField(entitlementgrant.FieldLastComputedAt, field.TypeTime)
+	}
+	if value, ok := egu.mutation.QuotaCrossedAt(); ok {
+		_spec.SetField(entitlementgrant.FieldQuotaCrossedAt, field.TypeTime, value)
+	}
+	if egu.mutation.QuotaCrossedAtCleared() {
+		_spec.ClearField(entitlementgrant.FieldQuotaCrossedAt, field.TypeTime)
 	}
 	if n, err = sqlgraph.UpdateNodes(ctx, egu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
@@ -337,6 +363,26 @@ func (eguo *EntitlementGrantUpdateOne) ClearLastComputedAt() *EntitlementGrantUp
 	return eguo
 }
 
+// SetQuotaCrossedAt sets the "quota_crossed_at" field.
+func (eguo *EntitlementGrantUpdateOne) SetQuotaCrossedAt(t time.Time) *EntitlementGrantUpdateOne {
+	eguo.mutation.SetQuotaCrossedAt(t)
+	return eguo
+}
+
+// SetNillableQuotaCrossedAt sets the "quota_crossed_at" field if the given value is not nil.
+func (eguo *EntitlementGrantUpdateOne) SetNillableQuotaCrossedAt(t *time.Time) *EntitlementGrantUpdateOne {
+	if t != nil {
+		eguo.SetQuotaCrossedAt(*t)
+	}
+	return eguo
+}
+
+// ClearQuotaCrossedAt clears the value of the "quota_crossed_at" field.
+func (eguo *EntitlementGrantUpdateOne) ClearQuotaCrossedAt() *EntitlementGrantUpdateOne {
+	eguo.mutation.ClearQuotaCrossedAt()
+	return eguo
+}
+
 // Mutation returns the EntitlementGrantMutation object of the builder.
 func (eguo *EntitlementGrantUpdateOne) Mutation() *EntitlementGrantMutation {
 	return eguo.mutation
@@ -449,6 +495,12 @@ func (eguo *EntitlementGrantUpdateOne) sqlSave(ctx context.Context) (_node *Enti
 	}
 	if eguo.mutation.LastComputedAtCleared() {
 		_spec.ClearField(entitlementgrant.FieldLastComputedAt, field.TypeTime)
+	}
+	if value, ok := eguo.mutation.QuotaCrossedAt(); ok {
+		_spec.SetField(entitlementgrant.FieldQuotaCrossedAt, field.TypeTime, value)
+	}
+	if eguo.mutation.QuotaCrossedAtCleared() {
+		_spec.ClearField(entitlementgrant.FieldQuotaCrossedAt, field.TypeTime)
 	}
 	_node = &EntitlementGrant{config: eguo.config}
 	_spec.Assign = _node.assignValues

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -897,7 +897,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{EntitlementsColumns[1], EntitlementsColumns[7], EntitlementsColumns[8], EntitlementsColumns[9], EntitlementsColumns[10]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "((status)::text = 'published'::text)",
+					Where: "(((status)::text = 'published'::text) AND ((aggregation_mode)::text <> 'parallel'::text))",
 				},
 			},
 			{

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -947,6 +947,7 @@ var (
 		{Name: "valid_to", Type: field.TypeTime},
 		{Name: "grant_status", Type: field.TypeString, Default: "active", SchemaType: map[string]string{"postgres": "varchar(20)"}},
 		{Name: "last_computed_at", Type: field.TypeTime, Nullable: true},
+		{Name: "quota_crossed_at", Type: field.TypeTime, Nullable: true},
 	}
 	// EntitlementGrantsTable holds the schema information for the "entitlement_grants" table.
 	EntitlementGrantsTable = &schema.Table{

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -25735,6 +25735,7 @@ type EntitlementGrantMutation struct {
 	valid_to              *time.Time
 	grant_status          *types.EntitlementGrantStatus
 	last_computed_at      *time.Time
+	quota_crossed_at      *time.Time
 	clearedFields         map[string]struct{}
 	done                  bool
 	oldValue              func(context.Context) (*EntitlementGrant, error)
@@ -26581,6 +26582,55 @@ func (m *EntitlementGrantMutation) ResetLastComputedAt() {
 	delete(m.clearedFields, entitlementgrant.FieldLastComputedAt)
 }
 
+// SetQuotaCrossedAt sets the "quota_crossed_at" field.
+func (m *EntitlementGrantMutation) SetQuotaCrossedAt(t time.Time) {
+	m.quota_crossed_at = &t
+}
+
+// QuotaCrossedAt returns the value of the "quota_crossed_at" field in the mutation.
+func (m *EntitlementGrantMutation) QuotaCrossedAt() (r time.Time, exists bool) {
+	v := m.quota_crossed_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldQuotaCrossedAt returns the old "quota_crossed_at" field's value of the EntitlementGrant entity.
+// If the EntitlementGrant object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *EntitlementGrantMutation) OldQuotaCrossedAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldQuotaCrossedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldQuotaCrossedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldQuotaCrossedAt: %w", err)
+	}
+	return oldValue.QuotaCrossedAt, nil
+}
+
+// ClearQuotaCrossedAt clears the value of the "quota_crossed_at" field.
+func (m *EntitlementGrantMutation) ClearQuotaCrossedAt() {
+	m.quota_crossed_at = nil
+	m.clearedFields[entitlementgrant.FieldQuotaCrossedAt] = struct{}{}
+}
+
+// QuotaCrossedAtCleared returns if the "quota_crossed_at" field was cleared in this mutation.
+func (m *EntitlementGrantMutation) QuotaCrossedAtCleared() bool {
+	_, ok := m.clearedFields[entitlementgrant.FieldQuotaCrossedAt]
+	return ok
+}
+
+// ResetQuotaCrossedAt resets all changes to the "quota_crossed_at" field.
+func (m *EntitlementGrantMutation) ResetQuotaCrossedAt() {
+	m.quota_crossed_at = nil
+	delete(m.clearedFields, entitlementgrant.FieldQuotaCrossedAt)
+}
+
 // Where appends a list predicates to the EntitlementGrantMutation builder.
 func (m *EntitlementGrantMutation) Where(ps ...predicate.EntitlementGrant) {
 	m.predicates = append(m.predicates, ps...)
@@ -26615,7 +26665,7 @@ func (m *EntitlementGrantMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *EntitlementGrantMutation) Fields() []string {
-	fields := make([]string, 0, 19)
+	fields := make([]string, 0, 20)
 	if m.tenant_id != nil {
 		fields = append(fields, entitlementgrant.FieldTenantID)
 	}
@@ -26673,6 +26723,9 @@ func (m *EntitlementGrantMutation) Fields() []string {
 	if m.last_computed_at != nil {
 		fields = append(fields, entitlementgrant.FieldLastComputedAt)
 	}
+	if m.quota_crossed_at != nil {
+		fields = append(fields, entitlementgrant.FieldQuotaCrossedAt)
+	}
 	return fields
 }
 
@@ -26719,6 +26772,8 @@ func (m *EntitlementGrantMutation) Field(name string) (ent.Value, bool) {
 		return m.GrantStatus()
 	case entitlementgrant.FieldLastComputedAt:
 		return m.LastComputedAt()
+	case entitlementgrant.FieldQuotaCrossedAt:
+		return m.QuotaCrossedAt()
 	}
 	return nil, false
 }
@@ -26766,6 +26821,8 @@ func (m *EntitlementGrantMutation) OldField(ctx context.Context, name string) (e
 		return m.OldGrantStatus(ctx)
 	case entitlementgrant.FieldLastComputedAt:
 		return m.OldLastComputedAt(ctx)
+	case entitlementgrant.FieldQuotaCrossedAt:
+		return m.OldQuotaCrossedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown EntitlementGrant field %s", name)
 }
@@ -26908,6 +26965,13 @@ func (m *EntitlementGrantMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetLastComputedAt(v)
 		return nil
+	case entitlementgrant.FieldQuotaCrossedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetQuotaCrossedAt(v)
+		return nil
 	}
 	return fmt.Errorf("unknown EntitlementGrant field %s", name)
 }
@@ -26950,6 +27014,9 @@ func (m *EntitlementGrantMutation) ClearedFields() []string {
 	if m.FieldCleared(entitlementgrant.FieldLastComputedAt) {
 		fields = append(fields, entitlementgrant.FieldLastComputedAt)
 	}
+	if m.FieldCleared(entitlementgrant.FieldQuotaCrossedAt) {
+		fields = append(fields, entitlementgrant.FieldQuotaCrossedAt)
+	}
 	return fields
 }
 
@@ -26975,6 +27042,9 @@ func (m *EntitlementGrantMutation) ClearField(name string) error {
 		return nil
 	case entitlementgrant.FieldLastComputedAt:
 		m.ClearLastComputedAt()
+		return nil
+	case entitlementgrant.FieldQuotaCrossedAt:
+		m.ClearQuotaCrossedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown EntitlementGrant nullable field %s", name)
@@ -27040,6 +27110,9 @@ func (m *EntitlementGrantMutation) ResetField(name string) error {
 		return nil
 	case entitlementgrant.FieldLastComputedAt:
 		m.ResetLastComputedAt()
+		return nil
+	case entitlementgrant.FieldQuotaCrossedAt:
+		m.ResetQuotaCrossedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown EntitlementGrant field %s", name)

--- a/ent/schema/entitlement.go
+++ b/ent/schema/entitlement.go
@@ -130,7 +130,7 @@ func (Entitlement) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tenant_id", "environment_id", "entity_type", "entity_id", "feature_id").
 			Unique().
-			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND ((aggregation_mode)::text <> 'parallel'::text))")),
 
 		index.Fields("tenant_id", "environment_id", "entity_type", "entity_id"),
 		index.Fields("tenant_id", "environment_id", "feature_id"),

--- a/ent/schema/entitlement_grant.go
+++ b/ent/schema/entitlement_grant.go
@@ -103,6 +103,13 @@ func (EntitlementGrant) Fields() []ent.Field {
 		field.Time("last_computed_at").
 			Optional().
 			Nillable(),
+
+		// Set once by the evaluator when it first sees usage > quota. Holds the
+		// EVALUATION time, not the exact event-level crossing — billing only
+		// charges usage after this point (pro-customer, bounded by the debounce).
+		field.Time("quota_crossed_at").
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/internal/api/dto/meter_usage.go
+++ b/internal/api/dto/meter_usage.go
@@ -40,11 +40,9 @@ func (r *MeterUsageQueryRequest) ToParams(tenantID, environmentID string) *event
 	}
 }
 
-// GrantWindowUsageRequest builds the raw meter-usage query for an entitlement
-// grant window. Used for quantity-measure grants only — amount-measure grants
-// price usage through the billing path (per-line-item date-range segmentation),
-// not a raw meter query.
-type GrantWindowUsageRequest struct {
+// UsageTotalRequest queries a meter's aggregated usage total over one or more
+// time windows.
+type UsageTotalRequest struct {
 	TenantID            string
 	EnvironmentID       string
 	ExternalCustomerIDs []string
@@ -52,10 +50,13 @@ type GrantWindowUsageRequest struct {
 	AggregationType     types.AggregationType
 	StartTime           time.Time
 	EndTime             time.Time
+	// TimeRanges, when non-empty, replaces StartTime/EndTime with multiple
+	// disjoint windows measured in one query.
+	TimeRanges []events.TimeRange
 }
 
 // ToParams converts the request to domain query params (FINAL consistency).
-func (r *GrantWindowUsageRequest) ToParams() *events.MeterUsageQueryParams {
+func (r *UsageTotalRequest) ToParams() *events.MeterUsageQueryParams {
 	return &events.MeterUsageQueryParams{
 		TenantID:            r.TenantID,
 		EnvironmentID:       r.EnvironmentID,
@@ -63,6 +64,7 @@ func (r *GrantWindowUsageRequest) ToParams() *events.MeterUsageQueryParams {
 		MeterID:             r.MeterID,
 		StartTime:           r.StartTime,
 		EndTime:             r.EndTime,
+		TimeRanges:          r.TimeRanges,
 		AggregationType:     r.AggregationType,
 		UseFinal:            true,
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -169,7 +169,8 @@ func NewRouter(
 			events.POST("", write(types.EntityEvent, types.ActionWrite), handlers.Events.IngestEvent)
 			events.POST("/bulk", write(types.EntityEvent, types.ActionWrite), handlers.Events.BulkIngestEvent)
 			events.GET("", handlers.Events.GetEvents)
-			events.GET("/:id", handlers.Events.GetEventByID)
+			events.GET("/lookup", handlers.Events.GetEventByID)
+			events.GET("/:id", handlers.Events.GetEventByID) // legacy alias, remove once no caller uses /events/:id
 			events.POST("/query", handlers.Events.QueryEvents)
 			events.POST("/usage", handlers.Events.GetUsage)
 			events.POST("/usage/meter", handlers.Events.GetUsageByMeter)

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -453,18 +453,22 @@ func validateStartAndEndTime(startTime, endTime time.Time) (time.Time, time.Time
 
 // @Summary Get event
 // @ID getEvent
-// @Description Use when debugging a specific event (e.g. why it failed or how it was aggregated). Reads the meter-usage pipeline; includes processing status and step-by-step debug tracker when unprocessed.
+// @Description Use when debugging a specific event (e.g. why it failed or how it was aggregated). Reads the meter-usage pipeline; includes processing status and step-by-step debug tracker when unprocessed. Uses ?id= query param because event IDs can contain "/".
 // @Tags Events
 // @Produce json
 // @Security ApiKeyAuth
-// @Param id path string true "Event ID"
+// @Param id query string true "Event ID"
 // @Success 200 {object} dto.GetEventByIDResponse
 // @Failure 404 {object} ierr.ErrorResponse
 // @Failure 500 {object} ierr.ErrorResponse "Server error"
-// @Router /events/{id} [get]
+// @Router /events/lookup [get]
 func (h *EventsHandler) GetEventByID(c *gin.Context) {
 	ctx := c.Request.Context()
-	eventID := c.Param("id")
+	// Prefer ?id= (avoids "/" collisions in event IDs); fall back to legacy /events/:id path param.
+	eventID := c.Query("id")
+	if eventID == "" {
+		eventID = c.Param("id")
+	}
 	if eventID == "" {
 		c.Error(ierr.NewError("event ID is required").
 			WithHint("Please provide a valid event ID").

--- a/internal/domain/entitlementgrant/builder.go
+++ b/internal/domain/entitlementgrant/builder.go
@@ -23,6 +23,10 @@ func NewEntitlementGrantBuilder(g *EntitlementGrant) *entitlementGrantBuilder {
 		t := *g.LastComputedAt
 		copied.LastComputedAt = &t
 	}
+	if g.QuotaCrossedAt != nil {
+		t := *g.QuotaCrossedAt
+		copied.QuotaCrossedAt = &t
+	}
 	return &entitlementGrantBuilder{grant: &copied}
 }
 
@@ -115,6 +119,15 @@ func (b *entitlementGrantBuilder) WithLastComputedAt(t *time.Time) *entitlementG
 	b.grant.LastComputedAt = t
 	return b
 }
+
+func (b *entitlementGrantBuilder) WithQuotaCrossedAt(t *time.Time) *entitlementGrantBuilder {
+	if b == nil || b.grant == nil {
+		return b
+	}
+	b.grant.QuotaCrossedAt = t
+	return b
+}
+
 
 func (b *entitlementGrantBuilder) WithEnvironmentID(id string) *entitlementGrantBuilder {
 	if b == nil || b.grant == nil {

--- a/internal/domain/entitlementgrant/model.go
+++ b/internal/domain/entitlementgrant/model.go
@@ -115,16 +115,11 @@ func (g *EntitlementGrant) Validate() error {
 			WithReportableDetails(map[string]interface{}{"usage": g.Usage.String()}).
 			Mark(ierr.ErrValidation)
 	}
+	// No window-length minimum here: the 1h floor is a config-level rule
+	// (smallest duration unit is one hour); instantiated windows at the cycle
+	// boundary may be shorter — coverage beats window-length aesthetics.
 	if !g.ValidTo.After(g.ValidFrom) {
 		return ierr.NewError("valid_to must be strictly after valid_from").
-			WithReportableDetails(map[string]interface{}{
-				"valid_from": g.ValidFrom,
-				"valid_to":   g.ValidTo,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-	if g.ValidTo.Sub(g.ValidFrom) < types.EntitlementGrantMinDuration {
-		return ierr.NewError("grant window must be at least 1 hour").
 			WithReportableDetails(map[string]interface{}{
 				"valid_from": g.ValidFrom,
 				"valid_to":   g.ValidTo,

--- a/internal/domain/entitlementgrant/model.go
+++ b/internal/domain/entitlementgrant/model.go
@@ -26,7 +26,10 @@ type EntitlementGrant struct {
 	ValidTo             time.Time                             `json:"valid_to"`
 	GrantStatus         types.EntitlementGrantStatus          `json:"grant_status"`
 	LastComputedAt      *time.Time                            `json:"last_computed_at,omitempty"`
-	EnvironmentID       string                                `json:"environment_id"`
+	// QuotaCrossedAt is set once, when the evaluator first sees usage > quota.
+	// It holds the evaluation time, not the exact event-level crossing.
+	QuotaCrossedAt *time.Time `json:"quota_crossed_at,omitempty"`
+	EnvironmentID  string     `json:"environment_id"`
 	types.BaseModel
 }
 
@@ -150,6 +153,7 @@ func FromEnt(e *ent.EntitlementGrant) *EntitlementGrant {
 		ValidTo:             e.ValidTo,
 		GrantStatus:         e.GrantStatus,
 		LastComputedAt:      e.LastComputedAt,
+		QuotaCrossedAt:      e.QuotaCrossedAt,
 		EnvironmentID:       e.EnvironmentID,
 		BaseModel: types.BaseModel{
 			TenantID:  e.TenantID,

--- a/internal/domain/entitlementgrant/model_test.go
+++ b/internal/domain/entitlementgrant/model_test.go
@@ -80,16 +80,12 @@ func TestValidate_WindowShape(t *testing.T) {
 		t.Fatalf("valid_to must be strictly after valid_from")
 	}
 
+	// The 1h minimum is config-level and best-effort at the boundary: short
+	// instantiated windows (forced cycle tails) are legal rows.
 	g = baseGrant()
 	g.ValidTo = g.ValidFrom.Add(30 * time.Minute)
-	if err := g.Validate(); err == nil {
-		t.Fatalf("sub-1h window must be rejected")
-	}
-
-	g = baseGrant()
-	g.ValidTo = g.ValidFrom.Add(time.Hour)
 	if err := g.Validate(); err != nil {
-		t.Fatalf("exactly-1h window should validate, got %v", err)
+		t.Fatalf("short boundary window should validate, got %v", err)
 	}
 }
 

--- a/internal/domain/events/meter_usage.go
+++ b/internal/domain/events/meter_usage.go
@@ -25,17 +25,26 @@ type MeterUsage struct {
 }
 
 // MeterUsageQueryParams defines filters for querying the meter_usage table
+// TimeRange is a half-open [Start, End) window.
+type TimeRange struct {
+	Start time.Time
+	End   time.Time
+}
+
 type MeterUsageQueryParams struct {
 	TenantID           string
 	EnvironmentID      string
 	ExternalCustomerID string
 	// ExternalCustomerIDs supports multi-customer queries (e.g. inherited subscriptions)
 	ExternalCustomerIDs []string
-	MeterID             string
-	MeterIDs            []string
-	StartTime           time.Time
-	EndTime             time.Time
-	AggregationType     types.AggregationType
+	MeterID  string
+	MeterIDs []string
+	StartTime time.Time
+	EndTime   time.Time
+	// TimeRanges, when non-empty, replaces StartTime/EndTime with multiple
+	// OR'd half-open [Start, End) windows — one query for disjoint ranges.
+	TimeRanges      []TimeRange
+	AggregationType types.AggregationType
 	WindowSize          types.WindowSize
 	BillingAnchor       *time.Time
 	// Timezone is the customer's IANA timezone name. See UsageParams.Timezone.

--- a/internal/ee/service/alert.go
+++ b/internal/ee/service/alert.go
@@ -41,6 +41,12 @@ type AlertService interface {
 	// different query path and their own throttle.
 	EvaluateSpendAndEntitlementAlertsForCustomer(ctx context.Context, cust *customer.Customer) error
 
+	// RefreshEntitlementGrantsForCustomer runs one grants-only pass (ensure +
+	// usage refresh + billable-overage ledger accrual) so the materialized
+	// numbers billing reads are exact. Watermark-idempotent; used by invoice
+	// creation to close the debounce gap at the money moment.
+	RefreshEntitlementGrantsForCustomer(ctx context.Context, customerID string) error
+
 	// EvaluateWalletAlertsForCustomer resolves the tenant's wallet alert config,
 	// fetches every wallet for the customer, computes real-time balance for each,
 	// and runs wallet-level + feature-level alert checks and auto-topup.

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -340,6 +340,10 @@ func (s *alertService) refreshEntitlementGrantUsage(
 		if err != nil {
 			return decimal.Zero, err
 		}
+
+		s.Logger.Debug(ctx, "quantity measure: entitlement grant evaluation: usage refreshed",
+			"grant_id", g.ID, "usage", result.TotalValue,
+		)
 		return result.TotalValue, nil
 	}
 
@@ -347,6 +351,7 @@ func (s *alertService) refreshEntitlementGrantUsage(
 	subUsage, err := meterUsageSvc.GetSubscriptionMeterUsageWithSub(ctx, sub, &GetSubscriptionMeterUsageRequest{
 		SubscriptionID:  sub.ID,
 		StartTime:       g.ValidFrom,
+		MeterIDs:        []string{m.ID},
 		EndTime:         end,
 		UseFinal:        true,
 		IncludeChildren: true,
@@ -369,6 +374,10 @@ func (s *alertService) refreshEntitlementGrantUsage(
 			total = total.Add(decimal.NewFromFloat(c.Amount))
 		}
 	}
+
+	s.Logger.Debug(ctx, "amount measure: entitlement grant evaluation: usage refreshed",
+		"grant_id", g.ID, "usage", total,
+	)
 	return total, nil
 }
 

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -243,6 +243,8 @@ func (s *alertService) RefreshEntitlementGrantsForCustomer(ctx context.Context, 
 // refresh). Alert-log dedup makes it safe under Temporal retries. meta is the
 // lookup bundle built during EnsureGrantsForSubscriptions; grants whose
 // subscription is not in it (e.g. cancelled mid-window) are skipped.
+// Per-grant failures never block the remaining grants; they join into the
+// returned error so the Temporal retry decision sees them.
 func (s *alertService) evaluateEntitlementGrantsForCustomer(
 	ctx context.Context,
 	cust *customer.Customer,
@@ -271,6 +273,7 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 
 	alertLogsSvc := NewAlertLogsService(s.ServiceParams)
 
+	var errs []error
 	for _, g := range featureGrants {
 		f, ok := meta.featureByID[g.ScopeEntityID]
 		if !ok || f.MeterID == "" {
@@ -292,6 +295,7 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 		if err != nil {
 			s.Logger.Error(ctx, "entitlement grant evaluation: external customer id lookup failed",
 				"grant_id", g.ID, "subscription_id", sub.ID, "error", err)
+			errs = append(errs, err)
 			continue
 		}
 
@@ -299,12 +303,14 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 		if err != nil {
 			s.Logger.Error(ctx, "entitlement grant evaluation: usage refresh failed",
 				"grant_id", g.ID, "error", err)
+			errs = append(errs, err)
 			continue
 		}
 
 		if err := s.transitionEntitlementGrantAlert(ctx, alertLogsSvc, cust, g, usage, at); err != nil {
 			s.Logger.Error(ctx, "entitlement grant evaluation: alert transition failed",
 				"grant_id", g.ID, "error", err)
+			errs = append(errs, err)
 		}
 
 		// Record the quota exhaustion timestamp, once per grant.
@@ -331,9 +337,10 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 		if err := s.EntitlementGrantRepo.UpdateSnapshot(ctx, builder.Build()); err != nil {
 			s.Logger.Error(ctx, "entitlement grant evaluation: snapshot write failed",
 				"grant_id", g.ID, "error", err)
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // refreshEntitlementGrantUsage refreshes the grant's consumed usage over

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -217,6 +217,27 @@ func (s *alertService) EvaluateSpendAndEntitlementAlertsForCustomer(
 	return errors.Join(spendErr, grantErr)
 }
 
+func (s *alertService) RefreshEntitlementGrantsForCustomer(ctx context.Context, customerID string) error {
+	cust, err := s.CustomerRepo.Get(ctx, customerID)
+	if err != nil {
+		return err
+	}
+	subs, err := s.listActiveSubscriptions(ctx, cust.ID)
+	if err != nil {
+		return err
+	}
+	if len(subs) == 0 {
+		return nil
+	}
+	at := time.Now().UTC()
+	grantSvc := NewEntitlementGrantService(s.ServiceParams)
+	grants, meta, err := grantSvc.EnsureGrantsForSubscriptions(ctx, cust, subs, at)
+	if err != nil {
+		return err
+	}
+	return s.evaluateEntitlementGrantsForCustomer(ctx, cust, meta, grants, at)
+}
+
 // evaluateEntitlementGrantsForCustomer refreshes usage and fires alerts for
 // each returned grant (open windows plus closed ones getting their final
 // refresh). Alert-log dedup makes it safe under Temporal retries. meta is the
@@ -286,11 +307,24 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 				"grant_id", g.ID, "error", err)
 		}
 
-		// Snapshot the refreshed usage; last_computed_at >= valid_to marks a
+		// Record the quota exhaustion timestamp, once per grant.
+		// NOTE: this is the EVALUATION time, not the exact crossing time.
+		// finding that exactly needs extra ClickHouse queries (binary search on the
+		// running usage). Billing only charges usage AFTER this timestamp, so
+		// overage accrued before detection is never billed: pro-customer,
+		// bounded by the debounce delay. If exactness is ever needed, the
+		// upgrade path is the binary-searched crossing (see ERD decisions).
+		cross := g.QuotaCrossedAt
+		if cross == nil && usage.GreaterThan(g.Quota) {
+			cross = &at
+		}
+
+		// Snapshot the refreshed state; last_computed_at >= valid_to marks a
 		// closed window as finalized so it never re-enters the refresh set.
 		builder := entitlementgrant.NewEntitlementGrantBuilder(g).
 			WithUsage(usage).
-			WithLastComputedAt(&at)
+			WithLastComputedAt(&at).
+			WithQuotaCrossedAt(cross)
 		if usage.GreaterThanOrEqual(g.Quota) && g.GrantStatus == types.EntitlementGrantStatusActive {
 			builder = builder.WithGrantStatus(types.EntitlementGrantStatusExhausted)
 		}
@@ -326,8 +360,9 @@ func (s *alertService) refreshEntitlementGrantUsage(
 		return decimal.Zero, nil
 	}
 
+	meterUsageSvc := NewMeterUsageService(s.ServiceParams)
 	if g.Measure == types.EntitlementGrantMeasureQuantity {
-		req := &dto.GrantWindowUsageRequest{
+		usage, err := meterUsageSvc.GetUsageTotal(ctx, &dto.UsageTotalRequest{
 			TenantID:            g.TenantID,
 			EnvironmentID:       g.EnvironmentID,
 			ExternalCustomerIDs: extCustomerIDs,
@@ -335,44 +370,20 @@ func (s *alertService) refreshEntitlementGrantUsage(
 			AggregationType:     m.Aggregation.Type,
 			StartTime:           g.ValidFrom,
 			EndTime:             end,
-		}
-		result, err := s.MeterUsageRepo.GetUsage(ctx, req.ToParams())
+		})
 		if err != nil {
 			return decimal.Zero, err
 		}
 
 		s.Logger.Debug(ctx, "quantity measure: entitlement grant evaluation: usage refreshed",
-			"grant_id", g.ID, "usage", result.TotalValue,
+			"grant_id", g.ID, "usage", usage,
 		)
-		return result.TotalValue, nil
+		return usage, nil
 	}
 
-	meterUsageSvc := NewMeterUsageService(s.ServiceParams)
-	subUsage, err := meterUsageSvc.GetSubscriptionMeterUsageWithSub(ctx, sub, &GetSubscriptionMeterUsageRequest{
-		SubscriptionID:  sub.ID,
-		StartTime:       g.ValidFrom,
-		MeterIDs:        []string{m.ID},
-		EndTime:         end,
-		UseFinal:        true,
-		IncludeChildren: true,
-	})
+	total, err := meterUsageSvc.GetMeterWindowCost(ctx, sub, m.ID, g.ValidFrom, end)
 	if err != nil {
 		return decimal.Zero, err
-	}
-
-	// The returned totalCost spans every meter on the subscription; the grant
-	// only owns its meter, so filter charges down to m.ID (a meter can carry
-	// several charges when price segments split the window).
-	charges, _, err := meterUsageSvc.ConvertToBillingCharges(ctx, subUsage)
-	if err != nil {
-		return decimal.Zero, err
-	}
-
-	total := decimal.Zero
-	for _, c := range charges {
-		if c != nil && c.MeterID == m.ID {
-			total = total.Add(decimal.NewFromFloat(c.Amount))
-		}
 	}
 
 	s.Logger.Debug(ctx, "amount measure: entitlement grant evaluation: usage refreshed",

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -179,7 +179,10 @@ func (s *billingService) CalculateMeterUsageCharges(
 		grantResult, grantsApplied := adjustMeterUsageGrantsResult{}, false
 		if !matchingCharge.IsOverage {
 			if grantsForMeter := grantsByMeterID[item.MeterID]; len(grantsForMeter) > 0 {
-				grantResult, grantsApplied = s.adjustMeterUsageGrants(ctx, item, matchingCharge, grantsForMeter, priceService)
+				grantResult, grantsApplied, err = s.adjustMeterUsageGrants(ctx, item, matchingCharge, grantsForMeter, priceService, m, sub, extCustomerIDs)
+				if err != nil {
+					return nil, decimal.Zero, err
+				}
 			}
 		}
 

--- a/internal/ee/service/billing_meter_usage_grants.go
+++ b/internal/ee/service/billing_meter_usage_grants.go
@@ -99,7 +99,7 @@ func (s *billingService) adjustMeterUsageGrants(
 		return adjustMeterUsageGrantsResult{}, false, nil
 	}
 
-	if guardErr := grantPricingGuard(measure, item, matchingCharge.Price); guardErr != nil {
+	if guardErr := grantPricingGuard(measure, item, matchingCharge.Price, m); guardErr != nil {
 		s.Logger.Error(ctx, "entitlement grant overage: line item rejected, skipping grants",
 			"meter_id", item.MeterID,
 			"line_item_id", item.ID,
@@ -252,12 +252,25 @@ func mergeIntervals(in []timeInterval) []timeInterval {
 }
 
 // grantPricingGuard returns nil when grants may fold into this line item.
+// The fold assumes usage is additive over disjoint time windows (snapshot sums
+// per window, merged-window measurement) — so non-additive aggregations
+// (MAX, LATEST, AVG, ...) and bucketed meters are rejected outright.
 // Tiered prices are rejected for both measures (tiers walk with cumulative
 // cycle quantity; overage priced standalone would land in the wrong tier).
 // Commitment/true-up reject only the amount measure — they reconcile the
 // whole cycle, which pre-priced overage bypasses; the quantity measure feeds
 // its qty back into the normal pipeline where they compose correctly.
-func grantPricingGuard(measure types.EntitlementGrantMeasure, item *subscription.SubscriptionLineItem, price *priceDomain.Price) error {
+func grantPricingGuard(measure types.EntitlementGrantMeasure, item *subscription.SubscriptionLineItem, price *priceDomain.Price, m *meter.Meter) error {
+	if m != nil {
+		switch m.Aggregation.Type {
+		case types.AggregationSum, types.AggregationCount, types.AggregationSumWithMultiplier:
+		default:
+			return errGrantNonAdditiveAggregation
+		}
+		if m.Aggregation.BucketSize != "" {
+			return errGrantBucketedMeter
+		}
+	}
 	if price != nil && price.BillingModel == types.BILLING_MODEL_TIERED {
 		return errGrantTiered
 	}
@@ -274,10 +287,12 @@ func grantPricingGuard(measure types.EntitlementGrantMeasure, item *subscription
 }
 
 var (
-	errGrantAmountCommitment = grantGuardError("line item carries a commitment")
-	errGrantAmountTrueUp     = grantGuardError("line item enables true-up")
-	errGrantTiered           = grantGuardError("price uses tiered billing")
-	errGrantDepsMissing      = grantGuardError("measurement dependencies unavailable")
+	errGrantAmountCommitment       = grantGuardError("line item carries a commitment")
+	errGrantAmountTrueUp           = grantGuardError("line item enables true-up")
+	errGrantTiered                 = grantGuardError("price uses tiered billing")
+	errGrantDepsMissing            = grantGuardError("measurement dependencies unavailable")
+	errGrantNonAdditiveAggregation = grantGuardError("meter aggregation is not additive over time windows")
+	errGrantBucketedMeter          = grantGuardError("meter uses bucketed aggregation")
 )
 
 type grantGuardError string

--- a/internal/ee/service/billing_meter_usage_grants.go
+++ b/internal/ee/service/billing_meter_usage_grants.go
@@ -2,10 +2,13 @@ package service
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/entitlementgrant"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/meter"
 	priceDomain "github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/types"
@@ -13,13 +16,12 @@ import (
 )
 
 // adjustMeterUsageGrantsResult is the per-line-item output of the grant folding.
-// Exactly one of {AdjustedQty, OverageAmount} carries the load per invocation,
-// selected by Measure.
+// Overage is in meter units for the quantity measure and in currency for the
+// amount measure; PerECOverage decomposes it per entitlement config.
 type adjustMeterUsageGrantsResult struct {
-	Measure        types.EntitlementGrantMeasure
-	AdjustedQty    decimal.Decimal
-	OverageAmount  decimal.Decimal
-	AppliedGrantID string
+	Measure      types.EntitlementGrantMeasure
+	Overage      decimal.Decimal
+	PerECOverage map[string]decimal.Decimal
 }
 
 // loadEntitlementGrantsByMeterID returns grants overlapping the billing cycle
@@ -72,120 +74,212 @@ func (s *billingService) loadEntitlementGrantsByMeterID(
 	return out, nil
 }
 
-// adjustMeterUsageGrants folds Σ max(0, grant.usage − grant.quota) into the line
-// item. Quantity lane returns AdjustedQty for the pricer; amount lane returns
-// OverageAmount (already priced) and zeros the qty. Returns applied=false when
-// the runtime pricing guard rejects an amount-lane line item.
+// adjustMeterUsageGrants folds the meter's EG overage into the line item.
+// Quantity measure: overage re-enters the pricer as the billable quantity.
+// Amount measure: overage is already money and bypasses the pricer.
+// applied=false when the pricing guard rejects the line item; a measurement
+// error propagates — billing a knowingly wrong number is never an option.
 func (s *billingService) adjustMeterUsageGrants(
 	ctx context.Context,
 	item *subscription.SubscriptionLineItem,
 	matchingCharge *dto.SubscriptionUsageByMetersResponse,
 	grants []*entitlementgrant.EntitlementGrant,
 	priceService PriceService,
-) (adjustMeterUsageGrantsResult, bool) {
+	m *meter.Meter,
+	sub *subscription.Subscription,
+	extCustomerIDs []string,
+) (adjustMeterUsageGrantsResult, bool, error) {
 	if len(grants) == 0 {
-		return adjustMeterUsageGrantsResult{}, false
+		return adjustMeterUsageGrantsResult{}, false, nil
 	}
-	// Measure is set on the EC and copied to every grant at open time; EC-write
-	// validation keeps it consistent per feature, so we can trust the first row.
+	// Measure is copied from the EC to every grant; EC-write validation keeps
+	// it consistent per feature, so the first row is authoritative.
 	measure := grants[0].Measure
 	if measure == "" {
-		return adjustMeterUsageGrantsResult{}, false
+		return adjustMeterUsageGrantsResult{}, false, nil
 	}
 
-	// Runtime-only guard: commitments and true-up live on the sub line item, not
-	// the plan-level EC, so this check has to happen here — EC-write validation
-	// can't see them at config time.
-	if measure == types.EntitlementGrantMeasureAmount {
-		if guardErr := amountLanePricingGuard(item, matchingCharge.Price); guardErr != nil {
-			s.Logger.Error(ctx, "entitlement grant overage: amount lane rejected, skipping grants",
-				"meter_id", item.MeterID,
-				"line_item_id", item.ID,
-				"error", guardErr,
-			)
-			return adjustMeterUsageGrantsResult{}, false
-		}
+	if guardErr := grantPricingGuard(measure, item, matchingCharge.Price); guardErr != nil {
+		s.Logger.Error(ctx, "entitlement grant overage: line item rejected, skipping grants",
+			"meter_id", item.MeterID,
+			"line_item_id", item.ID,
+			"measure", measure,
+			"error", guardErr,
+		)
+		return adjustMeterUsageGrantsResult{}, false, nil
 	}
 
-	res := adjustMeterUsageGrantsResult{Measure: measure}
+	// Per-EC violation totals (usage − quota). ECs share the usage stream, so
+	// these overlap — attribution only, never summed into the bill directly.
+	perECOverage := make(map[string]decimal.Decimal)
+	ecIDs := make(map[string]struct{})
 	for _, g := range grants {
 		if g == nil {
 			continue
 		}
-		overage := g.Overage()
-		if !overage.IsPositive() {
-			continue
+		ecIDs[g.EntitlementConfigID] = struct{}{}
+		if overage := g.Overage(); overage.IsPositive() {
+			perECOverage[g.EntitlementConfigID] = perECOverage[g.EntitlementConfigID].Add(overage)
 		}
-		if res.AppliedGrantID == "" {
-			res.AppliedGrantID = g.ID
+	}
+
+	res := adjustMeterUsageGrantsResult{Measure: measure, PerECOverage: perECOverage}
+	if len(ecIDs) <= 1 {
+		// Single EC: its windows never overlap, so the snapshot sum is exact
+		for _, total := range perECOverage {
+			res.Overage = res.Overage.Add(total)
 		}
-		switch measure {
-		case types.EntitlementGrantMeasureQuantity:
-			res.AdjustedQty = res.AdjustedQty.Add(overage)
-		case types.EntitlementGrantMeasureAmount:
-			res.OverageAmount = res.OverageAmount.Add(overage)
+	} else {
+		overage, err := s.mergedOverage(ctx, m, sub, extCustomerIDs, grants, measure)
+		if err != nil {
+			return adjustMeterUsageGrantsResult{}, false, err
 		}
+		res.Overage = overage
 	}
 
 	switch measure {
 	case types.EntitlementGrantMeasureQuantity:
+		matchingCharge.Quantity = res.Overage.InexactFloat64()
 		if matchingCharge.Price != nil {
-			adjustedAmount := priceService.CalculateCost(ctx, matchingCharge.Price, res.AdjustedQty)
-			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(adjustedAmount, matchingCharge.Price.Currency)
+			cost := priceService.CalculateCost(ctx, matchingCharge.Price, res.Overage)
+			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(cost, matchingCharge.Price.Currency)
 		} else {
 			matchingCharge.Amount = 0
 		}
-		matchingCharge.Quantity = res.AdjustedQty.InexactFloat64()
 	case types.EntitlementGrantMeasureAmount:
+		// Already money — zero the qty so aggregation doesn't double-count.
 		if matchingCharge.Price != nil {
-			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(res.OverageAmount, matchingCharge.Price.Currency)
+			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(res.Overage, matchingCharge.Price.Currency)
 		} else {
-			matchingCharge.Amount = res.OverageAmount.InexactFloat64()
+			matchingCharge.Amount = res.Overage.InexactFloat64()
 		}
-		// Amount-lane grants are already priced; zero the qty so aggregation doesn't double-count.
 		matchingCharge.Quantity = 0
 	}
-	return res, true
+	return res, true, nil
 }
 
-// amountLanePricingGuard returns nil when the line item is safe for the amount lane.
+// mergedOverage bills usage inside the unique overage windows across the
+// meter's ECs. Each quota-crossed EG contributes [quota_crossed_at, valid_to);
+// overlapping windows merge, so a unit bills once no matter how many EGs were in overage.
 //
-// Why each of these disqualifies amount grants:
-//   - commitment: the pricer walks the sub line's minimum commitment across the
-//     full cycle. Amount grants pre-price a slice of usage inside a window and
-//     hand back OverageAmount; the pricer would then re-apply commitment on top
-//     and either double-charge or under-charge the commit floor.
-//   - true-up: same shape — true-up reconciles the whole cycle against actual
-//     usage. Pre-priced overage bypasses it and produces a wrong final invoice.
-//   - tiered: tier boundaries walk with cumulative cycle quantity. A grant only
-//     knows its own window's qty, so it can't price against the right tier.
-//     EC-write validation already rejects this, but the guard keeps the
-//     billing path safe if a tier is ever added after the EC was created.
-func amountLanePricingGuard(item *subscription.SubscriptionLineItem, price *priceDomain.Price) error {
-	if item == nil {
+// Quantity measure: one ClickHouse query over all windows (TimeRanges)
+// Amount measure: one billing-path pricing per window.
+// Zero queries when nothing crossed.
+func (s *billingService) mergedOverage(
+	ctx context.Context,
+	m *meter.Meter,
+	sub *subscription.Subscription,
+	extCustomerIDs []string,
+	grants []*entitlementgrant.EntitlementGrant,
+	measure types.EntitlementGrantMeasure,
+) (decimal.Decimal, error) {
+	overageIntervals := make([]timeInterval, 0, len(grants))
+	for _, g := range grants {
+		if g != nil && g.QuotaCrossedAt != nil {
+			overageIntervals = append(overageIntervals, timeInterval{start: *g.QuotaCrossedAt, end: g.ValidTo})
+		}
+	}
+	if len(overageIntervals) == 0 {
+		return decimal.Zero, nil
+	}
+	if m == nil {
+		return decimal.Zero, errGrantDepsMissing
+	}
+
+	overageWindows := mergeIntervals(overageIntervals)
+	billableRanges := make([]events.TimeRange, 0, len(overageWindows))
+	for _, w := range overageWindows {
+		billableRanges = append(billableRanges, events.TimeRange{Start: w.start, End: w.end})
+	}
+
+	meterUsageSvc := NewMeterUsageService(s.ServiceParams)
+	total := decimal.Zero
+	switch measure {
+	case types.EntitlementGrantMeasureQuantity:
+		usage, err := meterUsageSvc.GetUsageTotal(ctx, &dto.UsageTotalRequest{
+			TenantID:            types.GetTenantID(ctx),
+			EnvironmentID:       types.GetEnvironmentID(ctx),
+			ExternalCustomerIDs: extCustomerIDs,
+			MeterID:             m.ID,
+			AggregationType:     m.Aggregation.Type,
+			TimeRanges:          billableRanges,
+		})
+		if err != nil {
+			return decimal.Zero, err
+		}
+		total = usage
+	case types.EntitlementGrantMeasureAmount:
+		if sub == nil {
+			return decimal.Zero, errGrantDepsMissing
+		}
+		for _, r := range billableRanges {
+			cost, err := meterUsageSvc.GetMeterWindowCost(ctx, sub, m.ID, r.Start, r.End)
+			if err != nil {
+				return decimal.Zero, err
+			}
+			total = total.Add(cost)
+		}
+	}
+	return total, nil
+}
+
+// timeInterval is a half-open [start, end) range.
+type timeInterval struct {
+	start, end time.Time
+}
+
+// mergeIntervals coalesces overlapping/touching intervals; empty ones drop.
+func mergeIntervals(in []timeInterval) []timeInterval {
+	valid := make([]timeInterval, 0, len(in))
+	for _, iv := range in {
+		if iv.end.After(iv.start) {
+			valid = append(valid, iv)
+		}
+	}
+	sort.Slice(valid, func(i, j int) bool { return valid[i].start.Before(valid[j].start) })
+
+	out := make([]timeInterval, 0, len(valid))
+	for _, iv := range valid {
+		if n := len(out); n > 0 && !iv.start.After(out[n-1].end) {
+			if iv.end.After(out[n-1].end) {
+				out[n-1].end = iv.end
+			}
+			continue
+		}
+		out = append(out, iv)
+	}
+	return out
+}
+
+// grantPricingGuard returns nil when grants may fold into this line item.
+// Tiered prices are rejected for both measures (tiers walk with cumulative
+// cycle quantity; overage priced standalone would land in the wrong tier).
+// Commitment/true-up reject only the amount measure — they reconcile the
+// whole cycle, which pre-priced overage bypasses; the quantity measure feeds
+// its qty back into the normal pipeline where they compose correctly.
+func grantPricingGuard(measure types.EntitlementGrantMeasure, item *subscription.SubscriptionLineItem, price *priceDomain.Price) error {
+	if price != nil && price.BillingModel == types.BILLING_MODEL_TIERED {
+		return errGrantTiered
+	}
+	if measure != types.EntitlementGrantMeasureAmount || item == nil {
 		return nil
 	}
 	if item.HasAnyCommitment() {
-		return errAmountLaneCommitment
+		return errGrantAmountCommitment
 	}
 	if item.HasTrueUpEnabled() {
-		return errAmountLaneTrueUp
-	}
-	if price == nil {
-		return nil
-	}
-	if price.BillingModel == types.BILLING_MODEL_TIERED {
-		return errAmountLaneTiered
+		return errGrantAmountTrueUp
 	}
 	return nil
 }
 
 var (
-	errAmountLaneCommitment = errAmountLaneReason("line item carries a commitment")
-	errAmountLaneTrueUp     = errAmountLaneReason("line item enables true-up")
-	errAmountLaneTiered     = errAmountLaneReason("price uses tiered billing")
+	errGrantAmountCommitment = grantGuardError("line item carries a commitment")
+	errGrantAmountTrueUp     = grantGuardError("line item enables true-up")
+	errGrantTiered           = grantGuardError("price uses tiered billing")
+	errGrantDepsMissing      = grantGuardError("measurement dependencies unavailable")
 )
 
-type errAmountLaneReason string
+type grantGuardError string
 
-func (e errAmountLaneReason) Error() string { return string(e) }
+func (e grantGuardError) Error() string { return string(e) }

--- a/internal/ee/service/billing_meter_usage_grants_test.go
+++ b/internal/ee/service/billing_meter_usage_grants_test.go
@@ -246,6 +246,41 @@ func TestAdjustMeterUsageGrants_QuantityLane_TieredPriceGuardRejects(t *testing.
 	}
 }
 
+func TestAdjustMeterUsageGrants_NonAdditiveAggregationGuardRejects(t *testing.T) {
+	// Snapshot sums and merged-window measurement assume usage is additive over
+	// disjoint time windows; MAX/LATEST/AVG do not decompose that way.
+	bs := newTestBillingService()
+	li := linItem(false, false)
+	c := charge(flatPrice(0.01))
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeGrant(100, 250, types.EntitlementGrantMeasureQuantity),
+	}
+	m := &meter.Meter{ID: "meter_max", Aggregation: meter.Aggregation{Type: types.AggregationMax}}
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), m, nil, nil)
+	if applied {
+		t.Fatalf("MAX aggregation must reject grant folding")
+	}
+	if c.Quantity != 1000 {
+		t.Fatalf("matchingCharge should be untouched when guard trips")
+	}
+}
+
+func TestAdjustMeterUsageGrants_BucketedMeterGuardRejects(t *testing.T) {
+	// Bucketed meters price through their own bucketed cost path; window
+	// measurement over raw usage would disagree with it.
+	bs := newTestBillingService()
+	li := linItem(false, false)
+	c := charge(flatPrice(0.01))
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeGrant(100, 250, types.EntitlementGrantMeasureQuantity),
+	}
+	m := &meter.Meter{ID: "meter_bucketed", Aggregation: meter.Aggregation{Type: types.AggregationSum, BucketSize: types.WindowSizeHour}}
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), m, nil, nil)
+	if applied {
+		t.Fatalf("bucketed meter must reject grant folding")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Merged overage windows: grants pre-materialized (quota_crossed_at, as the
 // evaluator writes it), fold measures usage inside the merged windows.

--- a/internal/ee/service/billing_meter_usage_grants_test.go
+++ b/internal/ee/service/billing_meter_usage_grants_test.go
@@ -8,9 +8,12 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/domain/entitlementgrant"
+	eventsDomain "github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/meter"
 	priceDomain "github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 )
@@ -108,7 +111,7 @@ func TestAdjustMeterUsageGrants_NoGrants(t *testing.T) {
 	bs := newTestBillingService()
 	li := linItem(false, false)
 	c := charge(flatPrice(0.01))
-	_, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, nil, newTestPriceService())
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, nil, newTestPriceService(), nil, nil, nil)
 	if applied {
 		t.Fatalf("empty grants should not be applied")
 	}
@@ -117,8 +120,16 @@ func TestAdjustMeterUsageGrants_NoGrants(t *testing.T) {
 	}
 }
 
+func makeSlotGrant(ecID string, quota, usage int64, measure types.EntitlementGrantMeasure) *entitlementgrant.EntitlementGrant {
+	g := makeGrant(quota, usage, measure)
+	g.ID = "eg_" + ecID + "_" + decimal.NewFromInt(quota).String()
+	g.EntitlementConfigID = ecID
+	return g
+}
+
 func TestAdjustMeterUsageGrants_QuantityLane_SumOfOverages(t *testing.T) {
-	// Overage-sum model: sum(max(0, usage-quota)) across grants; only the second contributes.
+	// All grants share one EC slot (sequential windows of the same bucket):
+	// their windows partition distinct events, so overages SUM.
 	bs := newTestBillingService()
 	li := linItem(false, false)
 	c := charge(flatPrice(0.5))
@@ -128,13 +139,13 @@ func TestAdjustMeterUsageGrants_QuantityLane_SumOfOverages(t *testing.T) {
 		makeGrant(50, 60, types.EntitlementGrantMeasureQuantity),    // overage 10
 	}
 
-	res, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService())
+	res, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
 	if !applied {
 		t.Fatalf("expected applied=true for qty grants")
 	}
 	wantQty := decimal.NewFromInt(160) // 150 + 10
-	if !res.AdjustedQty.Equal(wantQty) {
-		t.Fatalf("AdjustedQty = %s; want %s", res.AdjustedQty, wantQty)
+	if !res.Overage.Equal(wantQty) {
+		t.Fatalf("Overage = %s; want %s", res.Overage, wantQty)
 	}
 
 	// matchingCharge.Quantity mutated to the billable qty; Amount recomputed
@@ -156,12 +167,12 @@ func TestAdjustMeterUsageGrants_AmountLane_FlatPricingAccepted(t *testing.T) {
 	grants := []*entitlementgrant.EntitlementGrant{
 		makeGrant(100, 250, types.EntitlementGrantMeasureAmount), // overage 150
 	}
-	res, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService())
+	res, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
 	if !applied {
 		t.Fatalf("expected applied=true for flat-priced amount grants")
 	}
-	if !res.OverageAmount.Equal(decimal.NewFromInt(150)) {
-		t.Fatalf("OverageAmount = %s; want 150", res.OverageAmount)
+	if !res.Overage.Equal(decimal.NewFromInt(150)) {
+		t.Fatalf("Overage = %s; want 150", res.Overage)
 	}
 	if int(c.Amount) != 150 {
 		t.Fatalf("matchingCharge.Amount = %v; want 150", c.Amount)
@@ -180,7 +191,7 @@ func TestAdjustMeterUsageGrants_AmountLane_TieredPriceGuardRejects(t *testing.T)
 	grants := []*entitlementgrant.EntitlementGrant{
 		makeGrant(100, 250, types.EntitlementGrantMeasureAmount),
 	}
-	_, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService())
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
 	if applied {
 		t.Fatalf("tiered price must reject amount-lane grants")
 	}
@@ -197,7 +208,7 @@ func TestAdjustMeterUsageGrants_AmountLane_LineItemCommitmentGuardRejects(t *tes
 	grants := []*entitlementgrant.EntitlementGrant{
 		makeGrant(100, 200, types.EntitlementGrantMeasureAmount),
 	}
-	_, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService())
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
 	if applied {
 		t.Fatalf("committed line item must reject amount-lane grants")
 	}
@@ -210,9 +221,178 @@ func TestAdjustMeterUsageGrants_AmountLane_TrueUpGuardRejects(t *testing.T) {
 	grants := []*entitlementgrant.EntitlementGrant{
 		makeGrant(100, 200, types.EntitlementGrantMeasureAmount),
 	}
-	_, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService())
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
 	if applied {
 		t.Fatalf("true-up enabled must reject amount-lane grants")
+	}
+}
+
+func TestAdjustMeterUsageGrants_QuantityLane_TieredPriceGuardRejects(t *testing.T) {
+	// The quantity lane prices the overage standalone — on a tiered price that
+	// would restart at tier 1 and misprice the marginal units. Guard rejects;
+	// the caller falls back to the legacy path.
+	bs := newTestBillingService()
+	li := linItem(false, false)
+	c := charge(tieredPrice())
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeGrant(100, 250, types.EntitlementGrantMeasureQuantity),
+	}
+	_, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
+	if applied {
+		t.Fatalf("tiered price must reject quantity-lane grants too")
+	}
+	if c.Quantity != 1000 {
+		t.Fatalf("matchingCharge should be untouched when guard trips")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Merged overage windows: grants pre-materialized (quota_crossed_at, as the
+// evaluator writes it), fold measures usage inside the merged windows.
+// ---------------------------------------------------------------------------
+
+var unionT0 = time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
+// makeCrossedGrant builds a grant whose quota exhaustion the evaluator has
+// already recorded.
+func makeCrossedGrant(ecID string, quota, usage int64, from, to time.Time, crossedAt time.Time) *entitlementgrant.EntitlementGrant {
+	g := makeGrant(quota, usage, types.EntitlementGrantMeasureQuantity)
+	g.ID = "eg_" + ecID + "_" + from.Format("15:04:05")
+	g.EntitlementConfigID = ecID
+	g.ValidFrom = from
+	g.ValidTo = to
+	g.QuotaCrossedAt = &crossedAt
+	return g
+}
+
+func newMergedWindowBillingService(t *testing.T, events []struct {
+	at  time.Time
+	qty int64
+}) (*billingService, *meter.Meter) {
+	t.Helper()
+	store := testutil.NewInMemoryMeterUsageStore()
+	rows := make([]*eventsDomain.MeterUsage, 0, len(events))
+	for i, e := range events {
+		rows = append(rows, &eventsDomain.MeterUsage{
+			Event: eventsDomain.Event{
+				ID:                 decimal.NewFromInt(int64(i)).String(),
+				ExternalCustomerID: "cust_ext",
+				EventName:          "api_call",
+				Timestamp:          e.at,
+			},
+			MeterID:  "meter_x",
+			QtyTotal: decimal.NewFromInt(e.qty),
+		})
+	}
+	if err := store.BulkInsertMeterUsage(context.Background(), rows); err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+	bs := &billingService{ServiceParams: ServiceParams{Logger: newTestLogger(), MeterUsageRepo: store}}
+	m := &meter.Meter{ID: "meter_x", Aggregation: meter.Aggregation{Type: types.AggregationSum}}
+	return bs, m
+}
+
+func TestAdjustMeterUsageGrants_MergedWindows_DisjointWindowsBothBill(t *testing.T) {
+	// Two ECs exhausted at different times with non-overlapping overage
+	// windows: usage after each exhaustion bills — 300 + 700 = 1000.
+	dayCross := unionT0.Add(2 * time.Hour)
+	weekCross := unionT0.Add(3 * 24 * time.Hour)
+	bs, m := newMergedWindowBillingService(t, []struct {
+		at  time.Time
+		qty int64
+	}{
+		{unionT0.Add(1 * time.Hour), 3000},     // pre-exhaustion, never billed
+		{unionT0.Add(4 * time.Hour), 300},      // after day EC exhausted
+		{unionT0.Add(4 * 24 * time.Hour), 700}, // after week EC exhausted
+	})
+
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeCrossedGrant("ec_day", 2000, 3300, unionT0, unionT0.Add(24*time.Hour), dayCross),
+		makeCrossedGrant("ec_week", 3500, 4000, unionT0, unionT0.Add(7*24*time.Hour), weekCross),
+	}
+	li := linItem(false, false)
+	c := charge(flatPrice(1))
+
+	res, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), m, nil, []string{"cust_ext"})
+	if !applied {
+		t.Fatalf("expected applied=true")
+	}
+	if !res.Overage.Equal(decimal.NewFromInt(1000)) {
+		t.Fatalf("Overage = %s; want 1000 (300 after day cross + 700 after week cross)", res.Overage)
+	}
+}
+
+func TestAdjustMeterUsageGrants_MergedWindows_OverlapBillsOnce(t *testing.T) {
+	// Both ECs in overage over an overlapping stretch: the windows merge, so
+	// shared usage bills once — 50 (EC-a only region) + 100 (shared) = 150,
+	// never 250.
+	aCross := unionT0.Add(10 * time.Minute)
+	bCross := unionT0.Add(30 * time.Minute)
+	bs, m := newMergedWindowBillingService(t, []struct {
+		at  time.Time
+		qty int64
+	}{
+		{unionT0.Add(20 * time.Minute), 50},  // inside EC-a's window only
+		{unionT0.Add(40 * time.Minute), 100}, // inside both windows
+	})
+
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeCrossedGrant("ec_a", 10, 160, unionT0, unionT0.Add(time.Hour), aCross),
+		makeCrossedGrant("ec_b", 40, 150, unionT0, unionT0.Add(24*time.Hour), bCross),
+	}
+	li := linItem(false, false)
+	c := charge(flatPrice(1))
+
+	res, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), m, nil, []string{"cust_ext"})
+	if !applied {
+		t.Fatalf("expected applied=true")
+	}
+	if !res.Overage.Equal(decimal.NewFromInt(150)) {
+		t.Fatalf("Overage = %s; want 150 (shared usage bills once)", res.Overage)
+	}
+}
+
+func TestAdjustMeterUsageGrants_MeasurementFailurePropagates(t *testing.T) {
+	// Money movement never bills a knowingly wrong number: when the merged
+	// windows can't be measured (here: no usage repo), the error propagates
+	// and the charge calculation fails instead of billing an approximation.
+	bs := newTestBillingService() // nil MeterUsageRepo
+	li := linItem(false, false)
+	c := charge(flatPrice(1))
+	cross := unionT0.Add(10 * time.Minute)
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeCrossedGrant("ec_a", 10, 150, unionT0, unionT0.Add(time.Hour), cross),
+		makeCrossedGrant("ec_b", 100, 150, unionT0, unionT0.Add(24*time.Hour), cross),
+	}
+	_, applied, err := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
+	if err == nil {
+		t.Fatalf("expected measurement error to propagate")
+	}
+	if applied {
+		t.Fatalf("nothing must be applied on error")
+	}
+}
+
+func TestAdjustMeterUsageGrants_MultiEC_NothingCrossed_QueryFree(t *testing.T) {
+	// Multiple ECs, none exhausted (or exhaustion not yet recorded): zero
+	// overage and zero queries — nil MeterUsageRepo proves ClickHouse is
+	// never touched. A recording lag just delays billing to the next pass.
+	bs := newTestBillingService()
+	li := linItem(false, false)
+	c := charge(flatPrice(1))
+	grants := []*entitlementgrant.EntitlementGrant{
+		makeSlotGrant("ec_a", 100, 150, types.EntitlementGrantMeasureQuantity), // over quota, crossing not recorded yet
+		makeSlotGrant("ec_b", 200, 40, types.EntitlementGrantMeasureQuantity),
+	}
+	res, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
+	if !applied {
+		t.Fatalf("expected applied=true")
+	}
+	if !res.Overage.IsZero() {
+		t.Fatalf("Overage = %s; want 0 (bills on the next pass once recorded)", res.Overage)
+	}
+	if !res.PerECOverage["ec_a"].Equal(decimal.NewFromInt(50)) {
+		t.Fatalf("PerECOverage attribution wrong: %v", res.PerECOverage)
 	}
 }
 
@@ -226,12 +406,12 @@ func TestAdjustMeterUsageGrants_AllUnderQuota_ZerosBillable(t *testing.T) {
 		makeGrant(100, 40, types.EntitlementGrantMeasureQuantity),
 		makeGrant(200, 100, types.EntitlementGrantMeasureQuantity),
 	}
-	res, applied := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService())
+	res, applied, _ := bs.adjustMeterUsageGrants(context.Background(), li, c, grants, newTestPriceService(), nil, nil, nil)
 	if !applied {
 		t.Fatalf("expected applied=true (grants exist even if no overage)")
 	}
-	if !res.AdjustedQty.IsZero() {
-		t.Fatalf("AdjustedQty should be zero, got %s", res.AdjustedQty)
+	if !res.Overage.IsZero() {
+		t.Fatalf("Overage should be zero, got %s", res.Overage)
 	}
 	if c.Amount != 0 || c.Quantity != 0 {
 		t.Fatalf("under-quota grants should zero the charge, got amount=%v qty=%v", c.Amount, c.Quantity)

--- a/internal/ee/service/entitlement_grant.go
+++ b/internal/ee/service/entitlement_grant.go
@@ -346,8 +346,11 @@ func (s *entitlementGrantService) openIfSlotFree(
 	opened := make([]*entitlementgrant.EntitlementGrant, 0, 1)
 	for {
 		lastEnd := latestEndBySlot[slot]
-		if lastEnd.After(at) {
-			return opened, nil // latest window is open (or slot just caught up)
+		// Done when the latest window is still open, or coverage already reaches
+		// cycle_end (catch-up finished, or rollover lag with a stale sub) — the
+		// anchor range would be empty, so skip the usage query outright.
+		if lastEnd.After(at) || !lastEnd.Before(sub.CurrentPeriodEnd) {
+			return opened, nil
 		}
 
 		g, err := s.openOneGrant(ctx, sub, candidate.ec, lastEnd, meta, at, candidate.quota)

--- a/internal/ee/service/entitlement_grant.go
+++ b/internal/ee/service/entitlement_grant.go
@@ -20,6 +20,9 @@ import (
 
 // EntitlementGrantService owns the lifecycle of entitlement_grants rows.
 type EntitlementGrantService interface {
+	// GetGrant returns one grant by id (webhook payloads, lookups).
+	GetGrant(ctx context.Context, id string) (*entitlementgrant.EntitlementGrant, error)
+
 	EnsureGrants(ctx context.Context, cust *customer.Customer, at time.Time) ([]*entitlementgrant.EntitlementGrant, *grantEvalMeta, error)
 
 	// EnsureGrantsForSubscriptions is the data-fed variant: the caller supplies
@@ -35,6 +38,10 @@ type entitlementGrantService struct {
 
 func NewEntitlementGrantService(params ServiceParams) EntitlementGrantService {
 	return &entitlementGrantService{ServiceParams: params}
+}
+
+func (s *entitlementGrantService) GetGrant(ctx context.Context, id string) (*entitlementgrant.EntitlementGrant, error) {
+	return s.EntitlementGrantRepo.Get(ctx, id)
 }
 
 // grantEvalMeta is the per-pass lookup bundle shared by grant opening and the

--- a/internal/ee/service/entitlement_grant.go
+++ b/internal/ee/service/entitlement_grant.go
@@ -261,13 +261,11 @@ func (s *entitlementGrantService) openMissingGrants(
 	for _, sub := range subs {
 		for _, featureECs := range s.eligibleGrantConfigsByFeature(ctx, sub, ecsBySub[sub.ID]) {
 			for _, candidate := range grantCandidatesForFeature(featureECs) {
-				g, err := s.openIfSlotFree(ctx, sub, candidate, latestEndBySlot, meta, at)
+				slotOpened, err := s.openIfSlotFree(ctx, sub, candidate, latestEndBySlot, meta, at)
 				if err != nil {
 					return nil, err
 				}
-				if g != nil {
-					opened = append(opened, g)
-				}
+				opened = append(opened, slotOpened...)
 			}
 		}
 	}
@@ -331,8 +329,11 @@ func grantCandidatesForFeature(featureECs []*entitlement.Entitlement) []grantCan
 	return []grantCandidate{{ec: primary, quota: total}}
 }
 
-// openIfSlotFree opens the candidate's grant unless the slot's latest window
-// is still open at `at`; a freshly opened grant claims the slot.
+// openIfSlotFree opens grants on the candidate's slot until it is caught up:
+// after a backlog (delayed evaluation, cycle rollover lag) a single tick walks
+// every missed usage-anchored window up to `at` instead of needing one future
+// event per window. Terminates because each window strictly advances the
+// covered range, bounded by cycle_end.
 func (s *entitlementGrantService) openIfSlotFree(
 	ctx context.Context,
 	sub *subscription.Subscription,
@@ -340,20 +341,25 @@ func (s *entitlementGrantService) openIfSlotFree(
 	latestEndBySlot map[string]time.Time,
 	meta *grantEvalMeta,
 	at time.Time,
-) (*entitlementgrant.EntitlementGrant, error) {
+) ([]*entitlementgrant.EntitlementGrant, error) {
 	slot := grantSlotKey(candidate.ec.ID, sub.ID)
-	lastEnd := latestEndBySlot[slot]
-	if lastEnd.After(at) {
-		return nil, nil
-	}
+	opened := make([]*entitlementgrant.EntitlementGrant, 0, 1)
+	for {
+		lastEnd := latestEndBySlot[slot]
+		if lastEnd.After(at) {
+			return opened, nil // latest window is open (or slot just caught up)
+		}
 
-	g, err := s.openOneGrant(ctx, sub, candidate.ec, lastEnd, meta, at, candidate.quota)
-	if err != nil || g == nil {
-		return nil, err
+		g, err := s.openOneGrant(ctx, sub, candidate.ec, lastEnd, meta, at, candidate.quota)
+		if err != nil {
+			return opened, err
+		}
+		if g == nil {
+			return opened, nil // no uncovered usage left
+		}
+		opened = append(opened, g)
+		latestEndBySlot[slot] = g.ValidTo
 	}
-
-	latestEndBySlot[slot] = g.ValidTo
-	return g, nil
 }
 
 // openOneGrant inserts the slot's next grant. On INSERT conflict — valid_from
@@ -415,9 +421,9 @@ func (s *entitlementGrantService) openOneGrant(
 
 // computeGrantWindow derives [valid_from, valid_to): the window opens at the
 // first usage event past the covered range; no uncovered usage → no window.
-// At the cycle boundary the window becomes the cycle's last `dur` — backdating
-// the start is safe because [coveredUntil, firstUncoveredEventAt) is event-free by
-// definition — and it stretches to cycle_end rather than leave a sub-1h stub.
+// The 1h minimum is best-effort: the window stretches to cycle_end rather
+// than leave a sub-1h stub behind it, but a forced tail may itself be short —
+// coverage beats window-length aesthetics.
 func (s *entitlementGrantService) computeGrantWindow(
 	ctx context.Context,
 	ec *entitlement.Entitlement,
@@ -430,23 +436,35 @@ func (s *entitlementGrantService) computeGrantWindow(
 	cycleStart := sub.CurrentPeriodStart
 	cycleEnd := sub.CurrentPeriodEnd
 	coveredUntil := latestOf(lastWindowEnd, cycleStart)
+	searchUntil := earliestOf(at, cycleEnd)
+
+	s.Logger.Debug(ctx, "computing grant window",
+		"coveredUntil", coveredUntil,
+		"searchUntil", searchUntil,
+		"cycleStart", cycleStart,
+		"cycleEnd", cycleEnd,
+		"eventTime", at,
+		"grantDuration", dur,
+	)
 
 	// The clamp to cycle_end keeps next-cycle events (sub object not yet rolled)
 	// out; an empty/inverted range simply finds nothing.
-	firstUncoveredEventAt, err := s.earliestUncoveredUsage(ctx, meta, sub, ec, coveredUntil, earliestOf(at, cycleEnd))
+	firstUncoveredEventAt, err := s.earliestUncoveredUsage(ctx, meta, sub, ec, coveredUntil, searchUntil)
 	if err != nil || firstUncoveredEventAt == nil {
 		return time.Time{}, time.Time{}, false, err
 	}
 
 	validFrom := *firstUncoveredEventAt
-	if cycleEnd.Sub(validFrom) < dur {
-		validFrom = latestOf(coveredUntil, cycleEnd.Add(-dur))
-	}
-
 	validTo := validFrom.Add(dur)
+	// Cap at cycle_end AND absorb a sub-minimum trailing remainder in one rule
 	if cycleEnd.Sub(validTo) < types.EntitlementGrantMinDuration {
 		validTo = cycleEnd
 	}
+
+	s.Logger.Debug(ctx, "computed grant window",
+		"validFrom", validFrom,
+		"validTo", validTo,
+	)
 	return validFrom, validTo, true, nil
 }
 
@@ -462,13 +480,19 @@ func (s *entitlementGrantService) earliestUncoveredUsage(
 ) (*time.Time, error) {
 	f := meta.featureByID[ec.FeatureID]
 	if f == nil || f.MeterID == "" {
+		s.Logger.Debug(ctx, "computing grant window: no meter found for feature",
+			"feature_id", ec.FeatureID,
+			"subscription_id", sub.ID,
+			"customer_id", sub.CustomerID,
+		)
 		return nil, nil
 	}
+
 	extIDs, err := meta.externalIDs(ctx, sub)
 	if err != nil {
 		return nil, err
 	}
-	return s.MeterUsageRepo.GetEarliestUsageTimestamp(ctx, &events.MeterUsageQueryParams{
+	timestamp, err := s.MeterUsageRepo.GetEarliestUsageTimestamp(ctx, &events.MeterUsageQueryParams{
 		TenantID:            types.GetTenantID(ctx),
 		EnvironmentID:       types.GetEnvironmentID(ctx),
 		ExternalCustomerIDs: extIDs,
@@ -476,6 +500,13 @@ func (s *entitlementGrantService) earliestUncoveredUsage(
 		StartTime:           coveredUntil,
 		EndTime:             until,
 	})
+	if err != nil {
+		s.Logger.Error(ctx, "computing grant window: error getting earliest usage timestamp", "error", err)
+		return nil, err
+	}
+
+	s.Logger.Debug(ctx, "computing grant window: earliest un-covered usage timestamp", "timestamp", timestamp)
+	return timestamp, nil
 }
 
 func latestOf(a, b time.Time) time.Time {

--- a/internal/ee/service/entitlement_grant_test.go
+++ b/internal/ee/service/entitlement_grant_test.go
@@ -1287,6 +1287,11 @@ func (s *EntitlementGrantSuite) TestEvaluate_OverQuota_FlipsExhaustedAndFiresAle
 	s.Equal(types.EntitlementGrantStatusExhausted, stored.GrantStatus)
 	s.Require().NotNil(stored.LastComputedAt)
 
+	// Quota exhaustion recorded once, at the evaluation time that first saw
+	// usage > quota (not the exact event time — see the note in the evaluator).
+	s.Require().NotNil(stored.QuotaCrossedAt, "exhaustion must be recorded once usage exceeds quota")
+	s.True(stored.QuotaCrossedAt.Equal(at), "quota_crossed_at = evaluation time, got %s", stored.QuotaCrossedAt)
+
 	logs, err := s.GetStores().AlertLogsRepo.ListByEntity(s.GetContext(), types.AlertEntityTypeEntitlementGrant, g.ID, 10)
 	s.Require().NoError(err)
 	s.Require().Len(logs, 1, "exhaustion must write exactly one alert log")

--- a/internal/ee/service/entitlement_grant_test.go
+++ b/internal/ee/service/entitlement_grant_test.go
@@ -437,9 +437,9 @@ func (s *EntitlementGrantSuite) TestComputeGrantWindow_IdleGapHop() {
 }
 
 func (s *EntitlementGrantSuite) TestComputeGrantWindow_CycleBoundaryCap() {
-	// A 24h duration anchored 6h before cycle_end: the full duration doesn't
-	// fit, so the window becomes the cycle's last 24h — backdated start (safe:
-	// [frontier, anchor) is event-free), capped end.
+	// A 24h duration anchored 6h before cycle_end: the window keeps its exact
+	// usage anchor and the end caps at cycle_end (6h window — best-effort
+	// minimum, coverage beats window-length aesthetics).
 	svc := s.grantService.(*entitlementGrantService)
 	fx := s.newWindowFixture("cap", 24)
 	eventAt := fx.cycleEnd.Add(-6 * time.Hour)
@@ -449,7 +449,7 @@ func (s *EntitlementGrantSuite) TestComputeGrantWindow_CycleBoundaryCap() {
 	from, to, ok, err := svc.computeGrantWindow(s.GetContext(), fx.ec, fx.sub, meta, last, eventAt.Add(10*time.Minute), 24*time.Hour)
 	s.NoError(err)
 	s.True(ok)
-	s.True(from.Equal(fx.cycleEnd.Add(-24*time.Hour)), "start must backdate to cycle_end-24h: got %s", from)
+	s.True(from.Equal(eventAt), "window must anchor at the event: got %s", from)
 	s.True(to.Equal(fx.cycleEnd), "valid_to must cap at cycle_end")
 }
 
@@ -472,10 +472,10 @@ func (s *EntitlementGrantSuite) TestComputeGrantWindow_TrailingStubAbsorbed() {
 	s.True(to.Equal(fx.cycleEnd), "final window must absorb the sub-minimum stub: got %s want %s", to, fx.cycleEnd)
 }
 
-func (s *EntitlementGrantSuite) TestComputeGrantWindow_ForcedTailBackdatedToFullDuration() {
-	// First uncovered event inside the cycle's final stretch: the window
-	// backdates its start to cycle_end − duration, covering the anchoring
-	// event with a full-length window ending at cycle_end.
+func (s *EntitlementGrantSuite) TestComputeGrantWindow_ForcedTailShortWindow() {
+	// First uncovered event inside the cycle's last hour: a short boundary
+	// window [event, cycle_end) opens — the 1h minimum is best-effort and
+	// coverage wins at the boundary.
 	svc := s.grantService.(*entitlementGrantService)
 	fx := s.newWindowFixture("tail", 5)
 	eventAt := fx.cycleEnd.Add(-30 * time.Minute)
@@ -484,8 +484,8 @@ func (s *EntitlementGrantSuite) TestComputeGrantWindow_ForcedTailBackdatedToFull
 	meta, last := s.windowArgs(fx)
 	from, to, ok, err := svc.computeGrantWindow(s.GetContext(), fx.ec, fx.sub, meta, last, fx.cycleEnd.Add(-10*time.Minute), 5*time.Hour)
 	s.NoError(err)
-	s.True(ok, "tail window must open, backdated to the full duration")
-	s.True(from.Equal(fx.cycleEnd.Add(-5*time.Hour)), "start must backdate to cycle_end-duration: got %s", from)
+	s.True(ok, "tail window must open even when shorter than the config minimum")
+	s.True(from.Equal(eventAt), "window must anchor at the event: got %s", from)
 	s.True(to.Equal(fx.cycleEnd))
 }
 
@@ -768,15 +768,21 @@ func (s *EntitlementGrantSuite) TestEnsureGrants_AdditiveECs_OneSummedGrant() {
 	m := s.simpleMeter("meter-add")
 	f := s.simpleFeature("feat-add", m.ID)
 	p := s.simplePlan("plan-add")
-
-	for i, quota := range []int64{100, 200} {
-		req := s.grantCreateRequest(f.ID, p.ID, types.EntitlementGrantMeasureQuantity, 5, decimal.NewFromInt(quota))
-		_, err := s.entService.CreateEntitlement(s.GetContext(), req)
-		s.Require().NoError(err, "creating additive EC %d", i)
-	}
-
 	cust := s.simpleCustomer("cust-add")
 	sub := s.simpleSubscription("sub-add", cust.ID, p.ID)
+
+	// Additive groups span entities: the DB allows one published non-parallel
+	// entitlement per (entity, feature), so the second EC lives on the
+	// subscription (override-style addition), like plan + addon in production.
+	_, err := s.entService.CreateEntitlement(s.GetContext(),
+		s.grantCreateRequest(f.ID, p.ID, types.EntitlementGrantMeasureQuantity, 5, decimal.NewFromInt(100)))
+	s.Require().NoError(err, "creating plan-level additive EC")
+
+	subReq := s.grantCreateRequest(f.ID, sub.ID, types.EntitlementGrantMeasureQuantity, 5, decimal.NewFromInt(200))
+	subReq.EntityType = types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION
+	_, err = s.entService.CreateEntitlement(s.GetContext(), subReq)
+	s.Require().NoError(err, "creating subscription-level additive EC")
+
 	s.seedMeterUsage(cust.ExternalID, m.ID, sub.CurrentPeriodStart.Add(5*time.Minute), 1)
 
 	grants, meta, err := s.grantService.EnsureGrants(s.GetContext(), cust, sub.CurrentPeriodStart.Add(10*time.Minute))
@@ -792,6 +798,23 @@ func (s *EntitlementGrantSuite) TestEnsureGrants_AdditiveECs_OneSummedGrant() {
 	s.Require().Len(again, 1)
 	s.Equal(grants[0].ID, again[0].ID)
 	s.NotNil(meta)
+}
+
+func (s *EntitlementGrantSuite) TestCreateEntitlement_RejectsDuplicateAdditiveOnSameEntityFeature() {
+	// The partial unique index allows one published non-parallel entitlement
+	// per (entity, feature); a bigger additive grant is a quota edit, not a
+	// second row. Parallel is the stacking mode (covered by ParallelECs test).
+	m := s.simpleMeter("meter-dup")
+	f := s.simpleFeature("feat-dup", m.ID)
+	p := s.simplePlan("plan-dup")
+
+	_, err := s.entService.CreateEntitlement(s.GetContext(),
+		s.grantCreateRequest(f.ID, p.ID, types.EntitlementGrantMeasureQuantity, 5, decimal.NewFromInt(100)))
+	s.Require().NoError(err)
+
+	_, err = s.entService.CreateEntitlement(s.GetContext(),
+		s.grantCreateRequest(f.ID, p.ID, types.EntitlementGrantMeasureQuantity, 5, decimal.NewFromInt(200)))
+	s.Require().Error(err, "second additive EC on the same (plan, feature) must be rejected")
 }
 
 func (s *EntitlementGrantSuite) TestCreateEntitlement_RejectsMixedModesOnFeature() {
@@ -931,6 +954,37 @@ func (s *EntitlementGrantSuite) TestEnsureGrants_DelayedEvaluationCoversGapUsage
 	s.True(grants[0].ValidFrom.Equal(gapEvent),
 		"gap usage must anchor the next window: got %s want %s", grants[0].ValidFrom, gapEvent)
 	s.NotNil(meta)
+}
+
+func (s *EntitlementGrantSuite) TestEnsureGrants_CatchUpOpensAllMissedWindows() {
+	// Rollover/outage backlog: evaluation resumes hours late with usage spread
+	// across several would-be windows. ONE tick must walk every missed window —
+	// draining the backlog must not depend on future events arriving.
+	_, sub, cust := s.setupCustomerSubWithGrantEC(types.EntitlementGrantMeasureQuantity) // 5h duration
+
+	// Events at +1h, +7h, +13h → three 5h windows: [1h,6h) [7h,12h) [13h,18h).
+	for _, offset := range []time.Duration{1 * time.Hour, 7 * time.Hour, 13 * time.Hour} {
+		s.seedMeterUsage(cust.ExternalID, "meter-quantity", sub.CurrentPeriodStart.Add(offset), 1)
+	}
+
+	at := sub.CurrentPeriodStart.Add(14 * time.Hour)
+	grants, _, err := s.grantService.EnsureGrants(s.GetContext(), cust, at)
+	s.Require().NoError(err)
+	s.Require().Len(grants, 3, "one pass must open every missed window")
+
+	froms := lo.Map(grants, func(g *entitlementgrant.EntitlementGrant, _ int) time.Duration {
+		return g.ValidFrom.Sub(sub.CurrentPeriodStart)
+	})
+	s.ElementsMatch([]time.Duration{1 * time.Hour, 7 * time.Hour, 13 * time.Hour}, froms,
+		"each window must anchor at its usage event")
+
+	// Idempotent: the caught-up slot opens nothing new on the next pass.
+	knownIDs := lo.Map(grants, func(g *entitlementgrant.EntitlementGrant, _ int) string { return g.ID })
+	again, _, err := s.grantService.EnsureGrants(s.GetContext(), cust, at.Add(time.Minute))
+	s.Require().NoError(err)
+	for _, g := range again {
+		s.Contains(knownIDs, g.ID)
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/ee/service/entitlement_test.go
+++ b/internal/ee/service/entitlement_test.go
@@ -864,9 +864,18 @@ func (s *EntitlementServiceSuite) TestConfigEntitlement() {
 	})
 
 	s.Run("Create config entitlement without config_value is allowed", func() {
+		// Own feature: only one published entitlement per (plan, feature).
+		configFeature2 := &feature.Feature{
+			ID:        "feat-config-2",
+			Name:      "Config Feature 2",
+			Type:      types.FeatureTypeConfig,
+			BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+		}
+		s.NoError(s.GetStores().FeatureRepo.Create(s.GetContext(), configFeature2))
+
 		req := dto.CreateEntitlementRequest{
 			PlanID:      testPlan.ID,
-			FeatureID:   configFeature.ID,
+			FeatureID:   configFeature2.ID,
 			FeatureType: types.FeatureTypeConfig,
 			IsEnabled:   true,
 		}

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -1914,6 +1914,17 @@ func (s *invoiceService) CreateSubscriptionInvoice(ctx context.Context, req *dto
 			Mark(ierr.ErrValidation)
 	}
 
+	// Ledger freshness at the money moment: materialize any pending entitlement
+	// grant overage (debounce gap) before charges are calculated. Idempotent;
+	// never blocks invoicing — worst case billing folds the last materialized
+	// values. Dep guard keeps partially-wired test services on the old path.
+	if s.EntitlementGrantRepo != nil && s.CustomerRepo != nil && s.SubRepo != nil && s.MeterUsageRepo != nil {
+		if err := NewAlertService(s.ServiceParams).RefreshEntitlementGrantsForCustomer(ctx, subscription.CustomerID); err != nil {
+			s.Logger.Warn(ctx, "entitlement grant refresh before invoicing failed; using last materialized overage",
+				"subscription_id", subscription.ID, "error", err)
+		}
+	}
+
 	// Draft-first: create zero-dollar draft (idempotent; returns existing if same period)
 	// Use ToDraftRequest to build from pre-fetched subscription, avoiding redundant DB fetch
 	draftReq := req.ToDraftRequest(

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -1920,7 +1920,7 @@ func (s *invoiceService) CreateSubscriptionInvoice(ctx context.Context, req *dto
 	// values. Dep guard keeps partially-wired test services on the old path.
 	if s.EntitlementGrantRepo != nil && s.CustomerRepo != nil && s.SubRepo != nil && s.MeterUsageRepo != nil {
 		if err := NewAlertService(s.ServiceParams).RefreshEntitlementGrantsForCustomer(ctx, subscription.CustomerID); err != nil {
-			s.Logger.Warn(ctx, "entitlement grant refresh before invoicing failed; using last materialized overage",
+			s.Logger.Error(ctx, "entitlement grant refresh before invoicing failed; using last materialized overage",
 				"subscription_id", subscription.ID, "error", err)
 		}
 	}

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -56,6 +56,14 @@ type MeterUsageService interface {
 	// ConvertToBillingCharges maps SubscriptionMeterUsage to billing charges.
 	ConvertToBillingCharges(ctx context.Context, usage *SubscriptionMeterUsage) ([]*dto.SubscriptionUsageByMetersResponse, decimal.Decimal, error)
 
+	// GetUsageTotal returns a meter's aggregated usage total (FINAL consistency;
+	// supports a single range or multiple disjoint TimeRanges in one query).
+	GetUsageTotal(ctx context.Context, req *dto.UsageTotalRequest) (decimal.Decimal, error)
+
+	// GetMeterWindowCost prices the meter's usage in [from, to) through the
+	// billing path, so a mid-window price change is priced per line-item segment.
+	GetMeterWindowCost(ctx context.Context, sub *subscription.Subscription, meterID string, from, to time.Time) (decimal.Decimal, error)
+
 	// DebugEvent powers GET /events/:id — reports processing status and
 	// per-lookup diagnostics for a single event under the meter-usage pipeline.
 	DebugEvent(ctx context.Context, eventID string) (*dto.GetEventByIDResponse, error)
@@ -77,6 +85,45 @@ func NewMeterUsageService(params ServiceParams) MeterUsageService {
 		repo:          params.MeterUsageRepo,
 		logger:        params.Logger,
 	}
+}
+
+func (s *meterUsageService) GetUsageTotal(ctx context.Context, req *dto.UsageTotalRequest) (decimal.Decimal, error) {
+	if s.repo == nil {
+		return decimal.Zero, ierr.NewError("meter usage repository is not configured").Mark(ierr.ErrSystem)
+	}
+	result, err := s.repo.GetUsage(ctx, req.ToParams())
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return result.TotalValue, nil
+}
+
+func (s *meterUsageService) GetMeterWindowCost(ctx context.Context, sub *subscription.Subscription, meterID string, from, to time.Time) (decimal.Decimal, error) {
+	if !to.After(from) {
+		return decimal.Zero, nil
+	}
+	subUsage, err := s.GetSubscriptionMeterUsageWithSub(ctx, sub, &GetSubscriptionMeterUsageRequest{
+		SubscriptionID:  sub.ID,
+		StartTime:       from,
+		EndTime:         to,
+		MeterIDs:        []string{meterID},
+		UseFinal:        true,
+		IncludeChildren: true,
+	})
+	if err != nil {
+		return decimal.Zero, err
+	}
+	charges, _, err := s.ConvertToBillingCharges(ctx, subUsage)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	total := decimal.Zero
+	for _, c := range charges {
+		if c != nil && c.MeterID == meterID {
+			total = total.Add(decimal.NewFromFloat(c.Amount))
+		}
+	}
+	return total, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -2227,8 +2227,9 @@ func (s *WalletServiceSuite) TestGetWalletBalanceWithEntitlements() {
 				_, err := s.GetStores().EntitlementRepo.Create(s.GetContext(), entitlement)
 				s.NoError(err)
 			},
-			expectedRealTimeBalance: decimal.NewFromInt(961),
-			expectedCurrentUsage:    decimal.NewFromInt(39),
+			// Limit 1000 alone covers less usage than case 1's 2000, so more is billed.
+			expectedRealTimeBalance: decimal.NewFromInt(951), // 1000 - 49
+			expectedCurrentUsage:    decimal.NewFromInt(49),
 			wantErr:                 false,
 		},
 		{
@@ -2256,9 +2257,6 @@ func (s *WalletServiceSuite) TestGetWalletBalanceWithEntitlements() {
 		{
 			name: "disabled_entitlement",
 			setupFunc: func() {
-				// Clear any existing entitlements first
-				s.GetStores().EntitlementRepo.(*testutil.InMemoryEntitlementStore).Clear()
-
 				entitlement := &entitlement.Entitlement{
 					ID:               "ent_test_4",
 					EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
@@ -2290,6 +2288,9 @@ func (s *WalletServiceSuite) TestGetWalletBalanceWithEntitlements() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			s.setupWallet()
+			// Each case models exactly one entitlement on (plan, feat_api_calls);
+			// the DB allows only one published entitlement per (entity, feature).
+			s.GetStores().EntitlementRepo.(*testutil.InMemoryEntitlementStore).Clear()
 			if tt.setupFunc != nil {
 				tt.setupFunc()
 			}

--- a/internal/repository/clickhouse/meter_usage_query_builder.go
+++ b/internal/repository/clickhouse/meter_usage_query_builder.go
@@ -162,14 +162,24 @@ func (qb *MeterUsageQueryBuilder) BuildWhereClause(params *events.MeterUsageQuer
 		conditions = append(conditions, fmt.Sprintf("meter_id IN (%s)", strings.Join(placeholders, ", ")))
 	}
 
-	// Time range
-	if !params.StartTime.IsZero() {
-		conditions = append(conditions, "timestamp >= ?")
-		args = append(args, params.StartTime.UTC())
-	}
-	if !params.EndTime.IsZero() {
-		conditions = append(conditions, "timestamp < ?")
-		args = append(args, params.EndTime.UTC())
+	// Time range: multiple OR'd windows when TimeRanges is set (one query for
+	// disjoint ranges), else the single [StartTime, EndTime) pair.
+	if len(params.TimeRanges) > 0 {
+		rangeClauses := make([]string, 0, len(params.TimeRanges))
+		for _, tr := range params.TimeRanges {
+			rangeClauses = append(rangeClauses, "(timestamp >= ? AND timestamp < ?)")
+			args = append(args, tr.Start.UTC(), tr.End.UTC())
+		}
+		conditions = append(conditions, "("+strings.Join(rangeClauses, " OR ")+")")
+	} else {
+		if !params.StartTime.IsZero() {
+			conditions = append(conditions, "timestamp >= ?")
+			args = append(args, params.StartTime.UTC())
+		}
+		if !params.EndTime.IsZero() {
+			conditions = append(conditions, "timestamp < ?")
+			args = append(args, params.EndTime.UTC())
+		}
 	}
 
 	// COUNT_UNIQUE requires non-empty unique_hash

--- a/internal/repository/ent/entitlementgrant.go
+++ b/internal/repository/ent/entitlementgrant.go
@@ -73,6 +73,7 @@ func (r *entitlementGrantRepository) Create(ctx context.Context, g *domainGrant.
 		SetValidTo(g.ValidTo).
 		SetGrantStatus(defaultedGrantStatus(g.GrantStatus)).
 		SetNillableLastComputedAt(g.LastComputedAt).
+		SetNillableQuotaCrossedAt(g.QuotaCrossedAt).
 		SetTenantID(g.TenantID).
 		SetEnvironmentID(g.EnvironmentID).
 		SetStatus(string(g.Status)).
@@ -203,6 +204,7 @@ func (r *entitlementGrantRepository) UpdateSnapshot(ctx context.Context, g *doma
 		SetUsage(g.Usage).
 		SetGrantStatus(defaultedGrantStatus(g.GrantStatus)).
 		SetNillableLastComputedAt(g.LastComputedAt).
+		SetNillableQuotaCrossedAt(g.QuotaCrossedAt).
 		SetUpdatedAt(time.Now().UTC())
 
 	if err := q.Exec(ctx); err != nil {

--- a/internal/testutil/inmemory_entitlement_grant_store.go
+++ b/internal/testutil/inmemory_entitlement_grant_store.go
@@ -212,6 +212,7 @@ func (s *InMemoryEntitlementGrantStore) UpdateSnapshot(ctx context.Context, g *e
 	existing.Usage = g.Usage
 	existing.GrantStatus = g.GrantStatus
 	existing.LastComputedAt = g.LastComputedAt
+	existing.QuotaCrossedAt = g.QuotaCrossedAt
 	existing.UpdatedAt = time.Now().UTC()
 	return s.InMemoryStore.Update(ctx, g.ID, existing)
 }

--- a/internal/testutil/inmemory_entitlement_store.go
+++ b/internal/testutil/inmemory_entitlement_store.go
@@ -106,6 +106,35 @@ func entitlementSortFn(i, j *entitlement.Entitlement) bool {
 	return i.CreatedAt.After(j.CreatedAt)
 }
 
+// checkUniquePerEntityFeature mirrors the partial unique index on
+// (tenant, env, entity_type, entity_id, feature_id) WHERE status='published'
+// AND aggregation_mode <> 'parallel': one published entitlement per
+// (entity, feature), except parallel-mode grant ECs which may stack.
+func (s *InMemoryEntitlementStore) checkUniquePerEntityFeature(ctx context.Context, e *entitlement.Entitlement) error {
+	if e.AggregationMode == types.EntitlementAggregationModeParallel || e.Status != types.StatusPublished {
+		return nil
+	}
+	existing, err := s.InMemoryStore.List(ctx, nil, func(cctx context.Context, other *entitlement.Entitlement, _ interface{}) bool {
+		return other != nil &&
+			other.Status == types.StatusPublished &&
+			other.AggregationMode != types.EntitlementAggregationModeParallel &&
+			other.EnvironmentID == e.EnvironmentID &&
+			other.EntityType == e.EntityType &&
+			other.EntityID == e.EntityID &&
+			other.FeatureID == e.FeatureID
+	}, entitlementSortFn)
+	if err == nil && len(existing) > 0 {
+		return errors.NewError("a published entitlement already exists for this entity and feature").
+			WithReportableDetails(map[string]interface{}{
+				"entity_type": e.EntityType,
+				"entity_id":   e.EntityID,
+				"feature_id":  e.FeatureID,
+			}).
+			Mark(errors.ErrAlreadyExists)
+	}
+	return nil
+}
+
 func (s *InMemoryEntitlementStore) Create(ctx context.Context, e *entitlement.Entitlement) (*entitlement.Entitlement, error) {
 	if e == nil {
 		return nil, errors.NewError("entitlement cannot be nil").Mark(errors.ErrValidation)
@@ -114,6 +143,10 @@ func (s *InMemoryEntitlementStore) Create(ctx context.Context, e *entitlement.En
 	// Set environment ID from context if not already set
 	if e.EnvironmentID == "" {
 		e.EnvironmentID = types.GetEnvironmentID(ctx)
+	}
+
+	if err := s.checkUniquePerEntityFeature(ctx, e); err != nil {
+		return nil, err
 	}
 
 	err := s.InMemoryStore.Create(ctx, e.ID, e)
@@ -209,6 +242,10 @@ func (s *InMemoryEntitlementStore) CreateBulk(ctx context.Context, entitlements 
 		// Set environment ID from context if not already set
 		if e.EnvironmentID == "" {
 			e.EnvironmentID = environmentID
+		}
+
+		if err := s.checkUniquePerEntityFeature(ctx, e); err != nil {
+			return nil, err
 		}
 
 		if err := s.InMemoryStore.Create(ctx, e.ID, e); err != nil {

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -78,11 +78,24 @@ func matchRecord(r *events.MeterUsage, p *events.MeterUsageQueryParams) bool {
 	if len(p.MeterIDs) > 0 && !containsString(p.MeterIDs, r.MeterID) {
 		return false
 	}
-	if !p.StartTime.IsZero() && r.Timestamp.Before(p.StartTime) {
-		return false
-	}
-	if !p.EndTime.IsZero() && !r.Timestamp.Before(p.EndTime) {
-		return false
+	if len(p.TimeRanges) > 0 {
+		inAny := false
+		for _, tr := range p.TimeRanges {
+			if !r.Timestamp.Before(tr.Start) && r.Timestamp.Before(tr.End) {
+				inAny = true
+				break
+			}
+		}
+		if !inAny {
+			return false
+		}
+	} else {
+		if !p.StartTime.IsZero() && r.Timestamp.Before(p.StartTime) {
+			return false
+		}
+		if !p.EndTime.IsZero() && !r.Timestamp.Before(p.EndTime) {
+			return false
+		}
 	}
 	if p.ExternalCustomerID != "" && r.ExternalCustomerID != p.ExternalCustomerID {
 		return false

--- a/internal/webhook/dto/alert.go
+++ b/internal/webhook/dto/alert.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/entitlementgrant"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/types"
 )
@@ -52,15 +53,20 @@ type AlertWebhookPayload struct {
 	Customer    *dto.CustomerResponse  `json:"customer,omitempty"`
 }
 
-// EntitlementGrantAlertEvent is the webhook payload for entitlement grant exhaustion.
-// UsageRatio is usage/quota at evaluation time (>= 1 when exhausted).
+// EntitlementGrantAlertEvent is the webhook payload for entitlement grant
+// exhaustion: four flat entities, no nesting — the builder strips the
+// subscription's embedded customer/line items/plan and the entitlement's
+// feature/plan expansions. UsageRatio is usage/quota at evaluation time
+// (>= 1 when exhausted).
 type EntitlementGrantAlertEvent struct {
-	Subscription       *dto.SubscriptionResponse `json:"subscription"`
-	EntitlementGrantID string                    `json:"entitlement_grant_id"`
-	AlertType          types.AlertType           `json:"alert_type"`
-	AlertStatus        types.AlertState          `json:"alert_status"`
-	UsageRatio         string                    `json:"usage_ratio"`
-	TriggeredAt        time.Time                 `json:"triggered_at"`
+	Subscription     *dto.SubscriptionResponseV2        `json:"subscription"`
+	Customer         *dto.CustomerResponse              `json:"customer"`
+	Entitlement      *dto.EntitlementResponse           `json:"entitlement"`
+	EntitlementGrant *entitlementgrant.EntitlementGrant `json:"entitlement_grant"`
+	AlertType        types.AlertType                    `json:"alert_type"`
+	AlertStatus      types.AlertState                   `json:"alert_status"`
+	UsageRatio       string                             `json:"usage_ratio"`
+	TriggeredAt      time.Time                          `json:"triggered_at"`
 }
 
 func NewAlertWebhookPayload(feature *dto.FeatureResponse, wallet *dto.WalletResponse, customer *dto.CustomerResponse, alertType types.AlertType, alertStatus types.AlertState, eventType types.WebhookEventName) *AlertWebhookPayload {

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -63,6 +63,7 @@ func providePayloadBuilderFactory(
 	creditNoteService service.CreditNoteService,
 	checkoutSessionService interfaces.CheckoutSessionService,
 	groupService service.GroupService,
+	entitlementGrantService service.EntitlementGrantService,
 ) payload.PayloadBuilderFactory {
 	services := payload.NewServices(
 		invoiceService,
@@ -78,6 +79,7 @@ func providePayloadBuilderFactory(
 		creditNoteService,
 		checkoutSessionService,
 		groupService,
+		entitlementGrantService,
 	)
 	return payload.NewPayloadBuilderFactory(services)
 }

--- a/internal/webhook/payload/alert.go
+++ b/internal/webhook/payload/alert.go
@@ -82,26 +82,45 @@ func (b *AlertPayloadBuilder) BuildPayload(ctx context.Context, eventType types.
 }
 
 // buildEntitlementGrantAlertPayload resolves a grant-exhaustion alert into its
-// webhook payload. entity_id is the grant; parent_entity_id is the subscription.
+// webhook payload: subscription, customer, entitlement (the EC) and the grant,
+// each flat — nested expansions are stripped. entity_id is the grant;
+// parent_entity_id is the subscription.
 func (b *AlertPayloadBuilder) buildEntitlementGrantAlertPayload(ctx context.Context, internalEvent webhookDto.InternalAlertEvent) (json.RawMessage, error) {
 	if internalEvent.ParentEntityID == "" {
 		return nil, ierr.NewError("entitlement grant alert missing subscription id").
 			WithReportableDetails(map[string]any{"entitlement_grant_id": internalEvent.EntityID}).
 			Mark(ierr.ErrValidation)
 	}
-	sub, err := b.services.SubscriptionService.GetSubscription(ctx, internalEvent.ParentEntityID)
+
+	grant, err := b.services.EntitlementGrantSvc.GetGrant(ctx, internalEvent.EntityID)
 	if err != nil {
 		return nil, err
 	}
-	sub.Plan = nil
+
+	sub, err := b.services.SubscriptionService.GetSubscriptionV2(ctx, internalEvent.ParentEntityID, types.Expand{})
+	if err != nil {
+		return nil, err
+	}
+
+	customer, err := b.services.CustomerService.GetCustomer(ctx, grant.CustomerID)
+	if err != nil {
+		return nil, err
+	}
+
+	ec, err := b.services.EntitlementService.GetEntitlement(ctx, grant.EntitlementConfigID)
+	if err != nil {
+		return nil, err
+	}
 
 	payload := &webhookDto.EntitlementGrantAlertEvent{
-		Subscription:       sub,
-		EntitlementGrantID: internalEvent.EntityID,
-		AlertType:          internalEvent.AlertType,
-		AlertStatus:        internalEvent.AlertStatus,
-		UsageRatio:         internalEvent.AlertInfo.ValueAtTime.String(),
-		TriggeredAt:        internalEvent.AlertInfo.Timestamp,
+		Subscription:     sub,
+		Customer:         customer,
+		Entitlement:      ec,
+		EntitlementGrant: grant,
+		AlertType:        internalEvent.AlertType,
+		AlertStatus:      internalEvent.AlertStatus,
+		UsageRatio:       internalEvent.AlertInfo.ValueAtTime.String(),
+		TriggeredAt:      internalEvent.AlertInfo.Timestamp,
 	}
 	return json.Marshal(payload)
 }

--- a/internal/webhook/payload/services.go
+++ b/internal/webhook/payload/services.go
@@ -25,6 +25,7 @@ type Services struct {
 	CreditNoteService      service.CreditNoteService
 	CheckoutSessionService interfaces.CheckoutSessionService
 	GroupService           service.GroupService
+	EntitlementGrantSvc    service.EntitlementGrantService
 }
 
 // NewServices creates a new Services container
@@ -42,6 +43,7 @@ func NewServices(
 	creditNoteService service.CreditNoteService,
 	checkoutSessionService interfaces.CheckoutSessionService,
 	groupService service.GroupService,
+	entitlementGrantSvc service.EntitlementGrantService,
 ) *Services {
 	return &Services{
 		InvoiceService:         invoiceService,
@@ -57,5 +59,6 @@ func NewServices(
 		CreditNoteService:      creditNoteService,
 		CheckoutSessionService: checkoutSessionService,
 		GroupService:           groupService,
+		EntitlementGrantSvc:    entitlementGrantSvc,
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an events lookup endpoint that accepts the event ID via query parameter while keeping the existing URL format.
  - Enhanced the entitlement-grant exhaustion webhook payload to embed entitlement grant, entitlement, subscription, and customer details (replacing the old grant-id field).
- **Improvements**
  - Refined entitlement “slot catch-up” to open all missed grant windows in a single evaluation.
  - Updated cycle-boundary behavior to cap at cycle end and treat the 1-hour minimum as best-effort.
  - Improved overage billing by merging overlapping overage windows to avoid double-charging.
  - Recorded `quota_crossed_at` when quota is first detected as exceeded during evaluation.
- **Bug Fixes**
  - Corrected wallet balance and entitlement-related usage/billing calculations.
- **Changes**
  - Enforced uniqueness for published, non-parallel entitlements per entity and feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->