### PR TITLE
fix(clickhouse): make the connection pool configurable (max_open_conns was a silent no-op)

### DIFF
--- a/internal/config/clickhouse_pool_test.go
+++ b/internal/config/clickhouse_pool_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+// TestClickHousePoolFromEnv guards the regression this fix closes: before
+// max_open_conns/max_idle_conns existed on ClickHouseConfig,
+// FLEXPRICE_CLICKHOUSE_MAX_OPEN_CONNS was a silent no-op and every process ran on
+// clickhouse-go's defaults (idle 5, open idle+5 = 10) — a hidden 10-query cap that
+// bottlenecks event ingest and surfaces only as client-side "acquire conn timeout".
+func TestClickHousePoolFromEnv(t *testing.T) {
+	t.Setenv("FLEXPRICE_CLICKHOUSE_MAX_OPEN_CONNS", "100")
+	t.Setenv("FLEXPRICE_CLICKHOUSE_MAX_IDLE_CONNS", "20")
+	t.Setenv("FLEXPRICE_CLICKHOUSE_DIAL_TIMEOUT", "3s")
+	t.Setenv("FLEXPRICE_CLICKHOUSE_READ_TIMEOUT", "45s")
+
+	cfg, err := NewConfig()
+	if err != nil {
+		t.Fatalf("NewConfig() error: %v", err)
+	}
+
+	if cfg.ClickHouse.MaxOpenConns != 100 {
+		t.Errorf("clickhouse.max_open_conns = %d, want 100 (env override not honored)", cfg.ClickHouse.MaxOpenConns)
+	}
+	if cfg.ClickHouse.MaxIdleConns != 20 {
+		t.Errorf("clickhouse.max_idle_conns = %d, want 20 (env override not honored)", cfg.ClickHouse.MaxIdleConns)
+	}
+
+	// The value must survive the hop into the driver options, not just land on the struct.
+	opts := cfg.ClickHouse.GetClientOptions()
+	if opts.MaxOpenConns != 100 {
+		t.Errorf("options.MaxOpenConns = %d, want 100 (config not passed to clickhouse-go)", opts.MaxOpenConns)
+	}
+	if opts.MaxIdleConns != 20 {
+		t.Errorf("options.MaxIdleConns = %d, want 20 (config not passed to clickhouse-go)", opts.MaxIdleConns)
+	}
+	if opts.DialTimeout != 3*time.Second {
+		t.Errorf("options.DialTimeout = %v, want 3s", opts.DialTimeout)
+	}
+	if opts.ReadTimeout != 45*time.Second {
+		t.Errorf("options.ReadTimeout = %v, want 45s", opts.ReadTimeout)
+	}
+}
+
+// TestClickHousePoolDefaults pins the unset behaviour: zero pool values are passed through
+// so clickhouse-go applies its own defaults, while the dial/read deadlines keep the finite
+// values that make an in-order dial fail over instead of hanging on a dead PrivateLink ENI.
+func TestClickHousePoolDefaults(t *testing.T) {
+	c := ClickHouseConfig{Address: "localhost:9000", Database: "flexprice"}
+	opts := c.GetClientOptions()
+
+	if opts.MaxOpenConns != 0 || opts.MaxIdleConns != 0 {
+		t.Errorf("unset pool = open %d/idle %d, want 0/0 so the driver applies its defaults",
+			opts.MaxOpenConns, opts.MaxIdleConns)
+	}
+	if opts.DialTimeout != defaultClickHouseDialTimeout {
+		t.Errorf("options.DialTimeout = %v, want %v", opts.DialTimeout, defaultClickHouseDialTimeout)
+	}
+	if opts.ReadTimeout != defaultClickHouseReadTimeout {
+		t.Errorf("options.ReadTimeout = %v, want %v", opts.ReadTimeout, defaultClickHouseReadTimeout)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -205,12 +205,28 @@ type KafkaTopicSpec struct {
 }
 
 type ClickHouseConfig struct {
-	Address        string `mapstructure:"address" validate:"required"`
-	TLS            bool   `mapstructure:"tls"`
-	Username       string `mapstructure:"username" validate:"required"`
-	Password       string `mapstructure:"password" validate:"required"`
-	Database       string `mapstructure:"database" validate:"required"`
-	MaxMemoryUsage int64  `mapstructure:"max_memory_usage" validate:"required"`
+	// MaxOpenConns caps concurrent ClickHouse queries per PROCESS, so insert throughput is
+	// bounded by (MaxOpenConns / insert latency) per pod/task no matter how many run. Left
+	// at 0 the driver applies MaxIdleConns+5 = 10, which silently caps a consumer fleet:
+	// 40 tasks x 10 conns / 685ms inserts = ~580 events/s. Exhaustion surfaces as
+	// clickhouse-go ErrAcquireConnTimeout ("acquire conn timeout") raised client-side —
+	// the query never reaches the server, so ClickHouse logs nothing. Size it against the
+	// server's spare admission (system.metrics Query vs max_concurrent_queries): raising it
+	// helps only when ClickHouse has headroom, and hurts when it is already saturated.
+	MaxOpenConns int `mapstructure:"max_open_conns"`
+	MaxIdleConns int `mapstructure:"max_idle_conns"`
+	// DialTimeout doubles as the pool-acquire deadline inside clickhouse-go
+	// (clickhouse.go acquire() waits on a semaphore of MaxOpenConns slots for DialTimeout),
+	// so it cannot be tuned for pool pressure without also changing dial failover — see
+	// the ConnOpenInOrder note in GetClientOptions. Prefer raising MaxOpenConns instead.
+	DialTimeout    time.Duration `mapstructure:"dial_timeout"`
+	ReadTimeout    time.Duration `mapstructure:"read_timeout"`
+	Address        string        `mapstructure:"address" validate:"required"`
+	TLS            bool          `mapstructure:"tls"`
+	Username       string        `mapstructure:"username" validate:"required"`
+	Password       string        `mapstructure:"password" validate:"required"`
+	Database       string        `mapstructure:"database" validate:"required"`
+	MaxMemoryUsage int64         `mapstructure:"max_memory_usage" validate:"required"`
 }
 
 type LoggingConfig struct {
@@ -816,6 +832,11 @@ func (c Configuration) Validate() error {
 // Legitimate for local dev; a red flag in any real deployment.
 const devDBPassword = "flexprice123"
 
+const (
+	defaultClickHouseDialTimeout = 10 * time.Second
+	defaultClickHouseReadTimeout = 30 * time.Second
+)
+
 // placeholderSecrets are the exact dev/sample values baked into config.yaml (plus empty).
 // A non-local deployment booting with any of these for an ENABLED feature is running on a
 // public credential, so validateSecrets flags it (warn-only — see NewValidatedConfig).
@@ -924,8 +945,18 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 		// fronted by multiple AZ ENIs, and an in-order dial to an ENI that never
 		// completes the TCP/native handshake hangs indefinitely with no default
 		// deadline. A finite DialTimeout makes it fail over to the next address.
-		DialTimeout: 10 * time.Second,
-		ReadTimeout: 30 * time.Second,
+		DialTimeout: defaultClickHouseDialTimeout,
+		ReadTimeout: defaultClickHouseReadTimeout,
+		// Pool sizing. Zero values leave the driver defaults (MaxIdleConns 5,
+		// MaxOpenConns MaxIdleConns+5), which cap per-process query concurrency at 10.
+		MaxOpenConns: c.MaxOpenConns,
+		MaxIdleConns: c.MaxIdleConns,
+	}
+	if c.DialTimeout > 0 {
+		options.DialTimeout = c.DialTimeout
+	}
+	if c.ReadTimeout > 0 {
+		options.ReadTimeout = c.ReadTimeout
 	}
 	if c.TLS {
 		options.TLS = &tls.Config{}

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -92,6 +92,20 @@ clickhouse:
   password: flexprice123
   database: flexprice
   max_memory_usage: 50
+  # Per-process connection pool (0 would fall back to clickhouse-go's defaults: idle 5,
+  # open idle+5 = 10 — a hidden 10-query cap per pod/task that bottlenecks event ingest,
+  # since consumers doing one INSERT per event are bounded by max_open_conns / insert latency).
+  # max_idle_conns stays lower than max_open_conns so the pool bursts under load and releases
+  # when idle: 100 idle x N pods would otherwise hold a permanent connection floor server-side.
+  # Sizing check before raising further: FLEET tasks x max_open_conns must stay under the
+  # server's max_connections (4096 on ClickHouse Cloud), and only helps while the server has
+  # spare admission (system.metrics Query vs max_concurrent_queries).
+  max_open_conns: 100
+  max_idle_conns: 20
+  # dial_timeout also bounds the pool-acquire wait inside the driver; read_timeout bounds
+  # a running query. 0 = built-in defaults (10s / 30s).
+  dial_timeout: 0s
+  read_timeout: 0s
 
 postgres:
   host: 127.0.0.1 # For local mode


### PR DESCRIPTION
## Problem

`ClickHouseConfig` had no `MaxOpenConns`/`MaxIdleConns` field and `GetClientOptions()` never set them, so **`FLEXPRICE_CLICKHOUSE_MAX_OPEN_CONNS` was silently ignored in every deployment** and clickhouse-go's defaults applied:

```
MaxIdleConns = 5
MaxOpenConns = MaxIdleConns + 5 = 10   // per PROCESS
```

That is a hard cap on event-consumption throughput, because a consumer doing **one INSERT per event** is bounded by `max_open_conns / insert latency` per task, no matter how many tasks run.

## Evidence (client prod fleet, 40 ECS consumer tasks, ClickHouse Cloud)

| | insert latency | predicted `400 / latency` | observed |
|---|---|---|---|
| healthy | ~57ms | ~7,000 events/s | ~5,000/s |
| degraded | ~685ms | ~580 events/s | ~410–900/s |

Against ~3,300 events/s of ingest, that left both consumer groups **~9M messages behind** while:

- consumer ECS **1.5% CPU**, Aurora **3% CPU** — not resource-bound
- ClickHouse ~85% idle: `TCPConnection` 501/4096, `Query` 283/1500, `DelayedInserts` 0, hot-partition parts **14** vs `parts_to_delay_insert` 1000

Pool exhaustion surfaces as clickhouse-go `ErrAcquireConnTimeout` — `failed to bulk insert meter usage: clickhouse: acquire conn timeout` — which is raised **client-side** (`acquire()` waits on a semaphore of `MaxOpenConns` slots). The query never reaches the server, so ClickHouse logs nothing and `system.query_log` **undercounts real demand**.

## Change

- Add `max_open_conns`, `max_idle_conns`, `dial_timeout`, `read_timeout` to `ClickHouseConfig` and pass them through `GetClientOptions()`.
- Zero pool values pass through so the driver applies its own defaults; dial/read deadlines keep their previous **10s / 30s** behaviour (now named constants, overridable).
- Baked default is an explicit **100 open / 20 idle**, so the hidden 10-query cap is gone by default. Idle is kept below open deliberately: idle is a floor the pool holds permanently, and `100 idle x 40 tasks = 4,000` would sit at ClickHouse Cloud's `max_connections` of 4,096 even when quiet.

## Tuning note (deliberately not "fixed" here)

`dial_timeout` **also bounds the pool-acquire wait** inside the driver (`acquire()` uses `DialTimeout` as its deadline). It is 10s on purpose so an in-order dial to a dead PrivateLink ENI fails over instead of hanging. So acquire pressure must be relieved by raising `max_open_conns`, not the timeout — clickhouse-go v2.35 exposes no separate acquire budget. Documented in-code rather than worked around.

Sizing rule before raising further: `fleet_tasks x max_open_conns` must stay under the server's `max_connections`, and it only helps while the server has spare admission (`system.metrics Query` vs `max_concurrent_queries`). Raising a pool against a **saturated** downstream makes things worse — the opposite call from a prior Aurora incident where the pool was acting as accidental admission control at 99.7% CPU.

The durable fix for one-insert-per-event remains **consumer-side batching**; this removes an artificial cap in the meantime.

## Testing

- New `internal/config/clickhouse_pool_test.go`: the env var binds **and** reaches the driver options (the actual regression), plus unset behaviour keeps driver defaults and the 10s/30s deadlines.
- `go build ./internal/... ./cmd/...`, `go vet`, `gofmt`, `go test ./internal/config/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ClickHouse connection-pool limits for maximum open and idle connections.
  * Added configurable ClickHouse dial and read timeouts through application settings and environment variables.
  * Documented default pool and timeout behavior in the configuration.

* **Bug Fixes**
  * ClickHouse connections now consistently apply configured or default timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->