### PR TITLE
fix(invoices): include base and overage charges for a line item

### DIFF
--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -121,9 +121,12 @@ func (s *billingService) CalculateMeterUsageCharges(
 		return nil, decimal.Zero, err
 	}
 
-	chargesByLineItemID := make(map[string]*dto.SubscriptionUsageByMetersResponse)
+	// A line item's usage may be split into multiple charges sharing the same
+	// SubscriptionLineItemID (e.g. a normal/base-slab charge and an overage charge
+	// when commitment pricing is active) — keep all of them, not just the last one.
+	chargesByLineItemID := make(map[string][]*dto.SubscriptionUsageByMetersResponse)
 	for _, charge := range usage.Charges {
-		chargesByLineItemID[charge.SubscriptionLineItemID] = charge
+		chargesByLineItemID[charge.SubscriptionLineItemID] = append(chargesByLineItemID[charge.SubscriptionLineItemID], charge)
 	}
 
 	// --- Per-line-item processing ---
@@ -137,7 +140,7 @@ func (s *billingService) CalculateMeterUsageCharges(
 			continue
 		}
 
-		matchingCharge, ok := chargesByLineItemID[item.ID]
+		matchingCharges, ok := chargesByLineItemID[item.ID]
 		if !ok {
 			continue
 		}
@@ -150,159 +153,161 @@ func (s *billingService) CalculateMeterUsageCharges(
 				Mark(ierr.ErrNotFound)
 		}
 
-		quantityForCalculation := decimal.NewFromFloat(matchingCharge.Quantity)
+		for _, matchingCharge := range matchingCharges {
+			quantityForCalculation := decimal.NewFromFloat(matchingCharge.Quantity)
 
-		// 1. Bucketed meter cost — use pre-fetched result or fallback to direct query
-		var cachedBucketedUsageResult *events.AggregationResult
-		if (m.IsBucketedMaxMeter() || m.IsBucketedSumMeter()) && matchingCharge.Price != nil {
-			usageResult := matchingCharge.BucketedUsageResult
-			if usageResult == nil {
-				usageResult, err = s.queryBucketedMeterUsageDirect(ctx, m, item, sub, extCustomerIDs, periodStart, periodEnd, querySource)
+			// 1. Bucketed meter cost — use pre-fetched result or fallback to direct query
+			var cachedBucketedUsageResult *events.AggregationResult
+			if (m.IsBucketedMaxMeter() || m.IsBucketedSumMeter()) && matchingCharge.Price != nil {
+				usageResult := matchingCharge.BucketedUsageResult
+				if usageResult == nil {
+					usageResult, err = s.queryBucketedMeterUsageDirect(ctx, m, item, sub, extCustomerIDs, periodStart, periodEnd, querySource)
+					if err != nil {
+						return nil, decimal.Zero, err
+					}
+				}
+				cachedBucketedUsageResult = usageResult
+
+				hasGroupBy := m.IsBucketedMaxMeter() && m.Aggregation.GroupBy != ""
+				cost := calculateBucketedMeterCost(ctx, priceService, matchingCharge.Price, usageResult, hasGroupBy)
+				matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(cost.Amount, matchingCharge.Price.Currency)
+				matchingCharge.Quantity = cost.Quantity.InexactFloat64()
+				quantityForCalculation = cost.Quantity
+			}
+
+			// 2. Entitlement adjustment — reads windowed usage from meter_usage (not raw events)
+			rawQtyBeforeEntitlement := quantityForCalculation
+			var entitlementAdjustedQty *decimal.Decimal
+			entitlement := entitlementsByMeterID[item.MeterID]
+
+			grantResult, grantsApplied := adjustMeterUsageGrantsResult{}, false
+			if !matchingCharge.IsOverage {
+				if grantsForMeter := grantsByMeterID[item.MeterID]; len(grantsForMeter) > 0 {
+					grantResult, grantsApplied, err = s.adjustMeterUsageGrants(ctx, item, matchingCharge, grantsForMeter, priceService, m, sub, extCustomerIDs)
+					if err != nil {
+						return nil, decimal.Zero, err
+					}
+				}
+			}
+
+			switch {
+			case grantsApplied:
+				// Grants replaced the legacy entitlement — adjustMeterUsageGrants
+				// already updated matchingCharge (Amount/Quantity). For the
+				// pricer, use the grant-derived quantity; amount-lane grants
+				// return zero here on purpose (already priced).
+				quantityForCalculation = decimal.NewFromFloat(matchingCharge.Quantity)
+				if grantResult.Measure == types.EntitlementGrantMeasureQuantity {
+					adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
+					entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
+				}
+			case !matchingCharge.IsOverage && entitlement != nil && entitlement.IsEnabled:
+				quantityForCalculation, err = s.adjustMeterUsageEntitlement(
+					ctx, item, m, matchingCharge, entitlement, sub, extCustomerIDs,
+					periodStart, periodEnd, priceService, querySource,
+				)
 				if err != nil {
 					return nil, decimal.Zero, err
 				}
-			}
-			cachedBucketedUsageResult = usageResult
-
-			hasGroupBy := m.IsBucketedMaxMeter() && m.Aggregation.GroupBy != ""
-			cost := calculateBucketedMeterCost(ctx, priceService, matchingCharge.Price, usageResult, hasGroupBy)
-			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(cost.Amount, matchingCharge.Price.Currency)
-			matchingCharge.Quantity = cost.Quantity.InexactFloat64()
-			quantityForCalculation = cost.Quantity
-		}
-
-		// 2. Entitlement adjustment — reads windowed usage from meter_usage (not raw events)
-		rawQtyBeforeEntitlement := quantityForCalculation
-		var entitlementAdjustedQty *decimal.Decimal
-		entitlement := entitlementsByMeterID[item.MeterID]
-
-		grantResult, grantsApplied := adjustMeterUsageGrantsResult{}, false
-		if !matchingCharge.IsOverage {
-			if grantsForMeter := grantsByMeterID[item.MeterID]; len(grantsForMeter) > 0 {
-				grantResult, grantsApplied, err = s.adjustMeterUsageGrants(ctx, item, matchingCharge, grantsForMeter, priceService, m, sub, extCustomerIDs)
-				if err != nil {
-					return nil, decimal.Zero, err
-				}
-			}
-		}
-
-		switch {
-		case grantsApplied:
-			// Grants replaced the legacy entitlement — adjustMeterUsageGrants
-			// already updated matchingCharge (Amount/Quantity). For the
-			// pricer, use the grant-derived quantity; amount-lane grants
-			// return zero here on purpose (already priced).
-			quantityForCalculation = decimal.NewFromFloat(matchingCharge.Quantity)
-			if grantResult.Measure == types.EntitlementGrantMeasureQuantity {
 				adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
 				entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
+			case !matchingCharge.IsOverage && !m.IsBucketedMaxMeter() && !m.IsBucketedSumMeter() && matchingCharge.Price != nil:
+				// No grant, no entitlement — recalculate cost for non-bucketed meters.
+				adjustedAmount := priceService.CalculateCost(ctx, matchingCharge.Price, quantityForCalculation)
+				matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(adjustedAmount, matchingCharge.Price.Currency)
 			}
-		case !matchingCharge.IsOverage && entitlement != nil && entitlement.IsEnabled:
-			quantityForCalculation, err = s.adjustMeterUsageEntitlement(
-				ctx, item, m, matchingCharge, entitlement, sub, extCustomerIDs,
-				periodStart, periodEnd, priceService, querySource,
-			)
-			if err != nil {
-				return nil, decimal.Zero, err
-			}
-			adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
-			entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
-		case !matchingCharge.IsOverage && !m.IsBucketedMaxMeter() && !m.IsBucketedSumMeter() && matchingCharge.Price != nil:
-			// No grant, no entitlement — recalculate cost for non-bucketed meters.
-			adjustedAmount := priceService.CalculateCost(ctx, matchingCharge.Price, quantityForCalculation)
-			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(adjustedAmount, matchingCharge.Price.Currency)
-		}
 
-		lineItemAmount := decimal.NewFromFloat(matchingCharge.Amount)
+			lineItemAmount := decimal.NewFromFloat(matchingCharge.Amount)
 
-		// 3. Cumulative commitment — collect for batch processing after the loop
-		if useCumulativePath {
-			baseAmount := lineItemAmount
-			if matchingCharge.IsOverage && overageFactor.GreaterThan(decimal.Zero) {
-				baseAmount = lineItemAmount.Div(overageFactor)
+			// 3. Cumulative commitment — collect for batch processing after the loop
+			if useCumulativePath {
+				baseAmount := lineItemAmount
+				if matchingCharge.IsOverage && overageFactor.GreaterThan(decimal.Zero) {
+					baseAmount = lineItemAmount.Div(overageFactor)
+				}
+				metadata := s.buildChargeMetadata(item, matchingCharge, entitlement)
+				displayName := lo.ToPtr(item.DisplayName)
+				if matchingCharge.IsOverage {
+					displayName = lo.ToPtr(fmt.Sprintf("%s (Overage)", item.DisplayName))
+				}
+				var priceUnitAmount decimal.Decimal
+				if item.PriceUnit != nil {
+					priceUnit, puErr := s.PriceUnitRepo.GetByCode(ctx, lo.FromPtr(item.PriceUnit))
+					if puErr == nil {
+						converted, convErr := priceunit.ConvertToPriceUnitAmount(ctx, lineItemAmount, priceUnit.ConversionRate, priceUnit.BaseCurrency)
+						if convErr == nil {
+							priceUnitAmount = converted
+						}
+					}
+				}
+				baseChargesForCumulative = append(baseChargesForCumulative, meterUsageBaseChargeInfo{
+					item: item, matchingCharge: matchingCharge, baseAmount: baseAmount,
+					quantityForCalculation: quantityForCalculation, priceUnitAmount: priceUnitAmount,
+					displayName: displayName, metadata: metadata,
+					adjustedEntitlementQuantity: entitlementAdjustedQty,
+				})
+				continue
 			}
+
+			// 4. Line-item commitment (windowed or flat)
+			var commitmentInfo *types.CommitmentInfo
+			if item.HasAnyCommitment() && matchingCharge.Price != nil {
+				lineItemAmount, commitmentInfo, err = s.applyMeterUsageCommitment(
+					ctx, item, m, matchingCharge, cachedBucketedUsageResult,
+					sub, extCustomerIDs, periodStart, periodEnd, asOf,
+					priceService, querySource, meterMap,
+				)
+				if err != nil {
+					return nil, decimal.Zero, err
+				}
+			}
+
+			totalUsageCost = totalUsageCost.Add(lineItemAmount)
+
 			metadata := s.buildChargeMetadata(item, matchingCharge, entitlement)
 			displayName := lo.ToPtr(item.DisplayName)
 			if matchingCharge.IsOverage {
 				displayName = lo.ToPtr(fmt.Sprintf("%s (Overage)", item.DisplayName))
 			}
+
+			s.Logger.Debug(ctx, "meter usage charges for line item",
+				"amount", matchingCharge.Amount, "quantity", matchingCharge.Quantity,
+				"is_overage", matchingCharge.IsOverage,
+				"subscription_id", sub.ID, "line_item_id", item.ID, "price_id", item.PriceID)
+
 			var priceUnitAmount decimal.Decimal
 			if item.PriceUnit != nil {
 				priceUnit, puErr := s.PriceUnitRepo.GetByCode(ctx, lo.FromPtr(item.PriceUnit))
-				if puErr == nil {
-					converted, convErr := priceunit.ConvertToPriceUnitAmount(ctx, lineItemAmount, priceUnit.ConversionRate, priceUnit.BaseCurrency)
-					if convErr == nil {
-						priceUnitAmount = converted
-					}
+				if puErr != nil {
+					return nil, decimal.Zero, puErr
+				}
+				priceUnitAmount, err = priceunit.ConvertToPriceUnitAmount(ctx, lineItemAmount, priceUnit.ConversionRate, priceUnit.BaseCurrency)
+				if err != nil {
+					return nil, decimal.Zero, err
 				}
 			}
-			baseChargesForCumulative = append(baseChargesForCumulative, meterUsageBaseChargeInfo{
-				item: item, matchingCharge: matchingCharge, baseAmount: baseAmount,
-				quantityForCalculation: quantityForCalculation, priceUnitAmount: priceUnitAmount,
-				displayName: displayName, metadata: metadata,
-				adjustedEntitlementQuantity: entitlementAdjustedQty,
+
+			usageCharges = append(usageCharges, dto.CreateInvoiceLineItemRequest{
+				EntityID:                    lo.ToPtr(item.EntityID),
+				EntityType:                  lo.ToPtr(string(item.EntityType)),
+				PlanDisplayName:             lo.ToPtr(item.PlanDisplayName),
+				PriceType:                   lo.ToPtr(string(item.PriceType)),
+				PriceID:                     lo.ToPtr(item.PriceID),
+				MeterID:                     lo.ToPtr(item.MeterID),
+				MeterDisplayName:            lo.ToPtr(item.MeterDisplayName),
+				PriceUnit:                   item.PriceUnit,
+				PriceUnitAmount:             lo.ToPtr(priceUnitAmount),
+				DisplayName:                 displayName,
+				Amount:                      lineItemAmount,
+				Quantity:                    quantityForCalculation,
+				AdjustedEntitlementQuantity: entitlementAdjustedQty,
+				PeriodStart:                 lo.ToPtr(item.GetPeriodStart(periodStart)),
+				PeriodEnd:                   lo.ToPtr(item.GetPeriodEnd(periodEnd)),
+				SubscriptionLineItemID:      lo.ToPtr(item.ID),
+				Metadata:                    metadata,
+				CommitmentInfo:              commitmentInfo,
 			})
-			continue
 		}
-
-		// 4. Line-item commitment (windowed or flat)
-		var commitmentInfo *types.CommitmentInfo
-		if item.HasAnyCommitment() && matchingCharge.Price != nil {
-			lineItemAmount, commitmentInfo, err = s.applyMeterUsageCommitment(
-				ctx, item, m, matchingCharge, cachedBucketedUsageResult,
-				sub, extCustomerIDs, periodStart, periodEnd, asOf,
-				priceService, querySource, meterMap,
-			)
-			if err != nil {
-				return nil, decimal.Zero, err
-			}
-		}
-
-		totalUsageCost = totalUsageCost.Add(lineItemAmount)
-
-		metadata := s.buildChargeMetadata(item, matchingCharge, entitlement)
-		displayName := lo.ToPtr(item.DisplayName)
-		if matchingCharge.IsOverage {
-			displayName = lo.ToPtr(fmt.Sprintf("%s (Overage)", item.DisplayName))
-		}
-
-		s.Logger.Debug(ctx, "meter usage charges for line item",
-			"amount", matchingCharge.Amount, "quantity", matchingCharge.Quantity,
-			"is_overage", matchingCharge.IsOverage,
-			"subscription_id", sub.ID, "line_item_id", item.ID, "price_id", item.PriceID)
-
-		var priceUnitAmount decimal.Decimal
-		if item.PriceUnit != nil {
-			priceUnit, puErr := s.PriceUnitRepo.GetByCode(ctx, lo.FromPtr(item.PriceUnit))
-			if puErr != nil {
-				return nil, decimal.Zero, puErr
-			}
-			priceUnitAmount, err = priceunit.ConvertToPriceUnitAmount(ctx, lineItemAmount, priceUnit.ConversionRate, priceUnit.BaseCurrency)
-			if err != nil {
-				return nil, decimal.Zero, err
-			}
-		}
-
-		usageCharges = append(usageCharges, dto.CreateInvoiceLineItemRequest{
-			EntityID:                    lo.ToPtr(item.EntityID),
-			EntityType:                  lo.ToPtr(string(item.EntityType)),
-			PlanDisplayName:             lo.ToPtr(item.PlanDisplayName),
-			PriceType:                   lo.ToPtr(string(item.PriceType)),
-			PriceID:                     lo.ToPtr(item.PriceID),
-			MeterID:                     lo.ToPtr(item.MeterID),
-			MeterDisplayName:            lo.ToPtr(item.MeterDisplayName),
-			PriceUnit:                   item.PriceUnit,
-			PriceUnitAmount:             lo.ToPtr(priceUnitAmount),
-			DisplayName:                 displayName,
-			Amount:                      lineItemAmount,
-			Quantity:                    quantityForCalculation,
-			AdjustedEntitlementQuantity: entitlementAdjustedQty,
-			PeriodStart:                 lo.ToPtr(item.GetPeriodStart(periodStart)),
-			PeriodEnd:                   lo.ToPtr(item.GetPeriodEnd(periodEnd)),
-			SubscriptionLineItemID:      lo.ToPtr(item.ID),
-			Metadata:                    metadata,
-			CommitmentInfo:              commitmentInfo,
-		})
 	}
 
 	// --- Post-loop: cumulative commitment or non-cumulative true-up ---

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -21,7 +21,6 @@ import (
 // for deferred processing by the cumulative commitment path.
 type meterUsageBaseChargeInfo struct {
 	item                        *subscription.SubscriptionLineItem
-	matchingCharge              *dto.SubscriptionUsageByMetersResponse
 	baseAmount                  decimal.Decimal
 	quantityForCalculation      decimal.Decimal
 	priceUnitAmount             decimal.Decimal
@@ -153,6 +152,18 @@ func (s *billingService) CalculateMeterUsageCharges(
 				Mark(ierr.ErrNotFound)
 		}
 
+		// Accumulated once per LINE ITEM (not per charge) for the cumulative-commitment
+		// path below: a base+overage split must contribute exactly one combined entry
+		// to baseChargesForCumulative, otherwise the item gets two allocated invoice
+		// lines and its contribution is misattributed between them (see step 3).
+		var cumulativeBaseAmount decimal.Decimal
+		var cumulativeQuantity decimal.Decimal
+		var cumulativePriceUnitAmount decimal.Decimal
+		var cumulativeDisplayName *string
+		var cumulativeMetadata types.Metadata
+		var cumulativeAdjustedEntitlementQty *decimal.Decimal
+		var cumulativePreferredCharge bool // true once a non-overage charge has set the fields above
+
 		for _, matchingCharge := range matchingCharges {
 			quantityForCalculation := decimal.NewFromFloat(matchingCharge.Quantity)
 
@@ -219,39 +230,48 @@ func (s *billingService) CalculateMeterUsageCharges(
 
 			lineItemAmount := decimal.NewFromFloat(matchingCharge.Amount)
 
-			// 3. Cumulative commitment — collect for batch processing after the loop
+			// 3. Cumulative commitment — accumulate into ONE combined entry per line
+			// item (appended after the charge loop below), not one per charge.
 			if useCumulativePath {
 				baseAmount := lineItemAmount
 				if matchingCharge.IsOverage && overageFactor.GreaterThan(decimal.Zero) {
 					baseAmount = lineItemAmount.Div(overageFactor)
 				}
-				metadata := s.buildChargeMetadata(item, matchingCharge, entitlement)
-				displayName := lo.ToPtr(item.DisplayName)
-				if matchingCharge.IsOverage {
-					displayName = lo.ToPtr(fmt.Sprintf("%s (Overage)", item.DisplayName))
-				}
-				var priceUnitAmount decimal.Decimal
+				cumulativeBaseAmount = cumulativeBaseAmount.Add(baseAmount)
+				cumulativeQuantity = cumulativeQuantity.Add(quantityForCalculation)
 				if item.PriceUnit != nil {
 					priceUnit, puErr := s.PriceUnitRepo.GetByCode(ctx, lo.FromPtr(item.PriceUnit))
 					if puErr == nil {
 						converted, convErr := priceunit.ConvertToPriceUnitAmount(ctx, lineItemAmount, priceUnit.ConversionRate, priceUnit.BaseCurrency)
 						if convErr == nil {
-							priceUnitAmount = converted
+							cumulativePriceUnitAmount = cumulativePriceUnitAmount.Add(converted)
 						}
 					}
 				}
-				baseChargesForCumulative = append(baseChargesForCumulative, meterUsageBaseChargeInfo{
-					item: item, matchingCharge: matchingCharge, baseAmount: baseAmount,
-					quantityForCalculation: quantityForCalculation, priceUnitAmount: priceUnitAmount,
-					displayName: displayName, metadata: metadata,
-					adjustedEntitlementQuantity: entitlementAdjustedQty,
-				})
+				// Prefer the non-overage charge's metadata/display name/entitlement
+				// info for the combined line; only an entirely-overage item (no
+				// non-overage charge at all) keeps the overage charge's info.
+				if !cumulativePreferredCharge || !matchingCharge.IsOverage {
+					cumulativeMetadata = s.buildChargeMetadata(item, matchingCharge, entitlement)
+					cumulativeDisplayName = lo.ToPtr(item.DisplayName)
+					if matchingCharge.IsOverage {
+						cumulativeDisplayName = lo.ToPtr(fmt.Sprintf("%s (Overage)", item.DisplayName))
+					}
+					cumulativeAdjustedEntitlementQty = entitlementAdjustedQty
+					cumulativePreferredCharge = !matchingCharge.IsOverage
+				}
 				continue
 			}
 
-			// 4. Line-item commitment (windowed or flat)
+			// 4. Line-item commitment (windowed or flat). Applied once per line item:
+			// when this item's usage was split into a normal + overage charge, only the
+			// non-overage charge goes through it — otherwise a floor/true-up would be
+			// enforced independently on each half instead of once for the item. A
+			// single (unsplit) charge is unaffected, overage or not.
 			var commitmentInfo *types.CommitmentInfo
-			if item.HasAnyCommitment() && matchingCharge.Price != nil {
+			applyItemCommitment := item.HasAnyCommitment() && matchingCharge.Price != nil &&
+				(!matchingCharge.IsOverage || len(matchingCharges) == 1)
+			if applyItemCommitment {
 				lineItemAmount, commitmentInfo, err = s.applyMeterUsageCommitment(
 					ctx, item, m, matchingCharge, cachedBucketedUsageResult,
 					sub, extCustomerIDs, periodStart, periodEnd, asOf,
@@ -306,6 +326,15 @@ func (s *billingService) CalculateMeterUsageCharges(
 				SubscriptionLineItemID:      lo.ToPtr(item.ID),
 				Metadata:                    metadata,
 				CommitmentInfo:              commitmentInfo,
+			})
+		}
+
+		if useCumulativePath {
+			baseChargesForCumulative = append(baseChargesForCumulative, meterUsageBaseChargeInfo{
+				item: item, baseAmount: cumulativeBaseAmount,
+				quantityForCalculation: cumulativeQuantity, priceUnitAmount: cumulativePriceUnitAmount,
+				displayName: cumulativeDisplayName, metadata: cumulativeMetadata,
+				adjustedEntitlementQuantity: cumulativeAdjustedEntitlementQty,
 			})
 		}
 	}

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -2869,6 +2869,72 @@ func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_SkipsInactiveLineIt
 	s.True(totalAmount.IsZero(), "Total should be zero: no charges should be attributed to active line items")
 }
 
+func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_ItemLevelCommitmentAppliedOnceWhenChargeIsSplit() {
+	// A line item can carry its own (flat, non-windowed) commitment independent of the
+	// subscription-level overage split. When the subscription-level split ALSO fires for
+	// this same line item (producing a normal charge + an overage charge sharing one
+	// SubscriptionLineItemID), the item's own commitment floor must be enforced ONCE for
+	// the line item — not once per charge — otherwise a true-up floor gets applied twice.
+	ctx := s.GetContext()
+	s.setupTestData()
+
+	itemCommitmentAmount := decimal.NewFromInt(5)
+	itemOverageFactor := decimal.NewFromFloat(1.2)
+	li := &subscription.SubscriptionLineItem{
+		ID:                      "sub_li_item_commit_split",
+		SubscriptionID:          s.testData.subscription.ID,
+		CustomerID:              s.testData.subscription.CustomerID,
+		EntityID:                s.testData.plan.ID,
+		EntityType:              types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName:         s.testData.plan.Name,
+		PriceID:                 s.testData.prices.apiCalls.ID,
+		PriceType:               types.PRICE_TYPE_USAGE,
+		MeterID:                 s.testData.meters.apiCalls.ID,
+		MeterDisplayName:        s.testData.meters.apiCalls.Name,
+		DisplayName:             "Item-Level Commitment Usage",
+		Quantity:                decimal.Zero,
+		Currency:                s.testData.subscription.Currency,
+		BillingPeriod:           s.testData.subscription.BillingPeriod,
+		InvoiceCadence:          types.InvoiceCadenceArrear,
+		StartDate:               s.testData.subscription.StartDate,
+		CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentAmount:        &itemCommitmentAmount,
+		CommitmentOverageFactor: &itemOverageFactor,
+		CommitmentTrueUpEnabled: true, // usage below commitment → floor charge up to the commitment amount
+		CommitmentWindowed:      false,
+		BaseModel:               types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, li))
+
+	subCopy := *s.testData.subscription
+	subCopy.LineItems = []*subscription.SubscriptionLineItem{li}
+
+	usage := &dto.GetUsageBySubscriptionResponse{
+		StartTime: subCopy.CurrentPeriodStart,
+		EndTime:   subCopy.CurrentPeriodEnd,
+		Currency:  subCopy.Currency,
+		Charges: []*dto.SubscriptionUsageByMetersResponse{
+			// Both charges are individually below the $5 item commitment, so the true-up
+			// floor would fire on EACH of them if applied per-charge instead of per-item.
+			{SubscriptionLineItemID: li.ID, Price: s.testData.prices.apiCalls, Quantity: 150, Amount: 3, IsOverage: false},
+			{SubscriptionLineItemID: li.ID, Price: s.testData.prices.apiCalls, Quantity: 200, Amount: 4, IsOverage: true, OverageFactor: 2},
+		},
+	}
+
+	lineItems, totalAmount, err := s.service.CalculateMeterUsageCharges(ctx, &subCopy, usage,
+		subCopy.CurrentPeriodStart, subCopy.CurrentPeriodEnd, types.UsageSourceInvoiceCreation,
+	)
+
+	s.NoError(err)
+	s.Len(lineItems, 2, "Should still have one line item for the normal slab and one for the overage slab")
+	// Correct: normal charge ($3) floors up to the $5 item commitment (true-up); the
+	// overage charge ($4) passes through unmodified by the item-level commitment —
+	// total = 5 + 4 = 9. Buggy (per-charge double-application): both charges
+	// independently floor to $5 → total = 10.
+	s.True(totalAmount.Equal(decimal.NewFromInt(9)),
+		"item-level commitment must apply once per line item, not once per charge: expected 9, got %s", totalAmount)
+}
+
 func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_KeepsBothNormalAndOverageChargesForSameLineItem() {
 	// When commitment/overage math splits one line item's usage into a normal (base slab)
 	// charge and an overage charge, both share the same SubscriptionLineItemID. Both must
@@ -3162,6 +3228,80 @@ func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_CumulativeCommitmen
 			},
 			currentUsageBase:    12,
 			expectedTotal:       decimal.NewFromInt(14), // 10 within + 4 overage
+			expectedOverageLine: decimal.NewFromInt(4),
+		},
+		{
+			// Same scenario as case1 (prior base 50, commitment 60, overage factor 2), but this
+			// period's usage arrives PRE-SPLIT into a normal charge ($8) and an overage charge
+			// ($8 at 2x, i.e. base-equivalent $4) for the SAME line item — exactly what
+			// GetMeterUsageBySubscription produces when the per-period split fires. Combined
+			// base-equivalent is 8+4=12, identical to case1's single currentUsageBase=12, so the
+			// expected result must be identical: this pins that splitting one line item's usage
+			// into two charges does NOT double-count its contribution to totalCurrentBase.
+			name: "case1_equivalent_but_pre_split_into_normal_and_overage_charges",
+			priorInvoices: []*invoice.Invoice{
+				{
+					ID:             "inv_1",
+					CustomerID:     sub.CustomerID,
+					SubscriptionID: lo.ToPtr(sub.ID),
+					InvoiceType:    types.InvoiceTypeSubscription,
+					InvoiceStatus:  types.InvoiceStatusFinalized,
+					PaymentStatus:  types.PaymentStatusPending,
+					Currency:       "usd",
+					AmountDue:      decimal.NewFromInt(30),
+					PeriodStart:    lo.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+					PeriodEnd:      lo.ToPtr(time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)),
+					BaseModel:      types.GetDefaultBaseModel(ctx),
+					LineItems: []*invoice.InvoiceLineItem{
+						{
+							ID:             "li_split_1",
+							InvoiceID:      "inv_1",
+							CustomerID:     sub.CustomerID,
+							SubscriptionID: lo.ToPtr(sub.ID),
+							PriceID:        lo.ToPtr(s.testData.prices.apiCalls.ID),
+							PriceType:      lo.ToPtr(string(types.PRICE_TYPE_USAGE)),
+							Amount:         decimal.NewFromInt(30),
+							Currency:       "usd",
+							PeriodStart:    lo.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+							PeriodEnd:      lo.ToPtr(time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)),
+							BaseModel:      types.GetDefaultBaseModel(ctx),
+						},
+					},
+				},
+				{
+					ID:             "inv_2",
+					CustomerID:     sub.CustomerID,
+					SubscriptionID: lo.ToPtr(sub.ID),
+					InvoiceType:    types.InvoiceTypeSubscription,
+					InvoiceStatus:  types.InvoiceStatusFinalized,
+					PaymentStatus:  types.PaymentStatusPending,
+					Currency:       "usd",
+					AmountDue:      decimal.NewFromInt(20),
+					PeriodStart:    lo.ToPtr(time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)),
+					PeriodEnd:      lo.ToPtr(time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)),
+					BaseModel:      types.GetDefaultBaseModel(ctx),
+					LineItems: []*invoice.InvoiceLineItem{
+						{
+							ID:             "li_split_2",
+							InvoiceID:      "inv_2",
+							CustomerID:     sub.CustomerID,
+							SubscriptionID: lo.ToPtr(sub.ID),
+							PriceID:        lo.ToPtr(s.testData.prices.apiCalls.ID),
+							PriceType:      lo.ToPtr(string(types.PRICE_TYPE_USAGE)),
+							Amount:         decimal.NewFromInt(20),
+							Currency:       "usd",
+							PeriodStart:    lo.ToPtr(time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)),
+							PeriodEnd:      lo.ToPtr(time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)),
+							BaseModel:      types.GetDefaultBaseModel(ctx),
+						},
+					},
+				},
+			},
+			customCharges: []*dto.SubscriptionUsageByMetersResponse{
+				{SubscriptionLineItemID: apiCallsLineItem.ID, Price: s.testData.prices.apiCalls, Quantity: 400, Amount: 8, IsOverage: false, OverageFactor: 2},
+				{SubscriptionLineItemID: apiCallsLineItem.ID, Price: s.testData.prices.apiCalls, Quantity: 200, Amount: 8, IsOverage: true, OverageFactor: 2},
+			},
+			expectedTotal:       decimal.NewFromInt(14), // Must match case1 exactly: 10 within + 4 overage
 			expectedOverageLine: decimal.NewFromInt(4),
 		},
 		{

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -2869,6 +2869,49 @@ func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_SkipsInactiveLineIt
 	s.True(totalAmount.IsZero(), "Total should be zero: no charges should be attributed to active line items")
 }
 
+func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_KeepsBothNormalAndOverageChargesForSameLineItem() {
+	// When commitment/overage math splits one line item's usage into a normal (base slab)
+	// charge and an overage charge, both share the same SubscriptionLineItemID. Both must
+	// produce their own invoice line item — the base slab must not be dropped.
+	ctx := s.GetContext()
+	s.setupTestData()
+
+	apiCallsLineItem := s.testData.subscription.LineItems[1]
+
+	usage := &dto.GetUsageBySubscriptionResponse{
+		StartTime: s.testData.subscription.CurrentPeriodStart,
+		EndTime:   s.testData.subscription.CurrentPeriodEnd,
+		Currency:  s.testData.subscription.Currency,
+		Charges: []*dto.SubscriptionUsageByMetersResponse{
+			{
+				SubscriptionLineItemID: apiCallsLineItem.ID,
+				Price:                  s.testData.prices.apiCalls,
+				Quantity:               300,
+				Amount:                 6,
+				IsOverage:              false,
+			},
+			{
+				SubscriptionLineItemID: apiCallsLineItem.ID,
+				Price:                  s.testData.prices.apiCalls,
+				Quantity:               200,
+				Amount:                 8,
+				IsOverage:              true,
+				OverageFactor:          2,
+			},
+		},
+	}
+
+	lineItems, totalAmount, err := s.service.CalculateMeterUsageCharges(ctx, s.testData.subscription, usage,
+		s.testData.subscription.CurrentPeriodStart,
+		s.testData.subscription.CurrentPeriodEnd,
+		types.UsageSourceInvoiceCreation,
+	)
+
+	s.NoError(err)
+	s.Len(lineItems, 2, "Should have one invoice line item for the normal slab AND one for the overage slab")
+	s.True(totalAmount.Equal(decimal.NewFromInt(14)), "Total should include both the normal and overage amounts")
+}
+
 func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_MatchesActiveLineItemBySubscriptionLineItemID() {
 	// When SubscriptionLineItemID is set and matches an active line item, the charge should be processed.
 	ctx := s.GetContext()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage-based billing to correctly handle split usage charges (e.g., standard + overage) that share the same subscription line item.
  * Ensured commitment pricing is applied only once where appropriate and that invoice totals include amounts from all matching charge parts.
* **Tests**
  * Added coverage for commitment behavior with split charges and for scenarios where both normal and overage charges must appear together with correct total amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->