### PR TITLE
feat(usage-alerts): Kill switch

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -568,7 +568,10 @@ type UsageAlertsConfig struct {
 	// than this past its intended time yields once (ContinueAsNew) to the back
 	// of the queue so fresher customers evaluate first, and each activity's
 	// ScheduleToStartTimeout is set to the same value.
-	StaleAfter time.Duration `mapstructure:"stale_after" default:"1h"`
+	StaleAfter               time.Duration `mapstructure:"stale_after" default:"1h"`
+	WalletAlertsEnabled      bool          `mapstructure:"wallet_alerts_enabled" default:"true"`
+	SpendAlertsEnabled       bool          `mapstructure:"spend_alerts_enabled" default:"true"`
+	EntitlementAlertsEnabled bool          `mapstructure:"entitlement_alerts_enabled" default:"true"`
 }
 
 // MeterUsageTrackingLazyConfig configures the lazy consumer for tenants that

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -396,6 +396,9 @@ usage_alerts:
   enabled: false # meter usage pushes the debounce workflow
   schedule_delay: "5m30s" # workflow StartDelay AND Redis schedule-throttle lock TTL
   stale_after: "1h" # workflow runs firing later than this yield (ContinueAsNew); also activity ScheduleToStartTimeout
+  wallet_alerts_enabled: true
+  spend_alerts_enabled: true
+  entitlement_alerts_enabled: true
 
 costsheet_usage_tracking:
   enabled: false

--- a/internal/ee/service/alert.go
+++ b/internal/ee/service/alert.go
@@ -39,7 +39,7 @@ type AlertService interface {
 	// alert_logs state, and snapshots the grant. Wallet alerts stay on their
 	// own activity (see EvaluateWalletAlertsForCustomer) — they need a
 	// different query path and their own throttle.
-	EvaluateSpendAndEntitlementAlertsForCustomer(ctx context.Context, cust *customer.Customer) error
+	EvaluateSpendAndEntitlementAlertsForCustomer(ctx context.Context, cust *customer.Customer, withSpendAlerts bool, withEntitlementAlerts bool) error
 
 	// RefreshEntitlementGrantsForCustomer runs one grants-only pass (ensure +
 	// usage refresh + billable-overage ledger accrual) so the materialized

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -185,6 +185,8 @@ func (s *alertService) EvaluateSpendBreachForEvent(ctx context.Context, event *e
 func (s *alertService) EvaluateSpendAndEntitlementAlertsForCustomer(
 	ctx context.Context,
 	cust *customer.Customer,
+	withSpendAlerts bool,
+	withEntitlementAlerts bool,
 ) error {
 	if cust == nil {
 		return nil
@@ -199,19 +201,27 @@ func (s *alertService) EvaluateSpendAndEntitlementAlertsForCustomer(
 		return nil
 	}
 
-	spendErr := s.evaluateSpendAlertsForSubscriptions(ctx, cust, subs)
-	if spendErr != nil {
-		s.Logger.Error(ctx, "fused evaluator: spend alerts returned error", "error", spendErr, "customer_id", cust.ID)
+	var spendErr error
+	if spendAlertsEnabled {
+		spendErr = s.evaluateSpendAlertsForSubscriptions(ctx, cust, subs)
+		if spendErr != nil {
+			s.Logger.Error(ctx, "fused evaluator: spend alerts returned error", "error", spendErr, "customer_id", cust.ID)
+		}
 	}
 
-	grantSvc := NewEntitlementGrantService(s.ServiceParams)
-	grants, meta, err := grantSvc.EnsureGrantsForSubscriptions(ctx, cust, subs, at)
-	if err != nil {
-		return err
-	}
-	grantErr := s.evaluateEntitlementGrantsForCustomer(ctx, cust, meta, grants, at)
-	if grantErr != nil {
-		s.Logger.Error(ctx, "fused evaluator: grant evaluation returned error", "error", grantErr, "customer_id", cust.ID)
+	var grantErr error
+	if entitlementAlertsEnabled {
+		grantSvc := NewEntitlementGrantService(s.ServiceParams)
+		grants, meta, err := grantSvc.EnsureGrantsForSubscriptions(ctx, cust, subs, at)
+		if err != nil {
+			s.Logger.Error(ctx, "fused evaluator: entitlement grants returned error", "error", err, "customer_id", cust.ID)
+			return errors.Join(spendErr, err)
+		}
+
+		grantErr = s.evaluateEntitlementGrantsForCustomer(ctx, cust, meta, grants, at)
+		if grantErr != nil {
+			s.Logger.Error(ctx, "fused evaluator: grant evaluation returned error", "error", grantErr, "customer_id", cust.ID)
+		}
 	}
 
 	return errors.Join(spendErr, grantErr)

--- a/internal/ee/service/alert_evaluation.go
+++ b/internal/ee/service/alert_evaluation.go
@@ -202,7 +202,7 @@ func (s *alertService) EvaluateSpendAndEntitlementAlertsForCustomer(
 	}
 
 	var spendErr error
-	if spendAlertsEnabled {
+	if withSpendAlerts {
 		spendErr = s.evaluateSpendAlertsForSubscriptions(ctx, cust, subs)
 		if spendErr != nil {
 			s.Logger.Error(ctx, "fused evaluator: spend alerts returned error", "error", spendErr, "customer_id", cust.ID)
@@ -210,7 +210,7 @@ func (s *alertService) EvaluateSpendAndEntitlementAlertsForCustomer(
 	}
 
 	var grantErr error
-	if entitlementAlertsEnabled {
+	if withEntitlementAlerts {
 		grantSvc := NewEntitlementGrantService(s.ServiceParams)
 		grants, meta, err := grantSvc.EnsureGrantsForSubscriptions(ctx, cust, subs, at)
 		if err != nil {

--- a/internal/ee/service/meter_usage_tracking_post_insert.go
+++ b/internal/ee/service/meter_usage_tracking_post_insert.go
@@ -73,6 +73,12 @@ func (s *meterUsageTrackingService) runMeterUsagePostInsertSideEffects(ctx conte
 // the workflow-side evaluators each bail on cheap indexed DB reads when there is
 // nothing to do.
 func (s *meterUsageTrackingService) scheduleUsageAlertWorkflow(ctx context.Context, cust *customer.Customer) {
+	usageAlertConfig := s.Config.UsageAlerts
+	if !usageAlertConfig.WalletAlertsEnabled && !usageAlertConfig.SpendAlertsEnabled && !usageAlertConfig.EntitlementAlertsEnabled {
+		s.Logger.Debug(ctx, "none of the usage alerts are enabled, skipping", "customer_id", cust.ID)
+		return
+	}
+
 	temporalSvc := temporalservice.GetGlobalTemporalService()
 	if temporalSvc == nil {
 		s.Logger.Debug(ctx, "temporal service not available, skipping usage alert workflow",
@@ -81,7 +87,7 @@ func (s *meterUsageTrackingService) scheduleUsageAlertWorkflow(ctx context.Conte
 		return
 	}
 
-	delay := s.Config.UsageAlerts.ScheduleDelay
+	delay := usageAlertConfig.ScheduleDelay
 
 	var throttleLock cache.Lock
 	if s.Locker != nil {
@@ -113,11 +119,14 @@ func (s *meterUsageTrackingService) scheduleUsageAlertWorkflow(ctx context.Conte
 		StartDelay: delay,
 	}
 	input := workflowModels.UsageAlertWorkflowInput{
-		TenantID:      tenantID,
-		EnvironmentID: envID,
-		CustomerID:    cust.ID,
-		ScheduledFor:  time.Now().UTC().Add(delay),
-		StaleAfter:    s.Config.UsageAlerts.StaleAfter,
+		TenantID:                 tenantID,
+		EnvironmentID:            envID,
+		CustomerID:               cust.ID,
+		ScheduledFor:             time.Now().UTC().Add(delay),
+		StaleAfter:               usageAlertConfig.StaleAfter,
+		WalletAlertsEnabled:      usageAlertConfig.WalletAlertsEnabled,
+		SpendAlertsEnabled:       usageAlertConfig.SpendAlertsEnabled,
+		EntitlementAlertsEnabled: usageAlertConfig.EntitlementAlertsEnabled,
 	}
 
 	if _, err := temporalSvc.StartWorkflow(ctx, options, types.TemporalUsageAlertWorkflow, input); err != nil {

--- a/internal/temporal/activities/alerts/alerts.go
+++ b/internal/temporal/activities/alerts/alerts.go
@@ -62,7 +62,7 @@ func (a *AlertActivities) SpendAndEntitlementAlertsActivity(ctx context.Context,
 		return nil
 	}
 
-	return service.NewAlertService(a.serviceParams).EvaluateSpendAndEntitlementAlertsForCustomer(ctx, cust)
+	return service.NewAlertService(a.serviceParams).EvaluateSpendAndEntitlementAlertsForCustomer(ctx, cust, input.SpendAlertsEnabled, input.EntitlementAlertsEnabled)
 }
 
 // WalletAlertsActivity evaluates wallet-balance alerts and auto-topup.

--- a/internal/temporal/models/usage_alert.go
+++ b/internal/temporal/models/usage_alert.go
@@ -32,7 +32,10 @@ type UsageAlertWorkflowInput struct {
 	// AlreadyRescheduled marks a run created by the staleness re-schedule — at
 	// most one re-schedule per chain, so a sustained backlog can't livelock on
 	// ContinueAsNew.
-	AlreadyRescheduled bool `json:"already_rescheduled,omitempty"`
+	AlreadyRescheduled       bool `json:"already_rescheduled,omitempty"`
+	WalletAlertsEnabled      bool `json:"wallet_alerts_enabled"`
+	SpendAlertsEnabled       bool `json:"spend_alerts_enabled"`
+	EntitlementAlertsEnabled bool `json:"entitlement_alerts_enabled"`
 }
 
 func (i UsageAlertWorkflowInput) Validate() error {
@@ -50,7 +53,9 @@ func (i UsageAlertWorkflowInput) Validate() error {
 
 // UsageAlertActivityInput is the input to the usage-alert activities.
 type UsageAlertActivityInput struct {
-	TenantID      string `json:"tenant_id"`
-	EnvironmentID string `json:"environment_id"`
-	CustomerID    string `json:"customer_id"`
+	TenantID                 string `json:"tenant_id"`
+	EnvironmentID            string `json:"environment_id"`
+	CustomerID               string `json:"customer_id"`
+	SpendAlertsEnabled       bool   `json:"spend_alerts_enabled"`
+	EntitlementAlertsEnabled bool   `json:"entitlement_alerts_enabled"`
 }

--- a/internal/temporal/workflows/usage_alert_workflow.go
+++ b/internal/temporal/workflows/usage_alert_workflow.go
@@ -70,9 +70,11 @@ func UsageAlertWorkflow(ctx workflow.Context, input models.UsageAlertWorkflowInp
 	)
 
 	activityInput := models.UsageAlertActivityInput{
-		TenantID:      input.TenantID,
-		EnvironmentID: input.EnvironmentID,
-		CustomerID:    input.CustomerID,
+		TenantID:                 input.TenantID,
+		EnvironmentID:            input.EnvironmentID,
+		CustomerID:               input.CustomerID,
+		SpendAlertsEnabled:       input.SpendAlertsEnabled,
+		EntitlementAlertsEnabled: input.EntitlementAlertsEnabled,
 	}
 
 	opts := workflow.ActivityOptions{
@@ -89,11 +91,15 @@ func UsageAlertWorkflow(ctx workflow.Context, input models.UsageAlertWorkflowInp
 	}
 	actCtx := workflow.WithActivityOptions(ctx, opts)
 
-	if err := workflow.ExecuteActivity(actCtx, ActivitySpendAndEntitlementAlerts, activityInput).Get(actCtx, nil); err != nil {
-		logger.Error("SpendAndEntitlementAlertsActivity returned error", "error", err)
+	if input.SpendAlertsEnabled || input.EntitlementAlertsEnabled {
+		if err := workflow.ExecuteActivity(actCtx, ActivitySpendAndEntitlementAlerts, activityInput).Get(actCtx, nil); err != nil {
+			logger.Error("SpendAndEntitlementAlertsActivity returned error", "error", err)
+		}
 	}
-	if err := workflow.ExecuteActivity(actCtx, ActivityWalletAlerts, activityInput).Get(actCtx, nil); err != nil {
-		logger.Error("WalletAlertsActivity returned error", "error", err)
+	if input.WalletAlertsEnabled {
+		if err := workflow.ExecuteActivity(actCtx, ActivityWalletAlerts, activityInput).Get(actCtx, nil); err != nil {
+			logger.Error("WalletAlertsActivity returned error", "error", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added independent enable/disable controls for wallet, spend, and entitlement usage alerts.
  * Alert workflows and activities now run only for enabled alert types.
  * When evaluating spend vs entitlement alerts, each side is gated by its flag and results are combined so enabled portions still report failures.
* **Configuration**
  * Wallet, spend, and entitlement usage alerts are enabled by default, and can be configured separately via `wallet_alerts_enabled`, `spend_alerts_enabled`, and `entitlement_alerts_enabled`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->