### PR TITLE
 feat(subscription): add one time charges

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3719,13 +3719,17 @@ func (s *subscriptionService) ValidateAndFilterPricesForSubscription(
 	var pricesResponse *dto.ListPricesResponse
 	var err error
 
-	if entityType == types.PRICE_ENTITY_TYPE_PLAN {
+	switch entityType {
+	case types.PRICE_ENTITY_TYPE_PLAN:
 		pricesResponse, err = priceService.GetPricesByPlanID(ctx, dto.GetPricesByPlanRequest{
-			PlanID:         entityID,
-			AllowExpired:   false,
-			BillingPeriods: []types.BillingPeriod{subscription.BillingPeriod},
+			PlanID:       entityID,
+			AllowExpired: false,
+			BillingPeriods: []types.BillingPeriod{
+				subscription.BillingPeriod,
+				types.BILLING_PERIOD_ONETIME,
+			},
 		})
-	} else if entityType == types.PRICE_ENTITY_TYPE_ADDON {
+	case types.PRICE_ENTITY_TYPE_ADDON:
 		pricesResponse, err = priceService.GetPricesByAddonID(ctx, entityID)
 	}
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3731,6 +3731,13 @@ func (s *subscriptionService) ValidateAndFilterPricesForSubscription(
 		})
 	case types.PRICE_ENTITY_TYPE_ADDON:
 		pricesResponse, err = priceService.GetPricesByAddonID(ctx, entityID)
+	default:
+		return nil, ierr.NewError("unsupported price entity type").
+			WithHint("Only PLAN and ADDON entity types are supported for subscription prices").
+			WithReportableDetails(map[string]interface{}{
+				"entity_type": entityType,
+			}).
+			Mark(ierr.ErrValidation)
 	}
 
 	if err != nil {

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -110,6 +110,38 @@ func (s *SubscriptionServiceSuite) TestPaymentBehaviorValidation() {
 	}
 }
 
+func (s *SubscriptionServiceSuite) TestValidateAndFilterPricesForSubscriptionRejectsUnsupportedEntityTypes() {
+	tests := []struct {
+		name       string
+		entityType types.PriceEntityType
+	}{
+		{
+			name:       "empty",
+			entityType: "",
+		},
+		{
+			name:       "subscription",
+			entityType: types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			_, err := s.service.(*subscriptionService).ValidateAndFilterPricesForSubscription(
+				s.GetContext(),
+				"entity_123",
+				tc.entityType,
+				nil,
+				nil,
+			)
+
+			s.Error(err)
+			s.True(ierr.IsValidation(err))
+			s.Contains(err.Error(), "unsupported price entity type")
+		})
+	}
+}
+
 // A recurring credit grant sourced from a ONETIME (time-bounded) addon must be
 // capped at the addon association's end date, not the subscription end date, so
 // the grant stops applying once the addon's single period is over.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan subscriptions now correctly include eligible one-time prices in addition to prices matching the subscription’s billing period.
  * Add-on price handling continues to work as expected.
* **Tests**
  * Added coverage to ensure unsupported price entity types are rejected with a validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->