### PR TITLE
feat(marketplace): implement final usage flush for cancelled subscriptions and resolve entity mapping bug

### DIFF
--- a/docs/design/2026-07-23-FLE-1071-marketplace-integration-v3.md
+++ b/docs/design/2026-07-23-FLE-1071-marketplace-integration-v3.md
@@ -9,6 +9,11 @@ This builds on the shipped state of
 The starting point is v2 as it actually shipped — its Section 12 deviations: `usage_records` is
 provider-agnostic with a `syncs` map, and there is no `connection_id` column.
 
+> **Superseded in part by [v4](2026-07-30-FLE-1106-marketplace-integration-v4.md).** v4 replaces the
+> cancellation timing contract in §10, corrects the `Suspend` row in the §10 lifecycle table, adds a
+> 24h bound to `ListUnsynced` (§8.2), and documents the post-cancellation reporting windows left open
+> in §2.5. See v4 §6 for the full list of what it changes here.
+
 ---
 
 ## 1. What we are building
@@ -191,7 +196,7 @@ strictly, with no exception for how the zero is encoded.
 | Report call          | `BatchMeterUsage`                                                        | `services.report`                                        | `usageEvent`                                |
 | Dedup key            | product + customer + dimension + `Timestamp` (byte-identical retry-safe) | `operationId` (caller-chosen)                            | `(resourceId, dimension, calendar hour)`    |
 | Quantity type        | int32 cents                                                              | int64 cents                                              | double (cents as a whole number)            |
-| Submission window    | 24h + 6h month-end grace                                                 | not documented; assumed similar                          | 24h, no stated grace                        |
+| Submission window    | 24h + 6h month-end grace                                                 | general window not documented; **1h after cancellation** ([v4](2026-07-30-FLE-1106-marketplace-integration-v4.md) §4) | 24h, no stated grace                        |
 | Per-call receipt     | `MeteringRecordId`                                                       | none — absence from `reportErrors` = success              | `usageEventId`                              |
 | Rejection outcome    | `Status` in `Results[]`, or absent (`UnprocessedRecords`, retried)       | listed in `reportErrors`; success is its absence          | distinct non-2xx status code, not a 200     |
 | Call-level ambiguity | none — an explicit outcome every time                                    | RPC-level failure = outcome unknown, retried              | none — an explicit outcome every time       |
@@ -580,7 +585,8 @@ does the same job for all three providers. `MarketplaceUsageReportActivity` grou
 marketplace connection by tenant/environment; `reportForTenant` then, for one tenant/environment:
 
 1. authenticates each connection once and loads its mappings (`prepareConnection`),
-2. reads that tenant's unsynced records once (`usageRecordRepo.ListUnsynced`),
+2. reads that tenant's unsynced records once (`usageRecordRepo.ListUnsynced` — gains a
+   `period_end >= now-24h` bound in [v4](2026-07-30-FLE-1106-marketplace-integration-v4.md) §5.2),
 3. keeps the eligible ones (`isEligibleForReport`: currency is USD, amount is not negative),
 4. reports each eligible record to every relevant connection it isn't already in the `syncs` map for
    (`isRelevantForSubscription`), one API call per record, and persists the record's `syncs` + `synced`
@@ -910,13 +916,19 @@ Azure's lifecycle events, all delivered to the tenant's webhook
 | `ChangePlan`     | approve, update the Flexprice subscription's plan mapping                  | Yes — PATCH the Operations API within 10s, or Azure auto-accepts |
 | `ChangeQuantity` | update seat count if relevant                                              | Yes — same 10s ACK window                                        |
 | `Renew`          | nothing                                                                    | notify-only                                                      |
-| `Suspend`        | nothing — mapping stays published, reporting continues until `Unsubscribe` | notify-only                                                      |
+| `Suspend`        | nothing — mapping stays published (`Reinstate` is possible). **Correction, see [v4](2026-07-30-FLE-1106-marketplace-integration-v4.md) §6:** reporting does *not* continue — Azure accepts usage only in `Subscribed` status and rejects a suspended subscription with `ResourceNotActive` | notify-only                                                      |
 | `Unsubscribe`    | cancel the Flexprice subscription → mapping archived → both crons stop     | notify-only                                                      |
 | `Reinstate`      | nothing — buyer's payment recovered                                        | notify-only                                                      |
 
 
 Timing is the same as AWS/GCP: the tenant should archive only after the snapshot cron's 4–10h lag has
 had a chance to capture the final active-period usage.
+
+> **Superseded by [v4](2026-07-30-FLE-1106-marketplace-integration-v4.md) §3.** Waiting for the snapshot cron's
+> 4–10h lag misses the providers' post-cancellation windows: AWS allows ~1 hour from
+> `License Deprovisioned`, and GCP 1 hour from cancellation. Cancelling a Flexprice subscription now
+> triggers a one-shot flush that reports the backlog and the final window immediately, then archives
+> the subscription mapping itself — the tenant does not wait, and does not archive anything by hand.
 
 ---
 
@@ -1018,6 +1030,9 @@ state (e.g. `expired`) set once a row's `period_end` passes the acceptance windo
 assumed similar for GCP), plus TTL/reaping of those rows so they stop being retried and stop
 accumulating. Alerting on the `error`-level log lines is a natural follow-on. None of this is built
 here.
+  **Partially addressed in [v4](2026-07-30-FLE-1106-marketplace-integration-v4.md) §5.2:** `ListUnsynced` gains
+  a `period_end >= now-24h` bound, so rows past the submission window stop being re-scanned. A true
+  terminal status is still not built.
 - **No dead-letter table.** A failed row is visible only as a log line plus its own state in
 `usage_records`. There is no place that surfaces "these rows have failed N times". Carried through
 v1 and v2; not blocking Azure.
@@ -1025,6 +1040,11 @@ v1 and v2; not blocking Azure.
 `effectiveStartTime`? No doc checked answers it. The 4–10h snapshot lag (§8.1) makes this a
 non-issue for ordinary reporting, but the edge case of a subscription closing right at the 24h
 boundary is untested. Same open status as the equivalent AWS/GCP question in v2.
+  **Partially resolved in [v4](2026-07-30-FLE-1106-marketplace-integration-v4.md) §4:** Azure rejects on
+  subscription status (`ResourceNotActive`, or a 400 "SaaS subscription isn't in Subscribed status")
+  independently of the 24h `effectiveStartTime` rule, and documents that usage for the period *before*
+  cancellation stays reportable. Whether lateness itself is judged by submission time or
+  `effectiveStartTime` is still unstated.
 - **Usage records are reported one at a time, not batched.** All three providers support a
 multi-record call — AWS and Azure up to 25 records, GCP up to a 1MB request. None of that is used
 here; every report is one API call per record. Two reasons this is deferred rather than done now:

--- a/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
+++ b/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
@@ -159,22 +159,23 @@ FlushActivity(subscriptionID, cancelAt, tenantID, environmentID):
        conn = resolve m's connection; prepareConnection(conn)
        on failure: log, set connectionResolutionFailed, continue   # never abort the others
 
-2. # Phase 1 — the pre-existing backlog. Fetched before phase 2 computes anything, so a first run
-   # never sees its own final record here.
-   backlog = List(subscription_id, synced=false, period_end >= now-24h, sort period_end asc)
+2. # Phase 1 — the pre-existing backlog. Bounded above by cancelAt so the final record is excluded:
+   # phase 2 owns it, and only phase 2 applies the reporting margin (§3.4).
+   backlog = List(subscription_id, synced=false,
+                  period_end >= now-24h, period_end < cancelAt, sort period_end asc)
    for rec in backlog:
        if not isEligibleForReport(rec): continue    # non-USD or negative (§8.2)
        reportRecordToConnections(rec, relevantConnections(rec)); MarkSynced(rec)
 
-3. # Phase 2 — the one final record.
-   computedThrough = MAX(period_end) over ALL published rows, else earliest mapping created_at (§3.3)
-   finalRec = buildFinalUsageRecord(computedThrough, cancelAt)     # nil if cancelAt <= computedThrough
+3. # Phase 2 — the one final record. Written first, then reported (§3.4).
+   computedThrough = MAX(period_end) over published rows with period_end < cancelAt,
+                     else earliest mapping created_at (§3.3)
+   finalRec = finalUsageRecord(computedThrough, cancelAt)   # nil if cancelAt <= computedThrough
+       # looks the window up first — on a retry the row is already there, so nothing is
+       # recomputed; otherwise compute and Create it with period_end = cancelAt
    if finalRec and isEligibleForReport(finalRec):
-       reportRecordToConnections(finalRec, relevantConnections(finalRec))
-       if fully reported:
-           finalRec.PeriodEnd = cancelAt            # stored exact; the wire got cancelAt - 1s (§3.4)
-           Create(finalRec)                         # first write, only now
-       else: finalUsageFlushFailed = true
+       report it with period_end - 1s on the wire (§3.4); MarkSynced(finalRec)
+       if not fully reported: finalUsageFlushFailed = true
 
 4. if connectionResolutionFailed or finalUsageFlushFailed or any backlog record failed:
        return error                                 # Temporal retries; mapping stays published (§3.5)
@@ -205,15 +206,15 @@ sequenceDiagram
     Flush->>DB: MarkSynced (true iff every relevant connection has an entry)
 
     Note over Flush,MP: Phase 2 — the one final record
-    Flush->>DB: frontier = MAX(period_end)
-    alt cancelAt > frontier
-        Flush->>Flush: compute usage — NOT written yet
-        Flush->>MP: report (wire timestamp = cancelAt - 1s)
-        alt fully reported
-            Flush->>DB: create record (period_end = cancelAt)
-        else any connection failed
-            Flush->>Flush: discard — next attempt recomputes fresh
+    Flush->>DB: last computed point = MAX(period_end) where period_end < cancelAt
+    alt cancelAt > that point
+        Flush->>Flush: compute usage for the remaining window
+        Flush->>DB: create record (period_end = cancelAt)
+        alt unique key collision
+            DB-->>Flush: an earlier attempt already wrote it — report that row
         end
+        Flush->>MP: report (wire timestamp = cancelAt - 1s)
+        Flush->>DB: MarkSynced
     end
 
     alt everything succeeded
@@ -225,11 +226,13 @@ sequenceDiagram
 
 ### 3.3 Window rules
 
-**The frontier spans all rows, not just unsynced ones.** Taking the max over unsynced rows alone can
-double-bill: if record A `[T-10h, T-4h]` failed to sync but B `[T-4h, T+2h]` succeeded, the unsynced
-max is `T-4h` and the flush window `[T-4h, cancelAt]` re-reports everything B covered. The max over
-**all published rows** is `T+2h`. Since snapshot windows are contiguous, the frontier has no holes
-behind it — every earlier span belongs to some row, and those rows are exactly what Phase 1 reports.
+**The window starts from all rows, not just unsynced ones.** Taking the max over unsynced rows alone
+can double-bill: if record A `[T-10h, T-4h]` failed to sync but B `[T-4h, T+2h]` succeeded, the
+unsynced max is `T-4h` and the flush window `[T-4h, cancelAt]` re-reports everything B covered. The
+max over **all published rows** is `T+2h`. Since snapshot windows are contiguous, there are no holes
+behind that point — every earlier span belongs to some row, and those rows are what Phase 1 reports.
+Rows ending at or after `cancelAt` are excluded so the final record cannot move its own starting
+point (§3.4).
 
 **Fallback when no usage record exists.** A subscription can be linked and cancelled without the
 snapshot cron ever running for it. The flush then uses the earliest subscription mapping's
@@ -238,24 +241,47 @@ from before it was linked is deliberately excluded.
 
 **Boundaries.** `period_start` is inclusive, `period_end` exclusive, inherited from the ClickHouse
 query builder (`timestamp >= ?` and `timestamp < ?`). Chaining `period_start = previous period_end`
-counts a boundary event exactly once. `buildFinalUsageRecord` early-returns when
-`cancelAt <= windowStart`, so a backdated cancellation can't produce an inverted window; the backlog
+counts a boundary event exactly once. The final record is skipped entirely when
+`cancelAt <= windowStart`, so a backdated cancellation cannot produce an inverted window; the backlog
 flush is then the whole job.
 
-### 3.4 Why the final record is reported before it is written
+### 3.4 The final record: written first, reported second
 
-Two earlier shapes were tried; each had a real bug the next one fixed.
+The record is created before it is reported, like every other write in the system, and an unreported
+record is deliberately left in the table for the reporting cron or a later attempt to pick up.
 
-| Shape | Stored `period_end` | Bug |
-| --- | --- | --- |
-| 1. Create first, with the margin baked in | `cancelAt - 1s` | The row instantly becomes the frontier, so `cancelAt > frontier` is *still true* on a retry — it creates a second, near-empty record for the 1-second sliver. |
-| 2. Create first, store the true instant | `cancelAt` | Fixes the sliver, but a partially-reported row (say GCP failed) sits `synced = false` and the **next run picks it up through Phase 1**, which applies no margin — GCP's strict `<` rejects it forever. |
-| **3. Report first, then create** (current) | `cancelAt` | None of the above. Nothing unreported is ever persisted, so a retry recomputes the same window from an unchanged frontier and reports it again with the margin correctly applied. |
+What makes that safe is that **every attempt computes the identical window**, so a retry collides with
+the unique key on `(tenant, environment, subscription, period_start, period_end)` and reports the
+existing row instead of writing a second one. Two bounds produce that:
 
-The cost of shape 3: nothing about a partially-successful attempt survives between retries for the
-final record, and each rebuild generates a fresh id. AWS de-duplicates on customer+dimension+timestamp
-so a resend is safe there; GCP de-duplicates on `OperationID` (= the record id), so it cannot recognise
-a retry as the same operation — see §7.
+- The last-computed point ignores rows ending at or after `cancelAt`, so the final record cannot move
+  the start of its own window. Without this, a retry would measure from the row the previous attempt
+  wrote and compute a narrower window — a **different `period_start`**, which the unique key would not
+  catch. That is a real trap, not a theoretical one: the index constrains the window, so nothing
+  protects against a window that changes between attempts.
+- Phase 1 excludes `period_end >= cancelAt`, so the final record is not also reported by the backlog
+  loop, which does not apply the reporting margin.
+
+Keeping one row across attempts also gives the record one identity, which matters for GCP: it
+de-duplicates on `OperationID`, which is the record id. A design that rebuilt the record per attempt
+would hand GCP a new id each time and could double-count usage it had already accepted. AWS and Azure
+de-duplicate on customer, dimension and timestamp, so they are unaffected either way.
+
+The window stability this depends on is covered by `TestUsageRecordFlushRetryReusesTheSameRecord`: a
+second attempt must compute the same window, find the same row, and be refused by the unique key. A
+change that lets the window move between attempts breaks that test rather than silently duplicating
+usage in production.
+
+The record is **not** recomputed or rewritten when it already exists — the amount stays exactly what
+was reported. §7 covers why revising it is not an option.
+
+**The stored `period_end` is the true `cancelAt`; only the value sent to a provider carries the
+margin.** One consequence worth knowing: if the flush fails and the reporting cron later retries the
+record, the cron sends the stored `cancelAt` with no margin. That is correct for AWS, which makes no
+such comparison, and for Azure, whose own documentation accepts usage ending exactly at the
+cancellation instant. For GCP it would be rejected — but GCP's post-cancellation window is about an
+hour and the cron runs every three, so by then the record is unacceptable regardless of its timestamp.
+The margin is only ever decisive inside the flush's own attempts.
 
 ### 3.5 Failure handling and when the mapping is delinked
 
@@ -385,10 +411,12 @@ an extension), and far more generous than GCP's hourly guidance.
 `ExistsForPeriod`, `ListUnsynced` and `MarkSynced`. Rather than one bespoke method per query, a filter
 following `EntityIntegrationMappingFilter`'s shape was added (embedded `*QueryFilter` /
 `*TimeRangeFilter`, `Filters`, `Sort`, plus explicit columns), with a matching `List` on the interface
-and Ent implementation. Both flush queries are the same call:
+and Ent implementation. All three flush queries are the same call:
 
-- frontier — `{subscription_id, sort: period_end desc, limit: 1}`
-- backlog — `{subscription_id, synced: false, period_end >= now-24h, sort: period_end asc}`
+- last computed point — `{subscription_id, period_end < cancel_at, sort: period_end desc, limit: 1}`
+- backlog — `{subscription_id, synced: false, period_end >= now-24h, period_end < cancel_at, sort: period_end asc}`
+- the existing final record — `{subscription_id, period_start, period_end}`, the exact window, which
+  the unique key makes single-valued
 
 `ListUnsynced` was **not** folded in; the report cron needs it tenant/environment-scoped rather than
 subscription-scoped.
@@ -435,19 +463,33 @@ well inside the hour, so exhausting them on a transient issue still leaves the c
 the deadline itself was already blown, no retry by anything can fix it — that's the marketplaces' rule,
 not a design gap.
 
-**GCP could double-count a final record split across retries.** Because shape 3 (§3.4) never persists
-an unreported record, a rebuild generates a fresh id, and GCP de-duplicates on `OperationID` = that id.
-If GCP accepts on attempt 1 but a *different* connection fails, attempt 2 reports the same usage to GCP
-under a new identity. Narrow, but real. Closing it means deriving the final record's id
-deterministically (e.g. from `subscription_id + cancel_at`) instead of a fresh UUID.
-
 **A connection broken for more than a day permanently loses that usage.** Inherent to the providers:
 the flush catches a broken connection up only for the last 24 hours, and AWS/Azure reject anything
-older. AWS is not double-reported — the frontier covers only genuinely new time, and the backlog step
+older. AWS is not double-reported — the window covers only genuinely new time, and the backlog step
 skips connections that already have an entry — so the loss is one-sided. The mitigation both Azure and
 GCP describe is rolling the expired quantity into a current-timestamped event, which weakens the
 customer's audit trail and is a case-by-case call, not something to automate. The real defence is
 alerting on the failure logs long before a cancellation exposes it.
+
+**Events arriving after a window was reported cannot be added to it.** A record's amount is fixed once
+it has been sent, so late usage for that window is lost. Revising the stored row does not recover it,
+and the reason is worth stating because it looks like an easy fix:
+
+- The reporter skips any connection already holding a `syncs` entry, so a revised amount is never sent
+  to a provider that accepted the original. The row would then claim an amount no marketplace ever
+  received, and nothing would flag the divergence — strictly worse than a stale figure, because
+  `syncs` stops being a truthful receipt.
+- Forcing a resend fails anyway. All three de-duplicate on (customer, dimension, timestamp), and the
+  timestamp does not move when the amount does — so a revision is *a different amount at an existing
+  key*. AWS answers `DuplicateRecord` (§8.4), GCP de-dupes on the unchanged `OperationID`, Azure
+  returns 409. Metering APIs are append-only by design, which is exactly the property that makes our
+  retries safe.
+
+The only mechanism the marketplaces offer for late usage is an **additional** record on a new window,
+which is what the snapshot cron already does for a live subscription. The final record has no such
+successor: once the mapping is archived no further window exists, and AWS/GCP's ~1 hour deadline
+closes before the next cron run regardless. Widening this would mean delaying the flush, which the
+same deadline forbids.
 
 ---
 
@@ -460,14 +502,23 @@ Levels are `error`, `info`, or `debug` only — never `warn`.
 (GCP). Provider errors pass through `utils.RedactSecrets`, which strips the tenant's identifiers and
 preserves everything else verbatim, because the status and reason are what make a failure diagnosable.
 
-Four message strings carry the whole feature. Grep these first:
+**Every message begins with one of three prefixes**, so a single grep scopes to a flow and the rest of
+the line says what happened. The `stage` tag is kept alongside for structured filtering, but the
+message alone is enough to read a failure:
 
-| Message | Emitted by | Meaning |
-| --- | --- | --- |
-| `marketplace usage snapshot failed` | snapshot cron | Always tagged `stage` |
-| `marketplace usage report failed` | report cron **and** the flush | Always tagged `stage`. Shared, because both call the same reporter — when debugging a flush, grep this too |
-| `marketplace subscription flush failed` | flush only | Always tagged `stage` |
-| `marketplace usage record synced` / `marketplace subscription flush: usage record synced` | report cron / flush | The only lines meaning a marketplace accepted a record |
+| Prefix | Emitted by |
+| --- | --- |
+| `marketplace usage snapshot:` | snapshot cron |
+| `marketplace usage report:` | report cron **and** the flush — both call the same reporter, so when debugging a flush, grep this too |
+| `marketplace subscription flush:` | flush only |
+
+```
+marketplace subscription flush: failed to list backlog usage records
+marketplace subscription flush: final usage record created
+marketplace usage report:       failed to assume the tenant's aws role
+marketplace usage report:       gcp rejected the usage record, will retry next run
+marketplace usage snapshot:     failed to check for an existing usage record
+```
 
 Every line tied to one connection carries `marketplace` and `connection_id`; every line tied to one
 record carries `usage_record_id`. Connection-level lines (auth, mapping load) have no
@@ -520,7 +571,7 @@ Tenant-wide by construction: `ListPublishedByProvider` deliberately bypasses ten
 query that does) so a job with no tenant on ctx can discover work, then groups by (tenant, environment)
 and sets both onto ctx before anything else.
 
-Its own stages — all under `marketplace usage report failed`:
+Its own failures — every message begins `marketplace usage report: failed to …`:
 
 | `stage` | What broke | Blast radius |
 | --- | --- | --- |
@@ -540,8 +591,8 @@ excluded from *every* count:
 
 | Level | Message | Meaning |
 | --- | --- | --- |
-| `debug` | `skipping marketplace usage record, currency not usd` | None of the three marketplaces accept non-USD. **Debug-level, so invisible at default settings** — a EUR marketplace subscription simply never syncs, with no signal. Check this first when records aren't syncing and nothing is logged. |
-| `error` | `marketplace usage record has negative amount` | A credit, not usage. An upstream billing bug; never sent. |
+| `debug` | `…skipping usage record, currency is not usd` | None of the three marketplaces accept non-USD. **Debug-level, so invisible at default settings** — a EUR marketplace subscription simply never syncs, with no signal. Check this first when records aren't syncing and nothing is logged. |
+| `error` | `…skipping usage record, amount is negative` | A credit, not usage. An upstream billing bug; never sent. |
 
 Reading the counts: `Total` counts records that reached at least one relevant connection. `succeeded` =
 every relevant connection has an entry and at least one is a real post (`synced` now true, done
@@ -569,41 +620,55 @@ Trigger-side, all emitted post-commit so none can affect the cancellation:
 
 Seeing **none** of the four is itself a finding: the subscription had no published marketplace mapping.
 
-Activity stages — all under `marketplace subscription flush failed`:
+Activity failures — every message begins `marketplace subscription flush: failed to …`:
 
-| `stage` | Phase | Blast radius |
-| --- | --- | --- |
-| `list_subscription_mappings` | setup | **Hard abort**, activity retries |
-| `get_connection` | setup | **Does not abort** — other mappings still processed, but this blocks delink |
-| `list_backlog` | 1 | **Hard abort** |
-| `mark_synced` | 1 | That record forced to `failed`; same warning as §8.2 |
-| `get_subscription` / `get_meter_usage` / `calculate_charges` | 2 | **Hard abort** |
-| `create_usage_record` | 2 | **Hard abort** — note this runs *after* the record was already reported, so the provider has the usage but the row isn't stored |
-| `delink_mapping` | 3 | Only reachable once everything else succeeded — a pure DB failure at the last step |
+| `stage` | Message ends | Phase | Blast radius |
+| --- | --- | --- | --- |
+| `list_subscription_mappings` | list subscription marketplace mappings | setup | **Hard abort**, activity retries |
+| `get_connection` | resolve marketplace connection | setup | **Does not abort** — other mappings still processed, but this blocks delink |
+| `list_backlog` | list backlog usage records | 1 | **Hard abort** |
+| `mark_synced` | record usage sync state | 1 and 2 | That record forced to `failed`; same warning as §8.2 |
+| `relevant_connections` | usage record has no connection to report to | 1 and 2 | Nothing is sent for that record and the run fails, so the mappings stay published — archiving them would put the record beyond the cron, which also needs the mapping to judge relevance |
+| `last_computed_period_end` | determine last computed period | 2 | **Hard abort** |
+| `get_existing_usage_record` | load the existing final usage record | 2 | **Hard abort** — runs before any computation, so nothing was computed |
+| `get_subscription` / `get_meter_usage` / `calculate_charges` | load subscription / compute meter usage / calculate charges | 2 | **Hard abort** |
+| `create_usage_record` | create final usage record | 2 | **Hard abort** — includes losing an insert race to a concurrent attempt; the retry finds that row |
+| `delink_mapping` | archive marketplace mapping | 3 | Only reachable once everything else succeeded — a pure DB failure at the last step |
 
 Success path:
 
 ```
 Starting MarketplaceSubscriptionFinalUsageFlushWorkflow   subscription_id=…
-[if not a marketplace sub] subscription has no marketplace mapping, nothing to flush   ← ends here
-marketplace subscription flush: usage record synced        (phase 1, per record per connection)
-marketplace subscription flush: final usage record created (phase 2, only after a successful report)
-marketplace subscription flush: usage record synced        (the final record's connections)
-MarketplaceSubscriptionFinalUsageFlushActivity completed   final_record_id=… records_succeeded=… records_skipped=… mappings_delinked=…
-MarketplaceSubscriptionFinalUsageFlushWorkflow completed   … records_failed=… …
+[if not a marketplace sub] marketplace subscription flush: subscription has no marketplace mapping…  ← ends here
+marketplace subscription flush: usage record synced          (phase 1, per record per connection)
+marketplace subscription flush: final usage record created   (phase 2, before it is reported)
+   — or —
+marketplace subscription flush: final usage record already exists, reporting it   (a retry)
+marketplace subscription flush: usage record synced          (the final record's connections)
+MarketplaceSubscriptionFinalUsageFlushActivity completed     final_record_id=… records_succeeded=… records_skipped=… mappings_delinked=…
+MarketplaceSubscriptionFinalUsageFlushWorkflow completed     final_record_id=… records_succeeded=… records_skipped=… mappings_delinked=…
 ```
 
-The activity's completion log omits `records_failed` (it only runs on the success path, where that
-count is zero); the workflow's includes it.
+**The result is only ever visible on a successful run.** When the activity returns an error Temporal
+discards its result value — the task is recorded as failed, carrying the failure and not the payload —
+so the workflow's `.Get` leaves the struct zero and its completion log never runs. The error itself
+carries only its message: a plain Go error is converted to an `ApplicationError` with `err.Error()`,
+so `WithReportableDetails` does not survive into Temporal either.
 
-**Confirming the final record — the most misread signal.** Because it is only written after a
-successful report (§3.4), a still-failing final record is **never in the table at all**: each retry
-rebuilds and re-attempts it with a new id. There is no partial row to find. `final usage record
-created` and a non-empty `final_record_id` are the only positive signals. If neither appears, exactly
-one of these is true, and the other logs say which: no final record was needed (`cancel_at` at or
-before the frontier), the connection didn't resolve (`stage=get_connection`), reporting failed (§8.4,
-carrying a `usage_record_id` that won't exist in `usage_records` — that's the discarded attempt), or
-the record was ineligible (§8.2's two pre-filter lines; the flush applies the same filter).
+On a failed run the record ids therefore exist **only in the logs above**, which is what the per-record
+lines are for. Do not expect the Temporal UI to show which record failed — grep `usage_record_id`.
+
+Neither completion log reports a failure count, and that is deliberate rather than an omission: the
+activity fails the run whenever a record failed, so any count printed on the success path could only
+ever be zero.
+
+**Confirming the final record.** It is written *before* it is reported (§3.4), so it exists in
+`usage_records` whether or not any marketplace accepted it — an unreported one sits there `synced =
+false` with a partial `syncs` map. Either `final usage record created` or `final usage record already
+exists, reporting it` appears on every run that needed one, and `final_record_id` on the completion
+log carries its id in both cases. If neither line appears, one of these is true and the other logs say
+which: no final record was needed (`cancel_at` at or before the last computed point), an earlier stage
+aborted, or the record was ineligible (§8.2's two pre-filter lines, which the flush applies too).
 
 **Confirming the delink.** No per-mapping success log — only `mappings_delinked` and the absence of
 `stage=delink_mapping`. Per §3.5 it must **only** happen on a fully successful run: a mapping archived
@@ -618,7 +683,7 @@ saturation.
 ### 8.4 Connection auth and the report call — shared by §8.2 and §8.3
 
 Both paths use the same reporter, so these lines are identical from either caller and all carry
-`marketplace usage report failed` — **including during a flush**.
+the `marketplace usage report:` prefix — **including during a flush**.
 
 **Auth has no success log.** If it works you see nothing; success is proven only by execution reaching
 the report call. A failure skips the **whole connection** for that run (and in the flush, blocks
@@ -633,7 +698,7 @@ delink).
 One check covers all three — empty output means every configured credential is valid:
 
 ```bash
-grep 'marketplace usage report failed' log | grep -E 'stage=(assume_role|wif_session|get_token)'
+grep 'marketplace usage report:' log | grep -E 'stage=(assume_role|wif_session|get_token)'
 ```
 
 **The report call.** First distinguish our data problem from their rejection: `stage=resolve_record`
@@ -645,13 +710,13 @@ resource_id / plan_id / dimension).
 | --- | --- | --- |
 | AWS | `stage=convert_quantity` | Amount doesn't fit AWS's int32 quantity |
 | AWS | `stage=batch_meter_usage` | Transport or malformed request — no verdict reached |
-| AWS | `marketplace usage record not processed by aws, will retry next run` (info) | No result row returned |
-| AWS | `…rejected by aws: customer not subscribed, will retry next run` | `CustomerNotSubscribed` — self-heals if the buyer re-subscribes. **Expected against a test customer** |
-| AWS | `…rejected by aws: conflicts with a different record already on file, needs manual investigation` | `DuplicateRecord` — AWS holds a *different* record for the same key. Retrying can't fix it |
-| AWS | `…rejected by aws: unrecognized status, will retry next run` | `aws_status` carries the raw value |
+| AWS | `…aws did not process the usage record, will retry next run` (info) | No result row returned |
+| AWS | `…aws rejected the usage record, customer not subscribed, will retry next run` | `CustomerNotSubscribed` — self-heals if the buyer re-subscribes. **Expected against a test customer** |
+| AWS | `…aws rejected the usage record, it conflicts with a different record already on file` | `DuplicateRecord` — AWS holds a *different* record for the same key. Retrying can't fix it |
+| AWS | `…aws returned an unrecognized status, will retry next run` | `aws_status` carries the raw value |
 | GCP | `stage=services_report` | Transport failure **or** an API-level rejection such as 403 — read the error text, not just the stage |
-| GCP | `marketplace usage report rejected by gcp, will retry next run` | HTTP 200 but `reportErrors` set. `error_code=5` NOT_FOUND (inactive consumer), `7` PERMISSION_DENIED (missing IAM grant), `3` INVALID_ARGUMENT |
-| Azure | `marketplace usage record skipped: zero quantity not supported by azure` (info) | **Not a failure.** Nothing sent; the connection resolves as a *skip*, permanently |
+| GCP | `…gcp rejected the usage record, will retry next run` | HTTP 200 but `reportErrors` set. `error_code=5` NOT_FOUND (inactive consumer), `7` PERMISSION_DENIED (missing IAM grant), `3` INVALID_ARGUMENT |
+| Azure | `…skipping usage record for azure, it does not accept a zero quantity` (info) | **Not a failure.** Nothing sent; the connection resolves as a *skip*, permanently |
 | Azure | `stage=usage_event` | Every other Azure outcome — rejection, status error and transport failure are indistinguishable at the stage level. Read the error text for the HTTP status |
 | All | `…usage record synced` | **Accepted.** `reporting_id` is AWS's `MeteringRecordId`, GCP's `operationId`, or Azure's `usageEventId` |
 
@@ -674,15 +739,6 @@ id, or `relevantConnections` excludes it silently.
 
 For a flush specifically, the final record's `period_end` must equal `cancel_at` **exactly**, not
 `cancel_at - 1s` — the margin exists only on the wire (§3.4).
-
-### 8.6 Local-dev noise — not this feature
-
-| Symptom | Explanation |
-| --- | --- |
-| `BadSearchAttributes: custom search attribute 'TenantID'/'EnvironmentID'/'SubscriptionID' not found` | From `ProcessSubscriptionBillingWorkflow`, the only caller of `UpsertWorkflowSearchAttributes`. The dev namespace never had them registered. Interleaved because one local worker runs many workflow types |
-| `Failed to track workflow start: tenant_id is required` + `workflow_execution not found` on the marketplace crons | Fixed: both crons are now in `temporalCronWorkflowTypes`, which excludes them from tracking like every other cron. They are tenant-wide, so there was never a tenant to write a tracking row with |
-| `redis: … connection refused` at boot | Non-fatal; ~500ms of retries |
-| `dial tcp 127.0.0.1:7233: connect: connection refused` | Fatal — every mode needs a reachable Temporal. `temporal server start-dev` (no Docker needed) |
 
 ---
 

--- a/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
+++ b/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
@@ -6,25 +6,21 @@ Status: design, pending approval
 Scope: two lifecycle defects and the final-usage flush that closes them. Applies to all three
 marketplaces (AWS, GCP, Azure) and, for the mapping defect, to every integration provider.
 
-This builds on
-[2026-07-23-FLE-1071-marketplace-integration-v3.md](2026-07-23-FLE-1071-marketplace-integration-v3.md).
-Everything in v3 stands except where §6 below marks it superseded.
+Builds on [v3](2026-07-23-FLE-1071-marketplace-integration-v3.md). Everything in v3 stands except
+where §6 marks it superseded.
 
 ---
 
 ## 1. What this changes
 
-Two defects, one new mechanism.
-
 | # | Problem | Fix |
 | --- | --- | --- |
 | 1 | Re-linking an entity after unlinking silently leaves the mapping `archived`. The API returns 200 but no active mapping exists. | Treat an archived row as absent: create a new published row instead of updating it (§2). |
-| 2 | Cancelling a subscription leaves its marketplace mapping `published`, and the final active-period usage is never reported inside the marketplaces' post-cancellation windows. | A one-shot flush on cancellation: report the backlog, compute and report the final window, then archive the subscription mapping (§3). |
+| 2 | Cancelling a subscription leaves its marketplace mapping `published`, and the final active-period usage is never reported inside the marketplaces' post-cancellation windows. | A one-shot flush on cancellation: report the backlog, compute and report the final window, then archive the mapping (§3). |
 
 The driver for #2 is timing. v3 §10 assumed the tenant could wait for the 6-hour snapshot cron's
-4–10h lag to catch the last window before archiving. Both AWS and GCP give roughly **one hour** after
-cancellation, so that assumption loses the final usage of every cancelled marketplace subscription
-(§4).
+4–10h lag before archiving. AWS and GCP give roughly **one hour** after cancellation, so that
+assumption loses the final usage of every cancelled marketplace subscription (§4).
 
 ---
 
@@ -32,56 +28,34 @@ cancellation, so that assumption loses the final usage of every cancelled market
 
 ### 2.1 What happens today
 
-`DelinkIntegrationMapping`
-([entityintegrationmapping.go:271-314](../../internal/ee/service/entityintegrationmapping.go))
-soft-deletes: it flips `status` to `archived` via `Delete`
-([repository/ent/entityintegrationmapping.go:310-356](../../internal/repository/ent/entityintegrationmapping.go)).
-The row stays, and its unique-index columns are untouched. That part is correct.
+`DelinkIntegrationMapping` soft-deletes: it flips `status` to `archived` and leaves the row and its
+unique-index columns untouched. That part is correct.
 
 The defect is in `upsertEntityMapping`
-([entityintegrationmapping.go:316-366](../../internal/ee/service/entityintegrationmapping.go)). It
-looks up existing mappings with `types.NewNoLimitQueryFilter()`, which leaves `Status` nil, so
-`GetStatus()` returns `""` and `ApplyStatusFilter` applies **no status predicate at all** — archived
-rows match. When the only existing row is the archived one, the service updates its
-`ProviderEntityID`, `Metadata` and timestamps, then returns:
+([entityintegrationmapping.go](../../internal/ee/service/entityintegrationmapping.go)). It looked up
+existing mappings with `types.NewNoLimitQueryFilter()`, which leaves `Status` nil, so
+`ApplyStatusFilter` applies **no status predicate** and archived rows match. With only an archived row
+present, the service updated it in place and returned it — `Update` writes back whatever status the
+caller passed, so the row stayed `archived`. The caller got a 200 and a mapping object, but no active
+mapping existed.
 
-```go
-if len(existing) > 0 {
-    mapping := existing[0]
-    mapping.ProviderEntityID = req.ProviderEntityID
-    mapping.Metadata = metadata
-    mapping.UpdatedAt = time.Now().UTC()
-    mapping.UpdatedBy = types.GetUserID(ctx)
-    if err := s.EntityIntegrationMappingRepo.Update(ctx, mapping); err != nil { ... }
-    return mapping, nil          // status is never reset to published
-}
-```
-
-`Update` writes whatever status the caller passed, so the row goes back to Postgres still
-`status = 'archived'`. The caller gets a 200 and a mapping object, but no active mapping exists.
-
-The marketplace path is **not** affected: `RegisterAgreement` / `createMappingIfAbsent`
-([marketplace.go:198-240](../../internal/ee/service/marketplace.go)) queries with
-`NewNoLimitPublishedQueryFilter()`, so an archived row is invisible to it and a re-link creates a
-fresh published row correctly.
+The marketplace path was never affected: `RegisterAgreement` / `createMappingIfAbsent`
+([marketplace.go](../../internal/ee/service/marketplace.go)) already queried with
+`NewNoLimitPublishedQueryFilter()`.
 
 ### 2.2 The fix
 
-Branch on the found row's status:
+One-line change: query published-only. An archived row is then invisible to the lookup, so a re-link
+falls through to the existing create path and gets a new published row. The archived row is never
+touched.
 
-```text
-existing = List(entity_id, entity_type, provider_type)     # status-blind, as today
-
-if a PUBLISHED row exists:
-    update it in place                                      # unchanged behaviour
-else if only ARCHIVED rows exist:
-    log.debug("entity mapping is archived, creating new mapping", entity_id, entity_type, provider_type)
-    create a NEW row with a new id and status = published    # never touch the archived row
-else:
-    create as today
+```go
+filter := &types.EntityIntegrationMappingFilter{
+    QueryFilter: types.NewNoLimitPublishedQueryFilter(),   // was NewNoLimitQueryFilter()
+    EntityID:    req.EntityID,
+    ...
+}
 ```
-
-The archived row is left exactly as it was.
 
 ```mermaid
 sequenceDiagram
@@ -90,44 +64,36 @@ sequenceDiagram
     participant DB
 
     Caller->>Svc: link(entity_id, entity_type, provider_type)
-    Svc->>DB: List (status-blind, as today)
-    DB-->>Svc: existing rows, if any
-
+    Svc->>DB: List (published only)
     alt a published row exists
+        DB-->>Svc: that row
         Svc->>DB: update it in place
-    else only archived rows exist
-        Svc->>Svc: log.debug "archived, creating new mapping"
-        Svc->>DB: create new row, status = published
-    else no rows exist
+    else none (no row, or only archived rows)
+        DB-->>Svc: empty
         Svc->>DB: create new row, status = published
     end
-    Svc-->>Caller: mapping (now genuinely published)
+    Svc-->>Caller: mapping (genuinely published)
 ```
 
-### 2.3 Why no `expired_at` / `terminated_at` column
+### 2.3 Why no `expired_at` column
 
-Considered and rejected. Reusing an archived row and flipping it back to `published` would need a
-separate timestamp to record when it had been archived — but that timestamp would then be overwritten
-on the next unlink, so it could not carry history anyway.
-
-Creating a new row makes the column unnecessary:
-
-- the archived row's own `updated_at` is when it was archived (set by `Delete`),
-- the new row's `created_at` is when it was re-linked,
-- the full link/unlink history is the ordered sequence of rows.
+Considered and rejected. Reusing an archived row would need a separate timestamp for when it had been
+archived — but that timestamp would be overwritten on the next unlink, so it could not carry history
+anyway. Creating a new row makes the column unnecessary: the archived row's `updated_at` is when it was
+archived, the new row's `created_at` is when it was re-linked, and the full history is the ordered
+sequence of rows.
 
 The unique index already permits this. It is **partial** —
 `Unique().Annotations(entsql.IndexWhere("((status)::text = 'published'::text)"))`
-([ent/schema/entityintegrationmapping.go:71-74](../../ent/schema/entityintegrationmapping.go)) — so
-any number of archived rows can coexist with one published row for the same
+([ent/schema/entityintegrationmapping.go](../../ent/schema/entityintegrationmapping.go)) — so any
+number of archived rows can coexist with one published row for the same
 `(tenant, environment, entity_type, entity_id, provider_type)`. No schema change.
 
 ### 2.4 Test gap
 
-`TestLinkIntegrationMapping_UpsertExistingMapping`
-([entityintegrationmapping_test.go:279-315](../../internal/ee/service/entityintegrationmapping_test.go))
-only covers link → link on a still-published row. Nothing exercises delink → re-link, which is why
-this shipped unnoticed. A regression test for that path is part of this work.
+`TestLinkIntegrationMapping_UpsertExistingMapping` only covered link → link on a still-published row.
+Nothing exercised delink → re-link, which is why this shipped unnoticed. A regression test for that
+path is part of this work.
 
 ---
 
@@ -135,20 +101,26 @@ this shipped unnoticed. A regression test for that path is part of this work.
 
 ### 3.1 Trigger
 
-`CancelSubscription` ([subscription.go:1931](../../internal/ee/service/subscription.go)) stays fast
-and is not restructured. After its existing `WithTx` (2035-2146) commits — alongside the existing
-`publishCancellationEvents` call (2155-2157) — it starts the flush workflow with `ExecuteWorkflow`
-(non-blocking; the blocking variant is `ExecuteWorkflowSync`,
-[temporal/service/interface.go:18,40,46](../../internal/temporal/service/interface.go)).
+`CancelSubscription` stays fast and is not restructured. After its existing `WithTx` commits — next to
+the existing `publishCancellationEvents` call — it starts the flush with `ExecuteWorkflow`
+(non-blocking), gated on:
 
-This matches the convention already in the codebase: `CreateSubscription` starts its HubSpot sync
-workflows after its transaction returns ([subscription.go:532-568, 851-877](../../internal/ee/service/subscription.go)),
-and `CreateCustomer` does the same for onboarding ([customer.go:87-99](../../internal/ee/service/customer.go)).
-No workflow is started inside a `WithTx` anywhere in `internal/ee/service`, for the obvious reason
-that a rollback would leave an orphaned workflow running against rows that were never written.
+```go
+subscription.SubscriptionStatus == types.SubscriptionStatusCancelled &&
+    subscription.CancelAt != nil &&
+    s.hasMarketplaceMapping(ctx, subscription.ID)
+```
 
-**This is not a cron.** It is one workflow execution per cancellation. The snapshot (6h) and report
-(3h) crons are unchanged and keep running for live subscriptions.
+The status check matters: `CancelAt` is set for all three cancellation types, but only `immediate`
+sets `Cancelled` synchronously. `end_of_period` and `scheduled_date` leave the subscription active
+until a later processor, so flushing then would report a final window for a subscription that has not
+ended. `hasMarketplaceMapping` gates at the call site so ordinary cancellations don't start a workflow
+that would immediately no-op; a lookup error is logged and treated as "no mapping", since this is a
+post-commit side effect that must never fail an already-committed cancellation.
+
+Starting workflows after the transaction matches the existing convention (`CreateSubscription`'s
+HubSpot syncs, `CreateCustomer`'s onboarding). **This is not a cron** — one execution per cancellation.
+The snapshot (6h) and report (3h) crons are unchanged.
 
 ```mermaid
 sequenceDiagram
@@ -156,53 +128,58 @@ sequenceDiagram
     participant MP as Marketplace
     participant Tenant
     participant FP as Flexprice API
-    participant Temporal
     participant Flush
 
     Buyer->>MP: cancels subscription
     MP->>Tenant: notification (carries the cancellation instant)
     Tenant->>FP: POST /cancel (immediate, cancel_at = that instant)
-    FP->>FP: commit — cancel subscription, CancelAt = cancel_at
+    FP->>FP: commit — CancelAt = cancel_at
     FP-->>Tenant: 200
-    FP->>Temporal: ExecuteWorkflow (non-blocking, after commit)
-    Temporal->>Flush: run
-    Flush->>MP: report backlog + final usage record
-    Flush->>Flush: delink the marketplace mapping
+    FP->>Flush: ExecuteWorkflow (non-blocking, post-commit)
+    Flush->>MP: report backlog, then the final record
+    Flush->>Flush: delink mapping (only if everything succeeded)
 ```
 
 ### 3.2 Sequence
 
+Workflow `MarketplaceSubscriptionFinalUsageFlushWorkflow`, activity
+`MarketplaceSubscriptionFinalUsageFlushActivity`. The workflow is a thin wrapper — one
+`ExecuteActivity` with 5 attempts (5s initial, 2× backoff, 1 min max, 5 min start-to-close). All logic
+is in the activity.
+
 ```text
-FlushSubscriptionUsage(subscriptionID, cancelAt):     # cancelAt = sub.CancelAt, NOT sub.CancelledAt — see §3.8
+FlushActivity(subscriptionID, cancelAt, tenantID, environmentID):
+    # cancelAt = sub.CancelAt, never sub.CancelledAt (§3.6)
+    # tenantID/environmentID come from the workflow input and are set onto ctx first —
+    # every repository call below is scoped by them.
 
 1. subMappings = published subscription mappings for [aws, gcp, azure]
-   if none: return                                    # not a marketplace subscription
+   if none: return                                  # not a marketplace subscription
+   for m in subMappings:
+       conn = resolve m's connection; prepareConnection(conn)
+       on failure: log, set connectionResolutionFailed, continue   # never abort the others
 
-   connections   = resolve each mapping's connection
-   preparedConns = [prepareConnection(c) for c in connections]      # report_activities.go:301, reused
+2. # Phase 1 — the pre-existing backlog. Fetched before phase 2 computes anything, so a first run
+   # never sees its own final record here.
+   backlog = List(subscription_id, synced=false, period_end >= now-24h, sort period_end asc)
+   for rec in backlog:
+       if not isEligibleForReport(rec): continue    # non-USD or negative (§8.2)
+       reportRecordToConnections(rec, relevantConnections(rec)); MarkSynced(rec)
 
-2. frontier = MAX(period_end) over ALL published usage_records for this subscription
-   if none:  frontier = subscription mapping's created_at           # §3.4
+3. # Phase 2 — the one final record.
+   computedThrough = MAX(period_end) over ALL published rows, else earliest mapping created_at (§3.3)
+   finalRec = buildFinalUsageRecord(computedThrough, cancelAt)     # nil if cancelAt <= computedThrough
+   if finalRec and isEligibleForReport(finalRec):
+       reportRecordToConnections(finalRec, relevantConnections(finalRec))
+       if fully reported:
+           finalRec.PeriodEnd = cancelAt            # stored exact; the wire got cancelAt - 1s (§3.4)
+           Create(finalRec)                         # first write, only now
+       else: finalUsageFlushFailed = true
 
-3. if cancelAt > frontier:                                          # §3.5
-       usage      = GetMeterUsageBySubscription(subscriptionID, frontier, cancelAt)   # true window — full amount
-       amount     = CalculateMeterUsageCharges(...)
-       reportedAt = cancelAt - 1 second                             # §3.8 — reported timestamp only
-       Create(UsageRecord{period_start: frontier, period_end: reportedAt, synced: false, ...})
-       # ErrAlreadyExists is success — same idempotency rule as snapshot_activities.go:272
-
-4. backlog = List(subscription_id, synced=false, period_end >= now-24h, sort period_end asc)
-   for rec in backlog:                                 # includes the row just created
-       for conn in preparedConns:                      # one API call per record per connection
-           entry, ok = reportAWS/GCP/AzureRecord(rec, conn)          # reused unchanged, sends rec.PeriodEnd
-           if ok: rec.Syncs[conn.ID] = entry
-       MarkSynced(rec.ID, rec.Syncs, allConnectionsPresent)
-
-   if any record failed to report:
-       return error                                    # Temporal retries; syncs map makes it idempotent
-
-5. for mapping in subMappings:                         # ALWAYS runs, even after exhausted retries
-       DelinkIntegrationMapping(subscriptionID, subscription, mapping.ProviderType)
+4. if connectionResolutionFailed or finalUsageFlushFailed or any backlog record failed:
+       return error                                 # Temporal retries; mapping stays published (§3.5)
+   else:
+       for m in subMappings: entityIntegrationMappingRepo.Delete(m)
 ```
 
 Customer and plan mappings are **not** archived. Only the subscription's marketplace mappings are.
@@ -211,115 +188,114 @@ Customer and plan mappings are **not** archived. Only the subscription's marketp
 sequenceDiagram
     participant Flush
     participant DB as usage_records
-    participant MP as Marketplace connections
+    participant MP as Marketplaces
 
-    Flush->>DB: frontier = MAX(period_end), all published rows
-    alt cancelAt > frontier
-        Flush->>Flush: compute usage [frontier, cancelAt]
-        Flush->>DB: create final record (period_end = cancelAt - 1s)
-    else
-        Flush->>Flush: nothing new to compute
-    end
-
-    Flush->>DB: backlog = unsynced, period_end within 24h
-    loop each record in backlog
-        loop each connection
-            Flush->>MP: report record
-            alt accepted
-                MP-->>Flush: reporting_id
-                Flush->>Flush: syncs[conn] = entry
-            else rejected or failed
-                Flush->>Flush: no entry — stays unsynced
-            end
+    Note over Flush,MP: Phase 1 — backlog (pre-existing rows only)
+    Flush->>DB: unsynced rows, period_end within 24h
+    loop each record × each relevant connection without an entry
+        Flush->>MP: report
+        alt accepted
+            MP-->>Flush: reporting_id → syncs[conn]
+        else Azure zero-amount
+            Flush->>Flush: syncs[conn] = skipped
+        else rejected / failed
+            Flush->>Flush: no entry — stays unsynced
         end
-        Flush->>DB: MarkSynced (true only if every connection has an entry)
+    end
+    Flush->>DB: MarkSynced (true iff every relevant connection has an entry)
+
+    Note over Flush,MP: Phase 2 — the one final record
+    Flush->>DB: frontier = MAX(period_end)
+    alt cancelAt > frontier
+        Flush->>Flush: compute usage — NOT written yet
+        Flush->>MP: report (wire timestamp = cancelAt - 1s)
+        alt fully reported
+            Flush->>DB: create record (period_end = cancelAt)
+        else any connection failed
+            Flush->>Flush: discard — next attempt recomputes fresh
+        end
     end
 
-    Flush->>Flush: delink mapping (always, even after failures)
+    alt everything succeeded
+        Flush->>Flush: delink every mapping
+    else any failure
+        Flush->>Flush: mapping stays published; return error
+    end
 ```
 
-Note step 3's `reportedAt`: the usage **amount** is computed over the true window `[frontier, cancelAt]` —
-nothing is under-billed. Only the persisted `period_end` (and therefore the timestamp every provider
-receives, since `reportAWSRecord`/`reportGCPRecord`/`reportAzureRecord` all send `rec.PeriodEnd`
-unchanged) is backed off by one second. See §3.8 for why.
+### 3.3 Window rules
 
-### 3.3 Why `frontier` spans all rows, not just unsynced ones
+**The frontier spans all rows, not just unsynced ones.** Taking the max over unsynced rows alone can
+double-bill: if record A `[T-10h, T-4h]` failed to sync but B `[T-4h, T+2h]` succeeded, the unsynced
+max is `T-4h` and the flush window `[T-4h, cancelAt]` re-reports everything B covered. The max over
+**all published rows** is `T+2h`. Since snapshot windows are contiguous, the frontier has no holes
+behind it — every earlier span belongs to some row, and those rows are exactly what Phase 1 reports.
 
-Taking the max over unsynced rows alone can double-bill. If record A `[T-10h, T-4h]` failed to sync
-but record B `[T-4h, T+2h]` succeeded, the max over unsynced rows is `T-4h`, and the flush window
-`[T-4h, cancelAt]` re-reports everything B already covered.
+**Fallback when no usage record exists.** A subscription can be linked and cancelled without the
+snapshot cron ever running for it. The flush then uses the earliest subscription mapping's
+`created_at` — the moment the subscription became reportable to that marketplace. Consequence: usage
+from before it was linked is deliberately excluded.
 
-The max over **all published rows** is `T+2h`, giving `[T+2h, cancelAt]`. Since the snapshot
-cron's windows are contiguous (`period_start = scheduledTime−10h`, `period_end = scheduledTime−4h`,
-every 6h), the frontier has no holes behind it: every span before it belongs to some row, and those
-rows are exactly what step 4 reports.
+**Boundaries.** `period_start` is inclusive, `period_end` exclusive, inherited from the ClickHouse
+query builder (`timestamp >= ?` and `timestamp < ?`). Chaining `period_start = previous period_end`
+counts a boundary event exactly once. `buildFinalUsageRecord` early-returns when
+`cancelAt <= windowStart`, so a backdated cancellation can't produce an inverted window; the backlog
+flush is then the whole job.
 
-### 3.4 Fallback when no usage record exists
+### 3.4 Why the final record is reported before it is written
 
-A subscription can be linked and cancelled without the snapshot cron ever having run for it. Then
-`frontier` is undefined and the flush uses the **subscription mapping's `created_at`**.
+Two earlier shapes were tried; each had a real bug the next one fixed.
 
-That is the moment the subscription became reportable to that marketplace; nothing before it could
-ever have been owed there. Note the consequence: if the subscription's billing period started before
-it was linked, that earlier usage is deliberately excluded from the flush. That is intended, not an
-oversight.
+| Shape | Stored `period_end` | Bug |
+| --- | --- | --- |
+| 1. Create first, with the margin baked in | `cancelAt - 1s` | The row instantly becomes the frontier, so `cancelAt > frontier` is *still true* on a retry — it creates a second, near-empty record for the 1-second sliver. |
+| 2. Create first, store the true instant | `cancelAt` | Fixes the sliver, but a partially-reported row (say GCP failed) sits `synced = false` and the **next run picks it up through Phase 1**, which applies no margin — GCP's strict `<` rejects it forever. |
+| **3. Report first, then create** (current) | `cancelAt` | None of the above. Nothing unreported is ever persisted, so a retry recomputes the same window from an unchanged frontier and reports it again with the margin correctly applied. |
 
-### 3.5 Boundary semantics
+The cost of shape 3: nothing about a partially-successful attempt survives between retries for the
+final record, and each rebuild generates a fresh id. AWS de-duplicates on customer+dimension+timestamp
+so a resend is safe there; GCP de-duplicates on `OperationID` (= the record id), so it cannot recognise
+a retry as the same operation — see §7.
 
-`period_start` is **inclusive**, `period_end` **exclusive** — inherited from the ClickHouse query
-builder, which emits `timestamp >= ?` and `timestamp < ?`
-([meter_usage_query_builder.go:166-173](../../internal/repository/clickhouse/meter_usage_query_builder.go)).
+### 3.5 Failure handling and when the mapping is delinked
 
-Chaining `period_start = previous period_end` therefore counts a boundary event exactly once: the
-previous window excluded it, this one includes it. Making `period_start` exclusive would **skip** any
-event landing precisely on the boundary. Keep it inclusive.
+A report failure does not stop the run: every backlog record is still attempted and every connection
+still resolved, exactly as the report cron behaves. Retries are idempotent for backlog records — a
+connection that already has a `rec.Syncs[connection_id]` entry (real accept *or* skip) is never
+re-attempted.
 
-Step 3 is guarded on `cancelAt > frontier` because a backdated cancellation would otherwise
-produce an inverted window. When the guard fails, the backlog flush is the whole job.
+Each record's outcome is exactly one of three, decided by the caller from `rec.Synced` and
+`anyRealEntry` (the shared reporter itself only reports; it does not classify):
 
-### 3.6 Failure handling
+- **succeeded** — every relevant connection has an entry, and at least one is a real post
+- **failed** — at least one relevant connection still has no entry
+- **skipped** — every relevant connection has an entry, but all are skips (today only Azure's
+  zero-amount case) — nothing was posted anywhere
 
-A report failure inside the flush returns an error from the activity so Temporal retries it. Retries
-are naturally idempotent: `if _, done := rec.Syncs[conn.ID]; done { continue }`
-([report_activities.go:239](../../internal/temporal/activities/marketplace/report_activities.go))
-means only the connections that actually failed are re-attempted.
+**Delink runs only when everything succeeded**: no failed backlog record, the final record (if needed)
+fully reported, and every mapped connection resolved. On any failure the mapping stays `published` and
+the activity returns an error.
 
-When retries are exhausted:
+This reverses the original draft, which delinked unconditionally on the reasoning that a cancelled
+subscription shouldn't keep a live-looking mapping. That trade was wrong: a published mapping is the
+*only* thing that keeps a subscription's backlog visible to the 3h report cron
+(`isRelevantForSubscription` resolves through published mappings only). Delinking on failure doesn't
+just look stale — it permanently strands whatever failed to report, with no path back short of a human
+re-publishing the mapping. Retries are cheap and idempotent, so there was no compensating benefit.
 
-- the failed records keep `synced = false` and gain no `syncs` entry — they are not marked skipped
-  and nothing is resolved silently,
-- an `error` line is logged carrying every non-secret identifier available: `subscription_id`,
-  `customer_id`, `usage_record_id`, `connection_id`, `marketplace`, `period_start`, `period_end`,
-  `amount`, and the provider-side identifier (`license_arn`, `consumer_id`/entitlement id, or
-  `resource_id`), plus the provider's own error text,
-- credentials are never logged, at any level: no `client_secret` or bearer token (Azure), no
-  `role_arn`, `external_id` or assumed-role credentials (AWS), no WIF JSON or federated token (GCP).
-  Provider errors go through `utils.RedactSecrets` first, exactly as v3 §8.4 requires,
-- the delink in step 5 **still runs**. The subscription is cancelled; leaving its mapping published
-  would be stale state. The trade-off is accepted deliberately: once archived, the 3h report cron
-  cannot retry those rows, because `isRelevantForSubscription` resolves through published mappings
-  only ([report_activities.go:86-96, 231-233](../../internal/temporal/activities/marketplace/report_activities.go)).
-  At that point the failure is a tenant-side credential or configuration problem, and the logged
-  error is the signal to act on.
+**No skip entries on the row itself.** An earlier draft resolved leftover rows with
+`{skipped: true, skip_reason: "subscription_flushed"}`. Dropped: the 24h bound (§5) already stops
+expired rows being re-scanned, and marking them synced would make a subscription whose connection was
+broken for days look cleanly resolved when revenue was actually lost. Do not confuse this with the
+per-run *skipped* outcome above, which is in-memory observability only and never persisted. Azure's
+`zero_amount_not_supported` remains the only place `Skipped: true` is set.
 
-### 3.7 No skip entries
+### 3.6 The cancellation timestamp — `CancelAt`, not `CancelledAt`
 
-An earlier draft resolved leftover rows with `{skipped: true, skip_reason: "subscription_flushed"}`.
-Dropped. The 24h bound in §5.2 already stops expired rows being re-scanned forever, and marking them
-`synced = true, skipped = true` would make a subscription whose connection was broken for days look
-cleanly resolved when in fact revenue was lost. `synced = false` on an old row is the more honest
-signal and preserves the diagnostic trail.
-
-The existing Azure zero-amount skip (`zero_amount_not_supported`, v3 §11.6) is unaffected.
-
-### 3.8 Sourcing the cancellation timestamp — `CancelAt`, not `CancelledAt`
-
-This closes what was an open risk in an earlier draft of this document: GCP requires the reported
-timestamp to be strictly *before* its own recorded cancellation instant, and Flexprice's own
-`cancelled_at` can never satisfy that, because it is set by definition *after* the marketplace's own
-cancellation already happened — buyer cancels at the marketplace, the marketplace notifies the tenant,
-the tenant then calls Flexprice, and only at that point does Flexprice record anything. No amount of
-speed on our side closes that gap; it's a causal ordering, not a latency problem.
+GCP requires the reported timestamp to be strictly *before* its own recorded cancellation instant, and
+Flexprice's `cancelled_at` can never satisfy that: it is set only after the marketplace already
+cancelled, the marketplace notified the tenant, and the tenant called us. That's causal ordering, not
+latency.
 
 ```mermaid
 sequenceDiagram
@@ -331,49 +307,34 @@ sequenceDiagram
     MP->>Tenant: notification (carries T0)
     Tenant->>FP: POST /cancel (cancel_at = T0)
     Note over FP: T2 — call processed.<br/>CancelledAt := T2 (now, always)<br/>CancelAt := T0 (the tenant's value)
-    Note over FP,MP: T0 < T2, always — use CancelAt, not CancelledAt
+    Note over FP,MP: T0 < T2 always — use CancelAt
 ```
 
-The fix doesn't need a buffer or a guess, because the API already carries the right value if the
-tenant is asked to supply it. `CancelSubscriptionRequest` already accepts `cancel_at` for a backdated
-immediate cancellation: *"For 'immediate', accepts past/current dates only... backdated
-cancellation"* ([dto/subscription.go:655-659](../../internal/api/dto/subscription.go)), validated to
-reject only a future date ([dto/subscription.go:737-743](../../internal/api/dto/subscription.go)) and
-to require it fall after the current period start
-([subscription.go:1982-1991](../../internal/ee/service/subscription.go)) — no upper bound on how far
-in the past it can be. **The tenant contract for a marketplace-linked subscription is: call `/cancel`
-with `cancellation_type: "immediate"` and `cancel_at` set to the marketplace's own cancellation
-instant** (from the same webhook/notification that told the tenant to call us in the first place).
+The API already carries the right value. `CancelSubscriptionRequest` accepts `cancel_at` for a
+backdated immediate cancellation, validated only to reject a future date and to require it fall after
+the current period start. **The tenant contract for a marketplace-linked subscription is: call
+`/cancel` with `cancellation_type: "immediate"` and `cancel_at` set to the marketplace's own
+cancellation instant** (from the same notification that prompted the call).
 
-The field this lands in matters, and it is easy to get wrong. Traced through
-`updateSubscriptionForCancellation` ([subscription.go:6100-6121](../../internal/ee/service/subscription.go)):
+Which field it lands in is easy to get wrong. In `updateSubscriptionForCancellation`:
 
 ```go
 now := time.Now().UTC()
-subscription.CancelledAt = &now                    // ALWAYS wall-clock now — never the tenant's cancel_at
-
+subscription.CancelledAt = &now                // ALWAYS wall-clock now
 switch cancellationType {
 case types.CancellationTypeImmediate:
-    subscription.CancelAt = &effectiveDate          // ← the tenant's backdated cancel_at lands HERE
-    subscription.EndDate = &effectiveDate           // ← and here
+    subscription.CancelAt = &effectiveDate     // ← the tenant's backdated value lands HERE
+    subscription.EndDate = &effectiveDate
 ```
 
-`CancelledAt` is unconditional — the comment above it says plainly *"cancelled_at is the time of the
-subscription cancellation [call]"*. `determineEffectiveDate`
-([subscription.go:5994-5998](../../internal/ee/service/subscription.go)) confirms a backdated
-`customDate` is returned unmodified for the immediate case. So the flush must read **`sub.CancelAt`**
-(equivalently `sub.EndDate` for the immediate path) — reading `sub.CancelledAt` here would silently
-reintroduce the exact causal-ordering problem this section exists to close. Verified against a real
-row: a subscription cancelled via `scheduled_date` showed `cancelled_at` at the API-call instant while
-`cancel_at`/`end_date` carried the requested effective date, several hours later — confirming the two
-fields diverge in practice, not just in the code path being read here.
+So the flush reads **`sub.CancelAt`**. Verified against a real row: a `scheduled_date` cancellation
+showed `cancelled_at` at the API-call instant while `cancel_at`/`end_date` carried the requested
+effective date hours later — the two genuinely diverge.
 
-With the tenant supplying the marketplace's own instant, `cancelAt - 1 second` (§3.2 step 3) is now a
-minimal, deterministic correction against the *real* comparison GCP makes — not an arbitrary safety
-margin against a value we could only estimate. One second costs nothing material and is not
-provider-specific: it satisfies GCP's strict `<` requirement, and does not conflict with Azure (whose
-own worked example already accepts landing exactly *at* the instant) or AWS (no such comparison exists
-at all).
+With the tenant supplying the marketplace's own instant, `cancelAt - 1 second` is a minimal
+deterministic correction against the real comparison GCP makes, applied uniformly to all three
+providers rather than branched: it satisfies GCP's strict `<`, and conflicts with neither Azure (whose
+documented example accepts landing exactly at the instant) nor AWS (no such comparison).
 
 ---
 
@@ -384,84 +345,59 @@ post-cancellation window far shorter than their general staleness limit.
 
 | | General staleness window | Post-cancellation window | Rejection for an inactive subscription |
 | --- | --- | --- | --- |
-| **AWS** | 24h, plus a month-end cutoff at 06:00 UTC on the 1st for the prior month | **~1 hour** from `License Deprovisioned` / `unsubscribe-pending` | `Status: CustomerNotSubscribed` |
+| **AWS** | 24h, plus a month-end cutoff at 06:00 UTC on the 1st | **~1 hour** from `License Deprovisioned` / `unsubscribe-pending` | `Status: CustomerNotSubscribed` |
 | **GCP** | no hard cutoff published; guidance is **within 1 hour** of the usage occurring, with a ≤30-day outage provision (re-timestamped, not backdated) | **1 hour**, and the timestamp must be *before* the cancellation | `reportErrors` `NOT_FOUND` — *inferred, not doc-confirmed* |
 | **Azure** | 24h from `effectiveStartTime` | none stated separately; the 24h rule governs | `ResourceNotActive` (batch) / 400 "SaaS subscription isn't in Subscribed status" (single) |
 
-Sources:
+Sources: AWS —
+[SaaS EventBridge integration](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-eventbridge-integration.html#saas-eventbridge-final-usage)
+("this event marks the start of a 1-hour final reporting window… After this window closes… usage
+reporting is no longer accepted"),
+[BatchMeterUsage](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_BatchMeterUsage.html),
+[UsageRecordResult](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_UsageRecordResult.html).
+GCP —
+[Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting#report_usage_after_an_entitlement_is_canceled)
+("you can still report it with a timestamp that reflects the actual time… Report this usage within one
+hour"). Azure —
+[Metering service APIs](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis),
+[FAQ on already-unsubscribed subscriptions](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq#what-happens-when-you-emit-usage-for-a-saas-subscription-that-s-already-unsubscribed-)
+("The only exception is reporting usage for the time that was before the SaaS subscription is
+cancelled").
 
-- AWS — [Managing SaaS subscription events with Amazon EventBridge](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-eventbridge-integration.html#saas-eventbridge-final-usage):
-  "this event marks the start of a 1-hour final reporting window… After this window closes, customer
-  entitlements are fully revoked and usage reporting is no longer accepted."
-  [BatchMeterUsage](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_BatchMeterUsage.html)
-  for the 24h + month-end rule;
-  [UsageRecordResult](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_UsageRecordResult.html)
-  for `CustomerNotSubscribed`.
-- GCP — [Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting#report_usage_after_an_entitlement_is_canceled):
-  "If you have unreported usage after an entitlement is canceled, you can still report it with a
-  timestamp that reflects the actual time when the usage was generated. Report this usage within one
-  hour. Do not report any usage as new usage after the entitlement ends."
-- Azure — [Metering service APIs](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis)
-  for the 24h rule and the `ResourceNotActive` / 400 statuses;
-  [Metering service APIs FAQ — "What happens when you emit usage for a SaaS subscription that's already unsubscribed?"](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq#what-happens-when-you-emit-usage-for-a-saas-subscription-that-s-already-unsubscribed-)
-  for the post-cancellation exception: "Usage can be emitted only for subscriptions in the Subscribed
-  status (and not for subscriptions in `PendingFulfillmentStart`, `Suspended`, or `Unsubscribed`
-  status). The only exception is reporting usage for the time that was before the SaaS subscription
-  is canceled. For example, the customer canceled the SaaS subscription today at 3 pm. Now is 5 pm,
-  the publisher can still emit usage for the period between 6 pm yesterday and 3 pm today."
-- Azure cancellation flow — [SaaS subscription life cycle](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-life-cycle),
-  [Implementing a webhook](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-webhook)
-  (the `Unsubscribe` action is notify-only: "There's no send to ACK for this event").
-
-### 4.1 Why the marketplace cannot tell us what we already reported
-
-Considered as a way to derive the flush window from the provider rather than our own table. Only one
-of three supports it, so `usage_records` stays the source of truth for all three:
-
-- **Azure** — yes: `GET /api/usageEvents?api-version=2018-08-31&usageStartDate=<date>` returns prior
-  submissions with `usageDate` and `reconStatus`.
-- **AWS** — no. The metering API is `MeterUsage` / `BatchMeterUsage` / `RegisterUsage` /
-  `ResolveCustomer`. AWS's own guidance for auditing past submissions is CloudTrail, which is the
-  tenant's audit log, not a seller-queryable metering API.
-- **GCP** — no. Service Control exposes only `check` and `report`.
+**Why the marketplace can't tell us what we already reported.** Only Azure supports it
+(`GET /api/usageEvents?usageStartDate=…`). AWS's metering API has no seller-queryable read (its
+guidance is CloudTrail, the tenant's own audit log); GCP's Service Control exposes only `check` and
+`report`. So `usage_records` stays the source of truth for all three.
 
 ---
 
-## 5. Schema, repository and filter changes
+## 5. Schema and repository changes
 
-### 5.1 No schema changes
+**No migrations.** `entity_integration_mapping` keeps its partial unique index (§2.3);
+`usage_records` is unchanged.
 
-Neither defect needs a migration. `entity_integration_mapping` keeps its partial unique index
-(§2.3); `usage_records` is unchanged.
+**`ListUnsynced` gains a 24h bound.** It previously returned every `synced = false` row forever, so
+rows past the submission window were re-scanned by every run and never resolved. Now bounded by
+`period_end >= now() - 24h` — Azure's exact limit, AWS's limit (whose month-end rule is a deadline, not
+an extension), and far more generous than GCP's hourly guidance.
 
-### 5.2 `ListUnsynced` gains a 24h bound
+**`UsageRecordFilter` added.** No filter type existed; the repository exposed only `Create`,
+`ExistsForPeriod`, `ListUnsynced` and `MarkSynced`. Rather than one bespoke method per query, a filter
+following `EntityIntegrationMappingFilter`'s shape was added (embedded `*QueryFilter` /
+`*TimeRangeFilter`, `Filters`, `Sort`, plus explicit columns), with a matching `List` on the interface
+and Ent implementation. Both flush queries are the same call:
 
-Today `ListUnsynced` ([repository/ent/usagerecord.go:127-154](../../internal/repository/ent/usagerecord.go))
-returns every `synced = false` row for a tenant/environment, forever. Rows past the submission window
-can never be accepted, so they are re-scanned by every run and never resolve.
+- frontier — `{subscription_id, sort: period_end desc, limit: 1}`
+- backlog — `{subscription_id, synced: false, period_end >= now-24h, sort: period_end asc}`
 
-Add `period_end >= now() - 24h`. Safe on all three providers: it is Azure's exact limit, it is AWS's
-limit (whose month-end rule is a *deadline*, not an extension, so a flat 24h never over-includes),
-and it is far more generous than GCP's hourly guidance.
+`ListUnsynced` was **not** folded in; the report cron needs it tenant/environment-scoped rather than
+subscription-scoped.
 
-This also removes the need for the skip entries discussed in §3.7 — an expired row is simply never
-fetched again, while its `synced = false` state remains visible for diagnosis.
-
-### 5.3 A generalized `UsageRecordFilter`
-
-No `UsageRecordFilter` exists today; the repository exposes only `Create`, `ExistsForPeriod`,
-`ListUnsynced` and `MarkSynced`. Rather than adding one bespoke method per query, add a filter type
-following the shape of `EntityIntegrationMappingFilter`
-([types/entityintegrationmapping.go:89-105](../../internal/types/entityintegrationmapping.go)):
-embedded `*QueryFilter` and `*TimeRangeFilter`, `Filters []*FilterCondition`, `Sort []*SortCondition`,
-plus entity-specific fields (`SubscriptionID`, `Synced`, …).
-
-Both flush queries are then the same `List(ctx, filter)` call:
-
-- `frontier` — `{subscription_id, status: published, sort: period_end desc, limit: 1}`
-- `backlog` — `{subscription_id, synced: false, period_end >= now-24h, sort: period_end asc}`
-
-`ListUnsynced` can fold into it later; it is not required by this change.
+**Tenant filter hardened.** `EntityIntegrationMappingQueryOptions.ApplyTenantFilter` skipped the tenant
+predicate when the ctx tenant was empty, failing *open* (cross-tenant rows) instead of closed. Now
+unconditional, matching `ConnectionQueryOptions`. No call site relied on the old behaviour — the only
+deliberately cross-tenant query is `Connection.ListPublishedByProvider`, a separate method that
+documents why.
 
 ---
 
@@ -469,176 +405,297 @@ Both flush queries are then the same `List(ctx, filter)` call:
 
 | v3 section | Status |
 | --- | --- |
-| §8.1 Snapshot cron | Still correct for live subscriptions. A cancelled subscription is now handled by the flush (§3), not by waiting for the next scheduled run. |
-| §8.2 Reporting cron | Still correct. `ListUnsynced` gains the 24h bound (§5.2). |
-| §10, "the tenant should archive only after the snapshot cron's 4–10h lag has had a chance to capture the final active-period usage" | **Superseded.** AWS and GCP allow roughly one hour after cancellation (§4); a 4–10h wait misses both windows. Cancellation now triggers the flush directly (§3). |
-| §10 lifecycle table, `Suspend` row: "mapping stays published, reporting continues until `Unsubscribe`" | **Incorrect.** Azure documents that usage may be emitted only in `Subscribed` status — explicitly not `Suspended` (§4). Reporting for a suspended Azure subscription is rejected with `ResourceNotActive`. The row should read: reporting will be rejected while suspended; the mapping stays published because `Reinstate` is possible. |
-| §2.5, "GCP submission window: not documented; assumed similar" | **Resolved, and the framing was wrong.** GCP documents its timing expectations clearly — "within one hour," stated for normal reporting, month-end, and post-cancellation alike (§7.1) — it simply does not publish a hard technical rejection cutoff the way AWS (`TimestampOutOfBoundsException`) and Azure (`Expired`) do. Checked directly against the raw text of all seven GCP references this ERD cites, plus the `manage-entitlements` and `providers.entitlements` API pages — no "24 hours" figure exists anywhere in GCP's marketplace documentation. |
-| §12, "No terminal state / TTL for un-acceptable or expired rows" | **Partially addressed.** The 24h bound (§5.2) stops expired rows being re-scanned. A true terminal status is still not built. |
-| §12, "Azure's late-submission rule is unconfirmed" | **Partially resolved.** Azure rejects on subscription status (`ResourceNotActive` / 400) independently of the 24h `effectiveStartTime` rule. Whether lateness is judged by submission time or `effectiveStartTime` is still unstated. |
+| §8.1 Snapshot cron | Still correct for live subscriptions. Cancelled ones are now handled by the flush (§3). |
+| §8.2 Reporting cron | Still correct. `ListUnsynced` gains the 24h bound (§5). |
+| §10, "archive only after the snapshot cron's 4–10h lag" | **Superseded.** AWS and GCP allow ~1 hour (§4); a 4–10h wait misses both windows. |
+| §10 lifecycle table, `Suspend` row | **Incorrect.** Azure permits usage only in `Subscribed` status, explicitly not `Suspended`. Should read: reporting is rejected while suspended; the mapping stays published because `Reinstate` is possible. |
+| §2.5, "GCP submission window not documented" | **Resolved, and the framing was wrong.** GCP documents "within one hour" clearly; what it doesn't publish is a hard rejection cutoff like AWS's `TimestampOutOfBoundsException` or Azure's `Expired`. |
+| §12, "no terminal state for expired rows" | **Partially addressed.** The 24h bound stops re-scanning; a true terminal status is still not built. |
 
 ---
 
 ## 7. Known gaps
 
-Every gap listed in v3 §12 is restated here in full, each with what v4 does about it. Nothing is
-dropped just because it was written down before.
+| Gap | Status |
+| --- | --- |
+| No "give up" marker on a record that can never be sent | **Partly fixed.** The 24h bound stops the cron re-scanning hopeless rows, but they still sit `synced = false` with nothing marking them dead. A terminal status remains future work. |
+| No dead-letter table | **Closed, not needed.** Failure logs carry every identifier (§8) and are queryable in SigNoz; a second copy would be a second thing to keep consistent. |
+| GCP's timing rules differ in shape from AWS's and Azure's | **Answered.** GCP expects hourly reporting but publishes no hard cutoff. The 24h bound is exact for AWS/Azure and simply a uniform choice for GCP. |
+| Which clock Azure measures lateness by | **Partly answered.** Azure rejects on *status* independently of the 24h rule, and usage from before cancellation stays reportable. Submission-time vs. timestamp is still unstated in any doc. |
+| One record per API call instead of batching | **Enhancement.** Not a flush risk: the 24h bound caps a backlog at ~4 records across ≤3 marketplaces, so a flush makes at most about a dozen calls. |
+| GCP could reject the final report as too late | **Resolved (§3.6)** by sourcing the timestamp from `sub.CancelAt` and reporting `cancelAt - 1s`. |
 
-Nothing below is an open risk to the launch. The one item that was — whether GCP rejects the final
-report because our timestamp lands after its own cancellation instant — is resolved by sourcing the
-timestamp correctly rather than guessing at a margin (§3.8). Everything else is either closed, an
-accepted trade-off, or a follow-up enhancement.
+**New in v4, still open:**
 
-### 7.1 Carried over from v3
+**Nothing re-triggers the flush once its own retries are exhausted.** Temporal does not restart it and
+`CancelSubscription` calls `ExecuteWorkflow` once. Recovery is then the 3h report cron's job, which is
+fine for the backlog (it has a real 24h window) but not for the final record's timestamp — AWS/GCP's
+~1 hour deadline doesn't care that the cron keeps trying. The 5 attempts are ~2.5 minutes of backoff,
+well inside the hour, so exhausting them on a transient issue still leaves the cron a full window. If
+the deadline itself was already blown, no retry by anything can fix it — that's the marketplaces' rule,
+not a design gap.
 
-**No "give up" marker on a record that can never be sent — _partly fixed; remainder is an enhancement, not a blocker_.**
+**GCP could double-count a final record split across retries.** Because shape 3 (§3.4) never persists
+an unreported record, a rebuild generates a fresh id, and GCP de-duplicates on `OperationID` = that id.
+If GCP accepts on attempt 1 but a *different* connection fails, attempt 2 reports the same usage to GCP
+under a new identity. Narrow, but real. Closing it means deriving the final record's id
+deterministically (e.g. from `subscription_id + cancel_at`) instead of a fresh UUID.
 
-Some usage records can never succeed, no matter how many times we try: the buyer's subscription
-closed, or the record is simply older than the marketplace will accept. The problem is that a record
-in that state looks exactly like a record that failed once and deserves another try — both just say
-`synced = false`. Nothing in the row distinguishes "retry me" from "this is hopeless."
-
-The consequence was that the reporting cron kept picking those hopeless records up on every run,
-forever, and the pile only grew.
-
-What v4 does: the reporting cron now only looks at records from the last 24 hours (§5.2). Anything
-older is never fetched again, so hopeless records stop being retried and the query stops getting
-slower over time. What v4 does **not** do is give those records a real "finished, expired" status —
-they are still sitting there marked unsynced, we simply stop looking at them. Anyone reading the
-table directly still has to work out for themselves that an old unsynced row is dead. A proper
-terminal status remains future work.
-
-**No dead-letter table — _closed, not needed_.**
-
-v3 listed the absence of a dead-letter table as a gap: nowhere to answer "which records are failing,
-and how often?" without grepping logs.
-
-Closing this rather than carrying it forward. The failure logs now carry every identifier needed to
-answer that question — subscription, customer, usage record, connection, marketplace, period, and the
-provider's own error text (§3.6) — and they are queryable in SigNoz. A dead-letter table would be a
-second copy of the same information in a second place to keep consistent. The original gap assumed
-logs could only be grepped; that is no longer the case.
-
-**GCP's timing rules are different in shape from AWS's and Azure's — _answered_.**
-
-v3 recorded GCP's submission window as "not documented; assumed similar" to AWS's 24 hours. That
-framing was wrong in both directions. GCP documents its timing expectations clearly; what it does
-*not* publish is a hard rejection cutoff.
-
-GCP's actual rules ([Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting)):
-
-- *"Service providers must report usage within one hour of the usage being generated."* — one hour,
-  not 24.
-- Month-end: report by 1 AM US Pacific the following day to land on that month's invoice.
-- Post-cancellation: within one hour, with a timestamp before the cancellation.
-- Extended outage: a grace period *"not exceeding 30 days"*, during which usage is collected in
-  hourly windows and then, once service is restored, reported *"as actual usage with the time the
-  data was collected"* — re-timestamped to the present, not backdated.
-
-So AWS and Azure both enforce a hard 24-hour wall (`TimestampOutOfBoundsException` and `Expired`
-respectively); GCP enforces no documented wall at all, but expects hourly reporting.
-
-One consequence for §5.2: the 24-hour bound on `ListUnsynced` matches AWS's and Azure's limits
-exactly, but for GCP it is simply a choice — it stops us retrying records GCP might still have
-accepted. This is deliberate, to keep one uniform rule across all three providers rather than a
-per-provider retention window.
-
-**We don't know which clock Azure measures lateness by — _partly answered_.**
-
-Azure won't accept usage older than 24 hours. What its docs never say is *which* 24 hours: measured
-from when we send the request, or from the timestamp we put inside the request. In normal operation
-this never matters, because our records are only 4–10 hours old when we send them. It would only
-matter right at the edge — a subscription cancelled just as a record approaches the 24-hour mark.
-
-v4 answers a neighbouring question but not this one. We confirmed Azure rejects usage for an inactive
-subscription on *status* grounds, separately from any lateness rule (`ResourceNotActive`, or a 400
-saying the subscription isn't in `Subscribed` status), and confirmed that usage for the period
-*before* cancellation stays reportable (§4). The submission-time-versus-timestamp question is still
-unanswered by any published doc.
-
-**We send one record per API call instead of batching — _enhancement; not a problem for the flush_.**
-
-All three marketplaces accept multiple records in a single call (AWS and Azure up to 25; GCP up to
-1 MB). We send them one at a time, so a tenant with many buyers makes many more API calls than
-strictly necessary.
-
-v4 does not change this, and deliberately so — the reasons in v3 §12 still hold (AWS and GCP scope a
-single call to one product, so batching would need records grouped by product first; and AWS's move
-to per-record `LicenseArn` for Concurrent Agreements by June 2026 will remove that constraint anyway).
-
-Worth noting explicitly for the flush specifically: this is not a throughput risk there. The 24-hour
-bound means a backlog can hold at most four records (the snapshot cron runs every 6 hours), and a
-subscription can be mapped to at most three marketplaces — so the flush makes at most about a dozen
-API calls, comfortably inside its one-hour deadline.
-
-### 7.2 New in v4
-
-**GCP could reject the final report because our timestamp was a moment too late — _resolved, see §3.8_.**
-
-GCP requires that any usage reported after a cancellation carries a timestamp from *before* the
-cancellation happened. The risk was sourcing that timestamp from Flexprice's own `cancelled_at` —
-which is causally always at or after the marketplace's own instant, since it's only ever set once the
-tenant, having been notified by the marketplace, calls us — so it could never satisfy "before."
-
-Closed by sourcing it correctly rather than padding for uncertainty: the tenant supplies the
-marketplace's own cancellation instant via the existing backdated-immediate-cancellation `cancel_at`
-field, the flush reads `sub.CancelAt` (not `sub.CancelledAt`, which is unconditionally wall-clock
-processing time — §3.8 traces this exactly), and reports `cancelAt - 1 second`. This affects GCP alone
-in practice — Azure's own documented example already accepts landing exactly at the cancellation
-instant, and AWS makes no such comparison — but the fix is applied uniformly to all three rather than
-branched per provider.
-
-**Once the flush gives up, nothing tries again — _accepted trade-off_.**
-
-Temporal retries the flush automatically, and those retries are safe to repeat. But when the retries
-are finally exhausted, the flush archives the subscription's mapping anyway (§3.6). From that moment
-the ordinary reporting cron cannot pick those records up, because it only considers subscriptions
-with a published mapping — even if hours of the marketplace's window were still left.
-
-This is a deliberate choice: a cancelled subscription should not keep a live-looking mapping. By the
-time retries are exhausted the cause is almost always a tenant-side credentials or configuration
-problem, and the error log is the signal for someone to act on.
-
-**A connection broken for more than a day permanently loses that usage — _inherent to the providers_.**
-
-Say a subscription is linked to both AWS and Azure. AWS has been reporting fine for weeks, but the
-Azure connection's client secret expired ten days ago, so every Azure report has failed since.
-
-When the buyer cancels, the flush catches Azure up — but only for the last 24 hours of records. Ten
-days of Azure usage sits in `usage_records`, correctly computed, and can never be sent: AWS and Azure
-both reject any record whose timestamp is more than 24 hours old, so re-sending them is not an option
-we can build our way around.
-
-To be clear about what does *not* go wrong here: AWS is not double-reported. The final window starts
-from the newest record's `period_end` regardless of who has synced it, so it covers only genuinely
-new time, and the backlog step skips any connection that already has an entry for a record. The loss
-is one-sided — the broken connection misses out, the healthy one is unaffected.
-
-The mitigation, if this revenue matters, is the one both Azure and GCP describe in their own docs:
-roll the expired quantity into a current-timestamped event instead of trying to backdate it. Neither
-provider lets you preserve the original timestamps, and Microsoft warns it weakens the customer's
-billing audit trail, so this is a deliberate choice to make case by case — not something to automate
-here.
-
-The real defence is not losing ten days in the first place: a broken connection should be alerted on
-from the `error` logs (§3.6) long before a cancellation exposes it.
+**A connection broken for more than a day permanently loses that usage.** Inherent to the providers:
+the flush catches a broken connection up only for the last 24 hours, and AWS/Azure reject anything
+older. AWS is not double-reported — the frontier covers only genuinely new time, and the backlog step
+skips connections that already have an entry — so the loss is one-sided. The mitigation both Azure and
+GCP describe is rolling the expired quantity into a current-timestamped event, which weakens the
+customer's audit trail and is a case-by-case call, not something to automate. The real defence is
+alerting on the failure logs long before a cancellation exposes it.
 
 ---
 
-## 8. Reference
+## 8. Logging and what to search for
+
+Levels are `error`, `info`, or `debug` only — never `warn`.
+
+**Credentials are never logged, at any level, for any provider** — no `client_secret` or bearer token
+(Azure), no `role_arn`, `external_id` or assumed-role credentials (AWS), no WIF JSON or federated token
+(GCP). Provider errors pass through `utils.RedactSecrets`, which strips the tenant's identifiers and
+preserves everything else verbatim, because the status and reason are what make a failure diagnosable.
+
+Four message strings carry the whole feature. Grep these first:
+
+| Message | Emitted by | Meaning |
+| --- | --- | --- |
+| `marketplace usage snapshot failed` | snapshot cron | Always tagged `stage` |
+| `marketplace usage report failed` | report cron **and** the flush | Always tagged `stage`. Shared, because both call the same reporter — when debugging a flush, grep this too |
+| `marketplace subscription flush failed` | flush only | Always tagged `stage` |
+| `marketplace usage record synced` / `marketplace subscription flush: usage record synced` | report cron / flush | The only lines meaning a marketplace accepted a record |
+
+Every line tied to one connection carries `marketplace` and `connection_id`; every line tied to one
+record carries `usage_record_id`. Connection-level lines (auth, mapping load) have no
+`usage_record_id`, because no record is in scope yet.
+
+### 8.1 Snapshot activity — every 6h, never contacts a marketplace
+
+Computes usage and writes `usage_records`. Every failure here is Flexprice-side. Window is anchored to
+the run's *scheduled* time: `[scheduledTime − 10h, scheduledTime − 4h]`, so re-runs recompute the
+identical window.
+
+```
+Starting MarketplaceUsageSnapshotWorkflow
+[warn-ish info] scheduled start time unavailable; falling back to current time   ← windows stop being reproducible
+Starting MarketplaceUsageSnapshotActivity   period_start=… period_end=…
+Completed MarketplaceUsageSnapshotActivity  total=… succeeded=… failed=…
+MarketplaceUsageSnapshotWorkflow completed  period_start=… period_end=… total=… succeeded=… failed=…
+```
+
+| `stage` | What broke | Blast radius |
+| --- | --- | --- |
+| `list_connections` | Listing published connections for a provider | That **provider** skipped; others continue |
+| `list_customer_mappings` | Customer mappings for a connection | That **connection** skipped |
+| `list_subscription_mappings` | Subscription mappings for a connection | That **connection** skipped |
+| `get_subscription` | `GetWithLineItems` | That subscription counted `failed` |
+| `check_existing` | The "already snapshotted" lookup | That subscription counted `failed` |
+| `get_meter_usage` | Usage retrieval | That subscription counted `failed` |
+| `calculate_charges` | `CalculateMeterUsageCharges` | That subscription counted `failed` |
+| `create_usage_record` | The insert, for a reason other than already-exists | That subscription counted `failed` |
+
+Reading the counts: `Total` counts **distinct subscriptions** (a subscription mapped to two
+marketplaces is deduplicated, not counted twice). `succeeded` means a row now exists — whether written
+this run, already present, or won by a concurrent insert; all three are correct. `failed` means that
+window's usage was never captured, and **nothing retries it** — the next scheduled run computes a
+different window.
+
+Two things are invisible here, and both matter:
+
+- The first three stages abort before reaching any subscription, so they increment nothing.
+  `total=0 succeeded=0 failed=0` next to one of them means "never got far enough to look", not
+  "nothing to do".
+- A subscription whose customer has no published customer mapping, or a connection whose tenant has no
+  mapped customers at all, is skipped with **no log and no count**. Legitimate, but silent.
+
+There is **no per-subscription success log**. The only evidence is the row itself.
+
+### 8.2 Report activity — every 3h, this is where marketplaces are called
+
+Tenant-wide by construction: `ListPublishedByProvider` deliberately bypasses tenant scoping (the one
+query that does) so a job with no tenant on ctx can discover work, then groups by (tenant, environment)
+and sets both onto ctx before anything else.
+
+Its own stages — all under `marketplace usage report failed`:
+
+| `stage` | What broke | Blast radius |
+| --- | --- | --- |
+| `list_connections` | Listing published connections for a provider | That provider skipped |
+| `list_unsynced` | Reading the tenant's unsynced records | That **tenant/environment group** skipped entirely |
+| `mark_synced` | Persisting sync state **after** the marketplace already accepted | See below |
+
+Auth and the report call itself are in §8.4 — they are shared with the flush.
+
+> `mark_synced` is the one genuinely dangerous stage: the provider has the usage, our table doesn't.
+> The next run re-reports. AWS de-duplicates on customer+dimension+timestamp and GCP on `OperationID`
+> (unchanged for a persisted row), so both are safe; Azure returns 409, surfacing as
+> `stage=usage_event`. Always investigate.
+
+**Pre-filter, before any connection is chosen** (provider-agnostic, so no `marketplace` tag). Both are
+excluded from *every* count:
+
+| Level | Message | Meaning |
+| --- | --- | --- |
+| `debug` | `skipping marketplace usage record, currency not usd` | None of the three marketplaces accept non-USD. **Debug-level, so invisible at default settings** — a EUR marketplace subscription simply never syncs, with no signal. Check this first when records aren't syncing and nothing is logged. |
+| `error` | `marketplace usage record has negative amount` | A credit, not usage. An upstream billing bug; never sent. |
+
+Reading the counts: `Total` counts records that reached at least one relevant connection. `succeeded` =
+every relevant connection has an entry and at least one is a real post (`synced` now true, done
+forever). `failed` = at least one connection still missing; the next run retries **only** the missing
+ones. `skipped` = every entry is a skip (Azure zero-amount only).
+
+Two caveats worth knowing:
+
+- `skipped` is in the workflow result but in **neither completion log** — both log only
+  `total`/`succeeded`/`failed`. Read it from the Temporal UI.
+- A record is `failed` if *any* relevant connection is missing, however many succeeded. With GCP broken
+  and AWS/Azure fine, you will see `…usage record synced` lines for AWS and Azure right next to the
+  record being counted `failed`. Expected, not contradictory.
+
+### 8.3 Flush activity — once per cancellation
+
+Trigger-side, all emitted post-commit so none can affect the cancellation:
+
+| Level | Message | Meaning |
+| --- | --- | --- |
+| `info` | **`marketplace subscription flush workflow started successfully`** | **The definitive confirmation.** Carries `workflow_id` |
+| `error` | `failed to look up marketplace mappings for subscription flush` | The gate query failed; treated as "no mapping" so the cancellation is never blocked. Nothing downstream ran |
+| `info` | `temporal service not available for marketplace subscription flush` | Temporal isn't wired into this process |
+| `error` | `failed to start marketplace subscription flush workflow` | `ExecuteWorkflow` failed — usually Temporal unreachable |
+
+Seeing **none** of the four is itself a finding: the subscription had no published marketplace mapping.
+
+Activity stages — all under `marketplace subscription flush failed`:
+
+| `stage` | Phase | Blast radius |
+| --- | --- | --- |
+| `list_subscription_mappings` | setup | **Hard abort**, activity retries |
+| `get_connection` | setup | **Does not abort** — other mappings still processed, but this blocks delink |
+| `list_backlog` | 1 | **Hard abort** |
+| `mark_synced` | 1 | That record forced to `failed`; same warning as §8.2 |
+| `get_subscription` / `get_meter_usage` / `calculate_charges` | 2 | **Hard abort** |
+| `create_usage_record` | 2 | **Hard abort** — note this runs *after* the record was already reported, so the provider has the usage but the row isn't stored |
+| `delink_mapping` | 3 | Only reachable once everything else succeeded — a pure DB failure at the last step |
+
+Success path:
+
+```
+Starting MarketplaceSubscriptionFinalUsageFlushWorkflow   subscription_id=…
+[if not a marketplace sub] subscription has no marketplace mapping, nothing to flush   ← ends here
+marketplace subscription flush: usage record synced        (phase 1, per record per connection)
+marketplace subscription flush: final usage record created (phase 2, only after a successful report)
+marketplace subscription flush: usage record synced        (the final record's connections)
+MarketplaceSubscriptionFinalUsageFlushActivity completed   final_record_id=… records_succeeded=… records_skipped=… mappings_delinked=…
+MarketplaceSubscriptionFinalUsageFlushWorkflow completed   … records_failed=… …
+```
+
+The activity's completion log omits `records_failed` (it only runs on the success path, where that
+count is zero); the workflow's includes it.
+
+**Confirming the final record — the most misread signal.** Because it is only written after a
+successful report (§3.4), a still-failing final record is **never in the table at all**: each retry
+rebuilds and re-attempts it with a new id. There is no partial row to find. `final usage record
+created` and a non-empty `final_record_id` are the only positive signals. If neither appears, exactly
+one of these is true, and the other logs say which: no final record was needed (`cancel_at` at or
+before the frontier), the connection didn't resolve (`stage=get_connection`), reporting failed (§8.4,
+carrying a `usage_record_id` that won't exist in `usage_records` — that's the discarded attempt), or
+the record was ineligible (§8.2's two pre-filter lines; the flush applies the same filter).
+
+**Confirming the delink.** No per-mapping success log — only `mappings_delinked` and the absence of
+`stage=delink_mapping`. Per §3.5 it must **only** happen on a fully successful run: a mapping archived
+on a run that also logged a failure is a bug worth reporting. Still `published` after a failed flush is
+correct and deliberate.
+
+**Timing.** 5 attempts, ~2.5 minutes of total backoff, 5-minute start-to-close per attempt —
+comfortably inside the one-hour window. What isn't bounded is queue delay: compare `start_time` on the
+tracking line against the line's own timestamp. Minutes is harmless; tens of minutes means worker
+saturation.
+
+### 8.4 Connection auth and the report call — shared by §8.2 and §8.3
+
+Both paths use the same reporter, so these lines are identical from either caller and all carry
+`marketplace usage report failed` — **including during a flush**.
+
+**Auth has no success log.** If it works you see nothing; success is proven only by execution reaching
+the report call. A failure skips the **whole connection** for that run (and in the flush, blocks
+delink).
+
+| Provider | `stage` values, in order |
+| --- | --- |
+| **AWS** | `read_connection` (missing secret data *or* missing `sync_config` region) → `decrypt_role_arn` → `decrypt_external_id` → `load_mappings` → `assume_role` |
+| **GCP** | `read_connection` → `decrypt_credentials_json` → `load_mappings` → `wif_session` |
+| **Azure** | `read_connection` → `decrypt_tenant_id` → `decrypt_client_id` → `decrypt_client_secret` → `load_mappings` → `get_token` (most commonly an **expired client secret** — the failure that appears after months of working) |
+
+One check covers all three — empty output means every configured credential is valid:
+
+```bash
+grep 'marketplace usage report failed' log | grep -E 'stage=(assume_role|wif_session|get_token)'
+```
+
+**The report call.** First distinguish our data problem from their rejection: `stage=resolve_record`
+means the entity mapping is missing a required field and **nothing was sent** (AWS: license_arn /
+customer account / plan dimension; GCP: usage_reporting_id / service_name / metric_name; Azure:
+resource_id / plan_id / dimension).
+
+| Provider | Log | Meaning |
+| --- | --- | --- |
+| AWS | `stage=convert_quantity` | Amount doesn't fit AWS's int32 quantity |
+| AWS | `stage=batch_meter_usage` | Transport or malformed request — no verdict reached |
+| AWS | `marketplace usage record not processed by aws, will retry next run` (info) | No result row returned |
+| AWS | `…rejected by aws: customer not subscribed, will retry next run` | `CustomerNotSubscribed` — self-heals if the buyer re-subscribes. **Expected against a test customer** |
+| AWS | `…rejected by aws: conflicts with a different record already on file, needs manual investigation` | `DuplicateRecord` — AWS holds a *different* record for the same key. Retrying can't fix it |
+| AWS | `…rejected by aws: unrecognized status, will retry next run` | `aws_status` carries the raw value |
+| GCP | `stage=services_report` | Transport failure **or** an API-level rejection such as 403 — read the error text, not just the stage |
+| GCP | `marketplace usage report rejected by gcp, will retry next run` | HTTP 200 but `reportErrors` set. `error_code=5` NOT_FOUND (inactive consumer), `7` PERMISSION_DENIED (missing IAM grant), `3` INVALID_ARGUMENT |
+| Azure | `marketplace usage record skipped: zero quantity not supported by azure` (info) | **Not a failure.** Nothing sent; the connection resolves as a *skip*, permanently |
+| Azure | `stage=usage_event` | Every other Azure outcome — rejection, status error and transport failure are indistinguishable at the stage level. Read the error text for the HTTP status |
+| All | `…usage record synced` | **Accepted.** `reporting_id` is AWS's `MeteringRecordId`, GCP's `operationId`, or Azure's `usageEventId` |
+
+**The "already reported" silence.** A connection that already holds an entry in `rec.Syncs` is skipped
+with no log and no API call — correct, but it means a provider can vanish from a run's logs because an
+earlier run already satisfied it. Absence of AWS lines does **not** mean AWS failed.
+
+### 8.5 Answering "was this record reported?"
+
+Logs alone can't always tell you, because of the two silences above. Read the row:
+
+```sql
+SELECT synced, syncs FROM usage_records WHERE id = '<usage_record_id>';
+```
+
+A connection id present with a real `reporting_id` = accepted (possibly on an earlier run). Present
+with `"skipped": true` = resolved via skip. **Absent** = never accepted — and check whether that
+provider is even relevant: the subscription mapping must exist *and* carry a non-empty provider entity
+id, or `relevantConnections` excludes it silently.
+
+For a flush specifically, the final record's `period_end` must equal `cancel_at` **exactly**, not
+`cancel_at - 1s` — the margin exists only on the wire (§3.4).
+
+### 8.6 Local-dev noise — not this feature
+
+| Symptom | Explanation |
+| --- | --- |
+| `BadSearchAttributes: custom search attribute 'TenantID'/'EnvironmentID'/'SubscriptionID' not found` | From `ProcessSubscriptionBillingWorkflow`, the only caller of `UpsertWorkflowSearchAttributes`. The dev namespace never had them registered. Interleaved because one local worker runs many workflow types |
+| `Failed to track workflow start: tenant_id is required` + `workflow_execution not found` on the marketplace crons | Fixed: both crons are now in `temporalCronWorkflowTypes`, which excludes them from tracking like every other cron. They are tenant-wide, so there was never a tenant to write a tracking row with |
+| `redis: … connection refused` at boot | Non-fatal; ~500ms of retries |
+| `dial tcp 127.0.0.1:7233: connect: connection refused` | Fatal — every mode needs a reachable Temporal. `temporal server start-dev` (no Docker needed) |
+
+---
+
+## 9. Reference
 
 Everything in v3 §13 still applies. Added here:
 
-**AWS**
-- [Managing SaaS subscription events with Amazon EventBridge](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-eventbridge-integration.html#saas-eventbridge-final-usage) — the 1-hour final reporting window
-- [Amazon SNS notifications for SaaS products](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-notification.html) — `unsubscribe-pending` / `unsubscribe-success`
-- [UsageRecordResult](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_UsageRecordResult.html) — `CustomerNotSubscribed`
+**AWS** — [SaaS EventBridge integration](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-eventbridge-integration.html#saas-eventbridge-final-usage) (1-hour final window) ·
+[SNS notifications](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-notification.html) (`unsubscribe-pending`) ·
+[UsageRecordResult](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_UsageRecordResult.html) (`CustomerNotSubscribed`)
 
-**GCP**
-- [Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting#report_usage_after_an_entitlement_is_canceled) — the 1-hour post-cancellation rule
+**GCP** — [Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting#report_usage_after_an_entitlement_is_canceled) (1-hour post-cancellation rule)
 
-**Azure**
-- [Metering service APIs FAQ — emitting usage for an already-unsubscribed SaaS subscription](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq#what-happens-when-you-emit-usage-for-a-saas-subscription-that-s-already-unsubscribed-) — status eligibility and the post-cancellation exception
-- [Metering service APIs FAQ — maximum delay between event and emission](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq) — the general 24h rule
-- [Managing the SaaS subscription life cycle](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-life-cycle) — `Unsubscribed` state
-- [Implementing a webhook on the SaaS service](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-webhook) — `Unsubscribe` is notify-only
+**Azure** — [Metering FAQ: already-unsubscribed](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq#what-happens-when-you-emit-usage-for-a-saas-subscription-that-s-already-unsubscribed-) ·
+[SaaS subscription life cycle](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-life-cycle) ·
+[Implementing a webhook](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-webhook) (`Unsubscribe` is notify-only)

--- a/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
+++ b/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
@@ -165,7 +165,7 @@ FlushActivity(subscriptionID, cancelAt, tenantID, environmentID):
                   period_end >= now-24h, period_end < cancelAt, sort period_end asc)
    for rec in backlog:
        if not isEligibleForReport(rec): continue    # non-USD or negative (§8.2)
-       reportRecordToConnections(rec, relevantConnections(rec)); MarkSynced(rec)
+       reportRecordToMarketplaces(rec, marketplaces it holds an agreement on); MarkSynced(rec)
 
 3. # Phase 2 — the one final record. Written first, then reported (§3.4).
    computedThrough = MAX(period_end) over published rows with period_end < cancelAt,
@@ -196,9 +196,9 @@ sequenceDiagram
     loop each record × each relevant connection without an entry
         Flush->>MP: report
         alt accepted
-            MP-->>Flush: reporting_id → syncs[conn]
+            MP-->>Flush: reporting_id → syncs[marketplace]
         else Azure zero-amount
-            Flush->>Flush: syncs[conn] = skipped
+            Flush->>Flush: syncs[marketplace] = skipped
         else rejected / failed
             Flush->>Flush: no entry — stays unsynced
         end
@@ -287,11 +287,18 @@ The margin is only ever decisive inside the flush's own attempts.
 
 A report failure does not stop the run: every backlog record is still attempted and every connection
 still resolved, exactly as the report cron behaves. Retries are idempotent for backlog records — a
-connection that already has a `rec.Syncs[connection_id]` entry (real accept *or* skip) is never
-re-attempted.
+marketplace that already holds a resolved `rec.Syncs[provider_type]` entry (real accept *or* skip) is
+never re-attempted.
 
-Each record's outcome is exactly one of three, decided by the caller from `rec.Synced` and
-`anyRealEntry` (the shared reporter itself only reports; it does not classify):
+**`syncs` is keyed by marketplace, not by connection.** A tenant can delete a connection and create
+another for the same marketplace; the connection id changes while the subscription's agreement does
+not. Keyed by connection, an already-reported record would read as unreported the moment that happens
+and be sent twice. The entry still records `connection_id`, for tracing which credentials were used,
+but never as part of the key. An entry counts as resolved only when it carries both `synced_at` and
+`agreement_id` — a half-written one is retried rather than mistaken for a completed report.
+
+Each record's outcome is exactly one of three, decided by the caller from `rec.Synced` and whether any
+mapped marketplace accepted it (the shared reporter itself only reports; it does not classify):
 
 - **succeeded** — every relevant connection has an entry, and at least one is a real post
 - **failed** — at least one relevant connection still has no entry
@@ -305,7 +312,7 @@ the activity returns an error.
 This reverses the original draft, which delinked unconditionally on the reasoning that a cancelled
 subscription shouldn't keep a live-looking mapping. That trade was wrong: a published mapping is the
 *only* thing that keeps a subscription's backlog visible to the 3h report cron
-(`isRelevantForSubscription` resolves through published mappings only). Delinking on failure doesn't
+(`hasAgreementFor` resolves through published mappings only). Delinking on failure doesn't
 just look stale — it permanently strands whatever failed to report, with no path back short of a human
 re-publishing the mapping. Retries are cheap and idempotent, so there was no compensating benefit.
 
@@ -475,7 +482,7 @@ alerting on the failure logs long before a cancellation exposes it.
 it has been sent, so late usage for that window is lost. Revising the stored row does not recover it,
 and the reason is worth stating because it looks like an easy fix:
 
-- The reporter skips any connection already holding a `syncs` entry, so a revised amount is never sent
+- The reporter skips any marketplace already holding a `syncs` entry, so a revised amount is never sent
   to a provider that accepted the original. The row would then claim an amount no marketplace ever
   received, and nothing would flag the divergence — strictly worse than a stale figure, because
   `syncs` stops being a truthful receipt.
@@ -520,7 +527,7 @@ marketplace usage report:       gcp rejected the usage record, will retry next r
 marketplace usage snapshot:     failed to check for an existing usage record
 ```
 
-Every line tied to one connection carries `marketplace` and `connection_id`; every line tied to one
+Every line tied to one connection carries `marketplace`; every line tied to one
 record carries `usage_record_id`. Connection-level lines (auth, mapping load) have no
 `usage_record_id`, because no record is in scope yet.
 
@@ -591,7 +598,7 @@ excluded from *every* count:
 
 | Level | Message | Meaning |
 | --- | --- | --- |
-| `debug` | `…skipping usage record, currency is not usd` | None of the three marketplaces accept non-USD. **Debug-level, so invisible at default settings** — a EUR marketplace subscription simply never syncs, with no signal. Check this first when records aren't syncing and nothing is logged. |
+| `info` | `…skipping usage record, currency is not usd` | None of the three marketplaces accept non-USD. A record in any other currency never syncs and will fall out of the submission window unreported, so this is logged at info rather than debug: it needs to be visible at default settings. |
 | `error` | `…skipping usage record, amount is negative` | A credit, not usage. An upstream billing bug; never sent. |
 
 Reading the counts: `Total` counts records that reached at least one relevant connection. `succeeded` =
@@ -720,9 +727,9 @@ resource_id / plan_id / dimension).
 | Azure | `stage=usage_event` | Every other Azure outcome — rejection, status error and transport failure are indistinguishable at the stage level. Read the error text for the HTTP status |
 | All | `…usage record synced` | **Accepted.** `reporting_id` is AWS's `MeteringRecordId`, GCP's `operationId`, or Azure's `usageEventId` |
 
-**The "already reported" silence.** A connection that already holds an entry in `rec.Syncs` is skipped
-with no log and no API call — correct, but it means a provider can vanish from a run's logs because an
-earlier run already satisfied it. Absence of AWS lines does **not** mean AWS failed.
+**The "already reported" silence.** A marketplace that already holds a resolved entry in `rec.Syncs`
+is skipped with no log and no API call — correct, but it means a provider can vanish from a run's logs
+because an earlier run already satisfied it. Absence of AWS lines does **not** mean AWS failed.
 
 ### 8.5 Answering "was this record reported?"
 
@@ -732,10 +739,12 @@ Logs alone can't always tell you, because of the two silences above. Read the ro
 SELECT synced, syncs FROM usage_records WHERE id = '<usage_record_id>';
 ```
 
-A connection id present with a real `reporting_id` = accepted (possibly on an earlier run). Present
-with `"skipped": true` = resolved via skip. **Absent** = never accepted — and check whether that
-provider is even relevant: the subscription mapping must exist *and* carry a non-empty provider entity
-id, or `relevantConnections` excludes it silently.
+The map is keyed by provider type (`aws_marketplace`, `gcp_marketplace`, `azure_marketplace`). A key
+present with a real `reporting_id` = accepted (possibly on an earlier run, possibly through a
+connection since replaced — `connection_id` on the entry says which). Present with `"skipped": true` =
+resolved via skip. **Absent** = never accepted — and check whether the subscription holds an agreement
+there at all: the mapping must exist *and* carry a non-empty provider entity id, or that marketplace is
+excluded silently.
 
 For a flush specifically, the final record's `period_end` must equal `cancel_at` **exactly**, not
 `cancel_at - 1s` — the margin exists only on the wire (§3.4).

--- a/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
+++ b/docs/design/2026-07-30-FLE-1106-marketplace-integration-v4.md
@@ -1,0 +1,644 @@
+# Marketplace Integration — Cancellation Flush & Entity Mapping Lifecycle
+
+Ticket: FLE-1106
+Author: Tsage
+Status: design, pending approval
+Scope: two lifecycle defects and the final-usage flush that closes them. Applies to all three
+marketplaces (AWS, GCP, Azure) and, for the mapping defect, to every integration provider.
+
+This builds on
+[2026-07-23-FLE-1071-marketplace-integration-v3.md](2026-07-23-FLE-1071-marketplace-integration-v3.md).
+Everything in v3 stands except where §6 below marks it superseded.
+
+---
+
+## 1. What this changes
+
+Two defects, one new mechanism.
+
+| # | Problem | Fix |
+| --- | --- | --- |
+| 1 | Re-linking an entity after unlinking silently leaves the mapping `archived`. The API returns 200 but no active mapping exists. | Treat an archived row as absent: create a new published row instead of updating it (§2). |
+| 2 | Cancelling a subscription leaves its marketplace mapping `published`, and the final active-period usage is never reported inside the marketplaces' post-cancellation windows. | A one-shot flush on cancellation: report the backlog, compute and report the final window, then archive the subscription mapping (§3). |
+
+The driver for #2 is timing. v3 §10 assumed the tenant could wait for the 6-hour snapshot cron's
+4–10h lag to catch the last window before archiving. Both AWS and GCP give roughly **one hour** after
+cancellation, so that assumption loses the final usage of every cancelled marketplace subscription
+(§4).
+
+---
+
+## 2. Defect 1 — re-link after unlink
+
+### 2.1 What happens today
+
+`DelinkIntegrationMapping`
+([entityintegrationmapping.go:271-314](../../internal/ee/service/entityintegrationmapping.go))
+soft-deletes: it flips `status` to `archived` via `Delete`
+([repository/ent/entityintegrationmapping.go:310-356](../../internal/repository/ent/entityintegrationmapping.go)).
+The row stays, and its unique-index columns are untouched. That part is correct.
+
+The defect is in `upsertEntityMapping`
+([entityintegrationmapping.go:316-366](../../internal/ee/service/entityintegrationmapping.go)). It
+looks up existing mappings with `types.NewNoLimitQueryFilter()`, which leaves `Status` nil, so
+`GetStatus()` returns `""` and `ApplyStatusFilter` applies **no status predicate at all** — archived
+rows match. When the only existing row is the archived one, the service updates its
+`ProviderEntityID`, `Metadata` and timestamps, then returns:
+
+```go
+if len(existing) > 0 {
+    mapping := existing[0]
+    mapping.ProviderEntityID = req.ProviderEntityID
+    mapping.Metadata = metadata
+    mapping.UpdatedAt = time.Now().UTC()
+    mapping.UpdatedBy = types.GetUserID(ctx)
+    if err := s.EntityIntegrationMappingRepo.Update(ctx, mapping); err != nil { ... }
+    return mapping, nil          // status is never reset to published
+}
+```
+
+`Update` writes whatever status the caller passed, so the row goes back to Postgres still
+`status = 'archived'`. The caller gets a 200 and a mapping object, but no active mapping exists.
+
+The marketplace path is **not** affected: `RegisterAgreement` / `createMappingIfAbsent`
+([marketplace.go:198-240](../../internal/ee/service/marketplace.go)) queries with
+`NewNoLimitPublishedQueryFilter()`, so an archived row is invisible to it and a re-link creates a
+fresh published row correctly.
+
+### 2.2 The fix
+
+Branch on the found row's status:
+
+```text
+existing = List(entity_id, entity_type, provider_type)     # status-blind, as today
+
+if a PUBLISHED row exists:
+    update it in place                                      # unchanged behaviour
+else if only ARCHIVED rows exist:
+    log.debug("entity mapping is archived, creating new mapping", entity_id, entity_type, provider_type)
+    create a NEW row with a new id and status = published    # never touch the archived row
+else:
+    create as today
+```
+
+The archived row is left exactly as it was.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Svc as upsertEntityMapping
+    participant DB
+
+    Caller->>Svc: link(entity_id, entity_type, provider_type)
+    Svc->>DB: List (status-blind, as today)
+    DB-->>Svc: existing rows, if any
+
+    alt a published row exists
+        Svc->>DB: update it in place
+    else only archived rows exist
+        Svc->>Svc: log.debug "archived, creating new mapping"
+        Svc->>DB: create new row, status = published
+    else no rows exist
+        Svc->>DB: create new row, status = published
+    end
+    Svc-->>Caller: mapping (now genuinely published)
+```
+
+### 2.3 Why no `expired_at` / `terminated_at` column
+
+Considered and rejected. Reusing an archived row and flipping it back to `published` would need a
+separate timestamp to record when it had been archived — but that timestamp would then be overwritten
+on the next unlink, so it could not carry history anyway.
+
+Creating a new row makes the column unnecessary:
+
+- the archived row's own `updated_at` is when it was archived (set by `Delete`),
+- the new row's `created_at` is when it was re-linked,
+- the full link/unlink history is the ordered sequence of rows.
+
+The unique index already permits this. It is **partial** —
+`Unique().Annotations(entsql.IndexWhere("((status)::text = 'published'::text)"))`
+([ent/schema/entityintegrationmapping.go:71-74](../../ent/schema/entityintegrationmapping.go)) — so
+any number of archived rows can coexist with one published row for the same
+`(tenant, environment, entity_type, entity_id, provider_type)`. No schema change.
+
+### 2.4 Test gap
+
+`TestLinkIntegrationMapping_UpsertExistingMapping`
+([entityintegrationmapping_test.go:279-315](../../internal/ee/service/entityintegrationmapping_test.go))
+only covers link → link on a still-published row. Nothing exercises delink → re-link, which is why
+this shipped unnoticed. A regression test for that path is part of this work.
+
+---
+
+## 3. Defect 2 — the cancellation flush
+
+### 3.1 Trigger
+
+`CancelSubscription` ([subscription.go:1931](../../internal/ee/service/subscription.go)) stays fast
+and is not restructured. After its existing `WithTx` (2035-2146) commits — alongside the existing
+`publishCancellationEvents` call (2155-2157) — it starts the flush workflow with `ExecuteWorkflow`
+(non-blocking; the blocking variant is `ExecuteWorkflowSync`,
+[temporal/service/interface.go:18,40,46](../../internal/temporal/service/interface.go)).
+
+This matches the convention already in the codebase: `CreateSubscription` starts its HubSpot sync
+workflows after its transaction returns ([subscription.go:532-568, 851-877](../../internal/ee/service/subscription.go)),
+and `CreateCustomer` does the same for onboarding ([customer.go:87-99](../../internal/ee/service/customer.go)).
+No workflow is started inside a `WithTx` anywhere in `internal/ee/service`, for the obvious reason
+that a rollback would leave an orphaned workflow running against rows that were never written.
+
+**This is not a cron.** It is one workflow execution per cancellation. The snapshot (6h) and report
+(3h) crons are unchanged and keep running for live subscriptions.
+
+```mermaid
+sequenceDiagram
+    participant Buyer
+    participant MP as Marketplace
+    participant Tenant
+    participant FP as Flexprice API
+    participant Temporal
+    participant Flush
+
+    Buyer->>MP: cancels subscription
+    MP->>Tenant: notification (carries the cancellation instant)
+    Tenant->>FP: POST /cancel (immediate, cancel_at = that instant)
+    FP->>FP: commit — cancel subscription, CancelAt = cancel_at
+    FP-->>Tenant: 200
+    FP->>Temporal: ExecuteWorkflow (non-blocking, after commit)
+    Temporal->>Flush: run
+    Flush->>MP: report backlog + final usage record
+    Flush->>Flush: delink the marketplace mapping
+```
+
+### 3.2 Sequence
+
+```text
+FlushSubscriptionUsage(subscriptionID, cancelAt):     # cancelAt = sub.CancelAt, NOT sub.CancelledAt — see §3.8
+
+1. subMappings = published subscription mappings for [aws, gcp, azure]
+   if none: return                                    # not a marketplace subscription
+
+   connections   = resolve each mapping's connection
+   preparedConns = [prepareConnection(c) for c in connections]      # report_activities.go:301, reused
+
+2. frontier = MAX(period_end) over ALL published usage_records for this subscription
+   if none:  frontier = subscription mapping's created_at           # §3.4
+
+3. if cancelAt > frontier:                                          # §3.5
+       usage      = GetMeterUsageBySubscription(subscriptionID, frontier, cancelAt)   # true window — full amount
+       amount     = CalculateMeterUsageCharges(...)
+       reportedAt = cancelAt - 1 second                             # §3.8 — reported timestamp only
+       Create(UsageRecord{period_start: frontier, period_end: reportedAt, synced: false, ...})
+       # ErrAlreadyExists is success — same idempotency rule as snapshot_activities.go:272
+
+4. backlog = List(subscription_id, synced=false, period_end >= now-24h, sort period_end asc)
+   for rec in backlog:                                 # includes the row just created
+       for conn in preparedConns:                      # one API call per record per connection
+           entry, ok = reportAWS/GCP/AzureRecord(rec, conn)          # reused unchanged, sends rec.PeriodEnd
+           if ok: rec.Syncs[conn.ID] = entry
+       MarkSynced(rec.ID, rec.Syncs, allConnectionsPresent)
+
+   if any record failed to report:
+       return error                                    # Temporal retries; syncs map makes it idempotent
+
+5. for mapping in subMappings:                         # ALWAYS runs, even after exhausted retries
+       DelinkIntegrationMapping(subscriptionID, subscription, mapping.ProviderType)
+```
+
+Customer and plan mappings are **not** archived. Only the subscription's marketplace mappings are.
+
+```mermaid
+sequenceDiagram
+    participant Flush
+    participant DB as usage_records
+    participant MP as Marketplace connections
+
+    Flush->>DB: frontier = MAX(period_end), all published rows
+    alt cancelAt > frontier
+        Flush->>Flush: compute usage [frontier, cancelAt]
+        Flush->>DB: create final record (period_end = cancelAt - 1s)
+    else
+        Flush->>Flush: nothing new to compute
+    end
+
+    Flush->>DB: backlog = unsynced, period_end within 24h
+    loop each record in backlog
+        loop each connection
+            Flush->>MP: report record
+            alt accepted
+                MP-->>Flush: reporting_id
+                Flush->>Flush: syncs[conn] = entry
+            else rejected or failed
+                Flush->>Flush: no entry — stays unsynced
+            end
+        end
+        Flush->>DB: MarkSynced (true only if every connection has an entry)
+    end
+
+    Flush->>Flush: delink mapping (always, even after failures)
+```
+
+Note step 3's `reportedAt`: the usage **amount** is computed over the true window `[frontier, cancelAt]` —
+nothing is under-billed. Only the persisted `period_end` (and therefore the timestamp every provider
+receives, since `reportAWSRecord`/`reportGCPRecord`/`reportAzureRecord` all send `rec.PeriodEnd`
+unchanged) is backed off by one second. See §3.8 for why.
+
+### 3.3 Why `frontier` spans all rows, not just unsynced ones
+
+Taking the max over unsynced rows alone can double-bill. If record A `[T-10h, T-4h]` failed to sync
+but record B `[T-4h, T+2h]` succeeded, the max over unsynced rows is `T-4h`, and the flush window
+`[T-4h, cancelAt]` re-reports everything B already covered.
+
+The max over **all published rows** is `T+2h`, giving `[T+2h, cancelAt]`. Since the snapshot
+cron's windows are contiguous (`period_start = scheduledTime−10h`, `period_end = scheduledTime−4h`,
+every 6h), the frontier has no holes behind it: every span before it belongs to some row, and those
+rows are exactly what step 4 reports.
+
+### 3.4 Fallback when no usage record exists
+
+A subscription can be linked and cancelled without the snapshot cron ever having run for it. Then
+`frontier` is undefined and the flush uses the **subscription mapping's `created_at`**.
+
+That is the moment the subscription became reportable to that marketplace; nothing before it could
+ever have been owed there. Note the consequence: if the subscription's billing period started before
+it was linked, that earlier usage is deliberately excluded from the flush. That is intended, not an
+oversight.
+
+### 3.5 Boundary semantics
+
+`period_start` is **inclusive**, `period_end` **exclusive** — inherited from the ClickHouse query
+builder, which emits `timestamp >= ?` and `timestamp < ?`
+([meter_usage_query_builder.go:166-173](../../internal/repository/clickhouse/meter_usage_query_builder.go)).
+
+Chaining `period_start = previous period_end` therefore counts a boundary event exactly once: the
+previous window excluded it, this one includes it. Making `period_start` exclusive would **skip** any
+event landing precisely on the boundary. Keep it inclusive.
+
+Step 3 is guarded on `cancelAt > frontier` because a backdated cancellation would otherwise
+produce an inverted window. When the guard fails, the backlog flush is the whole job.
+
+### 3.6 Failure handling
+
+A report failure inside the flush returns an error from the activity so Temporal retries it. Retries
+are naturally idempotent: `if _, done := rec.Syncs[conn.ID]; done { continue }`
+([report_activities.go:239](../../internal/temporal/activities/marketplace/report_activities.go))
+means only the connections that actually failed are re-attempted.
+
+When retries are exhausted:
+
+- the failed records keep `synced = false` and gain no `syncs` entry — they are not marked skipped
+  and nothing is resolved silently,
+- an `error` line is logged carrying every non-secret identifier available: `subscription_id`,
+  `customer_id`, `usage_record_id`, `connection_id`, `marketplace`, `period_start`, `period_end`,
+  `amount`, and the provider-side identifier (`license_arn`, `consumer_id`/entitlement id, or
+  `resource_id`), plus the provider's own error text,
+- credentials are never logged, at any level: no `client_secret` or bearer token (Azure), no
+  `role_arn`, `external_id` or assumed-role credentials (AWS), no WIF JSON or federated token (GCP).
+  Provider errors go through `utils.RedactSecrets` first, exactly as v3 §8.4 requires,
+- the delink in step 5 **still runs**. The subscription is cancelled; leaving its mapping published
+  would be stale state. The trade-off is accepted deliberately: once archived, the 3h report cron
+  cannot retry those rows, because `isRelevantForSubscription` resolves through published mappings
+  only ([report_activities.go:86-96, 231-233](../../internal/temporal/activities/marketplace/report_activities.go)).
+  At that point the failure is a tenant-side credential or configuration problem, and the logged
+  error is the signal to act on.
+
+### 3.7 No skip entries
+
+An earlier draft resolved leftover rows with `{skipped: true, skip_reason: "subscription_flushed"}`.
+Dropped. The 24h bound in §5.2 already stops expired rows being re-scanned forever, and marking them
+`synced = true, skipped = true` would make a subscription whose connection was broken for days look
+cleanly resolved when in fact revenue was lost. `synced = false` on an old row is the more honest
+signal and preserves the diagnostic trail.
+
+The existing Azure zero-amount skip (`zero_amount_not_supported`, v3 §11.6) is unaffected.
+
+### 3.8 Sourcing the cancellation timestamp — `CancelAt`, not `CancelledAt`
+
+This closes what was an open risk in an earlier draft of this document: GCP requires the reported
+timestamp to be strictly *before* its own recorded cancellation instant, and Flexprice's own
+`cancelled_at` can never satisfy that, because it is set by definition *after* the marketplace's own
+cancellation already happened — buyer cancels at the marketplace, the marketplace notifies the tenant,
+the tenant then calls Flexprice, and only at that point does Flexprice record anything. No amount of
+speed on our side closes that gap; it's a causal ordering, not a latency problem.
+
+```mermaid
+sequenceDiagram
+    participant MP as Marketplace
+    participant Tenant
+    participant FP as Flexprice
+
+    Note over MP: T0 — buyer cancels
+    MP->>Tenant: notification (carries T0)
+    Tenant->>FP: POST /cancel (cancel_at = T0)
+    Note over FP: T2 — call processed.<br/>CancelledAt := T2 (now, always)<br/>CancelAt := T0 (the tenant's value)
+    Note over FP,MP: T0 < T2, always — use CancelAt, not CancelledAt
+```
+
+The fix doesn't need a buffer or a guess, because the API already carries the right value if the
+tenant is asked to supply it. `CancelSubscriptionRequest` already accepts `cancel_at` for a backdated
+immediate cancellation: *"For 'immediate', accepts past/current dates only... backdated
+cancellation"* ([dto/subscription.go:655-659](../../internal/api/dto/subscription.go)), validated to
+reject only a future date ([dto/subscription.go:737-743](../../internal/api/dto/subscription.go)) and
+to require it fall after the current period start
+([subscription.go:1982-1991](../../internal/ee/service/subscription.go)) — no upper bound on how far
+in the past it can be. **The tenant contract for a marketplace-linked subscription is: call `/cancel`
+with `cancellation_type: "immediate"` and `cancel_at` set to the marketplace's own cancellation
+instant** (from the same webhook/notification that told the tenant to call us in the first place).
+
+The field this lands in matters, and it is easy to get wrong. Traced through
+`updateSubscriptionForCancellation` ([subscription.go:6100-6121](../../internal/ee/service/subscription.go)):
+
+```go
+now := time.Now().UTC()
+subscription.CancelledAt = &now                    // ALWAYS wall-clock now — never the tenant's cancel_at
+
+switch cancellationType {
+case types.CancellationTypeImmediate:
+    subscription.CancelAt = &effectiveDate          // ← the tenant's backdated cancel_at lands HERE
+    subscription.EndDate = &effectiveDate           // ← and here
+```
+
+`CancelledAt` is unconditional — the comment above it says plainly *"cancelled_at is the time of the
+subscription cancellation [call]"*. `determineEffectiveDate`
+([subscription.go:5994-5998](../../internal/ee/service/subscription.go)) confirms a backdated
+`customDate` is returned unmodified for the immediate case. So the flush must read **`sub.CancelAt`**
+(equivalently `sub.EndDate` for the immediate path) — reading `sub.CancelledAt` here would silently
+reintroduce the exact causal-ordering problem this section exists to close. Verified against a real
+row: a subscription cancelled via `scheduled_date` showed `cancelled_at` at the API-call instant while
+`cancel_at`/`end_date` carried the requested effective date, several hours later — confirming the two
+fields diverge in practice, not just in the code path being read here.
+
+With the tenant supplying the marketplace's own instant, `cancelAt - 1 second` (§3.2 step 3) is now a
+minimal, deterministic correction against the *real* comparison GCP makes — not an arbitrary safety
+margin against a value we could only estimate. One second costs nothing material and is not
+provider-specific: it satisfies GCP's strict `<` requirement, and does not conflict with Azure (whose
+own worked example already accepts landing exactly *at* the instant) or AWS (no such comparison exists
+at all).
+
+---
+
+## 4. What the marketplaces actually allow after cancellation
+
+All three reject usage for an inactive subscription; each does it differently, and two have a
+post-cancellation window far shorter than their general staleness limit.
+
+| | General staleness window | Post-cancellation window | Rejection for an inactive subscription |
+| --- | --- | --- | --- |
+| **AWS** | 24h, plus a month-end cutoff at 06:00 UTC on the 1st for the prior month | **~1 hour** from `License Deprovisioned` / `unsubscribe-pending` | `Status: CustomerNotSubscribed` |
+| **GCP** | no hard cutoff published; guidance is **within 1 hour** of the usage occurring, with a ≤30-day outage provision (re-timestamped, not backdated) | **1 hour**, and the timestamp must be *before* the cancellation | `reportErrors` `NOT_FOUND` — *inferred, not doc-confirmed* |
+| **Azure** | 24h from `effectiveStartTime` | none stated separately; the 24h rule governs | `ResourceNotActive` (batch) / 400 "SaaS subscription isn't in Subscribed status" (single) |
+
+Sources:
+
+- AWS — [Managing SaaS subscription events with Amazon EventBridge](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-eventbridge-integration.html#saas-eventbridge-final-usage):
+  "this event marks the start of a 1-hour final reporting window… After this window closes, customer
+  entitlements are fully revoked and usage reporting is no longer accepted."
+  [BatchMeterUsage](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_BatchMeterUsage.html)
+  for the 24h + month-end rule;
+  [UsageRecordResult](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_UsageRecordResult.html)
+  for `CustomerNotSubscribed`.
+- GCP — [Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting#report_usage_after_an_entitlement_is_canceled):
+  "If you have unreported usage after an entitlement is canceled, you can still report it with a
+  timestamp that reflects the actual time when the usage was generated. Report this usage within one
+  hour. Do not report any usage as new usage after the entitlement ends."
+- Azure — [Metering service APIs](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis)
+  for the 24h rule and the `ResourceNotActive` / 400 statuses;
+  [Metering service APIs FAQ — "What happens when you emit usage for a SaaS subscription that's already unsubscribed?"](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq#what-happens-when-you-emit-usage-for-a-saas-subscription-that-s-already-unsubscribed-)
+  for the post-cancellation exception: "Usage can be emitted only for subscriptions in the Subscribed
+  status (and not for subscriptions in `PendingFulfillmentStart`, `Suspended`, or `Unsubscribed`
+  status). The only exception is reporting usage for the time that was before the SaaS subscription
+  is canceled. For example, the customer canceled the SaaS subscription today at 3 pm. Now is 5 pm,
+  the publisher can still emit usage for the period between 6 pm yesterday and 3 pm today."
+- Azure cancellation flow — [SaaS subscription life cycle](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-life-cycle),
+  [Implementing a webhook](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-webhook)
+  (the `Unsubscribe` action is notify-only: "There's no send to ACK for this event").
+
+### 4.1 Why the marketplace cannot tell us what we already reported
+
+Considered as a way to derive the flush window from the provider rather than our own table. Only one
+of three supports it, so `usage_records` stays the source of truth for all three:
+
+- **Azure** — yes: `GET /api/usageEvents?api-version=2018-08-31&usageStartDate=<date>` returns prior
+  submissions with `usageDate` and `reconStatus`.
+- **AWS** — no. The metering API is `MeterUsage` / `BatchMeterUsage` / `RegisterUsage` /
+  `ResolveCustomer`. AWS's own guidance for auditing past submissions is CloudTrail, which is the
+  tenant's audit log, not a seller-queryable metering API.
+- **GCP** — no. Service Control exposes only `check` and `report`.
+
+---
+
+## 5. Schema, repository and filter changes
+
+### 5.1 No schema changes
+
+Neither defect needs a migration. `entity_integration_mapping` keeps its partial unique index
+(§2.3); `usage_records` is unchanged.
+
+### 5.2 `ListUnsynced` gains a 24h bound
+
+Today `ListUnsynced` ([repository/ent/usagerecord.go:127-154](../../internal/repository/ent/usagerecord.go))
+returns every `synced = false` row for a tenant/environment, forever. Rows past the submission window
+can never be accepted, so they are re-scanned by every run and never resolve.
+
+Add `period_end >= now() - 24h`. Safe on all three providers: it is Azure's exact limit, it is AWS's
+limit (whose month-end rule is a *deadline*, not an extension, so a flat 24h never over-includes),
+and it is far more generous than GCP's hourly guidance.
+
+This also removes the need for the skip entries discussed in §3.7 — an expired row is simply never
+fetched again, while its `synced = false` state remains visible for diagnosis.
+
+### 5.3 A generalized `UsageRecordFilter`
+
+No `UsageRecordFilter` exists today; the repository exposes only `Create`, `ExistsForPeriod`,
+`ListUnsynced` and `MarkSynced`. Rather than adding one bespoke method per query, add a filter type
+following the shape of `EntityIntegrationMappingFilter`
+([types/entityintegrationmapping.go:89-105](../../internal/types/entityintegrationmapping.go)):
+embedded `*QueryFilter` and `*TimeRangeFilter`, `Filters []*FilterCondition`, `Sort []*SortCondition`,
+plus entity-specific fields (`SubscriptionID`, `Synced`, …).
+
+Both flush queries are then the same `List(ctx, filter)` call:
+
+- `frontier` — `{subscription_id, status: published, sort: period_end desc, limit: 1}`
+- `backlog` — `{subscription_id, synced: false, period_end >= now-24h, sort: period_end asc}`
+
+`ListUnsynced` can fold into it later; it is not required by this change.
+
+---
+
+## 6. Corrections to v3
+
+| v3 section | Status |
+| --- | --- |
+| §8.1 Snapshot cron | Still correct for live subscriptions. A cancelled subscription is now handled by the flush (§3), not by waiting for the next scheduled run. |
+| §8.2 Reporting cron | Still correct. `ListUnsynced` gains the 24h bound (§5.2). |
+| §10, "the tenant should archive only after the snapshot cron's 4–10h lag has had a chance to capture the final active-period usage" | **Superseded.** AWS and GCP allow roughly one hour after cancellation (§4); a 4–10h wait misses both windows. Cancellation now triggers the flush directly (§3). |
+| §10 lifecycle table, `Suspend` row: "mapping stays published, reporting continues until `Unsubscribe`" | **Incorrect.** Azure documents that usage may be emitted only in `Subscribed` status — explicitly not `Suspended` (§4). Reporting for a suspended Azure subscription is rejected with `ResourceNotActive`. The row should read: reporting will be rejected while suspended; the mapping stays published because `Reinstate` is possible. |
+| §2.5, "GCP submission window: not documented; assumed similar" | **Resolved, and the framing was wrong.** GCP documents its timing expectations clearly — "within one hour," stated for normal reporting, month-end, and post-cancellation alike (§7.1) — it simply does not publish a hard technical rejection cutoff the way AWS (`TimestampOutOfBoundsException`) and Azure (`Expired`) do. Checked directly against the raw text of all seven GCP references this ERD cites, plus the `manage-entitlements` and `providers.entitlements` API pages — no "24 hours" figure exists anywhere in GCP's marketplace documentation. |
+| §12, "No terminal state / TTL for un-acceptable or expired rows" | **Partially addressed.** The 24h bound (§5.2) stops expired rows being re-scanned. A true terminal status is still not built. |
+| §12, "Azure's late-submission rule is unconfirmed" | **Partially resolved.** Azure rejects on subscription status (`ResourceNotActive` / 400) independently of the 24h `effectiveStartTime` rule. Whether lateness is judged by submission time or `effectiveStartTime` is still unstated. |
+
+---
+
+## 7. Known gaps
+
+Every gap listed in v3 §12 is restated here in full, each with what v4 does about it. Nothing is
+dropped just because it was written down before.
+
+Nothing below is an open risk to the launch. The one item that was — whether GCP rejects the final
+report because our timestamp lands after its own cancellation instant — is resolved by sourcing the
+timestamp correctly rather than guessing at a margin (§3.8). Everything else is either closed, an
+accepted trade-off, or a follow-up enhancement.
+
+### 7.1 Carried over from v3
+
+**No "give up" marker on a record that can never be sent — _partly fixed; remainder is an enhancement, not a blocker_.**
+
+Some usage records can never succeed, no matter how many times we try: the buyer's subscription
+closed, or the record is simply older than the marketplace will accept. The problem is that a record
+in that state looks exactly like a record that failed once and deserves another try — both just say
+`synced = false`. Nothing in the row distinguishes "retry me" from "this is hopeless."
+
+The consequence was that the reporting cron kept picking those hopeless records up on every run,
+forever, and the pile only grew.
+
+What v4 does: the reporting cron now only looks at records from the last 24 hours (§5.2). Anything
+older is never fetched again, so hopeless records stop being retried and the query stops getting
+slower over time. What v4 does **not** do is give those records a real "finished, expired" status —
+they are still sitting there marked unsynced, we simply stop looking at them. Anyone reading the
+table directly still has to work out for themselves that an old unsynced row is dead. A proper
+terminal status remains future work.
+
+**No dead-letter table — _closed, not needed_.**
+
+v3 listed the absence of a dead-letter table as a gap: nowhere to answer "which records are failing,
+and how often?" without grepping logs.
+
+Closing this rather than carrying it forward. The failure logs now carry every identifier needed to
+answer that question — subscription, customer, usage record, connection, marketplace, period, and the
+provider's own error text (§3.6) — and they are queryable in SigNoz. A dead-letter table would be a
+second copy of the same information in a second place to keep consistent. The original gap assumed
+logs could only be grepped; that is no longer the case.
+
+**GCP's timing rules are different in shape from AWS's and Azure's — _answered_.**
+
+v3 recorded GCP's submission window as "not documented; assumed similar" to AWS's 24 hours. That
+framing was wrong in both directions. GCP documents its timing expectations clearly; what it does
+*not* publish is a hard rejection cutoff.
+
+GCP's actual rules ([Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting)):
+
+- *"Service providers must report usage within one hour of the usage being generated."* — one hour,
+  not 24.
+- Month-end: report by 1 AM US Pacific the following day to land on that month's invoice.
+- Post-cancellation: within one hour, with a timestamp before the cancellation.
+- Extended outage: a grace period *"not exceeding 30 days"*, during which usage is collected in
+  hourly windows and then, once service is restored, reported *"as actual usage with the time the
+  data was collected"* — re-timestamped to the present, not backdated.
+
+So AWS and Azure both enforce a hard 24-hour wall (`TimestampOutOfBoundsException` and `Expired`
+respectively); GCP enforces no documented wall at all, but expects hourly reporting.
+
+One consequence for §5.2: the 24-hour bound on `ListUnsynced` matches AWS's and Azure's limits
+exactly, but for GCP it is simply a choice — it stops us retrying records GCP might still have
+accepted. This is deliberate, to keep one uniform rule across all three providers rather than a
+per-provider retention window.
+
+**We don't know which clock Azure measures lateness by — _partly answered_.**
+
+Azure won't accept usage older than 24 hours. What its docs never say is *which* 24 hours: measured
+from when we send the request, or from the timestamp we put inside the request. In normal operation
+this never matters, because our records are only 4–10 hours old when we send them. It would only
+matter right at the edge — a subscription cancelled just as a record approaches the 24-hour mark.
+
+v4 answers a neighbouring question but not this one. We confirmed Azure rejects usage for an inactive
+subscription on *status* grounds, separately from any lateness rule (`ResourceNotActive`, or a 400
+saying the subscription isn't in `Subscribed` status), and confirmed that usage for the period
+*before* cancellation stays reportable (§4). The submission-time-versus-timestamp question is still
+unanswered by any published doc.
+
+**We send one record per API call instead of batching — _enhancement; not a problem for the flush_.**
+
+All three marketplaces accept multiple records in a single call (AWS and Azure up to 25; GCP up to
+1 MB). We send them one at a time, so a tenant with many buyers makes many more API calls than
+strictly necessary.
+
+v4 does not change this, and deliberately so — the reasons in v3 §12 still hold (AWS and GCP scope a
+single call to one product, so batching would need records grouped by product first; and AWS's move
+to per-record `LicenseArn` for Concurrent Agreements by June 2026 will remove that constraint anyway).
+
+Worth noting explicitly for the flush specifically: this is not a throughput risk there. The 24-hour
+bound means a backlog can hold at most four records (the snapshot cron runs every 6 hours), and a
+subscription can be mapped to at most three marketplaces — so the flush makes at most about a dozen
+API calls, comfortably inside its one-hour deadline.
+
+### 7.2 New in v4
+
+**GCP could reject the final report because our timestamp was a moment too late — _resolved, see §3.8_.**
+
+GCP requires that any usage reported after a cancellation carries a timestamp from *before* the
+cancellation happened. The risk was sourcing that timestamp from Flexprice's own `cancelled_at` —
+which is causally always at or after the marketplace's own instant, since it's only ever set once the
+tenant, having been notified by the marketplace, calls us — so it could never satisfy "before."
+
+Closed by sourcing it correctly rather than padding for uncertainty: the tenant supplies the
+marketplace's own cancellation instant via the existing backdated-immediate-cancellation `cancel_at`
+field, the flush reads `sub.CancelAt` (not `sub.CancelledAt`, which is unconditionally wall-clock
+processing time — §3.8 traces this exactly), and reports `cancelAt - 1 second`. This affects GCP alone
+in practice — Azure's own documented example already accepts landing exactly at the cancellation
+instant, and AWS makes no such comparison — but the fix is applied uniformly to all three rather than
+branched per provider.
+
+**Once the flush gives up, nothing tries again — _accepted trade-off_.**
+
+Temporal retries the flush automatically, and those retries are safe to repeat. But when the retries
+are finally exhausted, the flush archives the subscription's mapping anyway (§3.6). From that moment
+the ordinary reporting cron cannot pick those records up, because it only considers subscriptions
+with a published mapping — even if hours of the marketplace's window were still left.
+
+This is a deliberate choice: a cancelled subscription should not keep a live-looking mapping. By the
+time retries are exhausted the cause is almost always a tenant-side credentials or configuration
+problem, and the error log is the signal for someone to act on.
+
+**A connection broken for more than a day permanently loses that usage — _inherent to the providers_.**
+
+Say a subscription is linked to both AWS and Azure. AWS has been reporting fine for weeks, but the
+Azure connection's client secret expired ten days ago, so every Azure report has failed since.
+
+When the buyer cancels, the flush catches Azure up — but only for the last 24 hours of records. Ten
+days of Azure usage sits in `usage_records`, correctly computed, and can never be sent: AWS and Azure
+both reject any record whose timestamp is more than 24 hours old, so re-sending them is not an option
+we can build our way around.
+
+To be clear about what does *not* go wrong here: AWS is not double-reported. The final window starts
+from the newest record's `period_end` regardless of who has synced it, so it covers only genuinely
+new time, and the backlog step skips any connection that already has an entry for a record. The loss
+is one-sided — the broken connection misses out, the healthy one is unaffected.
+
+The mitigation, if this revenue matters, is the one both Azure and GCP describe in their own docs:
+roll the expired quantity into a current-timestamped event instead of trying to backdate it. Neither
+provider lets you preserve the original timestamps, and Microsoft warns it weakens the customer's
+billing audit trail, so this is a deliberate choice to make case by case — not something to automate
+here.
+
+The real defence is not losing ten days in the first place: a broken connection should be alerted on
+from the `error` logs (§3.6) long before a cancellation exposes it.
+
+---
+
+## 8. Reference
+
+Everything in v3 §13 still applies. Added here:
+
+**AWS**
+- [Managing SaaS subscription events with Amazon EventBridge](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-eventbridge-integration.html#saas-eventbridge-final-usage) — the 1-hour final reporting window
+- [Amazon SNS notifications for SaaS products](https://docs.aws.amazon.com/marketplace/latest/userguide/saas-notification.html) — `unsubscribe-pending` / `unsubscribe-success`
+- [UsageRecordResult](https://docs.aws.amazon.com/marketplace/latest/APIReference/API_marketplace-metering_UsageRecordResult.html) — `CustomerNotSubscribed`
+
+**GCP**
+- [Best practices for usage reporting](https://docs.cloud.google.com/marketplace/docs/partners/integrated-saas/best-practices-reporting#report_usage_after_an_entitlement_is_canceled) — the 1-hour post-cancellation rule
+
+**Azure**
+- [Metering service APIs FAQ — emitting usage for an already-unsubscribed SaaS subscription](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq#what-happens-when-you-emit-usage-for-a-saas-subscription-that-s-already-unsubscribed-) — status eligibility and the post-cancellation exception
+- [Metering service APIs FAQ — maximum delay between event and emission](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/marketplace-metering-service-apis-faq) — the general 24h rule
+- [Managing the SaaS subscription life cycle](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-life-cycle) — `Unsubscribed` state
+- [Implementing a webhook on the SaaS service](https://learn.microsoft.com/en-us/partner-center/marketplace-offers/pc-saas-fulfillment-webhook) — `Unsubscribe` is notify-only

--- a/internal/api/v1/marketplace.go
+++ b/internal/api/v1/marketplace.go
@@ -26,7 +26,7 @@ func NewMarketplaceHandler(service service.MarketplaceService, log *logger.Logge
 
 // RegisterAgreement godoc
 // @Summary Register an AWS Marketplace agreement
-// @Description Registers an AWS Marketplace buyer agreement against an existing FlexPrice subscription, upserting plan/subscription/customer integration mappings in one call.
+// @Description Registers an AWS Marketplace buyer agreement against an existing Flexprice subscription, upserting plan/subscription/customer integration mappings in one call.
 // @Tags Marketplace
 // @Accept json
 // @Produce json

--- a/internal/domain/usagerecord/repository.go
+++ b/internal/domain/usagerecord/repository.go
@@ -20,7 +20,13 @@ type Repository interface {
 
 	// ListUnsynced returns this tenant/environment's usage records that are not yet fully synced
 	// (synced=false) — not scoped to any one connection, since a record can be relevant to several.
+	// Bounded to period_end within the last 24h: none of the three marketplaces accept a report
+	// older than that, so an older row is never re-fetched (ERD FLE-1106 §5.2).
 	ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*UsageRecord, error)
+
+	// List returns usage records matching filter — subscription-scoped queries (the cancellation
+	// flush's frontier and backlog lookups) go through this rather than a bespoke method per query.
+	List(ctx context.Context, filter *types.UsageRecordFilter) ([]*UsageRecord, error)
 
 	// MarkSynced writes the record's syncs map (one entry per connection it's been reported to) and
 	// the synced flag, which the caller sets true once every connection relevant to this record has

--- a/internal/domain/usagerecord/repository.go
+++ b/internal/domain/usagerecord/repository.go
@@ -18,14 +18,12 @@ type Repository interface {
 	// subscription was already processed by an earlier attempt.
 	ExistsForPeriod(ctx context.Context, subscriptionID string, periodStart, periodEnd time.Time) (bool, error)
 
-	// ListUnsynced returns this tenant/environment's usage records that are not yet fully synced
-	// (synced=false) — not scoped to any one connection, since a record can be relevant to several.
-	// Bounded to period_end within the last 24h: none of the three marketplaces accept a report
-	// older than that, so an older row is never re-fetched (ERD FLE-1106 §5.2).
+	// ListUnsynced returns the tenant and environment's records that have not reached every
+	// marketplace relevant to them. It is not scoped to a connection, since one record can be owed to
+	// several. Rows older than the submission window are excluded: no marketplace would accept them.
 	ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*UsageRecord, error)
 
-	// List returns usage records matching filter — subscription-scoped queries (the cancellation
-	// flush's frontier and backlog lookups) go through this rather than a bespoke method per query.
+	// List returns the records matching filter.
 	List(ctx context.Context, filter *types.UsageRecordFilter) ([]*UsageRecord, error)
 
 	// MarkSynced writes the record's syncs map (one entry per connection it's been reported to) and

--- a/internal/ee/service/entityintegrationmapping.go
+++ b/internal/ee/service/entityintegrationmapping.go
@@ -314,10 +314,9 @@ func (s *entityIntegrationMappingService) DelinkIntegrationMapping(ctx context.C
 }
 
 func (s *entityIntegrationMappingService) upsertEntityMapping(ctx context.Context, req dto.LinkIntegrationMappingRequest) (*entityintegrationmapping.EntityIntegrationMapping, error) {
-	// Published-only: an archived row (left behind by a previous delink) must not be updated in
-	// place. Resurrecting it by flipping its status back would overwrite the archive/re-link history
-	// the row otherwise preserves, so a re-link after an unlink falls through to the create below and
-	// gets a new published row (ERD FLE-1106 §2).
+	// Published rows only. An archived row left behind by an earlier unlink must not be updated in
+	// place: reviving it would overwrite the record of when it was archived, which is the only trace
+	// of that unlink. Re-linking therefore falls through to the create below and gets a fresh row.
 	filter := &types.EntityIntegrationMappingFilter{
 		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
 		EntityID:    req.EntityID,

--- a/internal/ee/service/entityintegrationmapping.go
+++ b/internal/ee/service/entityintegrationmapping.go
@@ -314,8 +314,12 @@ func (s *entityIntegrationMappingService) DelinkIntegrationMapping(ctx context.C
 }
 
 func (s *entityIntegrationMappingService) upsertEntityMapping(ctx context.Context, req dto.LinkIntegrationMappingRequest) (*entityintegrationmapping.EntityIntegrationMapping, error) {
+	// Published-only: an archived row (left behind by a previous delink) must not be updated in
+	// place. Resurrecting it by flipping its status back would overwrite the archive/re-link history
+	// the row otherwise preserves, so a re-link after an unlink falls through to the create below and
+	// gets a new published row (ERD FLE-1106 §2).
 	filter := &types.EntityIntegrationMappingFilter{
-		QueryFilter: types.NewNoLimitQueryFilter(),
+		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
 		EntityID:    req.EntityID,
 		EntityType:  req.EntityType,
 		ProviderTypes: []string{

--- a/internal/ee/service/entityintegrationmapping_test.go
+++ b/internal/ee/service/entityintegrationmapping_test.go
@@ -314,6 +314,61 @@ func (s *EntityIntegrationMappingServiceSuite) TestLinkIntegrationMapping_Upsert
 	assert.Len(s.T(), listResp.Items, 1)
 }
 
+// TestLinkIntegrationMapping_RelinkAfterDelink verifies that re-linking an entity whose only
+// existing mapping was archived creates a new published row rather than resurrecting the archived
+// one — regression coverage for the archived-row-blind upsert bug (ERD FLE-1106 §2).
+func (s *EntityIntegrationMappingServiceSuite) TestLinkIntegrationMapping_RelinkAfterDelink() {
+	ctx := s.testCtx()
+	s.seedConnection(types.SecretProviderRazorpay)
+	s.seedCustomer("cust_razorpay_003")
+
+	req := dto.LinkIntegrationMappingRequest{
+		EntityType:       types.IntegrationEntityTypeCustomer,
+		EntityID:         "cust_razorpay_003",
+		ProviderType:     string(types.SecretProviderRazorpay),
+		ProviderEntityID: "rzp_cust_v1",
+	}
+
+	firstResp, err := s.service.LinkIntegrationMapping(ctx, req)
+	require.NoError(s.T(), err)
+	firstID := firstResp.Mapping.ID
+
+	_, err = s.service.DelinkIntegrationMapping(ctx, dto.DelinkIntegrationMappingRequest{
+		EntityType:   types.IntegrationEntityTypeCustomer,
+		EntityID:     "cust_razorpay_003",
+		ProviderType: string(types.SecretProviderRazorpay),
+	})
+	require.NoError(s.T(), err)
+
+	// Re-link with a new provider entity ID — must create a fresh published row, not update the
+	// now-archived one in place.
+	req.ProviderEntityID = "rzp_cust_v2"
+	secondResp, err := s.service.LinkIntegrationMapping(ctx, req)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), secondResp.Mapping)
+
+	assert.NotEqual(s.T(), firstID, secondResp.Mapping.ID, "relink after delink must create a new row")
+	assert.Equal(s.T(), types.StatusPublished, secondResp.Mapping.Status, "relinked mapping must be published")
+	assert.Equal(s.T(), "rzp_cust_v2", secondResp.Mapping.ProviderEntityID)
+
+	// The archived row must be left untouched, not flipped back to published.
+	archived, err := s.service.GetEntityIntegrationMapping(ctx, firstID)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), types.StatusArchived, archived.Status)
+	assert.Equal(s.T(), "rzp_cust_v1", archived.ProviderEntityID, "archived row's data must not be overwritten")
+
+	// Exactly one published mapping should exist for this entity/provider.
+	listResp, err := s.service.GetEntityIntegrationMappings(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityID:      "cust_razorpay_003",
+		EntityType:    types.IntegrationEntityTypeCustomer,
+		ProviderTypes: []string{string(types.SecretProviderRazorpay)},
+	})
+	require.NoError(s.T(), err)
+	assert.Len(s.T(), listResp.Items, 1)
+	assert.Equal(s.T(), secondResp.Mapping.ID, listResp.Items[0].ID)
+}
+
 // TestLinkIntegrationMapping_CustomerMetadataUpdated verifies the side effect of stamping
 // razorpay_customer_id onto the customer metadata.
 func (s *EntityIntegrationMappingServiceSuite) TestLinkIntegrationMapping_CustomerMetadataUpdated() {

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -8064,16 +8064,10 @@ func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub
 		"checkout_url_present", sub.Metadata[paddleint.MetaKeyPaddleCheckoutURL] != "")
 }
 
-// triggerMarketplaceSubscriptionFinalUsageFlushWorkflow starts the one-shot cancellation flush (ERD FLE-1106
-// §3): it reports the subscription's final marketplace usage and archives its marketplace mapping.
-// cancelAt must be sub.CancelAt, not sub.CancelledAt — CancelledAt is always Flexprice's own
-// processing time, which is causally always at-or-after the marketplace's own cancellation instant,
-// never before it (see the workflow's own doc comment, and ERD §3.8).
 // hasMarketplaceMapping reports whether the subscription is linked to any marketplace. Most
-// cancellations are not marketplace subscriptions, so this gates the flush at the call site rather
-// than starting a Temporal execution per cancellation that would immediately no-op. A lookup failure
-// is logged and treated as "no mapping": the flush is an after-the-fact side effect and must never
-// fail the cancellation that already committed.
+// cancellations are not, so this gates the flush at the call site rather than starting a workflow per
+// cancellation that would immediately find nothing to do. A lookup failure is logged and treated as
+// no mapping: the flush follows a cancellation that has already committed and must never fail it.
 func (s *subscriptionService) hasMarketplaceMapping(ctx context.Context, subscriptionID string) bool {
 	mappings, err := s.EntityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
 		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
@@ -8094,6 +8088,12 @@ func (s *subscriptionService) hasMarketplaceMapping(ctx context.Context, subscri
 	return len(mappings) > 0
 }
 
+// triggerMarketplaceSubscriptionFinalUsageFlushWorkflow starts the cancellation flush, which reports
+// the subscription's outstanding marketplace usage and archives its mappings.
+//
+// cancelAt must be the marketplace's own cancellation instant, taken from the cancellation request,
+// not the time Flexprice processed it. The latter is always the later of the two, and reporting
+// against it would place the final usage after the cancellation the provider recorded.
 func (s *subscriptionService) triggerMarketplaceSubscriptionFinalUsageFlushWorkflow(ctx context.Context, subscriptionID string, cancelAt time.Time) {
 	temporalSvc := temporalservice.GetGlobalTemporalService()
 	if temporalSvc == nil {

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2157,6 +2157,16 @@ func (s *subscriptionService) CancelSubscription(
 		s.publishCancellationEvents(ctx, subscription, req.CancellationType)
 	}
 
+	// Gate on the resulting status, not the request's cancellation type: only an immediate
+	// cancellation sets Cancelled here. end_of_period and scheduled_date both set CancelAt but leave
+	// the subscription active until the cancellation schedule processor fires, so flushing now would
+	// report a final usage window for a subscription that has not ended yet.
+	if subscription.SubscriptionStatus == types.SubscriptionStatusCancelled &&
+		subscription.CancelAt != nil &&
+		s.hasMarketplaceMapping(ctx, subscription.ID) {
+		s.triggerMarketplaceSubscriptionFinalUsageFlushWorkflow(ctx, subscription.ID, *subscription.CancelAt)
+	}
+
 	// Step 11: Build response
 	response := &dto.CancelSubscriptionResponse{
 		SubscriptionID:    subscription.ID,
@@ -8052,4 +8062,64 @@ func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub
 	s.Logger.Info(ctx, "paddle subscription synced synchronously",
 		"subscription_id", sub.ID,
 		"checkout_url_present", sub.Metadata[paddleint.MetaKeyPaddleCheckoutURL] != "")
+}
+
+// triggerMarketplaceSubscriptionFinalUsageFlushWorkflow starts the one-shot cancellation flush (ERD FLE-1106
+// §3): it reports the subscription's final marketplace usage and archives its marketplace mapping.
+// cancelAt must be sub.CancelAt, not sub.CancelledAt — CancelledAt is always Flexprice's own
+// processing time, which is causally always at-or-after the marketplace's own cancellation instant,
+// never before it (see the workflow's own doc comment, and ERD §3.8).
+// hasMarketplaceMapping reports whether the subscription is linked to any marketplace. Most
+// cancellations are not marketplace subscriptions, so this gates the flush at the call site rather
+// than starting a Temporal execution per cancellation that would immediately no-op. A lookup failure
+// is logged and treated as "no mapping": the flush is an after-the-fact side effect and must never
+// fail the cancellation that already committed.
+func (s *subscriptionService) hasMarketplaceMapping(ctx context.Context, subscriptionID string) bool {
+	mappings, err := s.EntityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter: types.NewNoLimitPublishedQueryFilter(),
+		EntityID:    subscriptionID,
+		EntityType:  types.IntegrationEntityTypeSubscription,
+		ProviderTypes: []string{
+			string(types.SecretProviderAWSMarketplace),
+			string(types.SecretProviderGCPMarketplace),
+			string(types.SecretProviderAzureMarketplace),
+		},
+	})
+	if err != nil {
+		s.Logger.Error(ctx, "failed to look up marketplace mappings for subscription flush",
+			"error", err,
+			"subscription_id", subscriptionID)
+		return false
+	}
+	return len(mappings) > 0
+}
+
+func (s *subscriptionService) triggerMarketplaceSubscriptionFinalUsageFlushWorkflow(ctx context.Context, subscriptionID string, cancelAt time.Time) {
+	temporalSvc := temporalservice.GetGlobalTemporalService()
+	if temporalSvc == nil {
+		s.Logger.Info(ctx, "temporal service not available for marketplace subscription flush",
+			"subscription_id", subscriptionID)
+		return
+	}
+
+	input := models.MarketplaceSubscriptionFinalUsageFlushWorkflowInput{
+		SubscriptionID: subscriptionID,
+		CancelAt:       cancelAt,
+	}
+
+	workflowRun, err := temporalSvc.ExecuteWorkflow(
+		ctx,
+		types.TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow,
+		input,
+	)
+	if err != nil {
+		s.Logger.Error(ctx, "failed to start marketplace subscription flush workflow",
+			"error", err,
+			"subscription_id", subscriptionID)
+		return
+	}
+
+	s.Logger.Info(ctx, "marketplace subscription flush workflow started successfully",
+		"subscription_id", subscriptionID,
+		"workflow_id", workflowRun.GetID())
 }

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -689,6 +689,8 @@ func (s *SubscriptionServiceSuite) setupService() {
 		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
 		IntegrationFactory:         s.GetIntegrationFactory(),
 		PlanPriceSyncRepo:          s.GetStores().PlanPriceSyncRepo,
+		// Read on cancellation to decide whether a marketplace usage flush is needed.
+		EntityIntegrationMappingRepo: s.GetStores().EntityIntegrationMappingRepo,
 	})
 }
 

--- a/internal/repository/ent/usagerecord.go
+++ b/internal/repository/ent/usagerecord.go
@@ -128,9 +128,8 @@ func (r *usageRecordRepository) ExistsForPeriod(ctx context.Context, subscriptio
 	return exists, nil
 }
 
-// submissionWindow bounds ListUnsynced to rows still within a marketplace's submission
-// window. None of AWS, GCP or Azure accept a report older than this, so an older row would only be
-// re-fetched and re-skipped forever (ERD FLE-1106 §5.2).
+// submissionWindow bounds ListUnsynced to rows a marketplace can still accept. None of AWS, GCP or
+// Azure take a report older than this, so an older row would be fetched and rejected on every run.
 const submissionWindow = 24 * time.Hour
 
 func (r *usageRecordRepository) ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*domainUsageRecord.UsageRecord, error) {
@@ -229,14 +228,16 @@ func (o UsageRecordQueryOptions) ApplyStatusFilter(query UsageRecordQuery, statu
 }
 
 func (o UsageRecordQueryOptions) ApplySortFilter(query UsageRecordQuery, field string, order string) UsageRecordQuery {
-	if field != "" {
-		if order == types.OrderDesc {
-			query = query.Order(ent.Desc(o.GetFieldName(field)))
-		} else {
-			query = query.Order(ent.Asc(o.GetFieldName(field)))
-		}
+	// Guard the resolved name rather than the caller's: an unknown column resolves to "", and ordering
+	// by "" attaches an error to the whole query instead of leaving it unsorted.
+	fieldName := o.GetFieldName(field)
+	if fieldName == "" {
+		return query
 	}
-	return query
+	if order == types.OrderDesc {
+		return query.Order(ent.Desc(fieldName))
+	}
+	return query.Order(ent.Asc(fieldName))
 }
 
 func (o UsageRecordQueryOptions) ApplyPaginationFilter(query UsageRecordQuery, limit int, offset int) UsageRecordQuery {
@@ -249,8 +250,8 @@ func (o UsageRecordQueryOptions) ApplyPaginationFilter(query UsageRecordQuery, l
 	return query
 }
 
-// GetFieldName returns the ent field name for usage_records; delegates to ent's ValidColumn so new
-// schema fields are supported automatically.
+// GetFieldName resolves a caller-supplied field to a usage_records column, returning "" if no such
+// column exists. Validation is delegated to the generated schema so new columns need no change here.
 func (o UsageRecordQueryOptions) GetFieldName(field string) string {
 	if usagerecord.ValidColumn(field) {
 		return field
@@ -298,6 +299,16 @@ func (o UsageRecordQueryOptions) applyEntityQueryOptions(_ context.Context, f *t
 	if f.Synced != nil {
 		query = query.Where(usagerecord.SyncedEQ(*f.Synced))
 	}
+	// Bounds when the row was written, not the usage window it covers: that is PeriodStart/PeriodEnd
+	// above, and range comparisons over it go through the DSL filters below.
+	if f.TimeRangeFilter != nil {
+		if f.StartTime != nil {
+			query = query.Where(usagerecord.CreatedAtGTE(*f.StartTime))
+		}
+		if f.EndTime != nil {
+			query = query.Where(usagerecord.CreatedAtLTE(*f.EndTime))
+		}
+	}
 
 	var err error
 	if f.Filters != nil {
@@ -327,8 +338,7 @@ func (o UsageRecordQueryOptions) applyEntityQueryOptions(_ context.Context, f *t
 	return query, nil
 }
 
-// List returns usage records matching filter. Entity-scoped queries (the cancellation flush's
-// frontier and backlog lookups) go through this rather than a bespoke method per query.
+// List returns the usage records matching filter.
 func (r *usageRecordRepository) List(ctx context.Context, filter *types.UsageRecordFilter) ([]*domainUsageRecord.UsageRecord, error) {
 	client := r.client.Reader(ctx)
 

--- a/internal/repository/ent/usagerecord.go
+++ b/internal/repository/ent/usagerecord.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/ent"
+	"github.com/flexprice/flexprice/ent/predicate"
 	"github.com/flexprice/flexprice/ent/usagerecord"
 	domainUsageRecord "github.com/flexprice/flexprice/internal/domain/usagerecord"
+	"github.com/flexprice/flexprice/internal/dsl"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/postgres"
@@ -15,15 +17,17 @@ import (
 
 // usageRecordRepository implements domainUsageRecord.Repository against the Ent client.
 type usageRecordRepository struct {
-	client postgres.IClient
-	log    *logger.Logger
+	client    postgres.IClient
+	log       *logger.Logger
+	queryOpts UsageRecordQueryOptions
 }
 
 // NewUsageRecordRepository creates a new usage record repository.
 func NewUsageRecordRepository(client postgres.IClient, log *logger.Logger) domainUsageRecord.Repository {
 	return &usageRecordRepository{
-		client: client,
-		log:    log,
+		client:    client,
+		log:       log,
+		queryOpts: UsageRecordQueryOptions{},
 	}
 }
 
@@ -124,6 +128,11 @@ func (r *usageRecordRepository) ExistsForPeriod(ctx context.Context, subscriptio
 	return exists, nil
 }
 
+// submissionWindow bounds ListUnsynced to rows still within a marketplace's submission
+// window. None of AWS, GCP or Azure accept a report older than this, so an older row would only be
+// re-fetched and re-skipped forever (ERD FLE-1106 §5.2).
+const submissionWindow = 24 * time.Hour
+
 func (r *usageRecordRepository) ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*domainUsageRecord.UsageRecord, error) {
 	client := r.client.Reader(ctx)
 
@@ -139,6 +148,7 @@ func (r *usageRecordRepository) ListUnsynced(ctx context.Context, tenantID, envi
 			usagerecord.EnvironmentID(environmentID),
 			usagerecord.Synced(false),
 			usagerecord.StatusEQ(string(types.StatusPublished)),
+			usagerecord.PeriodEndGTE(time.Now().UTC().Add(-submissionWindow)),
 		).
 		All(ctx)
 
@@ -191,4 +201,161 @@ func (r *usageRecordRepository) MarkSynced(ctx context.Context, id string, syncs
 
 	SetSpanSuccess(span)
 	return nil
+}
+
+// UsageRecordQuery type alias for better readability.
+type UsageRecordQuery = *ent.UsageRecordQuery
+
+// UsageRecordQueryOptions implements BaseQueryOptions for usage record queries.
+type UsageRecordQueryOptions struct{}
+
+func (o UsageRecordQueryOptions) ApplyTenantFilter(ctx context.Context, query UsageRecordQuery) UsageRecordQuery {
+	return query.Where(usagerecord.TenantIDEQ(types.GetTenantID(ctx)))
+}
+
+func (o UsageRecordQueryOptions) ApplyEnvironmentFilter(ctx context.Context, query UsageRecordQuery) UsageRecordQuery {
+	environmentID := types.GetEnvironmentID(ctx)
+	if environmentID != "" {
+		return query.Where(usagerecord.EnvironmentIDEQ(environmentID))
+	}
+	return query
+}
+
+func (o UsageRecordQueryOptions) ApplyStatusFilter(query UsageRecordQuery, status string) UsageRecordQuery {
+	if status == "" {
+		return query.Where(usagerecord.StatusEQ(string(types.StatusPublished)))
+	}
+	return query.Where(usagerecord.StatusEQ(status))
+}
+
+func (o UsageRecordQueryOptions) ApplySortFilter(query UsageRecordQuery, field string, order string) UsageRecordQuery {
+	if field != "" {
+		if order == types.OrderDesc {
+			query = query.Order(ent.Desc(o.GetFieldName(field)))
+		} else {
+			query = query.Order(ent.Asc(o.GetFieldName(field)))
+		}
+	}
+	return query
+}
+
+func (o UsageRecordQueryOptions) ApplyPaginationFilter(query UsageRecordQuery, limit int, offset int) UsageRecordQuery {
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if offset > 0 {
+		query = query.Offset(offset)
+	}
+	return query
+}
+
+// GetFieldName returns the ent field name for usage_records; delegates to ent's ValidColumn so new
+// schema fields are supported automatically.
+func (o UsageRecordQueryOptions) GetFieldName(field string) string {
+	if usagerecord.ValidColumn(field) {
+		return field
+	}
+	return ""
+}
+
+func (o UsageRecordQueryOptions) GetFieldResolver(field string) (string, error) {
+	fieldName := o.GetFieldName(field)
+	if fieldName == "" {
+		return "", ierr.NewErrorf("unknown field name '%s' in usage record query", field).
+			Mark(ierr.ErrValidation)
+	}
+	return fieldName, nil
+}
+
+// applyEntityQueryOptions applies usage-record-specific filters: the owning entity columns, currency,
+// an exact window, and synced — plus the generic DSL Filters/Sort, which is how range predicates such
+// as the marketplaces' submission-window floor are expressed.
+func (o UsageRecordQueryOptions) applyEntityQueryOptions(_ context.Context, f *types.UsageRecordFilter, query UsageRecordQuery) (UsageRecordQuery, error) {
+	if f == nil {
+		return query, nil
+	}
+	if f.SubscriptionID != "" {
+		query = query.Where(usagerecord.SubscriptionIDEQ(f.SubscriptionID))
+	}
+	if f.CustomerID != "" {
+		query = query.Where(usagerecord.CustomerIDEQ(f.CustomerID))
+	}
+	if f.CustomerExternalID != "" {
+		query = query.Where(usagerecord.CustomerExternalIDEQ(f.CustomerExternalID))
+	}
+	if f.PlanID != "" {
+		query = query.Where(usagerecord.PlanIDEQ(f.PlanID))
+	}
+	if f.Currency != "" {
+		query = query.Where(usagerecord.CurrencyEQ(f.Currency))
+	}
+	if f.PeriodStart != nil {
+		query = query.Where(usagerecord.PeriodStartEQ(*f.PeriodStart))
+	}
+	if f.PeriodEnd != nil {
+		query = query.Where(usagerecord.PeriodEndEQ(*f.PeriodEnd))
+	}
+	if f.Synced != nil {
+		query = query.Where(usagerecord.SyncedEQ(*f.Synced))
+	}
+
+	var err error
+	if f.Filters != nil {
+		query, err = dsl.ApplyFilters[UsageRecordQuery, predicate.UsageRecord](
+			query,
+			f.Filters,
+			o.GetFieldResolver,
+			func(p dsl.Predicate) predicate.UsageRecord { return predicate.UsageRecord(p) },
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if f.Sort != nil {
+		query, err = dsl.ApplySorts[UsageRecordQuery, usagerecord.OrderOption](
+			query,
+			f.Sort,
+			o.GetFieldResolver,
+			func(o dsl.OrderFunc) usagerecord.OrderOption { return usagerecord.OrderOption(o) },
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return query, nil
+}
+
+// List returns usage records matching filter. Entity-scoped queries (the cancellation flush's
+// frontier and backlog lookups) go through this rather than a bespoke method per query.
+func (r *usageRecordRepository) List(ctx context.Context, filter *types.UsageRecordFilter) ([]*domainUsageRecord.UsageRecord, error) {
+	client := r.client.Reader(ctx)
+
+	span := StartRepositorySpan(ctx, "usage_record", "list", map[string]interface{}{
+		"filter": filter,
+	})
+	defer FinishSpan(span)
+
+	query := client.UsageRecord.Query()
+	query = ApplyBaseFilters(ctx, query, filter, r.queryOpts)
+	query = ApplyPagination(query, filter, r.queryOpts)
+	query = ApplySorting(query, filter, r.queryOpts)
+
+	query, err := r.queryOpts.applyEntityQueryOptions(ctx, filter, query)
+	if err != nil {
+		SetSpanError(span, err)
+		return nil, err
+	}
+
+	records, err := query.All(ctx)
+	if err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to list usage records").
+			Mark(ierr.ErrDatabase)
+	}
+
+	SetSpanSuccess(span)
+	return domainUsageRecord.FromEntList(records), nil
 }

--- a/internal/temporal/activities/marketplace/final_usage_flush_activities.go
+++ b/internal/temporal/activities/marketplace/final_usage_flush_activities.go
@@ -174,6 +174,9 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	}
 
 	for _, rec := range backlog {
+		if !a.reporter.isEligibleForReport(ctx, rec) {
+			continue
+		}
 		a.reportRecord(ctx, rec, preparedConns, result)
 	}
 
@@ -193,8 +196,11 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		return nil, err
 	}
 
+	// An ineligible final record (non-USD, or a negative amount) can never be accepted by any
+	// marketplace, so it is not reported and not written — same rule the report cron applies to the
+	// backlog, and isEligibleForReport logs which of the two it was.
 	finalUsageFlushFailed := false
-	if finalUsageFlush != nil {
+	if finalUsageFlush != nil && a.reporter.isEligibleForReport(ctx, finalUsageFlush) {
 		relevantConns := relevantConnections(finalUsageFlush, preparedConns)
 		var reportedConnIDs []string
 		if len(relevantConns) > 0 {

--- a/internal/temporal/activities/marketplace/final_usage_flush_activities.go
+++ b/internal/temporal/activities/marketplace/final_usage_flush_activities.go
@@ -294,7 +294,7 @@ func (a *FlushActivities) reportRecord(
 	// success: nothing was posted anywhere.
 	anyAccepted := false
 	for _, marketplaceConn := range reportableConns {
-		if entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; ok && entry.IsResolved() && !entry.Skipped {
+		if entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; ok && entry.IsSynced() {
 			anyAccepted = true
 			break
 		}

--- a/internal/temporal/activities/marketplace/final_usage_flush_activities.go
+++ b/internal/temporal/activities/marketplace/final_usage_flush_activities.go
@@ -1,0 +1,439 @@
+package marketplace
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/connection"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/domain/usagerecord"
+	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+	temporalModels "github.com/flexprice/flexprice/internal/temporal/models"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"go.temporal.io/sdk/activity"
+)
+
+// reportTimestampSafetyMargin is subtracted from the final record's period_end when it is reported,
+// never when it is stored. GCP requires the reported timestamp to be strictly before its own recorded
+// cancellation instant, and CancelAt is exactly that instant (sub.CancelAt, never sub.CancelledAt —
+// see ERD FLE-1106 §3.8), so one second satisfies the strict "<" without materially under-billing.
+// Applied uniformly to all three providers rather than branched per provider.
+//
+// Storing the exact cancelAt also keeps lastComputedPeriodEnd's MAX(period_end) frontier equal to
+// cancelAt after a successful write, so a retry computes no leftover sliver window.
+const reportTimestampSafetyMargin = 1 * time.Second
+
+// backlogSubmissionWindow mirrors ListUnsynced's own bound (repository/ent/usagerecord.go) — none of
+// the three marketplaces accept a report older than this, so there's no reason to fetch it here either.
+const backlogSubmissionWindow = 24 * time.Hour
+
+// FlushActivities computes and reports a cancelled subscription's final marketplace usage. It is
+// started once per cancellation from CancelSubscription (post-commit, non-blocking) — not on a
+// schedule — because AWS and GCP only accept a final report within roughly an hour of cancellation,
+// far tighter than the ordinary 6h snapshot / 3h report cron cadence (ERD FLE-1106 §4).
+//
+// The per-provider mechanics live on the shared marketplaceReporter, the same instance the scheduled
+// reporting cron holds, so the two report paths can never drift out of sync with each other.
+type FlushActivities struct {
+	subscriptionService          service.SubscriptionService
+	billingService               service.BillingService
+	connectionRepo               connection.Repository
+	entityIntegrationMappingRepo entityintegrationmapping.Repository
+	subscriptionRepo             subscription.Repository
+	customerRepo                 customer.Repository
+	usageRecordRepo              usagerecord.Repository
+	reporter                     *marketplaceReporter
+	logger                       *logger.Logger
+}
+
+// NewFlushActivities takes ServiceParams rather than each repo individually (the pattern used by
+// NewInvoiceSyncActivities and friends) — every dependency below already lives on it. The reporter is
+// the same instance the scheduled reporting cron holds, so both report through identical per-provider
+// code and cannot drift apart.
+func NewFlushActivities(params service.ServiceParams, reporter *marketplaceReporter, log *logger.Logger) *FlushActivities {
+	return &FlushActivities{
+		subscriptionService:          service.NewSubscriptionService(params),
+		billingService:               service.NewBillingService(params),
+		connectionRepo:               params.ConnectionRepo,
+		entityIntegrationMappingRepo: params.EntityIntegrationMappingRepo,
+		subscriptionRepo:             params.SubRepo,
+		customerRepo:                 params.CustomerRepo,
+		usageRecordRepo:              params.UsageRecordRepo,
+		reporter:                     reporter,
+		logger:                       log,
+	}
+}
+
+// subscriptionMarketplaceMappings resolves the published marketplace mappings for a subscription,
+// scoped to the same three providers the snapshot/report crons iterate.
+func (a *FlushActivities) subscriptionMarketplaceMappings(ctx context.Context, subscriptionID string) ([]*entityintegrationmapping.EntityIntegrationMapping, error) {
+	providerTypes := make([]string, len(marketplaceProviderTypes))
+	for i, p := range marketplaceProviderTypes {
+		providerTypes[i] = string(p)
+	}
+	return a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityID:      subscriptionID,
+		EntityType:    types.IntegrationEntityTypeSubscription,
+		ProviderTypes: providerTypes,
+	})
+}
+
+// MarketplaceSubscriptionFinalUsageFlushActivity reports the pre-existing backlog of unsynced records,
+// then computes, writes and reports the final usage window, then archives the subscription's
+// marketplace mapping(s). The backlog and the final record are two explicit, separately logged phases
+// — not merged into one query — so a reader of the logs always knows which one they're looking at.
+//
+// The delink only runs once every record across both phases has fully synced and every mapped
+// connection could be resolved. On any failure the mapping stays published and nothing else is done
+// about it here — there is no dedicated retry for a failed flush today beyond this activity's own
+// Temporal retries (up to 5 attempts). Leaving the mapping published is what keeps the subscription's
+// backlog visible to the scheduled report cron, which will keep retrying it independently of this
+// activity; a purpose-built catch-up mechanism for a flush that exhausted its retries is a known gap,
+// not yet built.
+func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
+	ctx context.Context,
+	input temporalModels.MarketplaceSubscriptionFinalUsageFlushActivityInput,
+) (*temporalModels.MarketplaceSubscriptionFinalUsageFlushWorkflowResult, error) {
+	ctx = types.SetTenantID(ctx, input.TenantID)
+	ctx = types.SetEnvironmentID(ctx, input.EnvironmentID)
+
+	log := activity.GetLogger(ctx)
+	tenantID := input.TenantID
+	environmentID := input.EnvironmentID
+	result := &temporalModels.MarketplaceSubscriptionFinalUsageFlushWorkflowResult{
+		SubscriptionID: input.SubscriptionID,
+	}
+
+	subMappings, err := a.subscriptionMarketplaceMappings(ctx, input.SubscriptionID)
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
+			"error", err, "stage", "list_subscription_mappings")
+		return nil, err
+	}
+	if len(subMappings) == 0 {
+		log.Info("subscription has no marketplace mapping, nothing to flush", "subscription_id", input.SubscriptionID)
+		return result, nil
+	}
+
+	// A connection that fails to resolve for one mapping must not stop the other mappings from being
+	// reported — but it does block delink below (via connectionResolutionFailed), since this provider
+	// was never actually attempted this run.
+	preparedConns := make([]*preparedConnection, 0, len(subMappings))
+	connectionResolutionFailed := false
+	for _, m := range subMappings {
+		conn, err := a.connectionRepo.GetByProvider(ctx, types.SecretProvider(m.ProviderType))
+		if err != nil {
+			a.logger.Error(ctx, "marketplace subscription flush failed",
+				"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
+				"provider_type", m.ProviderType, "error", err, "stage", "get_connection")
+			connectionResolutionFailed = true
+			continue
+		}
+		prepared, err := a.reporter.prepareConnection(ctx, conn)
+		if err != nil {
+			// already logged inside prepareConnection at the stage that failed
+			connectionResolutionFailed = true
+			continue
+		}
+		preparedConns = append(preparedConns, prepared)
+	}
+
+	// Phase 1: report the backlog — every unsynced record the snapshot cron already wrote. Fetched
+	// before phase 2 creates anything, so a first run never sees its own final record here. On a
+	// Temporal retry it does: the final record the previous attempt wrote is by then just another
+	// unsynced row, and phase 2 will decline to create a second one.
+	backlog, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
+		QueryFilter: &types.QueryFilter{
+			Sort:  lo.ToPtr("period_end"),
+			Order: lo.ToPtr(types.OrderAsc),
+		},
+		SubscriptionID: input.SubscriptionID,
+		Synced:         lo.ToPtr(false),
+		// Bound to the marketplaces' submission window: a row older than this can no longer be
+		// accepted by any of the three providers (ERD FLE-1106 §5.2).
+		Filters: []*types.FilterCondition{{
+			Field:    lo.ToPtr("period_end"),
+			Operator: lo.ToPtr(types.GREATER_THAN_EQUAL),
+			DataType: lo.ToPtr(types.DataTypeDate),
+			Value:    &types.Value{Date: lo.ToPtr(time.Now().UTC().Add(-backlogSubmissionWindow))},
+		}},
+	})
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
+			"error", err, "stage", "list_backlog")
+		return nil, err
+	}
+
+	for _, rec := range backlog {
+		a.reportRecord(ctx, rec, preparedConns, result)
+	}
+
+	// Phase 2: this subscription's one final usage record — computed and reported as its own step.
+	cancelAt := input.CancelAt.UTC()
+
+	computedThrough, err := a.lastComputedPeriodEnd(ctx, input.SubscriptionID, subMappings)
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
+			"error", err, "stage", "last_computed_period_end")
+		return nil, err
+	}
+
+	finalUsageFlush, err := a.buildFinalUsageRecord(ctx, input.SubscriptionID, computedThrough, cancelAt, environmentID)
+	if err != nil {
+		return nil, err
+	}
+
+	finalUsageFlushFailed := false
+	if finalUsageFlush != nil {
+		relevantConns := relevantConnections(finalUsageFlush, preparedConns)
+		var reportedConnIDs []string
+		if len(relevantConns) > 0 {
+			reportedConnIDs = a.reporter.reportRecordToConnections(ctx, finalUsageFlush, relevantConns)
+		}
+		finalUsageFlushFailed = len(relevantConns) == 0 || !finalUsageFlush.Synced
+
+		if !finalUsageFlushFailed {
+			// The wire carried cancelAt minus the margin; the row keeps the true instant.
+			finalUsageFlush.PeriodEnd = cancelAt
+			if err := a.createFinalUsageRecord(ctx, finalUsageFlush); err != nil {
+				return nil, err
+			}
+			a.logReported(ctx, finalUsageFlush, reportedConnIDs)
+
+			result.FinalRecordID = finalUsageFlush.ID
+			result.PeriodStart = finalUsageFlush.PeriodStart
+			result.PeriodEnd = finalUsageFlush.PeriodEnd
+			if anyRealEntry(finalUsageFlush, relevantConns) {
+				result.SucceededRecordIDs = append(result.SucceededRecordIDs, finalUsageFlush.ID)
+			} else {
+				result.SkippedRecordIDs = append(result.SkippedRecordIDs, finalUsageFlush.ID)
+			}
+		}
+	}
+
+	if connectionResolutionFailed || finalUsageFlushFailed || len(result.FailedRecordIDs) > 0 {
+		// Mapping stays published — see this function's doc comment. Returned so Temporal retries the
+		// whole activity; the syncs map already written makes a retry idempotent, since only the
+		// connections still missing an entry are re-attempted.
+		return result, ierr.NewErrorf("marketplace subscription flush: %d of %d records did not fully sync",
+			len(result.FailedRecordIDs), len(result.SucceededRecordIDs)+len(result.FailedRecordIDs)+len(result.SkippedRecordIDs)).
+			WithReportableDetails(map[string]any{"subscription_id": input.SubscriptionID}).
+			Mark(ierr.ErrInternal)
+	}
+
+	delinkedIDs, err := a.delinkSubscriptionMappings(ctx, subMappings)
+	if err != nil {
+		return result, err
+	}
+	result.DelinkedMappingIDs = delinkedIDs
+
+	log.Info("MarketplaceSubscriptionFinalUsageFlushActivity completed",
+		"subscription_id", input.SubscriptionID,
+		"final_record_id", result.FinalRecordID,
+		"records_succeeded", len(result.SucceededRecordIDs),
+		"records_skipped", len(result.SkippedRecordIDs),
+		"mappings_delinked", len(result.DelinkedMappingIDs))
+	return result, nil
+}
+
+// reportRecord reports one record to every relevant connection, logs what happened, and records the
+// outcome on result. Mirrors ReportActivities.reportRecord on the cron side.
+func (a *FlushActivities) reportRecord(
+	ctx context.Context,
+	rec *usagerecord.UsageRecord,
+	preparedConns []*preparedConnection,
+	result *temporalModels.MarketplaceSubscriptionFinalUsageFlushWorkflowResult,
+) {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	relevantConns := relevantConnections(rec, preparedConns)
+	if len(relevantConns) == 0 {
+		return // no resolved connection is mapped to this subscription
+	}
+	reportedConnIDs := a.reporter.reportRecordToConnections(ctx, rec, relevantConns)
+	a.logReported(ctx, rec, reportedConnIDs)
+
+	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, rec.Synced); err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "error", err, "stage", "mark_synced")
+		rec.Synced = false
+	}
+
+	switch {
+	case !rec.Synced:
+		result.FailedRecordIDs = append(result.FailedRecordIDs, rec.ID)
+	case anyRealEntry(rec, relevantConns):
+		result.SucceededRecordIDs = append(result.SucceededRecordIDs, rec.ID)
+	default:
+		result.SkippedRecordIDs = append(result.SkippedRecordIDs, rec.ID)
+	}
+}
+
+// logReported logs one line per connection that accepted this record on this run.
+func (a *FlushActivities) logReported(ctx context.Context, rec *usagerecord.UsageRecord, reportedConnIDs []string) {
+	for _, connectionID := range reportedConnIDs {
+		entry := rec.Syncs[connectionID]
+		a.logger.Info(ctx, "marketplace subscription flush: usage record synced",
+			"tenant_id", types.GetTenantID(ctx), "environment_id", types.GetEnvironmentID(ctx),
+			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID,
+			"connection_id", connectionID, "marketplace", entry.Marketplace,
+			"reporting_id", entry.ReportingID)
+	}
+}
+
+// delinkSubscriptionMappings archives the subscription's marketplace mappings, returning how many
+// were archived. Uses the repository's soft-delete directly rather than the service's
+// DelinkIntegrationMapping, which would re-query for the same rows already resolved here.
+func (a *FlushActivities) delinkSubscriptionMappings(ctx context.Context, subMappings []*entityintegrationmapping.EntityIntegrationMapping) ([]string, error) {
+	delinked := make([]string, 0, len(subMappings))
+	for _, m := range subMappings {
+		if err := a.entityIntegrationMappingRepo.Delete(ctx, m); err != nil {
+			a.logger.Error(ctx, "marketplace subscription flush failed",
+				"tenant_id", types.GetTenantID(ctx), "environment_id", types.GetEnvironmentID(ctx),
+				"subscription_id", m.EntityID, "provider_type", m.ProviderType,
+				"error", err, "stage", "delink_mapping")
+			return delinked, err
+		}
+		delinked = append(delinked, m.ID)
+	}
+	return delinked, nil
+}
+
+// lastComputedPeriodEnd returns the point this subscription's usage has already been computed up to:
+// the latest period_end across every published usage_record, regardless of sync state. Using only
+// unsynced rows would risk re-reporting a span an earlier, already-synced row already covered
+// (ERD FLE-1106 §3.3). It is the start of the final flush window.
+//
+// Falls back to the earliest of the subscription's marketplace mappings' own created_at when no
+// usage_record exists yet (ERD §3.4): a mapping's creation is when this subscription became
+// reportable to that marketplace, so nothing before it could ever have been owed there.
+func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptionID string, subMappings []*entityintegrationmapping.EntityIntegrationMapping) (time.Time, error) {
+	rows, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
+		QueryFilter: &types.QueryFilter{
+			Sort:  lo.ToPtr("period_end"),
+			Order: lo.ToPtr(types.OrderDesc),
+			Limit: lo.ToPtr(1),
+		},
+		SubscriptionID: subscriptionID,
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	if len(rows) > 0 {
+		return rows[0].PeriodEnd, nil
+	}
+
+	earliest := subMappings[0].CreatedAt
+	for _, m := range subMappings[1:] {
+		if m.CreatedAt.Before(earliest) {
+			earliest = m.CreatedAt
+		}
+	}
+	return earliest, nil
+}
+
+// buildFinalUsageRecord computes the subscription's final usage for [windowStart, cancelAt) and
+// returns the record to report, without writing it — the caller inserts it only once a marketplace
+// has accepted it (see createFinalUsageRecord). Returns nil when there is nothing left to compute:
+// cancelAt at or before windowStart, which is what a backdated cancellation looks like, and also what
+// a Temporal retry sees once an earlier attempt already wrote the record.
+//
+// The usage amount covers the true window up to cancelAt, but PeriodEnd on the returned record is the
+// wire timestamp — cancelAt minus the reporting margin. The caller restores the true instant before
+// storing it.
+func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptionID string, windowStart, cancelAt time.Time, environmentID string) (*usagerecord.UsageRecord, error) {
+	if !cancelAt.After(windowStart) {
+		return nil, nil
+	}
+
+	tenantID := types.GetTenantID(ctx)
+
+	sub, _, err := a.subscriptionRepo.GetWithLineItems(ctx, subscriptionID)
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
+			"error", err, "stage", "get_subscription")
+		return nil, err
+	}
+
+	usageResp, err := a.subscriptionService.GetMeterUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
+		SubscriptionID: subscriptionID,
+		StartTime:      windowStart,
+		EndTime:        cancelAt,
+		Source:         string(types.UsageSourceInvoiceCreation),
+	})
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
+			"customer_id", sub.CustomerID, "error", err, "stage", "get_meter_usage")
+		return nil, err
+	}
+
+	_, totalAmount, err := a.billingService.CalculateMeterUsageCharges(
+		ctx, sub, usageResp, windowStart, cancelAt, types.UsageSourceInvoiceCreation,
+	)
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
+			"customer_id", sub.CustomerID, "error", err, "stage", "calculate_charges")
+		return nil, err
+	}
+
+	customerExternalID := ""
+	if cust, custErr := a.customerRepo.Get(ctx, sub.CustomerID); custErr == nil && cust != nil {
+		customerExternalID = cust.ExternalID
+	}
+
+	return &usagerecord.UsageRecord{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USAGE_RECORD),
+		CustomerID:         sub.CustomerID,
+		CustomerExternalID: customerExternalID,
+		SubscriptionID:     sub.ID,
+		PlanID:             sub.PlanID,
+		Amount:             totalAmount,
+		Currency:           usageResp.Currency,
+		PeriodStart:        windowStart,
+		PeriodEnd:          cancelAt.Add(-reportTimestampSafetyMargin),
+		EnvironmentID:      environmentID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}, nil
+}
+
+// createFinalUsageRecord writes the final record once its marketplaces have accepted it. rec already
+// carries the sync state the report produced.
+func (a *FlushActivities) createFinalUsageRecord(ctx context.Context, rec *usagerecord.UsageRecord) error {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	if err := a.usageRecordRepo.Create(ctx, rec); err != nil {
+		// A concurrent attempt can win the race between computing this window and inserting it. That
+		// attempt reported the same usage and wrote the row, so this one has nothing left to do.
+		if ierr.IsAlreadyExists(err) {
+			return nil
+		}
+		a.logger.Error(ctx, "marketplace subscription flush failed",
+			"tenant_id", tenantID, "environment_id", environmentID,
+			"subscription_id", rec.SubscriptionID, "customer_id", rec.CustomerID,
+			"usage_record_id", rec.ID, "error", err, "stage", "create_usage_record")
+		return err
+	}
+
+	a.logger.Info(ctx, "marketplace subscription flush: final usage record created",
+		"tenant_id", tenantID, "environment_id", environmentID,
+		"subscription_id", rec.SubscriptionID, "customer_id", rec.CustomerID, "usage_record_id", rec.ID,
+		"period_start", rec.PeriodStart, "period_end", rec.PeriodEnd, "amount", rec.Amount,
+		"synced", rec.Synced)
+	return nil
+}

--- a/internal/temporal/activities/marketplace/final_usage_flush_activities.go
+++ b/internal/temporal/activities/marketplace/final_usage_flush_activities.go
@@ -24,8 +24,8 @@ import (
 // cancellation instant it holds, and cancelAt is exactly that instant, so a second satisfies the
 // comparison without materially under-billing. Applied to every provider rather than branched.
 //
-// Storing the exact cancelAt keeps the computed-through frontier equal to it after a successful
-// write, so a retry finds nothing left to compute rather than a one-second sliver.
+// Storing the exact cancelAt keeps the record's window identical on every attempt, so a retry finds
+// the same row rather than computing a second one a second wide.
 const reportTimestampSafetyMargin = 1 * time.Second
 
 // backlogSubmissionWindow bounds the backlog to rows a marketplace can still accept. None of the
@@ -107,13 +107,13 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 
 	subMappings, err := a.subscriptionMarketplaceMappings(ctx, input.SubscriptionID)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to list subscription marketplace mappings",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
 			"error", err, "stage", "list_subscription_mappings")
 		return nil, err
 	}
 	if len(subMappings) == 0 {
-		log.Info("subscription has no marketplace mapping, nothing to flush", "subscription_id", input.SubscriptionID)
+		log.Info("marketplace subscription flush: subscription has no marketplace mapping, nothing to flush", "subscription_id", input.SubscriptionID)
 		return result, nil
 	}
 
@@ -124,7 +124,7 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	for _, m := range subMappings {
 		conn, err := a.connectionRepo.GetByProvider(ctx, types.SecretProvider(m.ProviderType))
 		if err != nil {
-			a.logger.Error(ctx, "marketplace subscription flush failed",
+			a.logger.Error(ctx, "marketplace subscription flush: failed to resolve marketplace connection",
 				"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
 				"provider_type", m.ProviderType, "error", err, "stage", "get_connection")
 			connectionResolutionFailed = true
@@ -139,9 +139,12 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		preparedConns = append(preparedConns, prepared)
 	}
 
-	// Phase 1: the backlog already written by earlier snapshots. Read before phase 2 creates anything,
-	// so a first run never picks up its own final record. A retry does — by then a previous attempt's
-	// record is just another unsynced row, and phase 2 declines to create a second one.
+	cancelAt := input.CancelAt.UTC()
+
+	// Phase 1: the backlog written by earlier snapshots. Bounded below by the submission window, since
+	// an older row can no longer be accepted by any provider, and above by cancelAt, which excludes
+	// the final record — phase 2 owns that one, and reporting it here would send it without the
+	// timestamp margin the providers require.
 	backlog, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
 		QueryFilter: &types.QueryFilter{
 			Sort:  lo.ToPtr("period_end"),
@@ -149,16 +152,23 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		},
 		SubscriptionID: input.SubscriptionID,
 		Synced:         lo.ToPtr(false),
-		// Bound to the submission window: an older row can no longer be accepted by any provider.
-		Filters: []*types.FilterCondition{{
-			Field:    lo.ToPtr("period_end"),
-			Operator: lo.ToPtr(types.GREATER_THAN_EQUAL),
-			DataType: lo.ToPtr(types.DataTypeDate),
-			Value:    &types.Value{Date: lo.ToPtr(time.Now().UTC().Add(-backlogSubmissionWindow))},
-		}},
+		Filters: []*types.FilterCondition{
+			{
+				Field:    lo.ToPtr("period_end"),
+				Operator: lo.ToPtr(types.GREATER_THAN_EQUAL),
+				DataType: lo.ToPtr(types.DataTypeDate),
+				Value:    &types.Value{Date: lo.ToPtr(time.Now().UTC().Add(-backlogSubmissionWindow))},
+			},
+			{
+				Field:    lo.ToPtr("period_end"),
+				Operator: lo.ToPtr(types.LESS_THAN),
+				DataType: lo.ToPtr(types.DataTypeDate),
+				Value:    &types.Value{Date: lo.ToPtr(cancelAt)},
+			},
+		},
 	})
 	if err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to list backlog usage records",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
 			"error", err, "stage", "list_backlog")
 		return nil, err
@@ -172,49 +182,32 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	}
 
 	// Phase 2: the single record covering everything from the last computed point up to cancellation.
-	cancelAt := input.CancelAt.UTC()
-
-	computedThrough, err := a.lastComputedPeriodEnd(ctx, input.SubscriptionID, subMappings)
+	computedThrough, err := a.lastComputedPeriodEnd(ctx, input.SubscriptionID, cancelAt, subMappings)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to determine last computed period",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", input.SubscriptionID,
 			"error", err, "stage", "last_computed_period_end")
 		return nil, err
 	}
 
-	finalUsageFlush, err := a.buildFinalUsageRecord(ctx, input.SubscriptionID, computedThrough, cancelAt, environmentID)
+	finalUsageFlush, err := a.finalUsageRecord(ctx, input.SubscriptionID, computedThrough, cancelAt, environmentID)
 	if err != nil {
 		return nil, err
 	}
 
-	// An ineligible record — non-USD, or a negative amount — can never be accepted, so it is neither
-	// reported nor written. The eligibility check logs which of the two it was.
+	// An ineligible record — non-USD, or a negative amount — can never be accepted, so it is not
+	// reported. The eligibility check logs which of the two it was.
 	finalUsageFlushFailed := false
 	if finalUsageFlush != nil && a.reporter.isEligibleForReport(ctx, finalUsageFlush) {
-		relevantConns := relevantConnections(finalUsageFlush, preparedConns)
-		var reportedConnIDs []string
-		if len(relevantConns) > 0 {
-			reportedConnIDs = a.reporter.reportRecordToConnections(ctx, finalUsageFlush, relevantConns)
-		}
-		finalUsageFlushFailed = len(relevantConns) == 0 || !finalUsageFlush.Synced
+		result.FinalRecordID = finalUsageFlush.ID
+		result.PeriodStart = finalUsageFlush.PeriodStart
+		result.PeriodEnd = finalUsageFlush.PeriodEnd
 
-		if !finalUsageFlushFailed {
-			// The providers received cancelAt less the margin; the stored row keeps the true instant.
-			finalUsageFlush.PeriodEnd = cancelAt
-			if err := a.createFinalUsageRecord(ctx, finalUsageFlush); err != nil {
-				return nil, err
-			}
-			a.logReported(ctx, finalUsageFlush, reportedConnIDs)
-
-			result.FinalRecordID = finalUsageFlush.ID
-			result.PeriodStart = finalUsageFlush.PeriodStart
-			result.PeriodEnd = finalUsageFlush.PeriodEnd
-			if anyRealEntry(finalUsageFlush, relevantConns) {
-				result.SucceededRecordIDs = append(result.SucceededRecordIDs, finalUsageFlush.ID)
-			} else {
-				result.SkippedRecordIDs = append(result.SkippedRecordIDs, finalUsageFlush.ID)
-			}
-		}
+		// The providers receive cancelAt less the margin; the stored row keeps the true instant, and
+		// reporting never writes period_end back.
+		finalUsageFlush.PeriodEnd = cancelAt.Add(-reportTimestampSafetyMargin)
+		finalUsageFlushFailed = a.reportRecord(ctx, finalUsageFlush, preparedConns, result)
+		finalUsageFlush.PeriodEnd = cancelAt
 	}
 
 	if connectionResolutionFailed || finalUsageFlushFailed || len(result.FailedRecordIDs) > 0 {
@@ -251,26 +244,39 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	return result, nil
 }
 
-// reportRecord reports one record to every relevant connection, logs what was accepted, and records
-// the outcome on result.
+// reportRecord reports one record to every connection mapped to its subscription, persists the
+// outcome, and records it on result. It reports whether the record was left unreported, which is what
+// keeps the mappings published: archiving a subscription whose records never reached a marketplace
+// would put them beyond the reporting cron's reach, since that cron also needs the mapping to decide
+// a record is relevant to a connection.
 func (a *FlushActivities) reportRecord(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
 	preparedConns []*preparedConnection,
 	result *temporalModels.MarketplaceSubscriptionFinalUsageFlushWorkflowResult,
-) {
+) (failed bool) {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
 
 	relevantConns := relevantConnections(rec, preparedConns)
 	if len(relevantConns) == 0 {
-		return // no resolved connection is mapped to this subscription
+		// No provider can be reached, so the record stays exactly as it is: unreported and unsynced.
+		// The subscription resolved a connection but is not mapped to it for reporting, which means its
+		// mapping carries no provider entity id.
+		a.logger.Error(ctx, "marketplace subscription flush: usage record has no connection to report to",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connections_resolved", len(preparedConns),
+			"error", "subscription is not mapped to any resolved marketplace connection",
+			"stage", "relevant_connections")
+		result.FailedRecordIDs = append(result.FailedRecordIDs, rec.ID)
+		return true
 	}
+
 	reportedConnIDs := a.reporter.reportRecordToConnections(ctx, rec, relevantConns)
 	a.logReported(ctx, rec, reportedConnIDs)
 
 	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, rec.Synced); err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to record usage sync state",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "error", err, "stage", "mark_synced")
 		rec.Synced = false
@@ -279,11 +285,13 @@ func (a *FlushActivities) reportRecord(
 	switch {
 	case !rec.Synced:
 		result.FailedRecordIDs = append(result.FailedRecordIDs, rec.ID)
+		return true
 	case anyRealEntry(rec, relevantConns):
 		result.SucceededRecordIDs = append(result.SucceededRecordIDs, rec.ID)
 	default:
 		result.SkippedRecordIDs = append(result.SkippedRecordIDs, rec.ID)
 	}
+	return false
 }
 
 // logReported logs one line per connection that accepted this record on this run.
@@ -304,7 +312,7 @@ func (a *FlushActivities) delinkSubscriptionMappings(ctx context.Context, subMap
 	delinked := make([]string, 0, len(subMappings))
 	for _, m := range subMappings {
 		if err := a.entityIntegrationMappingRepo.Delete(ctx, m); err != nil {
-			a.logger.Error(ctx, "marketplace subscription flush failed",
+			a.logger.Error(ctx, "marketplace subscription flush: failed to archive marketplace mapping",
 				"tenant_id", types.GetTenantID(ctx), "environment_id", types.GetEnvironmentID(ctx),
 				"subscription_id", m.EntityID, "provider_type", m.ProviderType,
 				"error", err, "stage", "delink_mapping")
@@ -320,9 +328,13 @@ func (a *FlushActivities) delinkSubscriptionMappings(ctx context.Context, subMap
 // its sync state. Taking the latest unsynced row instead would re-report a span an already-synced row
 // covers, billing it twice.
 //
+// Rows ending at or after cancelAt are excluded so the final record cannot move this point past
+// itself. Without that, a retry would measure from the record the previous attempt wrote and compute a
+// second, narrower window — a different period_start, so the unique index would not catch it.
+//
 // With no usage record yet, it falls back to the earliest marketplace mapping's creation time — the
 // point the subscription became reportable, before which nothing could have been owed.
-func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptionID string, subMappings []*entityintegrationmapping.EntityIntegrationMapping) (time.Time, error) {
+func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptionID string, cancelAt time.Time, subMappings []*entityintegrationmapping.EntityIntegrationMapping) (time.Time, error) {
 	rows, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
 		QueryFilter: &types.QueryFilter{
 			Sort:  lo.ToPtr("period_end"),
@@ -330,6 +342,12 @@ func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptio
 			Limit: lo.ToPtr(1),
 		},
 		SubscriptionID: subscriptionID,
+		Filters: []*types.FilterCondition{{
+			Field:    lo.ToPtr("period_end"),
+			Operator: lo.ToPtr(types.LESS_THAN),
+			DataType: lo.ToPtr(types.DataTypeDate),
+			Value:    &types.Value{Date: lo.ToPtr(cancelAt)},
+		}},
 	})
 	if err != nil {
 		return time.Time{}, err
@@ -347,24 +365,47 @@ func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptio
 	return earliest, nil
 }
 
-// buildFinalUsageRecord computes the subscription's usage for [windowStart, cancelAt) and returns the
-// record to report without writing it: the caller stores it only after a marketplace has accepted it,
-// so an unreportable record never reaches the table. Returns nil when cancelAt is at or before
-// windowStart and there is nothing left to compute — a backdated cancellation, or a retry after an
-// earlier attempt already recorded this window.
+// finalUsageRecord returns the stored record covering [windowStart, cancelAt), computing and writing
+// it if this is the first attempt. Returns nil when cancelAt is at or before windowStart and there is
+// nothing left to compute, which is what a backdated cancellation looks like.
 //
-// The amount covers the window through cancelAt, but PeriodEnd on the returned record carries the
-// reporting margin already applied; the caller restores the true instant before storing it.
-func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptionID string, windowStart, cancelAt time.Time, environmentID string) (*usagerecord.UsageRecord, error) {
+// A retry recomputes the same window, since the starting point ignores this record, so the insert
+// collides with the unique key and the existing row is returned instead. The record therefore keeps
+// one identity across every attempt, which is what lets a provider recognise a resend as the same
+// usage rather than new usage.
+func (a *FlushActivities) finalUsageRecord(ctx context.Context, subscriptionID string, windowStart, cancelAt time.Time, environmentID string) (*usagerecord.UsageRecord, error) {
 	if !cancelAt.After(windowStart) {
 		return nil, nil
 	}
 
 	tenantID := types.GetTenantID(ctx)
 
+	// Looked up before any computation, not just before the insert: on a retry an earlier attempt has
+	// already written this exact window, and there is no reason to recompute usage and charges only to
+	// discard them a moment later. The unique key over the window means at most one row can match.
+	existing, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
+		QueryFilter:    types.NewNoLimitQueryFilter(),
+		SubscriptionID: subscriptionID,
+		PeriodStart:    &windowStart,
+		PeriodEnd:      &cancelAt,
+	})
+	if err != nil {
+		a.logger.Error(ctx, "marketplace subscription flush: failed to load the existing final usage record",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
+			"error", err, "stage", "get_existing_usage_record")
+		return nil, err
+	}
+	if len(existing) > 0 {
+		a.logger.Info(ctx, "marketplace subscription flush: final usage record already exists, reporting it",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
+			"usage_record_id", existing[0].ID, "period_start", existing[0].PeriodStart,
+			"period_end", existing[0].PeriodEnd, "synced", existing[0].Synced)
+		return existing[0], nil
+	}
+
 	sub, _, err := a.subscriptionRepo.GetWithLineItems(ctx, subscriptionID)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to load subscription",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
 			"error", err, "stage", "get_subscription")
 		return nil, err
@@ -377,7 +418,7 @@ func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptio
 		Source:         string(types.UsageSourceInvoiceCreation),
 	})
 	if err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to compute meter usage",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
 			"customer_id", sub.CustomerID, "error", err, "stage", "get_meter_usage")
 		return nil, err
@@ -387,7 +428,7 @@ func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptio
 		ctx, sub, usageResp, windowStart, cancelAt, types.UsageSourceInvoiceCreation,
 	)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace subscription flush failed",
+		a.logger.Error(ctx, "marketplace subscription flush: failed to calculate charges",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
 			"customer_id", sub.CustomerID, "error", err, "stage", "calculate_charges")
 		return nil, err
@@ -398,7 +439,7 @@ func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptio
 		customerExternalID = cust.ExternalID
 	}
 
-	return &usagerecord.UsageRecord{
+	rec := &usagerecord.UsageRecord{
 		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USAGE_RECORD),
 		CustomerID:         sub.CustomerID,
 		CustomerExternalID: customerExternalID,
@@ -407,35 +448,24 @@ func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptio
 		Amount:             totalAmount,
 		Currency:           usageResp.Currency,
 		PeriodStart:        windowStart,
-		PeriodEnd:          cancelAt.Add(-reportTimestampSafetyMargin),
+		PeriodEnd:          cancelAt,
 		EnvironmentID:      environmentID,
 		BaseModel:          types.GetDefaultBaseModel(ctx),
-	}, nil
-}
+	}
 
-// createFinalUsageRecord stores the final record after its marketplaces have accepted it. rec already
-// carries the sync state that reporting produced.
-func (a *FlushActivities) createFinalUsageRecord(ctx context.Context, rec *usagerecord.UsageRecord) error {
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-
+	// An already-exists error here means a concurrent attempt won the race against the check above.
+	// It is returned like any other failure: the next attempt's check finds that row and reports it.
 	if err := a.usageRecordRepo.Create(ctx, rec); err != nil {
-		// A concurrent attempt can win the race between computing this window and inserting it. That
-		// attempt reported the same usage and wrote the row, so this one has nothing left to do.
-		if ierr.IsAlreadyExists(err) {
-			return nil
-		}
-		a.logger.Error(ctx, "marketplace subscription flush failed",
-			"tenant_id", tenantID, "environment_id", environmentID,
-			"subscription_id", rec.SubscriptionID, "customer_id", rec.CustomerID,
-			"usage_record_id", rec.ID, "error", err, "stage", "create_usage_record")
-		return err
+		a.logger.Error(ctx, "marketplace subscription flush: failed to create final usage record",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
+			"customer_id", sub.CustomerID, "usage_record_id", rec.ID, "error", err,
+			"stage", "create_usage_record")
+		return nil, err
 	}
 
 	a.logger.Info(ctx, "marketplace subscription flush: final usage record created",
 		"tenant_id", tenantID, "environment_id", environmentID,
 		"subscription_id", rec.SubscriptionID, "customer_id", rec.CustomerID, "usage_record_id", rec.ID,
-		"period_start", rec.PeriodStart, "period_end", rec.PeriodEnd, "amount", rec.Amount,
-		"synced", rec.Synced)
-	return nil
+		"period_start", rec.PeriodStart, "period_end", rec.PeriodEnd, "amount", rec.Amount)
+	return rec, nil
 }

--- a/internal/temporal/activities/marketplace/final_usage_flush_activities.go
+++ b/internal/temporal/activities/marketplace/final_usage_flush_activities.go
@@ -20,26 +20,25 @@ import (
 )
 
 // reportTimestampSafetyMargin is subtracted from the final record's period_end when it is reported,
-// never when it is stored. GCP requires the reported timestamp to be strictly before its own recorded
-// cancellation instant, and CancelAt is exactly that instant (sub.CancelAt, never sub.CancelledAt —
-// see ERD FLE-1106 §3.8), so one second satisfies the strict "<" without materially under-billing.
-// Applied uniformly to all three providers rather than branched per provider.
+// never when it is stored. GCP requires the reported timestamp to be strictly earlier than the
+// cancellation instant it holds, and cancelAt is exactly that instant, so a second satisfies the
+// comparison without materially under-billing. Applied to every provider rather than branched.
 //
-// Storing the exact cancelAt also keeps lastComputedPeriodEnd's MAX(period_end) frontier equal to
-// cancelAt after a successful write, so a retry computes no leftover sliver window.
+// Storing the exact cancelAt keeps the computed-through frontier equal to it after a successful
+// write, so a retry finds nothing left to compute rather than a one-second sliver.
 const reportTimestampSafetyMargin = 1 * time.Second
 
-// backlogSubmissionWindow mirrors ListUnsynced's own bound (repository/ent/usagerecord.go) — none of
-// the three marketplaces accept a report older than this, so there's no reason to fetch it here either.
+// backlogSubmissionWindow bounds the backlog to rows a marketplace can still accept. None of the
+// three take a report older than this, so there is no point fetching one.
 const backlogSubmissionWindow = 24 * time.Hour
 
-// FlushActivities computes and reports a cancelled subscription's final marketplace usage. It is
-// started once per cancellation from CancelSubscription (post-commit, non-blocking) — not on a
-// schedule — because AWS and GCP only accept a final report within roughly an hour of cancellation,
-// far tighter than the ordinary 6h snapshot / 3h report cron cadence (ERD FLE-1106 §4).
+// FlushActivities computes and reports a cancelled subscription's final marketplace usage, then
+// archives its marketplace mappings. It runs once per cancellation rather than on a schedule because
+// AWS and GCP accept a final report for only about an hour after cancellation, far tighter than the
+// reporting crons' cadence.
 //
-// The per-provider mechanics live on the shared marketplaceReporter, the same instance the scheduled
-// reporting cron holds, so the two report paths can never drift out of sync with each other.
+// The per-provider mechanics live on the shared reporter, the same instance the reporting cron holds,
+// so the two report paths cannot drift apart.
 type FlushActivities struct {
 	subscriptionService          service.SubscriptionService
 	billingService               service.BillingService
@@ -52,10 +51,8 @@ type FlushActivities struct {
 	logger                       *logger.Logger
 }
 
-// NewFlushActivities takes ServiceParams rather than each repo individually (the pattern used by
-// NewInvoiceSyncActivities and friends) — every dependency below already lives on it. The reporter is
-// the same instance the scheduled reporting cron holds, so both report through identical per-provider
-// code and cannot drift apart.
+// NewFlushActivities builds the activity set. The reporter is constructed once at registration and
+// shared with the reporting cron.
 func NewFlushActivities(params service.ServiceParams, reporter *marketplaceReporter, log *logger.Logger) *FlushActivities {
 	return &FlushActivities{
 		subscriptionService:          service.NewSubscriptionService(params),
@@ -70,8 +67,8 @@ func NewFlushActivities(params service.ServiceParams, reporter *marketplaceRepor
 	}
 }
 
-// subscriptionMarketplaceMappings resolves the published marketplace mappings for a subscription,
-// scoped to the same three providers the snapshot/report crons iterate.
+// subscriptionMarketplaceMappings returns the subscription's published mappings for the marketplace
+// providers.
 func (a *FlushActivities) subscriptionMarketplaceMappings(ctx context.Context, subscriptionID string) ([]*entityintegrationmapping.EntityIntegrationMapping, error) {
 	providerTypes := make([]string, len(marketplaceProviderTypes))
 	for i, p := range marketplaceProviderTypes {
@@ -85,18 +82,15 @@ func (a *FlushActivities) subscriptionMarketplaceMappings(ctx context.Context, s
 	})
 }
 
-// MarketplaceSubscriptionFinalUsageFlushActivity reports the pre-existing backlog of unsynced records,
-// then computes, writes and reports the final usage window, then archives the subscription's
-// marketplace mapping(s). The backlog and the final record are two explicit, separately logged phases
-// — not merged into one query — so a reader of the logs always knows which one they're looking at.
+// MarketplaceSubscriptionFinalUsageFlushActivity reports the subscription's outstanding usage in two
+// phases — first the backlog of unsynced records, then the final window up to the cancellation — and
+// archives its marketplace mappings. The phases are kept separate, and logged separately, so a run's
+// logs say which one a line belongs to.
 //
-// The delink only runs once every record across both phases has fully synced and every mapped
-// connection could be resolved. On any failure the mapping stays published and nothing else is done
-// about it here — there is no dedicated retry for a failed flush today beyond this activity's own
-// Temporal retries (up to 5 attempts). Leaving the mapping published is what keeps the subscription's
-// backlog visible to the scheduled report cron, which will keep retrying it independently of this
-// activity; a purpose-built catch-up mechanism for a flush that exhausted its retries is a known gap,
-// not yet built.
+// Archiving only happens once every record in both phases has fully synced and every mapped
+// connection resolved. On any failure the mappings stay published: that is what keeps the
+// subscription's backlog visible to the reporting cron, which retries it independently of this
+// activity. Archiving early would strand whatever failed with no way to reach it again.
 func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	ctx context.Context,
 	input temporalModels.MarketplaceSubscriptionFinalUsageFlushActivityInput,
@@ -123,9 +117,8 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		return result, nil
 	}
 
-	// A connection that fails to resolve for one mapping must not stop the other mappings from being
-	// reported — but it does block delink below (via connectionResolutionFailed), since this provider
-	// was never actually attempted this run.
+	// One unresolvable connection must not stop the others from being reported, but it does block
+	// archiving below: that provider was never attempted, so nothing can be concluded about it.
 	preparedConns := make([]*preparedConnection, 0, len(subMappings))
 	connectionResolutionFailed := false
 	for _, m := range subMappings {
@@ -146,10 +139,9 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		preparedConns = append(preparedConns, prepared)
 	}
 
-	// Phase 1: report the backlog — every unsynced record the snapshot cron already wrote. Fetched
-	// before phase 2 creates anything, so a first run never sees its own final record here. On a
-	// Temporal retry it does: the final record the previous attempt wrote is by then just another
-	// unsynced row, and phase 2 will decline to create a second one.
+	// Phase 1: the backlog already written by earlier snapshots. Read before phase 2 creates anything,
+	// so a first run never picks up its own final record. A retry does — by then a previous attempt's
+	// record is just another unsynced row, and phase 2 declines to create a second one.
 	backlog, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
 		QueryFilter: &types.QueryFilter{
 			Sort:  lo.ToPtr("period_end"),
@@ -157,8 +149,7 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		},
 		SubscriptionID: input.SubscriptionID,
 		Synced:         lo.ToPtr(false),
-		// Bound to the marketplaces' submission window: a row older than this can no longer be
-		// accepted by any of the three providers (ERD FLE-1106 §5.2).
+		// Bound to the submission window: an older row can no longer be accepted by any provider.
 		Filters: []*types.FilterCondition{{
 			Field:    lo.ToPtr("period_end"),
 			Operator: lo.ToPtr(types.GREATER_THAN_EQUAL),
@@ -180,7 +171,7 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		a.reportRecord(ctx, rec, preparedConns, result)
 	}
 
-	// Phase 2: this subscription's one final usage record — computed and reported as its own step.
+	// Phase 2: the single record covering everything from the last computed point up to cancellation.
 	cancelAt := input.CancelAt.UTC()
 
 	computedThrough, err := a.lastComputedPeriodEnd(ctx, input.SubscriptionID, subMappings)
@@ -196,9 +187,8 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		return nil, err
 	}
 
-	// An ineligible final record (non-USD, or a negative amount) can never be accepted by any
-	// marketplace, so it is not reported and not written — same rule the report cron applies to the
-	// backlog, and isEligibleForReport logs which of the two it was.
+	// An ineligible record — non-USD, or a negative amount — can never be accepted, so it is neither
+	// reported nor written. The eligibility check logs which of the two it was.
 	finalUsageFlushFailed := false
 	if finalUsageFlush != nil && a.reporter.isEligibleForReport(ctx, finalUsageFlush) {
 		relevantConns := relevantConnections(finalUsageFlush, preparedConns)
@@ -209,7 +199,7 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		finalUsageFlushFailed = len(relevantConns) == 0 || !finalUsageFlush.Synced
 
 		if !finalUsageFlushFailed {
-			// The wire carried cancelAt minus the margin; the row keeps the true instant.
+			// The providers received cancelAt less the margin; the stored row keeps the true instant.
 			finalUsageFlush.PeriodEnd = cancelAt
 			if err := a.createFinalUsageRecord(ctx, finalUsageFlush); err != nil {
 				return nil, err
@@ -228,12 +218,21 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	}
 
 	if connectionResolutionFailed || finalUsageFlushFailed || len(result.FailedRecordIDs) > 0 {
-		// Mapping stays published — see this function's doc comment. Returned so Temporal retries the
-		// whole activity; the syncs map already written makes a retry idempotent, since only the
-		// connections still missing an entry are re-attempted.
-		return result, ierr.NewErrorf("marketplace subscription flush: %d of %d records did not fully sync",
-			len(result.FailedRecordIDs), len(result.SucceededRecordIDs)+len(result.FailedRecordIDs)+len(result.SkippedRecordIDs)).
-			WithReportableDetails(map[string]any{"subscription_id": input.SubscriptionID}).
+		// Each cause is reported separately: an unresolved connection and an unreported final record
+		// both fail the run while leaving no failed record ids behind, so counts alone would describe
+		// the failure as affecting zero records and hide what actually went wrong.
+		//
+		// Returning an error retries the whole activity. That is safe to repeat: connections already
+		// holding a sync entry are not attempted again.
+		return result, ierr.NewErrorf("marketplace subscription flush failed for subscription %s", input.SubscriptionID).
+			WithReportableDetails(map[string]any{
+				"subscription_id":              input.SubscriptionID,
+				"connection_resolution_failed": connectionResolutionFailed,
+				"final_usage_flush_failed":     finalUsageFlushFailed,
+				"records_failed":               len(result.FailedRecordIDs),
+				"records_succeeded":            len(result.SucceededRecordIDs),
+				"records_skipped":              len(result.SkippedRecordIDs),
+			}).
 			Mark(ierr.ErrInternal)
 	}
 
@@ -252,8 +251,8 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	return result, nil
 }
 
-// reportRecord reports one record to every relevant connection, logs what happened, and records the
-// outcome on result. Mirrors ReportActivities.reportRecord on the cron side.
+// reportRecord reports one record to every relevant connection, logs what was accepted, and records
+// the outcome on result.
 func (a *FlushActivities) reportRecord(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
@@ -299,9 +298,8 @@ func (a *FlushActivities) logReported(ctx context.Context, rec *usagerecord.Usag
 	}
 }
 
-// delinkSubscriptionMappings archives the subscription's marketplace mappings, returning how many
-// were archived. Uses the repository's soft-delete directly rather than the service's
-// DelinkIntegrationMapping, which would re-query for the same rows already resolved here.
+// delinkSubscriptionMappings archives the subscription's marketplace mappings and returns the ids it
+// archived. It soft-deletes through the repository directly, since the rows are already resolved.
 func (a *FlushActivities) delinkSubscriptionMappings(ctx context.Context, subMappings []*entityintegrationmapping.EntityIntegrationMapping) ([]string, error) {
 	delinked := make([]string, 0, len(subMappings))
 	for _, m := range subMappings {
@@ -317,14 +315,13 @@ func (a *FlushActivities) delinkSubscriptionMappings(ctx context.Context, subMap
 	return delinked, nil
 }
 
-// lastComputedPeriodEnd returns the point this subscription's usage has already been computed up to:
-// the latest period_end across every published usage_record, regardless of sync state. Using only
-// unsynced rows would risk re-reporting a span an earlier, already-synced row already covered
-// (ERD FLE-1106 §3.3). It is the start of the final flush window.
+// lastComputedPeriodEnd returns the point this subscription's usage has already been computed up to,
+// which is where the final window starts: the latest period_end across every published row, whatever
+// its sync state. Taking the latest unsynced row instead would re-report a span an already-synced row
+// covers, billing it twice.
 //
-// Falls back to the earliest of the subscription's marketplace mappings' own created_at when no
-// usage_record exists yet (ERD §3.4): a mapping's creation is when this subscription became
-// reportable to that marketplace, so nothing before it could ever have been owed there.
+// With no usage record yet, it falls back to the earliest marketplace mapping's creation time — the
+// point the subscription became reportable, before which nothing could have been owed.
 func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptionID string, subMappings []*entityintegrationmapping.EntityIntegrationMapping) (time.Time, error) {
 	rows, err := a.usageRecordRepo.List(ctx, &types.UsageRecordFilter{
 		QueryFilter: &types.QueryFilter{
@@ -350,15 +347,14 @@ func (a *FlushActivities) lastComputedPeriodEnd(ctx context.Context, subscriptio
 	return earliest, nil
 }
 
-// buildFinalUsageRecord computes the subscription's final usage for [windowStart, cancelAt) and
-// returns the record to report, without writing it — the caller inserts it only once a marketplace
-// has accepted it (see createFinalUsageRecord). Returns nil when there is nothing left to compute:
-// cancelAt at or before windowStart, which is what a backdated cancellation looks like, and also what
-// a Temporal retry sees once an earlier attempt already wrote the record.
+// buildFinalUsageRecord computes the subscription's usage for [windowStart, cancelAt) and returns the
+// record to report without writing it: the caller stores it only after a marketplace has accepted it,
+// so an unreportable record never reaches the table. Returns nil when cancelAt is at or before
+// windowStart and there is nothing left to compute — a backdated cancellation, or a retry after an
+// earlier attempt already recorded this window.
 //
-// The usage amount covers the true window up to cancelAt, but PeriodEnd on the returned record is the
-// wire timestamp — cancelAt minus the reporting margin. The caller restores the true instant before
-// storing it.
+// The amount covers the window through cancelAt, but PeriodEnd on the returned record carries the
+// reporting margin already applied; the caller restores the true instant before storing it.
 func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptionID string, windowStart, cancelAt time.Time, environmentID string) (*usagerecord.UsageRecord, error) {
 	if !cancelAt.After(windowStart) {
 		return nil, nil
@@ -417,8 +413,8 @@ func (a *FlushActivities) buildFinalUsageRecord(ctx context.Context, subscriptio
 	}, nil
 }
 
-// createFinalUsageRecord writes the final record once its marketplaces have accepted it. rec already
-// carries the sync state the report produced.
+// createFinalUsageRecord stores the final record after its marketplaces have accepted it. rec already
+// carries the sync state that reporting produced.
 func (a *FlushActivities) createFinalUsageRecord(ctx context.Context, rec *usagerecord.UsageRecord) error {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)

--- a/internal/temporal/activities/marketplace/final_usage_flush_activities.go
+++ b/internal/temporal/activities/marketplace/final_usage_flush_activities.go
@@ -47,13 +47,13 @@ type FlushActivities struct {
 	subscriptionRepo             subscription.Repository
 	customerRepo                 customer.Repository
 	usageRecordRepo              usagerecord.Repository
-	reporter                     *marketplaceReporter
+	mktplaceReporter             *MarketplaceReporter
 	logger                       *logger.Logger
 }
 
 // NewFlushActivities builds the activity set. The reporter is constructed once at registration and
 // shared with the reporting cron.
-func NewFlushActivities(params service.ServiceParams, reporter *marketplaceReporter, log *logger.Logger) *FlushActivities {
+func NewFlushActivities(params service.ServiceParams, mktplaceReporter *MarketplaceReporter, log *logger.Logger) *FlushActivities {
 	return &FlushActivities{
 		subscriptionService:          service.NewSubscriptionService(params),
 		billingService:               service.NewBillingService(params),
@@ -62,7 +62,7 @@ func NewFlushActivities(params service.ServiceParams, reporter *marketplaceRepor
 		subscriptionRepo:             params.SubRepo,
 		customerRepo:                 params.CustomerRepo,
 		usageRecordRepo:              params.UsageRecordRepo,
-		reporter:                     reporter,
+		mktplaceReporter:             mktplaceReporter,
 		logger:                       log,
 	}
 }
@@ -119,7 +119,7 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 
 	// One unresolvable connection must not stop the others from being reported, but it does block
 	// archiving below: that provider was never attempted, so nothing can be concluded about it.
-	preparedConns := make([]*preparedConnection, 0, len(subMappings))
+	marketplaceConns := make([]*marketplaceConnection, 0, len(subMappings))
 	connectionResolutionFailed := false
 	for _, m := range subMappings {
 		conn, err := a.connectionRepo.GetByProvider(ctx, types.SecretProvider(m.ProviderType))
@@ -130,13 +130,13 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 			connectionResolutionFailed = true
 			continue
 		}
-		prepared, err := a.reporter.prepareConnection(ctx, conn)
+		prepared, err := a.mktplaceReporter.prepareMarketplaceConnection(ctx, conn)
 		if err != nil {
-			// already logged inside prepareConnection at the stage that failed
+			// already logged inside prepareMarketplaceConnection at the stage that failed
 			connectionResolutionFailed = true
 			continue
 		}
-		preparedConns = append(preparedConns, prepared)
+		marketplaceConns = append(marketplaceConns, prepared)
 	}
 
 	cancelAt := input.CancelAt.UTC()
@@ -175,10 +175,10 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	}
 
 	for _, rec := range backlog {
-		if !a.reporter.isEligibleForReport(ctx, rec) {
+		if !a.mktplaceReporter.isEligibleForReport(ctx, rec) {
 			continue
 		}
-		a.reportRecord(ctx, rec, preparedConns, result)
+		a.reportRecord(ctx, rec, marketplaceConns, result)
 	}
 
 	// Phase 2: the single record covering everything from the last computed point up to cancellation.
@@ -198,7 +198,7 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	// An ineligible record — non-USD, or a negative amount — can never be accepted, so it is not
 	// reported. The eligibility check logs which of the two it was.
 	finalUsageFlushFailed := false
-	if finalUsageFlush != nil && a.reporter.isEligibleForReport(ctx, finalUsageFlush) {
+	if finalUsageFlush != nil && a.mktplaceReporter.isEligibleForReport(ctx, finalUsageFlush) {
 		result.FinalRecordID = finalUsageFlush.ID
 		result.PeriodStart = finalUsageFlush.PeriodStart
 		result.PeriodEnd = finalUsageFlush.PeriodEnd
@@ -206,14 +206,14 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 		// The providers receive cancelAt less the margin; the stored row keeps the true instant, and
 		// reporting never writes period_end back.
 		finalUsageFlush.PeriodEnd = cancelAt.Add(-reportTimestampSafetyMargin)
-		finalUsageFlushFailed = a.reportRecord(ctx, finalUsageFlush, preparedConns, result)
+		finalUsageFlushFailed = a.reportRecord(ctx, finalUsageFlush, marketplaceConns, result)
 		finalUsageFlush.PeriodEnd = cancelAt
 	}
 
-	if connectionResolutionFailed || finalUsageFlushFailed || len(result.FailedRecordIDs) > 0 {
+	if connectionResolutionFailed || finalUsageFlushFailed || result.RecordsFailed > 0 {
 		// Each cause is reported separately: an unresolved connection and an unreported final record
-		// both fail the run while leaving no failed record ids behind, so counts alone would describe
-		// the failure as affecting zero records and hide what actually went wrong.
+		// both fail the run while leaving the failed-record count at zero, so that count alone would
+		// describe the failure as affecting no records and hide what actually went wrong.
 		//
 		// Returning an error retries the whole activity. That is safe to repeat: connections already
 		// holding a sync entry are not attempted again.
@@ -222,9 +222,9 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 				"subscription_id":              input.SubscriptionID,
 				"connection_resolution_failed": connectionResolutionFailed,
 				"final_usage_flush_failed":     finalUsageFlushFailed,
-				"records_failed":               len(result.FailedRecordIDs),
-				"records_succeeded":            len(result.SucceededRecordIDs),
-				"records_skipped":              len(result.SkippedRecordIDs),
+				"records_failed":               result.RecordsFailed,
+				"records_succeeded":            result.RecordsSucceeded,
+				"records_skipped":              result.RecordsSkipped,
 			}).
 			Mark(ierr.ErrInternal)
 	}
@@ -233,47 +233,55 @@ func (a *FlushActivities) MarketplaceSubscriptionFinalUsageFlushActivity(
 	if err != nil {
 		return result, err
 	}
-	result.DelinkedMappingIDs = delinkedIDs
+	result.MappingsDelinked = len(delinkedIDs)
 
-	log.Info("MarketplaceSubscriptionFinalUsageFlushActivity completed",
+	// Emitted through the structured logger, not the workflow logger, so a completed run is greppable
+	// under the same prefix as this activity's failures.
+	a.logger.Info(ctx, "marketplace subscription flush: completed",
+		"tenant_id", tenantID, "environment_id", environmentID,
 		"subscription_id", input.SubscriptionID,
 		"final_record_id", result.FinalRecordID,
-		"records_succeeded", len(result.SucceededRecordIDs),
-		"records_skipped", len(result.SkippedRecordIDs),
-		"mappings_delinked", len(result.DelinkedMappingIDs))
+		"records_succeeded", result.RecordsSucceeded,
+		"records_skipped", result.RecordsSkipped,
+		"mappings_delinked", result.MappingsDelinked)
 	return result, nil
 }
 
-// reportRecord reports one record to every connection mapped to its subscription, persists the
+// reportRecord reports one record to every marketplace its subscription holds an agreement on, persists the
 // outcome, and records it on result. It reports whether the record was left unreported, which is what
 // keeps the mappings published: archiving a subscription whose records never reached a marketplace
 // would put them beyond the reporting cron's reach, since that cron also needs the mapping to decide
-// a record is relevant to a connection.
+// a record belongs to a marketplace.
 func (a *FlushActivities) reportRecord(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
-	preparedConns []*preparedConnection,
+	marketplaceConns []*marketplaceConnection,
 	result *temporalModels.MarketplaceSubscriptionFinalUsageFlushWorkflowResult,
 ) (failed bool) {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
 
-	relevantConns := relevantConnections(rec, preparedConns)
-	if len(relevantConns) == 0 {
+	var reportableConns []*marketplaceConnection
+	for _, marketplaceConn := range marketplaceConns {
+		if marketplaceConn.hasAgreementFor(rec.SubscriptionID) {
+			reportableConns = append(reportableConns, marketplaceConn)
+		}
+	}
+	if len(reportableConns) == 0 {
 		// No provider can be reached, so the record stays exactly as it is: unreported and unsynced.
-		// The subscription resolved a connection but is not mapped to it for reporting, which means its
-		// mapping carries no provider entity id.
+		// A connection resolved for the subscription's marketplace, but the subscription holds no
+		// agreement there: its mapping carries no provider entity id.
 		a.logger.Error(ctx, "marketplace subscription flush: usage record has no connection to report to",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connections_resolved", len(preparedConns),
-			"error", "subscription is not mapped to any resolved marketplace connection",
+			"usage_record_id", rec.ID, "connections_resolved", len(marketplaceConns),
+			"error", "subscription holds no agreement on any resolved marketplace",
 			"stage", "relevant_connections")
-		result.FailedRecordIDs = append(result.FailedRecordIDs, rec.ID)
+		result.RecordsFailed++
 		return true
 	}
 
-	reportedConnIDs := a.reporter.reportRecordToConnections(ctx, rec, relevantConns)
-	a.logReported(ctx, rec, reportedConnIDs)
+	reportedMarketplaces := a.mktplaceReporter.reportRecordToMarketplaces(ctx, rec, reportableConns)
+	a.logReported(ctx, rec, reportedMarketplaces)
 
 	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, rec.Synced); err != nil {
 		a.logger.Error(ctx, "marketplace subscription flush: failed to record usage sync state",
@@ -282,26 +290,36 @@ func (a *FlushActivities) reportRecord(
 		rec.Synced = false
 	}
 
+	// A record that reached every marketplace it has an agreement on but was skipped by all of them is not a
+	// success: nothing was posted anywhere.
+	anyAccepted := false
+	for _, marketplaceConn := range reportableConns {
+		if entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; ok && entry.IsResolved() && !entry.Skipped {
+			anyAccepted = true
+			break
+		}
+	}
+
 	switch {
 	case !rec.Synced:
-		result.FailedRecordIDs = append(result.FailedRecordIDs, rec.ID)
+		result.RecordsFailed++
 		return true
-	case anyRealEntry(rec, relevantConns):
-		result.SucceededRecordIDs = append(result.SucceededRecordIDs, rec.ID)
+	case anyAccepted:
+		result.RecordsSucceeded++
 	default:
-		result.SkippedRecordIDs = append(result.SkippedRecordIDs, rec.ID)
+		result.RecordsSkipped++
 	}
 	return false
 }
 
 // logReported logs one line per connection that accepted this record on this run.
-func (a *FlushActivities) logReported(ctx context.Context, rec *usagerecord.UsageRecord, reportedConnIDs []string) {
-	for _, connectionID := range reportedConnIDs {
-		entry := rec.Syncs[connectionID]
+func (a *FlushActivities) logReported(ctx context.Context, rec *usagerecord.UsageRecord, reportedMarketplaces []string) {
+	for _, marketplace := range reportedMarketplaces {
+		entry := rec.Syncs[marketplace]
 		a.logger.Info(ctx, "marketplace subscription flush: usage record synced",
 			"tenant_id", types.GetTenantID(ctx), "environment_id", types.GetEnvironmentID(ctx),
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID,
-			"connection_id", connectionID, "marketplace", entry.Marketplace,
+			"marketplace", marketplace, "agreement_id", entry.AgreementID,
 			"reporting_id", entry.ReportingID)
 	}
 }

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -2,134 +2,40 @@ package marketplace
 
 import (
 	"context"
-	"math"
-	"time"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/flexprice/flexprice/internal/domain/connection"
-	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
 	"github.com/flexprice/flexprice/internal/domain/usagerecord"
-	ierr "github.com/flexprice/flexprice/internal/errors"
-	"github.com/flexprice/flexprice/internal/integration/awsmarketplace"
-	"github.com/flexprice/flexprice/internal/integration/azuremarketplace"
-	"github.com/flexprice/flexprice/internal/integration/gcpmarketplace"
+	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/security"
 	temporalModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/activity"
-	servicecontrol "google.golang.org/api/servicecontrol/v1"
 )
 
-// marketplaceReportingCurrency is the currency all three marketplaces bill in; none offers
-// seller-facing currency selection.
-const marketplaceReportingCurrency = "usd"
-
-// awsPlanMapping holds the plan-level AWS configuration resolved from the plan's entity mapping.
-type awsPlanMapping struct {
-	productCode          string
-	dimension            string
-	concurrentAgreements bool
-}
-
-// awsConnectionMappings holds the AWS identifiers for a connection, indexed by Flexprice entity id.
-type awsConnectionMappings struct {
-	licenseArnBySubscription map[string]string
-	awsAccountByCustomer     map[string]string
-	plan                     map[string]awsPlanMapping
-}
-
-// gcpPlanMapping holds the plan-level GCP configuration resolved from the plan's entity mapping.
-type gcpPlanMapping struct {
-	serviceName string
-	metricName  string
-}
-
-// gcpConnectionMappings holds the GCP identifiers for a connection, indexed by Flexprice entity id.
-// consumerId comes entirely from the subscription mapping, so no customer index is needed.
-type gcpConnectionMappings struct {
-	usageReportingIDBySubscription map[string]string
-	plan                           map[string]gcpPlanMapping
-}
-
-// azurePlanMapping holds the plan-level Azure configuration resolved from the plan's entity mapping.
-type azurePlanMapping struct {
-	planID    string
-	dimension string
-}
-
-// azureConnectionMappings holds the Azure identifiers for a connection, indexed by Flexprice entity id.
-type azureConnectionMappings struct {
-	resourceIDBySubscription map[string]string
-	plan                     map[string]azurePlanMapping
-}
-
-// preparedConnection is a published marketplace connection that's been authenticated and had its
-// mappings loaded, ready to report records through. Exactly one provider's fields are set, matching
-// conn.ProviderType.
-type preparedConnection struct {
-	conn *connection.Connection
-
-	awsCreds    awssdk.Credentials
-	awsRegion   string
-	awsMappings *awsConnectionMappings
-
-	gcpSvc      *servicecontrol.Service
-	gcpMappings *gcpConnectionMappings
-
-	azureToken    azuremarketplace.Token
-	azureMappings *azureConnectionMappings
-}
-
-// isRelevantForSubscription reports whether this connection is mapped to subscriptionID — i.e.
-// whether a usage record for that subscription needs to reach it at all.
-func (preparedConn *preparedConnection) isRelevantForSubscription(subscriptionID string) bool {
-	switch preparedConn.conn.ProviderType {
-	case types.SecretProviderAWSMarketplace:
-		return preparedConn.awsMappings != nil && preparedConn.awsMappings.licenseArnBySubscription[subscriptionID] != ""
-	case types.SecretProviderGCPMarketplace:
-		return preparedConn.gcpMappings != nil && preparedConn.gcpMappings.usageReportingIDBySubscription[subscriptionID] != ""
-	case types.SecretProviderAzureMarketplace:
-		return preparedConn.azureMappings != nil && preparedConn.azureMappings.resourceIDBySubscription[subscriptionID] != ""
-	}
-	return false
-}
-
 // ReportActivities reports usage records that have not yet reached every marketplace connection
-// relevant to them. For every tenant/environment with a published marketplace connection (AWS, GCP
-// or Azure), it authenticates each connection once, reads that tenant's unsynced usage records once,
-// and reports each record to whichever relevant connections it hasn't already reached. A record a
-// marketplace rejects is left unsynced so the next run retries it; there is no terminal failure state.
+// relevant to them. For every tenant/environment with a published marketplace connection it
+// authenticates each connection once, reads that tenant's unsynced usage records once, and reports
+// each record to whichever relevant connections it hasn't already reached. A record a marketplace
+// rejects is left unsynced so the next run retries it; there is no terminal failure state.
+//
+// The per-provider mechanics live on the shared marketplaceReporter, the same instance the
+// cancellation flush holds, so the two cannot drift apart.
 type ReportActivities struct {
-	connectionRepo               connection.Repository
-	entityIntegrationMappingRepo entityintegrationmapping.Repository
-	usageRecordRepo              usagerecord.Repository
-	encryptionService            security.EncryptionService
-	awsClient                    awsmarketplace.Client
-	gcpClient                    gcpmarketplace.Client
-	azureClient                  azuremarketplace.Client
-	logger                       *logger.Logger
+	reporter        *marketplaceReporter
+	connectionRepo  connection.Repository
+	usageRecordRepo usagerecord.Repository
+	logger          *logger.Logger
 }
 
-func NewReportActivities(
-	connectionRepo connection.Repository,
-	entityIntegrationMappingRepo entityintegrationmapping.Repository,
-	usageRecordRepo usagerecord.Repository,
-	encryptionService security.EncryptionService,
-	awsClient awsmarketplace.Client,
-	gcpClient gcpmarketplace.Client,
-	azureClient azuremarketplace.Client,
-	log *logger.Logger,
-) *ReportActivities {
+// NewReportActivities takes ServiceParams for its own repos (the pattern used by
+// NewInvoiceSyncActivities and friends); the reporter is constructed once in registration and shared
+// with FlushActivities.
+func NewReportActivities(params service.ServiceParams, reporter *marketplaceReporter, log *logger.Logger) *ReportActivities {
 	return &ReportActivities{
-		connectionRepo:               connectionRepo,
-		entityIntegrationMappingRepo: entityIntegrationMappingRepo,
-		usageRecordRepo:              usageRecordRepo,
-		encryptionService:            encryptionService,
-		awsClient:                    awsClient,
-		gcpClient:                    gcpClient,
-		azureClient:                  azureClient,
-		logger:                       log,
+		reporter:        reporter,
+		connectionRepo:  params.ConnectionRepo,
+		usageRecordRepo: params.UsageRecordRepo,
+		logger:          log,
 	}
 }
 
@@ -183,7 +89,7 @@ func (a *ReportActivities) reportForTenant(
 ) {
 	preparedConns := make([]*preparedConnection, 0, len(conns))
 	for _, conn := range conns {
-		preparedConn, err := a.prepareConnection(ctx, conn)
+		preparedConn, err := a.reporter.prepareConnection(ctx, conn)
 		if err != nil {
 			continue // already logged inside prepareConnection at the stage that failed
 		}
@@ -201,662 +107,70 @@ func (a *ReportActivities) reportForTenant(
 	}
 
 	for _, rec := range records {
-		if a.isEligibleForReport(ctx, rec) {
+		if a.reporter.isEligibleForReport(ctx, rec) {
 			a.reportRecord(ctx, rec, preparedConns, result)
 		}
 	}
 }
 
-// reportRecord reports one record to every connection relevant to its subscription (relevantConns)
-// that doesn't already have a syncs entry, then persists the updated map once — with synced=true only
-// if every connection in relevantConns now has an entry. A connection that rejects the record leaves
-// it unsynced for the next run.
+// reportRecord reports one record to every connection relevant to its subscription and classifies the
+// result into exactly one of Succeeded/Failed/Skipped. The per-connection mechanics and the
+// classification rule live on the shared reporter (reportRecordToConnections) so the cron and the
+// cancellation flush can never disagree on what "succeeded" means; this function only logs and
+// bookkeeps in its own words.
 func (a *ReportActivities) reportRecord(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
 	preparedConns []*preparedConnection,
 	result *temporalModels.MarketplaceUsageReportWorkflowResult,
 ) {
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-
-	// relevantConns is the subset of this tenant's prepared connections that are mapped to rec's
-	// subscription — i.e. the connections rec must actually reach for this run to be done with it.
-	var relevantConns []*preparedConnection
-	for _, preparedConn := range preparedConns {
-		if preparedConn.isRelevantForSubscription(rec.SubscriptionID) {
-			relevantConns = append(relevantConns, preparedConn)
-		}
-	}
+	relevantConns := relevantConnections(rec, preparedConns)
 	if len(relevantConns) == 0 {
 		return // no published connection is mapped to this subscription right now
 	}
+	reportedConnIDs := a.reporter.reportRecordToConnections(ctx, rec, relevantConns)
+
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	for _, connectionID := range reportedConnIDs {
+		entry := rec.Syncs[connectionID]
+		a.logger.Info(ctx, "marketplace usage record synced",
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", connectionID,
+			"marketplace", entry.Marketplace, "reporting_id", entry.ReportingID)
+	}
+
+	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, rec.Synced); err != nil {
+		a.logger.Error(ctx, "marketplace usage report failed",
+			"tenant_id", tenantID, "environment_id", environmentID,
+			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "error", err, "stage", "mark_synced")
+		rec.Synced = false
+	}
 
 	result.Total++
-
-	added := false
-	for _, preparedConn := range relevantConns {
-		if _, done := rec.Syncs[preparedConn.conn.ID]; done {
-			continue // already reported to this connection on an earlier run
-		}
-
-		var entry types.UsageRecordSyncEntry
-		var ok bool
-		switch preparedConn.conn.ProviderType {
-		case types.SecretProviderAWSMarketplace:
-			entry, ok = a.reportAWSRecord(ctx, rec, preparedConn)
-		case types.SecretProviderGCPMarketplace:
-			entry, ok = a.reportGCPRecord(ctx, rec, preparedConn)
-		case types.SecretProviderAzureMarketplace:
-			entry, ok = a.reportAzureRecord(ctx, rec, preparedConn)
-		}
-		if !ok {
-			continue // already logged inside the provider method
-		}
-
-		rec.Syncs[preparedConn.conn.ID] = entry
-		added = true
-		// A skip (Azure's zero-amount case) already has its own log line, emitted where the skip
-		// decision was made. Logging "synced" for it here as well would claim something was posted
-		// to the marketplace when nothing was.
-		if !entry.Skipped {
-			a.logger.Info(ctx, "marketplace usage record synced",
-				"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-				"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "marketplace", preparedConn.conn.ProviderType,
-				"reporting_id", entry.ReportingID)
-		}
-	}
-
-	// Fully synced only when every connection in relevantConns has an entry.
-	synced := true
-	for _, preparedConn := range relevantConns {
-		if _, done := rec.Syncs[preparedConn.conn.ID]; !done {
-			synced = false
-			break
-		}
-	}
-
-	// Nothing new reported and still not fully synced: leave the row as-is for the next run.
-	if !added && !synced {
-		result.Failed++
-		return
-	}
-
-	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, synced); err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed",
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "error", err, "stage", "mark_synced")
-		result.Failed++
-		return
-	}
-
-	if synced {
-		result.Succeeded++
-	} else {
-		result.Failed++
+	switch {
+	case !rec.Synced:
+		result.AppendFailedRecordID(rec.ID)
+	case anyRealEntry(rec, relevantConns):
+		result.AppendSucceededRecordID(rec.ID)
+	default:
+		result.AppendSkippedRecordID(rec.ID)
 	}
 }
 
-// prepareConnection decrypts and authenticates one connection and loads its provider's mappings once.
-func (a *ReportActivities) prepareConnection(ctx context.Context, conn *connection.Connection) (*preparedConnection, error) {
-	switch conn.ProviderType {
-	case types.SecretProviderAWSMarketplace:
-		creds, region, mappings, err := a.authAWSConnection(ctx, conn)
-		if err != nil {
-			return nil, err
-		}
-		return &preparedConnection{conn: conn, awsCreds: creds, awsRegion: region, awsMappings: mappings}, nil
-	case types.SecretProviderGCPMarketplace:
-		svc, mappings, err := a.authGCPConnection(ctx, conn)
-		if err != nil {
-			return nil, err
-		}
-		return &preparedConnection{conn: conn, gcpSvc: svc, gcpMappings: mappings}, nil
-	case types.SecretProviderAzureMarketplace:
-		token, mappings, err := a.authAzureConnection(ctx, conn)
-		if err != nil {
-			return nil, err
-		}
-		return &preparedConnection{conn: conn, azureToken: token, azureMappings: mappings}, nil
-	}
-	return nil, ierr.NewErrorf("unsupported marketplace provider type %q", conn.ProviderType).Mark(ierr.ErrValidation)
-}
-
-// isEligibleForReport applies the validation common to every provider before any payload is built:
-// only USD is accepted (a non-USD record stays unsynced, retried once currency conversion lands),
-// and a negative amount is never valid on any provider — it means an upstream billing computation
-// produced a bad value, not a marketplace rejection, so it is left unsynced for investigation rather
-// than sent. A zero amount passes this check; whether it is reportable is provider-specific and is
-// decided in reportAzureRecord.
-func (a *ReportActivities) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
+// isEligibleForReport filters out records that must never reach a marketplace at all: non-USD
+// currency (none of the three marketplaces accept it) and negative amounts (a credit, not usage).
+func (r *marketplaceReporter) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
 	if !types.IsMatchingCurrency(rec.Currency, marketplaceReportingCurrency) {
-		a.logger.Debug(ctx, "skipping marketplace usage record, currency not usd",
+		r.logger.Debug(ctx, "skipping marketplace usage record, currency not usd",
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "currency", rec.Currency)
 		return false
 	}
 	if rec.Amount.IsNegative() {
-		a.logger.Error(ctx, "marketplace usage record has negative amount",
+		r.logger.Error(ctx, "marketplace usage record has negative amount",
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "amount", rec.Amount,
 			"error", "negative_amount")
 		return false
 	}
 	return true
-}
-
-// ---------------------------------------------------------------------------
-// AWS
-// ---------------------------------------------------------------------------
-
-// authAWSConnection decrypts a connection's AWS secret, loads its mappings, and assumes the tenant's
-// role once.
-func (a *ReportActivities) authAWSConnection(ctx context.Context, conn *connection.Connection) (awssdk.Credentials, string, *awsConnectionMappings, error) {
-	tenantID := conn.TenantID
-	environmentID := conn.EnvironmentID
-
-	if conn.EncryptedSecretData.AWSMarketplace == nil {
-		err := ierr.NewError("connection has no aws_marketplace secret data").Mark(ierr.ErrValidation)
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
-		return awssdk.Credentials{}, "", nil, err
-	}
-
-	// The region is saved on the connection at creation time (sync_config.aws_marketplace.region,
-	// same home as S3's bucket/region); it selects the AWS Marketplace Metering endpoint and is required.
-	if conn.SyncConfig == nil || conn.SyncConfig.AWSMarketplace == nil || conn.SyncConfig.AWSMarketplace.Region == "" {
-		err := ierr.NewError("connection has no region in sync_config").Mark(ierr.ErrValidation)
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
-		return awssdk.Credentials{}, "", nil, err
-	}
-	region := conn.SyncConfig.AWSMarketplace.Region
-
-	roleArn, err := a.encryptionService.Decrypt(conn.EncryptedSecretData.AWSMarketplace.RoleArn)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_role_arn")
-		return awssdk.Credentials{}, "", nil, err
-	}
-	externalID, err := a.encryptionService.Decrypt(conn.EncryptedSecretData.AWSMarketplace.ExternalID)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_external_id")
-		return awssdk.Credentials{}, "", nil, err
-	}
-
-	mappings, err := a.loadAWSMappings(ctx)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
-		return awssdk.Credentials{}, "", nil, err
-	}
-
-	// Assume the tenant's role once; the same static credentials are reused for every record this
-	// connection reports (they are a one-time snapshot, not a live auto-refreshing provider). A busy
-	// tenant's loop can run close to the activity's 30-minute StartToCloseTimeout, so the session
-	// must outlive that — 1 hour is requested because every IAM role supports it without the tenant
-	// needing to raise MaxSessionDuration.
-	creds, err := a.awsClient.AssumeRole(ctx, roleArn, externalID, time.Hour)
-	if err != nil {
-		// err is already redacted of the role ARN and external ID by AssumeRole.
-		a.logger.Error(ctx, "marketplace usage report failed",
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID,
-			"region", region,
-			"error", err, "stage", "assume_role")
-		return awssdk.Credentials{}, "", nil, err
-	}
-
-	return creds, region, mappings, nil
-}
-
-// reportAWSRecord reports a single usage record to AWS and returns the sync entry to persist on
-// success.
-func (a *ReportActivities) reportAWSRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-	mappings := preparedConn.awsMappings
-
-	licenseArn := mappings.licenseArnBySubscription[rec.SubscriptionID]
-	customerAWSAccountID := mappings.awsAccountByCustomer[rec.CustomerID]
-	plan, planFound := mappings.plan[rec.PlanID]
-	if licenseArn == "" || customerAWSAccountID == "" || !planFound || plan.dimension == "" {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
-			"error", "missing license_arn, customer_aws_account_id, or plan dimension mapping", "stage", "resolve_record")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	// ProductCode is sent only for legacy products; for concurrent-agreements products the license
-	// identifies the product and ProductCode must be omitted.
-	productCode := plan.productCode
-	if plan.concurrentAgreements {
-		productCode = ""
-	}
-
-	// Only called for USD records (see isEligibleForReport). AWS only accepts a whole number, so it's
-	// sent in USD cents — the tenant prices their dimension per cent. Turning cents into a charge is
-	// AWS's job: it bills quantity x the dimension's rate.
-	quantity := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
-	if quantity > math.MaxInt32 {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
-			"error", "quantity exceeds the maximum aws accepts", "stage", "convert_quantity")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	res, err := a.awsClient.BatchMeterUsage(ctx, preparedConn.awsCreds, preparedConn.awsRegion, awsmarketplace.UsageRecordInput{
-		CustomerAWSAccountID: customerAWSAccountID,
-		LicenseArn:           licenseArn,
-		ProductCode:          productCode,
-		Dimension:            plan.dimension,
-		Quantity:             int32(quantity),
-		// PeriodEnd is the timestamp so a retry sends an identical record and AWS de-duplicates it.
-		Timestamp: rec.PeriodEnd,
-	})
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
-			"error", err, "stage", "batch_meter_usage")
-		return types.UsageRecordSyncEntry{}, false
-	}
-	if res == nil {
-		// AWS returned the record as unprocessed; leaving it unsynced retries it next run.
-		a.logger.Info(ctx, "marketplace usage record not processed by aws, will retry next run", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	// A present result is not the same as an accepted record — AWS's Status must be checked. Only
-	// StatusSuccess means the record was honored; the other two are distinct failure modes with
-	// different causes, so each gets its own log line.
-	switch res.Status {
-	case awsmarketplace.StatusSuccess:
-		// falls through to the return below
-	case awsmarketplace.StatusCustomerNotSubscribed:
-		// The buyer has no active agreement for this product, or their AWS account was suspended.
-		// Resolves itself once the buyer (re)subscribes, so it keeps retrying rather than needing
-		// manual action.
-		a.logger.Error(ctx, "marketplace usage report rejected by aws: customer not subscribed, will retry next run", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
-			"dimension", plan.dimension, "amount", rec.Amount, "error", "customer_not_subscribed")
-		return types.UsageRecordSyncEntry{}, false
-	case awsmarketplace.StatusDuplicateRecord:
-		// NOT "AWS already has this exact record, safe to skip" — AWS has a DIFFERENT record for the
-		// same customer+dimension+timestamp already on file, and rejected this one. Retrying with the
-		// same amount hits the same rejection every time; this needs a human to fix the mismatch.
-		a.logger.Error(ctx, "marketplace usage report rejected by aws: conflicts with a different record already on file, needs manual investigation", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
-			"dimension", plan.dimension, "amount", rec.Amount, "period_end", rec.PeriodEnd, "error", "duplicate_record")
-		return types.UsageRecordSyncEntry{}, false
-	default:
-		a.logger.Error(ctx, "marketplace usage report rejected by aws: unrecognized status, will retry next run", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
-			"aws_status", res.Status, "error", "unrecognized_aws_status")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	return types.UsageRecordSyncEntry{
-		Marketplace: types.SecretProviderAWSMarketplace,
-		ReportingID: res.MeteringRecordID,
-		SyncedAt:    time.Now().UTC(),
-	}, true
-}
-
-// loadAWSMappings loads the subscription, customer and plan mappings for the current tenant/
-// environment and indexes them for lookup while reporting.
-func (a *ReportActivities) loadAWSMappings(ctx context.Context) (*awsConnectionMappings, error) {
-	providerType := string(types.SecretProviderAWSMarketplace)
-
-	subMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypeSubscription,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-	customerMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypeCustomer,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-	planMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypePlan,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	m := &awsConnectionMappings{
-		licenseArnBySubscription: make(map[string]string, len(subMappings)),
-		awsAccountByCustomer:     make(map[string]string, len(customerMappings)),
-		plan:                     make(map[string]awsPlanMapping, len(planMappings)),
-	}
-	for _, sm := range subMappings {
-		m.licenseArnBySubscription[sm.EntityID] = sm.ProviderEntityID
-	}
-	for _, cm := range customerMappings {
-		m.awsAccountByCustomer[cm.EntityID] = cm.ProviderEntityID
-	}
-	for _, pm := range planMappings {
-		concurrent, _ := pm.Metadata["concurrent_agreements"].(bool)
-		dimension, _ := pm.Metadata["dimension"].(string)
-		m.plan[pm.EntityID] = awsPlanMapping{
-			productCode:          pm.ProviderEntityID,
-			dimension:            dimension,
-			concurrentAgreements: concurrent,
-		}
-	}
-	return m, nil
-}
-
-// ---------------------------------------------------------------------------
-// GCP
-// ---------------------------------------------------------------------------
-
-// authGCPConnection decrypts a connection's GCP secret, loads its mappings, and performs the WIF
-// exchange once.
-func (a *ReportActivities) authGCPConnection(ctx context.Context, conn *connection.Connection) (*servicecontrol.Service, *gcpConnectionMappings, error) {
-	tenantID := conn.TenantID
-	environmentID := conn.EnvironmentID
-
-	if conn.EncryptedSecretData.GCPMarketplace == nil {
-		err := ierr.NewError("connection has no gcp_marketplace secret data").Mark(ierr.ErrValidation)
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
-		return nil, nil, err
-	}
-
-	credentialsJSON, err := a.encryptionService.Decrypt(conn.EncryptedSecretData.GCPMarketplace.CredentialsJSON)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_credentials_json")
-		return nil, nil, err
-	}
-
-	mappings, err := a.loadGCPMappings(ctx)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
-		return nil, nil, err
-	}
-
-	// One WIF exchange per connection; the resulting client is reused for every record this
-	// connection reports, mirroring the single AssumeRole-per-connection pattern on the AWS path.
-	svc, err := a.gcpClient.WifSession(ctx, credentialsJSON)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "wif_session")
-		return nil, nil, err
-	}
-
-	return svc, mappings, nil
-}
-
-// reportGCPRecord reports a single usage record to GCP and returns the sync entry to persist on
-// success.
-func (a *ReportActivities) reportGCPRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-	mappings := preparedConn.gcpMappings
-
-	consumerID := mappings.usageReportingIDBySubscription[rec.SubscriptionID]
-	plan, planFound := mappings.plan[rec.PlanID]
-	if consumerID == "" || !planFound || plan.serviceName == "" || plan.metricName == "" {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
-			"error", "missing usage_reporting_id or plan service_name/metric_name mapping", "stage", "resolve_record")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	// Only called for USD records (see isEligibleForReport). GCP accepts an int64 value, and
-	// ToSmallestUnit already returns int64, so unlike AWS's int32 Quantity there's no overflow guard.
-	cents := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
-
-	reportResult, err := a.gcpClient.Report(ctx, preparedConn.gcpSvc, gcpmarketplace.UsageReportInput{
-		ServiceName: plan.serviceName,
-		ConsumerID:  consumerID,
-		MetricName:  plan.metricName,
-		ValueCents:  cents,
-		// OperationID = the record's own id, so a retry sends an identical operation and GCP de-dupes.
-		OperationID: rec.ID,
-		StartTime:   rec.PeriodStart,
-		EndTime:     rec.PeriodEnd,
-	})
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "error", err, "stage", "services_report")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	// HTTP 200 is not the same as accepted — reportErrors must be checked. Common codes:
-	// 5=NOT_FOUND (consumer inactive), 7=PERMISSION_DENIED, 3=INVALID_ARGUMENT.
-	if !reportResult.Accepted {
-		a.logger.Error(ctx, "marketplace usage report rejected by gcp, will retry next run", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "error", "rejected_by_gcp", "error_code", reportResult.ErrorCode,
-			"error_message", reportResult.ErrorMessage)
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	// GCP returns no per-record receipt; the operationId echoed back (== rec.ID) becomes this
-	// connection's reporting_id, read from the result rather than re-derived.
-	return types.UsageRecordSyncEntry{
-		Marketplace: types.SecretProviderGCPMarketplace,
-		ReportingID: reportResult.OperationID,
-		SyncedAt:    time.Now().UTC(),
-	}, true
-}
-
-// loadGCPMappings loads the subscription and plan mappings for the current tenant/environment and
-// indexes them for lookup while reporting.
-func (a *ReportActivities) loadGCPMappings(ctx context.Context) (*gcpConnectionMappings, error) {
-	providerType := string(types.SecretProviderGCPMarketplace)
-
-	subMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypeSubscription,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-	planMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypePlan,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	m := &gcpConnectionMappings{
-		usageReportingIDBySubscription: make(map[string]string, len(subMappings)),
-		plan:                           make(map[string]gcpPlanMapping, len(planMappings)),
-	}
-	for _, sm := range subMappings {
-		m.usageReportingIDBySubscription[sm.EntityID] = sm.ProviderEntityID
-	}
-	for _, pm := range planMappings {
-		metricName, _ := pm.Metadata["metric_name"].(string)
-		m.plan[pm.EntityID] = gcpPlanMapping{
-			serviceName: pm.ProviderEntityID,
-			metricName:  metricName,
-		}
-	}
-	return m, nil
-}
-
-// ---------------------------------------------------------------------------
-// Azure
-// ---------------------------------------------------------------------------
-
-// authAzureConnection decrypts a connection's Azure secret, loads its mappings, and requests a
-// client_credentials token once.
-func (a *ReportActivities) authAzureConnection(ctx context.Context, conn *connection.Connection) (azuremarketplace.Token, *azureConnectionMappings, error) {
-	tenantID := conn.TenantID
-	environmentID := conn.EnvironmentID
-
-	if conn.EncryptedSecretData.AzureMarketplace == nil {
-		err := ierr.NewError("connection has no azure_marketplace secret data").Mark(ierr.ErrValidation)
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
-		return azuremarketplace.Token{}, nil, err
-	}
-
-	azureTenantID, err := a.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.TenantID)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_tenant_id")
-		return azuremarketplace.Token{}, nil, err
-	}
-	clientID, err := a.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.ClientID)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_client_id")
-		return azuremarketplace.Token{}, nil, err
-	}
-	clientSecret, err := a.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.ClientSecret)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_client_secret")
-		return azuremarketplace.Token{}, nil, err
-	}
-
-	mappings, err := a.loadAzureMappings(ctx)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
-		return azuremarketplace.Token{}, nil, err
-	}
-
-	// One token request per connection; the resulting token is reused for every record this
-	// connection reports, mirroring the AssumeRole/WifSession pattern on the AWS/GCP paths.
-	token, err := a.azureClient.GetToken(ctx, azureTenantID, clientID, clientSecret)
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "get_token")
-		return azuremarketplace.Token{}, nil, err
-	}
-
-	return token, mappings, nil
-}
-
-// reportAzureRecord reports a single usage record to Azure and returns the sync entry to persist on
-// success. A row whose reportable quantity is zero cents is never sent — Azure treats a quantity
-// of zero as invalid — and instead resolves this connection with Skipped=true, so a record is not
-// permanently blocked from reaching synced=true just because Azure cannot accept a zero quantity.
-func (a *ReportActivities) reportAzureRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-	mappings := preparedConn.azureMappings
-
-	resourceID := mappings.resourceIDBySubscription[rec.SubscriptionID]
-	plan, planFound := mappings.plan[rec.PlanID]
-	if resourceID == "" || !planFound || plan.planID == "" || plan.dimension == "" {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
-			"error", "missing resource_id or plan plan_id/dimension mapping", "stage", "resolve_record")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	// Only called for USD records (see isEligibleForReport). Azure's quantity is a double, but is
-	// always sent as a whole number of cents — the tenant prices their dimension per cent.
-	cents := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
-
-	// Skip on cents, not rec.Amount: a positive sub-cent amount rounds to zero cents and Azure
-	// rejects a zero quantity. Negatives are already filtered upstream (isEligibleForReport).
-	if cents == 0 {
-		a.logger.Info(ctx, "marketplace usage record skipped: zero quantity not supported by azure", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount)
-		return types.UsageRecordSyncEntry{
-			Marketplace: types.SecretProviderAzureMarketplace,
-			SyncedAt:    time.Now().UTC(),
-			Skipped:     true,
-			// Azure documents a quantity of zero as invalid, so this is never sent and never retried.
-			SkipReason: "zero_amount_not_supported",
-		}, true
-	}
-
-	res, err := a.azureClient.ReportUsageEvent(ctx, preparedConn.azureToken, azuremarketplace.UsageEventInput{
-		ResourceID: resourceID,
-		Dimension:  plan.dimension,
-		PlanID:     plan.planID,
-		Quantity:   float64(cents),
-		// PeriodEnd is effectiveStartTime so a retry sends an identical record.
-		EffectiveStartTime: rec.PeriodEnd,
-	})
-	// Azure has no "present result, check its status" step: the single-event endpoint's 200 response
-	// is unconditionally Accepted, and every rejection (Duplicate, Expired, invalid resource,
-	// malformed request) comes back as a distinct non-2xx status, which the client already turns into
-	// an error. Duplicate is ambiguous — nothing in a 409 confirms the existing event is ours — so any
-	// error here, rejection or transient failure alike, is left unsynced and retried next run, never
-	// resolved by inference.
-	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
-			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"connection_id", preparedConn.conn.ID, "resource_id", resourceID, "dimension", plan.dimension, "amount", rec.Amount,
-			"error", err, "stage", "usage_event")
-		return types.UsageRecordSyncEntry{}, false
-	}
-
-	return types.UsageRecordSyncEntry{
-		Marketplace: types.SecretProviderAzureMarketplace,
-		ReportingID: res.UsageEventID,
-		SyncedAt:    time.Now().UTC(),
-	}, true
-}
-
-// loadAzureMappings loads the subscription and plan mappings for the current tenant/environment and
-// indexes them for lookup while reporting.
-func (a *ReportActivities) loadAzureMappings(ctx context.Context) (*azureConnectionMappings, error) {
-	providerType := string(types.SecretProviderAzureMarketplace)
-
-	subMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypeSubscription,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-	planMappings, err := a.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
-		EntityType:    types.IntegrationEntityTypePlan,
-		ProviderTypes: []string{providerType},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	m := &azureConnectionMappings{
-		resourceIDBySubscription: make(map[string]string, len(subMappings)),
-		plan:                     make(map[string]azurePlanMapping, len(planMappings)),
-	}
-	for _, sm := range subMappings {
-		m.resourceIDBySubscription[sm.EntityID] = sm.ProviderEntityID
-	}
-	for _, pm := range planMappings {
-		dimension, _ := pm.Metadata["dimension"].(string)
-		m.plan[pm.EntityID] = azurePlanMapping{
-			planID:    pm.ProviderEntityID,
-			dimension: dimension,
-		}
-	}
-	return m, nil
 }

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -56,7 +56,7 @@ func (a *ReportActivities) MarketplaceUsageReportActivity(
 	for _, providerType := range marketplaceProviderTypes {
 		conns, err := a.connectionRepo.ListPublishedByProvider(ctx, providerType)
 		if err != nil {
-			a.logger.Error(ctx, "marketplace usage report failed", "marketplace", providerType, "error", err, "stage", "list_connections")
+			a.logger.Error(ctx, "marketplace usage report: failed to list marketplace connections", "marketplace", providerType, "error", err, "stage", "list_connections")
 			continue
 		}
 		for _, conn := range conns {
@@ -100,7 +100,7 @@ func (a *ReportActivities) reportForTenant(
 
 	records, err := a.usageRecordRepo.ListUnsynced(ctx, tenantID, environmentID)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed",
+		a.logger.Error(ctx, "marketplace usage report: failed to list unsynced usage records",
 			"tenant_id", tenantID, "environment_id", environmentID, "error", err, "stage", "list_unsynced")
 		return
 	}
@@ -130,14 +130,14 @@ func (a *ReportActivities) reportRecord(
 	environmentID := types.GetEnvironmentID(ctx)
 	for _, connectionID := range reportedConnIDs {
 		entry := rec.Syncs[connectionID]
-		a.logger.Info(ctx, "marketplace usage record synced",
+		a.logger.Info(ctx, "marketplace usage report: usage record synced",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", connectionID,
 			"marketplace", entry.Marketplace, "reporting_id", entry.ReportingID)
 	}
 
 	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, rec.Synced); err != nil {
-		a.logger.Error(ctx, "marketplace usage report failed",
+		a.logger.Error(ctx, "marketplace usage report: failed to record usage sync state",
 			"tenant_id", tenantID, "environment_id", environmentID,
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "error", err, "stage", "mark_synced")
 		rec.Synced = false

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -156,7 +156,7 @@ func (a *ReportActivities) reportRecord(
 	// success: nothing was posted anywhere.
 	anyAccepted := false
 	for _, marketplaceConn := range reportableConns {
-		if entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; ok && entry.IsResolved() && !entry.Skipped {
+		if entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; ok && entry.IsSynced() {
 			anyAccepted = true
 			break
 		}

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -12,16 +12,16 @@ import (
 	"go.temporal.io/sdk/activity"
 )
 
-// ReportActivities reports usage records that have not yet reached every marketplace connection
-// relevant to them. For every tenant/environment with a published marketplace connection it
+// ReportActivities reports usage records that have not yet reached every marketplace their
+// subscription is mapped to. For every tenant/environment with a published marketplace connection it
 // authenticates each connection once, reads that tenant's unsynced usage records once, and reports
-// each record to whichever relevant connections it hasn't already reached. A record a marketplace
-// rejects is left unsynced so the next run retries it; there is no terminal failure state.
+// each record to whichever marketplaces it has not already reached. A record a marketplace rejects is
+// left unsynced so the next run retries it; there is no terminal failure state.
 //
-// The per-provider mechanics live on the shared marketplaceReporter, the same instance the
+// The per-provider mechanics live on the shared MarketplaceReporter, the same instance the
 // cancellation flush holds, so the two cannot drift apart.
 type ReportActivities struct {
-	reporter        *marketplaceReporter
+	reporter        *MarketplaceReporter
 	connectionRepo  connection.Repository
 	usageRecordRepo usagerecord.Repository
 	logger          *logger.Logger
@@ -29,7 +29,7 @@ type ReportActivities struct {
 
 // NewReportActivities builds the activity set. The reporter is constructed once at registration and
 // shared with the cancellation flush.
-func NewReportActivities(params service.ServiceParams, reporter *marketplaceReporter, log *logger.Logger) *ReportActivities {
+func NewReportActivities(params service.ServiceParams, reporter *MarketplaceReporter, log *logger.Logger) *ReportActivities {
 	return &ReportActivities{
 		reporter:        reporter,
 		connectionRepo:  params.ConnectionRepo,
@@ -38,7 +38,7 @@ func NewReportActivities(params service.ServiceParams, reporter *marketplaceRepo
 	}
 }
 
-// MarketplaceUsageReportActivity is the activity entrypoint. A record's relevant connections and its
+// MarketplaceUsageReportActivity is the activity entrypoint. A record's reportable connections and its
 // unsynced status are both tenant/environment-scoped, so it groups every published marketplace
 // connection by tenant/environment and reports each group independently — a failure in one tenant
 // does not stop the others.
@@ -71,13 +71,17 @@ func (a *ReportActivities) MarketplaceUsageReportActivity(
 		a.reportForTenant(ctx, key.tenantID, key.environmentID, conns, result)
 	}
 
-	log.Info("Completed MarketplaceUsageReportActivity",
-		"total", result.Total, "succeeded", result.Succeeded, "failed", result.Failed)
+	// Emitted through the structured logger, not the workflow logger, so a completed run is greppable
+	// under the same prefix as this activity's failures.
+	a.logger.Info(ctx, "marketplace usage report: completed",
+		"total", result.Total, "succeeded", result.Succeeded,
+		"failed", result.Failed)
 	return result, nil
 }
 
 // reportForTenant authenticates each of this tenant/environment's published connections once,
-// fetches its unsynced usage records once, and reports each record to the relevant ones. Both lists
+// fetches its unsynced usage records once, and reports each record to the marketplaces it holds an
+// agreement on. Both lists
 // are fixed for the whole call — nothing is re-queried mid-run, so a connection deleted while this
 // run executes only takes effect from the next scheduled run.
 func (a *ReportActivities) reportForTenant(
@@ -86,15 +90,15 @@ func (a *ReportActivities) reportForTenant(
 	conns []*connection.Connection,
 	result *temporalModels.MarketplaceUsageReportWorkflowResult,
 ) {
-	preparedConns := make([]*preparedConnection, 0, len(conns))
+	marketplaceConns := make([]*marketplaceConnection, 0, len(conns))
 	for _, conn := range conns {
-		preparedConn, err := a.reporter.prepareConnection(ctx, conn)
+		marketplaceConn, err := a.reporter.prepareMarketplaceConnection(ctx, conn)
 		if err != nil {
-			continue // already logged inside prepareConnection at the stage that failed
+			continue // already logged inside prepareMarketplaceConnection at the stage that failed
 		}
-		preparedConns = append(preparedConns, preparedConn)
+		marketplaceConns = append(marketplaceConns, marketplaceConn)
 	}
-	if len(preparedConns) == 0 {
+	if len(marketplaceConns) == 0 {
 		return
 	}
 
@@ -107,33 +111,38 @@ func (a *ReportActivities) reportForTenant(
 
 	for _, rec := range records {
 		if a.reporter.isEligibleForReport(ctx, rec) {
-			a.reportRecord(ctx, rec, preparedConns, result)
+			a.reportRecord(ctx, rec, marketplaceConns, result)
 		}
 	}
 }
 
-// reportRecord reports one record to every connection relevant to its subscription, persists the
-// outcome, and classifies the record as succeeded, failed or skipped.
+// reportRecord reports one record to every marketplace its subscription holds an agreement on,
+// persists the outcome, and classifies the record as succeeded, failed or skipped.
 func (a *ReportActivities) reportRecord(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
-	preparedConns []*preparedConnection,
+	marketplaceConns []*marketplaceConnection,
 	result *temporalModels.MarketplaceUsageReportWorkflowResult,
 ) {
-	relevantConns := relevantConnections(rec, preparedConns)
-	if len(relevantConns) == 0 {
-		return // no published connection is mapped to this subscription right now
+	var reportableConns []*marketplaceConnection
+	for _, marketplaceConn := range marketplaceConns {
+		if marketplaceConn.hasAgreementFor(rec.SubscriptionID) {
+			reportableConns = append(reportableConns, marketplaceConn)
+		}
 	}
-	reportedConnIDs := a.reporter.reportRecordToConnections(ctx, rec, relevantConns)
+	if len(reportableConns) == 0 {
+		return // the subscription holds no agreement on any connected marketplace right now
+	}
+	reportedMarketplaces := a.reporter.reportRecordToMarketplaces(ctx, rec, reportableConns)
 
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
-	for _, connectionID := range reportedConnIDs {
-		entry := rec.Syncs[connectionID]
+	for _, marketplace := range reportedMarketplaces {
+		entry := rec.Syncs[marketplace]
 		a.logger.Info(ctx, "marketplace usage report: usage record synced",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", connectionID,
-			"marketplace", entry.Marketplace, "reporting_id", entry.ReportingID)
+			"usage_record_id", rec.ID, "marketplace", marketplace,
+			"agreement_id", entry.AgreementID, "reporting_id", entry.ReportingID)
 	}
 
 	if err := a.usageRecordRepo.MarkSynced(ctx, rec.ID, rec.Syncs, rec.Synced); err != nil {
@@ -143,13 +152,23 @@ func (a *ReportActivities) reportRecord(
 		rec.Synced = false
 	}
 
+	// A record that reached every marketplace it has an agreement on but was skipped by all of them is not a
+	// success: nothing was posted anywhere.
+	anyAccepted := false
+	for _, marketplaceConn := range reportableConns {
+		if entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; ok && entry.IsResolved() && !entry.Skipped {
+			anyAccepted = true
+			break
+		}
+	}
+
 	result.Total++
 	switch {
 	case !rec.Synced:
-		result.AppendFailedRecordID(rec.ID)
-	case anyRealEntry(rec, relevantConns):
-		result.AppendSucceededRecordID(rec.ID)
+		result.Failed++
+	case anyAccepted:
+		result.Succeeded++
 	default:
-		result.AppendSkippedRecordID(rec.ID)
+		result.Skipped++
 	}
 }

--- a/internal/temporal/activities/marketplace/report_activities.go
+++ b/internal/temporal/activities/marketplace/report_activities.go
@@ -27,9 +27,8 @@ type ReportActivities struct {
 	logger          *logger.Logger
 }
 
-// NewReportActivities takes ServiceParams for its own repos (the pattern used by
-// NewInvoiceSyncActivities and friends); the reporter is constructed once in registration and shared
-// with FlushActivities.
+// NewReportActivities builds the activity set. The reporter is constructed once at registration and
+// shared with the cancellation flush.
 func NewReportActivities(params service.ServiceParams, reporter *marketplaceReporter, log *logger.Logger) *ReportActivities {
 	return &ReportActivities{
 		reporter:        reporter,
@@ -113,11 +112,8 @@ func (a *ReportActivities) reportForTenant(
 	}
 }
 
-// reportRecord reports one record to every connection relevant to its subscription and classifies the
-// result into exactly one of Succeeded/Failed/Skipped. The per-connection mechanics and the
-// classification rule live on the shared reporter (reportRecordToConnections) so the cron and the
-// cancellation flush can never disagree on what "succeeded" means; this function only logs and
-// bookkeeps in its own words.
+// reportRecord reports one record to every connection relevant to its subscription, persists the
+// outcome, and classifies the record as succeeded, failed or skipped.
 func (a *ReportActivities) reportRecord(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
@@ -156,21 +152,4 @@ func (a *ReportActivities) reportRecord(
 	default:
 		result.AppendSkippedRecordID(rec.ID)
 	}
-}
-
-// isEligibleForReport filters out records that must never reach a marketplace at all: non-USD
-// currency (none of the three marketplaces accept it) and negative amounts (a credit, not usage).
-func (r *marketplaceReporter) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
-	if !types.IsMatchingCurrency(rec.Currency, marketplaceReportingCurrency) {
-		r.logger.Debug(ctx, "skipping marketplace usage record, currency not usd",
-			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "currency", rec.Currency)
-		return false
-	}
-	if rec.Amount.IsNegative() {
-		r.logger.Error(ctx, "marketplace usage record has negative amount",
-			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "amount", rec.Amount,
-			"error", "negative_amount")
-		return false
-	}
-	return true
 }

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -153,7 +153,7 @@ func (r *MarketplaceReporter) reportRecordToMarketplaces(
 		marketplace := string(marketplaceConn.conn.ProviderType)
 		// A skip leaves an entry as well, so a marketplace that skipped this record is treated as
 		// resolved and never attempted again: the amount will not change on a retry.
-		if _, ok := rec.Syncs[marketplace]; ok {
+		if entry, ok := rec.Syncs[marketplace]; ok && entry.IsSynced() {
 			continue
 		}
 

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -1,0 +1,769 @@
+package marketplace
+
+import (
+	"context"
+	"math"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/flexprice/flexprice/internal/domain/connection"
+	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/usagerecord"
+	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/integration/awsmarketplace"
+	"github.com/flexprice/flexprice/internal/integration/azuremarketplace"
+	"github.com/flexprice/flexprice/internal/integration/gcpmarketplace"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/security"
+	"github.com/flexprice/flexprice/internal/types"
+	servicecontrol "google.golang.org/api/servicecontrol/v1"
+)
+
+// marketplaceReportingCurrency is the currency all three marketplaces bill in; none offers
+// seller-facing currency selection.
+const marketplaceReportingCurrency = "usd"
+
+// MarketplaceReporter is exported only so registration can construct one; callers treat it as opaque.
+type MarketplaceReporter = marketplaceReporter
+
+// marketplaceReporter owns everything needed to authenticate a marketplace connection and report one
+// usage record to it. It is deliberately not a Temporal activity: it is the shared implementation
+// behind both the scheduled reporting cron (ReportActivities) and the one-shot cancellation flush
+// (FlushActivities), so neither can drift from the other in how it talks to a provider. Both hold
+// the same instance rather than one activity reaching into the other.
+type marketplaceReporter struct {
+	entityIntegrationMappingRepo entityintegrationmapping.Repository
+	encryptionService            security.EncryptionService
+	awsClient                    awsmarketplace.Client
+	gcpClient                    gcpmarketplace.Client
+	azureClient                  azuremarketplace.Client
+	logger                       *logger.Logger
+}
+
+// NewMarketplaceReporter builds the shared reporter; registration creates one and hands the same
+// instance to both ReportActivities and FlushActivities.
+func NewMarketplaceReporter(
+	params service.ServiceParams,
+	awsClient awsmarketplace.Client,
+	gcpClient gcpmarketplace.Client,
+	azureClient azuremarketplace.Client,
+	log *logger.Logger,
+) *marketplaceReporter {
+	return &marketplaceReporter{
+		entityIntegrationMappingRepo: params.EntityIntegrationMappingRepo,
+		encryptionService:            params.EncryptionService,
+		awsClient:                    awsClient,
+		gcpClient:                    gcpClient,
+		azureClient:                  azureClient,
+		logger:                       log,
+	}
+}
+
+// awsPlanMapping holds the plan-level AWS configuration resolved from the plan's entity mapping.
+type awsPlanMapping struct {
+	productCode          string
+	dimension            string
+	concurrentAgreements bool
+}
+
+// awsConnectionMappings holds the AWS identifiers for a connection, indexed by Flexprice entity id.
+type awsConnectionMappings struct {
+	licenseArnBySubscription map[string]string
+	awsAccountByCustomer     map[string]string
+	plan                     map[string]awsPlanMapping
+}
+
+// gcpPlanMapping holds the plan-level GCP configuration resolved from the plan's entity mapping.
+type gcpPlanMapping struct {
+	serviceName string
+	metricName  string
+}
+
+// gcpConnectionMappings holds the GCP identifiers for a connection, indexed by Flexprice entity id.
+// consumerId comes entirely from the subscription mapping, so no customer index is needed.
+type gcpConnectionMappings struct {
+	usageReportingIDBySubscription map[string]string
+	plan                           map[string]gcpPlanMapping
+}
+
+// azurePlanMapping holds the plan-level Azure configuration resolved from the plan's entity mapping.
+type azurePlanMapping struct {
+	planID    string
+	dimension string
+}
+
+// azureConnectionMappings holds the Azure identifiers for a connection, indexed by Flexprice entity id.
+type azureConnectionMappings struct {
+	resourceIDBySubscription map[string]string
+	plan                     map[string]azurePlanMapping
+}
+
+// preparedConnection is a published marketplace connection that's been authenticated and had its
+// mappings loaded, ready to report records through. Exactly one provider's fields are set, matching
+// conn.ProviderType.
+type preparedConnection struct {
+	conn *connection.Connection
+
+	awsCreds    awssdk.Credentials
+	awsRegion   string
+	awsMappings *awsConnectionMappings
+
+	gcpSvc      *servicecontrol.Service
+	gcpMappings *gcpConnectionMappings
+
+	azureToken    azuremarketplace.Token
+	azureMappings *azureConnectionMappings
+}
+
+// isRelevantForSubscription reports whether this connection is mapped to subscriptionID — i.e.
+// whether a usage record for that subscription needs to reach it at all.
+func (preparedConn *preparedConnection) isRelevantForSubscription(subscriptionID string) bool {
+	switch preparedConn.conn.ProviderType {
+	case types.SecretProviderAWSMarketplace:
+		return preparedConn.awsMappings != nil && preparedConn.awsMappings.licenseArnBySubscription[subscriptionID] != ""
+	case types.SecretProviderGCPMarketplace:
+		return preparedConn.gcpMappings != nil && preparedConn.gcpMappings.usageReportingIDBySubscription[subscriptionID] != ""
+	case types.SecretProviderAzureMarketplace:
+		return preparedConn.azureMappings != nil && preparedConn.azureMappings.resourceIDBySubscription[subscriptionID] != ""
+	}
+	return false
+}
+
+// relevantConnections returns the subset of preparedConns mapped to rec's subscription. Callers use
+// this both to decide whether there's anything to report and, after reporting, to read back which of
+// those connections' entries in rec.Syncs are real vs. skipped.
+func relevantConnections(rec *usagerecord.UsageRecord, preparedConns []*preparedConnection) []*preparedConnection {
+	var relevant []*preparedConnection
+	for _, preparedConn := range preparedConns {
+		if preparedConn.isRelevantForSubscription(rec.SubscriptionID) {
+			relevant = append(relevant, preparedConn)
+		}
+	}
+	return relevant
+}
+
+// reportRecordToConnections reports rec to every one of relevantConns that doesn't already have a
+// sync entry. Shared by the scheduled report cron and the cancellation flush so the two can never
+// report the same situation differently — see the package doc on marketplaceReporter.
+//
+// It sets rec.Synced and updates rec.Syncs in place but never persists: the cancellation flush
+// reports its final record before that record exists in the table, so persisting is the caller's
+// decision.
+//
+// The returned connection ids are the ones that accepted a real post on this call — the caller looks
+// each one up in rec.Syncs to log it. Skips are excluded — one already logged itself where the skip
+// was decided, and calling it "synced" would claim something was posted when nothing was.
+func (r *marketplaceReporter) reportRecordToConnections(
+	ctx context.Context,
+	rec *usagerecord.UsageRecord,
+	relevantConns []*preparedConnection,
+) (reportedConnIDs []string) {
+	if rec.Syncs == nil {
+		rec.Syncs = map[string]types.UsageRecordSyncEntry{}
+	}
+
+	for _, preparedConn := range relevantConns {
+		// A prior skip wrote an entry here too, so this correctly treats "already skipped" the same
+		// as "already reported" and never re-attempts it.
+		if _, alreadyReported := rec.Syncs[preparedConn.conn.ID]; alreadyReported {
+			continue
+		}
+
+		var entry types.UsageRecordSyncEntry
+		var ok bool
+		switch preparedConn.conn.ProviderType {
+		case types.SecretProviderAWSMarketplace:
+			entry, ok = r.reportAWSRecord(ctx, rec, preparedConn)
+		case types.SecretProviderGCPMarketplace:
+			entry, ok = r.reportGCPRecord(ctx, rec, preparedConn)
+		case types.SecretProviderAzureMarketplace:
+			entry, ok = r.reportAzureRecord(ctx, rec, preparedConn)
+		}
+		if !ok {
+			continue // already logged inside the provider method
+		}
+
+		rec.Syncs[preparedConn.conn.ID] = entry
+		if !entry.Skipped {
+			reportedConnIDs = append(reportedConnIDs, preparedConn.conn.ID)
+		}
+	}
+
+	// rec.Synced: every relevant connection has an entry, skip or real — a skip is a permanent fact
+	// about the record (the amount doesn't change on retry), so requiring a real post here would
+	// re-attempt an Azure skip forever.
+	rec.Synced = true
+	for _, preparedConn := range relevantConns {
+		if _, alreadyReported := rec.Syncs[preparedConn.conn.ID]; !alreadyReported {
+			rec.Synced = false
+			break
+		}
+	}
+
+	return reportedConnIDs
+}
+
+// anyRealEntry reports whether any of relevantConns has a real (non-skip) entry in rec.Syncs — the
+// caller uses this after reportRecordToConnections to tell "succeeded" apart from "skipped", since
+// both leave every relevant connection with an entry and rec.Synced true.
+func anyRealEntry(rec *usagerecord.UsageRecord, relevantConns []*preparedConnection) bool {
+	for _, preparedConn := range relevantConns {
+		if entry, ok := rec.Syncs[preparedConn.conn.ID]; ok && !entry.Skipped {
+			return true
+		}
+	}
+	return false
+}
+
+// ReportActivities reports usage records that have not yet reached every marketplace connection
+// relevant to them. For every tenant/environment with a published marketplace connection (AWS, GCP
+// or Azure), it authenticates each connection once, reads that tenant's unsynced usage records once,
+// and reports each record to whichever relevant connections it hasn't already reached. A record a
+func (r *marketplaceReporter) prepareConnection(ctx context.Context, conn *connection.Connection) (*preparedConnection, error) {
+	switch conn.ProviderType {
+	case types.SecretProviderAWSMarketplace:
+		creds, region, mappings, err := r.authAWSConnection(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		return &preparedConnection{conn: conn, awsCreds: creds, awsRegion: region, awsMappings: mappings}, nil
+	case types.SecretProviderGCPMarketplace:
+		svc, mappings, err := r.authGCPConnection(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		return &preparedConnection{conn: conn, gcpSvc: svc, gcpMappings: mappings}, nil
+	case types.SecretProviderAzureMarketplace:
+		token, mappings, err := r.authAzureConnection(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		return &preparedConnection{conn: conn, azureToken: token, azureMappings: mappings}, nil
+	}
+	return nil, ierr.NewErrorf("unsupported marketplace provider type %q", conn.ProviderType).Mark(ierr.ErrValidation)
+}
+
+// isEligibleForReport applies the validation common to every provider before any payload is built:
+// only USD is accepted (a non-USD record stays unsynced, retried once currency conversion lands),
+// and a negative amount is never valid on any provider — it means an upstream billing computation
+// produced a bad value, not a marketplace rejection, so it is left unsynced for investigation rather
+// than sent. A zero amount passes this check; whether it is reportable is provider-specific and is
+// decided in reportAzureRecord.
+// ---------------------------------------------------------------------------
+// AWS
+// ---------------------------------------------------------------------------
+
+// authAWSConnection decrypts a connection's AWS secret, loads its mappings, and assumes the tenant's
+// role once.
+func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *connection.Connection) (awssdk.Credentials, string, *awsConnectionMappings, error) {
+	tenantID := conn.TenantID
+	environmentID := conn.EnvironmentID
+
+	if conn.EncryptedSecretData.AWSMarketplace == nil {
+		err := ierr.NewError("connection has no aws_marketplace secret data").Mark(ierr.ErrValidation)
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
+		return awssdk.Credentials{}, "", nil, err
+	}
+
+	// The region is saved on the connection at creation time (sync_config.aws_marketplace.region,
+	// same home as S3's bucket/region); it selects the AWS Marketplace Metering endpoint and is required.
+	if conn.SyncConfig == nil || conn.SyncConfig.AWSMarketplace == nil || conn.SyncConfig.AWSMarketplace.Region == "" {
+		err := ierr.NewError("connection has no region in sync_config").Mark(ierr.ErrValidation)
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
+		return awssdk.Credentials{}, "", nil, err
+	}
+	region := conn.SyncConfig.AWSMarketplace.Region
+
+	roleArn, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AWSMarketplace.RoleArn)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_role_arn")
+		return awssdk.Credentials{}, "", nil, err
+	}
+	externalID, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AWSMarketplace.ExternalID)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_external_id")
+		return awssdk.Credentials{}, "", nil, err
+	}
+
+	mappings, err := r.loadAWSMappings(ctx)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
+		return awssdk.Credentials{}, "", nil, err
+	}
+
+	// Assume the tenant's role once; the same static credentials are reused for every record this
+	// connection reports (they are a one-time snapshot, not a live auto-refreshing provider). A busy
+	// tenant's loop can run close to the activity's 30-minute StartToCloseTimeout, so the session
+	// must outlive that — 1 hour is requested because every IAM role supports it without the tenant
+	// needing to raise MaxSessionDuration.
+	creds, err := r.awsClient.AssumeRole(ctx, roleArn, externalID, time.Hour)
+	if err != nil {
+		// err is already redacted of the role ARN and external ID by AssumeRole.
+		r.logger.Error(ctx, "marketplace usage report failed",
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID,
+			"region", region,
+			"error", err, "stage", "assume_role")
+		return awssdk.Credentials{}, "", nil, err
+	}
+
+	return creds, region, mappings, nil
+}
+
+// reportAWSRecord reports a single usage record to AWS and returns the sync entry to persist on
+// success.
+func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	mappings := preparedConn.awsMappings
+
+	licenseArn := mappings.licenseArnBySubscription[rec.SubscriptionID]
+	customerAWSAccountID := mappings.awsAccountByCustomer[rec.CustomerID]
+	plan, planFound := mappings.plan[rec.PlanID]
+	if licenseArn == "" || customerAWSAccountID == "" || !planFound || plan.dimension == "" {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
+			"error", "missing license_arn, customer_aws_account_id, or plan dimension mapping", "stage", "resolve_record")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	// ProductCode is sent only for legacy products; for concurrent-agreements products the license
+	// identifies the product and ProductCode must be omitted.
+	productCode := plan.productCode
+	if plan.concurrentAgreements {
+		productCode = ""
+	}
+
+	// Only called for USD records (see isEligibleForReport). AWS only accepts a whole number, so it's
+	// sent in USD cents — the tenant prices their dimension per cent. Turning cents into a charge is
+	// AWS's job: it bills quantity x the dimension's rate.
+	quantity := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
+	if quantity > math.MaxInt32 {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
+			"error", "quantity exceeds the maximum aws accepts", "stage", "convert_quantity")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	res, err := r.awsClient.BatchMeterUsage(ctx, preparedConn.awsCreds, preparedConn.awsRegion, awsmarketplace.UsageRecordInput{
+		CustomerAWSAccountID: customerAWSAccountID,
+		LicenseArn:           licenseArn,
+		ProductCode:          productCode,
+		Dimension:            plan.dimension,
+		Quantity:             int32(quantity),
+		// PeriodEnd is the timestamp so a retry sends an identical record and AWS de-duplicates it.
+		Timestamp: rec.PeriodEnd,
+	})
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"error", err, "stage", "batch_meter_usage")
+		return types.UsageRecordSyncEntry{}, false
+	}
+	if res == nil {
+		// AWS returned the record as unprocessed; leaving it unsynced retries it next run.
+		r.logger.Info(ctx, "marketplace usage record not processed by aws, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	// A present result is not the same as an accepted record — AWS's Status must be checked. Only
+	// StatusSuccess means the record was honored; the other two are distinct failure modes with
+	// different causes, so each gets its own log line.
+	switch res.Status {
+	case awsmarketplace.StatusSuccess:
+		// falls through to the return below
+	case awsmarketplace.StatusCustomerNotSubscribed:
+		// The buyer has no active agreement for this product, or their AWS account was suspended.
+		// Resolves itself once the buyer (re)subscribes, so it keeps retrying rather than needing
+		// manual action.
+		r.logger.Error(ctx, "marketplace usage report rejected by aws: customer not subscribed, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
+			"dimension", plan.dimension, "amount", rec.Amount, "error", "customer_not_subscribed")
+		return types.UsageRecordSyncEntry{}, false
+	case awsmarketplace.StatusDuplicateRecord:
+		// NOT "AWS already has this exact record, safe to skip" — AWS has a DIFFERENT record for the
+		// same customer+dimension+timestamp already on file, and rejected this one. Retrying with the
+		// same amount hits the same rejection every time; this needs a human to fix the mismatch.
+		r.logger.Error(ctx, "marketplace usage report rejected by aws: conflicts with a different record already on file, needs manual investigation", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
+			"dimension", plan.dimension, "amount", rec.Amount, "period_end", rec.PeriodEnd, "error", "duplicate_record")
+		return types.UsageRecordSyncEntry{}, false
+	default:
+		r.logger.Error(ctx, "marketplace usage report rejected by aws: unrecognized status, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"aws_status", res.Status, "error", "unrecognized_aws_status")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	return types.UsageRecordSyncEntry{
+		Marketplace: types.SecretProviderAWSMarketplace,
+		ReportingID: res.MeteringRecordID,
+		SyncedAt:    time.Now().UTC(),
+	}, true
+}
+
+// loadAWSMappings loads the subscription, customer and plan mappings for the current tenant/
+// environment and indexes them for lookup while reporting.
+func (r *marketplaceReporter) loadAWSMappings(ctx context.Context) (*awsConnectionMappings, error) {
+	providerType := string(types.SecretProviderAWSMarketplace)
+
+	subMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypeSubscription,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+	customerMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypeCustomer,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+	planMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypePlan,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m := &awsConnectionMappings{
+		licenseArnBySubscription: make(map[string]string, len(subMappings)),
+		awsAccountByCustomer:     make(map[string]string, len(customerMappings)),
+		plan:                     make(map[string]awsPlanMapping, len(planMappings)),
+	}
+	for _, sm := range subMappings {
+		m.licenseArnBySubscription[sm.EntityID] = sm.ProviderEntityID
+	}
+	for _, cm := range customerMappings {
+		m.awsAccountByCustomer[cm.EntityID] = cm.ProviderEntityID
+	}
+	for _, pm := range planMappings {
+		concurrent, _ := pm.Metadata["concurrent_agreements"].(bool)
+		dimension, _ := pm.Metadata["dimension"].(string)
+		m.plan[pm.EntityID] = awsPlanMapping{
+			productCode:          pm.ProviderEntityID,
+			dimension:            dimension,
+			concurrentAgreements: concurrent,
+		}
+	}
+	return m, nil
+}
+
+// ---------------------------------------------------------------------------
+// GCP
+// ---------------------------------------------------------------------------
+
+// authGCPConnection decrypts a connection's GCP secret, loads its mappings, and performs the WIF
+// exchange once.
+func (r *marketplaceReporter) authGCPConnection(ctx context.Context, conn *connection.Connection) (*servicecontrol.Service, *gcpConnectionMappings, error) {
+	tenantID := conn.TenantID
+	environmentID := conn.EnvironmentID
+
+	if conn.EncryptedSecretData.GCPMarketplace == nil {
+		err := ierr.NewError("connection has no gcp_marketplace secret data").Mark(ierr.ErrValidation)
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
+		return nil, nil, err
+	}
+
+	credentialsJSON, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.GCPMarketplace.CredentialsJSON)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_credentials_json")
+		return nil, nil, err
+	}
+
+	mappings, err := r.loadGCPMappings(ctx)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
+		return nil, nil, err
+	}
+
+	// One WIF exchange per connection; the resulting client is reused for every record this
+	// connection reports, mirroring the single AssumeRole-per-connection pattern on the AWS path.
+	svc, err := r.gcpClient.WifSession(ctx, credentialsJSON)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "wif_session")
+		return nil, nil, err
+	}
+
+	return svc, mappings, nil
+}
+
+// reportGCPRecord reports a single usage record to GCP and returns the sync entry to persist on
+// success.
+func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	mappings := preparedConn.gcpMappings
+
+	consumerID := mappings.usageReportingIDBySubscription[rec.SubscriptionID]
+	plan, planFound := mappings.plan[rec.PlanID]
+	if consumerID == "" || !planFound || plan.serviceName == "" || plan.metricName == "" {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
+			"error", "missing usage_reporting_id or plan service_name/metric_name mapping", "stage", "resolve_record")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	// Only called for USD records (see isEligibleForReport). GCP accepts an int64 value, and
+	// ToSmallestUnit already returns int64, so unlike AWS's int32 Quantity there's no overflow guard.
+	cents := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
+
+	reportResult, err := r.gcpClient.Report(ctx, preparedConn.gcpSvc, gcpmarketplace.UsageReportInput{
+		ServiceName: plan.serviceName,
+		ConsumerID:  consumerID,
+		MetricName:  plan.metricName,
+		ValueCents:  cents,
+		// OperationID = the record's own id, so a retry sends an identical operation and GCP de-dupes.
+		OperationID: rec.ID,
+		StartTime:   rec.PeriodStart,
+		EndTime:     rec.PeriodEnd,
+	})
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "error", err, "stage", "services_report")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	// HTTP 200 is not the same as accepted — reportErrors must be checked. Common codes:
+	// 5=NOT_FOUND (consumer inactive), 7=PERMISSION_DENIED, 3=INVALID_ARGUMENT.
+	if !reportResult.Accepted {
+		r.logger.Error(ctx, "marketplace usage report rejected by gcp, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "error", "rejected_by_gcp", "error_code", reportResult.ErrorCode,
+			"error_message", reportResult.ErrorMessage)
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	// GCP returns no per-record receipt; the operationId echoed back (== rec.ID) becomes this
+	// connection's reporting_id, read from the result rather than re-derived.
+	return types.UsageRecordSyncEntry{
+		Marketplace: types.SecretProviderGCPMarketplace,
+		ReportingID: reportResult.OperationID,
+		SyncedAt:    time.Now().UTC(),
+	}, true
+}
+
+// loadGCPMappings loads the subscription and plan mappings for the current tenant/environment and
+// indexes them for lookup while reporting.
+func (r *marketplaceReporter) loadGCPMappings(ctx context.Context) (*gcpConnectionMappings, error) {
+	providerType := string(types.SecretProviderGCPMarketplace)
+
+	subMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypeSubscription,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+	planMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypePlan,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m := &gcpConnectionMappings{
+		usageReportingIDBySubscription: make(map[string]string, len(subMappings)),
+		plan:                           make(map[string]gcpPlanMapping, len(planMappings)),
+	}
+	for _, sm := range subMappings {
+		m.usageReportingIDBySubscription[sm.EntityID] = sm.ProviderEntityID
+	}
+	for _, pm := range planMappings {
+		metricName, _ := pm.Metadata["metric_name"].(string)
+		m.plan[pm.EntityID] = gcpPlanMapping{
+			serviceName: pm.ProviderEntityID,
+			metricName:  metricName,
+		}
+	}
+	return m, nil
+}
+
+// ---------------------------------------------------------------------------
+// Azure
+// ---------------------------------------------------------------------------
+
+// authAzureConnection decrypts a connection's Azure secret, loads its mappings, and requests a
+// client_credentials token once.
+func (r *marketplaceReporter) authAzureConnection(ctx context.Context, conn *connection.Connection) (azuremarketplace.Token, *azureConnectionMappings, error) {
+	tenantID := conn.TenantID
+	environmentID := conn.EnvironmentID
+
+	if conn.EncryptedSecretData.AzureMarketplace == nil {
+		err := ierr.NewError("connection has no azure_marketplace secret data").Mark(ierr.ErrValidation)
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
+		return azuremarketplace.Token{}, nil, err
+	}
+
+	azureTenantID, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.TenantID)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_tenant_id")
+		return azuremarketplace.Token{}, nil, err
+	}
+	clientID, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.ClientID)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_client_id")
+		return azuremarketplace.Token{}, nil, err
+	}
+	clientSecret, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.ClientSecret)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_client_secret")
+		return azuremarketplace.Token{}, nil, err
+	}
+
+	mappings, err := r.loadAzureMappings(ctx)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
+		return azuremarketplace.Token{}, nil, err
+	}
+
+	// One token request per connection; the resulting token is reused for every record this
+	// connection reports, mirroring the AssumeRole/WifSession pattern on the AWS/GCP paths.
+	token, err := r.azureClient.GetToken(ctx, azureTenantID, clientID, clientSecret)
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "get_token")
+		return azuremarketplace.Token{}, nil, err
+	}
+
+	return token, mappings, nil
+}
+
+// reportAzureRecord reports a single usage record to Azure and returns the sync entry to persist on
+// success. A row whose reportable quantity is zero cents is never sent — Azure treats a quantity
+// of zero as invalid — and instead resolves this connection with Skipped=true, so a record is not
+// permanently blocked from reaching synced=true just because Azure cannot accept a zero quantity.
+func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	mappings := preparedConn.azureMappings
+
+	resourceID := mappings.resourceIDBySubscription[rec.SubscriptionID]
+	plan, planFound := mappings.plan[rec.PlanID]
+	if resourceID == "" || !planFound || plan.planID == "" || plan.dimension == "" {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
+			"error", "missing resource_id or plan plan_id/dimension mapping", "stage", "resolve_record")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	// Only called for USD records (see isEligibleForReport). Azure's quantity is a double, but is
+	// always sent as a whole number of cents — the tenant prices their dimension per cent.
+	cents := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
+
+	// Skip on cents, not rec.Amount: a positive sub-cent amount rounds to zero cents and Azure
+	// rejects a zero quantity. Negatives are already filtered upstream (isEligibleForReport).
+	if cents == 0 {
+		r.logger.Info(ctx, "marketplace usage record skipped: zero quantity not supported by azure", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount)
+		return types.UsageRecordSyncEntry{
+			Marketplace: types.SecretProviderAzureMarketplace,
+			SyncedAt:    time.Now().UTC(),
+			Skipped:     true,
+			// Azure documents a quantity of zero as invalid, so this is never sent and never retried.
+			SkipReason: "zero_amount_not_supported",
+		}, true
+	}
+
+	res, err := r.azureClient.ReportUsageEvent(ctx, preparedConn.azureToken, azuremarketplace.UsageEventInput{
+		ResourceID: resourceID,
+		Dimension:  plan.dimension,
+		PlanID:     plan.planID,
+		Quantity:   float64(cents),
+		// PeriodEnd is effectiveStartTime so a retry sends an identical record.
+		EffectiveStartTime: rec.PeriodEnd,
+	})
+	// Azure has no "present result, check its status" step: the single-event endpoint's 200 response
+	// is unconditionally Accepted, and every rejection (Duplicate, Expired, invalid resource,
+	// malformed request) comes back as a distinct non-2xx status, which the client already turns into
+	// an error. Duplicate is ambiguous — nothing in a 409 confirms the existing event is ours — so any
+	// error here, rejection or transient failure alike, is left unsynced and retried next run, never
+	// resolved by inference.
+	if err != nil {
+		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
+			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "resource_id", resourceID, "dimension", plan.dimension, "amount", rec.Amount,
+			"error", err, "stage", "usage_event")
+		return types.UsageRecordSyncEntry{}, false
+	}
+
+	return types.UsageRecordSyncEntry{
+		Marketplace: types.SecretProviderAzureMarketplace,
+		ReportingID: res.UsageEventID,
+		SyncedAt:    time.Now().UTC(),
+	}, true
+}
+
+// loadAzureMappings loads the subscription and plan mappings for the current tenant/environment and
+// indexes them for lookup while reporting.
+func (r *marketplaceReporter) loadAzureMappings(ctx context.Context) (*azureConnectionMappings, error) {
+	providerType := string(types.SecretProviderAzureMarketplace)
+
+	subMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypeSubscription,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+	planMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
+		QueryFilter:   types.NewNoLimitPublishedQueryFilter(),
+		EntityType:    types.IntegrationEntityTypePlan,
+		ProviderTypes: []string{providerType},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m := &azureConnectionMappings{
+		resourceIDBySubscription: make(map[string]string, len(subMappings)),
+		plan:                     make(map[string]azurePlanMapping, len(planMappings)),
+	}
+	for _, sm := range subMappings {
+		m.resourceIDBySubscription[sm.EntityID] = sm.ProviderEntityID
+	}
+	for _, pm := range planMappings {
+		dimension, _ := pm.Metadata["dimension"].(string)
+		m.plan[pm.EntityID] = azurePlanMapping{
+			planID:    pm.ProviderEntityID,
+			dimension: dimension,
+		}
+	}
+	return m, nil
+}

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -24,15 +24,12 @@ import (
 // seller-facing currency selection.
 const marketplaceReportingCurrency = "usd"
 
-// MarketplaceReporter is exported only so registration can construct one; callers treat it as opaque.
-type MarketplaceReporter = marketplaceReporter
-
-// marketplaceReporter owns everything needed to authenticate a marketplace connection and report one
+// MarketplaceReporter owns everything needed to authenticate a marketplace connection and report one
 // usage record to it. It is deliberately not a Temporal activity: it is the shared implementation
 // behind both the scheduled reporting cron (ReportActivities) and the one-shot cancellation flush
 // (FlushActivities), so neither can drift from the other in how it talks to a provider. Both hold
 // the same instance rather than one activity reaching into the other.
-type marketplaceReporter struct {
+type MarketplaceReporter struct {
 	entityIntegrationMappingRepo entityintegrationmapping.Repository
 	encryptionService            security.EncryptionService
 	awsClient                    awsmarketplace.Client
@@ -49,8 +46,8 @@ func NewMarketplaceReporter(
 	gcpClient gcpmarketplace.Client,
 	azureClient azuremarketplace.Client,
 	log *logger.Logger,
-) *marketplaceReporter {
-	return &marketplaceReporter{
+) *MarketplaceReporter {
+	return &MarketplaceReporter{
 		entityIntegrationMappingRepo: params.EntityIntegrationMappingRepo,
 		encryptionService:            params.EncryptionService,
 		awsClient:                    awsClient,
@@ -99,9 +96,9 @@ type azureConnectionMappings struct {
 	plan                     map[string]azurePlanMapping
 }
 
-// preparedConnection is an authenticated connection with its entity mappings loaded, ready to report
+// marketplaceConnection is an authenticated connection with its entity mappings loaded, ready to report
 // records through. Only the fields for conn.ProviderType are populated.
-type preparedConnection struct {
+type marketplaceConnection struct {
 	conn *connection.Connection
 
 	awsCreds    awssdk.Credentials
@@ -115,126 +112,110 @@ type preparedConnection struct {
 	azureMappings *azureConnectionMappings
 }
 
-// isRelevantForSubscription reports whether this connection is mapped to subscriptionID — i.e.
-// whether a usage record for that subscription needs to reach it at all.
-func (preparedConn *preparedConnection) isRelevantForSubscription(subscriptionID string) bool {
-	switch preparedConn.conn.ProviderType {
+// hasAgreementFor reports whether the subscription holds an agreement on this connection's
+// marketplace, which is what makes a usage record for it reportable here.
+//
+// A subscription is never mapped to a connection: an entity mapping records the subscription's
+// identifier on a marketplace (license_arn, usage_reporting_id, resource_id) against a provider type,
+// and a connection is only the credentials for talking to that provider. Replacing the connection
+// leaves the agreement untouched.
+func (marketplaceConn *marketplaceConnection) hasAgreementFor(subscriptionID string) bool {
+	switch marketplaceConn.conn.ProviderType {
 	case types.SecretProviderAWSMarketplace:
-		return preparedConn.awsMappings != nil && preparedConn.awsMappings.licenseArnBySubscription[subscriptionID] != ""
+		return marketplaceConn.awsMappings != nil && marketplaceConn.awsMappings.licenseArnBySubscription[subscriptionID] != ""
 	case types.SecretProviderGCPMarketplace:
-		return preparedConn.gcpMappings != nil && preparedConn.gcpMappings.usageReportingIDBySubscription[subscriptionID] != ""
+		return marketplaceConn.gcpMappings != nil && marketplaceConn.gcpMappings.usageReportingIDBySubscription[subscriptionID] != ""
 	case types.SecretProviderAzureMarketplace:
-		return preparedConn.azureMappings != nil && preparedConn.azureMappings.resourceIDBySubscription[subscriptionID] != ""
+		return marketplaceConn.azureMappings != nil && marketplaceConn.azureMappings.resourceIDBySubscription[subscriptionID] != ""
 	}
 	return false
 }
 
-// relevantConnections returns the connections mapped to the record's subscription — those it must
-// reach before it can be considered synced.
-func relevantConnections(rec *usagerecord.UsageRecord, preparedConns []*preparedConnection) []*preparedConnection {
-	var relevant []*preparedConnection
-	for _, preparedConn := range preparedConns {
-		if preparedConn.isRelevantForSubscription(rec.SubscriptionID) {
-			relevant = append(relevant, preparedConn)
-		}
-	}
-	return relevant
-}
-
-// reportRecordToConnections reports rec to each of relevantConns that does not already hold a sync
-// entry, and sets rec.Synced once every one of them does.
+// reportRecordToMarketplaces reports a record to every marketplace its subscription holds an
+// agreement on that does not already hold a sync entry, and marks it synced once all of them do.
 //
-// It updates rec in place but never persists it: the final flush record is reported before it exists
-// in the table, so storing the outcome is left to the caller.
+// The record is updated in place but never persisted: the final flush record is reported before it
+// exists in the table, so storing the outcome is left to the caller.
 //
-// The returned connection ids are those that accepted the record on this call, for the caller to log;
-// the entry itself is on rec.Syncs. Skips are excluded — they are logged where the decision is made,
-// and reporting one as synced would claim something was sent when nothing was.
-func (r *marketplaceReporter) reportRecordToConnections(
+// Returns the marketplaces that accepted the record on this call, for the caller to log; the entry
+// itself is on the record. Skips are excluded, since they are logged where the decision is made and
+// reporting one as accepted would claim something was sent when nothing was.
+func (r *MarketplaceReporter) reportRecordToMarketplaces(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
-	relevantConns []*preparedConnection,
-) (reportedConnIDs []string) {
+	reportableConns []*marketplaceConnection,
+) (reportedMarketplaces []string) {
 	if rec.Syncs == nil {
 		rec.Syncs = map[string]types.UsageRecordSyncEntry{}
 	}
 
-	for _, preparedConn := range relevantConns {
-		// A skip leaves an entry as well, so a connection that skipped this record is treated as
-		// resolved and never attempted again.
-		if _, alreadyReported := rec.Syncs[preparedConn.conn.ID]; alreadyReported {
+	for _, marketplaceConn := range reportableConns {
+		marketplace := string(marketplaceConn.conn.ProviderType)
+		// A skip leaves an entry as well, so a marketplace that skipped this record is treated as
+		// resolved and never attempted again. Only a complete entry counts: a half-written one is
+		// retried rather than mistaken for a report that already happened.
+		if entry, ok := rec.Syncs[marketplace]; ok && entry.IsResolved() {
 			continue
 		}
 
 		var entry types.UsageRecordSyncEntry
 		var ok bool
-		switch preparedConn.conn.ProviderType {
+		switch marketplaceConn.conn.ProviderType {
 		case types.SecretProviderAWSMarketplace:
-			entry, ok = r.reportAWSRecord(ctx, rec, preparedConn)
+			entry, ok = r.reportAWSRecord(ctx, rec, marketplaceConn)
 		case types.SecretProviderGCPMarketplace:
-			entry, ok = r.reportGCPRecord(ctx, rec, preparedConn)
+			entry, ok = r.reportGCPRecord(ctx, rec, marketplaceConn)
 		case types.SecretProviderAzureMarketplace:
-			entry, ok = r.reportAzureRecord(ctx, rec, preparedConn)
+			entry, ok = r.reportAzureRecord(ctx, rec, marketplaceConn)
 		}
 		if !ok {
 			continue // already logged inside the provider method
 		}
 
-		rec.Syncs[preparedConn.conn.ID] = entry
+		rec.Syncs[marketplace] = entry
 		if !entry.Skipped {
-			reportedConnIDs = append(reportedConnIDs, preparedConn.conn.ID)
+			reportedMarketplaces = append(reportedMarketplaces, marketplace)
 		}
 	}
 
-	// Synced means every relevant connection is resolved, whether it accepted the record or skipped
+	// Synced means every marketplace with an agreement is resolved, whether it accepted or skipped
 	// it. A skip is permanent — the amount will not change on a retry — so requiring an acceptance
 	// here would leave the record pending forever.
 	rec.Synced = true
-	for _, preparedConn := range relevantConns {
-		if _, alreadyReported := rec.Syncs[preparedConn.conn.ID]; !alreadyReported {
+	for _, marketplaceConn := range reportableConns {
+		entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]
+		if !ok || !entry.IsResolved() {
 			rec.Synced = false
 			break
 		}
 	}
 
-	return reportedConnIDs
+	return reportedMarketplaces
 }
 
-// anyRealEntry reports whether any relevant connection actually accepted the record, as opposed to
-// every one of them skipping it. Both outcomes leave the record synced, so this is what separates a
-// record that reached a marketplace from one that never did.
-func anyRealEntry(rec *usagerecord.UsageRecord, relevantConns []*preparedConnection) bool {
-	for _, preparedConn := range relevantConns {
-		if entry, ok := rec.Syncs[preparedConn.conn.ID]; ok && !entry.Skipped {
-			return true
-		}
-	}
-	return false
-}
-
-// prepareConnection authenticates one connection and loads its provider's entity mappings, returning
+// prepareMarketplaceConnection authenticates one connection and loads its provider's entity mappings, returning
 // a handle ready to report records through. Called once per connection per run, before any record is
 // touched, so a failure here defers every record for that connection.
-func (r *marketplaceReporter) prepareConnection(ctx context.Context, conn *connection.Connection) (*preparedConnection, error) {
+func (r *MarketplaceReporter) prepareMarketplaceConnection(ctx context.Context, conn *connection.Connection) (*marketplaceConnection, error) {
 	switch conn.ProviderType {
 	case types.SecretProviderAWSMarketplace:
 		creds, region, mappings, err := r.authAWSConnection(ctx, conn)
 		if err != nil {
 			return nil, err
 		}
-		return &preparedConnection{conn: conn, awsCreds: creds, awsRegion: region, awsMappings: mappings}, nil
+		return &marketplaceConnection{conn: conn, awsCreds: creds, awsRegion: region, awsMappings: mappings}, nil
 	case types.SecretProviderGCPMarketplace:
 		svc, mappings, err := r.authGCPConnection(ctx, conn)
 		if err != nil {
 			return nil, err
 		}
-		return &preparedConnection{conn: conn, gcpSvc: svc, gcpMappings: mappings}, nil
+		return &marketplaceConnection{conn: conn, gcpSvc: svc, gcpMappings: mappings}, nil
 	case types.SecretProviderAzureMarketplace:
 		token, mappings, err := r.authAzureConnection(ctx, conn)
 		if err != nil {
 			return nil, err
 		}
-		return &preparedConnection{conn: conn, azureToken: token, azureMappings: mappings}, nil
+		return &marketplaceConnection{conn: conn, azureToken: token, azureMappings: mappings}, nil
 	}
 	return nil, ierr.NewErrorf("unsupported marketplace provider type %q", conn.ProviderType).Mark(ierr.ErrValidation)
 }
@@ -245,9 +226,9 @@ func (r *marketplaceReporter) prepareConnection(ctx context.Context, conn *conne
 // produced a bad value, not a marketplace rejection, so it is left unsynced for investigation rather
 // than sent. A zero amount passes this check; whether it is reportable is provider-specific and is
 // decided in reportAzureRecord.
-func (r *marketplaceReporter) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
+func (r *MarketplaceReporter) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
 	if !types.IsMatchingCurrency(rec.Currency, marketplaceReportingCurrency) {
-		r.logger.Debug(ctx, "marketplace usage report: skipping usage record, currency is not usd",
+		r.logger.Info(ctx, "marketplace usage report: skipping usage record, currency is not usd",
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "currency", rec.Currency)
 		return false
 	}
@@ -266,7 +247,7 @@ func (r *marketplaceReporter) isEligibleForReport(ctx context.Context, rec *usag
 
 // authAWSConnection decrypts a connection's AWS secret, loads its mappings, and assumes the tenant's
 // role once.
-func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *connection.Connection) (awssdk.Credentials, string, *awsConnectionMappings, error) {
+func (r *MarketplaceReporter) authAWSConnection(ctx context.Context, conn *connection.Connection) (awssdk.Credentials, string, *awsConnectionMappings, error) {
 	tenantID := conn.TenantID
 	environmentID := conn.EnvironmentID
 
@@ -327,18 +308,18 @@ func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *conne
 
 // reportAWSRecord reports a single usage record to AWS and returns the sync entry to persist on
 // success.
-func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
+func (r *MarketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerecord.UsageRecord, marketplaceConn *marketplaceConnection) (types.UsageRecordSyncEntry, bool) {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
-	mappings := preparedConn.awsMappings
+	mappings := marketplaceConn.awsMappings
 
 	licenseArn := mappings.licenseArnBySubscription[rec.SubscriptionID]
 	customerAWSAccountID := mappings.awsAccountByCustomer[rec.CustomerID]
 	plan, planFound := mappings.plan[rec.PlanID]
 	if licenseArn == "" || customerAWSAccountID == "" || !planFound || plan.dimension == "" {
-		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
+			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", marketplaceConn.conn.ID,
 			"error", "missing license_arn, customer_aws_account_id, or plan dimension mapping", "stage", "resolve_record")
 		return types.UsageRecordSyncEntry{}, false
 	}
@@ -355,14 +336,14 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 	// AWS's job: it bills quantity x the dimension's rate.
 	quantity := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
 	if quantity > math.MaxInt32 {
-		r.logger.Error(ctx, "marketplace usage report: failed to convert amount to an aws quantity", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to convert amount to an aws quantity", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
 			"error", "quantity exceeds the maximum aws accepts", "stage", "convert_quantity")
 		return types.UsageRecordSyncEntry{}, false
 	}
 
-	res, err := r.awsClient.BatchMeterUsage(ctx, preparedConn.awsCreds, preparedConn.awsRegion, awsmarketplace.UsageRecordInput{
+	res, err := r.awsClient.BatchMeterUsage(ctx, marketplaceConn.awsCreds, marketplaceConn.awsRegion, awsmarketplace.UsageRecordInput{
 		CustomerAWSAccountID: customerAWSAccountID,
 		LicenseArn:           licenseArn,
 		ProductCode:          productCode,
@@ -372,17 +353,17 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 		Timestamp: rec.PeriodEnd,
 	})
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report: aws batch meter usage call failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws batch meter usage call failed", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
 			"error", err, "stage", "batch_meter_usage")
 		return types.UsageRecordSyncEntry{}, false
 	}
 	if res == nil {
 		// AWS returned the record as unprocessed; leaving it unsynced retries it next run.
-		r.logger.Info(ctx, "marketplace usage report: aws did not process the usage record, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Info(ctx, "marketplace usage report: aws did not process the usage record, will retry next run", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
 		return types.UsageRecordSyncEntry{}, false
 	}
 
@@ -396,38 +377,39 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 		// The buyer has no active agreement for this product, or their AWS account was suspended.
 		// Resolves itself once the buyer (re)subscribes, so it keeps retrying rather than needing
 		// manual action.
-		r.logger.Error(ctx, "marketplace usage report: aws rejected the usage record, customer not subscribed, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws rejected the usage record, customer not subscribed, will retry next run", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
 			"dimension", plan.dimension, "amount", rec.Amount, "error", "customer_not_subscribed")
 		return types.UsageRecordSyncEntry{}, false
 	case awsmarketplace.StatusDuplicateRecord:
 		// NOT "AWS already has this exact record, safe to skip" — AWS has a DIFFERENT record for the
 		// same customer+dimension+timestamp already on file, and rejected this one. Retrying with the
 		// same amount hits the same rejection every time; this needs a human to fix the mismatch.
-		r.logger.Error(ctx, "marketplace usage report: aws rejected the usage record, it conflicts with a different record already on file, needs manual investigation", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws rejected the usage record, it conflicts with a different record already on file, needs manual investigation", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
 			"dimension", plan.dimension, "amount", rec.Amount, "period_end", rec.PeriodEnd, "error", "duplicate_record")
 		return types.UsageRecordSyncEntry{}, false
 	default:
-		r.logger.Error(ctx, "marketplace usage report: aws returned an unrecognized status, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws returned an unrecognized status, will retry next run", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
 			"aws_status", res.Status, "error", "unrecognized_aws_status")
 		return types.UsageRecordSyncEntry{}, false
 	}
 
 	return types.UsageRecordSyncEntry{
-		Marketplace: types.SecretProviderAWSMarketplace,
-		ReportingID: res.MeteringRecordID,
-		SyncedAt:    time.Now().UTC(),
+		AgreementID:  licenseArn,
+		ReportingID:  res.MeteringRecordID,
+		SyncedAt:     time.Now().UTC(),
+		ConnectionID: marketplaceConn.conn.ID,
 	}, true
 }
 
 // loadAWSMappings loads the subscription, customer and plan mappings for the current tenant/
 // environment and indexes them for lookup while reporting.
-func (r *marketplaceReporter) loadAWSMappings(ctx context.Context) (*awsConnectionMappings, error) {
+func (r *MarketplaceReporter) loadAWSMappings(ctx context.Context) (*awsConnectionMappings, error) {
 	providerType := string(types.SecretProviderAWSMarketplace)
 
 	subMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
@@ -484,7 +466,7 @@ func (r *marketplaceReporter) loadAWSMappings(ctx context.Context) (*awsConnecti
 
 // authGCPConnection decrypts a connection's GCP secret, loads its mappings, and performs the WIF
 // exchange once.
-func (r *marketplaceReporter) authGCPConnection(ctx context.Context, conn *connection.Connection) (*servicecontrol.Service, *gcpConnectionMappings, error) {
+func (r *MarketplaceReporter) authGCPConnection(ctx context.Context, conn *connection.Connection) (*servicecontrol.Service, *gcpConnectionMappings, error) {
 	tenantID := conn.TenantID
 	environmentID := conn.EnvironmentID
 
@@ -523,17 +505,17 @@ func (r *marketplaceReporter) authGCPConnection(ctx context.Context, conn *conne
 
 // reportGCPRecord reports a single usage record to GCP and returns the sync entry to persist on
 // success.
-func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
+func (r *MarketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerecord.UsageRecord, marketplaceConn *marketplaceConnection) (types.UsageRecordSyncEntry, bool) {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
-	mappings := preparedConn.gcpMappings
+	mappings := marketplaceConn.gcpMappings
 
 	consumerID := mappings.usageReportingIDBySubscription[rec.SubscriptionID]
 	plan, planFound := mappings.plan[rec.PlanID]
 	if consumerID == "" || !planFound || plan.serviceName == "" || plan.metricName == "" {
-		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
+			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", marketplaceConn.conn.ID,
 			"error", "missing usage_reporting_id or plan service_name/metric_name mapping", "stage", "resolve_record")
 		return types.UsageRecordSyncEntry{}, false
 	}
@@ -542,7 +524,7 @@ func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerec
 	// ToSmallestUnit already returns int64, so unlike AWS's int32 Quantity there's no overflow guard.
 	cents := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
 
-	reportResult, err := r.gcpClient.Report(ctx, preparedConn.gcpSvc, gcpmarketplace.UsageReportInput{
+	reportResult, err := r.gcpClient.Report(ctx, marketplaceConn.gcpSvc, gcpmarketplace.UsageReportInput{
 		ServiceName: plan.serviceName,
 		ConsumerID:  consumerID,
 		MetricName:  plan.metricName,
@@ -553,18 +535,18 @@ func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerec
 		EndTime:     rec.PeriodEnd,
 	})
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report: gcp services report call failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: gcp services report call failed", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "error", err, "stage", "services_report")
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "error", err, "stage", "services_report")
 		return types.UsageRecordSyncEntry{}, false
 	}
 
 	// HTTP 200 is not the same as accepted — reportErrors must be checked. Common codes:
 	// 5=NOT_FOUND (consumer inactive), 7=PERMISSION_DENIED, 3=INVALID_ARGUMENT.
 	if !reportResult.Accepted {
-		r.logger.Error(ctx, "marketplace usage report: gcp rejected the usage record, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: gcp rejected the usage record, will retry next run", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "error", "rejected_by_gcp", "error_code", reportResult.ErrorCode,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "error", "rejected_by_gcp", "error_code", reportResult.ErrorCode,
 			"error_message", reportResult.ErrorMessage)
 		return types.UsageRecordSyncEntry{}, false
 	}
@@ -572,15 +554,16 @@ func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerec
 	// GCP returns no per-record receipt; the operationId echoed back (== rec.ID) becomes this
 	// connection's reporting_id, read from the result rather than re-derived.
 	return types.UsageRecordSyncEntry{
-		Marketplace: types.SecretProviderGCPMarketplace,
-		ReportingID: reportResult.OperationID,
-		SyncedAt:    time.Now().UTC(),
+		AgreementID:  consumerID,
+		ReportingID:  reportResult.OperationID,
+		SyncedAt:     time.Now().UTC(),
+		ConnectionID: marketplaceConn.conn.ID,
 	}, true
 }
 
 // loadGCPMappings loads the subscription and plan mappings for the current tenant/environment and
 // indexes them for lookup while reporting.
-func (r *marketplaceReporter) loadGCPMappings(ctx context.Context) (*gcpConnectionMappings, error) {
+func (r *MarketplaceReporter) loadGCPMappings(ctx context.Context) (*gcpConnectionMappings, error) {
 	providerType := string(types.SecretProviderGCPMarketplace)
 
 	subMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
@@ -623,7 +606,7 @@ func (r *marketplaceReporter) loadGCPMappings(ctx context.Context) (*gcpConnecti
 
 // authAzureConnection decrypts a connection's Azure secret, loads its mappings, and requests a
 // client_credentials token once.
-func (r *marketplaceReporter) authAzureConnection(ctx context.Context, conn *connection.Connection) (azuremarketplace.Token, *azureConnectionMappings, error) {
+func (r *MarketplaceReporter) authAzureConnection(ctx context.Context, conn *connection.Connection) (azuremarketplace.Token, *azureConnectionMappings, error) {
 	tenantID := conn.TenantID
 	environmentID := conn.EnvironmentID
 
@@ -676,17 +659,17 @@ func (r *marketplaceReporter) authAzureConnection(ctx context.Context, conn *con
 // success. A row whose reportable quantity is zero cents is never sent — Azure treats a quantity
 // of zero as invalid — and instead resolves this connection with Skipped=true, so a record is not
 // permanently blocked from reaching synced=true just because Azure cannot accept a zero quantity.
-func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usagerecord.UsageRecord, preparedConn *preparedConnection) (types.UsageRecordSyncEntry, bool) {
+func (r *MarketplaceReporter) reportAzureRecord(ctx context.Context, rec *usagerecord.UsageRecord, marketplaceConn *marketplaceConnection) (types.UsageRecordSyncEntry, bool) {
 	tenantID := types.GetTenantID(ctx)
 	environmentID := types.GetEnvironmentID(ctx)
-	mappings := preparedConn.azureMappings
+	mappings := marketplaceConn.azureMappings
 
 	resourceID := mappings.resourceIDBySubscription[rec.SubscriptionID]
 	plan, planFound := mappings.plan[rec.PlanID]
 	if resourceID == "" || !planFound || plan.planID == "" || plan.dimension == "" {
-		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
+			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", marketplaceConn.conn.ID,
 			"error", "missing resource_id or plan plan_id/dimension mapping", "stage", "resolve_record")
 		return types.UsageRecordSyncEntry{}, false
 	}
@@ -698,19 +681,20 @@ func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usager
 	// Skip on cents, not rec.Amount: a positive sub-cent amount rounds to zero cents and Azure
 	// rejects a zero quantity. Negatives are already filtered upstream (isEligibleForReport).
 	if cents == 0 {
-		r.logger.Info(ctx, "marketplace usage report: skipping usage record for azure, it does not accept a zero quantity", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Info(ctx, "marketplace usage report: skipping usage record for azure, it does not accept a zero quantity", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount)
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "amount", rec.Amount)
 		return types.UsageRecordSyncEntry{
-			Marketplace: types.SecretProviderAzureMarketplace,
-			SyncedAt:    time.Now().UTC(),
-			Skipped:     true,
+			AgreementID:  resourceID,
+			SyncedAt:     time.Now().UTC(),
+			ConnectionID: marketplaceConn.conn.ID,
+			Skipped:      true,
 			// Azure documents a quantity of zero as invalid, so this is never sent and never retried.
 			SkipReason: "zero_amount_not_supported",
 		}, true
 	}
 
-	res, err := r.azureClient.ReportUsageEvent(ctx, preparedConn.azureToken, azuremarketplace.UsageEventInput{
+	res, err := r.azureClient.ReportUsageEvent(ctx, marketplaceConn.azureToken, azuremarketplace.UsageEventInput{
 		ResourceID: resourceID,
 		Dimension:  plan.dimension,
 		PlanID:     plan.planID,
@@ -725,23 +709,24 @@ func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usager
 	// error here, rejection or transient failure alike, is left unsynced and retried next run, never
 	// resolved by inference.
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report: azure usage event call failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: azure usage event call failed", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
-			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "resource_id", resourceID, "dimension", plan.dimension, "amount", rec.Amount,
+			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "resource_id", resourceID, "dimension", plan.dimension, "amount", rec.Amount,
 			"error", err, "stage", "usage_event")
 		return types.UsageRecordSyncEntry{}, false
 	}
 
 	return types.UsageRecordSyncEntry{
-		Marketplace: types.SecretProviderAzureMarketplace,
-		ReportingID: res.UsageEventID,
-		SyncedAt:    time.Now().UTC(),
+		AgreementID:  resourceID,
+		ReportingID:  res.UsageEventID,
+		SyncedAt:     time.Now().UTC(),
+		ConnectionID: marketplaceConn.conn.ID,
 	}, true
 }
 
 // loadAzureMappings loads the subscription and plan mappings for the current tenant/environment and
 // indexes them for lookup while reporting.
-func (r *marketplaceReporter) loadAzureMappings(ctx context.Context) (*azureConnectionMappings, error) {
+func (r *MarketplaceReporter) loadAzureMappings(ctx context.Context) (*azureConnectionMappings, error) {
 	providerType := string(types.SecretProviderAzureMarketplace)
 
 	subMappings, err := r.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -99,9 +99,8 @@ type azureConnectionMappings struct {
 	plan                     map[string]azurePlanMapping
 }
 
-// preparedConnection is a published marketplace connection that's been authenticated and had its
-// mappings loaded, ready to report records through. Exactly one provider's fields are set, matching
-// conn.ProviderType.
+// preparedConnection is an authenticated connection with its entity mappings loaded, ready to report
+// records through. Only the fields for conn.ProviderType are populated.
 type preparedConnection struct {
 	conn *connection.Connection
 
@@ -130,9 +129,8 @@ func (preparedConn *preparedConnection) isRelevantForSubscription(subscriptionID
 	return false
 }
 
-// relevantConnections returns the subset of preparedConns mapped to rec's subscription. Callers use
-// this both to decide whether there's anything to report and, after reporting, to read back which of
-// those connections' entries in rec.Syncs are real vs. skipped.
+// relevantConnections returns the connections mapped to the record's subscription — those it must
+// reach before it can be considered synced.
 func relevantConnections(rec *usagerecord.UsageRecord, preparedConns []*preparedConnection) []*preparedConnection {
 	var relevant []*preparedConnection
 	for _, preparedConn := range preparedConns {
@@ -143,17 +141,15 @@ func relevantConnections(rec *usagerecord.UsageRecord, preparedConns []*prepared
 	return relevant
 }
 
-// reportRecordToConnections reports rec to every one of relevantConns that doesn't already have a
-// sync entry. Shared by the scheduled report cron and the cancellation flush so the two can never
-// report the same situation differently — see the package doc on marketplaceReporter.
+// reportRecordToConnections reports rec to each of relevantConns that does not already hold a sync
+// entry, and sets rec.Synced once every one of them does.
 //
-// It sets rec.Synced and updates rec.Syncs in place but never persists: the cancellation flush
-// reports its final record before that record exists in the table, so persisting is the caller's
-// decision.
+// It updates rec in place but never persists it: the final flush record is reported before it exists
+// in the table, so storing the outcome is left to the caller.
 //
-// The returned connection ids are the ones that accepted a real post on this call — the caller looks
-// each one up in rec.Syncs to log it. Skips are excluded — one already logged itself where the skip
-// was decided, and calling it "synced" would claim something was posted when nothing was.
+// The returned connection ids are those that accepted the record on this call, for the caller to log;
+// the entry itself is on rec.Syncs. Skips are excluded — they are logged where the decision is made,
+// and reporting one as synced would claim something was sent when nothing was.
 func (r *marketplaceReporter) reportRecordToConnections(
 	ctx context.Context,
 	rec *usagerecord.UsageRecord,
@@ -164,8 +160,8 @@ func (r *marketplaceReporter) reportRecordToConnections(
 	}
 
 	for _, preparedConn := range relevantConns {
-		// A prior skip wrote an entry here too, so this correctly treats "already skipped" the same
-		// as "already reported" and never re-attempts it.
+		// A skip leaves an entry as well, so a connection that skipped this record is treated as
+		// resolved and never attempted again.
 		if _, alreadyReported := rec.Syncs[preparedConn.conn.ID]; alreadyReported {
 			continue
 		}
@@ -190,9 +186,9 @@ func (r *marketplaceReporter) reportRecordToConnections(
 		}
 	}
 
-	// rec.Synced: every relevant connection has an entry, skip or real — a skip is a permanent fact
-	// about the record (the amount doesn't change on retry), so requiring a real post here would
-	// re-attempt an Azure skip forever.
+	// Synced means every relevant connection is resolved, whether it accepted the record or skipped
+	// it. A skip is permanent — the amount will not change on a retry — so requiring an acceptance
+	// here would leave the record pending forever.
 	rec.Synced = true
 	for _, preparedConn := range relevantConns {
 		if _, alreadyReported := rec.Syncs[preparedConn.conn.ID]; !alreadyReported {
@@ -204,9 +200,9 @@ func (r *marketplaceReporter) reportRecordToConnections(
 	return reportedConnIDs
 }
 
-// anyRealEntry reports whether any of relevantConns has a real (non-skip) entry in rec.Syncs — the
-// caller uses this after reportRecordToConnections to tell "succeeded" apart from "skipped", since
-// both leave every relevant connection with an entry and rec.Synced true.
+// anyRealEntry reports whether any relevant connection actually accepted the record, as opposed to
+// every one of them skipping it. Both outcomes leave the record synced, so this is what separates a
+// record that reached a marketplace from one that never did.
 func anyRealEntry(rec *usagerecord.UsageRecord, relevantConns []*preparedConnection) bool {
 	for _, preparedConn := range relevantConns {
 		if entry, ok := rec.Syncs[preparedConn.conn.ID]; ok && !entry.Skipped {
@@ -216,10 +212,9 @@ func anyRealEntry(rec *usagerecord.UsageRecord, relevantConns []*preparedConnect
 	return false
 }
 
-// ReportActivities reports usage records that have not yet reached every marketplace connection
-// relevant to them. For every tenant/environment with a published marketplace connection (AWS, GCP
-// or Azure), it authenticates each connection once, reads that tenant's unsynced usage records once,
-// and reports each record to whichever relevant connections it hasn't already reached. A record a
+// prepareConnection authenticates one connection and loads its provider's entity mappings, returning
+// a handle ready to report records through. Called once per connection per run, before any record is
+// touched, so a failure here defers every record for that connection.
 func (r *marketplaceReporter) prepareConnection(ctx context.Context, conn *connection.Connection) (*preparedConnection, error) {
 	switch conn.ProviderType {
 	case types.SecretProviderAWSMarketplace:
@@ -250,6 +245,21 @@ func (r *marketplaceReporter) prepareConnection(ctx context.Context, conn *conne
 // produced a bad value, not a marketplace rejection, so it is left unsynced for investigation rather
 // than sent. A zero amount passes this check; whether it is reportable is provider-specific and is
 // decided in reportAzureRecord.
+func (r *marketplaceReporter) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
+	if !types.IsMatchingCurrency(rec.Currency, marketplaceReportingCurrency) {
+		r.logger.Debug(ctx, "skipping marketplace usage record, currency not usd",
+			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "currency", rec.Currency)
+		return false
+	}
+	if rec.Amount.IsNegative() {
+		r.logger.Error(ctx, "marketplace usage record has negative amount",
+			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "amount", rec.Amount,
+			"error", "negative_amount")
+		return false
+	}
+	return true
+}
+
 // ---------------------------------------------------------------------------
 // AWS
 // ---------------------------------------------------------------------------

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -247,12 +247,12 @@ func (r *marketplaceReporter) prepareConnection(ctx context.Context, conn *conne
 // decided in reportAzureRecord.
 func (r *marketplaceReporter) isEligibleForReport(ctx context.Context, rec *usagerecord.UsageRecord) bool {
 	if !types.IsMatchingCurrency(rec.Currency, marketplaceReportingCurrency) {
-		r.logger.Debug(ctx, "skipping marketplace usage record, currency not usd",
+		r.logger.Debug(ctx, "marketplace usage report: skipping usage record, currency is not usd",
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "currency", rec.Currency)
 		return false
 	}
 	if rec.Amount.IsNegative() {
-		r.logger.Error(ctx, "marketplace usage record has negative amount",
+		r.logger.Error(ctx, "marketplace usage report: skipping usage record, amount is negative",
 			"subscription_id", rec.SubscriptionID, "usage_record_id", rec.ID, "amount", rec.Amount,
 			"error", "negative_amount")
 		return false
@@ -272,7 +272,7 @@ func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *conne
 
 	if conn.EncryptedSecretData.AWSMarketplace == nil {
 		err := ierr.NewError("connection has no aws_marketplace secret data").Mark(ierr.ErrValidation)
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to read connection configuration", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
 		return awssdk.Credentials{}, "", nil, err
 	}
@@ -281,7 +281,7 @@ func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *conne
 	// same home as S3's bucket/region); it selects the AWS Marketplace Metering endpoint and is required.
 	if conn.SyncConfig == nil || conn.SyncConfig.AWSMarketplace == nil || conn.SyncConfig.AWSMarketplace.Region == "" {
 		err := ierr.NewError("connection has no region in sync_config").Mark(ierr.ErrValidation)
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to read connection configuration", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
 		return awssdk.Credentials{}, "", nil, err
 	}
@@ -289,20 +289,20 @@ func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *conne
 
 	roleArn, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AWSMarketplace.RoleArn)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to decrypt aws role arn", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_role_arn")
 		return awssdk.Credentials{}, "", nil, err
 	}
 	externalID, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AWSMarketplace.ExternalID)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to decrypt aws external id", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_external_id")
 		return awssdk.Credentials{}, "", nil, err
 	}
 
 	mappings, err := r.loadAWSMappings(ctx)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to load entity mappings", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
 		return awssdk.Credentials{}, "", nil, err
 	}
@@ -315,7 +315,7 @@ func (r *marketplaceReporter) authAWSConnection(ctx context.Context, conn *conne
 	creds, err := r.awsClient.AssumeRole(ctx, roleArn, externalID, time.Hour)
 	if err != nil {
 		// err is already redacted of the role ARN and external ID by AssumeRole.
-		r.logger.Error(ctx, "marketplace usage report failed",
+		r.logger.Error(ctx, "marketplace usage report: failed to assume the tenant's aws role",
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID,
 			"region", region,
 			"error", err, "stage", "assume_role")
@@ -336,7 +336,7 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 	customerAWSAccountID := mappings.awsAccountByCustomer[rec.CustomerID]
 	plan, planFound := mappings.plan[rec.PlanID]
 	if licenseArn == "" || customerAWSAccountID == "" || !planFound || plan.dimension == "" {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
 			"error", "missing license_arn, customer_aws_account_id, or plan dimension mapping", "stage", "resolve_record")
@@ -355,7 +355,7 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 	// AWS's job: it bills quantity x the dimension's rate.
 	quantity := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
 	if quantity > math.MaxInt32 {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to convert amount to an aws quantity", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
 			"error", "quantity exceeds the maximum aws accepts", "stage", "convert_quantity")
@@ -372,7 +372,7 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 		Timestamp: rec.PeriodEnd,
 	})
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws batch meter usage call failed", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
 			"error", err, "stage", "batch_meter_usage")
@@ -380,7 +380,7 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 	}
 	if res == nil {
 		// AWS returned the record as unprocessed; leaving it unsynced retries it next run.
-		r.logger.Info(ctx, "marketplace usage record not processed by aws, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Info(ctx, "marketplace usage report: aws did not process the usage record, will retry next run", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount)
 		return types.UsageRecordSyncEntry{}, false
@@ -396,7 +396,7 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 		// The buyer has no active agreement for this product, or their AWS account was suspended.
 		// Resolves itself once the buyer (re)subscribes, so it keeps retrying rather than needing
 		// manual action.
-		r.logger.Error(ctx, "marketplace usage report rejected by aws: customer not subscribed, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws rejected the usage record, customer not subscribed, will retry next run", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
 			"dimension", plan.dimension, "amount", rec.Amount, "error", "customer_not_subscribed")
@@ -405,13 +405,13 @@ func (r *marketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 		// NOT "AWS already has this exact record, safe to skip" — AWS has a DIFFERENT record for the
 		// same customer+dimension+timestamp already on file, and rejected this one. Retrying with the
 		// same amount hits the same rejection every time; this needs a human to fix the mismatch.
-		r.logger.Error(ctx, "marketplace usage report rejected by aws: conflicts with a different record already on file, needs manual investigation", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws rejected the usage record, it conflicts with a different record already on file, needs manual investigation", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "customer_id", rec.CustomerID, "license_arn", licenseArn,
 			"dimension", plan.dimension, "amount", rec.Amount, "period_end", rec.PeriodEnd, "error", "duplicate_record")
 		return types.UsageRecordSyncEntry{}, false
 	default:
-		r.logger.Error(ctx, "marketplace usage report rejected by aws: unrecognized status, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: aws returned an unrecognized status, will retry next run", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "license_arn", licenseArn, "dimension", plan.dimension, "amount", rec.Amount,
 			"aws_status", res.Status, "error", "unrecognized_aws_status")
@@ -490,21 +490,21 @@ func (r *marketplaceReporter) authGCPConnection(ctx context.Context, conn *conne
 
 	if conn.EncryptedSecretData.GCPMarketplace == nil {
 		err := ierr.NewError("connection has no gcp_marketplace secret data").Mark(ierr.ErrValidation)
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to read connection configuration", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
 		return nil, nil, err
 	}
 
 	credentialsJSON, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.GCPMarketplace.CredentialsJSON)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to decrypt gcp credentials", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_credentials_json")
 		return nil, nil, err
 	}
 
 	mappings, err := r.loadGCPMappings(ctx)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to load entity mappings", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
 		return nil, nil, err
 	}
@@ -513,7 +513,7 @@ func (r *marketplaceReporter) authGCPConnection(ctx context.Context, conn *conne
 	// connection reports, mirroring the single AssumeRole-per-connection pattern on the AWS path.
 	svc, err := r.gcpClient.WifSession(ctx, credentialsJSON)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to establish the gcp workload identity session", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "wif_session")
 		return nil, nil, err
 	}
@@ -531,7 +531,7 @@ func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerec
 	consumerID := mappings.usageReportingIDBySubscription[rec.SubscriptionID]
 	plan, planFound := mappings.plan[rec.PlanID]
 	if consumerID == "" || !planFound || plan.serviceName == "" || plan.metricName == "" {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
 			"error", "missing usage_reporting_id or plan service_name/metric_name mapping", "stage", "resolve_record")
@@ -553,7 +553,7 @@ func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerec
 		EndTime:     rec.PeriodEnd,
 	})
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: gcp services report call failed", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "error", err, "stage", "services_report")
 		return types.UsageRecordSyncEntry{}, false
@@ -562,7 +562,7 @@ func (r *marketplaceReporter) reportGCPRecord(ctx context.Context, rec *usagerec
 	// HTTP 200 is not the same as accepted — reportErrors must be checked. Common codes:
 	// 5=NOT_FOUND (consumer inactive), 7=PERMISSION_DENIED, 3=INVALID_ARGUMENT.
 	if !reportResult.Accepted {
-		r.logger.Error(ctx, "marketplace usage report rejected by gcp, will retry next run", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: gcp rejected the usage record, will retry next run", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "error", "rejected_by_gcp", "error_code", reportResult.ErrorCode,
 			"error_message", reportResult.ErrorMessage)
@@ -629,33 +629,33 @@ func (r *marketplaceReporter) authAzureConnection(ctx context.Context, conn *con
 
 	if conn.EncryptedSecretData.AzureMarketplace == nil {
 		err := ierr.NewError("connection has no azure_marketplace secret data").Mark(ierr.ErrValidation)
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to read connection configuration", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "read_connection")
 		return azuremarketplace.Token{}, nil, err
 	}
 
 	azureTenantID, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.TenantID)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to decrypt azure tenant id", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_tenant_id")
 		return azuremarketplace.Token{}, nil, err
 	}
 	clientID, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.ClientID)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to decrypt azure client id", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_client_id")
 		return azuremarketplace.Token{}, nil, err
 	}
 	clientSecret, err := r.encryptionService.Decrypt(conn.EncryptedSecretData.AzureMarketplace.ClientSecret)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to decrypt azure client secret", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "decrypt_client_secret")
 		return azuremarketplace.Token{}, nil, err
 	}
 
 	mappings, err := r.loadAzureMappings(ctx)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to load entity mappings", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "load_mappings")
 		return azuremarketplace.Token{}, nil, err
 	}
@@ -664,7 +664,7 @@ func (r *marketplaceReporter) authAzureConnection(ctx context.Context, conn *con
 	// connection reports, mirroring the AssumeRole/WifSession pattern on the AWS/GCP paths.
 	token, err := r.azureClient.GetToken(ctx, azureTenantID, clientID, clientSecret)
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to obtain an azure access token", "marketplace", conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "get_token")
 		return azuremarketplace.Token{}, nil, err
 	}
@@ -684,7 +684,7 @@ func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usager
 	resourceID := mappings.resourceIDBySubscription[rec.SubscriptionID]
 	plan, planFound := mappings.plan[rec.PlanID]
 	if resourceID == "" || !planFound || plan.planID == "" || plan.dimension == "" {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: failed to resolve the record's marketplace identifiers", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "customer_id", rec.CustomerID, "plan_id", rec.PlanID, "connection_id", preparedConn.conn.ID,
 			"error", "missing resource_id or plan plan_id/dimension mapping", "stage", "resolve_record")
@@ -698,7 +698,7 @@ func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usager
 	// Skip on cents, not rec.Amount: a positive sub-cent amount rounds to zero cents and Azure
 	// rejects a zero quantity. Negatives are already filtered upstream (isEligibleForReport).
 	if cents == 0 {
-		r.logger.Info(ctx, "marketplace usage record skipped: zero quantity not supported by azure", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Info(ctx, "marketplace usage report: skipping usage record for azure, it does not accept a zero quantity", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "amount", rec.Amount)
 		return types.UsageRecordSyncEntry{
@@ -725,7 +725,7 @@ func (r *marketplaceReporter) reportAzureRecord(ctx context.Context, rec *usager
 	// error here, rejection or transient failure alike, is left unsynced and retried next run, never
 	// resolved by inference.
 	if err != nil {
-		r.logger.Error(ctx, "marketplace usage report failed", "marketplace", preparedConn.conn.ProviderType,
+		r.logger.Error(ctx, "marketplace usage report: azure usage event call failed", "marketplace", preparedConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", preparedConn.conn.ID, "resource_id", resourceID, "dimension", plan.dimension, "amount", rec.Amount,
 			"error", err, "stage", "usage_event")

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -152,9 +152,8 @@ func (r *MarketplaceReporter) reportRecordToMarketplaces(
 	for _, marketplaceConn := range reportableConns {
 		marketplace := string(marketplaceConn.conn.ProviderType)
 		// A skip leaves an entry as well, so a marketplace that skipped this record is treated as
-		// resolved and never attempted again. Only a complete entry counts: a half-written one is
-		// retried rather than mistaken for a report that already happened.
-		if entry, ok := rec.Syncs[marketplace]; ok && entry.IsResolved() {
+		// resolved and never attempted again: the amount will not change on a retry.
+		if _, ok := rec.Syncs[marketplace]; ok {
 			continue
 		}
 
@@ -183,8 +182,7 @@ func (r *MarketplaceReporter) reportRecordToMarketplaces(
 	// here would leave the record pending forever.
 	rec.Synced = true
 	for _, marketplaceConn := range reportableConns {
-		entry, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]
-		if !ok || !entry.IsResolved() {
+		if _, ok := rec.Syncs[string(marketplaceConn.conn.ProviderType)]; !ok {
 			rec.Synced = false
 			break
 		}
@@ -685,12 +683,12 @@ func (r *MarketplaceReporter) reportAzureRecord(ctx context.Context, rec *usager
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "amount", rec.Amount)
 		return types.UsageRecordSyncEntry{
-			AgreementID:  resourceID,
-			SyncedAt:     time.Now().UTC(),
+			AgreementID: resourceID,
+			// SyncedAt stays zero: nothing was sent, so nothing was synced. Azure documents a quantity
+			// of zero as invalid, so this is never sent and never retried.
 			ConnectionID: marketplaceConn.conn.ID,
 			Skipped:      true,
-			// Azure documents a quantity of zero as invalid, so this is never sent and never retried.
-			SkipReason: "zero_amount_not_supported",
+			SkipReason:   types.SkipReasonZeroAmountNotSupported,
 		}, true
 	}
 

--- a/internal/temporal/activities/marketplace/snapshot_activities.go
+++ b/internal/temporal/activities/marketplace/snapshot_activities.go
@@ -44,24 +44,17 @@ type SnapshotActivities struct {
 	logger                       *logger.Logger
 }
 
-func NewSnapshotActivities(
-	subscriptionService service.SubscriptionService,
-	billingService service.BillingService,
-	connectionRepo connection.Repository,
-	entityIntegrationMappingRepo entityintegrationmapping.Repository,
-	subscriptionRepo subscription.Repository,
-	customerRepo customer.Repository,
-	usageRecordRepo usagerecord.Repository,
-	log *logger.Logger,
-) *SnapshotActivities {
+// NewSnapshotActivities takes ServiceParams rather than each repo individually (the pattern used by
+// NewInvoiceSyncActivities and friends) — every dependency below already lives on it.
+func NewSnapshotActivities(params service.ServiceParams, log *logger.Logger) *SnapshotActivities {
 	return &SnapshotActivities{
-		subscriptionService:          subscriptionService,
-		billingService:               billingService,
-		connectionRepo:               connectionRepo,
-		entityIntegrationMappingRepo: entityIntegrationMappingRepo,
-		subscriptionRepo:             subscriptionRepo,
-		customerRepo:                 customerRepo,
-		usageRecordRepo:              usageRecordRepo,
+		subscriptionService:          service.NewSubscriptionService(params),
+		billingService:               service.NewBillingService(params),
+		connectionRepo:               params.ConnectionRepo,
+		entityIntegrationMappingRepo: params.EntityIntegrationMappingRepo,
+		subscriptionRepo:             params.SubRepo,
+		customerRepo:                 params.CustomerRepo,
+		usageRecordRepo:              params.UsageRecordRepo,
 		logger:                       log,
 	}
 }
@@ -91,8 +84,11 @@ func (a *SnapshotActivities) MarketplaceUsageSnapshotActivity(
 	log.Info("Starting MarketplaceUsageSnapshotActivity", "period_start", input.PeriodStart, "period_end", input.PeriodEnd)
 
 	run := &snapshotRun{
-		result: &temporalModels.MarketplaceUsageSnapshotWorkflowResult{},
-		seen:   make(map[string]bool),
+		result: &temporalModels.MarketplaceUsageSnapshotWorkflowResult{
+			PeriodStart: input.PeriodStart,
+			PeriodEnd:   input.PeriodEnd,
+		},
+		seen: make(map[string]bool),
 	}
 
 	for _, providerType := range marketplaceProviderTypes {
@@ -179,7 +175,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "get_subscription")
-		run.result.Failed++
+		run.result.AppendFailedSubscriptionID(subscriptionID)
 		return
 	}
 
@@ -208,11 +204,11 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "check_existing")
-		run.result.Failed++
+		run.result.AppendFailedSubscriptionID(sub.ID)
 		return
 	}
 	if alreadyExists {
-		run.result.Succeeded++
+		run.result.AppendSucceededSubscriptionID(sub.ID)
 		return
 	}
 
@@ -226,7 +222,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "get_meter_usage")
-		run.result.Failed++
+		run.result.AppendFailedSubscriptionID(sub.ID)
 		return
 	}
 
@@ -237,7 +233,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "calculate_charges")
-		run.result.Failed++
+		run.result.AppendFailedSubscriptionID(sub.ID)
 		return
 	}
 
@@ -270,15 +266,15 @@ func (a *SnapshotActivities) snapshotSubscription(
 		// win the race between the check and this insert; that shows up here as ErrAlreadyExists,
 		// and means the record is already written, so it's a success, not a failure.
 		if ierr.IsAlreadyExists(err) {
-			run.result.Succeeded++
+			run.result.AppendSucceededSubscriptionID(sub.ID)
 			return
 		}
 		a.logger.Error(ctx, "marketplace usage snapshot failed",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "create_usage_record")
-		run.result.Failed++
+		run.result.AppendFailedSubscriptionID(sub.ID)
 		return
 	}
 
-	run.result.Succeeded++
+	run.result.AppendSucceededSubscriptionID(sub.ID)
 }

--- a/internal/temporal/activities/marketplace/snapshot_activities.go
+++ b/internal/temporal/activities/marketplace/snapshot_activities.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/domain/usagerecord"
 	"github.com/flexprice/flexprice/internal/ee/service"
-	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	temporalModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
@@ -25,14 +24,15 @@ var marketplaceProviderTypes = []types.SecretProvider{
 }
 
 // SnapshotActivities creates the usage records that will later be reported to a marketplace. For
-// every published marketplace connection (AWS, GCP or Azure) it computes each mapped subscription's usage
+// every published marketplace connection (AWS, GCP or Azure) it computes the usage of each subscription
+// holding an agreement on that marketplace
 // for the reporting window, using the same commitment- and overage-aware computation as real
 // invoicing, and writes one usage record per subscription in the subscription's own billing currency
 // — marketplace-mandated currency conversion (both AWS and GCP require USD) happens per-marketplace
 // at report time, not here. A record is provider-agnostic: it does not pin a connection_id, so if a
 // subscription is mapped to more than one marketplace, the unique index on (subscription_id,
 // period_start, period_end) collapses every connection's attempt into the same one row — the
-// reporting cron fans that single row out to every relevant connection itself.
+// reporting cron fans that single row out to every mapped marketplace itself.
 type SnapshotActivities struct {
 	subscriptionService          service.SubscriptionService
 	billingService               service.BillingService
@@ -105,16 +105,21 @@ func (a *SnapshotActivities) MarketplaceUsageSnapshotActivity(
 		}
 	}
 
-	log.Info("Completed MarketplaceUsageSnapshotActivity",
+	// Emitted through the structured logger, not the workflow logger, so a completed run is greppable
+	// under the same prefix as this activity's failures. Without it a healthy run produces no
+	// marketplace-prefixed line at all, since every other line here is an error.
+	a.logger.Info(ctx, "marketplace usage snapshot: completed",
+		"period_start", input.PeriodStart, "period_end", input.PeriodEnd,
 		"total", run.result.Total, "succeeded", run.result.Succeeded, "failed", run.result.Failed)
 	return run.result, nil
 }
 
-// processConnection writes a usage record for each of the connection's mapped subscriptions. It
-// resolves the connection's mapped customers first, then snapshots each mapped subscription that
+// processConnection writes a usage record for each subscription holding an agreement on this
+// connection's marketplace. It resolves that marketplace's mapped customers first, then snapshots
+// each such subscription that
 // belongs to one of them. Subscriptions are scoped to this connection's own provider_type — not "any
 // marketplace" — but the resulting row itself is provider-agnostic: if the same subscription is also
-// mapped to a different connection, that connection's own pass over this loop resolves to the same
+// mapped to a different marketplace, that marketplace's own pass over this loop resolves to the same
 // (subscription_id, period_start, period_end) and is absorbed by run.seen/ExistsForPeriod in
 // snapshotSubscription below, rather than writing a second row or double-counting the result.
 func (a *SnapshotActivities) processConnection(
@@ -175,7 +180,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot: failed to load subscription",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "get_subscription")
-		run.result.AppendFailedSubscriptionID(subscriptionID)
+		run.result.Failed++
 		return
 	}
 
@@ -184,7 +189,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		return
 	}
 
-	// A subscription mapped to more than one marketplace connection reaches this point once per
+	// A subscription mapped to more than one marketplace reaches this point once per
 	// connection. It is only ever counted and processed on the first of those passes in this run —
 	// the second pass would only rediscover the same row via ExistsForPeriod below, contributing
 	// nothing new, so it is skipped before counting rather than counted again after finding nothing.
@@ -204,11 +209,11 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot: failed to check for an existing usage record",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "check_existing")
-		run.result.AppendFailedSubscriptionID(sub.ID)
+		run.result.Failed++
 		return
 	}
 	if alreadyExists {
-		run.result.AppendSucceededSubscriptionID(sub.ID)
+		run.result.Succeeded++
 		return
 	}
 
@@ -222,7 +227,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot: failed to compute meter usage",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "get_meter_usage")
-		run.result.AppendFailedSubscriptionID(sub.ID)
+		run.result.Failed++
 		return
 	}
 
@@ -233,7 +238,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		a.logger.Error(ctx, "marketplace usage snapshot: failed to calculate charges",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "calculate_charges")
-		run.result.AppendFailedSubscriptionID(sub.ID)
+		run.result.Failed++
 		return
 	}
 
@@ -261,20 +266,12 @@ func (a *SnapshotActivities) snapshotSubscription(
 	}
 
 	if err := a.usageRecordRepo.Create(ctx, rec); err != nil {
-		// The ExistsForPeriod check above is a fast pre-check, not the source of truth — the unique
-		// index on (subscription_id, period_start, period_end) is. A concurrent execution can still
-		// win the race between the check and this insert; that shows up here as ErrAlreadyExists,
-		// and means the record is already written, so it's a success, not a failure.
-		if ierr.IsAlreadyExists(err) {
-			run.result.AppendSucceededSubscriptionID(sub.ID)
-			return
-		}
 		a.logger.Error(ctx, "marketplace usage snapshot: failed to create usage record",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "create_usage_record")
-		run.result.AppendFailedSubscriptionID(sub.ID)
+		run.result.Failed++
 		return
 	}
 
-	run.result.AppendSucceededSubscriptionID(sub.ID)
+	run.result.Succeeded++
 }

--- a/internal/temporal/activities/marketplace/snapshot_activities.go
+++ b/internal/temporal/activities/marketplace/snapshot_activities.go
@@ -94,7 +94,7 @@ func (a *SnapshotActivities) MarketplaceUsageSnapshotActivity(
 	for _, providerType := range marketplaceProviderTypes {
 		conns, err := a.connectionRepo.ListPublishedByProvider(ctx, providerType)
 		if err != nil {
-			a.logger.Error(ctx, "marketplace usage snapshot failed", "provider_type", providerType, "error", err, "stage", "list_connections")
+			a.logger.Error(ctx, "marketplace usage snapshot: failed to list marketplace connections", "provider_type", providerType, "error", err, "stage", "list_connections")
 			continue
 		}
 
@@ -133,7 +133,7 @@ func (a *SnapshotActivities) processConnection(
 		ProviderTypes: []string{providerType},
 	})
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to list customer mappings",
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "list_customer_mappings")
 		return
 	}
@@ -151,7 +151,7 @@ func (a *SnapshotActivities) processConnection(
 		ProviderTypes: []string{providerType},
 	})
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to list subscription mappings",
 			"tenant_id", tenantID, "environment_id", environmentID, "connection_id", conn.ID, "error", err, "stage", "list_subscription_mappings")
 		return
 	}
@@ -172,7 +172,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 	// CalculateMeterUsageCharges iterates sub.LineItems to drive its per-line-item recalculation
 	sub, _, err := a.subscriptionRepo.GetWithLineItems(ctx, subscriptionID)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to load subscription",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", subscriptionID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "get_subscription")
 		run.result.AppendFailedSubscriptionID(subscriptionID)
@@ -201,7 +201,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 	// re-inserting it — this is what makes the activity safe to retry.
 	alreadyExists, err := a.usageRecordRepo.ExistsForPeriod(ctx, sub.ID, input.PeriodStart, input.PeriodEnd)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to check for an existing usage record",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "check_existing")
 		run.result.AppendFailedSubscriptionID(sub.ID)
@@ -219,7 +219,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		Source:         string(types.UsageSourceInvoiceCreation),
 	})
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to compute meter usage",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "get_meter_usage")
 		run.result.AppendFailedSubscriptionID(sub.ID)
@@ -230,7 +230,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 		ctx, sub, usageResp, input.PeriodStart, input.PeriodEnd, types.UsageSourceInvoiceCreation,
 	)
 	if err != nil {
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to calculate charges",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "calculate_charges")
 		run.result.AppendFailedSubscriptionID(sub.ID)
@@ -269,7 +269,7 @@ func (a *SnapshotActivities) snapshotSubscription(
 			run.result.AppendSucceededSubscriptionID(sub.ID)
 			return
 		}
-		a.logger.Error(ctx, "marketplace usage snapshot failed",
+		a.logger.Error(ctx, "marketplace usage snapshot: failed to create usage record",
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", sub.ID, "customer_id", sub.CustomerID,
 			"period_start", input.PeriodStart, "period_end", input.PeriodEnd, "error", err, "stage", "create_usage_record")
 		run.result.AppendFailedSubscriptionID(sub.ID)

--- a/internal/temporal/models/marketplace.go
+++ b/internal/temporal/models/marketplace.go
@@ -4,9 +4,8 @@ import "time"
 
 // ===================== MarketplaceUsageSnapshot (Cron A, every 6h) =====================
 
-// MarketplaceUsageSnapshotWorkflowInput is the input for MarketplaceUsageSnapshotWorkflow.
-// No fields required — period_start/period_end are derived inside the workflow from the run's
-// scheduled_time (design doc FLE-981 §8.3).
+// MarketplaceUsageSnapshotWorkflowInput is the input for the snapshot cron. It is empty: the
+// reporting window is derived inside the workflow from the run's scheduled time.
 type MarketplaceUsageSnapshotWorkflowInput struct{}
 
 // MarketplaceUsageSnapshotActivityInput carries the reporting window computed by the workflow.
@@ -103,12 +102,15 @@ func (r *MarketplaceUsageReportWorkflowResult) AppendSkippedRecordID(id string) 
 
 // ===================== MarketplaceSubscriptionFinalUsageFlush (triggered by CancelSubscription) =====================
 
-// MarketplaceSubscriptionFinalUsageFlushWorkflowInput is the input for MarketplaceSubscriptionFinalUsageFlushWorkflow,
-// started once per cancellation — not on a schedule. CancelAt must be the marketplace's own
-// cancellation instant (sourced from sub.CancelAt, never sub.CancelledAt — see ERD FLE-1106 §3.8).
-// TenantID/EnvironmentID are stamped on by temporalService.buildWorkflowInput from the triggering
-// ctx — required so the workflow-tracking interceptor (which reads them via reflection off this
-// struct) and every repository call inside the activity have a tenant to scope to.
+// MarketplaceSubscriptionFinalUsageFlushWorkflowInput is the input for the cancellation flush.
+//
+// CancelAt must be the marketplace's own cancellation instant, which the tenant supplies on the
+// cancellation request. It is not the time Flexprice processed that request: that is always later,
+// and reporting against it would put the final usage after the cancellation the provider recorded.
+//
+// TenantID and EnvironmentID are stamped on from the triggering context when the workflow starts.
+// They are required, not informational: the activity scopes every query by them, and workflow
+// tracking reads them from this struct.
 type MarketplaceSubscriptionFinalUsageFlushWorkflowInput struct {
 	SubscriptionID string    `json:"subscription_id"`
 	CancelAt       time.Time `json:"cancel_at"`

--- a/internal/temporal/models/marketplace.go
+++ b/internal/temporal/models/marketplace.go
@@ -14,43 +14,21 @@ type MarketplaceUsageSnapshotActivityInput struct {
 	PeriodEnd   time.Time `json:"period_end"`
 }
 
-// MaxReportedIDs caps the ID lists carried on a workflow result. A result is persisted in Temporal's
-// workflow history, so a tenant-wide failure (e.g. one broken connection) must not write an
-// unbounded list into it. The counts are always exact; only the ID lists are truncated.
-const MaxReportedIDs = 100
-
 // MarketplaceUsageSnapshotWorkflowResult captures outcome metrics. Total counts distinct
 // subscriptions walked; Succeeded counts those that now have a usage record for the window (whether
 // this run wrote it or found one already there); Failed counts those that could not be snapshotted.
 // The window is echoed back so a run's output is self-describing in the Temporal UI without having
-// to cross-reference the schedule's fire time, and the ID lists name exactly which subscriptions
-// landed and which need investigating, without grepping logs first.
+// to cross-reference the schedule's fire time.
+//
+// Counts only, no id lists: a run walks every marketplace subscription in the deployment, so naming
+// them would write an unbounded list into Temporal's workflow history. The per-subscription detail
+// lives in the logs, keyed by subscription_id.
 type MarketplaceUsageSnapshotWorkflowResult struct {
 	Total       int       `json:"total"`
 	Succeeded   int       `json:"succeeded"`
 	Failed      int       `json:"failed"`
 	PeriodStart time.Time `json:"period_start"`
 	PeriodEnd   time.Time `json:"period_end"`
-
-	// ID lists are truncated to MaxReportedIDs; the counts above carry the true totals.
-	SucceededSubscriptionIDs []string `json:"succeeded_subscription_ids,omitempty"`
-	FailedSubscriptionIDs    []string `json:"failed_subscription_ids,omitempty"`
-}
-
-// AppendSucceededSubscriptionID records a subscription that now has a usage record for the window.
-func (r *MarketplaceUsageSnapshotWorkflowResult) AppendSucceededSubscriptionID(id string) {
-	r.Succeeded++
-	if len(r.SucceededSubscriptionIDs) < MaxReportedIDs {
-		r.SucceededSubscriptionIDs = append(r.SucceededSubscriptionIDs, id)
-	}
-}
-
-// AppendFailedSubscriptionID records a subscription that could not be snapshotted.
-func (r *MarketplaceUsageSnapshotWorkflowResult) AppendFailedSubscriptionID(id string) {
-	r.Failed++
-	if len(r.FailedSubscriptionIDs) < MaxReportedIDs {
-		r.FailedSubscriptionIDs = append(r.FailedSubscriptionIDs, id)
-	}
 }
 
 // MarketplaceUsageReportWorkflowInput is the input for MarketplaceUsageReportWorkflow. It is
@@ -59,45 +37,18 @@ type MarketplaceUsageReportWorkflowInput struct{}
 
 // MarketplaceUsageReportWorkflowResult captures outcome metrics. Total counts records that reached
 // at least one relevant connection this run; Succeeded counts those now fully synced to every
-// relevant connection; Failed counts those still awaiting at least one. Skipped counts sync entries
+// relevant marketplace; Failed counts those still awaiting at least one. Skipped counts sync entries
 // resolved without anything being posted (today only Azure's zero-quantity case), which would
-// otherwise be indistinguishable from a real acceptance in Succeeded. The ID lists name the rows
-// behind each count, so a run is actionable from the Temporal UI alone.
+// otherwise be indistinguishable from a real acceptance in Succeeded.
+//
+// Counts only, never ids: a run covers every record across every tenant, so any id list here would be
+// unbounded in Temporal's workflow history. Every id is already on the per-record log lines, which is
+// where debugging starts.
 type MarketplaceUsageReportWorkflowResult struct {
 	Total     int `json:"total"`
 	Succeeded int `json:"succeeded"`
 	Failed    int `json:"failed"`
 	Skipped   int `json:"skipped"`
-
-	// ID lists are truncated to MaxReportedIDs; the counts above carry the true totals.
-	SucceededRecordIDs []string `json:"succeeded_record_ids,omitempty"`
-	FailedRecordIDs    []string `json:"failed_record_ids,omitempty"`
-	SkippedRecordIDs   []string `json:"skipped_record_ids,omitempty"`
-}
-
-// AppendSucceededRecordID records a usage record now fully synced to every relevant connection.
-func (r *MarketplaceUsageReportWorkflowResult) AppendSucceededRecordID(id string) {
-	r.Succeeded++
-	if len(r.SucceededRecordIDs) < MaxReportedIDs {
-		r.SucceededRecordIDs = append(r.SucceededRecordIDs, id)
-	}
-}
-
-// AppendFailedRecordID records a usage record that did not fully sync.
-func (r *MarketplaceUsageReportWorkflowResult) AppendFailedRecordID(id string) {
-	r.Failed++
-	if len(r.FailedRecordIDs) < MaxReportedIDs {
-		r.FailedRecordIDs = append(r.FailedRecordIDs, id)
-	}
-}
-
-// AppendSkippedRecordID records a connection resolved without anything being posted. Skipped is
-// counted per sync entry, so one record can appear here once per connection that skipped it.
-func (r *MarketplaceUsageReportWorkflowResult) AppendSkippedRecordID(id string) {
-	r.Skipped++
-	if len(r.SkippedRecordIDs) < MaxReportedIDs {
-		r.SkippedRecordIDs = append(r.SkippedRecordIDs, id)
-	}
 }
 
 // ===================== MarketplaceSubscriptionFinalUsageFlush (triggered by CancelSubscription) =====================
@@ -127,9 +78,7 @@ type MarketplaceSubscriptionFinalUsageFlushActivityInput struct {
 	EnvironmentID  string    `json:"environment_id"`
 }
 
-// MarketplaceSubscriptionFinalUsageFlushWorkflowResult captures what one flush did. It carries full
-// id lists rather than truncated ones: a flush covers at most a day of records across at most three
-// marketplaces.
+// MarketplaceSubscriptionFinalUsageFlushWorkflowResult captures what one flush did.
 type MarketplaceSubscriptionFinalUsageFlushWorkflowResult struct {
 	SubscriptionID string `json:"subscription_id"`
 
@@ -141,15 +90,16 @@ type MarketplaceSubscriptionFinalUsageFlushWorkflowResult struct {
 	PeriodEnd     time.Time `json:"period_end,omitempty"`
 	FinalRecordID string    `json:"final_record_id,omitempty"`
 
-	// Every record this run reported, the backlog and the final one alike, split by outcome. A record
-	// is succeeded once every marketplace mapped to it has accepted or skipped it and at least one
-	// accepted; skipped when they all skipped; failed while any is still outstanding.
-	SucceededRecordIDs []string `json:"succeeded_record_ids,omitempty"`
-	FailedRecordIDs    []string `json:"failed_record_ids,omitempty"`
-	SkippedRecordIDs   []string `json:"skipped_record_ids,omitempty"`
+	// Every record this run reported, the backlog and the final one alike, counted by outcome. A
+	// record is succeeded once every marketplace mapped to it has accepted or skipped it and at least
+	// one accepted; skipped when they all skipped; failed while any is still outstanding. Counted
+	// rather than named: a cancellation can carry a full day of backlog behind it.
+	RecordsSucceeded int `json:"records_succeeded"`
+	RecordsFailed    int `json:"records_failed"`
+	RecordsSkipped   int `json:"records_skipped"`
 
-	// The marketplace mappings archived by this run. Empty unless every record above synced and every
+	// How many marketplace mappings this run archived. Zero unless every record above synced and every
 	// mapped connection resolved: the mappings stay published on any failure so the reporting cron can
 	// still find the outstanding records.
-	DelinkedMappingIDs []string `json:"delinked_mapping_ids,omitempty"`
+	MappingsDelinked int `json:"mappings_delinked"`
 }

--- a/internal/temporal/models/marketplace.go
+++ b/internal/temporal/models/marketplace.go
@@ -15,20 +15,145 @@ type MarketplaceUsageSnapshotActivityInput struct {
 	PeriodEnd   time.Time `json:"period_end"`
 }
 
-// MarketplaceUsageSnapshotWorkflowResult captures outcome metrics.
+// MaxReportedIDs caps the ID lists carried on a workflow result. A result is persisted in Temporal's
+// workflow history, so a tenant-wide failure (e.g. one broken connection) must not write an
+// unbounded list into it. The counts are always exact; only the ID lists are truncated.
+const MaxReportedIDs = 100
+
+// MarketplaceUsageSnapshotWorkflowResult captures outcome metrics. Total counts distinct
+// subscriptions walked; Succeeded counts those that now have a usage record for the window (whether
+// this run wrote it or found one already there); Failed counts those that could not be snapshotted.
+// The window is echoed back so a run's output is self-describing in the Temporal UI without having
+// to cross-reference the schedule's fire time, and the ID lists name exactly which subscriptions
+// landed and which need investigating, without grepping logs first.
 type MarketplaceUsageSnapshotWorkflowResult struct {
-	Total     int `json:"total"`
-	Succeeded int `json:"succeeded"`
-	Failed    int `json:"failed"`
+	Total       int       `json:"total"`
+	Succeeded   int       `json:"succeeded"`
+	Failed      int       `json:"failed"`
+	PeriodStart time.Time `json:"period_start"`
+	PeriodEnd   time.Time `json:"period_end"`
+
+	// ID lists are truncated to MaxReportedIDs; the counts above carry the true totals.
+	SucceededSubscriptionIDs []string `json:"succeeded_subscription_ids,omitempty"`
+	FailedSubscriptionIDs    []string `json:"failed_subscription_ids,omitempty"`
+}
+
+// AppendSucceededSubscriptionID records a subscription that now has a usage record for the window.
+func (r *MarketplaceUsageSnapshotWorkflowResult) AppendSucceededSubscriptionID(id string) {
+	r.Succeeded++
+	if len(r.SucceededSubscriptionIDs) < MaxReportedIDs {
+		r.SucceededSubscriptionIDs = append(r.SucceededSubscriptionIDs, id)
+	}
+}
+
+// AppendFailedSubscriptionID records a subscription that could not be snapshotted.
+func (r *MarketplaceUsageSnapshotWorkflowResult) AppendFailedSubscriptionID(id string) {
+	r.Failed++
+	if len(r.FailedSubscriptionIDs) < MaxReportedIDs {
+		r.FailedSubscriptionIDs = append(r.FailedSubscriptionIDs, id)
+	}
 }
 
 // MarketplaceUsageReportWorkflowInput is the input for MarketplaceUsageReportWorkflow. It is
 // empty; the activity reads all unsynced usage records itself.
 type MarketplaceUsageReportWorkflowInput struct{}
 
-// MarketplaceUsageReportWorkflowResult captures outcome metrics.
+// MarketplaceUsageReportWorkflowResult captures outcome metrics. Total counts records that reached
+// at least one relevant connection this run; Succeeded counts those now fully synced to every
+// relevant connection; Failed counts those still awaiting at least one. Skipped counts sync entries
+// resolved without anything being posted (today only Azure's zero-quantity case), which would
+// otherwise be indistinguishable from a real acceptance in Succeeded. The ID lists name the rows
+// behind each count, so a run is actionable from the Temporal UI alone.
 type MarketplaceUsageReportWorkflowResult struct {
 	Total     int `json:"total"`
 	Succeeded int `json:"succeeded"`
 	Failed    int `json:"failed"`
+	Skipped   int `json:"skipped"`
+
+	// ID lists are truncated to MaxReportedIDs; the counts above carry the true totals.
+	SucceededRecordIDs []string `json:"succeeded_record_ids,omitempty"`
+	FailedRecordIDs    []string `json:"failed_record_ids,omitempty"`
+	SkippedRecordIDs   []string `json:"skipped_record_ids,omitempty"`
+}
+
+// AppendSucceededRecordID records a usage record now fully synced to every relevant connection.
+func (r *MarketplaceUsageReportWorkflowResult) AppendSucceededRecordID(id string) {
+	r.Succeeded++
+	if len(r.SucceededRecordIDs) < MaxReportedIDs {
+		r.SucceededRecordIDs = append(r.SucceededRecordIDs, id)
+	}
+}
+
+// AppendFailedRecordID records a usage record that did not fully sync.
+func (r *MarketplaceUsageReportWorkflowResult) AppendFailedRecordID(id string) {
+	r.Failed++
+	if len(r.FailedRecordIDs) < MaxReportedIDs {
+		r.FailedRecordIDs = append(r.FailedRecordIDs, id)
+	}
+}
+
+// AppendSkippedRecordID records a connection resolved without anything being posted. Skipped is
+// counted per sync entry, so one record can appear here once per connection that skipped it.
+func (r *MarketplaceUsageReportWorkflowResult) AppendSkippedRecordID(id string) {
+	r.Skipped++
+	if len(r.SkippedRecordIDs) < MaxReportedIDs {
+		r.SkippedRecordIDs = append(r.SkippedRecordIDs, id)
+	}
+}
+
+// ===================== MarketplaceSubscriptionFinalUsageFlush (triggered by CancelSubscription) =====================
+
+// MarketplaceSubscriptionFinalUsageFlushWorkflowInput is the input for MarketplaceSubscriptionFinalUsageFlushWorkflow,
+// started once per cancellation — not on a schedule. CancelAt must be the marketplace's own
+// cancellation instant (sourced from sub.CancelAt, never sub.CancelledAt — see ERD FLE-1106 §3.8).
+// TenantID/EnvironmentID are stamped on by temporalService.buildWorkflowInput from the triggering
+// ctx — required so the workflow-tracking interceptor (which reads them via reflection off this
+// struct) and every repository call inside the activity have a tenant to scope to.
+type MarketplaceSubscriptionFinalUsageFlushWorkflowInput struct {
+	SubscriptionID string    `json:"subscription_id"`
+	CancelAt       time.Time `json:"cancel_at"`
+	TenantID       string    `json:"tenant_id"`
+	EnvironmentID  string    `json:"environment_id"`
+}
+
+// MarketplaceSubscriptionFinalUsageFlushActivityInput mirrors the workflow input; kept as a separate type so
+// the activity signature doesn't change if the workflow input grows fields the activity doesn't need.
+type MarketplaceSubscriptionFinalUsageFlushActivityInput struct {
+	SubscriptionID string    `json:"subscription_id"`
+	CancelAt       time.Time `json:"cancel_at"`
+	TenantID       string    `json:"tenant_id"`
+	EnvironmentID  string    `json:"environment_id"`
+}
+
+// MarketplaceSubscriptionFinalUsageFlushWorkflowResult captures what the flush actually did. Scoped to a single
+// subscription, so it carries full IDs rather than the truncated lists the two scheduled results use —
+// a flush covers at most a day's backlog across at most three marketplaces. The three record-ID lists
+// mirror MarketplaceUsageReportWorkflowResult's classification exactly (both are produced by the same
+// shared reportRecordToConnections), so the two report paths can never disagree on what "succeeded"
+// means.
+type MarketplaceSubscriptionFinalUsageFlushWorkflowResult struct {
+	SubscriptionID string `json:"subscription_id"`
+
+	// PeriodStart/PeriodEnd and FinalRecordID describe the final record this run wrote — PeriodEnd is
+	// the true cancellation instant, without the reporting margin (that's applied on the wire only).
+	// All three are zero/empty unless this run both computed AND fully reported the record. That
+	// covers three different cases the same way: nothing was left to compute (cancel_at at or before
+	// the frontier — also what a retry sees once an earlier attempt's record already advanced it), the
+	// record's connection couldn't be resolved this run, or reporting it didn't fully succeed. The
+	// last two also make this run return an error.
+	PeriodStart   time.Time `json:"period_start,omitempty"`
+	PeriodEnd     time.Time `json:"period_end,omitempty"`
+	FinalRecordID string    `json:"final_record_id,omitempty"`
+
+	// Record IDs cover the backlog plus the final record (once persisted, it's just another backlog
+	// row), reported through the same shared loop.
+	SucceededRecordIDs []string `json:"succeeded_record_ids,omitempty"`
+	FailedRecordIDs    []string `json:"failed_record_ids,omitempty"`
+	SkippedRecordIDs   []string `json:"skipped_record_ids,omitempty"`
+
+	// DelinkedMappingIDs are the entity_integration_mapping rows archived by this run. Empty unless
+	// every record above fully synced and every mapped connection could be resolved — a cancelled
+	// subscription's mapping stays published on any failure so the next attempt (this activity's own
+	// Temporal retry, or a future catch-up mechanism) can still find and retry it.
+	DelinkedMappingIDs []string `json:"delinked_mapping_ids,omitempty"`
 }

--- a/internal/temporal/models/marketplace.go
+++ b/internal/temporal/models/marketplace.go
@@ -127,35 +127,29 @@ type MarketplaceSubscriptionFinalUsageFlushActivityInput struct {
 	EnvironmentID  string    `json:"environment_id"`
 }
 
-// MarketplaceSubscriptionFinalUsageFlushWorkflowResult captures what the flush actually did. Scoped to a single
-// subscription, so it carries full IDs rather than the truncated lists the two scheduled results use —
-// a flush covers at most a day's backlog across at most three marketplaces. The three record-ID lists
-// mirror MarketplaceUsageReportWorkflowResult's classification exactly (both are produced by the same
-// shared reportRecordToConnections), so the two report paths can never disagree on what "succeeded"
-// means.
+// MarketplaceSubscriptionFinalUsageFlushWorkflowResult captures what one flush did. It carries full
+// id lists rather than truncated ones: a flush covers at most a day of records across at most three
+// marketplaces.
 type MarketplaceSubscriptionFinalUsageFlushWorkflowResult struct {
 	SubscriptionID string `json:"subscription_id"`
 
-	// PeriodStart/PeriodEnd and FinalRecordID describe the final record this run wrote — PeriodEnd is
-	// the true cancellation instant, without the reporting margin (that's applied on the wire only).
-	// All three are zero/empty unless this run both computed AND fully reported the record. That
-	// covers three different cases the same way: nothing was left to compute (cancel_at at or before
-	// the frontier — also what a retry sees once an earlier attempt's record already advanced it), the
-	// record's connection couldn't be resolved this run, or reporting it didn't fully succeed. The
-	// last two also make this run return an error.
+	// The final usage record covering the span up to cancellation, whether this run created it or
+	// found one an earlier attempt had already written. PeriodEnd is the true cancellation instant;
+	// the reporting margin is applied only to the value sent to the providers. All three are empty
+	// when no such record was needed, which is what a backdated cancellation looks like.
 	PeriodStart   time.Time `json:"period_start,omitempty"`
 	PeriodEnd     time.Time `json:"period_end,omitempty"`
 	FinalRecordID string    `json:"final_record_id,omitempty"`
 
-	// Record IDs cover the backlog plus the final record (once persisted, it's just another backlog
-	// row), reported through the same shared loop.
+	// Every record this run reported, the backlog and the final one alike, split by outcome. A record
+	// is succeeded once every marketplace mapped to it has accepted or skipped it and at least one
+	// accepted; skipped when they all skipped; failed while any is still outstanding.
 	SucceededRecordIDs []string `json:"succeeded_record_ids,omitempty"`
 	FailedRecordIDs    []string `json:"failed_record_ids,omitempty"`
 	SkippedRecordIDs   []string `json:"skipped_record_ids,omitempty"`
 
-	// DelinkedMappingIDs are the entity_integration_mapping rows archived by this run. Empty unless
-	// every record above fully synced and every mapped connection could be resolved — a cancelled
-	// subscription's mapping stays published on any failure so the next attempt (this activity's own
-	// Temporal retry, or a future catch-up mechanism) can still find and retry it.
+	// The marketplace mappings archived by this run. Empty unless every record above synced and every
+	// mapped connection resolved: the mappings stay published on any failure so the reporting cron can
+	// still find the outstanding records.
 	DelinkedMappingIDs []string `json:"delinked_mapping_ids,omitempty"`
 }

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -286,7 +286,7 @@ func RegisterWorkflowsAndActivities(
 	azureMarketplaceClient := azuremarketplace.NewClient(params.Logger)
 	// One reporter shared by both the scheduled reporting cron and the cancellation flush, so the two
 	// report through identical per-provider code.
-	marketplaceReporter := marketplaceActivities.NewMarketplaceReporter(
+	mktplaceReporter := marketplaceActivities.NewMarketplaceReporter(
 		params,
 		awsMarketplaceClient,
 		gcpMarketplaceClient,
@@ -294,8 +294,8 @@ func RegisterWorkflowsAndActivities(
 		params.Logger,
 	)
 	marketplaceSnapshotActivities := marketplaceActivities.NewSnapshotActivities(params, params.Logger)
-	marketplaceReportActivities := marketplaceActivities.NewReportActivities(params, marketplaceReporter, params.Logger)
-	marketplaceFlushActivities := marketplaceActivities.NewFlushActivities(params, marketplaceReporter, params.Logger)
+	marketplaceReportActivities := marketplaceActivities.NewReportActivities(params, mktplaceReporter, params.Logger)
+	marketplaceFlushActivities := marketplaceActivities.NewFlushActivities(params, mktplaceReporter, params.Logger)
 
 	cronBundle := &cronActivityBundle{
 		creditGrant:                  cronActivities.NewCreditGrantActivities(creditGrantService),

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -281,30 +281,21 @@ func RegisterWorkflowsAndActivities(
 	settingsService := service.NewSettingsService(params)
 	environmentService := service.NewEnvironmentService(params.EnvironmentRepo, envAccessService, settingsService, params)
 	// Marketplace activities
-	billingService := service.NewBillingService(params)
 	awsMarketplaceClient := awsmarketplace.NewClient(params.Config, params.Logger)
 	gcpMarketplaceClient := gcpmarketplace.NewClient(params.Config, params.Logger)
 	azureMarketplaceClient := azuremarketplace.NewClient(params.Logger)
-	marketplaceSnapshotActivities := marketplaceActivities.NewSnapshotActivities(
-		subscriptionService,
-		billingService,
-		params.ConnectionRepo,
-		params.EntityIntegrationMappingRepo,
-		params.SubRepo,
-		params.CustomerRepo,
-		params.UsageRecordRepo,
-		params.Logger,
-	)
-	marketplaceReportActivities := marketplaceActivities.NewReportActivities(
-		params.ConnectionRepo,
-		params.EntityIntegrationMappingRepo,
-		params.UsageRecordRepo,
-		params.EncryptionService,
+	// One reporter shared by both the scheduled reporting cron and the cancellation flush, so the two
+	// report through identical per-provider code.
+	marketplaceReporter := marketplaceActivities.NewMarketplaceReporter(
+		params,
 		awsMarketplaceClient,
 		gcpMarketplaceClient,
 		azureMarketplaceClient,
 		params.Logger,
 	)
+	marketplaceSnapshotActivities := marketplaceActivities.NewSnapshotActivities(params, params.Logger)
+	marketplaceReportActivities := marketplaceActivities.NewReportActivities(params, marketplaceReporter, params.Logger)
+	marketplaceFlushActivities := marketplaceActivities.NewFlushActivities(params, marketplaceReporter, params.Logger)
 
 	cronBundle := &cronActivityBundle{
 		creditGrant:                  cronActivities.NewCreditGrantActivities(creditGrantService),
@@ -321,7 +312,7 @@ func RegisterWorkflowsAndActivities(
 
 	// Get all task queues and register workflows/activities for each
 	for _, taskQueue := range types.GetAllTaskQueues() {
-		config := buildWorkerConfig(taskQueue, workflowTrackingActivities, planActivities, prepareEventsActivities, taskActivities, taskActivity, scheduledTaskActivity, exportActivity, hubspotDealSyncActivities, hubspotInvoiceSyncActivities, hubspotQuoteSyncActivities, qbPriceSyncActivities, nomodInvoiceSyncActivities, nomodCustomerSyncActivities, whopInvoiceSyncActivities, moyasarInvoiceSyncActivities, paddleInvoiceSyncActivities, paddleCustomerSyncActivities, paddleSubscriptionSyncActivities, stripeInvoiceSyncActivities, stripeCustomerSyncActivities, razorpayInvoiceSyncActivities, razorpayCustomerSyncActivities, chargebeeInvoiceSyncActivities, chargebeeCustomerSyncActivities, qbInvoiceSyncActivities, qbCustomerSyncActivities, zohoInvoiceSyncActivities, tabsInvoiceSyncActivities, customerActivities, scheduleBillingActivities, billingActivities, invoiceActs, reprocessRawEventsActivities, envActivities, cronBundle, alertActs)
+		config := buildWorkerConfig(taskQueue, workflowTrackingActivities, planActivities, prepareEventsActivities, taskActivities, taskActivity, scheduledTaskActivity, exportActivity, hubspotDealSyncActivities, hubspotInvoiceSyncActivities, hubspotQuoteSyncActivities, qbPriceSyncActivities, nomodInvoiceSyncActivities, nomodCustomerSyncActivities, whopInvoiceSyncActivities, moyasarInvoiceSyncActivities, paddleInvoiceSyncActivities, paddleCustomerSyncActivities, paddleSubscriptionSyncActivities, stripeInvoiceSyncActivities, stripeCustomerSyncActivities, razorpayInvoiceSyncActivities, razorpayCustomerSyncActivities, chargebeeInvoiceSyncActivities, chargebeeCustomerSyncActivities, qbInvoiceSyncActivities, qbCustomerSyncActivities, zohoInvoiceSyncActivities, tabsInvoiceSyncActivities, customerActivities, scheduleBillingActivities, billingActivities, invoiceActs, reprocessRawEventsActivities, envActivities, cronBundle, alertActs, marketplaceFlushActivities)
 		if err := registerWorker(temporalService, config); err != nil {
 			return fmt.Errorf("failed to register worker for task queue %s: %w", taskQueue, err)
 		}
@@ -369,6 +360,7 @@ func buildWorkerConfig(
 	envActivities *environmentActivities.EnvironmentActivities,
 	cron *cronActivityBundle,
 	alertActs *alertActivities.AlertActivities,
+	marketplaceFlushActivities *marketplaceActivities.FlushActivities,
 ) WorkerConfig {
 	workflowsList := []interface{}{}
 	// Add tracking activity to all task queues
@@ -469,6 +461,7 @@ func buildWorkerConfig(
 			subscriptionWorkflows.ScheduleSubscriptionBillingWorkflow,
 			subscriptionWorkflows.ProcessSubscriptionBillingWorkflow,
 			invoiceWorkflows.RecalculateInvoiceWorkflow,
+			subscriptionWorkflows.MarketplaceSubscriptionFinalUsageFlushWorkflow,
 		)
 		activitiesList = append(activitiesList,
 			// Schedule billing activities
@@ -483,6 +476,7 @@ func buildWorkerConfig(
 			billingActivities.TriggerInvoiceWorkflowActivity,
 			// Invoice recalculation (v2)
 			invoiceActs.RecalculateInvoiceActivity,
+			marketplaceFlushActivities.MarketplaceSubscriptionFinalUsageFlushActivity,
 		)
 
 	case types.TemporalTaskQueueInvoice:

--- a/internal/temporal/service/service.go
+++ b/internal/temporal/service/service.go
@@ -527,6 +527,10 @@ func (s *temporalService) extractWorkflowContextID(workflowType types.TemporalWo
 		if input, ok := params.(models.PaddleSubscriptionSyncWorkflowInput); ok {
 			return input.SubscriptionID
 		}
+	case types.TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow:
+		if input, ok := params.(models.MarketplaceSubscriptionFinalUsageFlushWorkflowInput); ok {
+			return input.SubscriptionID
+		}
 	case types.TemporalRecalculateInvoiceWorkflow:
 		// Extract invoice ID from RecalculateInvoiceWorkflowInput
 		if input, ok := params.(invoiceModels.RecalculateInvoiceWorkflowInput); ok {
@@ -654,6 +658,8 @@ func (s *temporalService) buildWorkflowInput(ctx context.Context, workflowType t
 		return s.buildPaddleCustomerSyncInput(ctx, tenantID, environmentID, params)
 	case types.TemporalPaddleSubscriptionSyncWorkflow:
 		return s.buildPaddleSubscriptionSyncInput(ctx, tenantID, environmentID, params)
+	case types.TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow:
+		return s.buildMarketplaceSubscriptionFinalUsageFlushInput(ctx, tenantID, environmentID, params)
 	case types.TemporalCustomerOnboardingWorkflow:
 		return s.buildCustomerOnboardingInput(ctx, tenantID, environmentID, userID, params)
 	case types.TemporalPrepareProcessedEventsWorkflow:
@@ -1196,6 +1202,18 @@ func (s *temporalService) buildPaddleSubscriptionSyncInput(_ context.Context, te
 	if !ok {
 		return nil, errors.NewError("invalid input for Paddle subscription sync workflow").
 			WithHint("Provide PaddleSubscriptionSyncWorkflowInput with subscription_id").
+			Mark(errors.ErrValidation)
+	}
+	input.TenantID = tenantID
+	input.EnvironmentID = environmentID
+	return input, nil
+}
+
+func (s *temporalService) buildMarketplaceSubscriptionFinalUsageFlushInput(_ context.Context, tenantID, environmentID string, params interface{}) (interface{}, error) {
+	input, ok := params.(models.MarketplaceSubscriptionFinalUsageFlushWorkflowInput)
+	if !ok {
+		return nil, errors.NewError("invalid input for marketplace subscription final usage flush workflow").
+			WithHint("Provide MarketplaceSubscriptionFinalUsageFlushWorkflowInput with subscription_id and cancel_at").
 			Mark(errors.ErrValidation)
 	}
 	input.TenantID = tenantID

--- a/internal/temporal/workflows/subscription/marketplace_subscription_final_usage_flush_workflow.go
+++ b/internal/temporal/workflows/subscription/marketplace_subscription_final_usage_flush_workflow.go
@@ -55,9 +55,8 @@ func MarketplaceSubscriptionFinalUsageFlushWorkflow(
 	log.Info("MarketplaceSubscriptionFinalUsageFlushWorkflow completed",
 		"subscription_id", input.SubscriptionID,
 		"final_record_id", result.FinalRecordID,
-		"records_succeeded", len(result.SucceededRecordIDs),
-		"records_failed", len(result.FailedRecordIDs),
-		"records_skipped", len(result.SkippedRecordIDs),
-		"mappings_delinked", len(result.DelinkedMappingIDs))
+		"records_succeeded", result.RecordsSucceeded,
+		"records_skipped", result.RecordsSkipped,
+		"mappings_delinked", result.MappingsDelinked)
 	return &result, nil
 }

--- a/internal/temporal/workflows/subscription/marketplace_subscription_final_usage_flush_workflow.go
+++ b/internal/temporal/workflows/subscription/marketplace_subscription_final_usage_flush_workflow.go
@@ -15,15 +15,13 @@ const (
 	ActivityMarketplaceSubscriptionFinalUsageFlush = "MarketplaceSubscriptionFinalUsageFlushActivity"
 )
 
-// MarketplaceSubscriptionFinalUsageFlushWorkflow reports a cancelled subscription's final marketplace usage
-// and archives its marketplace mapping. Started once per cancellation from CancelSubscription
-// (post-commit, non-blocking) — not on a schedule, because AWS and GCP only accept a final report
-// within roughly an hour of cancellation, far tighter than the 6h snapshot / 3h report cadence
-// (ERD FLE-1106 §3, §4).
+// MarketplaceSubscriptionFinalUsageFlushWorkflow reports a cancelled subscription's outstanding
+// marketplace usage and archives its marketplace mappings. It is started once per cancellation, after
+// the cancellation commits, rather than on a schedule: AWS and GCP accept a final report for only
+// about an hour afterwards, far tighter than the reporting crons' cadence.
 //
-// A thin wrapper around a single activity, matching MarketplaceUsageReportWorkflow. The activity only
-// delinks once everything reported successfully — the mapping stays published on any failure, so the
-// report cron can keep retrying it. See ERD FLE-1106 §3.6.
+// The activity archives the mappings only once everything reported successfully; on failure they stay
+// published so the reporting cron can keep retrying the records.
 func MarketplaceSubscriptionFinalUsageFlushWorkflow(
 	ctx workflow.Context,
 	input models.MarketplaceSubscriptionFinalUsageFlushWorkflowInput,

--- a/internal/temporal/workflows/subscription/marketplace_subscription_final_usage_flush_workflow.go
+++ b/internal/temporal/workflows/subscription/marketplace_subscription_final_usage_flush_workflow.go
@@ -1,0 +1,65 @@
+package subscription
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/temporal/models"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	// Workflow name - must match the function name
+	WorkflowMarketplaceSubscriptionFinalUsageFlush = "MarketplaceSubscriptionFinalUsageFlushWorkflow"
+	// Activity name - must match the registered method name
+	ActivityMarketplaceSubscriptionFinalUsageFlush = "MarketplaceSubscriptionFinalUsageFlushActivity"
+)
+
+// MarketplaceSubscriptionFinalUsageFlushWorkflow reports a cancelled subscription's final marketplace usage
+// and archives its marketplace mapping. Started once per cancellation from CancelSubscription
+// (post-commit, non-blocking) — not on a schedule, because AWS and GCP only accept a final report
+// within roughly an hour of cancellation, far tighter than the 6h snapshot / 3h report cadence
+// (ERD FLE-1106 §3, §4).
+//
+// A thin wrapper around a single activity, matching MarketplaceUsageReportWorkflow. The activity only
+// delinks once everything reported successfully — the mapping stays published on any failure, so the
+// report cron can keep retrying it. See ERD FLE-1106 §3.6.
+func MarketplaceSubscriptionFinalUsageFlushWorkflow(
+	ctx workflow.Context,
+	input models.MarketplaceSubscriptionFinalUsageFlushWorkflowInput,
+) (*models.MarketplaceSubscriptionFinalUsageFlushWorkflowResult, error) {
+	log := workflow.GetLogger(ctx)
+	log.Info("Starting MarketplaceSubscriptionFinalUsageFlushWorkflow", "subscription_id", input.SubscriptionID)
+
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 5 * time.Minute,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 2.0,
+			MaximumInterval:    1 * time.Minute,
+			MaximumAttempts:    5,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var result models.MarketplaceSubscriptionFinalUsageFlushWorkflowResult
+	if err := workflow.ExecuteActivity(ctx, ActivityMarketplaceSubscriptionFinalUsageFlush, models.MarketplaceSubscriptionFinalUsageFlushActivityInput{
+		SubscriptionID: input.SubscriptionID,
+		CancelAt:       input.CancelAt,
+		TenantID:       input.TenantID,
+		EnvironmentID:  input.EnvironmentID,
+	}).Get(ctx, &result); err != nil {
+		log.Error("MarketplaceSubscriptionFinalUsageFlushWorkflow activity failed",
+			"subscription_id", input.SubscriptionID, "error", err)
+		return nil, err
+	}
+
+	log.Info("MarketplaceSubscriptionFinalUsageFlushWorkflow completed",
+		"subscription_id", input.SubscriptionID,
+		"final_record_id", result.FinalRecordID,
+		"records_succeeded", len(result.SucceededRecordIDs),
+		"records_failed", len(result.FailedRecordIDs),
+		"records_skipped", len(result.SkippedRecordIDs),
+		"mappings_delinked", len(result.DelinkedMappingIDs))
+	return &result, nil
+}

--- a/internal/testutil/inmemory_entityintegrationmapping_store.go
+++ b/internal/testutil/inmemory_entityintegrationmapping_store.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -90,9 +91,19 @@ func (s *InMemoryEntityIntegrationMappingStore) Update(ctx context.Context, mapp
 	return s.InMemoryStore.Update(ctx, mapping.ID, copyEntityIntegrationMapping(mapping))
 }
 
-// Delete removes an entity integration mapping
+// Delete soft-deletes an entity integration mapping by flipping status to archived, mirroring the
+// real Ent repository (repository/ent/entityintegrationmapping.go) — the row is never removed, so a
+// re-link can still find it via a status-blind List.
 func (s *InMemoryEntityIntegrationMappingStore) Delete(ctx context.Context, mapping *entityintegrationmapping.EntityIntegrationMapping) error {
-	return s.InMemoryStore.Delete(ctx, mapping.ID)
+	existing, err := s.InMemoryStore.Get(ctx, mapping.ID)
+	if err != nil {
+		return err
+	}
+	archived := copyEntityIntegrationMapping(existing)
+	archived.Status = types.StatusArchived
+	archived.UpdatedAt = time.Now().UTC()
+	archived.UpdatedBy = types.GetUserID(ctx)
+	return s.InMemoryStore.Update(ctx, archived.ID, archived)
 }
 
 // GetByEntityAndProvider retrieves an entity integration mapping by entity and provider
@@ -219,6 +230,13 @@ func entityIntegrationMappingFilterFn(ctx context.Context, m *entityintegrationm
 
 	// Apply environment filter
 	if !CheckEnvironmentFilter(ctx, m.EnvironmentID) {
+		return false
+	}
+
+	// Apply status filter — mirrors ApplyStatusFilter in repository/ent: no predicate when unset,
+	// so a status-blind filter (e.g. NewNoLimitQueryFilter) matches archived rows too, matching the
+	// real repository's behaviour that the relink-after-delink fix depends on.
+	if f.GetStatus() != "" && string(m.Status) != f.GetStatus() {
 		return false
 	}
 

--- a/internal/testutil/inmemory_usagerecord_store.go
+++ b/internal/testutil/inmemory_usagerecord_store.go
@@ -64,17 +64,123 @@ func (s *InMemoryUsageRecordStore) ExistsForPeriod(ctx context.Context, subscrip
 	return len(items) > 0, nil
 }
 
+// unsyncedSubmissionWindow mirrors the real repository's bound (repository/ent/usagerecord.go) —
+// none of the three marketplaces accept a report older than this.
+const unsyncedSubmissionWindow = 24 * time.Hour
+
 func (s *InMemoryUsageRecordStore) ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*usagerecord.UsageRecord, error) {
+	cutoff := time.Now().UTC().Add(-unsyncedSubmissionWindow)
 	filterFn := func(_ context.Context, r *usagerecord.UsageRecord, _ interface{}) bool {
 		return r.TenantID == tenantID &&
 			r.EnvironmentID == environmentID &&
 			!r.Synced &&
-			r.Status == types.StatusPublished
+			r.Status == types.StatusPublished &&
+			!r.PeriodEnd.Before(cutoff)
 	}
 	items, err := s.store.List(ctx, nil, filterFn, nil)
 	if err != nil {
 		return nil, err
 	}
+	result := make([]*usagerecord.UsageRecord, len(items))
+	for i, item := range items {
+		result[i] = copyUsageRecord(item)
+	}
+	return result, nil
+}
+
+// List returns usage records matching filter, mirroring the real repository's semantics
+// (repository/ent/usagerecord.go): tenant/environment always scoped, status defaults to published
+// unless the filter is status-blind, sorted and limited per the embedded QueryFilter.
+func (s *InMemoryUsageRecordStore) List(ctx context.Context, filter *types.UsageRecordFilter) ([]*usagerecord.UsageRecord, error) {
+	if filter == nil {
+		filter = types.NewUsageRecordFilter()
+	}
+
+	filterFn := func(ctx context.Context, r *usagerecord.UsageRecord, _ interface{}) bool {
+		if !CheckTenantFilter(ctx, r.TenantID) || !CheckEnvironmentFilter(ctx, r.EnvironmentID) {
+			return false
+		}
+		// Unlike entity_integration_mapping, an empty status here defaults to published rather than
+		// matching every status — mirrors UsageRecordQueryOptions.ApplyStatusFilter in
+		// repository/ent/usagerecord.go. Nothing archives a usage record today, so this is always
+		// what every caller wants.
+		status := filter.GetStatus()
+		if status == "" {
+			status = string(types.StatusPublished)
+		}
+		if string(r.Status) != status {
+			return false
+		}
+		if filter.SubscriptionID != "" && r.SubscriptionID != filter.SubscriptionID {
+			return false
+		}
+		if filter.CustomerID != "" && r.CustomerID != filter.CustomerID {
+			return false
+		}
+		if filter.CustomerExternalID != "" && r.CustomerExternalID != filter.CustomerExternalID {
+			return false
+		}
+		if filter.PlanID != "" && r.PlanID != filter.PlanID {
+			return false
+		}
+		if filter.Currency != "" && r.Currency != filter.Currency {
+			return false
+		}
+		if filter.PeriodStart != nil && !r.PeriodStart.Equal(*filter.PeriodStart) {
+			return false
+		}
+		if filter.PeriodEnd != nil && !r.PeriodEnd.Equal(*filter.PeriodEnd) {
+			return false
+		}
+		if filter.Synced != nil && r.Synced != *filter.Synced {
+			return false
+		}
+		return matchesUsageRecordDSLFilters(r, filter.Filters)
+	}
+
+	sortField, sortAsc := filter.GetSort(), filter.GetOrder() == types.OrderAsc
+	if len(filter.Sort) > 0 {
+		// DSL sort wins, matching dsl.ApplySorts being applied after ApplySorting in the real repo.
+		sortField = filter.Sort[0].Field
+		sortAsc = filter.Sort[0].Direction == types.SortDirectionAsc
+	}
+
+	var sortFn func(i, j *usagerecord.UsageRecord) bool
+	switch sortField {
+	case "period_end":
+		sortFn = func(i, j *usagerecord.UsageRecord) bool {
+			if sortAsc {
+				return i.PeriodEnd.Before(j.PeriodEnd)
+			}
+			return i.PeriodEnd.After(j.PeriodEnd)
+		}
+	case "period_start":
+		sortFn = func(i, j *usagerecord.UsageRecord) bool {
+			if sortAsc {
+				return i.PeriodStart.Before(j.PeriodStart)
+			}
+			return i.PeriodStart.After(j.PeriodStart)
+		}
+	case "created_at":
+		sortFn = func(i, j *usagerecord.UsageRecord) bool {
+			if sortAsc {
+				return i.CreatedAt.Before(j.CreatedAt)
+			}
+			return i.CreatedAt.After(j.CreatedAt)
+		}
+	}
+
+	items, err := s.store.List(ctx, nil, filterFn, sortFn)
+	if err != nil {
+		return nil, err
+	}
+
+	if !filter.IsUnlimited() {
+		if limit := filter.GetLimit(); limit > 0 && limit < len(items) {
+			items = items[:limit]
+		}
+	}
+
 	result := make([]*usagerecord.UsageRecord, len(items))
 	for i, item := range items {
 		result[i] = copyUsageRecord(item)
@@ -135,4 +241,52 @@ func copyUsageRecord(r *usagerecord.UsageRecord) *usagerecord.UsageRecord {
 			UpdatedBy: r.UpdatedBy,
 		},
 	}
+}
+
+// matchesUsageRecordDSLFilters evaluates the generic DSL conditions the real repository hands to
+// dsl.ApplyFilters. Only the date and string comparisons usage_records actually needs are supported;
+// an unrecognised field or operator fails the match loudly rather than silently passing, so a test
+// exercising an unsupported condition cannot quietly get wrong results.
+func matchesUsageRecordDSLFilters(r *usagerecord.UsageRecord, conditions []*types.FilterCondition) bool {
+	for _, c := range conditions {
+		if c == nil || c.Field == nil || c.Operator == nil {
+			continue
+		}
+		var field time.Time
+		switch *c.Field {
+		case "period_end":
+			field = r.PeriodEnd
+		case "period_start":
+			field = r.PeriodStart
+		case "created_at":
+			field = r.CreatedAt
+		default:
+			return false // unsupported field — see doc comment
+		}
+		if c.Value == nil || c.Value.Date == nil {
+			return false
+		}
+		want := *c.Value.Date
+		switch *c.Operator {
+		case types.GREATER_THAN_EQUAL:
+			if field.Before(want) {
+				return false
+			}
+		case types.GREATER_THAN, types.AFTER:
+			if !field.After(want) {
+				return false
+			}
+		case types.LESS_THAN, types.BEFORE:
+			if !field.Before(want) {
+				return false
+			}
+		case types.EQUAL:
+			if !field.Equal(want) {
+				return false
+			}
+		default:
+			return false // unsupported operator — see doc comment
+		}
+	}
+	return true
 }

--- a/internal/testutil/inmemory_usagerecord_store.go
+++ b/internal/testutil/inmemory_usagerecord_store.go
@@ -31,9 +31,8 @@ func (s *InMemoryUsageRecordStore) Create(ctx context.Context, rec *usagerecord.
 		rec.Syncs = map[string]types.UsageRecordSyncEntry{}
 	}
 
-	// Mirrors the unique index on (tenant_id, environment_id, subscription_id, period_start,
-	// period_end) — kept in-memory since it costs nothing and exercises snapshotSubscription's
-	// ErrAlreadyExists path.
+	// Enforces the table's unique key on (tenant, environment, subscription, period_start,
+	// period_end), so callers relying on the already-exists error behave as they do against Postgres.
 	exists, _ := s.ExistsForPeriod(ctx, rec.SubscriptionID, rec.PeriodStart, rec.PeriodEnd)
 	if exists {
 		return ierr.NewError("usage record already exists for this subscription and period").
@@ -64,8 +63,8 @@ func (s *InMemoryUsageRecordStore) ExistsForPeriod(ctx context.Context, subscrip
 	return len(items) > 0, nil
 }
 
-// unsyncedSubmissionWindow mirrors the real repository's bound (repository/ent/usagerecord.go) —
-// none of the three marketplaces accept a report older than this.
+// unsyncedSubmissionWindow bounds unsynced rows to those a marketplace can still accept, as the
+// repository does.
 const unsyncedSubmissionWindow = 24 * time.Hour
 
 func (s *InMemoryUsageRecordStore) ListUnsynced(ctx context.Context, tenantID, environmentID string) ([]*usagerecord.UsageRecord, error) {
@@ -88,9 +87,9 @@ func (s *InMemoryUsageRecordStore) ListUnsynced(ctx context.Context, tenantID, e
 	return result, nil
 }
 
-// List returns usage records matching filter, mirroring the real repository's semantics
-// (repository/ent/usagerecord.go): tenant/environment always scoped, status defaults to published
-// unless the filter is status-blind, sorted and limited per the embedded QueryFilter.
+// List returns the usage records matching filter, reproducing the repository's semantics: always
+// scoped to the caller's tenant and environment, defaulting to published rows, sorted and paginated
+// per the embedded query filter.
 func (s *InMemoryUsageRecordStore) List(ctx context.Context, filter *types.UsageRecordFilter) ([]*usagerecord.UsageRecord, error) {
 	if filter == nil {
 		filter = types.NewUsageRecordFilter()
@@ -100,10 +99,8 @@ func (s *InMemoryUsageRecordStore) List(ctx context.Context, filter *types.Usage
 		if !CheckTenantFilter(ctx, r.TenantID) || !CheckEnvironmentFilter(ctx, r.EnvironmentID) {
 			return false
 		}
-		// Unlike entity_integration_mapping, an empty status here defaults to published rather than
-		// matching every status — mirrors UsageRecordQueryOptions.ApplyStatusFilter in
-		// repository/ent/usagerecord.go. Nothing archives a usage record today, so this is always
-		// what every caller wants.
+		// An unset status means published rather than any status, as the repository does. Nothing
+		// archives a usage record, so every caller wants published rows.
 		status := filter.GetStatus()
 		if status == "" {
 			status = string(types.StatusPublished)
@@ -135,12 +132,21 @@ func (s *InMemoryUsageRecordStore) List(ctx context.Context, filter *types.Usage
 		if filter.Synced != nil && r.Synced != *filter.Synced {
 			return false
 		}
+		// Bounds created_at, as the repository does.
+		if filter.TimeRangeFilter != nil {
+			if filter.StartTime != nil && r.CreatedAt.Before(*filter.StartTime) {
+				return false
+			}
+			if filter.EndTime != nil && r.CreatedAt.After(*filter.EndTime) {
+				return false
+			}
+		}
 		return matchesUsageRecordDSLFilters(r, filter.Filters)
 	}
 
 	sortField, sortAsc := filter.GetSort(), filter.GetOrder() == types.OrderAsc
 	if len(filter.Sort) > 0 {
-		// DSL sort wins, matching dsl.ApplySorts being applied after ApplySorting in the real repo.
+		// A sort condition overrides the query filter's, since it is applied last.
 		sortField = filter.Sort[0].Field
 		sortAsc = filter.Sort[0].Direction == types.SortDirectionAsc
 	}
@@ -170,15 +176,11 @@ func (s *InMemoryUsageRecordStore) List(ctx context.Context, filter *types.Usage
 		}
 	}
 
-	items, err := s.store.List(ctx, nil, filterFn, sortFn)
+	// Passing the filter through applies offset as well as limit. Slicing by limit here instead would
+	// ignore a non-zero offset and return the first page where the database returns a later one.
+	items, err := s.store.List(ctx, filter, filterFn, sortFn)
 	if err != nil {
 		return nil, err
-	}
-
-	if !filter.IsUnlimited() {
-		if limit := filter.GetLimit(); limit > 0 && limit < len(items) {
-			items = items[:limit]
-		}
 	}
 
 	result := make([]*usagerecord.UsageRecord, len(items))

--- a/internal/testutil/inmemory_usagerecord_store_test.go
+++ b/internal/testutil/inmemory_usagerecord_store_test.go
@@ -304,13 +304,13 @@ func TestUsageRecordSyncSurvivesConnectionReplacement(t *testing.T) {
 	// unchanged, so the record must still read as reported.
 	got, ok := syncs[awsKey]
 	require.True(t, ok, "the entry is found by marketplace regardless of which connection wrote it")
-	require.True(t, got.IsResolved())
+	require.True(t, got.IsSynced())
 	require.Equal(t, "conn_old", got.ConnectionID, "the reporting connection stays recorded for tracing")
 }
 
-// A half-written entry must not be mistaken for a completed report: treating one as done would
-// silently drop the usage it stands for.
-func TestUsageRecordSyncEntryIsResolved(t *testing.T) {
+// A skip resolves the marketplace so it is not retried, but it is not a delivery: nothing was sent,
+// so it must not be counted as synced and must carry no SyncedAt.
+func TestUsageRecordSyncEntryIsSynced(t *testing.T) {
 	now := time.Now().UTC()
 	cases := []struct {
 		name  string
@@ -318,14 +318,25 @@ func TestUsageRecordSyncEntryIsResolved(t *testing.T) {
 		want  bool
 	}{
 		{"accepted", types.UsageRecordSyncEntry{AgreementID: "a", ReportingID: "r", SyncedAt: now}, true},
-		{"skipped still resolves", types.UsageRecordSyncEntry{AgreementID: "a", SyncedAt: now, Skipped: true, SkipReason: "zero_amount_not_supported"}, true},
-		{"zero value", types.UsageRecordSyncEntry{}, false},
-		{"no synced_at", types.UsageRecordSyncEntry{AgreementID: "a", ReportingID: "r"}, false},
-		{"no agreement id", types.UsageRecordSyncEntry{ReportingID: "r", SyncedAt: now}, false},
+		{"skipped", types.UsageRecordSyncEntry{AgreementID: "a", Skipped: true, SkipReason: types.SkipReasonZeroAmountNotSupported}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, tc.entry.IsResolved())
+			require.Equal(t, tc.want, tc.entry.IsSynced())
 		})
 	}
+}
+
+// A skip records no SyncedAt, since synced_at means the marketplace accepted the usage and a skip
+// never sent it.
+func TestUsageRecordSkipCarriesNoSyncedAt(t *testing.T) {
+	skip := types.UsageRecordSyncEntry{
+		AgreementID:  "resource-id",
+		ConnectionID: "conn_azure",
+		Skipped:      true,
+		SkipReason:   types.SkipReasonZeroAmountNotSupported,
+	}
+	require.True(t, skip.SyncedAt.IsZero(), "a skip sent nothing, so it was never synced at any time")
+	require.False(t, skip.IsSynced())
+	require.Empty(t, skip.ReportingID, "a skip has no marketplace receipt")
 }

--- a/internal/testutil/inmemory_usagerecord_store_test.go
+++ b/internal/testutil/inmemory_usagerecord_store_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/domain/usagerecord"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +86,199 @@ func TestInMemoryUsageRecordStore(t *testing.T) {
 	unsynced, err = store.ListUnsynced(ctx, "tenant_1", "env_1")
 	require.NoError(t, err)
 	require.Len(t, unsynced, 0)
+}
+
+// usageRecordAt builds a published record covering [end-1h, end) for the given subscription.
+func usageRecordAt(ctx context.Context, id, subscriptionID string, end time.Time) *usagerecord.UsageRecord {
+	return &usagerecord.UsageRecord{
+		ID:             id,
+		CustomerID:     "cust_1",
+		SubscriptionID: subscriptionID,
+		PlanID:         "plan_1",
+		Amount:         decimal.NewFromInt(10),
+		Currency:       "usd",
+		PeriodStart:    end.Add(-time.Hour),
+		PeriodEnd:      end,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+}
+
+func periodEndCondition(op types.FilterOperatorType, at time.Time) *types.FilterCondition {
+	return &types.FilterCondition{
+		Field:    lo.ToPtr("period_end"),
+		Operator: lo.ToPtr(op),
+		DataType: lo.ToPtr(types.DataTypeDate),
+		Value:    &types.Value{Date: lo.ToPtr(at)},
+	}
+}
+
+// Covers the List query shapes the cancellation flush depends on: the exact-window lookup for an
+// existing final record, and the period_end bounds used for the backlog and the last computed point.
+func TestInMemoryUsageRecordStore_ListFilters(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.CtxTenantID, "tenant_1")
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, "env_1")
+
+	store := NewInMemoryUsageRecordStore()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	ends := []time.Time{
+		now.Add(-5 * time.Hour),
+		now.Add(-4 * time.Hour),
+		now.Add(-3 * time.Hour),
+		now.Add(-2 * time.Hour),
+		now.Add(-1 * time.Hour),
+	}
+	ids := []string{"ur_5h", "ur_4h", "ur_3h", "ur_2h", "ur_1h"}
+	for i, end := range ends {
+		require.NoError(t, store.Create(ctx, usageRecordAt(ctx, ids[i], "sub_1", end)))
+	}
+	// A second subscription must never leak into a subscription-scoped query.
+	require.NoError(t, store.Create(ctx, usageRecordAt(ctx, "ur_other", "sub_2", ends[0])))
+
+	t.Run("exact window identifies a single row", func(t *testing.T) {
+		got, err := store.List(ctx, &types.UsageRecordFilter{
+			QueryFilter:    types.NewNoLimitQueryFilter(),
+			SubscriptionID: "sub_1",
+			PeriodStart:    lo.ToPtr(ends[2].Add(-time.Hour)),
+			PeriodEnd:      &ends[2],
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1, "the unique key over the window admits at most one row")
+		require.Equal(t, "ur_3h", got[0].ID)
+	})
+
+	t.Run("exact window returns nothing when the row is absent", func(t *testing.T) {
+		unwritten := now.Add(30 * time.Minute)
+		got, err := store.List(ctx, &types.UsageRecordFilter{
+			QueryFilter:    types.NewNoLimitQueryFilter(),
+			SubscriptionID: "sub_1",
+			PeriodStart:    lo.ToPtr(unwritten.Add(-time.Hour)),
+			PeriodEnd:      &unwritten,
+		})
+		require.NoError(t, err)
+		require.Empty(t, got, "an empty result is how the flush decides to compute the record")
+	})
+
+	t.Run("period_end bounds, sorted ascending", func(t *testing.T) {
+		got, err := store.List(ctx, &types.UsageRecordFilter{
+			// No Limit, exactly as the flush's backlog query builds it: an unset limit is unbounded.
+			QueryFilter: &types.QueryFilter{
+				Sort:  lo.ToPtr("period_end"),
+				Order: lo.ToPtr(types.OrderAsc),
+			},
+			SubscriptionID: "sub_1",
+			Filters: []*types.FilterCondition{
+				periodEndCondition(types.GREATER_THAN_EQUAL, ends[1]),
+				periodEndCondition(types.LESS_THAN, ends[4]),
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"ur_4h", "ur_3h", "ur_2h"}, recordIDs(got),
+			"lower bound inclusive, upper bound exclusive")
+	})
+
+	t.Run("last computed point excludes the boundary row", func(t *testing.T) {
+		got, err := store.List(ctx, &types.UsageRecordFilter{
+			QueryFilter: &types.QueryFilter{
+				Sort:  lo.ToPtr("period_end"),
+				Order: lo.ToPtr(types.OrderDesc),
+				Limit: lo.ToPtr(1),
+			},
+			SubscriptionID: "sub_1",
+			Filters:        []*types.FilterCondition{periodEndCondition(types.LESS_THAN, ends[4])},
+		})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, "ur_2h", got[0].ID, "newest row strictly before the cutoff")
+	})
+
+	t.Run("pagination applies offset as well as limit", func(t *testing.T) {
+		got, err := store.List(ctx, &types.UsageRecordFilter{
+			QueryFilter: &types.QueryFilter{
+				Sort:   lo.ToPtr("period_end"),
+				Order:  lo.ToPtr(types.OrderAsc),
+				Limit:  lo.ToPtr(2),
+				Offset: lo.ToPtr(2),
+			},
+			SubscriptionID: "sub_1",
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"ur_3h", "ur_2h"}, recordIDs(got),
+			"a non-zero offset must not silently return the first page")
+	})
+}
+
+// The invariant the cancellation flush rests on: every attempt computes the same window, so a retry
+// collides with the unique key and reuses the existing row instead of writing a second one. If the
+// window could shift between attempts the key would differ and nothing would catch the duplicate.
+func TestUsageRecordFlushRetryReusesTheSameRecord(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, types.CtxTenantID, "tenant_1")
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, "env_1")
+
+	store := NewInMemoryUsageRecordStore()
+	cancelAt := time.Now().UTC().Truncate(time.Second)
+	snapshotEnd := cancelAt.Add(-4 * time.Hour)
+	require.NoError(t, store.Create(ctx, usageRecordAt(ctx, "ur_snapshot", "sub_1", snapshotEnd)))
+
+	// lastComputedPeriodEnd: newest period_end strictly before cancelAt, so the final record can
+	// never move the start of its own window.
+	windowStart := func() time.Time {
+		rows, err := store.List(ctx, &types.UsageRecordFilter{
+			QueryFilter: &types.QueryFilter{
+				Sort: lo.ToPtr("period_end"), Order: lo.ToPtr(types.OrderDesc), Limit: lo.ToPtr(1),
+			},
+			SubscriptionID: "sub_1",
+			Filters:        []*types.FilterCondition{periodEndCondition(types.LESS_THAN, cancelAt)},
+		})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		return rows[0].PeriodEnd
+	}
+
+	// Attempt 1: nothing covers the window yet, so the record is computed and written.
+	first := windowStart()
+	require.Equal(t, snapshotEnd, first)
+	final := &usagerecord.UsageRecord{
+		ID: "ur_final", CustomerID: "cust_1", SubscriptionID: "sub_1", PlanID: "plan_1",
+		Amount: decimal.NewFromInt(42), Currency: "usd",
+		PeriodStart: first, PeriodEnd: cancelAt, BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	require.NoError(t, store.Create(ctx, final))
+
+	// Attempt 2: the window is unchanged, the lookup finds the row, and no second one is written.
+	require.Equal(t, first, windowStart(), "the final record must not move the window it starts from")
+
+	existing, err := store.List(ctx, &types.UsageRecordFilter{
+		QueryFilter:    types.NewNoLimitQueryFilter(),
+		SubscriptionID: "sub_1",
+		PeriodStart:    &first,
+		PeriodEnd:      &cancelAt,
+	})
+	require.NoError(t, err)
+	require.Len(t, existing, 1)
+	require.Equal(t, "ur_final", existing[0].ID, "the record keeps one identity across attempts")
+
+	duplicate := *final
+	duplicate.ID = "ur_final_retry"
+	require.Error(t, store.Create(ctx, &duplicate), "the unique key must reject a second final record")
+
+	all, err := store.List(ctx, &types.UsageRecordFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(), SubscriptionID: "sub_1",
+	})
+	require.NoError(t, err)
+	require.Len(t, all, 2, "one snapshot row and one final record")
+
+	// The stored window ends at the true cancellation instant; the reporting margin is applied only
+	// to the value sent to a provider.
+	require.Equal(t, cancelAt, existing[0].PeriodEnd)
+}
+
+func recordIDs(records []*usagerecord.UsageRecord) []string {
+	ids := make([]string, len(records))
+	for i, r := range records {
+		ids[i] = r.ID
+	}
+	return ids
 }

--- a/internal/testutil/inmemory_usagerecord_store_test.go
+++ b/internal/testutil/inmemory_usagerecord_store_test.go
@@ -55,21 +55,24 @@ func TestInMemoryUsageRecordStore(t *testing.T) {
 	require.Len(t, unsynced, 1)
 	require.Equal(t, "ur_1", unsynced[0].ID)
 
-	// Reported to one of two relevant connections — synced stays false, still in the unsynced list
+	// Reported to one of two marketplaces the subscription has an agreement on — synced stays false,
+	// so the record is still in the unsynced list
+	awsKey := string(types.SecretProviderAWSMarketplace)
+	gcpKey := string(types.SecretProviderGCPMarketplace)
 	err = store.MarkSynced(ctx, "ur_1", map[string]types.UsageRecordSyncEntry{
-		"conn_aws": {Marketplace: types.SecretProviderAWSMarketplace, ReportingID: "aws-report-1", SyncedAt: time.Now().UTC()},
+		awsKey: {AgreementID: "arn:aws:license-manager::l-abc", ReportingID: "aws-report-1", SyncedAt: time.Now().UTC(), ConnectionID: "conn_aws"},
 	}, false)
 	require.NoError(t, err)
 
 	unsynced, err = store.ListUnsynced(ctx, "tenant_1", "env_1")
 	require.NoError(t, err)
-	require.Len(t, unsynced, 1, "still relevant to a second connection, so still unsynced")
-	require.Contains(t, unsynced[0].Syncs, "conn_aws")
+	require.Len(t, unsynced, 1, "a second marketplace is still outstanding, so still unsynced")
+	require.Contains(t, unsynced[0].Syncs, awsKey)
 
-	// Reported to the second connection too — now fully synced, drops out of the unsynced list
+	// Reported to the second marketplace too — now fully synced, drops out of the unsynced list
 	err = store.MarkSynced(ctx, "ur_1", map[string]types.UsageRecordSyncEntry{
-		"conn_aws": {Marketplace: types.SecretProviderAWSMarketplace, ReportingID: "aws-report-1", SyncedAt: time.Now().UTC()},
-		"conn_gcp": {Marketplace: types.SecretProviderGCPMarketplace, ReportingID: "gcp-report-1", SyncedAt: time.Now().UTC()},
+		awsKey: {AgreementID: "arn:aws:license-manager::l-abc", ReportingID: "aws-report-1", SyncedAt: time.Now().UTC(), ConnectionID: "conn_aws"},
+		gcpKey: {AgreementID: "gcp-usage-reporting-id", ReportingID: "gcp-report-1", SyncedAt: time.Now().UTC(), ConnectionID: "conn_gcp"},
 	}, true)
 	require.NoError(t, err)
 
@@ -79,8 +82,8 @@ func TestInMemoryUsageRecordStore(t *testing.T) {
 
 	stored, err := store.store.Get(ctx, "ur_1")
 	require.NoError(t, err)
-	require.Contains(t, stored.Syncs, "conn_aws")
-	require.Contains(t, stored.Syncs, "conn_gcp")
+	require.Contains(t, stored.Syncs, awsKey)
+	require.Contains(t, stored.Syncs, gcpKey)
 
 	store.Clear()
 	unsynced, err = store.ListUnsynced(ctx, "tenant_1", "env_1")
@@ -281,4 +284,48 @@ func recordIDs(records []*usagerecord.UsageRecord) []string {
 		ids[i] = r.ID
 	}
 	return ids
+}
+
+// The sync map is keyed by marketplace, not by the connection that reported it, so replacing a
+// connection must not make an already reported record look unreported. Keyed by connection id this
+// would report the same usage to the same marketplace twice.
+func TestUsageRecordSyncSurvivesConnectionReplacement(t *testing.T) {
+	awsKey := string(types.SecretProviderAWSMarketplace)
+
+	entry := types.UsageRecordSyncEntry{
+		AgreementID:  "arn:aws:license-manager::l-abc",
+		ReportingID:  "aws-report-1",
+		SyncedAt:     time.Now().UTC(),
+		ConnectionID: "conn_old",
+	}
+	syncs := map[string]types.UsageRecordSyncEntry{awsKey: entry}
+
+	// The tenant deletes conn_old and connects conn_new for the same marketplace. The agreement is
+	// unchanged, so the record must still read as reported.
+	got, ok := syncs[awsKey]
+	require.True(t, ok, "the entry is found by marketplace regardless of which connection wrote it")
+	require.True(t, got.IsResolved())
+	require.Equal(t, "conn_old", got.ConnectionID, "the reporting connection stays recorded for tracing")
+}
+
+// A half-written entry must not be mistaken for a completed report: treating one as done would
+// silently drop the usage it stands for.
+func TestUsageRecordSyncEntryIsResolved(t *testing.T) {
+	now := time.Now().UTC()
+	cases := []struct {
+		name  string
+		entry types.UsageRecordSyncEntry
+		want  bool
+	}{
+		{"accepted", types.UsageRecordSyncEntry{AgreementID: "a", ReportingID: "r", SyncedAt: now}, true},
+		{"skipped still resolves", types.UsageRecordSyncEntry{AgreementID: "a", SyncedAt: now, Skipped: true, SkipReason: "zero_amount_not_supported"}, true},
+		{"zero value", types.UsageRecordSyncEntry{}, false},
+		{"no synced_at", types.UsageRecordSyncEntry{AgreementID: "a", ReportingID: "r"}, false},
+		{"no agreement id", types.UsageRecordSyncEntry{ReportingID: "r", SyncedAt: now}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.entry.IsResolved())
+		})
+	}
 }

--- a/internal/types/temporal.go
+++ b/internal/types/temporal.go
@@ -55,58 +55,61 @@ type TemporalWorkflowType string
 
 const (
 	// Workflow Types - only include implemented workflows
-	TemporalCreditGrantProcessingWorkflow              TemporalWorkflowType = "CreditGrantProcessingWorkflow"
-	TemporalSubscriptionAutoCancellationWorkflow       TemporalWorkflowType = "SubscriptionAutoCancellationWorkflow"
-	TemporalWalletCreditExpiryWorkflow                 TemporalWorkflowType = "WalletCreditExpiryWorkflow"
-	TemporalSubscriptionBillingPeriodsWorkflow         TemporalWorkflowType = "SubscriptionBillingPeriodsWorkflow"
-	TemporalSubscriptionRenewalDueAlertsWorkflow       TemporalWorkflowType = "SubscriptionRenewalDueAlertsWorkflow"
-	TemporalOutboundWebhookStaleRetryWorkflow          TemporalWorkflowType = "OutboundWebhookStaleRetryWorkflow"
-	TemporalAutoInvoiceThresholdBillingWorkflow        TemporalWorkflowType = "AutoInvoiceThresholdBillingWorkflow"
-	TemporalChargebeeCustomerSyncWorkflow              TemporalWorkflowType = "ChargebeeCustomerSyncWorkflow"
-	TemporalChargebeeInvoiceSyncWorkflow               TemporalWorkflowType = "ChargebeeInvoiceSyncWorkflow"
-	TemporalComputeInvoiceWorkflow                     TemporalWorkflowType = "ComputeInvoiceWorkflow"
-	TemporalCustomerOnboardingWorkflow                 TemporalWorkflowType = "CustomerOnboardingWorkflow"
-	TemporalDraftAndComputeSubscriptionInvoiceWorkflow TemporalWorkflowType = "DraftAndComputeSubscriptionInvoiceWorkflow"
-	TemporalEnvironmentCloneWorkflow                   TemporalWorkflowType = "EnvironmentCloneWorkflow"
-	TemporalExecuteExportWorkflow                      TemporalWorkflowType = "ExecuteExportWorkflow"
-	TemporalFinalizeDraftInvoiceWorkflow               TemporalWorkflowType = "FinalizeDraftInvoiceWorkflow"
-	TemporalHubSpotDealSyncWorkflow                    TemporalWorkflowType = "HubSpotDealSyncWorkflow"
-	TemporalHubSpotInvoiceSyncWorkflow                 TemporalWorkflowType = "HubSpotInvoiceSyncWorkflow"
-	TemporalHubSpotQuoteSyncWorkflow                   TemporalWorkflowType = "HubSpotQuoteSyncWorkflow"
-	TemporalUsageAlertWorkflow                         TemporalWorkflowType = "UsageAlertWorkflow"
-	TemporalMoyasarInvoiceSyncWorkflow                 TemporalWorkflowType = "MoyasarInvoiceSyncWorkflow"
-	TemporalNomodCustomerSyncWorkflow                  TemporalWorkflowType = "NomodCustomerSyncWorkflow"
-	TemporalNomodInvoiceSyncWorkflow                   TemporalWorkflowType = "NomodInvoiceSyncWorkflow"
-	TemporalPaddleCustomerSyncWorkflow                 TemporalWorkflowType = "PaddleCustomerSyncWorkflow"
-	TemporalPaddleInvoiceSyncWorkflow                  TemporalWorkflowType = "PaddleInvoiceSyncWorkflow"
-	TemporalPaddleInvoicePullSyncWorkflow              TemporalWorkflowType = "PaddleInvoicePullSyncWorkflow"
-	TemporalPaddleSubscriptionSyncWorkflow             TemporalWorkflowType = "PaddleSubscriptionSyncWorkflow"
-	TemporalPrepareProcessedEventsWorkflow             TemporalWorkflowType = "PrepareProcessedEventsWorkflow"
-	TemporalPriceSyncWorkflow                          TemporalWorkflowType = "PriceSyncWorkflow"
-	TemporalPriceSyncV2Workflow                        TemporalWorkflowType = "PriceSyncV2Workflow"
-	TemporalProcessInvoiceWorkflow                     TemporalWorkflowType = "ProcessInvoiceWorkflow"
-	TemporalProcessSubscriptionBillingWorkflow         TemporalWorkflowType = "ProcessSubscriptionBillingWorkflow"
-	TemporalQuickBooksCustomerSyncWorkflow             TemporalWorkflowType = "QuickBooksCustomerSyncWorkflow"
-	TemporalQuickBooksInvoiceSyncWorkflow              TemporalWorkflowType = "QuickBooksInvoiceSyncWorkflow"
-	TemporalQuickBooksPriceSyncWorkflow                TemporalWorkflowType = "QuickBooksPriceSyncWorkflow"
-	TemporalRazorpayCustomerSyncWorkflow               TemporalWorkflowType = "RazorpayCustomerSyncWorkflow"
-	TemporalRazorpayInvoiceSyncWorkflow                TemporalWorkflowType = "RazorpayInvoiceSyncWorkflow"
-	TemporalRecalculateInvoiceWorkflow                 TemporalWorkflowType = "RecalculateInvoiceWorkflow"
-	TemporalReprocessRawEventsWorkflow                 TemporalWorkflowType = "ReprocessRawEventsWorkflow"
-	TemporalScheduleDraftFinalizationWorkflow          TemporalWorkflowType = "ScheduleDraftFinalizationWorkflow"
-	TemporalScheduleSubscriptionBillingWorkflow        TemporalWorkflowType = "ScheduleSubscriptionBillingWorkflow"
-	TemporalStripeCustomerSyncWorkflow                 TemporalWorkflowType = "StripeCustomerSyncWorkflow"
-	TemporalStripeIntegrationWorkflow                  TemporalWorkflowType = "StripeIntegrationWorkflow"
-	TemporalStripeInvoiceSyncWorkflow                  TemporalWorkflowType = "StripeInvoiceSyncWorkflow"
-	TemporalWhopInvoiceSyncWorkflow                    TemporalWorkflowType = "WhopInvoiceSyncWorkflow"
-	TemporalWhopInvoiceMarkPaidWorkflow                TemporalWorkflowType = "WhopInvoiceMarkPaidWorkflow"
-	TemporalZohoBooksInvoiceSyncWorkflow               TemporalWorkflowType = "ZohoBooksInvoiceSyncWorkflow"
-	TemporalZohoBooksInvoiceMarkPaidWorkflow           TemporalWorkflowType = "ZohoBooksInvoiceMarkPaidWorkflow"
-	TemporalTabsInvoiceSyncWorkflow                    TemporalWorkflowType = "TabsInvoiceSyncWorkflow"
-	TemporalSubscriptionChangeWorkflow                 TemporalWorkflowType = "SubscriptionChangeWorkflow"
-	TemporalSubscriptionCreationWorkflow               TemporalWorkflowType = "SubscriptionCreationWorkflow"
-	TemporalTaskProcessingWorkflow                     TemporalWorkflowType = "TaskProcessingWorkflow"
-	TemporalDailyDraftAndComputeWorkflow               TemporalWorkflowType = "DailyDraftAndComputeWorkflow"
+	TemporalCreditGrantProcessingWorkflow                  TemporalWorkflowType = "CreditGrantProcessingWorkflow"
+	TemporalSubscriptionAutoCancellationWorkflow           TemporalWorkflowType = "SubscriptionAutoCancellationWorkflow"
+	TemporalWalletCreditExpiryWorkflow                     TemporalWorkflowType = "WalletCreditExpiryWorkflow"
+	TemporalSubscriptionBillingPeriodsWorkflow             TemporalWorkflowType = "SubscriptionBillingPeriodsWorkflow"
+	TemporalSubscriptionRenewalDueAlertsWorkflow           TemporalWorkflowType = "SubscriptionRenewalDueAlertsWorkflow"
+	TemporalOutboundWebhookStaleRetryWorkflow              TemporalWorkflowType = "OutboundWebhookStaleRetryWorkflow"
+	TemporalAutoInvoiceThresholdBillingWorkflow            TemporalWorkflowType = "AutoInvoiceThresholdBillingWorkflow"
+	TemporalChargebeeCustomerSyncWorkflow                  TemporalWorkflowType = "ChargebeeCustomerSyncWorkflow"
+	TemporalChargebeeInvoiceSyncWorkflow                   TemporalWorkflowType = "ChargebeeInvoiceSyncWorkflow"
+	TemporalComputeInvoiceWorkflow                         TemporalWorkflowType = "ComputeInvoiceWorkflow"
+	TemporalCustomerOnboardingWorkflow                     TemporalWorkflowType = "CustomerOnboardingWorkflow"
+	TemporalDraftAndComputeSubscriptionInvoiceWorkflow     TemporalWorkflowType = "DraftAndComputeSubscriptionInvoiceWorkflow"
+	TemporalEnvironmentCloneWorkflow                       TemporalWorkflowType = "EnvironmentCloneWorkflow"
+	TemporalExecuteExportWorkflow                          TemporalWorkflowType = "ExecuteExportWorkflow"
+	TemporalFinalizeDraftInvoiceWorkflow                   TemporalWorkflowType = "FinalizeDraftInvoiceWorkflow"
+	TemporalHubSpotDealSyncWorkflow                        TemporalWorkflowType = "HubSpotDealSyncWorkflow"
+	TemporalHubSpotInvoiceSyncWorkflow                     TemporalWorkflowType = "HubSpotInvoiceSyncWorkflow"
+	TemporalHubSpotQuoteSyncWorkflow                       TemporalWorkflowType = "HubSpotQuoteSyncWorkflow"
+	TemporalUsageAlertWorkflow                             TemporalWorkflowType = "UsageAlertWorkflow"
+	TemporalMoyasarInvoiceSyncWorkflow                     TemporalWorkflowType = "MoyasarInvoiceSyncWorkflow"
+	TemporalNomodCustomerSyncWorkflow                      TemporalWorkflowType = "NomodCustomerSyncWorkflow"
+	TemporalNomodInvoiceSyncWorkflow                       TemporalWorkflowType = "NomodInvoiceSyncWorkflow"
+	TemporalPaddleCustomerSyncWorkflow                     TemporalWorkflowType = "PaddleCustomerSyncWorkflow"
+	TemporalPaddleInvoiceSyncWorkflow                      TemporalWorkflowType = "PaddleInvoiceSyncWorkflow"
+	TemporalPaddleInvoicePullSyncWorkflow                  TemporalWorkflowType = "PaddleInvoicePullSyncWorkflow"
+	TemporalPaddleSubscriptionSyncWorkflow                 TemporalWorkflowType = "PaddleSubscriptionSyncWorkflow"
+	TemporalPrepareProcessedEventsWorkflow                 TemporalWorkflowType = "PrepareProcessedEventsWorkflow"
+	TemporalPriceSyncWorkflow                              TemporalWorkflowType = "PriceSyncWorkflow"
+	TemporalPriceSyncV2Workflow                            TemporalWorkflowType = "PriceSyncV2Workflow"
+	TemporalProcessInvoiceWorkflow                         TemporalWorkflowType = "ProcessInvoiceWorkflow"
+	TemporalProcessSubscriptionBillingWorkflow             TemporalWorkflowType = "ProcessSubscriptionBillingWorkflow"
+	TemporalQuickBooksCustomerSyncWorkflow                 TemporalWorkflowType = "QuickBooksCustomerSyncWorkflow"
+	TemporalQuickBooksInvoiceSyncWorkflow                  TemporalWorkflowType = "QuickBooksInvoiceSyncWorkflow"
+	TemporalQuickBooksPriceSyncWorkflow                    TemporalWorkflowType = "QuickBooksPriceSyncWorkflow"
+	TemporalRazorpayCustomerSyncWorkflow                   TemporalWorkflowType = "RazorpayCustomerSyncWorkflow"
+	TemporalRazorpayInvoiceSyncWorkflow                    TemporalWorkflowType = "RazorpayInvoiceSyncWorkflow"
+	TemporalRecalculateInvoiceWorkflow                     TemporalWorkflowType = "RecalculateInvoiceWorkflow"
+	TemporalReprocessRawEventsWorkflow                     TemporalWorkflowType = "ReprocessRawEventsWorkflow"
+	TemporalScheduleDraftFinalizationWorkflow              TemporalWorkflowType = "ScheduleDraftFinalizationWorkflow"
+	TemporalScheduleSubscriptionBillingWorkflow            TemporalWorkflowType = "ScheduleSubscriptionBillingWorkflow"
+	TemporalStripeCustomerSyncWorkflow                     TemporalWorkflowType = "StripeCustomerSyncWorkflow"
+	TemporalStripeIntegrationWorkflow                      TemporalWorkflowType = "StripeIntegrationWorkflow"
+	TemporalStripeInvoiceSyncWorkflow                      TemporalWorkflowType = "StripeInvoiceSyncWorkflow"
+	TemporalWhopInvoiceSyncWorkflow                        TemporalWorkflowType = "WhopInvoiceSyncWorkflow"
+	TemporalWhopInvoiceMarkPaidWorkflow                    TemporalWorkflowType = "WhopInvoiceMarkPaidWorkflow"
+	TemporalZohoBooksInvoiceSyncWorkflow                   TemporalWorkflowType = "ZohoBooksInvoiceSyncWorkflow"
+	TemporalZohoBooksInvoiceMarkPaidWorkflow               TemporalWorkflowType = "ZohoBooksInvoiceMarkPaidWorkflow"
+	TemporalTabsInvoiceSyncWorkflow                        TemporalWorkflowType = "TabsInvoiceSyncWorkflow"
+	TemporalSubscriptionChangeWorkflow                     TemporalWorkflowType = "SubscriptionChangeWorkflow"
+	TemporalSubscriptionCreationWorkflow                   TemporalWorkflowType = "SubscriptionCreationWorkflow"
+	TemporalTaskProcessingWorkflow                         TemporalWorkflowType = "TaskProcessingWorkflow"
+	TemporalDailyDraftAndComputeWorkflow                   TemporalWorkflowType = "DailyDraftAndComputeWorkflow"
+	TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow TemporalWorkflowType = "MarketplaceSubscriptionFinalUsageFlushWorkflow"
+	TemporalMarketplaceUsageSnapshotWorkflow               TemporalWorkflowType = "MarketplaceUsageSnapshotWorkflow"
+	TemporalMarketplaceUsageReportWorkflow                 TemporalWorkflowType = "MarketplaceUsageReportWorkflow"
 )
 
 // temporalCronWorkflowTypes is the single list of schedule/worker cron workflows (keeps
@@ -120,6 +123,8 @@ var temporalCronWorkflowTypes = []TemporalWorkflowType{
 	TemporalOutboundWebhookStaleRetryWorkflow,
 	TemporalAutoInvoiceThresholdBillingWorkflow,
 	TemporalDailyDraftAndComputeWorkflow,
+	TemporalMarketplaceUsageSnapshotWorkflow,
+	TemporalMarketplaceUsageReportWorkflow,
 }
 
 var workflowTypesExcludedFromTrackingCore = []TemporalWorkflowType{
@@ -199,6 +204,7 @@ func (w TemporalWorkflowType) Validate() error {
 		TemporalSubscriptionChangeWorkflow,
 		TemporalSubscriptionCreationWorkflow,
 		TemporalTaskProcessingWorkflow,
+		TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow,
 	}...)
 	if lo.Contains(allowedWorkflows, w) {
 		return nil
@@ -226,6 +232,8 @@ func (w TemporalWorkflowType) TaskQueue() TemporalTaskQueue {
 	case TemporalProcessSubscriptionBillingWorkflow:
 		return TemporalTaskQueueSubscription
 	case TemporalRecalculateInvoiceWorkflow:
+		return TemporalTaskQueueSubscription
+	case TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow:
 		return TemporalTaskQueueSubscription
 	case TemporalProcessInvoiceWorkflow, TemporalFinalizeDraftInvoiceWorkflow, TemporalScheduleDraftFinalizationWorkflow, TemporalComputeInvoiceWorkflow, TemporalDraftAndComputeSubscriptionInvoiceWorkflow:
 		return TemporalTaskQueueInvoice
@@ -296,6 +304,7 @@ func GetWorkflowsForTaskQueue(taskQueue TemporalTaskQueue) []TemporalWorkflowTyp
 			TemporalScheduleSubscriptionBillingWorkflow,
 			TemporalProcessSubscriptionBillingWorkflow,
 			TemporalRecalculateInvoiceWorkflow,
+			TemporalMarketplaceSubscriptionFinalUsageFlushWorkflow,
 		}
 	case TemporalTaskQueueInvoice:
 		return []TemporalWorkflowType{

--- a/internal/types/usagerecords.go
+++ b/internal/types/usagerecords.go
@@ -2,23 +2,43 @@ package types
 
 import "time"
 
-// UsageRecordSyncEntry records the outcome of reporting a usage record to one destination (today,
-// always a marketplace connection). Stored in usage_records.syncs, keyed by connection_id.
-// Marketplace is carried on the entry itself so it reads back self-describing even if the
-// connection is later deleted.
+// UsageRecordSyncEntry records the outcome of reporting a usage record to one marketplace. Stored in
+// usage_records.syncs, keyed by provider type: aws_marketplace, gcp_marketplace or azure_marketplace.
+//
+// The key is the marketplace, not the connection that did the reporting. A tenant can delete a
+// connection and create another one for the same marketplace, which changes the connection id while
+// the subscription's agreement on that marketplace stays the same. Keyed by connection, an already
+// reported record would look unreported the moment that happens and be sent a second time. Keyed by
+// marketplace, the question asked is the one that actually matters: has this record reached AWS for
+// this subscription yet.
 //
 // An entry is one of two kinds, distinguished by Skipped:
 //   - A real acceptance: Skipped is false, ReportingID carries the marketplace's receipt.
 //   - A skip: Skipped is true, ReportingID is empty, SkipReason explains why. Used only when
 //     sending is deterministically pointless for this provider (e.g. a zero-amount row on Azure,
-//     which documents a zero quantity as invalid). This still resolves the connection so the row's
+//     which documents a zero quantity as invalid). This still resolves the marketplace so the row's
 //     synced flag can reach true, without claiming anything was posted.
 type UsageRecordSyncEntry struct {
-	Marketplace SecretProvider `json:"marketplace"`
-	ReportingID string         `json:"reporting_id"`
-	SyncedAt    time.Time      `json:"synced_at"`
-	Skipped     bool           `json:"skipped,omitempty"`
-	SkipReason  string         `json:"skip_reason,omitempty"`
+	// AgreementID is the subscription's identifier on this marketplace: license_arn on AWS,
+	// usage_reporting_id on GCP, resource_id on Azure. It records which agreement the usage was
+	// billed against, which stays meaningful after the connection that reported it is replaced.
+	AgreementID string    `json:"agreement_id"`
+	ReportingID string    `json:"reporting_id"`
+	SyncedAt    time.Time `json:"synced_at"`
+	Skipped     bool      `json:"skipped,omitempty"`
+	SkipReason  string    `json:"skip_reason,omitempty"`
+	// ConnectionID is the connection that reported this entry, kept for tracing which credentials
+	// were used. It is deliberately not part of the map key: a replaced connection must not make an
+	// already reported record look unreported.
+	ConnectionID string `json:"connection_id"`
+}
+
+// IsResolved reports whether this entry represents a completed attempt, accepted or skipped. A
+// zero-valued or half-written entry is not resolved and must be attempted again: treating one as
+// done would silently drop the usage it stands for. Every provider sets SyncedAt and AgreementID on
+// both outcomes, so those two are what a complete entry is recognised by.
+func (e UsageRecordSyncEntry) IsResolved() bool {
+	return !e.SyncedAt.IsZero() && e.AgreementID != ""
 }
 
 // UsageRecordFilter selects rows from usage_records. Tenant and environment are not fields: every

--- a/internal/types/usagerecords.go
+++ b/internal/types/usagerecords.go
@@ -20,3 +20,115 @@ type UsageRecordSyncEntry struct {
 	Skipped     bool           `json:"skipped,omitempty"`
 	SkipReason  string         `json:"skip_reason,omitempty"`
 }
+
+// UsageRecordFilter filters usage_records, following EntityIntegrationMappingFilter/ConnectionFilter's
+// shape (embedded QueryFilter/TimeRangeFilter plus entity-specific fields) for consistency. Fields
+// mirror the table's own columns; tenant and environment are not fields here because ApplyBaseFilters
+// always scopes them from context.
+type UsageRecordFilter struct {
+	*QueryFilter
+	*TimeRangeFilter
+
+	// Filters/Sort are the generic DSL escape hatch every other filter carries — range predicates
+	// (e.g. period_end >= now-24h) go through these rather than a bespoke field per comparison.
+	Filters []*FilterCondition `json:"filters,omitempty" form:"filters" validate:"omitempty"`
+	Sort    []*SortCondition   `json:"sort,omitempty" form:"sort" validate:"omitempty"`
+
+	SubscriptionID     string `json:"subscription_id,omitempty" form:"subscription_id" validate:"omitempty"`
+	CustomerID         string `json:"customer_id,omitempty" form:"customer_id" validate:"omitempty"`
+	CustomerExternalID string `json:"customer_external_id,omitempty" form:"customer_external_id" validate:"omitempty"`
+	PlanID             string `json:"plan_id,omitempty" form:"plan_id" validate:"omitempty"`
+	Currency           string `json:"currency,omitempty" form:"currency" validate:"omitempty"`
+
+	// PeriodStart/PeriodEnd match a window exactly, the same key ExistsForPeriod checks.
+	PeriodStart *time.Time `json:"period_start,omitempty" form:"period_start" validate:"omitempty"`
+	PeriodEnd   *time.Time `json:"period_end,omitempty" form:"period_end" validate:"omitempty"`
+
+	Synced *bool `json:"synced,omitempty" form:"synced" validate:"omitempty"`
+}
+
+// NewUsageRecordFilter creates a new UsageRecordFilter with default pagination.
+func NewUsageRecordFilter() *UsageRecordFilter {
+	return &UsageRecordFilter{
+		QueryFilter: NewDefaultQueryFilter(),
+	}
+}
+
+// NewNoLimitUsageRecordFilter creates a new UsageRecordFilter with no pagination limits.
+func NewNoLimitUsageRecordFilter() *UsageRecordFilter {
+	return &UsageRecordFilter{
+		QueryFilter: NewNoLimitQueryFilter(),
+	}
+}
+
+func (f UsageRecordFilter) Validate() error {
+	if f.QueryFilter != nil {
+		if err := f.QueryFilter.Validate(); err != nil {
+			return err
+		}
+	}
+	if f.TimeRangeFilter != nil {
+		if err := f.TimeRangeFilter.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, c := range f.Filters {
+		if err := c.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, c := range f.Sort {
+		if err := c.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetLimit implements BaseFilter interface
+func (f *UsageRecordFilter) GetLimit() int {
+	if f.QueryFilter == nil {
+		return NewDefaultQueryFilter().GetLimit()
+	}
+	return f.QueryFilter.GetLimit()
+}
+
+// GetOffset implements BaseFilter interface
+func (f *UsageRecordFilter) GetOffset() int {
+	if f.QueryFilter == nil {
+		return NewDefaultQueryFilter().GetOffset()
+	}
+	return f.QueryFilter.GetOffset()
+}
+
+// GetSort implements BaseFilter interface
+func (f *UsageRecordFilter) GetSort() string {
+	if f.QueryFilter == nil {
+		return NewDefaultQueryFilter().GetSort()
+	}
+	return f.QueryFilter.GetSort()
+}
+
+// GetOrder implements BaseFilter interface
+func (f *UsageRecordFilter) GetOrder() string {
+	if f.QueryFilter == nil {
+		return NewDefaultQueryFilter().GetOrder()
+	}
+	return f.QueryFilter.GetOrder()
+}
+
+// GetStatus implements BaseFilter interface
+func (f *UsageRecordFilter) GetStatus() string {
+	if f.QueryFilter == nil {
+		return NewDefaultQueryFilter().GetStatus()
+	}
+	return f.QueryFilter.GetStatus()
+}
+
+// IsUnlimited implements BaseFilter interface
+func (f *UsageRecordFilter) IsUnlimited() bool {
+	if f.QueryFilter == nil {
+		return false
+	}
+	return f.QueryFilter.IsUnlimited()
+}

--- a/internal/types/usagerecords.go
+++ b/internal/types/usagerecords.go
@@ -21,16 +21,17 @@ type UsageRecordSyncEntry struct {
 	SkipReason  string         `json:"skip_reason,omitempty"`
 }
 
-// UsageRecordFilter filters usage_records, following EntityIntegrationMappingFilter/ConnectionFilter's
-// shape (embedded QueryFilter/TimeRangeFilter plus entity-specific fields) for consistency. Fields
-// mirror the table's own columns; tenant and environment are not fields here because ApplyBaseFilters
-// always scopes them from context.
+// UsageRecordFilter selects rows from usage_records. Tenant and environment are not fields: every
+// query is scoped to the caller's context before these filters are applied.
 type UsageRecordFilter struct {
 	*QueryFilter
+
+	// Bounds created_at, the time the row was written. The usage window the row covers is
+	// PeriodStart/PeriodEnd below.
 	*TimeRangeFilter
 
-	// Filters/Sort are the generic DSL escape hatch every other filter carries — range predicates
-	// (e.g. period_end >= now-24h) go through these rather than a bespoke field per comparison.
+	// Generic predicate and ordering escape hatch, for comparisons that have no dedicated field
+	// below — a range such as period_end at or after a cutoff goes here.
 	Filters []*FilterCondition `json:"filters,omitempty" form:"filters" validate:"omitempty"`
 	Sort    []*SortCondition   `json:"sort,omitempty" form:"sort" validate:"omitempty"`
 
@@ -40,7 +41,8 @@ type UsageRecordFilter struct {
 	PlanID             string `json:"plan_id,omitempty" form:"plan_id" validate:"omitempty"`
 	Currency           string `json:"currency,omitempty" form:"currency" validate:"omitempty"`
 
-	// PeriodStart/PeriodEnd match a window exactly, the same key ExistsForPeriod checks.
+	// Exact-match on the window boundaries. Together with SubscriptionID these identify a single row:
+	// they are the columns the table's unique index is built on.
 	PeriodStart *time.Time `json:"period_start,omitempty" form:"period_start" validate:"omitempty"`
 	PeriodEnd   *time.Time `json:"period_end,omitempty" form:"period_end" validate:"omitempty"`
 

--- a/internal/types/usagerecords.go
+++ b/internal/types/usagerecords.go
@@ -12,33 +12,39 @@ import "time"
 // marketplace, the question asked is the one that actually matters: has this record reached AWS for
 // this subscription yet.
 //
+// SkipReasonZeroAmountNotSupported is the SkipReason for a record whose computed amount rounds to
+// zero. Azure rejects a zero usage quantity, so the record is resolved as skipped rather than sent.
+const SkipReasonZeroAmountNotSupported = "zero_amount_not_supported"
+
 // An entry is one of two kinds, distinguished by Skipped:
-//   - A real acceptance: Skipped is false, ReportingID carries the marketplace's receipt.
-//   - A skip: Skipped is true, ReportingID is empty, SkipReason explains why. Used only when
-//     sending is deterministically pointless for this provider (e.g. a zero-amount row on Azure,
-//     which documents a zero quantity as invalid). This still resolves the marketplace so the row's
-//     synced flag can reach true, without claiming anything was posted.
+//   - A real acceptance: Skipped is false, SyncedAt is when the marketplace accepted it, ReportingID
+//     carries its receipt.
+//   - A skip: Skipped is true, SyncedAt is left zero because nothing was sent, ReportingID is empty,
+//     and SkipReason explains why. Used only when sending is deterministically pointless for this
+//     provider (e.g. a zero-amount row on Azure, which documents a zero quantity as invalid). The
+//     entry still resolves the marketplace so the row's synced flag can reach true, without claiming
+//     anything was posted.
 type UsageRecordSyncEntry struct {
 	// AgreementID is the subscription's identifier on this marketplace: license_arn on AWS,
 	// usage_reporting_id on GCP, resource_id on Azure. It records which agreement the usage was
 	// billed against, which stays meaningful after the connection that reported it is replaced.
-	AgreementID string    `json:"agreement_id"`
-	ReportingID string    `json:"reporting_id"`
-	SyncedAt    time.Time `json:"synced_at"`
-	Skipped     bool      `json:"skipped,omitempty"`
-	SkipReason  string    `json:"skip_reason,omitempty"`
+	AgreementID string `json:"agreement_id"`
+	ReportingID string `json:"reporting_id"`
+	// SyncedAt is when the marketplace accepted the record. Zero on a skip, since nothing was sent.
+	SyncedAt   time.Time `json:"synced_at"`
+	Skipped    bool      `json:"skipped,omitempty"`
+	SkipReason string    `json:"skip_reason,omitempty"`
 	// ConnectionID is the connection that reported this entry, kept for tracing which credentials
 	// were used. It is deliberately not part of the map key: a replaced connection must not make an
 	// already reported record look unreported.
 	ConnectionID string `json:"connection_id"`
 }
 
-// IsResolved reports whether this entry represents a completed attempt, accepted or skipped. A
-// zero-valued or half-written entry is not resolved and must be attempted again: treating one as
-// done would silently drop the usage it stands for. Every provider sets SyncedAt and AgreementID on
-// both outcomes, so those two are what a complete entry is recognised by.
-func (e UsageRecordSyncEntry) IsResolved() bool {
-	return !e.SyncedAt.IsZero() && e.AgreementID != ""
+// IsSynced reports whether this entry represents usage actually delivered to the marketplace, as
+// opposed to a skip. Callers pair it with the syncs map lookup's ok: the zero value reports true,
+// so it distinguishes a real send from a skip, not a present entry from an absent one.
+func (e UsageRecordSyncEntry) IsSynced() bool {
+	return !e.Skipped
 }
 
 // UsageRecordFilter selects rows from usage_records. Tenant and environment are not fields: every


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Immediate marketplace subscription cancellations now flush pending and final usage before archiving mappings.
  * Re-linking after unlink creates a new active mapping without restoring archived records.
  * Marketplace reporting now provides clearer success, failure, and skipped-item results.
  * Subscription add-ons now reflect configured subscription price overrides.

* **Bug Fixes**
  * Usage reporting is limited to records from the previous 24 hours.

* **Documentation**
  * Added the v4 marketplace integration design and updated v3 guidance with lifecycle and reporting corrections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Capture final marketplace usage when subscriptions are cancelled and preserve mapping history

### What Changed
- Immediate cancellations for marketplace-linked subscriptions now trigger an immediate final usage flush before archiving the subscription mappings.
- The flush reports recent outstanding usage and the final usage window using the marketplace cancellation time, then keeps mappings active when reporting or connection setup fails so retries can continue.
- Usage syncs are tracked by marketplace agreement instead of connection, preventing duplicate reports when a marketplace connection is replaced.
- Re-linking after unlinking creates a new published mapping while preserving the archived mapping and its history.
- Usage reporting now ignores records older than 24 hours, distinguishes accepted, failed, and skipped results, and exposes filtering for final-usage lookups.
- Marketplace integration documentation and regression coverage were added for cancellation flushing, retry safety, mapping lifecycle, and reporting outcomes.

### Impact
`✅ Final usage captured within marketplace cancellation windows`
`✅ No duplicate usage after marketplace connection replacement`
`✅ Archived mapping history preserved during re-linking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
