### PR TITLE
feat(subscription): add support for overrides in grouped invoicing

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -471,20 +471,8 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		return err
 	}
 
-	if len(c.OverrideLineItems) > 0 {
-		priceIDsSeen := make(map[string]bool)
-		for i, override := range c.OverrideLineItems {
-			if priceIDsSeen[override.PriceID] {
-				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
-					WithHint("Each price can only be overridden once per subscription").
-					WithReportableDetails(map[string]interface{}{
-						"price_id": override.PriceID,
-						"index":    i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-			priceIDsSeen[override.PriceID] = true
-		}
+	if err := validateNoDuplicateOverridePriceIDs(c.OverrideLineItems); err != nil {
+		return err
 	}
 
 	const maxLineItems = 100

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -479,6 +479,108 @@ type SubscriptionCreationConfig struct {
 	Phases []SubscriptionPhaseCreateRequest `json:"phases,omitempty" validate:"omitempty,dive"`
 }
 
+// Validate validates the self-contained fields of SubscriptionCreationConfig — checks that
+// only ever need this struct's own fields, independent of the parent request's type,
+// billing status, or proration settings. Used by both CreateSubscriptionRequest.Validate()
+// and (transitively, via CreateSubscriptionRequest's own promoted fields) grouped-invoicing
+// child requests.
+func (c *SubscriptionCreationConfig) Validate() error {
+	// Validate commitment amount and overage factor
+	if c.CommitmentAmount != nil && c.CommitmentAmount.LessThan(decimal.Zero) {
+		return ierr.NewError("commitment_amount must be non-negative").
+			WithHint("Commitment amount must be greater than or equal to 0").
+			WithReportableDetails(map[string]interface{}{
+				"commitment_amount": *c.CommitmentAmount,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if c.OverageFactor != nil && c.OverageFactor.LessThan(decimal.NewFromInt(1)) {
+		return ierr.NewError("overage_factor must be at least 1.0").
+			WithHint("Overage factor must be greater than or equal to 1.0").
+			WithReportableDetails(map[string]interface{}{
+				"overage_factor": *c.OverageFactor,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	// Validate credit grants if provided
+	if len(c.CreditGrants) > 0 {
+		for i, grant := range c.CreditGrants {
+			// Force scope to SUBSCRIPTION for all grants added this way
+			if grant.Scope != types.CreditGrantScopeSubscription {
+				return ierr.NewError("invalid credit grant scope").
+					WithHint("Credit grants created with a subscription must have SUBSCRIPTION scope").
+					WithReportableDetails(map[string]interface{}{
+						"grant_scope": grant.Scope,
+						"grant_index": i,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		}
+	}
+
+	// taxrate overrides validation
+	if len(c.TaxRateOverrides) > 0 {
+		for _, taxRateOverride := range c.TaxRateOverrides {
+			if err := taxRateOverride.Validate(); err != nil {
+				return ierr.NewError("invalid tax rate override").
+					WithHint("Tax rate override validation failed").
+					WithReportableDetails(map[string]interface{}{
+						"error":             err.Error(),
+						"tax_rate_override": taxRateOverride,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		}
+	}
+
+	// Validate line item commitments if provided
+	if err := validateLineItemCommitments(c.LineItemCommitments); err != nil {
+		return err
+	}
+
+	// Validate override line items if provided
+	if len(c.OverrideLineItems) > 0 {
+		priceIDsSeen := make(map[string]bool)
+		for i, override := range c.OverrideLineItems {
+			// Check for duplicate price IDs
+			if priceIDsSeen[override.PriceID] {
+				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
+					WithHint("Each price can only be overridden once per subscription").
+					WithReportableDetails(map[string]interface{}{
+						"price_id": override.PriceID,
+						"index":    i,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+			priceIDsSeen[override.PriceID] = true
+		}
+	}
+
+	// Validate line_items if provided (each must have exactly one of price_id or price)
+	const maxLineItems = 100
+	if len(c.LineItems) > maxLineItems {
+		return ierr.NewError("line_items exceeds maximum allowed").
+			WithHint(fmt.Sprintf("At most %d line items can be added at subscription creation", maxLineItems)).
+			WithReportableDetails(map[string]interface{}{
+				"count": len(c.LineItems),
+				"max":   maxLineItems,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	for i, item := range c.LineItems {
+		if err := item.Validate(nil, nil); err != nil {
+			return ierr.WithError(err).
+				WithHint(fmt.Sprintf("Line item validation failed at index %d", i)).
+				WithReportableDetails(map[string]interface{}{"line_item_index": i}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	return nil
+}
+
 type CreateSubscriptionRequest struct {
 	// ID is an optional pre-generated subscription ID for internal use only.
 	// This exists as a temporary patch to allow Paddle entity mapping to be created
@@ -1046,98 +1148,8 @@ func (r *CreateSubscriptionRequest) Validate() error {
 		}
 	}
 
-	// Validate commitment amount and overage factor
-	if r.CommitmentAmount != nil && r.CommitmentAmount.LessThan(decimal.Zero) {
-		return ierr.NewError("commitment_amount must be non-negative").
-			WithHint("Commitment amount must be greater than or equal to 0").
-			WithReportableDetails(map[string]interface{}{
-				"commitment_amount": *r.CommitmentAmount,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-
-	if r.OverageFactor != nil && r.OverageFactor.LessThan(decimal.NewFromInt(1)) {
-		return ierr.NewError("overage_factor must be at least 1.0").
-			WithHint("Overage factor must be greater than or equal to 1.0").
-			WithReportableDetails(map[string]interface{}{
-				"overage_factor": *r.OverageFactor,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-
-	// Validate credit grants if provided
-	if len(r.CreditGrants) > 0 {
-		for i, grant := range r.CreditGrants {
-
-			// Force scope to SUBSCRIPTION for all grants added this way
-			if grant.Scope != types.CreditGrantScopeSubscription {
-				return ierr.NewError("invalid credit grant scope").
-					WithHint("Credit grants created with a subscription must have SUBSCRIPTION scope").
-					WithReportableDetails(map[string]interface{}{
-						"grant_scope": grant.Scope,
-						"grant_index": i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-		}
-	}
-
-	// taxrate overrides validation
-	if len(r.TaxRateOverrides) > 0 {
-		for _, taxRateOverride := range r.TaxRateOverrides {
-			if err := taxRateOverride.Validate(); err != nil {
-				return ierr.NewError("invalid tax rate override").
-					WithHint("Tax rate override validation failed").
-					WithReportableDetails(map[string]interface{}{
-						"error":             err.Error(),
-						"tax_rate_override": taxRateOverride,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-		}
-	}
-
-	// Validate line item commitments if provided
-	if err := validateLineItemCommitments(r.LineItemCommitments); err != nil {
+	if err := r.SubscriptionCreationConfig.Validate(); err != nil {
 		return err
-	}
-
-	// Validate override line items if provided
-	if len(r.OverrideLineItems) > 0 {
-		priceIDsSeen := make(map[string]bool)
-		for i, override := range r.OverrideLineItems {
-			// Check for duplicate price IDs
-			if priceIDsSeen[override.PriceID] {
-				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
-					WithHint("Each price can only be overridden once per subscription").
-					WithReportableDetails(map[string]interface{}{
-						"price_id": override.PriceID,
-						"index":    i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-			priceIDsSeen[override.PriceID] = true
-		}
-	}
-
-	// Validate line_items if provided (each must have exactly one of price_id or price)
-	const maxLineItems = 100
-	if len(r.LineItems) > maxLineItems {
-		return ierr.NewError("line_items exceeds maximum allowed").
-			WithHint(fmt.Sprintf("At most %d line items can be added at subscription creation", maxLineItems)).
-			WithReportableDetails(map[string]interface{}{
-				"count": len(r.LineItems),
-				"max":   maxLineItems,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-	for i, item := range r.LineItems {
-		if err := item.Validate(nil, nil); err != nil {
-			return ierr.WithError(err).
-				WithHint(fmt.Sprintf("Line item validation failed at index %d", i)).
-				WithReportableDetails(map[string]interface{}{"line_item_index": i}).
-				Mark(ierr.ErrValidation)
-		}
 	}
 
 	// Validate phases continuity if provided

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -16,7 +16,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// SubscriptionPhaseCreateRequest represents the request to create a subscription phase
 type SubscriptionPhaseCreateRequest struct {
 	StartDate time.Time  `json:"start_date" validate:"required"`
 	EndDate   *time.Time `json:"end_date,omitempty"`
@@ -30,18 +29,15 @@ type SubscriptionPhaseCreateRequest struct {
 	// Deprecated: use SubscriptionCoupons instead.
 	LineItemCoupons map[string][]string `json:"line_item_coupons,omitempty"`
 
-	// OverrideLineItems allows customizing specific prices for this phase
-	// If not provided, phase will use the same line items as the subscription (plan prices)
+	// OverrideLineItems overrides specific plan prices for this phase.
 	OverrideLineItems []OverrideLineItemRequest `json:"override_line_items,omitempty" validate:"omitempty,dive"`
 
-	// LineItems are extra line items to add during this phase, primarily one-time charges.
-	// Each item's start_date defaults to the phase's start_date when not provided.
+	// LineItems are extra (non-plan) line items for this phase; start_date defaults to phase start.
 	LineItems []CreateSubscriptionLineItemRequest `json:"line_items,omitempty" validate:"omitempty,dive"`
 
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-// Validate validates the SubscriptionPhaseCreateRequest
 func (r *SubscriptionPhaseCreateRequest) Validate() error {
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
@@ -53,9 +49,7 @@ func (r *SubscriptionPhaseCreateRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Validate each nested line item (price/price_id presence, date ordering, etc.)
-	// Price and subscription context are not available here; full business-rule
-	// validation is deferred to createPhaseExtraLineItems in the service layer.
+	// Full business-rule validation (price context, dates) is deferred to the service layer.
 	for i, li := range r.LineItems {
 		if err := li.Validate(nil, nil); err != nil {
 			return ierr.NewErrorf("invalid line_item at index %d: %s", i, err.Error()).
@@ -66,8 +60,6 @@ func (r *SubscriptionPhaseCreateRequest) Validate() error {
 
 	return nil
 }
-
-// ToSubscriptionPhase converts the request to a domain SubscriptionPhase
 
 func (r *SubscriptionPhaseCreateRequest) ToSubscriptionPhase(ctx context.Context, subscriptionID string) *subscription.SubscriptionPhase {
 	return &subscription.SubscriptionPhase{
@@ -81,44 +73,26 @@ func (r *SubscriptionPhaseCreateRequest) ToSubscriptionPhase(ctx context.Context
 	}
 }
 
-// LineItemCommitmentConfig represents commitment configuration for a line item
 type LineItemCommitmentConfig struct {
-	// CommitmentAmount is the minimum amount committed for this line item
-	CommitmentAmount *decimal.Decimal `json:"commitment_amount,omitempty"`
-
-	// CommitmentQuantity is the minimum quantity committed for this line item
-	CommitmentQuantity *decimal.Decimal `json:"commitment_quantity,omitempty"`
-
-	// CommitmentType specifies whether commitment is based on amount or quantity
-	CommitmentType types.CommitmentType `json:"commitment_type,omitempty"`
-
-	// OverageFactor is a multiplier applied to usage beyond the commitment
+	CommitmentAmount   *decimal.Decimal     `json:"commitment_amount,omitempty"`
+	CommitmentQuantity *decimal.Decimal     `json:"commitment_quantity,omitempty"`
+	CommitmentType     types.CommitmentType `json:"commitment_type,omitempty"`
+	// OverageFactor is a multiplier on usage beyond commitment; 1.0 = base rate.
 	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty"`
-
-	// EnableTrueUp determines if true-up fee should be applied when usage is below commitment
+	// EnableTrueUp charges the shortfall when usage is below commitment.
 	EnableTrueUp *bool `json:"enable_true_up,omitempty"`
-
-	// IsWindowCommitment determines if commitment is applied per window (e.g., per day) rather than per billing period
+	// IsWindowCommitment applies commitment per window (e.g. per day) rather than per billing period.
 	IsWindowCommitment *bool `json:"is_window_commitment,omitempty"`
-
-	// CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)
+	// CommitmentDuration allows a different period than billing (e.g. ANNUAL commitment on MONTHLY billing).
 	CommitmentDuration *types.BillingPeriod `json:"commitment_duration,omitempty"`
-
-	// CommitmentTimeBuckets defines per-bucket commitment + inline price for
-	// windows whose start UTC hour falls within each configured bucket. Each
-	// bucket carries its own price (materialized by the service). Requires
-	// IsWindowCommitment=true.
+	// CommitmentTimeBuckets scopes commitment to specific UTC-hour windows; requires IsWindowCommitment=true.
 	CommitmentTimeBuckets []CommitmentBucketRequest `json:"commitment_time_buckets,omitempty"`
 }
 
-// ToDomainBuckets maps the config's bucket requests to domain buckets (IDs +
-// commitment fields, empty PriceIDs); the service materializes a price per
-// bucket and fills in the PriceIDs.
 func (c *LineItemCommitmentConfig) ToDomainBuckets() types.TimeOfDayBuckets {
 	return bucketRequestsToDomain(c.CommitmentTimeBuckets)
 }
 
-// validateLineItemCommitments validates a map of price_id -> commitment configuration.
 func validateLineItemCommitments(commitments map[string]*LineItemCommitmentConfig) error {
 	if len(commitments) == 0 {
 		return nil
@@ -154,18 +128,15 @@ func validateLineItemCommitments(commitments map[string]*LineItemCommitmentConfi
 	return nil
 }
 
-// Validate validates the line item commitment configuration
 func (c *LineItemCommitmentConfig) Validate() error {
 	hasAmountCommitment := c.CommitmentAmount != nil && c.CommitmentAmount.GreaterThan(decimal.Zero)
 	hasQuantityCommitment := c.CommitmentQuantity != nil && c.CommitmentQuantity.GreaterThan(decimal.Zero)
 	hasCommitment := hasAmountCommitment || hasQuantityCommitment
 
 	if !hasCommitment {
-		// No commitment configured, nothing to validate
 		return nil
 	}
 
-	// Rule 1: Cannot set both commitment_amount and commitment_quantity
 	if hasAmountCommitment && hasQuantityCommitment {
 		return ierr.NewError("cannot set both commitment_amount and commitment_quantity").
 			WithHint("Specify either commitment_amount or commitment_quantity, not both").
@@ -176,7 +147,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 2: Commitment type must be valid and match the provided field
 	if c.CommitmentType != "" && !c.CommitmentType.Validate() {
 		return ierr.NewError("invalid commitment_type").
 			WithHint("Commitment type must be either 'amount' or 'quantity'").
@@ -186,7 +156,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Auto-set commitment type if not provided
 	if c.CommitmentType == "" {
 		if hasAmountCommitment {
 			c.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
@@ -194,7 +163,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			c.CommitmentType = types.COMMITMENT_TYPE_QUANTITY
 		}
 	} else {
-		// Validate commitment type matches the provided field
 		if hasAmountCommitment && c.CommitmentType != types.COMMITMENT_TYPE_AMOUNT {
 			return ierr.NewError("commitment_type mismatch").
 				WithHint("When commitment_amount is set, commitment_type must be 'amount'").
@@ -216,8 +184,7 @@ func (c *LineItemCommitmentConfig) Validate() error {
 		}
 	}
 
-	// Rule 3: Overage factor is required and must be at least 1.0 when commitment is set.
-	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
+	// overage_factor is required; 1.0 means usage beyond commitment bills at the base rate.
 	if c.OverageFactor == nil {
 		return ierr.NewError("overage_factor is required when commitment is set").
 			WithHint("Specify an overage_factor of 1.0 or greater").
@@ -233,7 +200,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 4: Validate commitment values are positive
 	if hasAmountCommitment && c.CommitmentAmount.IsNegative() {
 		return ierr.NewError("commitment_amount must be non-negative").
 			WithHint("Commitment amount cannot be negative").
@@ -252,8 +218,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 5: commitment_time_buckets only constrains the per-window application
-	// path — it has no meaning without is_window_commitment=true.
 	if len(c.CommitmentTimeBuckets) > 0 {
 		if c.IsWindowCommitment == nil || !*c.IsWindowCommitment {
 			return ierr.NewError("commitment_time_buckets requires is_window_commitment=true").
@@ -268,9 +232,7 @@ func (c *LineItemCommitmentConfig) Validate() error {
 	return nil
 }
 
-// SubscriptionCouponRequest represents a coupon to be applied to a subscription
-// If LineItemID is provided, the coupon is applied to that specific line item
-// If LineItemID is omitted, the coupon is applied at the subscription level
+// SubscriptionCouponRequest applies a coupon at subscription level or to a specific line item.
 type SubscriptionCouponRequest struct {
 	CouponID            string     `json:"coupon_id" validate:"required"`
 	StartDate           time.Time  `json:"start_date" validate:"required"`
@@ -279,14 +241,11 @@ type SubscriptionCouponRequest struct {
 	SubscriptionPhaseID *string    `json:"subscription_phase_id,omitempty"`
 }
 
-// Validate validates the SubscriptionCouponRequest
 func (r *SubscriptionCouponRequest) Validate() error {
-
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
 	}
 
-	// Validate date range if EndDate is provided
 	if r.EndDate != nil {
 		if r.EndDate.Before(r.StartDate) {
 			return ierr.NewError("end_date cannot be before start_date").
@@ -298,21 +257,15 @@ func (r *SubscriptionCouponRequest) Validate() error {
 	return nil
 }
 
-// SubscriptionCouponInput is the preferred coupon attachment request.
-// Identifies a coupon by human-readable code (never internal ID).
-// Optionally targets a specific subscription line item via price_id.
+// SubscriptionCouponInput is the preferred coupon attachment request (by coupon_code, not ID).
+// Optionally targets a specific line item via price_id; omit for subscription-level.
 type SubscriptionCouponInput struct {
-	// CouponCode is the coupon's human-readable code (case-insensitive). Required.
-	CouponCode string `json:"coupon_code" validate:"required"`
-	// StartDate is when the coupon starts; defaults to subscription/phase StartDate.
-	StartDate *time.Time `json:"start_date,omitempty"`
-	// EndDate is when the coupon ends; overrides duration_in_periods calculation.
-	EndDate *time.Time `json:"end_date,omitempty"`
-	// PriceID is the price ID of the line item to target; omit for subscription-level.
-	PriceID *string `json:"price_id,omitempty"`
+	CouponCode string     `json:"coupon_code" validate:"required"`
+	StartDate  *time.Time `json:"start_date,omitempty"`
+	EndDate    *time.Time `json:"end_date,omitempty"`
+	PriceID    *string    `json:"price_id,omitempty"`
 }
 
-// Validate validates SubscriptionCouponInput.
 func (r *SubscriptionCouponInput) Validate() error {
 	if r.CouponCode == "" {
 		return ierr.NewError("coupon_code is required").
@@ -326,95 +279,79 @@ func (r *SubscriptionCouponInput) Validate() error {
 	return nil
 }
 
-// GroupedInvoicingChildRequest creates one grouped_invoicing child under the parent in the same request.
-// Billing period, cycle, anchor, currency, and start_date are inherited from the parent;
-// everything in SubscriptionCreationConfig is independently configurable per child.
+// GroupedInvoicingChildRequest creates a grouped_invoicing child inline with the parent request.
+// Billing schedule fields (period, cycle, anchor, currency, start_date) are inherited from the parent.
 type GroupedInvoicingChildRequest struct {
 	PlanID             string `json:"plan_id" validate:"required"`
 	ExternalCustomerID string `json:"external_customer_id" validate:"required"`
 	SubscriptionCreationConfig
 }
 
-// SubscriptionInheritanceConfig groups all hierarchy and invoicing-routing fields for
-// subscription creation.
+// SubscriptionInheritanceConfig holds all customer-hierarchy and invoicing-routing fields.
 type SubscriptionInheritanceConfig struct {
-	// ExternalCustomerIDsToInheritSubscription: child customer external IDs for which
-	// inherited skeleton subscriptions will be created. Only valid for parent behavior.
+	// ExternalCustomerIDsToInheritSubscription creates inherited skeleton subscriptions for child customers. Parent only.
 	ExternalCustomerIDsToInheritSubscription []string `json:"external_customer_ids_to_inherit_subscription,omitempty"`
 
-	// ParentSubscriptionID links this subscription to an existing parent.
-	// Required for inherited and grouped_invoicing; rejected for standalone, delegated, parent.
+	// ParentSubscriptionID links to an existing parent. Required for inherited/grouped_invoicing; rejected for standalone/delegated/parent.
 	ParentSubscriptionID string `json:"parent_subscription_id,omitempty"`
 
-	// InvoicingCustomerExternalID sets a different billing recipient (external ID).
-	// Required for delegated; rejected for inherited; optional for others.
+	// InvoicingCustomerExternalID routes invoices to a different customer. Required for delegated; rejected for inherited.
 	InvoicingCustomerExternalID *string `json:"invoicing_customer_external_id,omitempty"`
 
-	// SubscriptionsIDsForGroupedInvoicing: existing standalone subscription IDs to convert to
-	// grouped_invoicing under this parent at creation time. Only valid for parent behavior.
+	// SubscriptionsIDsForGroupedInvoicing converts existing standalone subscriptions to grouped_invoicing under this parent. Parent only.
 	SubscriptionsIDsForGroupedInvoicing []string `json:"subscriptions_ids_for_grouped_invoicing,omitempty"`
 
-	// grouped_invoicing_children_to_create creates new grouped_invoicing children under this parent
 	GroupedInvoicingChildrenToCreate []GroupedInvoicingChildRequest `json:"grouped_invoicing_children_to_create,omitempty" validate:"omitempty,dive"`
 }
 
-// Validate enforces mutual-exclusivity constraints between inheritance fields.
 func (c *SubscriptionInheritanceConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
 
-	// Cannot combine explicit parent link with "create inherited children".
 	if c.ParentSubscriptionID != "" && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set parent_subscription_id together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either a parent subscription link or child customers to inherit, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Cannot delegate invoicing while also creating inherited children.
 	if c.InvoicingCustomerExternalID != nil && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set invoicing_customer_external_id together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either invoicing_customer_external_id or external_customer_ids_to_inherit_subscription, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing conversions only make sense when creating a parent (no parent link).
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && c.ParentSubscriptionID != "" {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with parent_subscription_id").
 			WithHint("subscriptions_ids_for_grouped_invoicing can only be used when creating a parent subscription").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing conversions cannot be combined with delegated invoicing.
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && c.InvoicingCustomerExternalID != nil {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with invoicing_customer_external_id").
 			WithHint("Use either grouped invoicing conversion or delegated invoicing, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing conversions cannot be combined with inherited child creation.
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either grouped invoicing conversion or inherited child creation, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing inline-child creation cannot be combined with existing-subscription conversion.
 	if len(c.GroupedInvoicingChildrenToCreate) > 0 && len(c.SubscriptionsIDsForGroupedInvoicing) > 0 {
 		return ierr.NewError("cannot set grouped_invoicing_children_to_create together with subscriptions_ids_for_grouped_invoicing").
 			WithHint("Use either inline child creation or existing-subscription conversion, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Inline children require creating a parent, not attaching under an existing parent.
-	// InvoicingCustomerExternalID is allowed (delegated payer for seat fees).
+	// InvoicingCustomerExternalID is still allowed here (delegated payer for seat fees).
 	if len(c.GroupedInvoicingChildrenToCreate) > 0 && c.ParentSubscriptionID != "" {
 		return ierr.NewError("cannot set grouped_invoicing_children_to_create together with parent_subscription_id").
 			WithHint("grouped_invoicing_children_to_create can only be used when creating a parent subscription").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Validate that no element in SubscriptionsIDsForGroupedInvoicing is empty.
 	for i, id := range c.SubscriptionsIDsForGroupedInvoicing {
 		if id == "" {
 			return ierr.NewError("subscriptions_ids_for_grouped_invoicing cannot contain empty values").
@@ -426,32 +363,21 @@ func (c *SubscriptionInheritanceConfig) Validate() error {
 	return nil
 }
 
-// SubscriptionCreationConfig groups every optional, per-subscription configuration field
-// that can be set at creation time, beyond plan/customer/billing-schedule. It is embedded
-// in both CreateSubscriptionRequest (top-level subscription creation) and
-// GroupedInvoicingChildRequest (inline grouped-invoicing child creation), so both use
-// identical JSON field names and identical validation.
+// SubscriptionCreationConfig holds optional configuration shared by CreateSubscriptionRequest and
+// GroupedInvoicingChildRequest, using identical JSON fields and validation for both.
 type SubscriptionCreationConfig struct {
-	// TrialPeriodDays: nil = inherit trial length from plan recurring-fixed prices (must be uniform).
-	// 0 = explicitly no trial (overrides catalog). >0 = override duration in days.
+	// TrialPeriodDays: nil = inherit from plan prices, 0 = no trial, >0 = override in days.
 	TrialPeriodDays *int `json:"trial_period_days,omitempty"`
 
-	// Credit grants to be applied when subscription is created
 	CreditGrants []CreateCreditGrantRequest `json:"credit_grants,omitempty"`
 
-	// CommitmentAmount is the minimum amount a customer commits to paying for a billing period
 	CommitmentAmount *decimal.Decimal `json:"commitment_amount,omitempty" swaggertype:"string"`
 
-	// CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)
+	// CommitmentDuration allows a different commitment period than billing (e.g. ANNUAL on MONTHLY).
 	CommitmentDuration *types.BillingPeriod `json:"commitment_duration,omitempty"`
 
-	// OverageFactor is a multiplier applied to usage beyond the commitment amount
-	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty" swaggertype:"string"`
-
-	// Enable Commitment True Up Fee
-	EnableTrueUp bool `json:"enable_true_up"`
-
-	// tax_rate_overrides is the tax rate overrides to be applied to the subscription
+	OverageFactor    *decimal.Decimal   `json:"overage_factor,omitempty" swaggertype:"string"`
+	EnableTrueUp     bool               `json:"enable_true_up"`
 	TaxRateOverrides []*TaxRateOverride `json:"tax_rate_overrides,omitempty"`
 
 	// SubscriptionCoupons is the preferred way to attach coupons at creation.
@@ -464,30 +390,19 @@ type SubscriptionCreationConfig struct {
 	// Deprecated: use SubscriptionCoupons instead.
 	LineItemCoupons map[string][]string `json:"line_item_coupons,omitempty"`
 
-	// LineItemCommitments allows setting commitment configuration per line item (keyed by price_id)
+	// LineItemCommitments sets per-line-item commitment config, keyed by price_id.
 	LineItemCommitments map[string]*LineItemCommitmentConfig `json:"line_item_commitments,omitempty" validate:"omitempty,dive"`
 
-	// OverrideLineItems allows customizing specific prices for this subscription
-	OverrideLineItems []OverrideLineItemRequest `json:"override_line_items,omitempty" validate:"omitempty,dive"`
-	// OverrideEntitlements allows customizing specific entitlements for this subscription
-	OverrideEntitlements []OverrideEntitlementRequest `json:"override_entitlements,omitempty" validate:"omitempty,dive"`
-	// Addons represents addons to be added to the subscription during creation
-	Addons []AddAddonToSubscriptionRequest `json:"addons,omitempty" validate:"omitempty,dive"`
-
-	// LineItems are extra line items to add at creation (each with price_id or price), in addition to plan prices
+	// OverrideLineItems overrides specific plan prices for this subscription.
+	OverrideLineItems    []OverrideLineItemRequest       `json:"override_line_items,omitempty" validate:"omitempty,dive"`
+	OverrideEntitlements []OverrideEntitlementRequest    `json:"override_entitlements,omitempty" validate:"omitempty,dive"`
+	Addons               []AddAddonToSubscriptionRequest `json:"addons,omitempty" validate:"omitempty,dive"`
+	// LineItems are extra (non-plan) line items added at creation.
 	LineItems []CreateSubscriptionLineItemRequest `json:"line_items,omitempty" validate:"omitempty,dive"`
-
-	// Phases represents subscription phases to be created with the subscription
-	Phases []SubscriptionPhaseCreateRequest `json:"phases,omitempty" validate:"omitempty,dive"`
+	Phases    []SubscriptionPhaseCreateRequest    `json:"phases,omitempty" validate:"omitempty,dive"`
 }
 
-// Validate validates the self-contained fields of SubscriptionCreationConfig — checks that
-// only ever need this struct's own fields, independent of the parent request's type,
-// billing status, or proration settings. Used by both CreateSubscriptionRequest.Validate()
-// and (transitively, via CreateSubscriptionRequest's own promoted fields) grouped-invoicing
-// child requests.
 func (c *SubscriptionCreationConfig) Validate() error {
-	// Validate commitment amount and overage factor
 	if c.CommitmentAmount != nil && c.CommitmentAmount.LessThan(decimal.Zero) {
 		return ierr.NewError("commitment_amount must be non-negative").
 			WithHint("Commitment amount must be greater than or equal to 0").
@@ -506,10 +421,9 @@ func (c *SubscriptionCreationConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Validate credit grants if provided
 	if len(c.CreditGrants) > 0 {
 		for i, grant := range c.CreditGrants {
-			// Force scope to SUBSCRIPTION for all grants added this way
+			// Grants created with a subscription must have SUBSCRIPTION scope.
 			if grant.Scope != types.CreditGrantScopeSubscription {
 				return ierr.NewError("invalid credit grant scope").
 					WithHint("Credit grants created with a subscription must have SUBSCRIPTION scope").
@@ -522,7 +436,6 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		}
 	}
 
-	// taxrate overrides validation
 	if len(c.TaxRateOverrides) > 0 {
 		for _, taxRateOverride := range c.TaxRateOverrides {
 			if err := taxRateOverride.Validate(); err != nil {
@@ -537,16 +450,13 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		}
 	}
 
-	// Validate line item commitments if provided
 	if err := validateLineItemCommitments(c.LineItemCommitments); err != nil {
 		return err
 	}
 
-	// Validate override line items if provided
 	if len(c.OverrideLineItems) > 0 {
 		priceIDsSeen := make(map[string]bool)
 		for i, override := range c.OverrideLineItems {
-			// Check for duplicate price IDs
 			if priceIDsSeen[override.PriceID] {
 				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
 					WithHint("Each price can only be overridden once per subscription").
@@ -560,7 +470,6 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		}
 	}
 
-	// Validate line_items if provided (each must have exactly one of price_id or price)
 	const maxLineItems = 100
 	if len(c.LineItems) > maxLineItems {
 		return ierr.NewError("line_items exceeds maximum allowed").
@@ -584,19 +493,12 @@ func (c *SubscriptionCreationConfig) Validate() error {
 }
 
 type CreateSubscriptionRequest struct {
-	// ID is an optional pre-generated subscription ID for internal use only.
-	// This exists as a temporary patch to allow Paddle entity mapping to be created
-	// before the subscription row is written, so both share the same transaction.
+	// ID is pre-generated for internal use (e.g. Paddle mapping before write). Never from external JSON.
 	// TODO: Remove once plan-change integration carryover is handled generically.
-	// Never populated from external JSON.
 	ID string `json:"-"`
 
-	// customer_id is the flexprice customer id
-	// and it is prioritized over external_customer_id in case both are provided.
-	CustomerID string `json:"customer_id"`
-
-	// external_customer_id is the customer id in your DB
-	// and must be same as what you provided as external_id while creating the customer in flexprice.
+	// CustomerID takes priority over ExternalCustomerID when both are provided.
+	CustomerID         string `json:"customer_id"`
 	ExternalCustomerID string `json:"external_customer_id"`
 
 	PlanID    string     `json:"plan_id" validate:"required"`
@@ -605,7 +507,7 @@ type CreateSubscriptionRequest struct {
 	StartDate *time.Time `json:"start_date,omitempty"`
 	EndDate   *time.Time `json:"end_date,omitempty"`
 
-	// TrialStart/TrialEnd are for internal integrations only (e.g. Stripe sync); not accepted from public JSON.
+	// TrialStart/TrialEnd are for internal integrations (e.g. Stripe sync); not accepted from public JSON.
 	TrialStart *time.Time `json:"-"`
 	TrialEnd   *time.Time `json:"-"`
 
@@ -614,89 +516,52 @@ type CreateSubscriptionRequest struct {
 	BillingPeriodCount int                  `json:"billing_period_count" default:"1"`
 	Metadata           map[string]string    `json:"metadata,omitempty"`
 
-	// BillingCycle is the cycle of the billing anchor.
-	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
-	// If not set, the default value is anniversary. Possible values are anniversary and calendar.
-	// Anniversary billing means the billing anchor will be the start date of the subscription.
-	// Calendar billing means the billing anchor will be the appropriate date based on the billing period.
-	// For example, if the billing period is month and the start date is 2025-04-15 then in case of
-	// calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
+	// BillingCycle controls the billing anchor. anniversary = start_date; calendar = period boundary
+	// (e.g. monthly with start 2025-04-15 → calendar anchor is 2025-05-01).
 	BillingCycle types.BillingCycle `json:"billing_cycle"`
 
-	// Payment behavior configuration
-	PaymentBehavior        *types.PaymentBehavior `json:"payment_behavior,omitempty"`
-	GatewayPaymentMethodID *string                `json:"gateway_payment_method_id,omitempty"`
-
-	// collection_method determines how invoices are collected
-	// "default_incomplete" - subscription waits for payment confirmation before activation
-	// "send_invoice" - subscription activates immediately, invoice is sent for payment
-	CollectionMethod *types.CollectionMethod `json:"collection_method,omitempty"`
-
-	// ProrationBehavior controls how proration is handled.
-	// If not set, the default value is none. Possible values are create_prorations and none.
-	// create_prorations means the proration will be calculated and applied.
-	// none means the proration will not be calculated.
-	// This is IGNORED when the billing cycle is anniversary.
+	PaymentBehavior        *types.PaymentBehavior  `json:"payment_behavior,omitempty"`
+	GatewayPaymentMethodID *string                 `json:"gateway_payment_method_id,omitempty"`
+	CollectionMethod       *types.CollectionMethod `json:"collection_method,omitempty"`
+	// ProrationBehavior: create_prorations or none (default). Ignored for anniversary billing.
 	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
-
-	// Timezone of the customer.
-	// If not set, the default value is UTC.
-	Timezone string `json:"timezone" validate:"omitempty,timezone"`
-
-	// BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.
-	// For monthly billing, the day-of-month (and time-of-day) define cycle boundaries: if start_date
-	// is before that day in the month, the first billing period ends on the next occurrence of that
-	// day in the same month (a shorter first period); subsequent periods follow the usual interval.
+	Timezone          string                  `json:"timezone" validate:"omitempty,timezone"`
+	// BillingAnchor overrides the derived anchor for anniversary billing. For monthly billing,
+	// the day-of-month defines cycle boundaries (shorter first period if start is before that day).
 	BillingAnchor *time.Time `json:"billing_anchor,omitempty"`
 
-	// Workflow
 	Workflow *types.TemporalWorkflowType `json:"-"`
 
-	// SubscriptionStatus determines the initial status of the subscription
-	// If set to "draft", the subscription will be created as a draft (skips invoice creation and payment processing)
+	// SubscriptionStatus: set to "draft" to skip invoice creation and payment on create.
 	SubscriptionStatus types.SubscriptionStatus `json:"subscription_status,omitempty"`
+	PaymentTerms       *types.PaymentTerms      `json:"payment_terms,omitempty"`
 
-	// PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end
-	PaymentTerms *types.PaymentTerms `json:"payment_terms,omitempty"`
-
-	// AutoInvoiceThreshold is the usage amount (in subscription currency) that triggers
-	// an intermediate invoice mid-period. Set once at creation; cannot be changed later.
-	// Allowed only when the subscription resolves to type standalone (no parent hierarchy rows).
-	// Plan line items must be usage-based only (no fixed or other non-usage plan prices).
-	// Nil means auto invoice threshold billing is disabled for this subscription.
+	// AutoInvoiceThreshold triggers a mid-period invoice when usage (in subscription currency) exceeds this amount.
+	// Standalone subscriptions only; all plan prices must be usage-based. Immutable after creation.
 	AutoInvoiceThreshold *decimal.Decimal `json:"auto_invoice_threshold,omitempty" swaggertype:"string"`
 
-	// Inheritance groups all customer-hierarchy fields.
-	// When provided with at least one child ID, the subscription becomes a PARENT type.
+	// Inheritance groups customer-hierarchy fields; providing child IDs makes this a PARENT subscription.
 	Inheritance *SubscriptionInheritanceConfig `json:"inheritance,omitempty"`
 
 	// SubscriptionType is set internally by the service layer.
 	SubscriptionType types.SubscriptionType `json:"-"`
 
-	// OpeningInvoiceAdjustmentAmount is internal: proration/cancel credit to net the new subscription's first (opening) invoice (e.g. CancelSubscriptionResponse.TotalCreditAmount on immediate plan change). Not in public JSON.
+	// OpeningInvoiceAdjustmentAmount nets the opening invoice against a proration/cancel credit (e.g. on plan change). Internal only.
 	OpeningInvoiceAdjustmentAmount *decimal.Decimal `json:"-"`
 
-	// SubscriptionCreationConfig holds every optional configuration field shared with
-	// GroupedInvoicingChildRequest (overrides, extra line items, coupons, taxes,
-	// commitments, trial, credit grants, entitlement overrides, addons, phases).
 	SubscriptionCreationConfig
 }
 
-// AddAddonRequest is used by body-based endpoint /subscriptions/addon
 type AddAddonRequest struct {
 	SubscriptionID                string `json:"subscription_id" validate:"required"`
 	AddAddonToSubscriptionRequest `json:",inline"`
 }
 
-// RemoveAddonRequest is used by body-based endpoint /subscriptions/addon (DELETE)
 type RemoveAddonRequest struct {
 	AddonAssociationID string                  `json:"addon_association_id" validate:"required"`
 	Reason             string                  `json:"reason,omitempty"`
 	ProrationBehavior  types.ProrationBehavior `json:"proration_behavior,omitempty"`
-	// EffectiveDate is the date the cancellation takes effect.
-	// When nil the addon is cancelled at the end of the current period.
-	// When provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period
-	// values combined with create_prorations will issue a wallet credit for unused time.
+	// EffectiveDate defaults to period end when nil; mid-period with create_prorations issues a wallet credit.
 	EffectiveDate *time.Time `json:"effective_date,omitempty"`
 }
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -327,10 +327,12 @@ func (r *SubscriptionCouponInput) Validate() error {
 }
 
 // GroupedInvoicingChildRequest creates one grouped_invoicing child under the parent in the same request.
-// Billing period, cycle, anchor, currency, and start_date are inherited from the parent.
+// Billing period, cycle, anchor, currency, and start_date are inherited from the parent;
+// everything in SubscriptionCreationConfig is independently configurable per child.
 type GroupedInvoicingChildRequest struct {
 	PlanID             string `json:"plan_id" validate:"required"`
 	ExternalCustomerID string `json:"external_customer_id" validate:"required"`
+	SubscriptionCreationConfig
 }
 
 // SubscriptionInheritanceConfig groups all hierarchy and invoicing-routing fields for

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -424,49 +424,15 @@ func (c *SubscriptionInheritanceConfig) Validate() error {
 	return nil
 }
 
-type CreateSubscriptionRequest struct {
-	// ID is an optional pre-generated subscription ID for internal use only.
-	// This exists as a temporary patch to allow Paddle entity mapping to be created
-	// before the subscription row is written, so both share the same transaction.
-	// TODO: Remove once plan-change integration carryover is handled generically.
-	// Never populated from external JSON.
-	ID string `json:"-"`
-
-	// customer_id is the flexprice customer id
-	// and it is prioritized over external_customer_id in case both are provided.
-	CustomerID string `json:"customer_id"`
-
-	// external_customer_id is the customer id in your DB
-	// and must be same as what you provided as external_id while creating the customer in flexprice.
-	ExternalCustomerID string `json:"external_customer_id"`
-
-	PlanID    string     `json:"plan_id" validate:"required"`
-	Currency  string     `json:"currency" validate:"required,len=3"`
-	LookupKey string     `json:"lookup_key"`
-	StartDate *time.Time `json:"start_date,omitempty"`
-	EndDate   *time.Time `json:"end_date,omitempty"`
-
+// SubscriptionCreationConfig groups every optional, per-subscription configuration field
+// that can be set at creation time, beyond plan/customer/billing-schedule. It is embedded
+// in both CreateSubscriptionRequest (top-level subscription creation) and
+// GroupedInvoicingChildRequest (inline grouped-invoicing child creation), so both use
+// identical JSON field names and identical validation.
+type SubscriptionCreationConfig struct {
 	// TrialPeriodDays: nil = inherit trial length from plan recurring-fixed prices (must be uniform).
 	// 0 = explicitly no trial (overrides catalog). >0 = override duration in days.
 	TrialPeriodDays *int `json:"trial_period_days,omitempty"`
-
-	// TrialStart/TrialEnd are for internal integrations only (e.g. Stripe sync); not accepted from public JSON.
-	TrialStart *time.Time `json:"-"`
-	TrialEnd   *time.Time `json:"-"`
-
-	BillingCadence     types.BillingCadence `json:"-"`
-	BillingPeriod      types.BillingPeriod  `json:"billing_period" validate:"required"`
-	BillingPeriodCount int                  `json:"billing_period_count" default:"1"`
-	Metadata           map[string]string    `json:"metadata,omitempty"`
-
-	// BillingCycle is the cycle of the billing anchor.
-	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
-	// If not set, the default value is anniversary. Possible values are anniversary and calendar.
-	// Anniversary billing means the billing anchor will be the start date of the subscription.
-	// Calendar billing means the billing anchor will be the appropriate date based on the billing period.
-	// For example, if the billing period is month and the start date is 2025-04-15 then in case of
-	// calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
-	BillingCycle types.BillingCycle `json:"billing_cycle"`
 
 	// Credit grants to be applied when subscription is created
 	CreditGrants []CreateCreditGrantRequest `json:"credit_grants,omitempty"`
@@ -480,7 +446,10 @@ type CreateSubscriptionRequest struct {
 	// OverageFactor is a multiplier applied to usage beyond the commitment amount
 	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty" swaggertype:"string"`
 
-	// tax_rate_overrides is the tax rate overrides	to be applied to the subscription
+	// Enable Commitment True Up Fee
+	EnableTrueUp bool `json:"enable_true_up"`
+
+	// tax_rate_overrides is the tax rate overrides to be applied to the subscription
 	TaxRateOverrides []*TaxRateOverride `json:"tax_rate_overrides,omitempty"`
 
 	// SubscriptionCoupons is the preferred way to attach coupons at creation.
@@ -508,6 +477,47 @@ type CreateSubscriptionRequest struct {
 
 	// Phases represents subscription phases to be created with the subscription
 	Phases []SubscriptionPhaseCreateRequest `json:"phases,omitempty" validate:"omitempty,dive"`
+}
+
+type CreateSubscriptionRequest struct {
+	// ID is an optional pre-generated subscription ID for internal use only.
+	// This exists as a temporary patch to allow Paddle entity mapping to be created
+	// before the subscription row is written, so both share the same transaction.
+	// TODO: Remove once plan-change integration carryover is handled generically.
+	// Never populated from external JSON.
+	ID string `json:"-"`
+
+	// customer_id is the flexprice customer id
+	// and it is prioritized over external_customer_id in case both are provided.
+	CustomerID string `json:"customer_id"`
+
+	// external_customer_id is the customer id in your DB
+	// and must be same as what you provided as external_id while creating the customer in flexprice.
+	ExternalCustomerID string `json:"external_customer_id"`
+
+	PlanID    string     `json:"plan_id" validate:"required"`
+	Currency  string     `json:"currency" validate:"required,len=3"`
+	LookupKey string     `json:"lookup_key"`
+	StartDate *time.Time `json:"start_date,omitempty"`
+	EndDate   *time.Time `json:"end_date,omitempty"`
+
+	// TrialStart/TrialEnd are for internal integrations only (e.g. Stripe sync); not accepted from public JSON.
+	TrialStart *time.Time `json:"-"`
+	TrialEnd   *time.Time `json:"-"`
+
+	BillingCadence     types.BillingCadence `json:"-"`
+	BillingPeriod      types.BillingPeriod  `json:"billing_period" validate:"required"`
+	BillingPeriodCount int                  `json:"billing_period_count" default:"1"`
+	Metadata           map[string]string    `json:"metadata,omitempty"`
+
+	// BillingCycle is the cycle of the billing anchor.
+	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
+	// If not set, the default value is anniversary. Possible values are anniversary and calendar.
+	// Anniversary billing means the billing anchor will be the start date of the subscription.
+	// Calendar billing means the billing anchor will be the appropriate date based on the billing period.
+	// For example, if the billing period is month and the start date is 2025-04-15 then in case of
+	// calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
+	BillingCycle types.BillingCycle `json:"billing_cycle"`
 
 	// Payment behavior configuration
 	PaymentBehavior        *types.PaymentBehavior `json:"payment_behavior,omitempty"`
@@ -545,9 +555,6 @@ type CreateSubscriptionRequest struct {
 	// PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end
 	PaymentTerms *types.PaymentTerms `json:"payment_terms,omitempty"`
 
-	// Enable Commitment True Up Fee
-	EnableTrueUp bool `json:"enable_true_up"`
-
 	// AutoInvoiceThreshold is the usage amount (in subscription currency) that triggers
 	// an intermediate invoice mid-period. Set once at creation; cannot be changed later.
 	// Allowed only when the subscription resolves to type standalone (no parent hierarchy rows).
@@ -564,6 +571,11 @@ type CreateSubscriptionRequest struct {
 
 	// OpeningInvoiceAdjustmentAmount is internal: proration/cancel credit to net the new subscription's first (opening) invoice (e.g. CancelSubscriptionResponse.TotalCreditAmount on immediate plan change). Not in public JSON.
 	OpeningInvoiceAdjustmentAmount *decimal.Decimal `json:"-"`
+
+	// SubscriptionCreationConfig holds every optional configuration field shared with
+	// GroupedInvoicingChildRequest (overrides, extra line items, coupons, taxes,
+	// commitments, trial, credit grants, entitlement overrides, addons, phases).
+	SubscriptionCreationConfig
 }
 
 // AddAddonRequest is used by body-based endpoint /subscriptions/addon

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7689,12 +7689,15 @@ func (s *subscriptionService) createInheritedSubscriptions(ctx context.Context, 
 
 // createGroupedInvoicingChildren creates each child spec as a brand-new grouped_invoicing
 // subscription under parent, inside the caller's existing transaction. Each child's own opening
-// invoice is suppressed (see the invoice-generation gate in createSubscriptionCore); its period-1
-// charges are folded into the parent's own opening invoice instead. Calls createSubscriptionCore
+// invoice is suppressed (see the invoice-generation gate in createSubscription); its period-1
+// charges are folded into the parent's own opening invoice instead. Calls createSubscription
 // directly (not the public CreateSubscription): it must reuse the caller's already-open
 // transaction and must not fire the child's own post-transaction side effects (webhook,
 // HubSpot/Paddle sync) — only the parent's single post-tx block should run, once, after
-// everything commits.
+// everything commits. Every field in the child's SubscriptionCreationConfig (overrides, extra
+// line items, coupons, taxes, commitments, trial, credit grants, entitlement overrides, addons,
+// phases) is copied through as-is and validated/applied by the same createSubscription call the
+// parent uses — no separate handling needed here.
 func (s *subscriptionService) createGroupedInvoicingChildren(
 	ctx context.Context,
 	parent *subscription.Subscription,
@@ -7702,15 +7705,28 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 ) error {
 	for _, c := range childRequests {
 		startDate := parent.StartDate
+
+		// BillingAnchor is only ever valid alongside BillingCycle == anniversary (enforced in
+		// CreateSubscriptionRequest.Validate()). Since BillingCycle is always inherited from the
+		// parent below, only pass the anchor through when that inherited cycle is anniversary —
+		// otherwise a calendar-cycle child would fail validation on a non-nil anchor pointer.
+		var billingAnchor *time.Time
+		if parent.BillingCycle == types.BillingCycleAnniversary {
+			anchor := parent.BillingAnchor
+			billingAnchor = &anchor
+		}
+
 		childReq := dto.CreateSubscriptionRequest{
-			ExternalCustomerID: c.ExternalCustomerID,
-			PlanID:             c.PlanID,
-			Currency:           parent.Currency,
-			StartDate:          &startDate,
-			BillingPeriod:      parent.BillingPeriod,
-			BillingPeriodCount: parent.BillingPeriodCount,
-			BillingCycle:       parent.BillingCycle,
-			SubscriptionType:   types.SubscriptionTypeGroupedInvoicing,
+			ExternalCustomerID:         c.ExternalCustomerID,
+			PlanID:                     c.PlanID,
+			Currency:                   parent.Currency,
+			StartDate:                  &startDate,
+			BillingPeriod:              parent.BillingPeriod,
+			BillingPeriodCount:         parent.BillingPeriodCount,
+			BillingCycle:               parent.BillingCycle,
+			BillingAnchor:              billingAnchor,
+			SubscriptionType:           types.SubscriptionTypeGroupedInvoicing,
+			SubscriptionCreationConfig: c.SubscriptionCreationConfig,
 			Inheritance: &dto.SubscriptionInheritanceConfig{
 				ParentSubscriptionID: parent.ID,
 			},

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7687,17 +7687,9 @@ func (s *subscriptionService) createInheritedSubscriptions(ctx context.Context, 
 	return nil
 }
 
-// createGroupedInvoicingChildren creates each child spec as a brand-new grouped_invoicing
-// subscription under parent, inside the caller's existing transaction. Each child's own opening
-// invoice is suppressed (see the invoice-generation gate in createSubscription); its period-1
-// charges are folded into the parent's own opening invoice instead. Calls createSubscription
-// directly (not the public CreateSubscription): it must reuse the caller's already-open
-// transaction and must not fire the child's own post-transaction side effects (webhook,
-// HubSpot/Paddle sync) — only the parent's single post-tx block should run, once, after
-// everything commits. Every field in the child's SubscriptionCreationConfig (overrides, extra
-// line items, coupons, taxes, commitments, trial, credit grants, entitlement overrides, addons,
-// phases) is copied through as-is and validated/applied by the same createSubscription call the
-// parent uses — no separate handling needed here.
+// createGroupedInvoicingChildren creates grouped_invoicing child subscriptions inside the caller's
+// transaction. Children suppress their own opening invoice (charges fold into the parent's);
+// post-tx side effects (webhooks, HubSpot/Paddle sync) run only from the parent's block.
 func (s *subscriptionService) createGroupedInvoicingChildren(
 	ctx context.Context,
 	parent *subscription.Subscription,
@@ -7706,10 +7698,7 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 	for _, c := range childRequests {
 		startDate := parent.StartDate
 
-		// BillingAnchor is only ever valid alongside BillingCycle == anniversary (enforced in
-		// CreateSubscriptionRequest.Validate()). Since BillingCycle is always inherited from the
-		// parent below, only pass the anchor through when that inherited cycle is anniversary —
-		// otherwise a calendar-cycle child would fail validation on a non-nil anchor pointer.
+		// BillingAnchor is only valid for anniversary billing; pass nil for calendar to avoid validation failure.
 		var billingAnchor *time.Time
 		if parent.BillingCycle == types.BillingCycleAnniversary {
 			anchor := parent.BillingAnchor
@@ -7978,14 +7967,8 @@ func (s *subscriptionService) processAutoInvoiceThresholdSubscription(
 	return nil
 }
 
-// runPaddleSubscriptionSync synchronously bootstraps a Paddle subscription for the given
-// subscription. It is called inline from CreateSubscription so the checkout URL is available
-// in the response without a round-trip through Temporal. All errors are soft-fail: the
-// subscription has already been persisted, so we only log and continue.
-//
-// On success, EnsureSubscriptionSynced persists paddle checkout metadata; it is copied back
-// onto the caller's sub so the create response includes paddle_checkout_url and
-// paddle_transaction_id.
+// runPaddleSubscriptionSync bootstraps Paddle inline (not via Temporal) so checkout metadata is
+// available in the create response. Errors are soft-fail — subscription is already persisted.
 func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub *subscription.Subscription) {
 	if s.IntegrationFactory == nil {
 		return

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -866,12 +866,14 @@ func (s *subscriptionChangeService) createNewSubscription(
 		Metadata:           lo.Assign(currentSub.Metadata, req.Metadata),
 		ProrationBehavior:  req.ProrationBehavior,
 		Timezone:           currentSub.Timezone,
-		CommitmentAmount:   currentSub.CommitmentAmount,
-		OverageFactor:      currentSub.OverageFactor,
 		PaymentTerms:       currentSub.PaymentTerms,
 		Workflow:           lo.ToPtr(types.TemporalSubscriptionCreationWorkflow),
 		Inheritance:        inheritance,
-		TrialPeriodDays:    lo.ToPtr(0), // THIS IS IMPORTANT: we don't want to inherit the trial period days from the old subscription
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			CommitmentAmount: currentSub.CommitmentAmount,
+			OverageFactor:    currentSub.OverageFactor,
+			TrialPeriodDays:  lo.ToPtr(0), // THIS IS IMPORTANT: we don't want to inherit the trial period days from the old subscription
+		},
 	}
 
 	// When doing an immediate plan change, we cancel the old subscription with proration but

--- a/internal/ee/service/subscription_price_override_test.go
+++ b/internal/ee/service/subscription_price_override_test.go
@@ -32,11 +32,13 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			BillingCycle:       types.BillingCycleAnniversary,
-			OverrideLineItems: []dto.OverrideLineItemRequest{
-				{
-					PriceID:  "test_price_789",
-					Amount:   &overrideAmount,
-					Quantity: &overrideQuantity,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{
+					{
+						PriceID:  "test_price_789",
+						Amount:   &overrideAmount,
+						Quantity: &overrideQuantity,
+					},
 				},
 			},
 		}
@@ -151,14 +153,16 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			BillingCycle:       types.BillingCycleAnniversary,
-			OverrideLineItems: []dto.OverrideLineItemRequest{
-				{
-					PriceID: "duplicate_price",
-					Amount:  &amount1,
-				},
-				{
-					PriceID: "duplicate_price", // Duplicate!
-					Amount:  &amount2,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{
+					{
+						PriceID: "duplicate_price",
+						Amount:  &amount1,
+					},
+					{
+						PriceID: "duplicate_price", // Duplicate!
+						Amount:  &amount2,
+					},
 				},
 			},
 		}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9044,13 +9044,22 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	ctx := s.GetContext()
 	seatPlan := s.setupSeatFeePlan()
 
+	// Create a separate plan as the entity for the onboarding fee so the price is NOT
+	// auto-included in seatPlan subscriptions, but the plan lookup in buildLineItemParamsForPrice succeeds.
+	onboardingPlan := &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Onboarding Plan T5",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, onboardingPlan))
+
 	onboardingFeeID := "price_onboarding_fee_child_t5"
 	onboardingFee := &price.Price{
 		ID:                 onboardingFeeID,
 		Amount:             decimal.NewFromInt(25),
 		Currency:           "usd",
 		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
-		EntityID:           seatPlan.ID,
+		EntityID:           onboardingPlan.ID,
 		Type:               types.PRICE_TYPE_FIXED,
 		BillingPeriod:      types.BILLING_PERIOD_ONETIME,
 		BillingPeriodCount: 1,

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9,15 +9,19 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addon"
+	"github.com/flexprice/flexprice/internal/domain/coupon"
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/settings"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
@@ -9134,4 +9138,503 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	for _, item := range parentItems {
 		s.NotEqual(onboardingFeeID, item.PriceID, "parent must not carry the child's extra line item")
 	}
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_SubscriptionCoupons() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	pct := decimal.NewFromInt(10)
+	couponID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON)
+	c := &coupon.Coupon{
+		ID:            couponID,
+		Name:          "Seat Coupon",
+		Type:          types.CouponTypePercentage,
+		Cadence:       types.CouponCadenceForever,
+		PercentageOff: &pct,
+		CouponCode:    lo.ToPtr(couponID),
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		BaseModel:     types.GetDefaultBaseModel(ctx),
+	}
+	c.Status = types.StatusPublished
+	s.Require().NoError(s.GetStores().CouponRepo.Create(ctx, c))
+
+	seatExternal := "ext_seat_coupon_t6"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Coupon",
+		Email:      "seatcoupon@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						SubscriptionCoupons: []dto.SubscriptionCouponInput{
+							{CouponCode: *c.CouponCode},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	assocFilter := &types.CouponAssociationFilter{
+		QueryFilter:     types.NewNoLimitQueryFilter(),
+		SubscriptionIDs: []string{children[0].ID},
+		CouponIDs:       []string{couponID},
+	}
+	assocs, err := s.GetStores().CouponAssociationRepo.List(ctx, assocFilter)
+	s.NoError(err)
+	s.Require().Len(assocs, 1, "expected the coupon to be associated with the child, not the parent")
+
+	parentAssocFilter := &types.CouponAssociationFilter{
+		QueryFilter:     types.NewNoLimitQueryFilter(),
+		SubscriptionIDs: []string{resp.ID},
+		CouponIDs:       []string{couponID},
+	}
+	parentAssocs, err := s.GetStores().CouponAssociationRepo.List(ctx, parentAssocFilter)
+	s.NoError(err)
+	s.Empty(parentAssocs, "parent must not carry the child's coupon association")
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_TaxRateOverrides() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	pct := decimal.NewFromInt(10)
+	taxCode := "seat_tax_t7a"
+	tr := &taxrate.TaxRate{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_TAX_RATE),
+		Name:            "Seat Tax Rate",
+		Code:            taxCode,
+		TaxRateStatus:   types.TaxRateStatusActive,
+		TaxRateType:     types.TaxRateTypePercentage,
+		PercentageValue: &pct,
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().TaxRateRepo.Create(ctx, tr))
+
+	seatExternal := "ext_seat_tax_t7a"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Tax",
+		Email:      "seattax@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						TaxRateOverrides: []*dto.TaxRateOverride{
+							{TaxRateCode: taxCode, Currency: "usd"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	taxFilter := &types.TaxAssociationFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		EntityType:  types.TaxRateEntityTypeSubscription,
+		EntityID:    children[0].ID,
+		TaxRateIDs:  []string{tr.ID},
+	}
+	assocs, err := s.GetStores().TaxAssociationRepo.List(ctx, taxFilter)
+	s.NoError(err)
+	s.Require().Len(assocs, 1, "expected the tax rate to be linked to the child")
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ExplicitCreditGrants() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_explicit_credit_t10"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Explicit Credit",
+		Email:      "seatexplicitcredit@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						CreditGrants: []dto.CreateCreditGrantRequest{
+							{
+								Name:           "Explicit Seat Credits",
+								Scope:          types.CreditGrantScopeSubscription,
+								Credits:        decimal.NewFromInt(250),
+								Cadence:        types.CreditGrantCadenceOneTime,
+								ExpirationType: types.CreditGrantExpiryTypeNever,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	wallets, err := s.GetStores().WalletRepo.GetWalletsByCustomerID(ctx, seat.ID)
+	s.NoError(err)
+	s.Require().Len(wallets, 1)
+	s.True(decimal.NewFromInt(250).Equal(wallets[0].Balance),
+		"expected seat wallet funded with the child's explicit 250 credits, got %s",
+		wallets[0].Balance.String())
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_OverrideEntitlements() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatFeature := &feature.Feature{
+		ID:        "feat_seat_override_t11",
+		Name:      "Seat Feature",
+		Type:      types.FeatureTypeMetered,
+		MeterID:   s.testData.meters.apiCalls.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, seatFeature))
+
+	planEntitlement := &entitlement.Entitlement{
+		ID:               "ent_seat_override_plan_t11",
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         seatPlan.ID,
+		FeatureID:        seatFeature.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       lo.ToPtr(int64(1000)),
+		UsageResetPeriod: types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, planEntitlement)
+	s.NoError(err)
+
+	seatExternal := "ext_seat_entitlement_override_t11"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Entitlement Override",
+		Email:      "seatentitlementoverride@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						OverrideEntitlements: []dto.OverrideEntitlementRequest{
+							{
+								EntitlementID: planEntitlement.ID,
+								UsageLimit:    lo.ToPtr(int64(50)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	entFilter := types.NewNoLimitEntitlementFilter()
+	entFilter.WithEntityIDs([]string{children[0].ID})
+	entFilter.WithEntityType(types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION)
+	childEntitlements, err := s.GetStores().EntitlementRepo.List(ctx, entFilter)
+	s.NoError(err)
+	s.Require().Len(childEntitlements, 1)
+	s.Equal(seatFeature.ID, childEntitlements[0].FeatureID)
+	s.Require().NotNil(childEntitlements[0].ParentEntitlementID)
+	s.Equal(planEntitlement.ID, *childEntitlements[0].ParentEntitlementID)
+	s.Require().NotNil(childEntitlements[0].UsageLimit)
+	s.Equal(int64(50), *childEntitlements[0].UsageLimit)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_Addons() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	addonID := "addon_seat_child_t12"
+	addonPriceID := "price_addon_seat_child_t12"
+
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Seat Child Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().AddonRepo.Create(ctx, a))
+
+	p := &price.Price{
+		ID:                 addonPriceID,
+		Amount:             decimal.NewFromFloat(15),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+
+	seatExternal := "ext_seat_addon_t12"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Addon",
+		Email:      "seataddon@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						Addons: []dto.AddAddonToSubscriptionRequest{
+							{AddonID: addonID},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	assocFilter := types.NewNoLimitAddonAssociationFilter()
+	assocFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	assocFilter.EntityIDs = []string{children[0].ID}
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, assocFilter)
+	s.Require().NoError(err)
+	s.Require().Len(associations, 1)
+	s.Equal(addonID, associations[0].AddonID)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_Phases() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_phases_t13"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Phases",
+		Email:      "seatphases@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	phaseStart := s.testData.now.Truncate(time.Millisecond)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(phaseStart),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						Phases: []dto.SubscriptionPhaseCreateRequest{
+							{
+								StartDate: phaseStart,
+								Metadata:  map[string]string{"phase": "seat_single_phase"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	phaseFilter := types.NewNoLimitSubscriptionPhaseFilter()
+	phaseFilter.SubscriptionIDs = []string{children[0].ID}
+	phases, err := s.GetStores().SubscriptionPhaseRepo.List(ctx, phaseFilter)
+	s.NoError(err)
+	s.Require().Len(phases, 1, "expected the child to have its own phase record")
+	s.Equal("seat_single_phase", phases[0].Metadata["phase"])
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_RejectsDuplicateOverridePriceID() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	priceFilter := types.NewNoLimitPriceFilter()
+	priceFilter.EntityType = lo.ToPtr(types.PRICE_ENTITY_TYPE_PLAN)
+	priceFilter.EntityIDs = []string{seatPlan.ID}
+	seatPrices, err := s.GetStores().PriceRepo.List(ctx, priceFilter)
+	s.Require().NoError(err)
+	s.Require().Len(seatPrices, 1)
+	seatPriceID := seatPrices[0].ID
+
+	seatExternal := "ext_seat_dup_override_t14"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Dup Override",
+		Email:      "seatdupoverride@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						OverrideLineItems: []dto.OverrideLineItemRequest{
+							{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(60.00))},
+							{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(70.00))},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = s.service.CreateSubscription(ctx, req)
+	s.Error(err, "expected duplicate price_id in a child's override_line_items to be rejected")
+	s.Contains(err.Error(), "duplicate price_id in override line items")
 }

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8923,3 +8923,69 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 			"expected child %s line item amount 50, got %s", childID, amount.String())
 	}
 }
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_OverrideLineItems verifies a child
+// can override its own plan's price at creation, independent of the parent.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_OverrideLineItems() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	priceFilter := types.NewNoLimitPriceFilter()
+	priceFilter.EntityType = lo.ToPtr(types.PRICE_ENTITY_TYPE_PLAN)
+	priceFilter.EntityIDs = []string{seatPlan.ID}
+	seatPrices, err := s.GetStores().PriceRepo.List(ctx, priceFilter)
+	s.Require().NoError(err)
+	s.Require().Len(seatPrices, 1)
+	seatPriceID := seatPrices[0].ID
+
+	seatExternal := "ext_seat_override"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Override",
+		Email:      "seatoverride@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						OverrideLineItems: []dto.OverrideLineItemRequest{
+							{
+								PriceID: seatPriceID,
+								Amount:  lo.ToPtr(decimal.NewFromFloat(75.00)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	s.verifyPriceOverridesCreated(ctx, children[0].ID,
+		[]dto.OverrideLineItemRequest{{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(75.00))}},
+		"child subscription must have its own subscription-scoped override price")
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8989,3 +8989,140 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 		[]dto.OverrideLineItemRequest{{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(75.00))}},
 		"child subscription must have its own subscription-scoped override price")
 }
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ChildInheritsParentBillingAnchor() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_anchor_t4"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Anchor",
+		Email:      "seatanchor@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	anchor := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		BillingAnchor:      lo.ToPtr(anchor),
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seatExternal},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	parentSub, err := s.GetStores().SubscriptionRepo.Get(ctx, resp.ID)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	s.True(parentSub.BillingAnchor.Equal(children[0].BillingAnchor),
+		"expected child billing_anchor %s to equal parent billing_anchor %s",
+		children[0].BillingAnchor, parentSub.BillingAnchor)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ExtraLineItems() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	onboardingFeeID := "price_onboarding_fee_child_t5"
+	onboardingFee := &price.Price{
+		ID:                 onboardingFeeID,
+		Amount:             decimal.NewFromInt(25),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           seatPlan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_ONETIME,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, onboardingFee))
+
+	seatExternal := "ext_seat_extra_line_item_t5"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Extra Line Item",
+		Email:      "seatextralineitem@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						LineItems: []dto.CreateSubscriptionLineItemRequest{
+							{PriceID: onboardingFeeID, Quantity: decimal.NewFromInt(1)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{children[0].ID}
+	items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+
+	found := false
+	for _, item := range items {
+		if item.PriceID == onboardingFeeID {
+			found = true
+		}
+	}
+	s.True(found, "expected child subscription to carry the extra onboarding-fee line item, got %+v", items)
+
+	parentLiFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	parentLiFilter.SubscriptionIDs = []string{resp.ID}
+	parentItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, parentLiFilter)
+	s.NoError(err)
+	for _, item := range parentItems {
+		s.NotEqual(onboardingFeeID, item.PriceID, "parent must not carry the child's extra line item")
+	}
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9140,6 +9140,121 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	}
 }
 
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_Commitment() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_commitment_t8"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Commitment",
+		Email:      "seatcommitment@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	commitmentAmount := decimal.NewFromInt(200)
+	overageFactor := decimal.NewFromFloat(1.5)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						CommitmentAmount:   &commitmentAmount,
+						CommitmentDuration: lo.ToPtr(types.BILLING_PERIOD_ANNUAL),
+						OverageFactor:      &overageFactor,
+						EnableTrueUp:       true,
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	child, err := s.GetStores().SubscriptionRepo.Get(ctx, children[0].ID)
+	s.NoError(err)
+	s.Require().NotNil(child.CommitmentAmount)
+	s.True(commitmentAmount.Equal(*child.CommitmentAmount))
+	s.Require().NotNil(child.CommitmentDuration)
+	s.Equal(types.BILLING_PERIOD_ANNUAL, *child.CommitmentDuration)
+	s.Require().NotNil(child.OverageFactor)
+	s.True(overageFactor.Equal(*child.OverageFactor))
+	s.True(child.EnableTrueUp)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_TrialPeriodDays() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_trial_t9"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Trial",
+		Email:      "seattrial@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						TrialPeriodDays: lo.ToPtr(14),
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	child, err := s.GetStores().SubscriptionRepo.Get(ctx, children[0].ID)
+	s.NoError(err)
+	s.Require().NotNil(child.TrialStart)
+	s.Require().NotNil(child.TrialEnd)
+	s.Equal(child.TrialStart.AddDate(0, 0, 14), *child.TrialEnd)
+}
+
 func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_SubscriptionCoupons() {
 	ctx := s.GetContext()
 	seatPlan := s.setupSeatFeePlan()

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -2004,9 +2004,11 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		BillingCycle:       types.BillingCycleAnniversary,
-		LineItems: []dto.CreateSubscriptionLineItemRequest{
-			{PriceID: planPriceID},
-			{Price: inlinePriceReq},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			LineItems: []dto.CreateSubscriptionLineItemRequest{
+				{PriceID: planPriceID},
+				{Price: inlinePriceReq},
+			},
 		},
 	}
 
@@ -2097,17 +2099,19 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems_Validatio
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			req := dto.CreateSubscriptionRequest{
-				CustomerID:         s.testData.customer.ID,
-				PlanID:             s.testData.plan.ID,
-				StartDate:          &start,
-				EndDate:            &end,
-				Currency:           "usd",
-				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-				BillingPeriodCount: 1,
-				BillingCycle:       types.BillingCycleAnniversary,
-				LineItems:          tt.lineItems,
-			}
+		req := dto.CreateSubscriptionRequest{
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			StartDate:          &start,
+			EndDate:            &end,
+			Currency:           "usd",
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingCycle:       types.BillingCycleAnniversary,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				LineItems: tt.lineItems,
+			},
+		}
 			_, err := s.service.CreateSubscription(ctx, req)
 			s.Error(err)
 			s.Contains(err.Error(), tt.wantErrCont)
@@ -2172,37 +2176,39 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_LineItemWithBuckets_Ma
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		BillingCycle:       types.BillingCycleAnniversary,
-		// Add a line item with CommitmentTimeBuckets — this goes through AddSubscriptionLineItem
-		// which calls resolveBucketPrices inside the transaction.
-		LineItems: []dto.CreateSubscriptionLineItemRequest{
-			{
-				PriceID:                 usagePriceForBucketSub.ID,
-				SkipEntitlementCheck:    true,
-				CommitmentAmount:        &commitmentAmount,
-				CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
-				CommitmentOverageFactor: &overageFactor,
-				CommitmentWindowed:      true,
-				CommitmentTimeBuckets: []dto.CommitmentBucketRequest{
-					{
-						Start: types.Bucket{Hour: 9, Minute: 0},
-						End:   types.Bucket{Hour: 17, Minute: 0},
-						Price: &dto.CreatePriceRequest{
-							Amount:               lo.ToPtr(bucketPriceAmount),
-							Currency:             "usd",
-							EntityType:           types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
-							Type:                 types.PRICE_TYPE_FIXED,
-							PriceUnitType:        types.PRICE_UNIT_TYPE_FIAT,
-							BillingPeriod:        types.BILLING_PERIOD_MONTHLY,
-							BillingPeriodCount:   1,
-							BillingModel:         types.BILLING_MODEL_FLAT_FEE,
-							InvoiceCadence:       types.InvoiceCadenceAdvance,
-							LookupKey:            "sub_create_bucket_price",
-							SkipEntityValidation: true,
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			// Add a line item with CommitmentTimeBuckets — this goes through AddSubscriptionLineItem
+			// which calls resolveBucketPrices inside the transaction.
+			LineItems: []dto.CreateSubscriptionLineItemRequest{
+				{
+					PriceID:                 usagePriceForBucketSub.ID,
+					SkipEntitlementCheck:    true,
+					CommitmentAmount:        &commitmentAmount,
+					CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+					CommitmentOverageFactor: &overageFactor,
+					CommitmentWindowed:      true,
+					CommitmentTimeBuckets: []dto.CommitmentBucketRequest{
+						{
+							Start: types.Bucket{Hour: 9, Minute: 0},
+							End:   types.Bucket{Hour: 17, Minute: 0},
+							Price: &dto.CreatePriceRequest{
+								Amount:               lo.ToPtr(bucketPriceAmount),
+								Currency:             "usd",
+								EntityType:           types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
+								Type:                 types.PRICE_TYPE_FIXED,
+								PriceUnitType:        types.PRICE_UNIT_TYPE_FIAT,
+								BillingPeriod:        types.BILLING_PERIOD_MONTHLY,
+								BillingPeriodCount:   1,
+								BillingModel:         types.BILLING_MODEL_FLAT_FEE,
+								InvoiceCadence:       types.InvoiceCadenceAdvance,
+								LookupKey:            "sub_create_bucket_price",
+								SkipEntityValidation: true,
+							},
+							CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
+							CommitmentValue: decimal.NewFromInt(300),
+							OverageFactor:   lo.ToPtr(decimal.NewFromFloat(1.5)),
+							TrueUpEnabled:   true,
 						},
-						CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
-						CommitmentValue: decimal.NewFromInt(300),
-						OverageFactor:   lo.ToPtr(decimal.NewFromFloat(1.5)),
-						TrueUpEnabled:   true,
 					},
 				},
 			},
@@ -6464,15 +6470,17 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithPriceOverrides() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			// Create subscription request with overrides
-			req := dto.CreateSubscriptionRequest{
-				CustomerID:         s.testData.customer.ID,
-				PlanID:             s.testData.plan.ID,
-				Currency:           "usd",
-				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-				BillingPeriodCount: 1,
-				BillingCycle:       types.BillingCycleAnniversary,
-				OverrideLineItems:  tc.overrideLineItems,
-			}
+		req := dto.CreateSubscriptionRequest{
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			Currency:           "usd",
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingCycle:       types.BillingCycleAnniversary,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: tc.overrideLineItems,
+			},
+		}
 
 			// Create subscription
 			resp, err := s.service.CreateSubscription(s.GetContext(), req)
@@ -6991,17 +6999,19 @@ func (s *SubscriptionServiceSuite) TestPriceOverrideIntegration() {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			BillingCycle:       types.BillingCycleAnniversary,
-			OverrideLineItems: []dto.OverrideLineItemRequest{
-				{
-					PriceID:      s.testData.prices.fixedMonthly.ID,
-					Amount:       lo.ToPtr(decimal.NewFromFloat(75.00)),
-					BillingModel: types.BILLING_MODEL_TIERED,
-					TierMode:     types.BILLING_TIER_VOLUME,
-					Tiers: []dto.CreatePriceTier{
-						{UpTo: lo.ToPtr(uint64(100)), UnitAmount: decimal.RequireFromString("0.50")},
-						{UpTo: nil, UnitAmount: decimal.RequireFromString("0.25")},
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{
+					{
+						PriceID:      s.testData.prices.fixedMonthly.ID,
+						Amount:       lo.ToPtr(decimal.NewFromFloat(75.00)),
+						BillingModel: types.BILLING_MODEL_TIERED,
+						TierMode:     types.BILLING_TIER_VOLUME,
+						Tiers: []dto.CreatePriceTier{
+							{UpTo: lo.ToPtr(uint64(100)), UnitAmount: decimal.RequireFromString("0.50")},
+							{UpTo: nil, UnitAmount: decimal.RequireFromString("0.25")},
+						},
+						Quantity: lo.ToPtr(decimal.NewFromInt(2)),
 					},
-					Quantity: lo.ToPtr(decimal.NewFromInt(2)),
 				},
 			},
 		}
@@ -7045,15 +7055,17 @@ func (s *SubscriptionServiceSuite) TestPriceOverrideIntegration() {
 		subscriptionIDs := make([]string, len(overrideScenarios))
 
 		for i, override := range overrideScenarios {
-			req := dto.CreateSubscriptionRequest{
-				CustomerID:         s.testData.customer.ID,
-				PlanID:             s.testData.plan.ID,
-				Currency:           "usd",
-				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-				BillingPeriodCount: 1,
-				BillingCycle:       types.BillingCycleAnniversary,
-				OverrideLineItems:  []dto.OverrideLineItemRequest{override},
-			}
+		req := dto.CreateSubscriptionRequest{
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			Currency:           "usd",
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingCycle:       types.BillingCycleAnniversary,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{override},
+			},
+		}
 
 			resp, err := s.service.CreateSubscription(s.GetContext(), req)
 			s.NoError(err, "Failed to create subscription %d with overrides", i+1)
@@ -7912,8 +7924,10 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_DraftWithAddons() {
 		BillingCycle:       types.BillingCycleAnniversary,
 		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
 		SubscriptionStatus: types.SubscriptionStatusDraft,
-		Addons: []dto.AddAddonToSubscriptionRequest{
-			{AddonID: addonID},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			Addons: []dto.AddAddonToSubscriptionRequest{
+				{AddonID: addonID},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -7982,8 +7996,10 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_WithAddons_Date
 		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
 		PaymentBehavior:    lo.ToPtr(types.PaymentBehaviorDefaultActive),
 		SubscriptionStatus: types.SubscriptionStatusDraft,
-		Addons: []dto.AddAddonToSubscriptionRequest{
-			{AddonID: addonID},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			Addons: []dto.AddAddonToSubscriptionRequest{
+				{AddonID: addonID},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -8049,8 +8065,10 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_OnetimeAddon_En
 		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
 		PaymentBehavior:    lo.ToPtr(types.PaymentBehaviorDefaultActive),
 		SubscriptionStatus: types.SubscriptionStatusDraft,
-		Addons: []dto.AddAddonToSubscriptionRequest{
-			{AddonID: addonID, Cadence: types.AddonCadenceOnetime},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			Addons: []dto.AddAddonToSubscriptionRequest{
+				{AddonID: addonID, Cadence: types.AddonCadenceOnetime},
+			},
 		},
 	})
 	s.Require().NoError(err)

--- a/internal/ee/service/subscription_trial_test.go
+++ b/internal/ee/service/subscription_trial_test.go
@@ -62,14 +62,14 @@ func TestSetCreateSubscriptionTrialWindow_RequestOverrideDays(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	sub := &subscription.Subscription{StartDate: start}
 	seven := 7
-	req := &dto.CreateSubscriptionRequest{TrialPeriodDays: &seven}
+	req := &dto.CreateSubscriptionRequest{SubscriptionCreationConfig: dto.SubscriptionCreationConfig{TrialPeriodDays: &seven}}
 	err := setCreateSubscriptionTrialWindow(req, sub, nil)
 	require.NoError(t, err)
 	assert.Equal(t, start, *sub.TrialStart)
 	assert.Equal(t, start.AddDate(0, 0, 7), *sub.TrialEnd)
 
 	zero := 0
-	req2 := &dto.CreateSubscriptionRequest{TrialPeriodDays: &zero}
+	req2 := &dto.CreateSubscriptionRequest{SubscriptionCreationConfig: dto.SubscriptionCreationConfig{TrialPeriodDays: &zero}}
 	sub2 := &subscription.Subscription{StartDate: start}
 	err2 := setCreateSubscriptionTrialWindow(req2, sub2, []*dto.PriceResponse{
 		{Price: &price.Price{BillingCadence: types.BILLING_CADENCE_RECURRING, Type: types.PRICE_TYPE_FIXED, TrialPeriodDays: 14}},
@@ -167,7 +167,7 @@ func TestSetCreateSubscriptionTrialWindow_ZeroClears(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	sub := &subscription.Subscription{StartDate: start, TrialStart: &start, TrialEnd: &start}
 	z := 0
-	req := &dto.CreateSubscriptionRequest{TrialPeriodDays: &z}
+	req := &dto.CreateSubscriptionRequest{SubscriptionCreationConfig: dto.SubscriptionCreationConfig{TrialPeriodDays: &z}}
 	prices := []*dto.PriceResponse{
 		{Price: &price.Price{BillingCadence: types.BILLING_CADENCE_RECURRING, Type: types.PRICE_TYPE_FIXED, TrialPeriodDays: 14}},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved subscription creation validation for commitments, overages, credits, tax overrides, line items, and duplicate price overrides.
  * Added more consistent handling of commitment types and billing anchors for grouped-invoicing child subscriptions.
  * Expanded grouped-invoicing support for subscription settings including addons, coupons, phases, trials, credits, tax overrides, and entitlements.

* **Tests**
  * Added comprehensive coverage for grouped-invoicing child subscription creation and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->