### PR TITLE
fix(entitlement): Quota exhausted comparison

### DIFF
--- a/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
+++ b/docs/design/2026-07-08-FLE-959-Entitlements-Revamp.md
@@ -78,7 +78,7 @@ CREATE TABLE entitlement_grants (
     valid_to               timestamptz NOT NULL,             -- <= sub.current_period_end
     grant_status           varchar(20) NOT NULL DEFAULT 'active',  -- active|exhausted; expiry derived from valid_to
     last_computed_at       timestamptz,                             -- snapshot watermark; >= valid_to marks a closed window finalized
-    quota_crossed_at       timestamptz                              -- set once: the EVALUATION time that first saw usage > quota (see §5.3 note)
+    quota_crossed_at       timestamptz                              -- set once: the EVALUATION time that first saw usage >= quota (see §5.3 note)
     -- + standard base columns (status, created_at, ...)
 );
 
@@ -270,7 +270,7 @@ Per returned feature-scoped grant (open windows plus the finalize set), over `[v
 
 Snapshot write (`UpdateSnapshot`): `usage`, `last_computed_at`, `quota_crossed_at`, and `active → exhausted` when `usage >= quota`.
 
-**Quota-exhaustion recording (once per grant lifetime):** when a refresh first sees `usage > quota`, the evaluator sets `quota_crossed_at = evaluation time` — no extra queries. **Note (deliberate approximation):** this is the *detection* time, not the exact event-level crossing; billing only charges usage *after* it, so overage accrued between the true crossing and detection is never billed — pro-customer, bounded by the debounce delay. The exact alternative, if ever needed, is binary-searching the crossing second on the running measure and storing the usage total through it (see decisions log). That is ALL the evaluator does for overage; billing derives everything else (§6).
+**Quota-exhaustion recording (once per grant lifetime):** when a refresh first sees `usage >= quota`, the evaluator sets `quota_crossed_at = evaluation time` — no extra queries. **Note (deliberate approximation):** this is the *detection* time, not the exact event-level crossing; billing only charges usage *after* it, so overage accrued between the true crossing and detection is never billed — pro-customer, bounded by the debounce delay. The exact alternative, if ever needed, is binary-searching the crossing second on the running measure and storing the usage total through it (see decisions log). That is ALL the evaluator does for overage; billing derives everything else (§6).
 
 **Alerts fire on exhaustion only** (`usage/quota >= 1`): one `alert_logs` row (`in_alarm`) per grant, deduped by state transition, delivered as the `entitlement.grant.exhausted` webhook (payload: subscription + grant id + usage ratio). Recovery is a new grant window, not a state flip.
 

--- a/ent/schema/entitlement_grant.go
+++ b/ent/schema/entitlement_grant.go
@@ -104,7 +104,7 @@ func (EntitlementGrant) Fields() []ent.Field {
 			Optional().
 			Nillable(),
 
-		// Set once by the evaluator when it first sees usage > quota. Holds the
+		// Set once by the evaluator when it first sees usage >= quota. Holds the
 		// EVALUATION time, not the exact event-level crossing — billing only
 		// charges usage after this point (pro-customer, bounded by the debounce).
 		field.Time("quota_crossed_at").

--- a/internal/domain/entitlementgrant/model.go
+++ b/internal/domain/entitlementgrant/model.go
@@ -26,7 +26,7 @@ type EntitlementGrant struct {
 	ValidTo             time.Time                             `json:"valid_to"`
 	GrantStatus         types.EntitlementGrantStatus          `json:"grant_status"`
 	LastComputedAt      *time.Time                            `json:"last_computed_at,omitempty"`
-	// QuotaCrossedAt is set once, when the evaluator first sees usage > quota.
+	// QuotaCrossedAt is set once, when the evaluator first sees usage >= quota
 	// It holds the evaluation time, not the exact event-level crossing.
 	QuotaCrossedAt *time.Time `json:"quota_crossed_at,omitempty"`
 	EnvironmentID  string     `json:"environment_id"`

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -313,7 +313,9 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 			errs = append(errs, err)
 		}
 
-		// Record the quota exhaustion timestamp, once per grant.
+		// Record the quota exhaustion timestamp, once per grant. Same >= as the
+		// exhausted flip below: once quota is fully consumed, every later unit
+		// is overage, so exhausted ⟺ crossing set.
 		// NOTE: this is the EVALUATION time, not the exact crossing time.
 		// finding that exactly needs extra ClickHouse queries (binary search on the
 		// running usage). Billing only charges usage AFTER this timestamp, so
@@ -321,7 +323,7 @@ func (s *alertService) evaluateEntitlementGrantsForCustomer(
 		// bounded by the debounce delay. If exactness is ever needed, the
 		// upgrade path is the binary-searched crossing (see ERD decisions).
 		cross := g.QuotaCrossedAt
-		if cross == nil && usage.GreaterThan(g.Quota) {
+		if cross == nil && usage.GreaterThanOrEqual(g.Quota) {
 			cross = &at
 		}
 

--- a/internal/ee/service/entitlement_grant_test.go
+++ b/internal/ee/service/entitlement_grant_test.go
@@ -1299,6 +1299,31 @@ func (s *EntitlementGrantSuite) TestEvaluate_OverQuota_FlipsExhaustedAndFiresAle
 	s.Equal(types.AlertTypeEntitlementGrantExhausted, logs[0].AlertType)
 }
 
+func (s *EntitlementGrantSuite) TestEvaluate_ExactQuota_FlipsExhaustedAndRecordsCrossing() {
+	// usage == quota: quota fully consumed, every later unit is overage. The
+	// crossing must be recorded with the same >= the exhausted flip uses —
+	// exhausted with a NULL quota_crossed_at is an illegal state.
+	_, sub, cust := s.setupCustomerSubWithGrantEC(types.EntitlementGrantMeasureQuantity)
+
+	first := sub.CurrentPeriodStart.Add(30 * time.Minute)
+	s.seedMeterUsage(cust.ExternalID, "meter-quantity", first, 100)
+
+	at := sub.CurrentPeriodStart.Add(2 * time.Hour)
+	grants, meta, err := s.grantService.EnsureGrantsForSubscriptions(s.GetContext(), cust, []*subscription.Subscription{sub}, at)
+	s.Require().NoError(err)
+	s.Require().Len(grants, 1)
+
+	s.Require().NoError(s.evalAlertService().evaluateEntitlementGrantsForCustomer(
+		s.GetContext(), cust, meta, grants, at))
+
+	stored, err := s.GetStores().EntitlementGrantRepo.Get(s.GetContext(), grants[0].ID)
+	s.Require().NoError(err)
+	s.True(stored.Usage.Equal(decimal.NewFromInt(100)))
+	s.Equal(types.EntitlementGrantStatusExhausted, stored.GrantStatus)
+	s.Require().NotNil(stored.QuotaCrossedAt, "usage == quota must record the crossing alongside the exhausted flip")
+	s.True(stored.QuotaCrossedAt.Equal(at))
+}
+
 func (s *EntitlementGrantSuite) TestEvaluate_UnderQuota_StaysActiveNoAlert() {
 	f, sub, cust := s.setupCustomerSubWithGrantEC(types.EntitlementGrantMeasureQuantity)
 	_ = f


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entitlement grants are now marked exhausted when usage reaches the configured quota exactly, rather than only when it exceeds the quota.
  * The quota-crossing timestamp is recorded at the moment exact quota exhaustion is detected.

* **Tests**
  * Added coverage for entitlement grants reaching their quota precisely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->