### PR TITLE
fix(wallet): real-time balance cache collides with the wallet entity cache — both miss every call

### DIFF
--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -3929,12 +3929,12 @@ func (s *walletService) setWalletRealtimeBalanceToCache(ctx context.Context, wal
 		return
 	}
 
-	span, spanCtx := cache.StartRedisCacheSpan(ctx, "wallet", "set", map[string]interface{}{
+	span, spanCtx := cache.StartRedisCacheSpan(ctx, "wallet_realtime_balance", "set", map[string]interface{}{
 		"wallet_id": walletID,
 	})
 	defer cache.FinishSpan(span)
 
-	cacheKey := cache.GenerateKey(spanCtx, cache.PrefixWallet, walletID)
+	cacheKey := cache.GenerateKey(spanCtx, cache.PrefixWalletRealTimeBalance, walletID)
 	s.RedisCache.ForceCacheSet(spanCtx, cacheKey, balance.String(), cache.ExpiryWalletBalance)
 }
 
@@ -3942,7 +3942,7 @@ func (s *walletService) invalidateWalletRealtimeBalanceCache(ctx context.Context
 	if walletID == "" || s.RedisCache == nil {
 		return
 	}
-	cacheKey := cache.GenerateKey(ctx, cache.PrefixWallet, walletID)
+	cacheKey := cache.GenerateKey(ctx, cache.PrefixWalletRealTimeBalance, walletID)
 	s.RedisCache.ForceCacheDelete(ctx, cacheKey)
 }
 
@@ -3951,12 +3951,12 @@ func (s *walletService) getWalletRealtimeBalanceFromCache(ctx context.Context, w
 		return nil
 	}
 
-	span, spanCtx := cache.StartRedisCacheSpan(ctx, "wallet", "get", map[string]interface{}{
+	span, spanCtx := cache.StartRedisCacheSpan(ctx, "wallet_realtime_balance", "get", map[string]interface{}{
 		"wallet_id": walletID,
 	})
 	defer cache.FinishSpan(span)
 
-	cacheKey := cache.GenerateKey(spanCtx, cache.PrefixWallet, walletID)
+	cacheKey := cache.GenerateKey(spanCtx, cache.PrefixWalletRealTimeBalance, walletID)
 
 	// When maxLiveSeconds is specified, check cache age via TTL
 	if maxLiveSeconds != nil {

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -3288,38 +3288,66 @@ func (s *WalletServiceSuite) TestGetWalletBalanceFromCache_FallbackIgnoresMaxLiv
 	s.True(resp.RealTimeBalance.Equal(decimal.NewFromInt(42)))
 }
 
-// The wallet ENTITY cache and the real-time-BALANCE cache used to share the key
-// `wallet:v1:<id>` while storing incompatible types (wallet JSON object vs bare
-// decimal string). Each write clobbered the other and every read failed to decode,
-// so both caches missed on every call and every request fell through to a full
-// ClickHouse recompute. Guard the namespace separation.
-func (s *WalletServiceSuite) TestRealtimeBalanceCache_DoesNotCollideWithWalletEntityCache() {
+// A warm read must come from the cache. The cold call populates it through the
+// real write path (setWalletRealtimeBalanceToCache), so this covers set→get end
+// to end rather than priming the key by hand — a get/set prefix mismatch fails here.
+func (s *WalletServiceSuite) TestGetWalletBalanceFromCache_WarmReadSkipsRecompute() {
+	ctx := s.GetContext()
+	w := s.buildFallbackTestWallet(decimal.NewFromInt(100))
+
+	computes := 0
+	s.installCompute(func(_ context.Context, _ *wallet.Wallet) (*dto.WalletBalanceResponse, error) {
+		computes++
+		return &dto.WalletBalanceResponse{
+			Wallet:                w,
+			RealTimeBalance:       lo.ToPtr(decimal.NewFromInt(88)),
+			RealTimeCreditBalance: lo.ToPtr(decimal.NewFromInt(88)),
+		}, nil
+	})
+
+	cold, err := s.service.GetWalletBalanceFromCache(ctx, w.ID, nil)
+	s.NoError(err)
+	s.Equal(1, computes, "cold read must compute")
+	s.True(cold.RealTimeBalance.Equal(decimal.NewFromInt(88)))
+	s.NotNil(s.readCachedBalance(ctx, w.ID), "cold read must populate the balance cache")
+
+	warm, err := s.service.GetWalletBalanceFromCache(ctx, w.ID, nil)
+	s.NoError(err)
+	s.Equal(1, computes, "warm read must be served from cache, not recomputed")
+	s.True(warm.RealTimeBalance.Equal(decimal.NewFromInt(88)))
+}
+
+// The non-cached path: once the balance is invalidated the next read must
+// recompute and return the new value, not a stale cached one.
+func (s *WalletServiceSuite) TestGetWalletBalanceFromCache_RecomputesAfterInvalidation() {
 	ctx := s.GetContext()
 	w := s.buildFallbackTestWallet(decimal.NewFromInt(100))
 	ws := s.service.(*walletService)
 
-	entityKey := cache.GenerateKey(ctx, cache.PrefixWallet, w.ID)
-	balanceKey := cache.GenerateKey(ctx, cache.PrefixWalletRealTimeBalance, w.ID)
-	s.NotEqual(entityKey, balanceKey, "balance cache must not share the entity cache key")
+	balance := decimal.NewFromInt(88)
+	computes := 0
+	s.installCompute(func(_ context.Context, _ *wallet.Wallet) (*dto.WalletBalanceResponse, error) {
+		computes++
+		return &dto.WalletBalanceResponse{
+			Wallet:                w,
+			RealTimeBalance:       lo.ToPtr(balance),
+			RealTimeCreditBalance: lo.ToPtr(balance),
+		}, nil
+	})
 
-	// Entity cache holds a *wallet.Wallet; balance cache holds a decimal string.
-	ws.RedisCache.ForceCacheSet(ctx, entityKey, w, cache.ExpiryWalletBalance)
-	s.primeCachedBalance(ctx, w.ID, decimal.NewFromInt(42), cache.ExpiryWalletBalance)
+	_, err := s.service.GetWalletBalanceFromCache(ctx, w.ID, nil)
+	s.NoError(err)
+	s.Equal(1, computes)
 
-	got := s.readCachedBalance(ctx, w.ID)
-	s.Require().NotNil(got, "balance read must hit its own key, not the entity object")
-	s.True(got.Equal(decimal.NewFromInt(42)), "expected 42, got %v", got)
-
-	raw, found := ws.RedisCache.ForceCacheGet(ctx, entityKey)
-	s.Require().True(found, "entity cache entry must survive a balance write")
-	_, clobbered := raw.(string)
-	s.False(clobbered, "entity cache key was overwritten by the balance decimal")
-
-	// Invalidating the balance must not evict the wallet entity.
 	ws.invalidateWalletRealtimeBalanceCache(ctx, w.ID)
-	s.Nil(s.readCachedBalance(ctx, w.ID), "balance should be gone after invalidate")
-	_, stillThere := ws.RedisCache.ForceCacheGet(ctx, entityKey)
-	s.True(stillThere, "invalidating the balance must not evict the wallet entity")
+	s.Nil(s.readCachedBalance(ctx, w.ID), "invalidate must clear the cached balance")
+
+	balance = decimal.NewFromInt(55)
+	after, err := s.service.GetWalletBalanceFromCache(ctx, w.ID, nil)
+	s.NoError(err)
+	s.Equal(2, computes, "read after invalidation must recompute")
+	s.True(after.RealTimeBalance.Equal(decimal.NewFromInt(55)), "must return the recomputed value, got %v", after.RealTimeBalance)
+	s.NotNil(s.readCachedBalance(ctx, w.ID), "recompute must repopulate the cache")
 }
 
 func (s *WalletServiceSuite) TestGetWalletBalanceV2_FallsBackToCacheOnTimeout() {

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -133,7 +133,7 @@ func (s *WalletServiceSuite) setupService() {
 		CustomerRepo:             stores.CustomerRepo,
 		InvoiceRepo:              stores.InvoiceRepo,
 		EntitlementRepo:          stores.EntitlementRepo,
-		EntitlementGrantRepo:         stores.EntitlementGrantRepo,
+		EntitlementGrantRepo:     stores.EntitlementGrantRepo,
 		FeatureRepo:              stores.FeatureRepo,
 		CouponRepo:               stores.CouponRepo,
 		CouponAssociationRepo:    stores.CouponAssociationRepo,
@@ -2437,7 +2437,7 @@ func (s *WalletAutoTopupInvoiceSuite) setupService() {
 		CustomerRepo:             stores.CustomerRepo,
 		InvoiceRepo:              stores.InvoiceRepo,
 		EntitlementRepo:          stores.EntitlementRepo,
-		EntitlementGrantRepo:         stores.EntitlementGrantRepo,
+		EntitlementGrantRepo:     stores.EntitlementGrantRepo,
 		FeatureRepo:              stores.FeatureRepo,
 		AddonAssociationRepo:     stores.AddonAssociationRepo,
 		SettingsRepo:             stores.SettingsRepo,
@@ -2958,7 +2958,7 @@ func (s *CheckWalletBalanceAlertSuite) setupService() {
 		CustomerRepo:             stores.CustomerRepo,
 		InvoiceRepo:              stores.InvoiceRepo,
 		EntitlementRepo:          stores.EntitlementRepo,
-		EntitlementGrantRepo:         stores.EntitlementGrantRepo,
+		EntitlementGrantRepo:     stores.EntitlementGrantRepo,
 		FeatureRepo:              stores.FeatureRepo,
 		AddonAssociationRepo:     stores.AddonAssociationRepo,
 		SettingsRepo:             stores.SettingsRepo,
@@ -3253,10 +3253,11 @@ func (s *WalletServiceSuite) installCompute(fn func(ctx context.Context, w *wall
 
 // primeCachedBalance writes a balance directly into the injected cache,
 // matching the on-disk format that the wallet service uses (decimal
-// stringified, wrapped via the wallet prefix).
+// stringified, under the dedicated real-time-balance prefix — NOT the wallet
+// entity prefix, which stores a full wallet JSON object).
 func (s *WalletServiceSuite) primeCachedBalance(ctx context.Context, walletID string, balance decimal.Decimal, ttl time.Duration) {
 	ws := s.service.(*walletService)
-	key := cache.GenerateKey(ctx, cache.PrefixWallet, walletID)
+	key := cache.GenerateKey(ctx, cache.PrefixWalletRealTimeBalance, walletID)
 	ws.RedisCache.ForceCacheSet(ctx, key, balance.String(), ttl)
 }
 
@@ -3285,6 +3286,40 @@ func (s *WalletServiceSuite) TestGetWalletBalanceFromCache_FallbackIgnoresMaxLiv
 	s.NoError(err)
 	s.True(resp.IsCachedFallback, "expected IsCachedFallback=true")
 	s.True(resp.RealTimeBalance.Equal(decimal.NewFromInt(42)))
+}
+
+// The wallet ENTITY cache and the real-time-BALANCE cache used to share the key
+// `wallet:v1:<id>` while storing incompatible types (wallet JSON object vs bare
+// decimal string). Each write clobbered the other and every read failed to decode,
+// so both caches missed on every call and every request fell through to a full
+// ClickHouse recompute. Guard the namespace separation.
+func (s *WalletServiceSuite) TestRealtimeBalanceCache_DoesNotCollideWithWalletEntityCache() {
+	ctx := s.GetContext()
+	w := s.buildFallbackTestWallet(decimal.NewFromInt(100))
+	ws := s.service.(*walletService)
+
+	entityKey := cache.GenerateKey(ctx, cache.PrefixWallet, w.ID)
+	balanceKey := cache.GenerateKey(ctx, cache.PrefixWalletRealTimeBalance, w.ID)
+	s.NotEqual(entityKey, balanceKey, "balance cache must not share the entity cache key")
+
+	// Entity cache holds a *wallet.Wallet; balance cache holds a decimal string.
+	ws.RedisCache.ForceCacheSet(ctx, entityKey, w, cache.ExpiryWalletBalance)
+	s.primeCachedBalance(ctx, w.ID, decimal.NewFromInt(42), cache.ExpiryWalletBalance)
+
+	got := s.readCachedBalance(ctx, w.ID)
+	s.Require().NotNil(got, "balance read must hit its own key, not the entity object")
+	s.True(got.Equal(decimal.NewFromInt(42)), "expected 42, got %v", got)
+
+	raw, found := ws.RedisCache.ForceCacheGet(ctx, entityKey)
+	s.Require().True(found, "entity cache entry must survive a balance write")
+	_, clobbered := raw.(string)
+	s.False(clobbered, "entity cache key was overwritten by the balance decimal")
+
+	// Invalidating the balance must not evict the wallet entity.
+	ws.invalidateWalletRealtimeBalanceCache(ctx, w.ID)
+	s.Nil(s.readCachedBalance(ctx, w.ID), "balance should be gone after invalidate")
+	_, stillThere := ws.RedisCache.ForceCacheGet(ctx, entityKey)
+	s.True(stillThere, "invalidating the balance must not evict the wallet entity")
 }
 
 func (s *WalletServiceSuite) TestGetWalletBalanceV2_FallsBackToCacheOnTimeout() {


### PR DESCRIPTION
## The bug

The wallet **entity** cache and the real-time **balance** cache both key on `wallet:v1:<walletID>`, but store incompatible types:

| writer | key | value |
|---|---|---|
| `repository/ent/wallet.go:1031/1041/1059` | `wallet:v1:<id>` | wallet **JSON object** |
| `ee/service/wallet.go:3937/3945/3959` | `wallet:v1:<id>` | bare **decimal string** `"986.47"` |

Each write clobbers the other; each read then fails to decode the other's type. So **both caches miss on every call** — `from_cache=true` still pays a full ClickHouse recompute (3 `meter_usage` queries) *plus* a needless Postgres entity load.

It's silent. Nothing errors; the cache simply never helps.

The failure needs two consecutive requests to show itself: request 1 writes the decimal, request 2's entity-cache read fails to decode it and rewrites the JSON, and only then does the balance read fail. That's why a single-request test never caught it.

Found during nane2 load testing via Redis `MONITOR` (two `SET`s of different value types to one key per request) and confirmed with a decode test. Present in `develop` and in what's deployed, so a redeploy alone doesn't fix it.

## The fix

Point the balance get/set/invalidate at `cache.PrefixWalletRealTimeBalance` (`wallet_realtime_balance:v1:`), already declared at `cache.go:95` with **zero references**. Separate namespaces → the entity read gets a real `Wallet`, the balance read gets a real decimal.

Expected effect: `from_cache=true` becomes Redis GET + PG resolve instead of 3 ClickHouse queries, and the wallet-entity cache starts working again (dropping the extra PG read).

## Spans

Renamed the balance cache spans `cache.wallet.{get,set}` → `cache.wallet_realtime_balance.{get,set}`.

This is why the collision never surfaced in tracing: both caches were instrumented, but emitted **identically named spans**, so entity hits and balance hits were indistinguishable in SigNoz. There was no way to see one clobbering the other.

## Tests

Two behavioural tests covering the paths callers actually care about, rather than asserting on cache internals:

- **`WarmReadSkipsRecompute`** — the cold read computes and populates the cache *through the real write path*, then a second read must be served from cache without recomputing. This exercises `set` → `get` end to end, so a namespace mismatch between them fails here. Verified by reverting only the get site: `warm read must be served from cache, not recomputed`.
- **`RecomputesAfterInvalidation`** — after invalidating, the next read must recompute, return the **new** value (not a stale one), and repopulate the cache.

Also updated `primeCachedBalance`, which primed the old prefix and would otherwise prime a key the service no longer reads.

### Why the existing tests were green

Every pre-existing cache test primes the key directly via `primeCachedBalance`, so it reads back its own write and passes whether or not the service's `get` and `set` agree on a namespace.

### Coverage limit, stated plainly

Unit tests use `NewInMemoryWalletStore`, which touches no cache, so the wallet-entity cache is never written in this suite. **These tests cannot reproduce the entity/balance collision itself** — that requires the ent repository (`repository/ent/wallet.go`) and real Redis. What they do cover is the get/set namespace agreement and the cached-vs-recomputed behaviour. Verifying the collision is fixed end to end needs a check against a real Redis (e.g. `MONITOR` on the two keys, or the integration suite).

## Checks

- `go build ./internal/...` clean
- `go test ./internal/ee/service -run TestWalletService` and `./internal/cache/...` pass
- `gofmt` clean, `go vet` clean
- `make lint-ci` exits **0**, no diagnostics on either changed file

## Deliberately not in this PR

Two adjacent items from the same investigation, kept separate to keep this reviewable:

1. **Double Redis round-trip** — `getWalletRealtimeBalanceFromCache` is called twice per request on the miss path (`wallet.go:3180` and `3192`); the first read with `maxLiveSeconds` discards the value and the second re-fetches the same key. Collapsible to one round-trip (and one span).
2. **No single-flight on recompute** — concurrent misses stampede the single ClickHouse node with 10–30s queries. Worth adding now that caching actually works, since the broken cache is what was masking the stampede risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet real-time balance caching by using a dedicated cache namespace/prefix for real-time balances.
  * Ensured cache invalidation clears the correct real-time balance entries so balances are recomputed when needed.
  * Added cache read/write tracing for real-time wallet balance operations.
* **Tests**
  * Added regression tests covering warm cache reads and recomputation after cache invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->