### PR TITLE
feat(wallet): Checkout wallet topup + Autocharge from mandate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,13 +177,29 @@ migrate-local:
 
 .PHONY: test test-verbose test-coverage
 
+# Run go test, stream output, then print a short failure summary at the end.
+# Usage: $(call run-go-test,<go test args...>)
+define run-go-test
+	@bash -c 'set -o pipefail; \
+	tmp=$$(mktemp -t flexprice-test.XXXXXX); \
+	go test $(1) 2>&1 | tee "$$tmp"; \
+	status=$$?; \
+	echo ""; \
+	echo "======== FAILED TESTS ========"; \
+	grep -E "^--- FAIL:" "$$tmp" || echo "(none)"; \
+	echo "======== FAILED PACKAGES ====="; \
+	grep -E "^FAIL[[:space:]]" "$$tmp" || echo "(none)"; \
+	rm -f "$$tmp"; \
+	exit $$status'
+endef
+
 # Run all tests
 test: install-typst
-	go test -v -race ./internal/...
+	$(call run-go-test,-v -race ./internal/...)
 
 # Run tests with verbose output
 test-verbose:
-	go test -v ./internal/...
+	$(call run-go-test,-v ./internal/...)
 
 # Run tests with coverage report
 test-coverage:

--- a/docs/design/2026-07-20-payment-gated-wallet-topup.md
+++ b/docs/design/2026-07-20-payment-gated-wallet-topup.md
@@ -1,0 +1,387 @@
+# Payment-Gated Wallet Top-Up — Design ERD
+
+Status: **Implemented (backend)** — pay-first wallet top-up live; swagger regen optional follow-up  
+Date: 2026-07-20  
+Related: [Payment-gated quantity change](2026-07-17-payment-gated-quantity-change.md), [Bonus credit top-up](2026-07-09-FLE-904-bonus-credit-topup.md), checkout create-subscription in `internal/ee/service/checkout_session.go`
+
+---
+
+## 1. Problem Statement
+
+`POST /wallets/{id}/top-up` with `transaction_reason: PURCHASED_CREDIT_INVOICED` today creates a wallet transaction and a ONE_OFF invoice, then either:
+
+- **Pay-later (default):** leaves the purchase **pending** until the invoice is paid; `ReconcilePaymentStatus(SUCCEEDED)` credits the wallet via `metadata.wallet_transaction_id`, or
+- **Auto-complete:** when tenant setting `AutoCompletePurchasedCreditTransaction` is true, credits the wallet **immediately** and marks the invoice paid — payment collection is deferred / assumed elsewhere.
+
+For B2B2C (and any flow that needs hosted checkout before credits land), the merchant must **collect payment first** and only then apply credits — the same gate as `create_subscription` and pay-first `quantity_change`.
+
+**Goal:** opt-in pay-first path on wallet top-up when the client sends a `checkout` object with `PURCHASED_CREDIT_INVOICED`; zero behavior change when `checkout` is omitted; reuse checkout sessions as the short-lived payment vehicle (no new pending-operations table, no parallel credit-apply path).
+
+---
+
+
+
+## 2. Approach
+
+
+
+### 2.1 API surface (backward compatible)
+
+- `POST /wallets/{id}/top-up` — default pay-later / auto-complete when `checkout` is omitted (unchanged).
+- Opt-in: optional `checkout` object (`CheckoutParams`) on the top-up request. Presence means “collect payment before crediting the wallet.”
+- Checkout is **allowlisted** to `transaction_reason = PURCHASED_CREDIT_INVOICED` only. Any other reason + `checkout` → validation error.
+- `POST /checkout/sessions` **rejects** `action: wallet_topup` — sessions are created only via top-up.
+
+```json
+{
+  "credits_to_add": "1000",
+  "transaction_reason": "PURCHASED_CREDIT_INVOICED",
+  "idempotency_key": "optional-wallet-tx-key",
+  "checkout": {
+    "payment_provider": "razorpay",
+    "success_url": "https://app.example.com/ok",
+    "failure_url": "https://app.example.com/fail",
+    "cancel_url": "https://app.example.com/cancel",
+    "idempotency_key": "optional-checkout-session-key",
+    "payment_provider_config": {},
+    "metadata": {}
+  }
+}
+```
+
+Reusable DTO (`internal/api/dto/checkout_session.go`):
+
+
+| Struct              | Fields                                        |
+| ------------------- | --------------------------------------------- |
+| `PaymentParams`     | `payment_provider`, `payment_provider_config` |
+| `RedirectionParams` | `success_url`, `failure_url`, `cancel_url`    |
+| `CheckoutParams`    | embeds both + `idempotency_key`, `metadata`   |
+
+
+`TopUpWalletRequest.Checkout` is `*CheckoutParams`. Not taken from a full create-session request: `customer_external_id` (from wallet → customer), `action` (implied `wallet_topup`), `configuration.create_subscription_params`.
+
+**Idempotency:**
+
+- Wallet transaction keeps existing top-up idempotency key generation (`idempotency_key` on the top-up body, or auto-generated).
+- Checkout session prefers `checkout.idempotency_key` (same pattern as modify / create-subscription).
+
+**Branching:**
+
+
+| Condition                                   | Behavior                                                                                              |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| No `checkout` + `PURCHASED_CREDIT_INVOICED` | Existing pay-later / auto-complete path (`handlePurchasedCreditInvoicedTransaction`)                  |
+| `checkout` + `PURCHASED_CREDIT_INVOICED`    | Pay-first: force pending wallet tx, DRAFT invoice, checkout session + payment link; balance unchanged |
+| `checkout` + any other `transaction_reason` | Validation error; no session / no balance change                                                      |
+| No `checkout` + other reasons               | Existing direct / free / etc. paths unchanged                                                         |
+
+
+
+
+### 2.2 Why force pending (ignore auto-complete)
+
+When `AutoCompletePurchasedCreditTransaction` is true, today’s invoiced path credits the wallet **before** payment is collected. That contradicts pay-first.
+
+Pay-first **always** forces:
+
+- Purchase (and bonus child, if any) → `pending`
+- Wallet credit balance **unchanged** until payment succeeds
+
+Do not read the auto-complete setting for this branch (or override it to false). The invoice must not be created as already-paid.
+
+### 2.3 Why DRAFT until complete
+
+Modify / create-subscription checkout leave the checkout invoice as **DRAFT** at execute, then finalize inside `completeCheckoutAction` after the provider confirms payment. That keeps:
+
+- Orphan cleanup simple (`cleanupCheckoutSession` / archive draft)
+- Finalize + `ReconcilePaymentStatus(SUCCEEDED)` as the single “money settled” moment
+
+Pay-first top-up follows the same pattern. Do **not** call `CreateOneOffInvoice` on the pay-first path if that helper finalizes; use draft create + compute (or equivalent) so status stays `DRAFT` until complete.
+
+Today’s pay-later path may create a finalized/pending invoice via `CreateOneOffInvoice` — that path is unchanged when `checkout` is omitted.
+
+### 2.4 Credit apply (reuse existing hook — do not invent a parallel path)
+
+Invoice metadata already carries:
+
+
+| Key                                         | Purpose                                    |
+| ------------------------------------------- | ------------------------------------------ |
+| `wallet_transaction_id`                     | Purchase tx to complete on payment success |
+| `wallet_id`                                 | Wallet that receives credits               |
+| `credits_amount`                            | Credits purchased (string)                 |
+| `auto_completed`                            | `"false"` on pay-first                     |
+| (+ optional request metadata / description) | Pass-through                               |
+
+
+On `ReconcilePaymentStatus(SUCCEEDED)`, `[invoice.go](../../internal/ee/service/invoice.go)` already calls `CompletePurchasedCreditTransactionWithRetry`, which completes the purchase and any pending bonus child (`parent_transaction_id`). Complete for `wallet_topup` only needs to finalize the draft, mark the checkout payment succeeded, and reconcile — **no new credit logic**.
+
+### 2.5 Lifecycle
+
+```text
+POST /wallets/{id}/top-up (checkout present, PURCHASED_CREDIT_INVOICED)
+  → Validate CheckoutParams + reason allowlist
+  → Concurrent guard (one pending/initiated wallet_topup per wallet)
+  → Create pending purchase tx (+ pending bonus child if any)
+  → Create DRAFT ONE_OFF with wallet_transaction_id metadata
+  → CheckoutSession (action = wallet_topup → pending)
+       configuration.wallet_topup_params = { wallet_id, wallet_transaction_id? }
+       checkout_invoice_id set before session Create
+  → On session Create failure → archive draft (orphan cleanup)
+  → createCheckoutPayment + callCheckoutProvider
+  → On fulfill failure → cleanupCheckoutSession
+  → Return TopUpWalletResponse:
+       wallet_transaction = pending purchase
+       invoice_id = draft
+       wallet = unchanged balance
+       checkout_session (includes payment_action.url)
+
+Razorpay webhook (payment_link.paid / payment.captured)
+  → CompleteCheckoutSession
+  → completeCheckoutAction (wallet_topup):
+       finalize draft if still DRAFT
+       mark checkout payment SUCCEEDED (+ gateway id)
+       ReconcilePaymentStatus(SUCCEEDED)
+         → existing metadata hook → CompletePurchasedCreditTransactionWithRetry
+         → purchase (+ bonus) completed; balance updated
+  → session completed
+
+fail / expire / cancel
+  → cleanupCheckoutSession (archive invoice/payment via session columns)
+  → wallet txs remain pending (or are handled by existing void/cleanup ops — no new path required for v1)
+```
+
+```mermaid
+flowchart TD
+  TopUp["POST /wallets/id/top-up"]
+  TopUp --> HasCheckout{checkout present?}
+  HasCheckout -->|no| PayLater["Existing PURCHASED_CREDIT_INVOICED path"]
+  HasCheckout -->|yes| Validate["Require PURCHASED_CREDIT_INVOICED + CheckoutParams.Validate"]
+  Validate --> Guard["Guard pending wallet_topup for wallet"]
+  Guard --> PendingTx["Create pending wallet tx + bonus child if any"]
+  PendingTx --> DraftInv["Create DRAFT ONE_OFF with wallet_transaction_id metadata"]
+  DraftInv --> Session["Create checkout session wallet_topup"]
+  Session --> Fulfill["createCheckoutPayment + callCheckoutProvider"]
+  Fulfill --> Link["Return TopUpWalletResponse + checkout_session.payment_action.url"]
+  Webhook["Razorpay payment_link.paid / payment.captured"] --> Complete["CompleteCheckoutSession"]
+  Complete --> Finalize["Finalize draft + mark payment SUCCEEDED"]
+  Finalize --> Reconcile["ReconcilePaymentStatus SUCCEEDED"]
+  Reconcile --> Credit["Existing CompletePurchasedCreditTransactionWithRetry"]
+```
+
+
+
+
+
+### 2.6 Concurrent guard
+
+Before pay-first session create: reject if any `initiated` / `pending` checkout session already exists for the **same wallet** (`action = wallet_topup`, match `configuration.wallet_topup_params.wallet_id`).
+
+List by customer + action (same pattern as modify), then filter by wallet id in config. No new DB unique index in v1.
+
+### 2.7 Orphan draft on session create failure
+
+If `CheckoutSessionRepo.Create` fails after the DRAFT invoice exists, archive/delete the draft immediately (same pattern as `settlePayFirst` in subscription quantity change). Do not leave an unpaid draft without a session.
+
+### 2.8 Client UX
+
+Redirect / new tab to `checkout_session.payment_action.url` → return on success/cancel URL → poll `GET /v1/checkout/sessions/{id}`. Closing a local polling UI does not cancel the session. After `completed`, refetch wallet / transaction for credited balance.
+
+---
+
+
+
+## 3. ERD
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ WALLET : "owns"
+    CUSTOMER ||--o{ CHECKOUT_SESSION : "initiates"
+    WALLET ||--o{ WALLET_TRANSACTION : "has"
+    CUSTOMER ||--o{ INVOICE : "billed_via"
+    INVOICE ||--o{ PAYMENT : "collected_via"
+    CHECKOUT_SESSION }o--o| INVOICE : "checkout_invoice_id"
+    CHECKOUT_SESSION }o--o| PAYMENT : "checkout_payment_id"
+    CHECKOUT_SESSION }o--|| WALLET : "wallet_id in config"
+    INVOICE }o--|| WALLET_TRANSACTION : "metadata.wallet_transaction_id"
+
+    CHECKOUT_SESSION {
+        string id PK
+        string customer_id FK
+        string action "wallet_topup"
+        string checkout_status "initiated pending completed failed expired"
+        string payment_provider
+        string checkout_invoice_id FK "DRAFT ONE_OFF — amount lock"
+        string checkout_payment_id FK "INITIATED until webhook"
+        jsonb configuration "wallet_topup_params"
+        jsonb provider_result "payment link / next_action"
+        jsonb result "unused for wallet_topup"
+        time expires_at
+        string success_url
+        string failure_url
+        string cancel_url
+    }
+
+    WALLET {
+        string id PK
+        string customer_id FK
+        decimal credit_balance "unchanged until checkout completed"
+    }
+
+    WALLET_TRANSACTION {
+        string id PK
+        string wallet_id FK
+        string transaction_reason "PURCHASED_CREDIT_INVOICED or PURCHASED_CREDIT_BONUS"
+        string tx_status "pending until reconcile then completed"
+        string parent_transaction_id "bonus child only"
+    }
+
+    INVOICE {
+        string id PK
+        string customer_id FK
+        string invoice_type "ONE_OFF"
+        string invoice_status "DRAFT until complete then FINALIZED"
+        string payment_status
+        decimal amount_due "currency amount for credits purchased"
+        jsonb metadata "wallet_transaction_id wallet_id credits_amount"
+    }
+
+    PAYMENT {
+        string id PK
+        string destination_id "invoice_id"
+        string payment_status "INITIATED then SUCCEEDED"
+    }
+```
+
+
+
+**No new tables.** Persistence delta:
+
+
+| Piece                                      | Change                     |
+| ------------------------------------------ | -------------------------- |
+| `checkout_sessions.action`                 | New value: `wallet_topup`  |
+| `checkout_sessions.configuration`          | `wallet_topup_params` (§4) |
+| `checkout_sessions.result`                 | **Unused** for this action |
+| Wallets / wallet txs / invoices / payments | Existing only              |
+
+
+---
+
+
+
+## 4. Configuration JSON (v1)
+
+Parallel to `CreateSubscriptionParams` / `ModifySubscriptionParams` in `internal/types/checkout_configuration.go`.
+
+### 4.1 `configuration.wallet_topup_params`
+
+```json
+{
+  "wallet_id": "wallet_...",
+  "wallet_transaction_id": "wtx_..."
+}
+```
+
+
+| Field                   | Meaning                                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `wallet_id`             | From top-up path; concurrent guard + optional revalidation on complete                                                 |
+| `wallet_transaction_id` | Purchase tx id after create (debugging / optional revalidation); money + credit apply still driven by invoice metadata |
+
+
+**Why not store the full top-up request?** Credits, currency, and bonus are already locked on the pending wallet txs + DRAFT invoice. Complete does not re-run top-up; it finalizes and reconciles so the existing invoice metadata hook credits the wallet.
+
+---
+
+
+
+## 5. Top-up response (pay-first)
+
+`TopUpWalletResponse` gains optional `checkout_session` (`CheckoutSessionResponse`).
+
+```json
+{
+  "wallet_transaction": {
+    "id": "wtx_...",
+    "wallet_id": "wallet_...",
+    "credits": "1000",
+    "transaction_status": "pending",
+    "transaction_reason": "PURCHASED_CREDIT_INVOICED"
+  },
+  "invoice_id": "inv_...",
+  "wallet": {
+    "id": "wallet_...",
+    "credit_balance": "0"
+  },
+  "checkout_session": {
+    "id": "cs_...",
+    "checkout_status": "pending",
+    "payment_action": {
+      "type": "payment_link",
+      "url": "https://rzp.io/..."
+    }
+  }
+}
+```
+
+- Payment URL lives on `checkout_session.payment_action` (not a top-level sibling).
+- Poll: `GET /v1/checkout/sessions/{checkout_session.id}`.
+- Wallet balance in the response is **pre-credit** (unchanged).
+
+---
+
+
+
+## 6. Status mapping
+
+
+| Phase                  | Checkout             | Invoice            | Checkout payment | Wallet txs                     | Wallet balance |
+| ---------------------- | -------------------- | ------------------ | ---------------- | ------------------------------ | -------------- |
+| After pay-first top-up | `pending`            | `DRAFT`            | `INITIATED`      | Purchase (+ bonus) `pending`   | Unchanged      |
+| After webhook success  | `completed`          | `FINALIZED` + paid | `SUCCEEDED`      | Purchase (+ bonus) `completed` | Credited       |
+| Fail / expire / cancel | `failed` / `expired` | Archived           | Archived         | Remain `pending`               | Unchanged      |
+
+
+---
+
+
+
+## 7. Scenarios
+
+
+| #   | Scenario                                     | Handling                                                          |
+| --- | -------------------------------------------- | ----------------------------------------------------------------- |
+| 1   | Top-up without `checkout`                    | Existing pay-later / auto-complete                                |
+| 2   | `checkout` + `PURCHASED_CREDIT_INVOICED`     | Session + DRAFT; pending txs; balance unchanged                   |
+| 3   | `checkout` + other reason                    | Validation error                                                  |
+| 4   | Second pay-first while session pending       | Rejected (concurrent guard)                                       |
+| 5   | Payment succeeds                             | Finalize + reconcile → existing complete credits wallet (+ bonus) |
+| 6   | Link cancel / expire / cron                  | Cleanup; balance unchanged; txs stay pending                      |
+| 7   | Auto-complete setting true + checkout        | Still force pending (ignore setting)                              |
+| 8   | Bonus slab / explicit `bonus_credits_to_add` | Bonus child created pending with purchase; completed on reconcile |
+| 9   | Session Create fails after draft             | Archive draft; return error                                       |
+| 10  | Client closes poll UI mid-pay                | Session continues; return URL / GET session / refetch wallet      |
+
+
+---
+
+
+
+## 8. Evolvability notes
+
+This reuses the same recipe as quantity-change pay-first:
+
+1. Opt-in `CheckoutParams` on an existing write API
+2. Lock money on a DRAFT invoice; persist minimal config intent
+3. Defer the “effect” (here: wallet credit) until webhook complete
+4. Complete = finalize same invoice + reconcile (existing hook applies effect)
+5. Concurrent guard per resource (wallet)
+
+**v1 scope:** `wallet_topup` + `WalletTopupParams` for `PURCHASED_CREDIT_INVOICED` only. Direct / free top-ups stay immediate and out of checkout.
+
+NOTES:
+
+- If in setting tenant has chosen autoCompleteTopupInvoices but has sent checkout object, we still force them to pay if the reason is purchaseCreditsInvoiced.
+

--- a/internal/api/dto/checkout_session.go
+++ b/internal/api/dto/checkout_session.go
@@ -44,7 +44,7 @@ type RedirectionParams struct {
 }
 
 // CheckoutParams is the reusable checkout opt-in payload shared by
-// create-session and payment-gated subscription modify.
+// create-session, payment-gated subscription modify, and wallet top-up.
 type CheckoutParams struct {
 	PaymentParams
 	RedirectionParams
@@ -83,6 +83,13 @@ func (r *CreateCheckoutSessionRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	// wallet_topup sessions are created only via wallet top-up (pay-first).
+	if r.Action == types.CheckoutActionWalletTopup {
+		return ierr.NewError("wallet_topup is not supported via create checkout session").
+			WithHint("Use POST /wallets/{id}/top-up with a checkout object instead").
+			Mark(ierr.ErrValidation)
+	}
+
 	if err := r.CheckoutParams.Validate(); err != nil {
 		return err
 	}
@@ -94,7 +101,6 @@ func (r *CreateCheckoutSessionRequest) Validate() error {
 	return nil
 }
 
-// ResolveExpiresAt returns when the session should expire based on the payment provider.
 func (r *CreateCheckoutSessionRequest) ResolveExpiresAt(now time.Time) time.Time {
 	return now.UTC().Add(r.PaymentProvider.SessionExpiry())
 }
@@ -139,6 +145,90 @@ type UpdateCheckoutSessionRequest struct {
 type CreateCheckoutPaymentRequest struct {
 	Invoice *invoice.Invoice
 	Gateway types.PaymentGatewayType
+}
+
+type PayFirstCheckoutRequest struct {
+	CustomerID    string
+	Action        types.CheckoutAction
+	Configuration types.CheckoutConfiguration
+	DraftInvoice  *invoice.Invoice
+	Checkout      *CheckoutParams
+}
+
+func (r *PayFirstCheckoutRequest) Validate() error {
+	if r == nil || r.Checkout == nil {
+		return ierr.NewError("pay-first checkout requires checkout params").
+			Mark(ierr.ErrValidation)
+	}
+
+	if r.DraftInvoice == nil || r.DraftInvoice.ID == "" {
+		return ierr.NewError("pay-first checkout requires a draft invoice").
+			Mark(ierr.ErrValidation)
+	}
+
+	if r.CustomerID == "" {
+		return ierr.NewError("pay-first checkout requires customer_id").
+			Mark(ierr.ErrValidation)
+	}
+
+	return nil
+}
+
+func (r *PayFirstCheckoutRequest) ToCheckoutSession(ctx context.Context, customerID string) *domainCheckout.CheckoutSession {
+	return &domainCheckout.CheckoutSession{
+		ID:                    types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CHECKOUT_SESSION),
+		EnvironmentID:         types.GetEnvironmentID(ctx),
+		CustomerID:            customerID,
+		Action:                r.Action,
+		CheckoutStatus:        types.CheckoutStatusInitiated,
+		PaymentProvider:       r.Checkout.PaymentProvider,
+		Configuration:         domainCheckout.ToJSONBCheckoutConfiguration(r.Configuration),
+		PaymentProviderConfig: domainCheckout.ToJSONBCheckoutPaymentProviderConfig(r.Checkout.PaymentProviderConfig),
+		IdempotencyKey:        r.Checkout.IdempotencyKey,
+		SuccessURL:            r.Checkout.SuccessURL,
+		FailureURL:            r.Checkout.FailureURL,
+		CancelURL:             r.Checkout.CancelURL,
+		ExpiresAt:             time.Now().UTC().Add(r.Checkout.PaymentProvider.SessionExpiry()),
+		Metadata:              r.Checkout.Metadata,
+		BaseModel:             types.GetDefaultBaseModel(ctx),
+	}
+}
+
+func ValidateCheckoutSessionForCompletion(session *domainCheckout.CheckoutSession) error {
+	if session == nil {
+		return ierr.NewError("checkout session is required").
+			Mark(ierr.ErrValidation)
+	}
+	if session.CheckoutInvoiceID == nil || *session.CheckoutInvoiceID == "" {
+		return ierr.NewError("session has no checkout invoice").
+			WithHint("checkout session must have checkout_invoice_id before it can be completed").
+			Mark(ierr.ErrValidation)
+	}
+	if session.CheckoutPaymentID == nil || *session.CheckoutPaymentID == "" {
+		return ierr.NewError("session has no checkout payment").
+			WithHint("checkout session must have checkout_payment_id before it can be completed").
+			Mark(ierr.ErrValidation)
+	}
+
+	cfg := session.Configuration.ToCheckoutConfiguration()
+	switch session.Action {
+	case types.CheckoutActionModifySubscription:
+		if cfg.ModifySubscriptionParams == nil {
+			return ierr.NewError("session has no modify_subscription_params").
+				WithHint("checkout session must have modify_subscription_params before it can be completed").
+				Mark(ierr.ErrValidation)
+		}
+		return cfg.ModifySubscriptionParams.Validate()
+	case types.CheckoutActionWalletTopup:
+		if cfg.WalletTopupParams == nil {
+			return ierr.NewError("session has no wallet_topup_params").
+				WithHint("checkout session must have wallet_topup_params before it can be completed").
+				Mark(ierr.ErrValidation)
+		}
+		return cfg.WalletTopupParams.Validate()
+	default:
+		return nil
+	}
 }
 
 // CheckoutSessionResponse is the API response for a single checkout session.

--- a/internal/api/dto/wallet.go
+++ b/internal/api/dto/wallet.go
@@ -350,6 +350,11 @@ type TopUpWalletRequest struct {
 	BonusCreditsExpiryDateUTC *time.Time `json:"bonus_credits_expiry_date_utc,omitempty"`
 
 	ForceSyncInvoice bool `json:"force_sync_invoice,omitempty"`
+
+	// checkout opts into pay-first hosted checkout for PURCHASED_CREDIT_INVOICED top-ups.
+	// When set, credits are applied only after checkout payment succeeds.
+	// Omit for today's pay-later / auto-complete behavior.
+	Checkout *CheckoutParams `json:"checkout,omitempty"`
 }
 
 func (r *TopUpWalletRequest) Validate() error {
@@ -411,6 +416,20 @@ func (r *TopUpWalletRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	if r.Checkout != nil {
+		if r.TransactionReason != types.TransactionReasonPurchasedCreditInvoiced {
+			return ierr.NewError("checkout is only supported for PURCHASED_CREDIT_INVOICED").
+				WithHint("Omit checkout, or set transaction_reason to PURCHASED_CREDIT_INVOICED").
+				WithReportableDetails(map[string]interface{}{
+					"transaction_reason": r.TransactionReason,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		if err := r.Checkout.Validate(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -422,6 +441,8 @@ type TopUpWalletResponse struct {
 	InvoiceID *string `json:"invoice_id,omitempty"`
 	// Wallet details after the operation
 	Wallet *WalletResponse `json:"wallet"`
+	// CheckoutSession is set when pay-first checkout was requested on top-up.
+	CheckoutSession *CheckoutSessionResponse `json:"checkout_session,omitempty"`
 }
 
 // WalletBalanceResponse represents the response for getting wallet balance

--- a/internal/api/dto/wallet_test.go
+++ b/internal/api/dto/wallet_test.go
@@ -1,0 +1,67 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopUpWalletRequest_ValidateCheckout(t *testing.T) {
+	validCheckout := &CheckoutParams{
+		PaymentParams: PaymentParams{
+			PaymentProvider: types.CheckoutPaymentProviderRazorpay,
+		},
+	}
+
+	t.Run("no_checkout_ok", func(t *testing.T) {
+		req := &TopUpWalletRequest{
+			CreditsToAdd:      decimal.NewFromInt(100),
+			TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		}
+		require.NoError(t, req.Validate())
+	})
+
+	t.Run("checkout_with_invoiced_ok", func(t *testing.T) {
+		req := &TopUpWalletRequest{
+			CreditsToAdd:      decimal.NewFromInt(100),
+			TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+			Checkout:          validCheckout,
+		}
+		require.NoError(t, req.Validate())
+	})
+
+	t.Run("checkout_with_direct_rejected", func(t *testing.T) {
+		req := &TopUpWalletRequest{
+			CreditsToAdd:      decimal.NewFromInt(100),
+			TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+			Checkout:          validCheckout,
+		}
+		err := req.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "checkout is only supported for PURCHASED_CREDIT_INVOICED")
+	})
+
+	t.Run("checkout_with_free_credit_rejected", func(t *testing.T) {
+		req := &TopUpWalletRequest{
+			CreditsToAdd:      decimal.NewFromInt(100),
+			TransactionReason: types.TransactionReasonFreeCredit,
+			Checkout:          validCheckout,
+		}
+		err := req.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "checkout is only supported for PURCHASED_CREDIT_INVOICED")
+	})
+
+	t.Run("checkout_missing_payment_provider_rejected", func(t *testing.T) {
+		req := &TopUpWalletRequest{
+			CreditsToAdd:      decimal.NewFromInt(100),
+			TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+			Checkout:          &CheckoutParams{},
+		}
+		err := req.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "PaymentProvider")
+	})
+}

--- a/internal/domain/invoice/model.go
+++ b/internal/domain/invoice/model.go
@@ -138,6 +138,13 @@ type Invoice struct {
 	types.BaseModel
 }
 
+func (i *Invoice) GetId() string {
+	if i == nil {
+		return ""
+	}
+	return i.ID
+}
+
 // FromEnt converts an ent.Invoice to domain Invoice
 func FromEnt(e *ent.Invoice) *Invoice {
 	if e == nil {

--- a/internal/ee/service/checkout_session.go
+++ b/internal/ee/service/checkout_session.go
@@ -415,3 +415,80 @@ func (s *checkoutSessionService) createCheckoutPayment(ctx context.Context, inv 
 		Gateway: gateway,
 	})
 }
+
+// StartPayFirstCheckoutSession creates a checkout session on an existing DRAFT invoice,
+// fulfills payment + provider link, and publishes checkout.session.initiated.
+// On session create failure the draft is archived. On fulfill failure the session is cleaned up.
+func (s *checkoutSessionService) StartPayFirstCheckoutSession(
+	ctx context.Context,
+	req *dto.PayFirstCheckoutRequest,
+) (*dto.CheckoutSessionResponse, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	providerCfg := &types.CheckoutPaymentProviderConfig{}
+	if req.Checkout.PaymentProviderConfig != nil {
+		providerCfg = req.Checkout.PaymentProviderConfig
+	}
+	if providerCfg.CollectionMethod == "" {
+		providerCfg.CollectionMethod = types.CollectionMethodSendInvoice
+	}
+	if err := providerCfg.Validate(); err != nil {
+		return nil, err
+	}
+	req.Checkout.PaymentProviderConfig = providerCfg
+
+	draftInvoiceID := req.DraftInvoice.ID
+	session := req.ToCheckoutSession(ctx, req.CustomerID)
+	session.CheckoutInvoiceID = lo.ToPtr(draftInvoiceID)
+
+	if err := s.CheckoutSessionRepo.Create(ctx, session); err != nil {
+		if delErr := s.InvoiceRepo.Delete(ctx, draftInvoiceID); delErr != nil {
+			s.Logger.Error(ctx, "failed to archive draft invoice after checkout session create failure",
+				"invoice_id", draftInvoiceID,
+				"error", delErr,
+				"original_err", err,
+			)
+		}
+		return nil, err
+	}
+
+	if err := s.fulfillCheckoutSession(ctx, session, req.DraftInvoice); err != nil {
+		if cleanupErr := s.cleanupCheckoutSession(ctx, session, err); cleanupErr != nil {
+			s.Logger.Error(ctx, "checkout cleanup failed after pay-first fulfillment error",
+				"session_id", session.ID,
+				"error", cleanupErr,
+				"original_err", err,
+			)
+		}
+		return nil, err
+	}
+
+	sessionResp := dto.ToCheckoutSessionResponse(session)
+	s.publishCheckoutEvent(ctx, sessionResp, types.WebhookEventCheckoutSessionInitiated)
+	return sessionResp, nil
+}
+
+// fulfillCheckoutSession creates the INITIATED payment, calls the provider for a
+// payment link / next action, and marks the session pending.
+func (s *checkoutSessionService) fulfillCheckoutSession(
+	ctx context.Context,
+	session *domainCheckout.CheckoutSession,
+	inv *invoice.Invoice,
+) error {
+	payResp, err := s.createCheckoutPayment(ctx, inv, session.PaymentProvider)
+	if err != nil {
+		return err
+	}
+	session.CheckoutInvoiceID = &inv.ID
+	session.CheckoutPaymentID = &payResp.ID
+
+	providerResult, err := s.callCheckoutProvider(ctx, session, payResp)
+	if err != nil {
+		return err
+	}
+	session.ProviderResult = (*domainCheckout.JSONBCheckoutProviderResult)(providerResult)
+	session.CheckoutStatus = types.CheckoutStatusPending
+	return s.CheckoutSessionRepo.Update(ctx, session)
+}

--- a/internal/ee/service/checkout_session_actions.go
+++ b/internal/ee/service/checkout_session_actions.go
@@ -96,7 +96,7 @@ func (s *checkoutSessionService) callCheckoutProvider(
 			return nil, err
 		}
 
-		resp, err = provider.CreateAuthorizationLink(ctx, interfaces.AuthorizationLinkRequest{
+		authReq := interfaces.AuthorizationLinkRequest{
 			InvoiceID:       req.InvoiceID,
 			CustomerID:      req.CustomerID,
 			PaymentID:       req.PaymentID,
@@ -107,7 +107,18 @@ func (s *checkoutSessionService) callCheckoutProvider(
 			SuccessURL:      req.SuccessURL,
 			CancelURL:       req.CancelURL,
 			Metadata:        req.Metadata,
-		})
+		}
+
+		// Prefer an existing confirmed token (off-session). If none / amount above
+		// mandate max, fall back to registration+charge auth link.
+		if chargedResp, charged, chargeErr := provider.TryAutoChargingSavedMethod(ctx, authReq); chargeErr != nil {
+			return nil, chargeErr
+		} else if charged {
+			resp = chargedResp
+			break
+		}
+
+		resp, err = provider.CreateAuthorizationLink(ctx, authReq)
 
 	case types.CollectionMethodSendInvoice:
 		resp, err = provider.CreatePaymentLink(ctx, req)
@@ -129,23 +140,26 @@ func (s *checkoutSessionService) callCheckoutProvider(
 	}
 
 	// Record ProviderSessionID → FlexPrice PaymentID so incoming webhooks can route back.
-	mappingSvc := NewEntityIntegrationMappingService(s.ServiceParams)
-	if _, err := mappingSvc.CreateEntityIntegrationMapping(ctx, dto.CreateEntityIntegrationMappingRequest{
-		EntityID:         payResp.ID,
-		EntityType:       types.IntegrationEntityTypePayment,
-		ProviderType:     session.PaymentProvider.String(),
-		ProviderEntityID: resp.ProviderSessionID,
-	}); err != nil {
-		return nil, err
+	if resp.ProviderSessionID != "" {
+		mappingSvc := NewEntityIntegrationMappingService(s.ServiceParams)
+		if _, err := mappingSvc.CreateEntityIntegrationMapping(ctx, dto.CreateEntityIntegrationMappingRequest{
+			EntityID:         payResp.ID,
+			EntityType:       types.IntegrationEntityTypePayment,
+			ProviderType:     session.PaymentProvider.String(),
+			ProviderEntityID: resp.ProviderSessionID,
+		}); err != nil {
+			return nil, err
+		}
 	}
 
-	return &types.CheckoutProviderResult{
-		NextAction:              &resp.NextAction,
+	result := &types.CheckoutProviderResult{
 		ProviderSessionID:       resp.ProviderSessionID,
 		ProviderPaymentIntentID: resp.ProviderPaymentIntentID,
 		ExpiresAt:               resp.ExpiresAt,
 		ProviderMetadata:        resp.ProviderMetadata,
-	}, nil
+		NextAction:              lo.ToPtr(resp.NextAction),
+	}
+	return result, nil
 }
 
 // resolveMaxMandateLimit caps MaxMandateLimit against the tenant's
@@ -194,6 +208,8 @@ func (s *checkoutSessionService) completeCheckoutAction(ctx context.Context, ses
 		return s.completeSubscriptionCheckout(ctx, session, providerResult)
 	case types.CheckoutActionModifySubscription:
 		return s.completeModifySubscriptionCheckout(ctx, session, providerResult)
+	case types.CheckoutActionWalletTopup:
+		return s.completeWalletTopupCheckout(ctx, session, providerResult)
 	default:
 		return ierr.NewError("unsupported checkout action for completion").
 			WithHint("No completion handler for this action type").
@@ -210,24 +226,12 @@ func (s *checkoutSessionService) completeModifySubscriptionCheckout(
 	session *domainCheckout.CheckoutSession,
 	providerResult *types.CheckoutProviderResult,
 ) error {
-	cfg := session.Configuration.ToCheckoutConfiguration()
-	params := cfg.ModifySubscriptionParams
-	if params == nil {
-		return ierr.NewError("session has no modify_subscription_params").
-			WithHint("checkout session must have modify_subscription_params before it can be completed").
-			Mark(ierr.ErrValidation)
-	}
-	if session.CheckoutInvoiceID == nil || *session.CheckoutInvoiceID == "" {
-		return ierr.NewError("session has no checkout invoice").
-			WithHint("checkout session must have checkout_invoice_id before it can be completed").
-			Mark(ierr.ErrValidation)
-	}
-	if session.CheckoutPaymentID == nil || *session.CheckoutPaymentID == "" {
-		return ierr.NewError("session has no checkout payment").
-			WithHint("checkout session must have checkout_payment_id before it can be completed").
-			Mark(ierr.ErrValidation)
+	if err := dto.ValidateCheckoutSessionForCompletion(session); err != nil {
+		return err
 	}
 
+	cfg := session.Configuration.ToCheckoutConfiguration()
+	params := cfg.ModifySubscriptionParams
 	invoiceID := *session.CheckoutInvoiceID
 	paymentID := *session.CheckoutPaymentID
 
@@ -240,40 +244,50 @@ func (s *checkoutSessionService) completeModifySubscriptionCheckout(
 		return err
 	}
 
-	// Finalize the draft invoice (idempotent: check status first).
-	invSvc := NewInvoiceService(s.ServiceParams)
-	invResp, err := invSvc.GetInvoice(ctx, invoiceID)
-	if err != nil {
-		return err
-	}
-	if invResp.InvoiceStatus != types.InvoiceStatusFinalized {
-		if err := invSvc.FinalizeInvoice(ctx, invoiceID); err != nil {
-			return err
-		}
-	}
-
-	// Mark the checkout payment as SUCCEEDED, storing the gateway payment ID.
-	statusStr := string(types.PaymentStatusSucceeded)
-	now := time.Now().UTC()
-	updateReq := dto.UpdatePaymentRequest{
-		PaymentStatus: &statusStr,
-		SucceededAt:   &now,
-	}
-	if providerResult != nil && providerResult.ProviderPaymentIntentID != "" {
-		id := providerResult.ProviderPaymentIntentID
-		updateReq.GatewayPaymentID = &id
-	}
-	paySvc := NewPaymentService(s.ServiceParams)
-	if _, err := paySvc.UpdatePayment(ctx, paymentID, updateReq); err != nil {
-		return err
-	}
-
-	if err := invSvc.ReconcilePaymentStatus(ctx, invoiceID, types.PaymentStatusSucceeded, nil); err != nil {
+	if err := s.finalizeCheckoutInvoiceAndPayment(ctx, invoiceID, paymentID, providerResult); err != nil {
 		return err
 	}
 
 	modSvc.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, params.SubscriptionID)
 	return nil
+}
+
+// completeWalletTopupCheckout finalizes the DRAFT credit-purchase invoice and reconciles
+// payment. Wallet credits are applied by the existing ReconcilePaymentStatus hook via
+// invoice metadata.wallet_transaction_id.
+func (s *checkoutSessionService) completeWalletTopupCheckout(
+	ctx context.Context,
+	session *domainCheckout.CheckoutSession,
+	providerResult *types.CheckoutProviderResult,
+) error {
+	if err := dto.ValidateCheckoutSessionForCompletion(session); err != nil {
+		return err
+	}
+
+	cfg := session.Configuration.ToCheckoutConfiguration()
+	params := cfg.WalletTopupParams
+
+	w, err := s.WalletRepo.GetWalletByID(ctx, params.WalletID)
+	if err != nil {
+		return err
+	}
+	if w.WalletStatus != types.WalletStatusActive {
+		return ierr.NewError("wallet is not active").
+			WithHint("The wallet must be active to complete a payment-gated top-up").
+			WithReportableDetails(map[string]any{
+				"wallet_id":     params.WalletID,
+				"wallet_status": w.WalletStatus,
+				"status":        w.Status,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	return s.finalizeCheckoutInvoiceAndPayment(
+		ctx,
+		*session.CheckoutInvoiceID,
+		*session.CheckoutPaymentID,
+		providerResult,
+	)
 }
 
 func (s *checkoutSessionService) completeSubscriptionCheckout(ctx context.Context, session *domainCheckout.CheckoutSession, providerResult *types.CheckoutProviderResult) error {
@@ -296,19 +310,29 @@ func (s *checkoutSessionService) completeSubscriptionCheckout(ctx context.Contex
 		}
 	}
 
-	// 2. Finalize the draft invoice (idempotent: check status first).
+	// 2. Finalize draft + mark payment succeeded + reconcile (credits wallet for top-up invoices).
+	return s.finalizeCheckoutInvoiceAndPayment(ctx, res.InvoiceID, res.PaymentID, providerResult)
+}
+
+// finalizeCheckoutInvoiceAndPayment finalizes a DRAFT checkout invoice (idempotent),
+// marks the checkout payment SUCCEEDED, and reconciles invoice payment status.
+func (s *checkoutSessionService) finalizeCheckoutInvoiceAndPayment(
+	ctx context.Context,
+	invoiceID string,
+	paymentID string,
+	providerResult *types.CheckoutProviderResult,
+) error {
 	invSvc := NewInvoiceService(s.ServiceParams)
-	invResp, err := invSvc.GetInvoice(ctx, res.InvoiceID)
+	invResp, err := invSvc.GetInvoice(ctx, invoiceID)
 	if err != nil {
 		return err
 	}
 	if invResp.InvoiceStatus != types.InvoiceStatusFinalized {
-		if err := invSvc.FinalizeInvoice(ctx, res.InvoiceID); err != nil {
+		if err := invSvc.FinalizeInvoice(ctx, invoiceID); err != nil {
 			return err
 		}
 	}
 
-	// 3. Mark the checkout payment as SUCCEEDED, storing the gateway payment ID.
 	statusStr := string(types.PaymentStatusSucceeded)
 	now := time.Now().UTC()
 	updateReq := dto.UpdatePaymentRequest{
@@ -320,10 +344,9 @@ func (s *checkoutSessionService) completeSubscriptionCheckout(ctx context.Contex
 		updateReq.GatewayPaymentID = &id
 	}
 	paySvc := NewPaymentService(s.ServiceParams)
-	if _, err := paySvc.UpdatePayment(ctx, res.PaymentID, updateReq); err != nil {
+	if _, err := paySvc.UpdatePayment(ctx, paymentID, updateReq); err != nil {
 		return err
 	}
 
-	// 4. Reconcile invoice payment status (marks invoice as paid — already idempotent).
-	return invSvc.ReconcilePaymentStatus(ctx, res.InvoiceID, types.PaymentStatusSucceeded, nil)
+	return invSvc.ReconcilePaymentStatus(ctx, invoiceID, types.PaymentStatusSucceeded, nil)
 }

--- a/internal/ee/service/checkout_session_test.go
+++ b/internal/ee/service/checkout_session_test.go
@@ -1,0 +1,205 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
+	"github.com/flexprice/flexprice/internal/domain/plan"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
+	taxassociation "github.com/flexprice/flexprice/internal/domain/taxassociation"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// CheckoutCreateDraftSubscriptionSuite exercises createDraftSubscription end-to-end —
+// the create-subscription checkout path that computes the draft invoice and applies taxes
+// before payment. Regression coverage for the stale-invoice / zero AmountDue bug.
+type CheckoutCreateDraftSubscriptionSuite struct {
+	testutil.BaseServiceTestSuite
+	svc      *checkoutSessionService
+	planID   string
+	charge   decimal.Decimal
+	customer *customer.Customer
+}
+
+func TestCheckoutCreateDraftSubscriptionSuite(t *testing.T) {
+	suite.Run(t, new(CheckoutCreateDraftSubscriptionSuite))
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.ClearStores()
+	s.charge = decimal.NewFromInt(20)
+	s.svc = NewCheckoutSessionService(s.buildParams()).(*checkoutSessionService)
+	s.setupPlanAndCustomer()
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) buildParams() ServiceParams {
+	return ServiceParams{
+		Logger:                       s.GetLogger(),
+		Config:                       s.GetConfig(),
+		DB:                           s.GetDB(),
+		SubRepo:                      s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo:     s.GetStores().SubscriptionLineItemRepo,
+		SubscriptionPhaseRepo:        s.GetStores().SubscriptionPhaseRepo,
+		SubScheduleRepo:              s.GetStores().SubscriptionScheduleRepo,
+		PlanRepo:                     s.GetStores().PlanRepo,
+		PriceRepo:                    s.GetStores().PriceRepo,
+		PriceUnitRepo:                s.GetStores().PriceUnitRepo,
+		EventRepo:                    s.GetStores().EventRepo,
+		MeterRepo:                    s.GetStores().MeterRepo,
+		CustomerRepo:                 s.GetStores().CustomerRepo,
+		InvoiceRepo:                  s.GetStores().InvoiceRepo,
+		InvoiceLineItemRepo:          s.GetStores().InvoiceLineItemRepo,
+		EntitlementRepo:              s.GetStores().EntitlementRepo,
+		EnvironmentRepo:              s.GetStores().EnvironmentRepo,
+		FeatureRepo:                  s.GetStores().FeatureRepo,
+		TenantRepo:                   s.GetStores().TenantRepo,
+		UserRepo:                     s.GetStores().UserRepo,
+		AuthRepo:                     s.GetStores().AuthRepo,
+		WalletRepo:                   s.GetStores().WalletRepo,
+		PaymentRepo:                  s.GetStores().PaymentRepo,
+		CreditGrantRepo:              s.GetStores().CreditGrantRepo,
+		CreditGrantApplicationRepo:   s.GetStores().CreditGrantApplicationRepo,
+		CouponRepo:                   s.GetStores().CouponRepo,
+		CouponAssociationRepo:        s.GetStores().CouponAssociationRepo,
+		CouponApplicationRepo:        s.GetStores().CouponApplicationRepo,
+		AddonRepo:                    s.GetStores().AddonRepo,
+		AddonAssociationRepo:         s.GetStores().AddonAssociationRepo,
+		ConnectionRepo:               s.GetStores().ConnectionRepo,
+		SettingsRepo:                 s.GetStores().SettingsRepo,
+		TaxAssociationRepo:           s.GetStores().TaxAssociationRepo,
+		TaxRateRepo:                  s.GetStores().TaxRateRepo,
+		TaxAppliedRepo:               s.GetStores().TaxAppliedRepo,
+		AlertLogsRepo:                s.GetStores().AlertLogsRepo,
+		CheckoutSessionRepo:          s.GetStores().CheckoutSessionRepo,
+		EntityIntegrationMappingRepo: s.GetStores().EntityIntegrationMappingRepo,
+		EventPublisher:               s.GetPublisher(),
+		WebhookPublisher:             s.GetWebhookPublisher(),
+		ProrationCalculator:          s.GetCalculator(),
+		IntegrationFactory:           s.GetIntegrationFactory(),
+		PlanPriceSyncRepo:            s.GetStores().PlanPriceSyncRepo,
+		WalletBalanceAlertPubSub:     types.WalletBalanceAlertPubSub{PubSub: testutil.NewInMemoryPubSub()},
+	}
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) setupPlanAndCustomer() {
+	ctx := s.GetContext()
+
+	s.customer = &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: "ext_checkout_draft_tax",
+		Name:       "Checkout Draft Tax Customer",
+		Email:      "checkout-draft-tax@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().CustomerRepo.Create(ctx, s.customer))
+
+	p := &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Checkout Draft Tax Plan",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PlanRepo.Create(ctx, p))
+	s.planID = p.ID
+
+	fixedPrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             s.charge,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           p.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, fixedPrice))
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) createCustomerTaxAssociation(pct int64) {
+	ctx := s.GetContext()
+	pctDec := decimal.NewFromInt(pct)
+	tr := &taxrate.TaxRate{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_TAX_RATE),
+		Name:            "Checkout Create Draft Tax",
+		Code:            "checkout_create_draft_tax_" + types.GenerateUUIDWithPrefix("code"),
+		TaxRateStatus:   types.TaxRateStatusActive,
+		TaxRateType:     types.TaxRateTypePercentage,
+		PercentageValue: &pctDec,
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().TaxRateRepo.Create(ctx, tr))
+
+	assoc := &taxassociation.TaxAssociation{
+		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_TAX_ASSOCIATION),
+		TaxRateID:     tr.ID,
+		EntityType:    types.TaxRateEntityTypeCustomer,
+		EntityID:      s.customer.ID,
+		Priority:      100,
+		AutoApply:     true,
+		Currency:      "usd",
+		StartDate:     time.Now().UTC().Add(-24 * time.Hour),
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		BaseModel:     types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().TaxAssociationRepo.Create(ctx, assoc))
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) newSession() *domainCheckout.CheckoutSession {
+	ctx := s.GetContext()
+	return &domainCheckout.CheckoutSession{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CHECKOUT_SESSION),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		CustomerID:     s.customer.ID,
+		Action:         types.CheckoutActionCreateSubscription,
+		CheckoutStatus: types.CheckoutStatusInitiated,
+		Configuration: domainCheckout.ToJSONBCheckoutConfiguration(types.CheckoutConfiguration{
+			CreateSubscriptionParams: &types.CreateSubscriptionParams{
+				PlanID:        s.planID,
+				Currency:      "usd",
+				BillingPeriod: types.BILLING_PERIOD_MONTHLY,
+			},
+		}),
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) TestCreateDraftSubscription_WithCustomerTax_AmountDueIncludesTax() {
+	s.createCustomerTaxAssociation(10)
+
+	_, invResp, err := s.svc.createDraftSubscription(s.GetContext(), s.newSession())
+	s.Require().NoError(err)
+	s.Require().NotNil(invResp)
+
+	expectedTax := types.RoundToCurrencyPrecision(s.charge.Mul(decimal.NewFromInt(10)).Div(decimal.NewFromInt(100)), "usd")
+	expectedDue := s.charge.Add(expectedTax)
+
+	s.True(expectedTax.Equal(invResp.TotalTax), "expected total_tax %s, got %s", expectedTax, invResp.TotalTax)
+	s.True(expectedDue.Equal(invResp.AmountDue),
+		"expected amount_due %s (checkout payment fails if zero), got %s", expectedDue, invResp.AmountDue)
+	s.True(invResp.AmountDue.GreaterThan(decimal.Zero))
+}
+
+func (s *CheckoutCreateDraftSubscriptionSuite) TestCreateDraftSubscription_NoTax_AmountDueEqualsCharge() {
+	_, invResp, err := s.svc.createDraftSubscription(s.GetContext(), s.newSession())
+	s.Require().NoError(err)
+	s.Require().NotNil(invResp)
+
+	s.True(invResp.TotalTax.IsZero(), "expected zero total_tax, got %s", invResp.TotalTax)
+	s.True(s.charge.Equal(invResp.AmountDue),
+		"expected amount_due %s, got %s", s.charge, invResp.AmountDue)
+}

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -37,6 +37,7 @@ type InvoiceService interface {
 	// Additional methods specific to this service
 	CreateOneOffInvoice(ctx context.Context, req dto.CreateInvoiceRequest) (*dto.InvoiceResponse, error)
 	CreateEmptyDraftInvoice(ctx context.Context, req dto.CreateDraftInvoiceRequest) (*dto.InvoiceResponse, error)
+	CreateComputedDraftInvoice(ctx context.Context, req dto.CreateInvoiceRequest) (*dto.InvoiceResponse, bool, error)
 	FinalizeInvoice(ctx context.Context, id string) error
 	VoidInvoice(ctx context.Context, id string, req dto.InvoiceVoidRequest) error
 	ProcessDraftInvoice(ctx context.Context, id string, paymentParams *dto.PaymentParameters, sub *subscription.Subscription, flowType types.InvoiceFlowType) error
@@ -342,6 +343,24 @@ func (s *invoiceService) CreateInvoice(ctx context.Context, req dto.CreateInvoic
 	}
 
 	return dto.NewInvoiceResponse(inv), nil
+}
+
+func (s *invoiceService) CreateComputedDraftInvoice(ctx context.Context, req dto.CreateInvoiceRequest) (*dto.InvoiceResponse, bool, error) {
+	draftResp, err := s.CreateEmptyDraftInvoice(ctx, req.ToDraftRequest())
+	if err != nil {
+		return nil, false, err
+	}
+
+	computeReq := req.ToComputeRequest()
+	inv, skipped, err := s.ComputeInvoice(ctx, draftResp.ID, &computeReq)
+	if err != nil {
+		return nil, false, err
+	}
+	if skipped {
+		return dto.NewInvoiceResponse(inv), true, nil
+	}
+
+	return dto.NewInvoiceResponse(inv), false, nil
 }
 
 // CreateDraftInvoiceForSubscription creates a zero-dollar draft invoice without line items for a subscription period.

--- a/internal/ee/service/subscription_modification_quantity.go
+++ b/internal/ee/service/subscription_modification_quantity.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
-	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
-	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/domain/checkout"
 	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
 
@@ -777,84 +777,41 @@ func (s *subscriptionModificationService) settlePayFirst(
 		return nil, err
 	}
 
-	if err := s.guardPendingModifyCheckout(ctx, sub.CustomerID, request.GetSubscriptionID()); err != nil {
+	existing, err := s.getAnyPendingCheckoutSession(ctx, sub.CustomerID, sub.ID)
+	if err != nil {
 		return nil, err
 	}
-
-	providerCfg := &types.CheckoutPaymentProviderConfig{}
-	if checkout.PaymentProviderConfig != nil {
-		providerCfg = checkout.PaymentProviderConfig
-	}
-	if providerCfg.CollectionMethod == "" {
-		providerCfg.CollectionMethod = types.CollectionMethodSendInvoice
-	}
-	if err := providerCfg.Validate(); err != nil {
-		return nil, err
+	if len(existing) > 0 {
+		return nil, ierr.NewError("a pending checkout session already exists for this subscription").
+			WithHint("Complete or cancel the existing checkout before starting another payment-gated modification").
+			WithReportableDetails(map[string]any{
+				"subscription_id":     sub.ID,
+				"checkout_session_id": existing[0].ID,
+			}).
+			Mark(ierr.ErrAlreadyExists)
 	}
 
 	draftInvoice, err := s.createAggregatedProrationDraftInvoice(ctx, sub, prorationResult)
 	if err != nil {
 		return nil, err
 	}
-	draftInvoiceID := draftInvoice.ID
 
-	var meta types.Metadata
-	if len(checkout.Metadata) > 0 {
-		meta = types.Metadata(checkout.Metadata)
-	}
-
-	session := &domainCheckout.CheckoutSession{
-		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CHECKOUT_SESSION),
-		EnvironmentID:   types.GetEnvironmentID(ctx),
-		CustomerID:      sub.CustomerID,
-		Action:          types.CheckoutActionModifySubscription,
-		CheckoutStatus:  types.CheckoutStatusInitiated,
-		PaymentProvider: checkout.PaymentProvider,
-		Configuration: domainCheckout.ToJSONBCheckoutConfiguration(types.CheckoutConfiguration{
+	checkoutSvc := NewCheckoutSessionService(sp)
+	sessionResp, err := checkoutSvc.StartPayFirstCheckoutSession(ctx, &dto.PayFirstCheckoutRequest{
+		CustomerID: sub.CustomerID,
+		Action:     types.CheckoutActionModifySubscription,
+		Configuration: types.CheckoutConfiguration{
 			ModifySubscriptionParams: modifyParams,
-		}),
-		PaymentProviderConfig: domainCheckout.ToJSONBCheckoutPaymentProviderConfig(providerCfg),
-		CheckoutInvoiceID:     &draftInvoiceID,
-		IdempotencyKey:        checkout.IdempotencyKey,
-		SuccessURL:            checkout.SuccessURL,
-		FailureURL:            checkout.FailureURL,
-		CancelURL:             checkout.CancelURL,
-		ExpiresAt:             time.Now().UTC().Add(checkout.PaymentProvider.SessionExpiry()),
-		Metadata:              meta,
-		BaseModel:             types.GetDefaultBaseModel(ctx),
-	}
-
-	if err := sp.CheckoutSessionRepo.Create(ctx, session); err != nil {
-		// Session never persisted — archive the draft so it is not orphaned.
-		if delErr := sp.InvoiceRepo.Delete(ctx, draftInvoiceID); delErr != nil {
-			sp.Logger.Error(ctx, "failed to archive draft invoice after checkout session create failure",
-				"invoice_id", draftInvoiceID,
-				"error", delErr,
-				"original_err", err,
-			)
-		}
+		},
+		DraftInvoice: &draftInvoice.Invoice,
+		Checkout:     checkout,
+	})
+	if err != nil {
 		return nil, err
 	}
-
-	checkoutSvc := &checkoutSessionService{ServiceParams: s.serviceParams}
-
-	// Fulfill: payment + provider link. On failure, best-effort cleanup.
-	if err := s.fulfillModifySubscriptionCheckout(ctx, checkoutSvc, session, &draftInvoice.Invoice); err != nil {
-		if cleanupErr := checkoutSvc.cleanupCheckoutSession(ctx, session, err); cleanupErr != nil {
-			sp.Logger.Error(ctx, "checkout cleanup failed after pay-first fulfillment error",
-				"session_id", session.ID,
-				"error", cleanupErr,
-				"original_err", err,
-			)
-		}
-		return nil, err
-	}
-
-	sessionResp := dto.ToCheckoutSessionResponse(session)
-	checkoutSvc.publishCheckoutEvent(ctx, sessionResp, types.WebhookEventCheckoutSessionInitiated)
 
 	subSvc := NewSubscriptionService(sp)
-	subResp, err := subSvc.GetSubscription(ctx, request.GetSubscriptionID())
+	subResp, err := subSvc.GetSubscription(ctx, sub.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -883,63 +840,20 @@ func (s *subscriptionModificationService) settlePayFirst(
 	}, nil
 }
 
-func (s *subscriptionModificationService) fulfillModifySubscriptionCheckout(
-	ctx context.Context,
-	checkoutSvc *checkoutSessionService,
-	session *domainCheckout.CheckoutSession,
-	inv *invoice.Invoice,
-) error {
-	payResp, err := checkoutSvc.createCheckoutPayment(ctx, inv, session.PaymentProvider)
-	if err != nil {
-		return err
-	}
-	session.CheckoutInvoiceID = &inv.ID
-	session.CheckoutPaymentID = &payResp.ID
-
-	providerResult, err := checkoutSvc.callCheckoutProvider(ctx, session, payResp)
-	if err != nil {
-		return err
-	}
-	session.ProviderResult = (*domainCheckout.JSONBCheckoutProviderResult)(providerResult)
-	session.CheckoutStatus = types.CheckoutStatusPending
-	return s.serviceParams.CheckoutSessionRepo.Update(ctx, session)
-}
-
-func (s *subscriptionModificationService) guardPendingModifyCheckout(
-	ctx context.Context,
-	customerID string,
-	subscriptionID string,
-) error {
-	filter := &types.CheckoutSessionFilter{
-		QueryFilter: types.NewNoLimitQueryFilter(),
+func (s *subscriptionModificationService) getAnyPendingCheckoutSession(ctx context.Context, customerID string, subscriptionID string) ([]*checkout.CheckoutSession, error) {
+	pendingFilter := &types.CheckoutSessionFilter{
+		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
 		CustomerIDs: []string{customerID},
 		Actions:     []types.CheckoutAction{types.CheckoutActionModifySubscription},
 		CheckoutStatuses: []types.CheckoutStatus{
 			types.CheckoutStatusInitiated,
 			types.CheckoutStatusPending,
 		},
+		Configuration: &types.CheckoutConfigurationFilter{SubscriptionID: subscriptionID},
 	}
-	sessions, err := s.serviceParams.CheckoutSessionRepo.List(ctx, filter)
-	if err != nil {
-		return err
-	}
-	for _, sess := range sessions {
-		if sess == nil {
-			continue
-		}
-		cfg := sess.Configuration.ToCheckoutConfiguration()
-		if cfg.ModifySubscriptionParams != nil &&
-			cfg.ModifySubscriptionParams.SubscriptionID == subscriptionID {
-			return ierr.NewError("a pending checkout session already exists for this subscription").
-				WithHint("Complete or cancel the existing checkout before starting another payment-gated modification").
-				WithReportableDetails(map[string]any{
-					"subscription_id":     subscriptionID,
-					"checkout_session_id": sess.ID,
-				}).
-				Mark(ierr.ErrAlreadyExists)
-		}
-	}
-	return nil
+	pendingFilter.Limit = lo.ToPtr(1)
+
+	return s.serviceParams.CheckoutSessionRepo.List(ctx, pendingFilter)
 }
 
 // createAggregatedProrationDraftInvoice locks the batch net (charges − credits) on one DRAFT ONE_OFF.
@@ -966,23 +880,21 @@ func (s *subscriptionModificationService) createAggregatedProrationDraftInvoice(
 	}
 
 	req := buildAggregatedProrationChargeInvoiceRequest(sub, items)
+
 	invoiceSvc := NewInvoiceService(s.serviceParams)
-	draftResp, err := invoiceSvc.CreateEmptyDraftInvoice(ctx, req.ToDraftRequest())
-	if err != nil {
-		return nil, err
-	}
-	computeReq := req.ToComputeRequest()
-	_, skipped, err := invoiceSvc.ComputeInvoice(ctx, draftResp.ID, &computeReq)
+	inv, skipped, err := invoiceSvc.CreateComputedDraftInvoice(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	if skipped {
-		return nil, ierr.NewError("proration draft invoice was skipped").
-			WithHint("Expected a non-zero proration charge").
-			WithReportableDetails(map[string]any{"invoice_id": draftResp.ID}).
+		return nil, ierr.NewError("draft invoice was skipped").
+			WithHint("Expected a non-zero invoice amount").
+			WithReportableDetails(map[string]any{
+				"invoice_id": inv.GetId(),
+			}).
 			Mark(ierr.ErrValidation)
 	}
-	return invoiceSvc.GetInvoice(ctx, draftResp.ID)
+	return inv, nil
 }
 
 func buildAggregatedProrationChargeInvoiceRequest(
@@ -1045,26 +957,22 @@ func (s *subscriptionModificationService) createProrationChargeInvoice(
 	req := buildProrationChargeInvoiceRequest(sub, item)
 
 	if draft {
-		draftResp, err := invoiceSvc.CreateEmptyDraftInvoice(ctx, req.ToDraftRequest())
+		latest, skipped, err := invoiceSvc.CreateComputedDraftInvoice(ctx, req)
 		if err != nil {
 			sp.Logger.Error(ctx, "failed to create draft proration invoice for quantity change", "error", err)
 			return nil, err
 		}
-		computeReq := req.ToComputeRequest()
-		_, skipped, err := invoiceSvc.ComputeInvoice(ctx, draftResp.ID, &computeReq)
-		if err != nil {
-			return nil, err
-		}
 		if skipped {
-			return nil, ierr.NewError("proration draft invoice was skipped").
-				WithHint("Expected a non-zero proration charge").
-				WithReportableDetails(map[string]any{"invoice_id": draftResp.ID}).
+			return nil, ierr.NewError("draft invoice was skipped").
+				WithHint("Expected a non-zero invoice amount").
+				WithReportableDetails(
+					map[string]any{
+						"invoice_id": latest.GetId(),
+					},
+				).
 				Mark(ierr.ErrValidation)
 		}
-		latest, err := invoiceSvc.GetInvoice(ctx, draftResp.ID)
-		if err != nil {
-			return nil, err
-		}
+		
 		return &dto.ChangedInvoice{
 			ID:      latest.ID,
 			Action:  dto.ChangedInvoiceActionCreated,

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/cache"
+	"github.com/flexprice/flexprice/internal/domain/checkout"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -622,10 +623,26 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 		})
 	}
 
-	// Handle special case for purchased credits with invoice
+	// Handle purchased credits with invoice (pay-later / auto-complete, or pay-first checkout).
 	if req.TransactionReason == types.TransactionReasonPurchasedCreditInvoiced {
-		// This creates a PENDING wallet transaction and invoice
-		// No wallet balance update happens yet
+		// Opt-in checkout: force pending + DRAFT so credits apply only after payment.
+		if req.Checkout != nil {
+			existing, err := s.getAnyPendingCheckoutSession(ctx, w.CustomerID, walletID)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(existing) > 0 {
+				return nil, ierr.NewError("a pending checkout session already exists for this wallet").
+					WithHint("Complete or cancel the existing checkout before starting another payment-gated top-up").
+					WithReportableDetails(map[string]any{
+						"wallet_id":           walletID,
+						"checkout_session_id": existing[0].ID,
+					}).
+					Mark(ierr.ErrAlreadyExists)
+			}
+		}
+
 		walletTransactionID, invoiceID, err := s.handlePurchasedCreditInvoicedTransaction(
 			ctx,
 			walletID,
@@ -641,26 +658,53 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 			"wallet_transaction_id", walletTransactionID,
 			"invoice_id", invoiceID,
 			"credits", req.CreditsToAdd.String(),
+			"pay_first", req.Checkout != nil,
 		)
 
-		// Get the wallet transaction
 		tx, err := s.WalletRepo.GetTransactionByID(ctx, walletTransactionID)
 		if err != nil {
 			return nil, err
 		}
 
-		// Get updated wallet
 		walletResp, err := s.GetWalletByID(ctx, walletID)
 		if err != nil {
 			return nil, err
 		}
 
-		// Return response with transaction, invoice ID, and wallet
-		return &dto.TopUpWalletResponse{
+		resp := &dto.TopUpWalletResponse{
 			WalletTransaction: dto.FromWalletTransaction(tx),
 			InvoiceID:         &invoiceID,
 			Wallet:            walletResp,
-		}, nil
+		}
+
+		if req.Checkout != nil {
+			invoiceSvc := NewInvoiceService(s.ServiceParams)
+			draftInvoice, err := invoiceSvc.GetInvoice(ctx, invoiceID)
+			if err != nil {
+				return nil, err
+			}
+
+			checkoutSvc := NewCheckoutSessionService(s.ServiceParams)
+			sessionResp, err := checkoutSvc.StartPayFirstCheckoutSession(ctx, &dto.PayFirstCheckoutRequest{
+				CustomerID: w.CustomerID,
+				Action:     types.CheckoutActionWalletTopup,
+				Configuration: types.CheckoutConfiguration{
+					WalletTopupParams: &types.WalletTopupParams{
+						WalletID:            walletID,
+						WalletTransactionID: walletTransactionID,
+					},
+				},
+				DraftInvoice: &draftInvoice.Invoice,
+				Checkout:     req.Checkout,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			resp.CheckoutSession = sessionResp
+		}
+
+		return resp, nil
 	}
 
 	// Handle direct credit purchase (PURCHASED_CREDIT_DIRECT) or any other transaction reason
@@ -712,6 +756,22 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 	}, nil
 }
 
+func (s *walletService) getAnyPendingCheckoutSession(ctx context.Context, customerID string, walletID string) ([]*checkout.CheckoutSession, error) {
+	pendingFilter := &types.CheckoutSessionFilter{
+		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
+		CustomerIDs: []string{customerID},
+		Actions:     []types.CheckoutAction{types.CheckoutActionWalletTopup},
+		CheckoutStatuses: []types.CheckoutStatus{
+			types.CheckoutStatusInitiated,
+			types.CheckoutStatusPending,
+		},
+		Configuration: &types.CheckoutConfigurationFilter{WalletID: walletID},
+	}
+	pendingFilter.Limit = lo.ToPtr(1)
+
+	return s.CheckoutSessionRepo.List(ctx, pendingFilter)
+}
+
 // findBonusSlab returns the highest-threshold slab that credits clears. Requires slabs sorted
 // descending by Threshold (enforced by BonusCreditsTopupConfig.Validate) — first match wins.
 func findBonusSlab(slabs []types.BonusCreditsSlab, credits decimal.Decimal) *types.BonusCreditsSlab {
@@ -742,6 +802,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 	// Initialize required services
 	invoiceService := NewInvoiceService(s.ServiceParams)
 	taxService := NewTaxService(s.ServiceParams)
+	isPayFirst := req.Checkout != nil
 
 	settingsService := &settingsService{
 		ServiceParams: s.ServiceParams,
@@ -763,12 +824,14 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 		return "", "", err
 	}
 
-	// Check if auto-complete is enabled
-	autoCompleteEnabled := invoiceConfig.AutoCompletePurchasedCreditTransaction
+	// Check if auto-complete is enabled. Pay-first checkout always forces pending
+	// so credits are not applied before payment succeeds.
+	autoCompleteEnabled := invoiceConfig.AutoCompletePurchasedCreditTransaction && !isPayFirst
 
 	s.Logger.Debug(ctx, "processing purchased credit transaction",
 		"wallet_id", walletID,
 		"auto_complete_enabled", autoCompleteEnabled,
+		"pay_first", isPayFirst,
 		"credits", req.CreditsToAdd.String(),
 	)
 
@@ -971,14 +1034,35 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 			PaymentStatus:    lo.ToPtr(paymentStatus),
 			Metadata:         invoiceMetadata,
 			BillingReason:    req.BillingReason,
-			ForceSyncInvoice: req.ForceSyncInvoice,
+			ForceSyncInvoice: req.ForceSyncInvoice && !isPayFirst,
 			TaxRates:         taxRateIDs,
 		}
-		inv, err := invoiceService.CreateOneOffInvoice(ctx, invReq)
-		if err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to create invoice for purchased credits").
-				Mark(ierr.ErrInternal)
+
+		var inv *dto.InvoiceResponse
+		var skipped bool
+		if isPayFirst {
+			// Pay-first: leave DRAFT until checkout complete finalizes + reconciles.
+			inv, skipped, err = invoiceService.CreateComputedDraftInvoice(ctx, invReq)
+			if err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to create draft invoice for purchased credits").
+					Mark(ierr.ErrInternal)
+			}
+			if skipped {
+				return ierr.NewError("draft invoice was skipped").
+					WithHint("Expected a non-zero invoice amount").
+					WithReportableDetails(map[string]any{
+						"invoice_id": inv.GetId(),
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		} else {
+			inv, err = invoiceService.CreateOneOffInvoice(ctx, invReq)
+			if err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to create invoice for purchased credits").
+					Mark(ierr.ErrInternal)
+			}
 		}
 
 		invoiceID = inv.ID
@@ -999,6 +1083,7 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 				"wallet_id", walletID,
 				"credits", req.CreditsToAdd.String(),
 				"amount", amount.String(),
+				"invoice_status", inv.InvoiceStatus,
 			)
 		}
 

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -74,10 +74,10 @@ func (s *WalletServiceSuite) TearDownTest() {
 	s.BaseServiceTestSuite.ClearStores()
 }
 
-func (s *WalletServiceSuite) setupService() {
+func (s *WalletServiceSuite) buildServiceParams() ServiceParams {
 	stores := s.GetStores()
 	pubsub := testutil.NewInMemoryPubSub()
-	s.service = NewWalletService(ServiceParams{
+	return ServiceParams{
 		Logger:                       s.GetLogger(),
 		Config:                       s.GetConfig(),
 		DB:                           s.GetDB(),
@@ -92,22 +92,33 @@ func (s *WalletServiceSuite) setupService() {
 		MeterRepo:                    stores.MeterRepo,
 		CustomerRepo:                 stores.CustomerRepo,
 		InvoiceRepo:                  stores.InvoiceRepo,
+		InvoiceLineItemRepo:          stores.InvoiceLineItemRepo,
 		EntitlementRepo:              stores.EntitlementRepo,
 		EntitlementGrantRepo:         stores.EntitlementGrantRepo,
 		FeatureRepo:                  stores.FeatureRepo,
 		AddonAssociationRepo:         stores.AddonAssociationRepo,
 		SettingsRepo:                 stores.SettingsRepo,
-		AlertLogsRepo:                s.GetStores().AlertLogsRepo,
+		AlertLogsRepo:                stores.AlertLogsRepo,
+		PaymentRepo:                  stores.PaymentRepo,
+		CheckoutSessionRepo:          stores.CheckoutSessionRepo,
+		CouponRepo:                   stores.CouponRepo,
+		CouponAssociationRepo:        stores.CouponAssociationRepo,
+		CouponApplicationRepo:        stores.CouponApplicationRepo,
+		TaxAssociationRepo:           stores.TaxAssociationRepo,
+		TaxRateRepo:                  stores.TaxRateRepo,
+		TaxAppliedRepo:               stores.TaxAppliedRepo,
 		EventPublisher:               s.GetPublisher(),
 		WebhookPublisher:             s.GetWebhookPublisher(),
 		WalletBalanceAlertPubSub:     types.WalletBalanceAlertPubSub{PubSub: pubsub},
 		IntegrationFactory:           s.GetIntegrationFactory(),
 		ConnectionRepo:               stores.ConnectionRepo,
 		EntityIntegrationMappingRepo: stores.EntityIntegrationMappingRepo,
-		TaxAssociationRepo:           stores.TaxAssociationRepo,
-		TaxRateRepo:                  stores.TaxRateRepo,
-		TaxAppliedRepo:               stores.TaxAppliedRepo,
-	})
+	}
+}
+
+func (s *WalletServiceSuite) setupService() {
+	s.service = NewWalletService(s.buildServiceParams())
+	stores := s.GetStores()
 	s.subsService = NewSubscriptionService(ServiceParams{
 		Logger:                   s.GetLogger(),
 		Config:                   s.GetConfig(),
@@ -566,6 +577,7 @@ func (s *WalletServiceSuite) setupTestData() {
 func (s *WalletServiceSuite) setupWallet() {
 	s.GetStores().WalletRepo.(*testutil.InMemoryWalletStore).Clear()
 	s.GetStores().PaymentRepo.(*testutil.InMemoryPaymentStore).Clear()
+	s.GetStores().CheckoutSessionRepo.(*testutil.InMemoryCheckoutSessionStore).Clear()
 
 	s.testData.wallet = &wallet.Wallet{
 		ID:                  "wallet-1",

--- a/internal/ee/service/wallet_topup_checkout_test.go
+++ b/internal/ee/service/wallet_topup_checkout_test.go
@@ -1,0 +1,268 @@
+package service
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+func (s *WalletServiceSuite) checkoutParamsRazorpay() *dto.CheckoutParams {
+	return &dto.CheckoutParams{
+		PaymentParams: dto.PaymentParams{
+			PaymentProvider: types.CheckoutPaymentProviderRazorpay,
+		},
+	}
+}
+
+func (s *WalletServiceSuite) seedPendingWalletTopupCheckout(walletID string, idempotencyKey *string) *domainCheckout.CheckoutSession {
+	ctx := s.GetContext()
+	session := &domainCheckout.CheckoutSession{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CHECKOUT_SESSION),
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		CustomerID:      s.testData.customer.ID,
+		Action:          types.CheckoutActionWalletTopup,
+		CheckoutStatus:  types.CheckoutStatusPending,
+		PaymentProvider: types.CheckoutPaymentProviderRazorpay,
+		Configuration: domainCheckout.ToJSONBCheckoutConfiguration(types.CheckoutConfiguration{
+			WalletTopupParams: &types.WalletTopupParams{WalletID: walletID},
+		}),
+		IdempotencyKey: idempotencyKey,
+		ExpiresAt:      time.Now().UTC().Add(time.Hour),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().CheckoutSessionRepo.Create(ctx, session))
+	return session
+}
+
+func (s *WalletServiceSuite) TestTopUpWallet_InvoicedNoCheckout_RegressionPending() {
+	s.seedAutoComplete(false)
+	ctx := s.GetContext()
+	balanceBefore := s.testData.wallet.CreditBalance
+
+	resp, err := s.service.TopUpWallet(ctx, s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		IdempotencyKey:    lo.ToPtr("topup-invoiced-no-checkout"),
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Nil(resp.CheckoutSession)
+	s.Require().NotNil(resp.WalletTransaction)
+	s.Equal(types.TransactionStatusPending, resp.WalletTransaction.TxStatus)
+	s.Require().NotNil(resp.InvoiceID)
+	s.True(balanceBefore.Equal(resp.Wallet.CreditBalance), "pay-later without auto-complete must not credit balance")
+}
+
+func (s *WalletServiceSuite) TestTopUpWallet_CheckoutWrongReason_Rejected() {
+	ctx := s.GetContext()
+	balanceBefore := s.testData.wallet.CreditBalance
+
+	_, err := s.service.TopUpWallet(ctx, s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		Checkout:          s.checkoutParamsRazorpay(),
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "checkout is only supported for PURCHASED_CREDIT_INVOICED")
+
+	w, err := s.GetStores().WalletRepo.GetWalletByID(ctx, s.testData.wallet.ID)
+	s.Require().NoError(err)
+	s.True(balanceBefore.Equal(w.CreditBalance))
+
+	sessions, err := s.GetStores().CheckoutSessionRepo.List(ctx, &types.CheckoutSessionFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		CustomerIDs: []string{s.testData.customer.ID},
+		Actions:     []types.CheckoutAction{types.CheckoutActionWalletTopup},
+	})
+	s.Require().NoError(err)
+	s.Empty(sessions)
+}
+
+func (s *WalletServiceSuite) TestTopUpWallet_CheckoutConcurrentGuard() {
+	s.seedAutoComplete(false)
+	ctx := s.GetContext()
+	s.seedPendingWalletTopupCheckout(s.testData.wallet.ID, nil)
+
+	filter := types.NewNoLimitInvoiceFilter()
+	filter.CustomerID = s.testData.customer.ID
+	before, err := s.GetStores().InvoiceRepo.List(ctx, filter)
+	s.Require().NoError(err)
+
+	_, err = s.service.TopUpWallet(ctx, s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		Checkout:          s.checkoutParamsRazorpay(),
+		IdempotencyKey:    lo.ToPtr("topup-checkout-concurrent"),
+	})
+	s.Require().Error(err)
+	s.True(ierr.IsAlreadyExists(err), "expected concurrent guard AlreadyExists, got %v", err)
+
+	after, err := s.GetStores().InvoiceRepo.List(ctx, filter)
+	s.Require().NoError(err)
+	s.Equal(len(before), len(after), "guard must reject before creating a credit-purchase draft")
+}
+
+func (s *WalletServiceSuite) TestTopUpWallet_CheckoutSessionCreateFailureArchivesDraft() {
+	s.seedAutoComplete(false)
+	ctx := s.GetContext()
+
+	// Same customer + checkout idempotency key, different wallet in config so the
+	// concurrent guard does not fire — only session Create's idempotency check fails
+	// after the draft invoice is created.
+	idempKey := "wallet-topup-orphan-idemp-key"
+	otherWalletID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET)
+	s.seedPendingWalletTopupCheckout(otherWalletID, &idempKey)
+
+	filter := types.NewNoLimitInvoiceFilter()
+	filter.CustomerID = s.testData.customer.ID
+	before, err := s.GetStores().InvoiceRepo.List(ctx, filter)
+	s.Require().NoError(err)
+
+	checkout := s.checkoutParamsRazorpay()
+	checkout.IdempotencyKey = &idempKey
+
+	_, err = s.service.TopUpWallet(ctx, s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100),
+		TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+		Checkout:          checkout,
+		IdempotencyKey:    lo.ToPtr("wallet-tx-orphan-1"),
+	})
+	s.Require().Error(err)
+	s.True(ierr.IsAlreadyExists(err), "expected session create AlreadyExists, got %v", err)
+
+	after, err := s.GetStores().InvoiceRepo.List(ctx, filter)
+	s.Require().NoError(err)
+	s.Equal(len(before), len(after), "draft invoice must be archived when session create fails")
+}
+
+func (s *WalletServiceSuite) TestHandlePurchasedCreditInvoiced_PayFirstForcesPendingDespiteAutoComplete() {
+	s.seedAutoComplete(true)
+	ctx := s.GetContext()
+	balanceBefore := s.testData.wallet.CreditBalance
+	ws := s.service.(*walletService)
+
+	txID, invID, err := ws.handlePurchasedCreditInvoicedTransaction(
+		ctx,
+		s.testData.wallet.ID,
+		lo.ToPtr("payfirst-force-pending"),
+		&dto.TopUpWalletRequest{
+			CreditsToAdd:      decimal.NewFromInt(250),
+			TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+			Checkout:          s.checkoutParamsRazorpay(),
+		},
+	)
+	s.Require().NoError(err)
+
+	tx, err := s.GetStores().WalletRepo.GetTransactionByID(ctx, txID)
+	s.Require().NoError(err)
+	s.Equal(types.TransactionStatusPending, tx.TxStatus)
+
+	invSvc := NewInvoiceService(s.buildServiceParams())
+	inv, err := invSvc.GetInvoice(ctx, invID)
+	s.Require().NoError(err)
+	s.Equal(types.InvoiceStatusDraft, inv.InvoiceStatus)
+	s.Equal(txID, inv.Metadata["wallet_transaction_id"])
+
+	w, err := s.GetStores().WalletRepo.GetWalletByID(ctx, s.testData.wallet.ID)
+	s.Require().NoError(err)
+	s.True(balanceBefore.Equal(w.CreditBalance), "pay-first must not credit before payment")
+}
+
+func (s *WalletServiceSuite) TestCompleteWalletTopupCheckout_CreditsWalletAndBonus() {
+	s.seedAutoComplete(false)
+	ctx := s.GetContext()
+	balanceBefore := s.testData.wallet.CreditBalance
+	credits := decimal.NewFromInt(500)
+	bonus := decimal.NewFromInt(50)
+	params := s.buildServiceParams()
+	ws := s.service.(*walletService)
+
+	txID, invID, err := ws.handlePurchasedCreditInvoicedTransaction(
+		ctx,
+		s.testData.wallet.ID,
+		lo.ToPtr("payfirst-complete-bonus"),
+		&dto.TopUpWalletRequest{
+			CreditsToAdd:      credits,
+			BonusCreditsToAdd: &bonus,
+			TransactionReason: types.TransactionReasonPurchasedCreditInvoiced,
+			Checkout:          s.checkoutParamsRazorpay(),
+		},
+	)
+	s.Require().NoError(err)
+
+	invSvc := NewInvoiceService(params)
+	draftInv, err := invSvc.GetInvoice(ctx, invID)
+	s.Require().NoError(err)
+	s.Equal(types.InvoiceStatusDraft, draftInv.InvoiceStatus)
+
+	checkoutSvc := &checkoutSessionService{ServiceParams: params}
+	payResp, err := checkoutSvc.createCheckoutPayment(ctx, &draftInv.Invoice, types.CheckoutPaymentProviderRazorpay)
+	s.Require().NoError(err)
+
+	session := &domainCheckout.CheckoutSession{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CHECKOUT_SESSION),
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		CustomerID:      s.testData.customer.ID,
+		Action:          types.CheckoutActionWalletTopup,
+		CheckoutStatus:  types.CheckoutStatusPending,
+		PaymentProvider: types.CheckoutPaymentProviderRazorpay,
+		Configuration: domainCheckout.ToJSONBCheckoutConfiguration(types.CheckoutConfiguration{
+			WalletTopupParams: &types.WalletTopupParams{
+				WalletID:            s.testData.wallet.ID,
+				WalletTransactionID: txID,
+			},
+		}),
+		CheckoutInvoiceID: &invID,
+		CheckoutPaymentID: &payResp.ID,
+		ExpiresAt:         time.Now().UTC().Add(time.Hour),
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().CheckoutSessionRepo.Create(ctx, session))
+
+	err = checkoutSvc.CompleteCheckoutSession(ctx, session.ID, &types.CheckoutProviderResult{
+		ProviderPaymentIntentID: "pay_wallet_topup_test_001",
+	})
+	s.Require().NoError(err)
+
+	purchaseTx, err := s.GetStores().WalletRepo.GetTransactionByID(ctx, txID)
+	s.Require().NoError(err)
+	s.Equal(types.TransactionStatusCompleted, purchaseTx.TxStatus)
+
+	filter := types.NewWalletTransactionFilter()
+	filter.WalletID = &s.testData.wallet.ID
+	txs, err := s.GetStores().WalletRepo.ListWalletTransactions(ctx, filter)
+	s.Require().NoError(err)
+	var foundBonus bool
+	for _, tx := range txs {
+		if tx.ParentTransactionID == txID && tx.TransactionReason == types.TransactionReasonPurchasedCreditBonus {
+			s.Equal(types.TransactionStatusCompleted, tx.TxStatus)
+			s.True(bonus.Equal(tx.CreditAmount))
+			foundBonus = true
+			break
+		}
+	}
+	s.True(foundBonus, "expected completed bonus child")
+
+	w, err := s.GetStores().WalletRepo.GetWalletByID(ctx, s.testData.wallet.ID)
+	s.Require().NoError(err)
+	expected := balanceBefore.Add(credits).Add(bonus)
+	s.True(expected.Equal(w.CreditBalance), "expected credit balance %s, got %s", expected, w.CreditBalance)
+
+	finalInv, err := invSvc.GetInvoice(ctx, invID)
+	s.Require().NoError(err)
+	s.Equal(types.InvoiceStatusFinalized, finalInv.InvoiceStatus)
+
+	paySvc := NewPaymentService(params)
+	finalPay, err := paySvc.GetPayment(ctx, payResp.ID)
+	s.Require().NoError(err)
+	s.Equal(types.PaymentStatusSucceeded, finalPay.PaymentStatus)
+
+	completed, err := s.GetStores().CheckoutSessionRepo.Get(ctx, session.ID)
+	s.Require().NoError(err)
+	s.Equal(types.CheckoutStatusCompleted, completed.CheckoutStatus)
+}

--- a/internal/integration/razorpay/autocharge_token_selection_test.go
+++ b/internal/integration/razorpay/autocharge_token_selection_test.go
@@ -29,7 +29,7 @@ func TestSelectAutoChargeToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := selectAutoChargeToken(tt.tokens, decimal.NewFromInt(100))
+			got, ok := selectAutoChargeToken(tt.tokens, "", decimal.NewFromInt(100))
 			assert.Equal(t, tt.wantFound, ok)
 			if tt.wantFound {
 				assert.Equal(t, tt.wantID, got.GatewayMethodID)

--- a/internal/integration/razorpay/customer.go
+++ b/internal/integration/razorpay/customer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
 
 // RazorpayCustomerService defines the interface for Razorpay customer operations
@@ -19,6 +20,7 @@ type RazorpayCustomerService interface {
 	SyncCustomerToRazorpay(ctx context.Context, flexpriceCustomer *customer.Customer) (string, error)
 	GetRazorpayCustomerID(ctx context.Context, customerID string) (string, error)
 	UpdateRazorpayCustomerNotes(ctx context.Context, razorpayCustomerID string, notes map[string]interface{}) error
+	ListConfirmedCustomerTokens(ctx context.Context, customerID string) (razorpayCustomerID string, tokens []*interfaces.ProviderPaymentMethod, err error)
 }
 
 // CustomerService handles Razorpay customer operations
@@ -264,6 +266,29 @@ func (s *CustomerService) GetRazorpayCustomerID(ctx context.Context, customerID 
 	}
 
 	return mappings[0].ProviderEntityID, nil
+}
+
+// ListConfirmedCustomerTokens resolves the Razorpay customer ID and returns
+// confirmed tokens normalized to ProviderPaymentMethod.
+func (s *CustomerService) ListConfirmedCustomerTokens(
+	ctx context.Context,
+	customerID string,
+) (string, []*interfaces.ProviderPaymentMethod, error) {
+	razorpayCustomerID, err := s.GetRazorpayCustomerID(ctx, customerID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	rawTokens, err := s.client.GetCustomerTokens(ctx, razorpayCustomerID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	tokens := lo.FilterMap(rawTokens, func(raw map[string]interface{}, _ int) (*interfaces.ProviderPaymentMethod, bool) {
+		pm, normErr := NormalizeRazorpayToken(raw)
+		return pm, normErr == nil && pm != nil
+	})
+	return razorpayCustomerID, tokens, nil
 }
 
 // mergeCustomerMetadata merges new metadata with existing customer metadata

--- a/internal/integration/razorpay/invoice.go
+++ b/internal/integration/razorpay/invoice.go
@@ -187,25 +187,6 @@ func (s *InvoiceSyncService) findOrCreateAutoChargePayment(
 	return newPayment, false, nil
 }
 
-// autoChargeMethodPriority is the order tokens are tried for auto-charge.
-var autoChargeMethodPriority = []types.PaymentMethodType{
-	types.PaymentMethodTypeCard,
-	types.PaymentMethodTypeUPI,
-}
-
-// selectAutoChargeToken finds the first usable token across autoChargeMethodPriority.
-func selectAutoChargeToken(
-	tokens []*interfaces.ProviderPaymentMethod,
-	invoiceTotal decimal.Decimal,
-) (*interfaces.ProviderPaymentMethod, bool) {
-	for _, method := range autoChargeMethodPriority {
-		if token, ok := SelectUsableToken(tokens, method, invoiceTotal); ok {
-			return token, true
-		}
-	}
-	return nil, false
-}
-
 // tryAutoCharge resolves the customer's Razorpay tokens; if a usable token
 // exists it calls executeAutoCharge and returns (true, nil). If token probing
 // fails for any reason it logs and returns (false, nil) so the caller falls
@@ -221,26 +202,14 @@ func (s *InvoiceSyncService) tryAutoCharge(
 		return false, nil
 	}
 
-	razorpayCustomerID, err := s.customerSvc.GetRazorpayCustomerID(ctx, inv.CustomerID)
+	razorpayCustomerID, tokens, err := s.customerSvc.ListConfirmedCustomerTokens(ctx, inv.CustomerID)
 	if err != nil {
-		s.logger.Info(ctx, "failed to resolve Razorpay customer ID, falling through to send invoice",
+		s.logger.Info(ctx, "failed to resolve Razorpay customer tokens, falling through to send invoice",
 			"invoice_id", inv.ID, "customer_id", inv.CustomerID, "error", err)
 		return false, nil
 	}
 
-	rawTokens, err := s.client.GetCustomerTokens(ctx, razorpayCustomerID)
-	if err != nil {
-		s.logger.Info(ctx, "failed to list customer tokens, falling through to send invoice",
-			"invoice_id", inv.ID, "error", err)
-		return false, nil
-	}
-
-	tokens := lo.FilterMap(rawTokens, func(raw map[string]interface{}, _ int) (*interfaces.ProviderPaymentMethod, bool) {
-		pm, normErr := NormalizeRazorpayToken(raw)
-		return pm, normErr == nil && pm != nil
-	})
-
-	token, ok := selectAutoChargeToken(tokens, inv.AmountRemaining)
+	token, ok := selectAutoChargeToken(tokens, "", inv.AmountRemaining)
 	if !ok {
 		s.logger.Debug(ctx, "no usable token found for any supported method, falling through to send invoice",
 			"invoice_id", inv.ID, "customer_id", inv.CustomerID,

--- a/internal/integration/razorpay/mandate.go
+++ b/internal/integration/razorpay/mandate.go
@@ -170,3 +170,46 @@ func (a *CheckoutAdapter) CreateAuthorizationLink(
 		NextAction:        types.PaymentAction{Type: types.PaymentActionTypePaymentLink, URL: shortURL},
 	}, nil
 }
+
+// TryAutoChargingSavedMethod implements interfaces.CheckoutProvider by delegating
+// to PaymentService.ChargeSavedToken and mapping into CheckoutProviderResponse.
+func (a *CheckoutAdapter) TryAutoChargingSavedMethod(
+	ctx context.Context,
+	req interfaces.AuthorizationLinkRequest,
+) (*interfaces.CheckoutProviderResponse, bool, error) {
+	if a == nil || a.Svc == nil || a.CustomerSvc == nil {
+		return nil, false, nil
+	}
+
+	custResp, err := a.CustomerSvc.GetCustomer(ctx, req.CustomerID)
+	if err != nil || custResp == nil || custResp.Customer == nil {
+		a.Svc.logger.Info(ctx, "checkout auto-charge: failed to load customer, falling back to auth link",
+			"customer_id", req.CustomerID, "error", err)
+		return nil, false, nil
+	}
+
+	result, charged, err := a.Svc.ChargeSavedToken(ctx, ChargeSavedTokenRequest{
+		Customer:           custResp.Customer,
+		InvoiceID:          req.InvoiceID,
+		Amount:             req.Amount,
+		Currency:           req.Currency,
+		FlexPricePaymentID: req.PaymentID,
+		PreferredMethod:    req.PreferredMethod,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if !charged || result == nil {
+		return nil, false, nil
+	}
+
+	sessionID := result.RazorpayOrderID
+	if sessionID == "" {
+		sessionID = result.RazorpayPaymentID
+	}
+	return &interfaces.CheckoutProviderResponse{
+		ProviderSessionID:       sessionID,
+		ProviderPaymentIntentID: result.RazorpayPaymentID,
+		// No NextAction — off-session charge; completion via payment webhook.
+	}, true, nil
+}

--- a/internal/integration/razorpay/payment.go
+++ b/internal/integration/razorpay/payment.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/cache"
+	"github.com/flexprice/flexprice/internal/domain/customer"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -33,6 +34,16 @@ type AutoChargeResult struct {
 	RazorpayPaymentID string // may be empty if the payment was already in-flight (AlreadySubmitted=true)
 	RazorpayOrderID   string // Razorpay order_xxx — always populated when a new or existing order was resolved
 	AlreadySubmitted  bool   // true = payment was previously submitted; webhook will reconcile
+}
+
+// ChargeSavedTokenRequest is the input for PaymentService.ChargeSavedToken.
+type ChargeSavedTokenRequest struct {
+	Customer           *customer.Customer
+	InvoiceID          string
+	Amount             decimal.Decimal
+	Currency           string
+	FlexPricePaymentID string
+	PreferredMethod    types.PaymentMethodType // empty = Card then UPI
 }
 
 // PaymentLinkStatus captures the fields the FlexPrice sync path needs from a
@@ -768,6 +779,88 @@ func extractPaymentMethodID(payment map[string]interface{}, method string) strin
 		}
 	}
 	return ""
+}
+
+// selectAutoChargeToken finds the first usable token. When preferred is set only
+// that method is tried; otherwise Card then UPI.
+func selectAutoChargeToken(
+	tokens []*interfaces.ProviderPaymentMethod,
+	preferred types.PaymentMethodType,
+	amount decimal.Decimal,
+) (*interfaces.ProviderPaymentMethod, bool) {
+	priority := []types.PaymentMethodType{
+		types.PaymentMethodTypeCard,
+		types.PaymentMethodTypeUPI,
+	}
+	if preferred != "" {
+		priority = []types.PaymentMethodType{preferred}
+	}
+
+	for _, method := range priority {
+		if token, ok := SelectUsableToken(tokens, method, amount); ok {
+			return token, true
+		}
+	}
+
+	return nil, false
+}
+
+// ChargeSavedToken selects a confirmed token for an already-mapped Razorpay
+// customer and submits AutoCharge.
+func (s *PaymentService) ChargeSavedToken(
+	ctx context.Context,
+	req ChargeSavedTokenRequest,
+) (*AutoChargeResult, bool, error) {
+	if s == nil || req.Customer == nil || req.Customer.ID == "" {
+		return nil, false, nil
+	}
+
+	razorpayCustomerID, tokens, err := s.customerSvc.ListConfirmedCustomerTokens(ctx, req.Customer.ID)
+	if err != nil {
+		s.logger.Info(ctx, "charge saved token: list tokens failed",
+			"customer_id", req.Customer.ID, "invoice_id", req.InvoiceID, "error", err)
+		return nil, false, nil
+	}
+
+	token, ok := selectAutoChargeToken(tokens, req.PreferredMethod, req.Amount)
+	if !ok {
+		s.logger.Info(ctx, "charge saved token: no usable token",
+			"customer_id", req.Customer.ID,
+			"invoice_id", req.InvoiceID,
+			"amount", req.Amount.String(),
+			"preferred_method", req.PreferredMethod,
+			"tokens_inspected", len(tokens))
+		return nil, false, nil
+	}
+
+	var contact string
+	if req.Customer.Contact != nil {
+		contact = *req.Customer.Contact
+	}
+
+	result, err := s.AutoCharge(ctx, AutoChargeRequest{
+		InvoiceID:          req.InvoiceID,
+		RazorpayCustomerID: razorpayCustomerID,
+		TokenID:            token.GatewayMethodID,
+		Amount:             req.Amount,
+		Currency:           req.Currency,
+		FlexPricePaymentID: req.FlexPricePaymentID,
+		Contact:            contact,
+		Email:              req.Customer.Email,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	s.logger.Info(ctx, "charge saved token: submitted",
+		"invoice_id", req.InvoiceID,
+		"token_id", token.GatewayMethodID,
+		"method", token.Method,
+		"razorpay_payment_id", result.RazorpayPaymentID,
+		"already_submitted", result.AlreadySubmitted,
+	)
+
+	return result, true, nil
 }
 
 // AutoCharge submits a server-initiated (off-session) recurring charge against an

--- a/internal/interfaces/checkout_provider.go
+++ b/internal/interfaces/checkout_provider.go
@@ -17,6 +17,11 @@ type CheckoutProvider interface {
 	// invoice as part of the same authorization. Unsupported providers return an
 	// error marked ierr.ErrNotImplemented.
 	CreateAuthorizationLink(ctx context.Context, req AuthorizationLinkRequest) (*CheckoutProviderResponse, error)
+
+	// TryAutoChargingSavedMethod attempts an off-session charge against a previously
+	// registered instrument. charged=false means no usable method (caller should
+	// fall back to CreateAuthorizationLink). A hard provider error is returned as err.
+	TryAutoChargingSavedMethod(ctx context.Context, req AuthorizationLinkRequest) (resp *CheckoutProviderResponse, charged bool, err error)
 }
 
 // CheckoutProviderRequest is the unified input for all checkout provider adapters.

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -228,6 +228,9 @@ type CheckoutSessionService interface {
 	// CompleteCheckoutSession activates the subscription, finalizes the invoice, and marks
 	// the payment succeeded. Called by gateway webhook handlers after payment confirmation.
 	CompleteCheckoutSession(ctx context.Context, sessionID string, providerResult *types.CheckoutProviderResult) error
+	// StartPayFirstCheckoutSession creates a checkout session on an existing DRAFT invoice,
+	// fulfills payment + provider link, and publishes checkout.session.initiated.
+	StartPayFirstCheckoutSession(ctx context.Context, req *dto.PayFirstCheckoutRequest) (*dto.CheckoutSessionResponse, error)
 }
 
 type ServiceDependencies struct {

--- a/internal/repository/ent/checkout_session.go
+++ b/internal/repository/ent/checkout_session.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"github.com/flexprice/flexprice/ent"
 	entCheckout "github.com/flexprice/flexprice/ent/checkoutsession"
+	"github.com/flexprice/flexprice/ent/predicate"
 	entSchema "github.com/flexprice/flexprice/ent/schema"
 	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -431,6 +434,26 @@ func (o CheckoutSessionQueryOptions) applyEntityQueryOptions(_ context.Context, 
 	}
 	if len(f.CheckoutPaymentIDs) > 0 {
 		query = query.Where(entCheckout.CheckoutPaymentIDIn(f.CheckoutPaymentIDs...))
+	}
+	if !f.Configuration.IsEmpty() {
+		if f.Configuration.WalletID != "" {
+			query = query.Where(predicate.CheckoutSession(func(s *sql.Selector) {
+				s.Where(sqljson.ValueEQ(
+					entCheckout.FieldConfiguration,
+					f.Configuration.WalletID,
+					sqljson.Path("wallet_topup_params", "wallet_id"),
+				))
+			}))
+		}
+		if f.Configuration.SubscriptionID != "" {
+			query = query.Where(predicate.CheckoutSession(func(s *sql.Selector) {
+				s.Where(sqljson.ValueEQ(
+					entCheckout.FieldConfiguration,
+					f.Configuration.SubscriptionID,
+					sqljson.Path("modify_subscription_params", "subscription_id"),
+				))
+			}))
+		}
 	}
 	return query, nil
 }

--- a/internal/testutil/inmemory_checkout_session_store.go
+++ b/internal/testutil/inmemory_checkout_session_store.go
@@ -91,6 +91,27 @@ func checkoutSessionFilterFn(ctx context.Context, session *domainCheckout.Checko
 			return false
 		}
 	}
+	if cfg := filter.Configuration; cfg != nil && !cfg.IsEmpty() {
+		sessionCfg := session.Configuration.ToCheckoutConfiguration()
+		if cfg.WalletID != "" {
+			if sessionCfg.WalletTopupParams == nil || sessionCfg.WalletTopupParams.WalletID != cfg.WalletID {
+				return false
+			}
+		}
+		if cfg.SubscriptionID != "" {
+			if sessionCfg.ModifySubscriptionParams == nil || sessionCfg.ModifySubscriptionParams.SubscriptionID != cfg.SubscriptionID {
+				return false
+			}
+		}
+	}
+	// Mirror Ent ApplyStatusFilter: empty status defaults to published.
+	status := filter.GetStatus()
+	if status == "" {
+		status = string(types.StatusPublished)
+	}
+	if session.Status != types.Status(status) {
+		return false
+	}
 	return true
 }
 

--- a/internal/types/checkout.go
+++ b/internal/types/checkout.go
@@ -43,6 +43,7 @@ type CheckoutAction string
 const (
 	CheckoutActionCreateSubscription CheckoutAction = "create_subscription"
 	CheckoutActionModifySubscription CheckoutAction = "modify_subscription"
+	CheckoutActionWalletTopup        CheckoutAction = "wallet_topup"
 )
 
 func (a CheckoutAction) String() string { return string(a) }
@@ -51,10 +52,11 @@ func (a CheckoutAction) Validate() error {
 	allowed := []CheckoutAction{
 		CheckoutActionCreateSubscription,
 		CheckoutActionModifySubscription,
+		CheckoutActionWalletTopup,
 	}
 	if a != "" && !lo.Contains(allowed, a) {
 		return ierr.NewError("invalid checkout action").
-			WithHint("Allowed values: create_subscription, modify_subscription").
+			WithHint("Allowed values: create_subscription, modify_subscription, wallet_topup").
 			WithReportableDetails(map[string]any{"allowed_values": allowed}).
 			Mark(ierr.ErrValidation)
 	}
@@ -123,17 +125,37 @@ type PaymentAction struct {
 
 type CheckoutSessionFilter struct {
 	*QueryFilter
-	CustomerIDs        []string                  `json:"customer_ids,omitempty"`
-	Actions            []CheckoutAction          `json:"actions,omitempty"`
-	PaymentProviders   []CheckoutPaymentProvider `json:"payment_providers,omitempty"`
-	CheckoutStatuses   []CheckoutStatus          `json:"checkout_statuses,omitempty"`
-	ExpiresAtLT        *time.Time                `json:"expires_at_lt,omitempty"`
-	CheckoutInvoiceIDs []string                  `json:"checkout_invoice_ids,omitempty"`
-	CheckoutPaymentIDs []string                  `json:"checkout_payment_ids,omitempty"`
+	CustomerIDs        []string                      `json:"customer_ids,omitempty"`
+	Actions            []CheckoutAction              `json:"actions,omitempty"`
+	PaymentProviders   []CheckoutPaymentProvider     `json:"payment_providers,omitempty"`
+	CheckoutStatuses   []CheckoutStatus              `json:"checkout_statuses,omitempty"`
+	ExpiresAtLT        *time.Time                    `json:"expires_at_lt,omitempty"`
+	CheckoutInvoiceIDs []string                      `json:"checkout_invoice_ids,omitempty"`
+	CheckoutPaymentIDs []string                      `json:"checkout_payment_ids,omitempty"`
+	Configuration      *CheckoutConfigurationFilter  `json:"configuration,omitempty"`
+}
+
+// CheckoutConfigurationFilter matches fields inside checkout_sessions.configuration
+// JSONB. Each non-empty field is ANDed as a path equality predicate.
+type CheckoutConfigurationFilter struct {
+	WalletID       string `json:"wallet_id,omitempty"`
+	SubscriptionID string `json:"subscription_id,omitempty"`
+}
+
+func (f *CheckoutConfigurationFilter) IsEmpty() bool {
+	return f == nil || (f.WalletID == "" && f.SubscriptionID == "")
 }
 
 func NewDefaultCheckoutSessionFilter() *CheckoutSessionFilter {
 	return &CheckoutSessionFilter{QueryFilter: NewDefaultQueryFilter()}
+}
+
+func (f *CheckoutSessionFilter) GetStatus() string {
+	if f == nil || f.QueryFilter == nil {
+		return ""
+	}
+
+	return f.QueryFilter.GetStatus()
 }
 
 func (f *CheckoutSessionFilter) Validate() error {

--- a/internal/types/checkout_configuration.go
+++ b/internal/types/checkout_configuration.go
@@ -4,12 +4,14 @@ import (
 	"time"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/validator"
 	"github.com/shopspring/decimal"
 )
 
 type CheckoutConfiguration struct {
 	CreateSubscriptionParams *CreateSubscriptionParams `json:"create_subscription_params,omitempty"`
 	ModifySubscriptionParams *ModifySubscriptionParams `json:"modify_subscription_params,omitempty"`
+	WalletTopupParams        *WalletTopupParams        `json:"wallet_topup_params,omitempty"`
 }
 
 // Validate validates that the configuration holds all required fields
@@ -31,6 +33,13 @@ func (c *CheckoutConfiguration) Validate(action CheckoutAction) error {
 				Mark(ierr.ErrValidation)
 		}
 		return c.ModifySubscriptionParams.Validate()
+	case CheckoutActionWalletTopup:
+		if c.WalletTopupParams == nil {
+			return ierr.NewError("wallet_topup_params is required for wallet_topup action").
+				WithHint("Provide wallet_topup_params in configuration").
+				Mark(ierr.ErrValidation)
+		}
+		return c.WalletTopupParams.Validate()
 	}
 	return nil
 }
@@ -126,6 +135,22 @@ func (p *ModifySubscriptionParams) Validate() error {
 	return nil
 }
 
+// WalletTopupParams is persisted on checkout sessions for payment-gated wallet
+// top-ups. Credits are applied on payment success via invoice metadata
+// (wallet_transaction_id), not by re-running top-up from this config.
+type WalletTopupParams struct {
+	WalletID            string `json:"wallet_id" validate:"required"`
+	WalletTransactionID string `json:"wallet_transaction_id,omitempty"`
+}
+
+func (p *WalletTopupParams) Validate() error {
+	if p == nil {
+		return ierr.NewError("wallet_topup_params is required").
+			Mark(ierr.ErrValidation)
+	}
+	return validator.ValidateRequest(p)
+}
+
 // ── JSONB result structs ──────────────────────────────────────────────────────
 
 type CheckoutResult struct {
@@ -185,6 +210,8 @@ func (c *CheckoutPaymentProviderConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
+
+	// PaymentMethod is optional (empty = provider picks / tries saved methods in order).
 	if c.PaymentMethod != "" {
 		if err := c.PaymentMethod.Validate(); err != nil {
 			return err


### PR DESCRIPTION
Reverts flexprice/flexprice#2369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in pay-first checkout flow for wallet top-ups.
  * Wallet top-ups can now return a checkout session and payment link.
  * Added support for automatically charging eligible saved payment methods.
  * Checkout completion now finalizes wallet top-ups and applies wallet and bonus credits.
  * Added safeguards against duplicate pending checkout sessions.

* **Bug Fixes**
  * Improved cleanup when checkout or payment setup fails.
  * Preserved existing wallet top-up behavior when checkout is not requested.

* **Documentation**
  * Added design documentation covering the pay-first wallet top-up flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->