### PR TITLE
feat(config): add onboarding configuration with default tenant name

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,7 +74,7 @@ type Configuration struct {
 }
 
 type OnboardingConfig struct {
-	DefaultTenantName string `mapstructure:"default_tenant_name" validate:"omitempty"`
+	DefaultTenantName string `mapstructure:"default_tenant_name" validate:"omitempty" default:"Flexprice"`
 }
 
 // WhopConfig holds Whop integration settings (non-secret, static config)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,11 @@ type Configuration struct {
 	WebhookRetryJob            WebhookRetryJobConfig            `mapstructure:"webhook_retry_job" validate:"omitempty"`
 	Gemini                     GeminiConfig                     `mapstructure:"gemini" validate:"omitempty"`
 	Whop                       WhopConfig                       `mapstructure:"whop" validate:"omitempty"`
+	Onboarding                 OnboardingConfig                 `mapstructure:"onboarding" validate:"omitempty"`
+}
+
+type OnboardingConfig struct {
+	DefaultTenantName string `mapstructure:"default_tenant_name" validate:"omitempty"`
 }
 
 // WhopConfig holds Whop integration settings (non-secret, static config)

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -469,3 +469,6 @@ onboarding_events:
 # Checkout base URL for the checkout page
 checkout:
   base_url: ""
+
+onboarding:
+  default_tenant_name: "Flexprice"

--- a/internal/ee/service/onboarding.go
+++ b/internal/ee/service/onboarding.go
@@ -417,7 +417,7 @@ func (s *onboardingService) createEventRequest(eventMsg *types.OnboardingEventsM
 func (s *onboardingService) OnboardNewUserWithTenant(ctx context.Context, req dto.OnboardNewUserWithTenantRequest) error {
 	tenantName := req.TenantName
 	if tenantName == "" {
-		tenantName = "Flexprice"
+		tenantName = s.Config.Onboarding.DefaultTenantName
 	}
 
 	tenantService := NewTenantService(s.ServiceParams)

--- a/internal/testutil/base_service_suite.go
+++ b/internal/testutil/base_service_suite.go
@@ -137,6 +137,9 @@ func (s *BaseServiceTestSuite) SetupSuite() {
 		Secrets: config.SecretsConfig{
 			EncryptionKey: "test-encryption-key-for-unit-tests-only",
 		},
+		Onboarding: config.OnboardingConfig{
+			DefaultTenantName: "Flexprice",
+		},
 	}
 	var err error
 	s.config = cfg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable onboarding settings, including a configurable default tenant name.
  * When onboarding a new user without a specified tenant name, the system now uses the configured default tenant name.

* **Configuration**
  * Introduced `onboarding.default_tenant_name` (default: “Flexprice”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->