### PR TITLE
feat(subscription): Allow overage to be 1

### DIFF
--- a/internal/api/dto/costsheet_analytics.go
+++ b/internal/api/dto/costsheet_analytics.go
@@ -24,6 +24,8 @@ type GetCostAnalyticsRequest struct {
 
 	// Expand options - specify which entities to expand
 	Expand []string `json:"expand,omitempty"` // "meter", "price"
+	// Property filters to filter the events by the keys in `properties` field of the event
+	PropertyFilters map[string][]string `json:"property_filters,omitempty"`
 
 	// Pagination
 	Limit  int `json:"limit,omitempty"`

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -216,15 +216,16 @@ func (c *LineItemCommitmentConfig) Validate() error {
 		}
 	}
 
-	// Rule 3: Overage factor is required and must be greater than 1.0 when commitment is set
+	// Rule 3: Overage factor is required and must be at least 1.0 when commitment is set.
+	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
 	if c.OverageFactor == nil {
 		return ierr.NewError("overage_factor is required when commitment is set").
-			WithHint("Specify an overage_factor greater than 1.0").
+			WithHint("Specify an overage_factor of 1.0 or greater").
 			Mark(ierr.ErrValidation)
 	}
 
-	if c.OverageFactor.LessThanOrEqual(decimal.NewFromInt(1)) {
-		return ierr.NewError("overage_factor must be greater than 1.0").
+	if c.OverageFactor.LessThan(decimal.NewFromInt(1)) {
+		return ierr.NewError("overage_factor must be at least 1.0").
 			WithHint("Overage factor determines the multiplier for usage beyond commitment").
 			WithReportableDetails(map[string]interface{}{
 				"overage_factor": c.OverageFactor,

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -365,15 +365,16 @@ func validateCommitmentFieldsCommon(
 		}
 	}
 
-	// Rule 5: Overage factor is required and must be greater than 1.0
+	// Rule 5: Overage factor is required and must be at least 1.0.
+	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
 	if commitmentOverageFactor == nil {
 		return ierr.NewError("commitment_overage_factor is required when commitment is set").
-			WithHint("Specify a commitment_overage_factor greater than 1.0").
+			WithHint("Specify a commitment_overage_factor of 1.0 or greater").
 			Mark(ierr.ErrValidation)
 	}
 
-	if commitmentOverageFactor.LessThanOrEqual(decimal.NewFromFloat(1)) {
-		return ierr.NewError("commitment_overage_factor must be greater than 1.0").
+	if commitmentOverageFactor.LessThan(decimal.NewFromFloat(1)) {
+		return ierr.NewError("commitment_overage_factor must be at least 1.0").
 			WithHint("Overage factor determines the multiplier for usage beyond commitment").
 			WithReportableDetails(map[string]interface{}{
 				"commitment_overage_factor": commitmentOverageFactor,

--- a/internal/api/dto/subscription_line_item_test.go
+++ b/internal/api/dto/subscription_line_item_test.go
@@ -285,3 +285,22 @@ func TestCreateSubscriptionLineItemRequest_ToSubscriptionLineItem_QuantityDefaul
 		})
 	}
 }
+
+func TestValidateCommitmentFieldsCommon_OverageFactor(t *testing.T) {
+	amount := decimal.NewFromInt(100)
+
+	t.Run("accepts overage factor of exactly 1.0", func(t *testing.T) {
+		err := validateCommitmentFieldsCommon(
+			&amount, nil, types.COMMITMENT_TYPE_AMOUNT, lo.ToPtr(decimal.NewFromInt(1)), true,
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects overage factor below 1.0", func(t *testing.T) {
+		err := validateCommitmentFieldsCommon(
+			&amount, nil, types.COMMITMENT_TYPE_AMOUNT, lo.ToPtr(decimal.NewFromFloat(0.5)), true,
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "commitment_overage_factor must be at least 1.0")
+	})
+}

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -6,8 +6,39 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
+
+func TestLineItemCommitmentConfig_Validate_OverageFactor(t *testing.T) {
+	amount := decimal.NewFromInt(100)
+
+	t.Run("accepts overage factor of exactly 1.0", func(t *testing.T) {
+		c := &LineItemCommitmentConfig{
+			CommitmentAmount: &amount,
+			CommitmentType:   types.COMMITMENT_TYPE_AMOUNT,
+			OverageFactor:    lo.ToPtr(decimal.NewFromInt(1)),
+		}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("rejects overage factor below 1.0", func(t *testing.T) {
+		c := &LineItemCommitmentConfig{
+			CommitmentAmount: &amount,
+			CommitmentType:   types.COMMITMENT_TYPE_AMOUNT,
+			OverageFactor:    lo.ToPtr(decimal.NewFromFloat(0.5)),
+		}
+		err := c.Validate()
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "overage_factor must be at least 1.0") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
 
 func baseCreateSubscriptionRequest() CreateSubscriptionRequest {
 	return CreateSubscriptionRequest{

--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -1525,7 +1525,8 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 		IncludeChildren: req.IncludeChildren,
 		// Group by meter_id so we get one row per meter (matches how the old
 		// costsheet_usage path keyed its results).
-		GroupBy: []string{"meter_id"},
+		GroupBy:         []string{"meter_id"},
+		PropertyFilters: req.PropertyFilters,
 	}
 	if cust != nil {
 		analyticsParams.ExternalCustomerID = cust.ExternalID

--- a/internal/ee/service/revenue_analytics.go
+++ b/internal/ee/service/revenue_analytics.go
@@ -38,38 +38,24 @@ func (s *revenueAnalyticsService) GetDetailedCostAnalytics(
 	}
 
 	// 1. Fetch cost analytics from the meter_usage-backed costsheet path.
-	var costAnalytics *dto.GetCostAnalyticsResponse
-	var err error
-	costAnalytics, err = s.costsheetUsageTrackingService.GetCostAnalyticsFromMeterUsage(ctx, req)
+	costAnalytics, err := s.costsheetUsageTrackingService.GetCostAnalyticsFromMeterUsage(ctx, req)
 	if err != nil {
 		s.Logger.Info(context.Background(), "failed to fetch cost analytics", "error", err)
 		costAnalytics = nil
 	}
 
 	// 2. Fetch revenue analytics from meter usage.
-	var revenueAnalytics *dto.GetUsageAnalyticsResponse
-	revenueReq := &dto.GetUsageAnalyticsRequest{
+	meterUsageService := NewMeterUsageService(s.ServiceParams)
+	revenueAnalytics, err := meterUsageService.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:           types.GetTenantID(ctx),
+		EnvironmentID:      types.GetEnvironmentID(ctx),
 		ExternalCustomerID: req.ExternalCustomerID,
 		FeatureIDs:         req.FeatureIDs,
 		StartTime:          req.StartTime,
 		EndTime:            req.EndTime,
+		Expand:             req.Expand,
+		PropertyFilters:    req.PropertyFilters,
 		IncludeChildren:    req.IncludeChildren,
-	}
-	meterUsageService := NewMeterUsageService(s.ServiceParams)
-	revenueAnalytics, err = meterUsageService.GetDetailedAnalytics(ctx, &events.MeterUsageDetailedAnalyticsParams{
-		TenantID:            types.GetTenantID(ctx),
-		EnvironmentID:       types.GetEnvironmentID(ctx),
-		ExternalCustomerID:  revenueReq.ExternalCustomerID,
-		ExternalCustomerIDs: revenueReq.ExternalCustomerIDs,
-		FeatureIDs:          revenueReq.FeatureIDs,
-		StartTime:           revenueReq.StartTime,
-		EndTime:             revenueReq.EndTime,
-		GroupBy:             revenueReq.GroupBy,
-		PropertyFilters:     revenueReq.PropertyFilters,
-		Sources:             revenueReq.Sources,
-		WindowSize:          revenueReq.WindowSize,
-		Expand:              revenueReq.Expand,
-		IncludeChildren:     revenueReq.IncludeChildren,
 	})
 	if err != nil {
 		s.Logger.Info(context.Background(), "failed to fetch revenue analytics", "error", err)

--- a/internal/ee/service/revenue_analytics.go
+++ b/internal/ee/service/revenue_analytics.go
@@ -40,7 +40,7 @@ func (s *revenueAnalyticsService) GetDetailedCostAnalytics(
 	// 1. Fetch cost analytics from the meter_usage-backed costsheet path.
 	costAnalytics, err := s.costsheetUsageTrackingService.GetCostAnalyticsFromMeterUsage(ctx, req)
 	if err != nil {
-		s.Logger.Info(context.Background(), "failed to fetch cost analytics", "error", err)
+		s.Logger.Info(ctx, "failed to fetch cost analytics", "error", err)
 		costAnalytics = nil
 	}
 
@@ -58,7 +58,7 @@ func (s *revenueAnalyticsService) GetDetailedCostAnalytics(
 		IncludeChildren:    req.IncludeChildren,
 	})
 	if err != nil {
-		s.Logger.Info(context.Background(), "failed to fetch revenue analytics", "error", err)
+		s.Logger.Info(ctx, "failed to fetch revenue analytics", "error", err)
 		revenueAnalytics = nil
 	}
 

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -700,15 +700,16 @@ func (s *subscriptionService) validateLineItemCommitment(ctx context.Context, li
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 2: Overage factor must be greater than 1.0 when commitment is set
+	// Rule 2: Overage factor must be at least 1.0 when commitment is set.
+	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
 	if lineItem.CommitmentOverageFactor == nil {
 		return ierr.NewError("commitment_overage_factor is required when commitment is set").
-			WithHint("Specify a commitment_overage_factor greater than 1.0").
+			WithHint("Specify a commitment_overage_factor of 1.0 or greater").
 			Mark(ierr.ErrValidation)
 	}
 
-	if lineItem.CommitmentOverageFactor.LessThanOrEqual(decimal.NewFromInt(1)) {
-		return ierr.NewError("commitment_overage_factor must be greater than 1.0").
+	if lineItem.CommitmentOverageFactor.LessThan(decimal.NewFromInt(1)) {
+		return ierr.NewError("commitment_overage_factor must be at least 1.0").
 			WithHint("Overage factor determines the multiplier for usage beyond commitment").
 			WithReportableDetails(map[string]interface{}{
 				"commitment_overage_factor": lineItem.CommitmentOverageFactor,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added property-based filtering to cost analytics requests, allowing events to be filtered by their properties.
* **Bug Fixes**
  * Commitment overage factors of exactly 1.0 are now accepted when commitments are configured.
  * Improved analytics processing and error logging while preserving available results when individual analytics retrievals fail.
* **Tests**
  * Added coverage for valid and invalid commitment overage-factor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->