### PR TITLE
fix(cache): Treat unmarshal error as cache miss

### DIFF
--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -235,14 +235,14 @@ func (r *meterRepository) GetMatchingMetersByEventName(ctx context.Context, even
 
 	if cached, found := r.cache.ForceCacheGet(ctx, cacheKey); found {
 		meters, ok := cache.UnmarshalCacheValue[[]*domainMeter.Meter](cached)
-		if !ok {
-			return nil, ierr.WithError(ierr.ErrInternal).
-				WithMessage("failed to unmarshal meters from cache").
-				WithHint("Failed to unmarshal meters from cache").
-				WithReportableDetails(map[string]any{"cache_key": cacheKey}).
-				Mark(ierr.ErrInternal)
+		if ok {
+			return *meters, nil
 		}
-		return *meters, nil
+		r.logger.Info(ctx, "failed to unmarshal meters from cache, treating as miss",
+			"cache_key", cacheKey,
+			"event_name", eventName,
+		)
+		r.cache.ForceCacheDelete(ctx, cacheKey)
 	}
 
 	filter := types.NewNoLimitMeterFilter()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meter lookup reliability by recovering gracefully from invalid cached data.
  * Invalid cache entries are removed and the lookup continues instead of returning an internal error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->