### PR TITLE
feat(kafka): support private CA for broker TLS verification

### DIFF
--- a/cmd/migrate/kafka.go
+++ b/cmd/migrate/kafka.go
@@ -60,7 +60,10 @@ func runKafkaMigration(dryRun bool) error {
 		log.Printf("desired topic: %s partitions=%d rf=%d", d.Name, d.Partitions, d.ReplicationFactor)
 	}
 
-	saramaCfg := kafka.GetSaramaConfig(&cfg.Kafka)
+	saramaCfg, err := kafka.GetSaramaConfig(&cfg.Kafka)
+	if err != nil {
+		return fmt.Errorf("build kafka client config: %w", err)
+	}
 
 	admin, err := sarama.NewClusterAdmin(cfg.Kafka.Brokers, saramaCfg)
 	if err != nil {

--- a/internal/config/autobind_test.go
+++ b/internal/config/autobind_test.go
@@ -20,6 +20,8 @@ func TestAutoBindEnvCategories(t *testing.T) {
 	t.Setenv("FLEXPRICE_OTEL_TRACES_ENDPOINT", "ingest.example.com:443")  // deep nested underscore
 	t.Setenv("FLEXPRICE_DEPLOYMENT_MODE", "consumer")                     // per-pod
 	t.Setenv("FLEXPRICE_KAFKA_SASL_PASSWORD", "scram-pw")                 // secret, nested
+	t.Setenv("FLEXPRICE_KAFKA_TLS_CA_CERT_FILE", "/etc/kafka-ca/ca.crt")  // no default tag
+	t.Setenv("FLEXPRICE_KAFKA_TLS_SERVER_NAME", "broker.internal")        // no default tag
 	t.Setenv("FLEXPRICE_KAFKA_SECONDARY_CONSUMER_GROUP", "gmk-dualwrite") // pointer struct field
 
 	cfg, err := NewConfig()
@@ -37,6 +39,11 @@ func TestAutoBindEnvCategories(t *testing.T) {
 		{"otel.traces.endpoint", cfg.Otel.Traces.Endpoint, "ingest.example.com:443"},
 		{"deployment.mode", string(cfg.Deployment.Mode), string(types.ModeConsumer)},
 		{"kafka.sasl_password", cfg.Kafka.SASLPassword, "scram-pw"},
+		// The Helm chart sets these two purely from the environment, so a missing
+		// binding would leave the private CA unused and TLS silently verifying
+		// against the OS trust store instead.
+		{"kafka.tls_ca_cert_file", cfg.Kafka.TLSCACertFile, "/etc/kafka-ca/ca.crt"},
+		{"kafka.tls_server_name", cfg.Kafka.TLSServerName, "broker.internal"},
 	}
 	for _, c := range cases {
 		if c.got != c.want {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,7 +219,13 @@ type KafkaConfig struct {
 	// crypto/x509 read PEM only. Convert with:
 	//
 	//	keytool -exportcert -alias <alias> -keystore truststore.jks -rfc -file ca.pem
-	TLSCACertFile string               `mapstructure:"tls_ca_cert_file"`
+	TLSCACertFile string `mapstructure:"tls_ca_cert_file"`
+	// TLSServerName overrides the hostname the broker certificate is verified
+	// against. Empty (the default) verifies against the dial address, i.e. the
+	// broker's advertised listener, which is correct almost always. Set it only
+	// when a private CA issues a certificate whose SAN does not match that name
+	// — a broker behind an SNI-mismatched load balancer, typically.
+	TLSServerName string               `mapstructure:"tls_server_name"`
 	UseSASL       bool                 `mapstructure:"use_sasl"`
 	SASLMechanism sarama.SASLMechanism `mapstructure:"sasl_mechanism"`
 	SASLUser      string               `mapstructure:"sasl_user"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,8 +206,20 @@ type KafkaConfig struct {
 	// TopicDLQ is the global fallback dead-letter Kafka topic used by handlers that
 	// do not define their own per-consumer-group topic_dlq. Empty disables DLQ for
 	// those handlers.
-	TopicDLQ      string               `mapstructure:"topic_dlq" default:""`
-	TLS           bool                 `mapstructure:"tls"` // set to true if using 9094 port else can set to false
+	TopicDLQ string `mapstructure:"topic_dlq" default:""`
+	TLS      bool   `mapstructure:"tls"` // set to true if using 9094 port else can set to false
+	// TLSCACertFile is the path to a PEM-encoded CA bundle used to verify the
+	// broker certificate. Empty (the default) means the OS trust store is used,
+	// which is correct for brokers with publicly-trusted certs (MSK, Confluent
+	// Cloud). Set it only when the broker presents a private/self-signed CA.
+	// The CA is applied to the Kafka client alone, so it does not affect other
+	// outbound TLS in the process (Stripe, GCP, webhooks).
+	//
+	// Must be PEM. JKS/PKCS12 truststores are not supported — sarama and Go's
+	// crypto/x509 read PEM only. Convert with:
+	//
+	//	keytool -exportcert -alias <alias> -keystore truststore.jks -rfc -file ca.pem
+	TLSCACertFile string               `mapstructure:"tls_ca_cert_file"`
 	UseSASL       bool                 `mapstructure:"use_sasl"`
 	SASLMechanism sarama.SASLMechanism `mapstructure:"sasl_mechanism"`
 	SASLUser      string               `mapstructure:"sasl_user"`

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -37,6 +37,11 @@ kafka:
   # self-signed broker CA. PEM only — a JKS truststore must be exported first:
   #   keytool -exportcert -alias <alias> -keystore truststore.jks -rfc -file ca.pem
   tls_ca_cert_file: ""
+  # Overrides the hostname the broker cert is verified against. Empty verifies
+  # against the dial address (the advertised listener), which is almost always
+  # right. Set only when the cert SAN does not match it — e.g. a broker behind
+  # an SNI-mismatched load balancer.
+  tls_server_name: ""
   use_sasl: false
   sasl_mechanism: ""
   sasl_user: ""

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -32,6 +32,11 @@ kafka:
   bulk_max_batch_bytes: 524288
   topic_dlq: "staging_events_dlq"
   tls: false
+  # Path to a PEM CA bundle for verifying the broker cert. Empty = OS trust
+  # store (correct for MSK / Confluent Cloud). Set only for a private or
+  # self-signed broker CA. PEM only — a JKS truststore must be exported first:
+  #   keytool -exportcert -alias <alias> -keystore truststore.jks -rfc -file ca.pem
+  tls_ca_cert_file: ""
   use_sasl: false
   sasl_mechanism: ""
   sasl_user: ""

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -334,6 +334,40 @@ Uses the temporalio/temporal subchart service name when internal, or user-suppli
 {{- end }}
 
 {{/*
+Kafka broker CA volume. Renders nothing unless kafkaConfig.tlsCASecret.name is
+set, so clusters using publicly-trusted brokers (MSK, Confluent Cloud) are
+untouched.
+
+The Secret is expected to already exist — created by an ExternalSecret, sealed
+secret, or by hand. The chart never renders certificate material itself, which
+keeps PEM bytes out of values files. Its `key` must hold a PEM bundle; JKS/PKCS12
+truststores are not readable by Go and must be exported with
+`keytool -exportcert -rfc` first.
+*/}}
+{{- define "flexprice.kafkaTLSVolume" -}}
+{{- if .Values.kafkaConfig.tlsCASecret.name }}
+- name: kafka-tls-ca
+  secret:
+    secretName: {{ .Values.kafkaConfig.tlsCASecret.name | quote }}
+    items:
+      - key: {{ .Values.kafkaConfig.tlsCASecret.key | default "ca.crt" | quote }}
+        path: {{ .Values.kafkaConfig.tlsCASecret.key | default "ca.crt" | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Mount for the Kafka broker CA. Path must match FLEXPRICE_KAFKA_TLS_CA_CERT_FILE
+in "flexprice.env".
+*/}}
+{{- define "flexprice.kafkaTLSVolumeMounts" -}}
+{{- if .Values.kafkaConfig.tlsCASecret.name }}
+- name: kafka-tls-ca
+  mountPath: {{ .Values.kafkaConfig.tlsCASecret.mountPath | default "/etc/flexprice/kafka-tls" | quote }}
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{/*
 Create environment variables from configuration.
 All service addresses are resolved via named templates above so this block stays clean.
 */}}
@@ -417,6 +451,16 @@ All service addresses are resolved via named templates above so this block stays
   value: {{ .Values.kafkaConfig.topicLazy | quote }}
 - name: FLEXPRICE_KAFKA_TLS
   value: {{ .Values.kafkaConfig.tls | quote }}
+{{- /*
+  Private/self-signed broker CA. Not gated on useSASL — a plain-TLS broker can
+  present a private CA too. The path must match the mount in
+  `flexprice.kafkaTLSVolumeMounts`. The file must be PEM; a JKS truststore has
+  to be exported first with `keytool -exportcert -rfc`.
+*/}}
+{{- if .Values.kafkaConfig.tlsCASecret.name }}
+- name: FLEXPRICE_KAFKA_TLS_CA_CERT_FILE
+  value: {{ printf "%s/%s" (.Values.kafkaConfig.tlsCASecret.mountPath | default "/etc/flexprice/kafka-tls") (.Values.kafkaConfig.tlsCASecret.key | default "ca.crt") | quote }}
+{{- end }}
 - name: FLEXPRICE_KAFKA_USE_SASL
   value: {{ .Values.kafkaConfig.useSASL | quote }}
 - name: FLEXPRICE_KAFKA_CLIENT_ID

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
@@ -78,6 +78,7 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- include "flexprice.kafkaTLSVolumeMounts" . | nindent 12 }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -89,6 +90,7 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- include "flexprice.kafkaTLSVolume" . | nindent 8 }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
@@ -85,6 +85,7 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- include "flexprice.kafkaTLSVolumeMounts" . | nindent 12 }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -96,6 +97,7 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- include "flexprice.kafkaTLSVolume" . | nindent 8 }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
@@ -76,6 +76,7 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- include "flexprice.kafkaTLSVolumeMounts" . | nindent 12 }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -87,6 +88,7 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- include "flexprice.kafkaTLSVolume" . | nindent 8 }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -37,11 +37,18 @@ spec:
         topic: {{ .Values.kafkaConfig.topic | quote }}
         lagThreshold: {{ .Values.consumer.keda.lagThreshold | default 1000 | quote }}
         offsetResetPolicy: {{ .Values.consumer.keda.offsetResetPolicy | default "earliest" | quote }}
-        {{- if .Values.kafkaConfig.tls }}
+        {{- if or .Values.kafkaConfig.tls .Values.kafkaConfig.useSASL }}
         tls: enable
         {{- end }}
         {{- if .Values.kafkaConfig.useSASL }}
-        sasl: {{ .Values.kafkaConfig.saslMechanism | default "plaintext" | quote }}
+        {{- /*
+          KEDA's Kafka scaler names mechanisms differently from sarama: it wants
+          lowercase, underscore-separated values (scram_sha512), not the
+          SCRAM-SHA-512 spelling kafkaConfig.saslMechanism carries. Passing the
+          sarama spelling through makes the scaler fail to authenticate, so map
+          it here rather than asking operators to set the value twice.
+        */}}
+        sasl: {{ get (dict "SCRAM-SHA-512" "scram_sha512" "SCRAM-SHA-256" "scram_sha256" "PLAIN" "plaintext" "OAUTHBEARER" "oauthbearer") .Values.kafkaConfig.saslMechanism | default "plaintext" | quote }}
         {{- end }}
       {{- with .Values.consumer.keda.authenticationRef }}
       authenticationRef:

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -47,8 +47,18 @@ spec:
           SCRAM-SHA-512 spelling kafkaConfig.saslMechanism carries. Passing the
           sarama spelling through makes the scaler fail to authenticate, so map
           it here rather than asking operators to set the value twice.
+
+          An unmapped mechanism fails the render instead of defaulting to
+          plaintext: a silent default produces a scaler that cannot authenticate
+          and reports a misleading error, which is the exact bug this mapping
+          exists to prevent.
         */}}
-        sasl: {{ get (dict "SCRAM-SHA-512" "scram_sha512" "SCRAM-SHA-256" "scram_sha256" "PLAIN" "plaintext" "OAUTHBEARER" "oauthbearer") .Values.kafkaConfig.saslMechanism | default "plaintext" | quote }}
+        {{- $saslMap := dict "SCRAM-SHA-512" "scram_sha512" "SCRAM-SHA-256" "scram_sha256" "PLAIN" "plaintext" "OAUTHBEARER" "oauthbearer" }}
+        {{- $mechanism := .Values.kafkaConfig.saslMechanism | default "PLAIN" }}
+        {{- if not (hasKey $saslMap $mechanism) }}
+        {{- fail (printf "kafkaConfig.saslMechanism %q has no KEDA equivalent; the KEDA Kafka scaler supports only: %s. Set the sarama spelling (e.g. SCRAM-SHA-512), or disable consumer.keda.enabled." $mechanism (join ", " (keys $saslMap | sortAlpha))) }}
+        {{- end }}
+        sasl: {{ get $saslMap $mechanism | quote }}
         {{- end }}
       {{- /*
         KEDA's operator dials Kafka itself, so it never sees the CA mounted from

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -50,6 +50,14 @@ spec:
         */}}
         sasl: {{ get (dict "SCRAM-SHA-512" "scram_sha512" "SCRAM-SHA-256" "scram_sha256" "PLAIN" "plaintext" "OAUTHBEARER" "oauthbearer") .Values.kafkaConfig.saslMechanism | default "plaintext" | quote }}
         {{- end }}
+      {{- /*
+        KEDA's operator dials Kafka itself, so it never sees the CA mounted from
+        kafkaConfig.tlsCASecret into the workload pods. Credentials and a private
+        broker CA both have to reach it through an operator-supplied
+        TriggerAuthentication — and through the SAME one, since a trigger takes a
+        single authenticationRef. See consumer.keda.authenticationRef in
+        values.yaml for the resource shape, including the `ca` parameter.
+      */}}
       {{- with .Values.consumer.keda.authenticationRef }}
       authenticationRef:
         {{- toYaml . | nindent 8 }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -313,12 +313,18 @@ spec:
               echo "✅ Ent migrations complete"
           env:
             {{- include "flexprice.env" . | nindent 12 }}
-          {{- if not .Values.env }}
+          {{- if or (not .Values.env) .Values.kafkaConfig.tlsCASecret.name }}
           volumeMounts:
+            {{- if not .Values.env }}
             - name: config
               mountPath: /app/config/config.yaml
               subPath: config.yaml
               readOnly: true
+            {{- end }}
+            {{- /* This step receives FLEXPRICE_KAFKA_TLS_CA_CERT_FILE via
+                   "flexprice.env"; mount the CA so the path it names always
+                   resolves, rather than dangling. */}}
+            {{- include "flexprice.kafkaTLSVolumeMounts" . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.migration.resources | nindent 12 }}
@@ -467,6 +473,7 @@ spec:
             {{- end }}
             - name: tools
               mountPath: /tools
+            {{- include "flexprice.kafkaTLSVolumeMounts" . | nindent 12 }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -481,6 +488,7 @@ spec:
         {{- end }}
         - name: tools
           emptyDir: {}
+        {{- include "flexprice.kafkaTLSVolume" . | nindent 8 }}
         {{- if .Values.migration.steps.clickhouse }}
         - name: migrations
           emptyDir: {}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -231,6 +231,29 @@ consumer:
     # Example:
     #   authenticationRef:
     #     name: kafka-msk-auth
+    #
+    # KEDA's operator connects to Kafka itself, separately from the consumer
+    # pod, so it does NOT see kafkaConfig.tlsCASecret — that Secret is only
+    # mounted into the workloads. A private/self-signed broker CA therefore has
+    # to be repeated here, in the same TriggerAuthentication that carries the
+    # SASL credentials (KEDA accepts one authenticationRef per trigger, so the
+    # CA and the credentials cannot be split across two resources):
+    #
+    #   apiVersion: keda.sh/v1alpha1
+    #   kind: TriggerAuthentication
+    #   metadata:
+    #     name: kafka-scram-auth
+    #   spec:
+    #     secretTargetRef:
+    #       - {parameter: sasl,     name: keda-kafka-secrets, key: sasl}
+    #       - {parameter: username, name: keda-kafka-secrets, key: username}
+    #       - {parameter: password, name: keda-kafka-secrets, key: password}
+    #       - {parameter: tls,      name: keda-kafka-secrets, key: tls}
+    #       - {parameter: ca,       name: keda-kafka-secrets, key: ca}
+    #
+    # The `ca` key holds the same PEM bundle as kafkaConfig.tlsCASecret. Without
+    # it the scaler fails its TLS handshake against a private CA and the
+    # consumer silently stops autoscaling.
     authenticationRef: {}
   podDisruptionBudget:
     enabled: true

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -525,6 +525,25 @@ kafkaConfig:
   topic: "events"
   topicLazy: "events_lazy"
   tls: false
+  # Broker CA for private/self-signed Kafka certificates. Leave name empty for
+  # brokers with publicly-trusted certs (MSK, Confluent Cloud) — the pods then
+  # verify against the OS trust store and no volume is mounted.
+  #
+  # The Secret must already exist; create it with an ExternalSecret (or sealed
+  # secret) so certificate material never lands in a values file. Its key must
+  # hold a PEM bundle. A JKS truststore must be converted first:
+  #   keytool -exportcert -alias <alias> -keystore truststore.jks -rfc -file ca.pem
+  #
+  # Setting `name` always mounts the Secret. On the legacy structured-env shape
+  # the chart also emits FLEXPRICE_KAFKA_TLS_CA_CERT_FILE pointing at the
+  # mounted path. On the MIGRATED generic-env shape (`.Values.env` set) the
+  # chart emits no kafkaConfig-derived env vars at all, so set it yourself:
+  #   env:
+  #     FLEXPRICE_KAFKA_TLS_CA_CERT_FILE: "/etc/flexprice/kafka-tls/ca.crt"
+  tlsCASecret:
+    name: ""                              # e.g. "flexprice-kafka-ca" (synced by ExternalSecret)
+    key: "ca.crt"                         # key inside the Secret holding the PEM bundle
+    mountPath: "/etc/flexprice/kafka-tls" # dir the key is mounted into
   useSASL: false
   saslMechanism: ""
   saslUser: ""

--- a/internal/ee/infrastructure/helm/values-prod.example.yaml
+++ b/internal/ee/infrastructure/helm/values-prod.example.yaml
@@ -222,9 +222,16 @@ kafkaConfig:
   brokers: "REPLACE-WITH-KAFKA-BROKERS.example.invalid:9094"
   useSASL: true
   saslMechanism: "SCRAM-SHA-512"
-  saslUsername: "flexprice"
+  saslUser: "flexprice"
   # saslPassword comes from existingSecret key: kafka-sasl-password
   tls: true
+  # Only needed when the broker presents a private/self-signed CA. Brokers with
+  # publicly-trusted certs (MSK, Confluent Cloud) verify against the OS trust
+  # store — leave name empty. The Secret is expected to be synced by an
+  # ExternalSecret; its key must hold a PEM bundle, not a JKS truststore.
+  # tlsCASecret:
+  #   name: "flexprice-kafka-ca"
+  #   key: "ca.crt"
 
 # ── Redis — EXTERNAL (ElastiCache / MemoryDB / Upstash) ───────────────────────
 redis:

--- a/internal/kafka/base.go
+++ b/internal/kafka/base.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash"
 
-	"crypto/tls"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -19,7 +18,10 @@ import (
 // cluster's KafkaConfig directly (rather than the whole Configuration) so the same
 // builder serves both the local cluster (cfg.Kafka) and the optional second cluster
 // (cfg.KafkaSecondary) during the AWS→GCP migration — see infrastructure/docs/GCP-CUTOVER-STEPWISE.md.
-func GetSaramaConfig(kafkaCfg *config.KafkaConfig) *sarama.Config {
+// It returns an error rather than panicking on unusable TLS/SASL material (bad
+// CA path, non-PEM bundle, missing GCP credentials) so a misconfigured deploy
+// surfaces as a normal startup failure instead of a stack trace.
+func GetSaramaConfig(kafkaCfg *config.KafkaConfig) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_1_0_0
 
@@ -38,20 +40,23 @@ func GetSaramaConfig(kafkaCfg *config.KafkaConfig) *sarama.Config {
 	// When rebalancing happens, use the last committed offset
 	saramaConfig.Consumer.Offsets.Retry.Max = 3
 
-	if kafkaCfg.TLS {
-		saramaConfig.Net.TLS.Enable = true
-		saramaConfig.Net.TLS.Config = &tls.Config{
-			InsecureSkipVerify: false,
+	// SASL implies TLS: SASL_SSL is the only SASL protocol this app speaks, so
+	// enabling SASL turns TLS on even when kafkaCfg.TLS is false.
+	if kafkaCfg.TLS || kafkaCfg.UseSASL {
+		tlsConfig, err := BuildTLSConfig(kafkaCfg)
+		if err != nil {
+			return nil, err
 		}
+		saramaConfig.Net.TLS.Enable = true
+		saramaConfig.Net.TLS.Config = tlsConfig
 	}
 
 	if !kafkaCfg.UseSASL {
-		return saramaConfig
+		return saramaConfig, nil
 	}
 
 	// SASL specific configs
 	saramaConfig.Net.SASL.Enable = true
-	saramaConfig.Net.TLS.Enable = true
 
 	// sasl configs
 	saramaConfig.Net.SASL.Mechanism = kafkaCfg.SASLMechanism
@@ -63,7 +68,7 @@ func GetSaramaConfig(kafkaCfg *config.KafkaConfig) *sarama.Config {
 		// User/Password are not used.
 		provider, err := newGCPTokenProvider(context.Background(), kafkaCfg.SASLOAuthScopes)
 		if err != nil {
-			panic(fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", kafkaCfg.SASLOAuthScopes, err))
+			return nil, fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", kafkaCfg.SASLOAuthScopes, err)
 		}
 		saramaConfig.Net.SASL.TokenProvider = provider
 	case sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512:
@@ -78,7 +83,7 @@ func GetSaramaConfig(kafkaCfg *config.KafkaConfig) *sarama.Config {
 		saramaConfig.Net.SASL.Password = kafkaCfg.SASLPassword
 	}
 
-	return saramaConfig
+	return saramaConfig, nil
 }
 
 // XDGSCRAMClient implements sarama.SCRAMClient for SCRAM authentication

--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -26,17 +26,19 @@ func NewConsumer(cfg *config.Configuration) (MessageConsumer, error) {
 	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
 	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
 
-	saramaConfig := GetSaramaConfig(&cfg.Kafka)
-	if saramaConfig != nil {
-		// Optimize consumer configs for throughput
-		// TODO: move this to config
-		saramaConfig.Consumer.Group.Session.Timeout = 45000 * time.Millisecond
-		saramaConfig.Consumer.Fetch.Min = 1                        // Minimum number of bytes to fetch in a request
-		saramaConfig.Consumer.Fetch.Max = 10 * 1024 * 1024         // Maximum number of bytes to fetch (10MB)
-		saramaConfig.Consumer.Fetch.Default = 1024 * 1024          // Default fetch size (1MB)
-		saramaConfig.Consumer.MaxWaitTime = 100 * time.Millisecond // Max time to wait for new data
-		saramaConfig.Consumer.MaxProcessingTime = 500 * time.Millisecond
+	saramaConfig, err := GetSaramaConfig(&cfg.Kafka)
+	if err != nil {
+		return nil, err
 	}
+
+	// Optimize consumer configs for throughput
+	// TODO: move this to config
+	saramaConfig.Consumer.Group.Session.Timeout = 45000 * time.Millisecond
+	saramaConfig.Consumer.Fetch.Min = 1                        // Minimum number of bytes to fetch in a request
+	saramaConfig.Consumer.Fetch.Max = 10 * 1024 * 1024         // Maximum number of bytes to fetch (10MB)
+	saramaConfig.Consumer.Fetch.Default = 1024 * 1024          // Default fetch size (1MB)
+	saramaConfig.Consumer.MaxWaitTime = 100 * time.Millisecond // Max time to wait for new data
+	saramaConfig.Consumer.MaxProcessingTime = 500 * time.Millisecond
 
 	subscriber, err := kafka.NewSubscriber(
 		kafka.SubscriberConfig{

--- a/internal/kafka/monitoring.go
+++ b/internal/kafka/monitoring.go
@@ -34,7 +34,11 @@ func NewMonitoringService(cfg *config.Configuration, log *logger.Logger) *Monito
 // GetConsumerLag calculates the consumer lag for a given topic and consumer group
 func (m *MonitoringService) GetConsumerLag(ctx context.Context, topic string, consumerGroup string) (*ConsumerLag, error) {
 	// Create Sarama config
-	saramaConfig := GetSaramaConfig(&m.config.Kafka)
+	saramaConfig, err := GetSaramaConfig(&m.config.Kafka)
+	if err != nil {
+		m.logger.Error(ctx, "failed to build Kafka client config", "error", err)
+		return nil, err
+	}
 	saramaConfig.Consumer.Return.Errors = true
 
 	// Create cluster admin client

--- a/internal/kafka/producer.go
+++ b/internal/kafka/producer.go
@@ -45,12 +45,14 @@ func NewSecondaryProducer(cfg *config.Configuration) (*SecondaryProducer, error)
 func newProducerForCluster(kafkaCfg *config.KafkaConfig, enableDebugLogs bool) (*Producer, error) {
 	// enableDebugLogs allows watermill DEBUG messages in debug mode.
 	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
-	saramaConfig := GetSaramaConfig(kafkaCfg)
-	if saramaConfig != nil {
-		// add producer configs
-		saramaConfig.Producer.Return.Successes = true
-		saramaConfig.Producer.Return.Errors = true
+	saramaConfig, err := GetSaramaConfig(kafkaCfg)
+	if err != nil {
+		return nil, err
 	}
+
+	// add producer configs
+	saramaConfig.Producer.Return.Successes = true
+	saramaConfig.Producer.Return.Errors = true
 
 	publisher, err := kafka.NewPublisher(
 		kafka.PublisherConfig{

--- a/internal/kafka/tls.go
+++ b/internal/kafka/tls.go
@@ -23,6 +23,11 @@ import (
 func BuildTLSConfig(kafkaCfg *config.KafkaConfig) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: false,
+		MinVersion:         tls.VersionTLS12,
+		// ServerName empty means Go verifies against the dial address, which is
+		// the broker's advertised listener. A private CA issuing a cert whose SAN
+		// does not match that name needs TLSServerName set to override it.
+		ServerName: kafkaCfg.TLSServerName,
 	}
 
 	if kafkaCfg.TLSCACertFile == "" {
@@ -37,9 +42,17 @@ func BuildTLSConfig(kafkaCfg *config.KafkaConfig) (*tls.Config, error) {
 	// Start from the system pool so a private CA augments the public roots
 	// rather than replacing them. A broker chaining to a public root keeps
 	// working even when a CA file is supplied.
+	//
+	// Failing here rather than falling back to an empty pool is deliberate: a
+	// silent fallback would leave RootCAs holding ONLY the private CA, so every
+	// publicly-trusted broker in the same bundle would stop verifying with no
+	// indication why.
 	pool, err := x509.SystemCertPool()
-	if err != nil || pool == nil {
-		pool = x509.NewCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("kafka tls: load system cert pool: %w", err)
+	}
+	if pool == nil {
+		return nil, fmt.Errorf("kafka tls: system cert pool unavailable; cannot augment it with %q", kafkaCfg.TLSCACertFile)
 	}
 
 	if !pool.AppendCertsFromPEM(pemBytes) {

--- a/internal/kafka/tls.go
+++ b/internal/kafka/tls.go
@@ -1,0 +1,54 @@
+package kafka
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/flexprice/flexprice/internal/config"
+)
+
+// BuildTLSConfig returns the *tls.Config for a Kafka client.
+//
+// With no CA file configured it returns a verifying config backed by the OS
+// trust store, which is what publicly-trusted brokers (MSK, Confluent Cloud)
+// need. When TLSCACertFile is set, the PEM bundle at that path is appended to a
+// copy of the system pool and installed as RootCAs. Scoping the pool to this
+// config — rather than setting SSL_CERT_FILE process-wide — keeps every other
+// outbound TLS caller (Stripe, GCP, webhooks) on the system roots.
+//
+// The file must be PEM. JKS/PKCS12 truststores are not readable by Go; convert
+// with `keytool -exportcert -alias <alias> -keystore truststore.jks -rfc -file ca.pem`.
+func BuildTLSConfig(kafkaCfg *config.KafkaConfig) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: false,
+	}
+
+	if kafkaCfg.TLSCACertFile == "" {
+		return tlsConfig, nil
+	}
+
+	pemBytes, err := os.ReadFile(kafkaCfg.TLSCACertFile)
+	if err != nil {
+		return nil, fmt.Errorf("kafka tls: read CA file %q: %w", kafkaCfg.TLSCACertFile, err)
+	}
+
+	// Start from the system pool so a private CA augments the public roots
+	// rather than replacing them. A broker chaining to a public root keeps
+	// working even when a CA file is supplied.
+	pool, err := x509.SystemCertPool()
+	if err != nil || pool == nil {
+		pool = x509.NewCertPool()
+	}
+
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf(
+			"kafka tls: no certificates parsed from %q — file must be PEM (a JKS/PKCS12 truststore will not work; export it with `keytool -exportcert -rfc`)",
+			kafkaCfg.TLSCACertFile,
+		)
+	}
+
+	tlsConfig.RootCAs = pool
+	return tlsConfig, nil
+}

--- a/internal/kafka/tls_test.go
+++ b/internal/kafka/tls_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -167,6 +168,108 @@ func TestBuildTLSConfig_NonPEMFileErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "JKS") {
 		t.Errorf("error %q should point the operator at the JKS→PEM conversion", err)
+	}
+}
+
+// The realistic operator mistakes after the JKS case: a file that is valid PEM
+// but carries no certificate, and a file that is a private key rather than the
+// CA certificate. Both reach AppendCertsFromPEM == false and must be rejected at
+// startup rather than producing a pool that silently verifies nothing.
+func TestBuildTLSConfig_PEMWithoutCertificateErrors(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		filename string
+		contents []byte
+	}{
+		{"empty file", "empty.pem", nil},
+		{"no PEM blocks", "notes.pem", []byte("# CA goes here\n")},
+		{
+			"private key instead of certificate",
+			"ca-key.pem",
+			pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), c.filename)
+			if err := os.WriteFile(path, c.contents, 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			_, err := BuildTLSConfig(&config.KafkaConfig{TLSCACertFile: path})
+			if err == nil {
+				t.Fatal("BuildTLSConfig() error = nil, want an error when no certificate parses")
+			}
+			if !strings.Contains(err.Error(), "no certificates parsed") {
+				t.Errorf("error %q should say no certificates were parsed", err)
+			}
+		})
+	}
+}
+
+// A directory path is an easy misconfiguration when the CA is mounted from a
+// Secret: pointing at the mount root rather than the key inside it.
+func TestBuildTLSConfig_DirectoryPathErrors(t *testing.T) {
+	_, err := BuildTLSConfig(&config.KafkaConfig{TLSCACertFile: t.TempDir()})
+	if err == nil {
+		t.Fatal("BuildTLSConfig() error = nil, want an error when the CA path is a directory")
+	}
+	if !strings.Contains(err.Error(), "read CA file") {
+		t.Errorf("error %q should name the failure as reading the CA file", err)
+	}
+}
+
+// TLS policy must hold on both paths — with and without a configured CA.
+func TestBuildTLSConfig_SetsMinVersionTLS12(t *testing.T) {
+	dir := t.TempDir()
+	path, _ := writeTestCA(t, dir, "ca")
+
+	for _, c := range []struct {
+		name string
+		cfg  *config.KafkaConfig
+	}{
+		{"no CA file", &config.KafkaConfig{}},
+		{"with CA file", &config.KafkaConfig{TLSCACertFile: path}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tlsCfg, err := BuildTLSConfig(c.cfg)
+			if err != nil {
+				t.Fatalf("BuildTLSConfig() error = %v, want nil", err)
+			}
+			if tlsCfg.MinVersion != tls.VersionTLS12 {
+				t.Errorf("MinVersion = %#x, want %#x (TLS 1.2)", tlsCfg.MinVersion, tls.VersionTLS12)
+			}
+		})
+	}
+}
+
+// ServerName defaults to empty so Go verifies against the dial address; it is
+// carried through only when the operator overrides it for an SNI mismatch.
+func TestBuildTLSConfig_ServerNameOverride(t *testing.T) {
+	tlsCfg, err := BuildTLSConfig(&config.KafkaConfig{})
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v, want nil", err)
+	}
+	if tlsCfg.ServerName != "" {
+		t.Errorf("ServerName = %q, want empty so verification uses the dial address", tlsCfg.ServerName)
+	}
+
+	tlsCfg, err = BuildTLSConfig(&config.KafkaConfig{TLSServerName: "broker.internal"})
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v, want nil", err)
+	}
+	if tlsCfg.ServerName != "broker.internal" {
+		t.Errorf("ServerName = %q, want %q", tlsCfg.ServerName, "broker.internal")
 	}
 }
 

--- a/internal/kafka/tls_test.go
+++ b/internal/kafka/tls_test.go
@@ -1,0 +1,266 @@
+package kafka
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/flexprice/flexprice/internal/config"
+)
+
+// writeTestCA generates a throwaway self-signed CA and writes it as PEM,
+// returning the path and the certificate's subject. Using a real generated cert
+// (rather than a fixture) keeps the test independent of any expiry date.
+func writeTestCA(t *testing.T, dir, name string) (string, pkix.Name) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	subject := pkix.Name{CommonName: "flexprice-test-kafka-ca-" + name}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               subject,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	path := filepath.Join(dir, name+".pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+
+	return path, subject
+}
+
+func TestBuildTLSConfig_NoCAFileUsesSystemRoots(t *testing.T) {
+	tlsCfg, err := BuildTLSConfig(&config.KafkaConfig{})
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v, want nil", err)
+	}
+	if tlsCfg.RootCAs != nil {
+		t.Error("RootCAs should be nil so Go falls back to the OS trust store")
+	}
+	if tlsCfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify must stay false — verification is not optional")
+	}
+}
+
+func TestBuildTLSConfig_LoadsCAIntoRootPool(t *testing.T) {
+	dir := t.TempDir()
+	path, subject := writeTestCA(t, dir, "ca")
+
+	tlsCfg, err := BuildTLSConfig(&config.KafkaConfig{TLSCACertFile: path})
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v, want nil", err)
+	}
+	if tlsCfg.RootCAs == nil {
+		t.Fatal("RootCAs is nil — the configured CA was not loaded")
+	}
+	if tlsCfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify must stay false even with a custom CA")
+	}
+
+	// The custom CA must actually be in the pool, not merely a non-nil pool.
+	var found bool
+	for _, rawSubject := range tlsCfg.RootCAs.Subjects() { //nolint:staticcheck // Subjects() is the only way to inspect pool contents
+		if strings.Contains(string(rawSubject), subject.CommonName) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("configured CA %q not present in RootCAs", subject.CommonName)
+	}
+}
+
+// A broker chaining to a public root must keep working when a private CA is
+// also configured — the pool has to be system roots PLUS ours, never ours
+// alone. Asserted by cloning the system pool the same way BuildTLSConfig does
+// and requiring the result to be a strict superset.
+//
+// Subjects() is empty on platforms where Go defers to the system verifier
+// (macOS), so the comparison is made against a freshly cloned system pool
+// rather than against a raw count, and is skipped where Go exposes no roots.
+func TestBuildTLSConfig_CAAugmentsRatherThanReplacesSystemRoots(t *testing.T) {
+	systemPool, err := x509.SystemCertPool()
+	if err != nil || systemPool == nil {
+		t.Skip("no system cert pool on this platform")
+	}
+	systemSubjects := systemPool.Subjects() //nolint:staticcheck // see above
+	if len(systemSubjects) == 0 {
+		t.Skip("Go exposes no system roots on this platform (macOS defers to the system verifier)")
+	}
+
+	dir := t.TempDir()
+	path, _ := writeTestCA(t, dir, "ca")
+
+	tlsCfg, err := BuildTLSConfig(&config.KafkaConfig{TLSCACertFile: path})
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v, want nil", err)
+	}
+
+	got := make(map[string]bool)
+	for _, s := range tlsCfg.RootCAs.Subjects() { //nolint:staticcheck // see above
+		got[string(s)] = true
+	}
+
+	for _, want := range systemSubjects {
+		if !got[string(want)] {
+			t.Fatalf("a system root was dropped from RootCAs — configuring a private CA must not "+
+				"replace the OS trust store (%d of %d system roots retained)", len(got)-1, len(systemSubjects))
+		}
+	}
+	if len(got) != len(systemSubjects)+1 {
+		t.Errorf("RootCAs has %d subjects, want %d (all system roots + 1 custom CA)",
+			len(got), len(systemSubjects)+1)
+	}
+}
+
+func TestBuildTLSConfig_MissingFileErrors(t *testing.T) {
+	_, err := BuildTLSConfig(&config.KafkaConfig{
+		TLSCACertFile: filepath.Join(t.TempDir(), "does-not-exist.pem"),
+	})
+	if err == nil {
+		t.Fatal("BuildTLSConfig() error = nil, want an error for a missing CA file")
+	}
+	if !strings.Contains(err.Error(), "read CA file") {
+		t.Errorf("error %q should name the failure as reading the CA file", err)
+	}
+}
+
+// A JKS truststore is the exact wrong-format case operators hit, since that is
+// what Java-based Kafka tooling produces. The error must say so rather than
+// failing later at connect time with an opaque TLS handshake error.
+func TestBuildTLSConfig_NonPEMFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "truststore.jks")
+	// First bytes of a real JKS file (magic number 0xFEEDFEED).
+	if err := os.WriteFile(path, []byte{0xFE, 0xED, 0xFE, 0xED, 0x00, 0x00, 0x00, 0x02}, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := BuildTLSConfig(&config.KafkaConfig{TLSCACertFile: path})
+	if err == nil {
+		t.Fatal("BuildTLSConfig() error = nil, want an error for a non-PEM file")
+	}
+	if !strings.Contains(err.Error(), "JKS") {
+		t.Errorf("error %q should point the operator at the JKS→PEM conversion", err)
+	}
+}
+
+// SASL_SSL is the protocol the SCRAM-SHA-512 setup uses: enabling SASL must
+// enable TLS and carry the CA through, even when kafka.tls is left false.
+func TestGetSaramaConfig_SASLEnablesTLSWithCA(t *testing.T) {
+	dir := t.TempDir()
+	path, _ := writeTestCA(t, dir, "ca")
+
+	cfg := &config.KafkaConfig{
+		TLS:           false, // deliberately false — UseSASL must still force TLS
+		UseSASL:       true,
+		SASLMechanism: sarama.SASLTypeSCRAMSHA512,
+		SASLUser:      "flexprice",
+		SASLPassword:  "secret",
+		TLSCACertFile: path,
+	}
+
+	saramaCfg, err := GetSaramaConfig(cfg)
+	if err != nil {
+		t.Fatalf("GetSaramaConfig() error = %v, want nil", err)
+	}
+	if !saramaCfg.Net.TLS.Enable {
+		t.Error("Net.TLS.Enable = false, want true — SASL implies SASL_SSL")
+	}
+	if saramaCfg.Net.TLS.Config == nil || saramaCfg.Net.TLS.Config.RootCAs == nil {
+		t.Fatal("custom CA was not applied to the SASL TLS config")
+	}
+	if !saramaCfg.Net.SASL.Enable {
+		t.Error("Net.SASL.Enable = false, want true")
+	}
+	if saramaCfg.Net.SASL.Mechanism != sarama.SASLTypeSCRAMSHA512 {
+		t.Errorf("Mechanism = %q, want %q", saramaCfg.Net.SASL.Mechanism, sarama.SASLTypeSCRAMSHA512)
+	}
+	if saramaCfg.Net.SASL.SCRAMClientGeneratorFunc == nil {
+		t.Fatal("SCRAMClientGeneratorFunc is nil — SCRAM auth would fail at handshake")
+	}
+
+	// The generator must produce a SHA-512 client; a SHA-256 client against a
+	// SHA-512 broker fails with an opaque authentication error.
+	client, ok := saramaCfg.Net.SASL.SCRAMClientGeneratorFunc().(*XDGSCRAMClient)
+	if !ok {
+		t.Fatal("SCRAMClientGeneratorFunc did not return an *XDGSCRAMClient")
+	}
+	if got := client.HashGeneratorFcn().Size(); got != 64 {
+		t.Errorf("SCRAM hash size = %d bytes, want 64 (SHA-512)", got)
+	}
+}
+
+func TestGetSaramaConfig_BadCAFilePropagatesError(t *testing.T) {
+	_, err := GetSaramaConfig(&config.KafkaConfig{
+		UseSASL:       true,
+		SASLMechanism: sarama.SASLTypeSCRAMSHA512,
+		TLSCACertFile: filepath.Join(t.TempDir(), "missing.pem"),
+	})
+	if err == nil {
+		t.Fatal("GetSaramaConfig() error = nil, want the CA failure surfaced as a startup error")
+	}
+}
+
+// Without SASL or TLS the CA is irrelevant and must not be read — a plaintext
+// local broker should not fail because a stale path is configured.
+func TestGetSaramaConfig_PlaintextIgnoresCA(t *testing.T) {
+	saramaCfg, err := GetSaramaConfig(&config.KafkaConfig{
+		TLS:           false,
+		UseSASL:       false,
+		TLSCACertFile: filepath.Join(t.TempDir(), "missing.pem"),
+	})
+	if err != nil {
+		t.Fatalf("GetSaramaConfig() error = %v, want nil for a plaintext broker", err)
+	}
+	if saramaCfg.Net.TLS.Enable {
+		t.Error("Net.TLS.Enable = true, want false for a plaintext broker")
+	}
+}
+
+// TLS without SASL is a valid combination (a broker on 9094 with no auth), and
+// must honour the CA too.
+func TestGetSaramaConfig_TLSWithoutSASLUsesCA(t *testing.T) {
+	dir := t.TempDir()
+	path, _ := writeTestCA(t, dir, "ca")
+
+	saramaCfg, err := GetSaramaConfig(&config.KafkaConfig{
+		TLS:           true,
+		UseSASL:       false,
+		TLSCACertFile: path,
+	})
+	if err != nil {
+		t.Fatalf("GetSaramaConfig() error = %v, want nil", err)
+	}
+	if !saramaCfg.Net.TLS.Enable {
+		t.Fatal("Net.TLS.Enable = false, want true")
+	}
+	if saramaCfg.Net.TLS.Config == nil || saramaCfg.Net.TLS.Config.RootCAs == nil {
+		t.Error("custom CA was not applied when TLS is enabled without SASL")
+	}
+}

--- a/internal/pubsub/kafka/base.go
+++ b/internal/pubsub/kafka/base.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash"
 
-	"crypto/tls"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -16,7 +15,12 @@ import (
 	"github.com/xdg-go/scram"
 )
 
-func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
+// GetSaramaConfig builds a Sarama config for the pubsub Kafka clients.
+//
+// It returns an error rather than panicking on unusable TLS/SASL material (bad
+// CA path, non-PEM bundle, missing GCP credentials) so a misconfigured deploy
+// surfaces as a normal startup failure instead of a stack trace.
+func GetSaramaConfig(cfg *config.Configuration) (*sarama.Config, error) {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.Version = sarama.V2_1_0_0
 
@@ -35,20 +39,25 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 	// When rebalancing happens, use the last committed offset
 	saramaConfig.Consumer.Offsets.Retry.Max = 3
 
-	if cfg.Kafka.TLS {
-		saramaConfig.Net.TLS.Enable = true
-		saramaConfig.Net.TLS.Config = &tls.Config{
-			InsecureSkipVerify: false,
+	// SASL implies TLS: SASL_SSL is the only SASL protocol this app speaks, so
+	// enabling SASL turns TLS on even when cfg.Kafka.TLS is false. TLS material
+	// is built by the shared helper in internal/kafka so both config builders
+	// honour kafka.tls_ca_cert_file identically.
+	if cfg.Kafka.TLS || cfg.Kafka.UseSASL {
+		tlsConfig, err := mainkafka.BuildTLSConfig(&cfg.Kafka)
+		if err != nil {
+			return nil, err
 		}
+		saramaConfig.Net.TLS.Enable = true
+		saramaConfig.Net.TLS.Config = tlsConfig
 	}
 
 	if !cfg.Kafka.UseSASL {
-		return saramaConfig
+		return saramaConfig, nil
 	}
 
 	// SASL specific configs
 	saramaConfig.Net.SASL.Enable = true
-	saramaConfig.Net.TLS.Enable = true
 
 	// sasl configs
 	saramaConfig.Net.SASL.Mechanism = cfg.Kafka.SASLMechanism
@@ -62,7 +71,7 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 		// User/Password are not used.
 		provider, err := mainkafka.NewGCPTokenProvider(context.Background(), cfg.Kafka.SASLOAuthScopes)
 		if err != nil {
-			panic(fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", cfg.Kafka.SASLOAuthScopes, err))
+			return nil, fmt.Errorf("kafka oauthbearer: init token provider (scopes=%v) — check GCP Application Default Credentials: %w", cfg.Kafka.SASLOAuthScopes, err)
 		}
 		saramaConfig.Net.SASL.TokenProvider = provider
 
@@ -80,7 +89,7 @@ func GetSaramaConfig(cfg *config.Configuration) *sarama.Config {
 		saramaConfig.Net.SASL.Password = cfg.Kafka.SASLPassword
 	}
 
-	return saramaConfig
+	return saramaConfig, nil
 }
 
 // XDGSCRAMClient implements sarama.SCRAMClient for SCRAM authentication

--- a/internal/pubsub/kafka/consumer.go
+++ b/internal/pubsub/kafka/consumer.go
@@ -26,17 +26,19 @@ func NewConsumer(cfg *config.Configuration, consumerGroupID string) (*Consumer, 
 	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
 	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
 
-	saramaConfig := GetSaramaConfig(cfg)
-	if saramaConfig != nil {
-		// Optimize consumer configs for throughput
-		// TODO: move this to config
-		saramaConfig.Consumer.Group.Session.Timeout = 45000 * time.Millisecond
-		saramaConfig.Consumer.Fetch.Min = 1                        // Minimum number of bytes to fetch in a request
-		saramaConfig.Consumer.Fetch.Max = 10 * 1024 * 1024         // Maximum number of bytes to fetch (10MB)
-		saramaConfig.Consumer.Fetch.Default = 1024 * 1024          // Default fetch size (1MB)
-		saramaConfig.Consumer.MaxWaitTime = 100 * time.Millisecond // Max time to wait for new data
-		saramaConfig.Consumer.MaxProcessingTime = 500 * time.Millisecond
+	saramaConfig, err := GetSaramaConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
+
+	// Optimize consumer configs for throughput
+	// TODO: move this to config
+	saramaConfig.Consumer.Group.Session.Timeout = 45000 * time.Millisecond
+	saramaConfig.Consumer.Fetch.Min = 1                        // Minimum number of bytes to fetch in a request
+	saramaConfig.Consumer.Fetch.Max = 10 * 1024 * 1024         // Maximum number of bytes to fetch (10MB)
+	saramaConfig.Consumer.Fetch.Default = 1024 * 1024          // Default fetch size (1MB)
+	saramaConfig.Consumer.MaxWaitTime = 100 * time.Millisecond // Max time to wait for new data
+	saramaConfig.Consumer.MaxProcessingTime = 500 * time.Millisecond
 
 	subscriber, err := kafka.NewSubscriber(
 		kafka.SubscriberConfig{

--- a/internal/pubsub/kafka/producer.go
+++ b/internal/pubsub/kafka/producer.go
@@ -16,12 +16,14 @@ func NewProducer(cfg *config.Configuration) (*Producer, error) {
 	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
 	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
 
-	saramaConfig := GetSaramaConfig(cfg)
-	if saramaConfig != nil {
-		// add producer configs
-		saramaConfig.Producer.Return.Successes = true
-		saramaConfig.Producer.Return.Errors = true
+	saramaConfig, err := GetSaramaConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
+
+	// add producer configs
+	saramaConfig.Producer.Return.Successes = true
+	saramaConfig.Producer.Return.Errors = true
 
 	publisher, err := kafka.NewPublisher(
 		kafka.PublisherConfig{

--- a/internal/pubsub/router/router.go
+++ b/internal/pubsub/router/router.go
@@ -64,11 +64,13 @@ func NewRouter(cfg *config.Configuration, logger *logger.Logger, tracingSvc *tra
 
 func createDLQPublisher(cfg *config.Configuration, logger *logger.Logger) (message.Publisher, error) {
 	kc := &cfg.Kafka
-	saramaConfig := kafka.GetSaramaConfig(kc)
-	if saramaConfig != nil {
-		saramaConfig.Producer.Return.Successes = true
-		saramaConfig.Producer.Return.Errors = true
+	saramaConfig, err := kafka.GetSaramaConfig(kc)
+	if err != nil {
+		return nil, err
 	}
+
+	saramaConfig.Producer.Return.Successes = true
+	saramaConfig.Producer.Return.Errors = true
 
 	publisher, err := watermillKafka.NewPublisher(
 		watermillKafka.PublisherConfig{


### PR DESCRIPTION
## **User description**
## Problem

Kafka brokers presenting a **private or self-signed certificate** cannot be used today. `GetSaramaConfig` always built `tls.Config{InsecureSkipVerify: false}` with an empty `RootCAs`, so verification fell back to the OS trust store, and no chart value existed to supply a CA.

The only workarounds were `SSL_CERT_FILE` or baking the CA into the image. Both **replace** the trust store process-wide, so every other outbound TLS caller in the same pod (Stripe, GCP, webhooks) would then validate against the customer's CA only.

This came out of a customer asking how to configure SASL_SSL + SCRAM-SHA-512 against a broker with an internal CA.

## Change

`kafka.tls_ca_cert_file` (`FLEXPRICE_KAFKA_TLS_CA_CERT_FILE`). When set, the PEM bundle is appended to a **clone of the system pool** and installed as `RootCAs` on the Kafka client alone — the rest of the process keeps the system roots. Empty (the default) preserves existing behaviour, so MSK / Confluent Cloud deployments are untouched.

PEM only. JKS/PKCS12 truststores aren't readable by Go, and the parse-failure error names the `keytool` invocation that converts one, since a Java truststore is what operators usually have on hand.

### Signature change

`GetSaramaConfig` now returns `(*sarama.Config, error)` instead of panicking, so a bad CA path surfaces as a normal startup failure. The existing OAUTHBEARER panic moves to the same path. All 7 call sites already returned an error and now propagate it — this also retires their `if saramaConfig != nil` guards, which could never fire under the old signature.

`internal/pubsub/kafka` held a near-verbatim copy of the TLS/SASL setup and had already drifted from `internal/kafka` once over OAUTHBEARER. It now calls the shared `BuildTLSConfig`, so both honour the CA identically.

### Helm

`kafkaConfig.tlsCASecret` mounts an **existing** Secret read-only into api / consumer / worker / migration and points the env var at it. The chart never renders the Secret, so certificate material stays out of values files and can be synced by an ExternalSecret.

On the migrated generic-env shape (`.Values.env` set) the chart emits no `kafkaConfig`-derived env vars by design — it still mounts, but leaves the env var to the operator. Documented in `values.yaml`.

```yaml
kafkaConfig:
  useSASL: true
  saslMechanism: "SCRAM-SHA-512"
  saslUser: "flexprice"
  tls: true
  tlsCASecret:
    name: "flexprice-kafka-ca"   # synced by ExternalSecret
    key: "ca.crt"
```

## Two adjacent bugs fixed

Both block this exact SASL_SSL + SCRAM-SHA-512 path:

- **`values-prod.example.yaml` set `saslUsername`**, but the chart reads `saslUser`. Copying the example produced an empty username and failed authentication.
- **The KEDA scaler forwarded `saslMechanism` verbatim.** KEDA names mechanisms `scram_sha512`, not `SCRAM-SHA-512`, so the scaler couldn't authenticate. Now mapped, rather than making operators configure the mechanism twice.

## Verification

| Check | Result |
|---|---|
| `go build ./internal/... ./cmd/...` | clean |
| `go vet` on affected packages | clean |
| `go test ./internal/...` | exit 0, no failures |
| 9 new TLS tests | pass |
| System-roots-superset assertion | run under `linux/golang:1.25` — Go exposes no roots to `Subjects()` on macOS, where it skips |
| `helm template`, CA configured | 5 containers, 0 dangling mounts |
| `helm template`, defaults | 0 env vars, 0 volumes — no regression |
| `helm template`, migrated env-map | 0 dangling |

Every container receiving the CA env var was confirmed to also get the volume and mount. That check caught a real gap during development: the `run-ent-migrations` init container had the env var without a mount, fixed here.

## Not included

The `create-kafka-topics` init container uses the Java `kafka-topics` CLI, which has no SASL/TLS wiring today and would need a JKS truststore plus `--command-config` — a different mechanism from the Go path. Left alone; worth a separate change if topic creation needs to run against an authenticated cluster.

Client certificates (mTLS) are also out of scope — a truststore implies server-auth only, and SCRAM carries the client identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for custom PEM CA certificates and server-name overrides for Kafka TLS.
  - Kafka certificates can be mounted across application workloads, autoscaling, and migration jobs.
  - Kafka connections now support TLS with SASL authentication and improved mechanism handling.
- **Bug Fixes**
  - Kafka configuration, certificate, and authentication errors are now reported clearly.
  - Unsupported SASL mechanisms now fail deployment validation instead of falling back to plaintext.
- **Documentation**
  - Added guidance for certificate Secrets and autoscaling authentication requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Support private Kafka certificates and make TLS/SASL failures clear

### What Changed
- Kafka clients can verify brokers with private or self-signed PEM certificates while retaining the system trust store for public brokers and other outbound connections
- Operators can override the certificate hostname for brokers behind SNI-mismatched load balancers
- Helm can mount an existing CA Secret into API, consumer, worker, and migration workloads without embedding certificate data in chart values
- SASL connections now enable TLS consistently, and KEDA maps supported SASL mechanisms to the names it expects
- Invalid CA files and missing OAuth credentials now stop startup with actionable errors instead of causing panics or delayed connection failures
- Added coverage for CA loading, trust-store preservation, hostname overrides, TLS/SASL combinations, and invalid certificate files

### Impact
`✅ Private-CA Kafka connections`
`✅ Preserved public Kafka certificate validation`
`✅ Clearer Kafka startup errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
