### PR TITLE
feat(dlq): add `dlq replay` tool to redrive dead-letter topics to origin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,15 @@ init-kafka:
 	echo "Error: Kafka failed to become ready after 10 attempts"; \
 	exit 1
 
+# Replay a dead-letter topic back to origin. Dry-run first, then drop DRY_RUN.
+#   make dlq-replay SOURCE=staging_events_dlq
+#   make dlq-replay SOURCE=production_event_processing_dlq DRY_RUN=
+.PHONY: dlq-replay
+DRY_RUN ?= --dry-run
+dlq-replay:
+	@if [ -z "$(SOURCE)" ]; then echo "usage: make dlq-replay SOURCE=<dlq-topic> [DRY_RUN=]"; exit 1; fi
+	go run ./cmd/dlq replay --source $(SOURCE) $(DRY_RUN)
+
 # Clean all docker containers and volumes related to the project
 .PHONY: clean-docker
 clean-docker:

--- a/cmd/dlq/README.md
+++ b/cmd/dlq/README.md
@@ -1,0 +1,109 @@
+# dlq — dead-letter queue replay
+
+Drains a watermill poison-queue (dead-letter) topic and routes each message back
+to the topic it was originally poisoned from.
+
+## Why this exists
+
+When a consumer handler exhausts its retries, watermill's `PoisonQueue`
+middleware writes the message to a DLQ topic with four metadata headers:
+
+| header | meaning |
+|---|---|
+| `topic_poisoned` | the origin topic — **the replay target** |
+| `reason_poisoned` | why it failed (e.g. `dial tcp …: connection refused`) |
+| `handler_poisoned` | the handler that rejected it |
+| `subscriber_poisoned` | the subscriber (e.g. `kafka.PubSub`) |
+
+Because the origin topic is carried on the message, replay is a mechanical
+"read the header, strip the poison headers, republish" — no hard-coded topic
+map to drift. This tool does exactly that, plus a loop guard.
+
+## Usage
+
+Broker + auth come from the standard `FLEXPRICE_*` env (same as `server` /
+`migrate`). **Always dry-run first** — it prints the routing and a poison-reason
+histogram without producing anything:
+
+```bash
+go run ./cmd/dlq replay --source staging_events_dlq --dry-run
+# or: make dlq-replay SOURCE=staging_events_dlq
+
+# real run once the reasons look transient and the root cause is resolved:
+go run ./cmd/dlq replay --source production_event_processing_dlq
+
+# bound a replay to a specific incident window:
+go run ./cmd/dlq replay --source production_meter_usage_tracking_service_dlq \
+    --since 2026-07-28T06:18:00Z
+```
+
+### Flags
+
+| flag | default | purpose |
+|---|---|---|
+| `--source` | (required) | DLQ topic to drain |
+| `--target` | per-message `topic_poisoned` | override destination for ALL messages (use only when the header is missing/wrong) |
+| `--group` | `dlq-replay-tool` | consumer group that tracks the resume offset |
+| `--since` | resume point | RFC3339; **ignore the resume point** and replay from the first message at/after this time |
+| `--from-start` | false | **ignore the resume point** and re-drain from each partition's oldest retained offset |
+| `--max` | 0 (no cap) | cap messages replayed |
+| `--max-replays` | 3 | quarantine a message once its `replay_count` hits this (loop guard) |
+| `--dry-run` | false | show routing + reasons, produce nothing, **commit nothing** |
+
+`--since` and `--from-start` are mutually exclusive.
+
+## Resume semantics (why a second run doesn't re-replay everything)
+
+Kafka does **not** delete a message when you consume it — it stays in the topic
+until retention expires. So a naive "read from the beginning" replay would
+re-send every message still in the DLQ on every run.
+
+Instead, progress is tracked as **committed offsets under a consumer group**
+(`--group`, default `dlq-replay-tool`), and an offset is committed **only after
+the message has been successfully republished**. Concretely:
+
+- **Day 1:** 50 messages arrive, you run replay → all 50 republished, offset
+  committed to 50.
+- **Day 2:** 50 more arrive → the next run resumes at offset 50 and replays only
+  the new 50. The day-1 messages are not touched.
+
+A crash mid-run re-replays only the uncommitted tail (at-least-once), never the
+whole topic. `--dry-run` commits nothing, so a preview never advances the resume
+point. To deliberately replay a window again, use `--from-start` or `--since`.
+
+> The tool tracks offsets under this group id via an offset manager; it does not
+> consume as a live group member, so it won't collide with real consumers. Don't
+> point a real consumer at the `dlq-replay-tool` group.
+
+## Safety model
+
+- **Bounded:** each partition is drained only up to its end offset at start, so a
+  run always terminates and never tails messages produced mid-run.
+- **Resumable, commit-after-publish:** offsets advance only past messages that
+  were actually republished (or deliberately skipped/quarantined), so a re-run
+  never double-sends what already succeeded and never skips what didn't.
+- **Loop guard:** every replay stamps/increments a `replay_count` header; once a
+  message reaches `--max-replays` it is quarantined (offset advances past it, but
+  it is not re-sent). This stops a re-poison loop during an ongoing outage.
+- **Contract-preserving:** republish uses watermill's `DefaultMarshaler`, so a
+  replayed message is byte-identical to a freshly produced one (keyless, same
+  UUID + metadata handling) — only the poison headers are removed.
+- **Idempotency is on the consumer side:** flexprice events carry an `id` and the
+  billing tables are `ReplacingMergeTree`, so a duplicate replay dedups. Confirm
+  the specific handler is idempotent before replaying non-event topics.
+
+## Before you replay — read the reason
+
+Check the `reason_poisoned` histogram in the dry-run:
+
+- **Transient infra** (`connection refused`, `dial tcp … timeout`,
+  `context canceled`, `database system is shutting down`) → safe to replay once
+  the burst has **stopped** and the root cause is resolved.
+- **Schema / code** (`pq: column … does not exist`) → only replay after the fix
+  is deployed, or every message will immediately re-poison.
+
+## Deployment
+
+Runs as a Kubernetes Job in-cluster under the consumer's Kafka auth (Workload
+Identity / OAUTHBEARER on GMK) — no bastion, no short-lived tokens. Job manifest
+lives in the infrastructure repo.

--- a/cmd/dlq/main.go
+++ b/cmd/dlq/main.go
@@ -1,0 +1,31 @@
+// Command dlq is the operational tool for draining a watermill dead-letter
+// (poison) topic back to the origin topic each message came from.
+//
+// It is deployed as a Kubernetes Job (see infrastructure repo) so it runs
+// in-cluster under the same Kafka auth (Workload Identity / OAUTHBEARER on GMK)
+// as the consumer, with no bastion or short-lived token handling. Broker and
+// auth config come from the standard FLEXPRICE_* env, exactly like the server
+// and migrate binaries.
+//
+//	dlq replay --source staging_events_dlq --dry-run
+//	dlq replay --source production_event_processing_dlq --since 2026-07-28T06:18:00Z
+package main
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	root := &cobra.Command{
+		Use:   "dlq",
+		Short: "FlexPrice dead-letter queue operations",
+	}
+
+	root.AddCommand(newReplayCmd())
+
+	if err := root.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/dlq/replay.go
+++ b/cmd/dlq/replay.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/kafka/dlq"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/spf13/cobra"
+)
+
+func newReplayCmd() *cobra.Command {
+	var (
+		source     string
+		target     string
+		group      string
+		since      string
+		fromStart  bool
+		maxMsgs    int
+		maxReplays int
+		timeout    time.Duration
+		dryRun     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "replay",
+		Short: "Replay messages from a DLQ topic back to their origin topic",
+		Long: "Drains a watermill poison-queue topic up to its current end offset and " +
+			"routes each message back to the topic named in its topic_poisoned header " +
+			"(or --target). Strips the watermill poison headers and increments a " +
+			"replay_count guard so a message that keeps failing is quarantined rather " +
+			"than looped.\n\n" +
+			"Progress is tracked as committed offsets under a consumer group (--group), " +
+			"committed only after a successful republish, so a re-run resumes where it " +
+			"left off instead of replaying the whole topic. Use --from-start or --since " +
+			"to override the resume point. Run with --dry-run first to see the routing " +
+			"and reason breakdown (dry-run never commits, so a later real run still sees " +
+			"everything).",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var sinceMs int64
+			if since != "" {
+				t, err := time.Parse(time.RFC3339, since)
+				if err != nil {
+					return fmt.Errorf("parse --since (want RFC3339, e.g. 2026-07-28T06:18:00Z): %w", err)
+				}
+				sinceMs = t.UnixMilli()
+			}
+
+			cfg, err := config.NewConfig()
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+			log, err := logger.NewLogger(cfg)
+			if err != nil {
+				return fmt.Errorf("init logger: %w", err)
+			}
+
+			if fromStart && sinceMs > 0 {
+				return fmt.Errorf("--from-start and --since are mutually exclusive")
+			}
+
+			// A hard wall-clock ceiling so no broker stall can wedge a run
+			// forever (the drain honors ctx cancellation). 0 disables it —
+			// rely on the K8s Job's activeDeadlineSeconds in that case.
+			ctx := context.Background()
+			if timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, timeout)
+				defer cancel()
+			}
+			sum, err := dlq.Replay(ctx, cfg, log, dlq.Options{
+				SourceTopic:    source,
+				TargetOverride: target,
+				Group:          group,
+				SinceMs:        sinceMs,
+				FromStart:      fromStart,
+				Max:            maxMsgs,
+				MaxReplays:     maxReplays,
+				DryRun:         dryRun,
+			})
+			if sum != nil {
+				printSummary(source, dryRun, sum)
+			}
+			return err
+		},
+	}
+
+	cmd.Flags().StringVar(&source, "source", "", "DLQ topic to drain (required), e.g. staging_events_dlq")
+	cmd.Flags().StringVar(&target, "target", "", "override destination topic for ALL messages (default: per-message topic_poisoned header)")
+	cmd.Flags().StringVar(&group, "group", dlq.DefaultGroup, "consumer group used to track resume offsets")
+	cmd.Flags().StringVar(&since, "since", "", "ignore resume point; replay from the first message appended at/after this RFC3339 time")
+	cmd.Flags().BoolVar(&fromStart, "from-start", false, "ignore resume point; re-drain each partition from its oldest retained offset")
+	cmd.Flags().IntVar(&maxMsgs, "max", 0, "cap number of messages replayed (0 = no cap)")
+	cmd.Flags().IntVar(&maxReplays, "max-replays", 3, "quarantine a message once it has been replayed this many times (loop guard)")
+	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Minute, "hard wall-clock ceiling for the run (0 = no ceiling; rely on the Job deadline)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show routing + reason breakdown without producing anything (does not commit offsets)")
+	_ = cmd.MarkFlagRequired("source")
+
+	return cmd
+}
+
+func printSummary(source string, dryRun bool, s *dlq.Summary) {
+	verb := "replayed"
+	if dryRun {
+		verb = "WOULD replay"
+	}
+	fmt.Printf("\nDLQ replay summary (%s)\n", source)
+	fmt.Printf("  scanned:     %d\n", s.Scanned)
+	fmt.Printf("  %s:  %d\n", verb, s.Replayed)
+	fmt.Printf("  skipped:     %d (unroutable)\n", s.Skipped)
+	fmt.Printf("  quarantined: %d (hit max-replays)\n", s.Quarantined)
+
+	if len(s.ByTarget) > 0 {
+		fmt.Println("  by target topic:")
+		for _, kv := range sortedDesc(s.ByTarget) {
+			fmt.Printf("    %-45s %d\n", kv.k, kv.v)
+		}
+	}
+	if len(s.ByReason) > 0 {
+		fmt.Println("  by poison reason:")
+		for _, kv := range sortedDesc(s.ByReason) {
+			fmt.Printf("    %-80s %d\n", kv.k, kv.v)
+		}
+	}
+	fmt.Println()
+}
+
+type kv struct {
+	k string
+	v int
+}
+
+func sortedDesc(m map[string]int) []kv {
+	out := make([]kv, 0, len(m))
+	for k, v := range m {
+		out = append(out, kv{k, v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].v != out[j].v {
+			return out[i].v > out[j].v
+		}
+		return out[i].k < out[j].k
+	})
+	return out
+}

--- a/internal/kafka/dlq/replay.go
+++ b/internal/kafka/dlq/replay.go
@@ -1,0 +1,452 @@
+// Package dlq replays messages out of a watermill poison-queue (dead-letter)
+// topic back to their origin topic.
+//
+// Every message the consumer poison-queue middleware writes to a DLQ carries
+// watermill's poison metadata — the origin topic lives in the
+// middleware.PoisonedTopicKey ("topic_poisoned") header. This package routes
+// each message by that header rather than by any hard-coded mapping, so the
+// replay target can never drift from what the middleware actually wrote.
+//
+// Replay is contract-preserving: it uses watermill's DefaultMarshaler in both
+// directions, so a republished message is byte-for-byte what a normally
+// published one would be (watermill UUID + metadata → kafka headers, keyless
+// like every other flexprice producer). The only mutations are (a) the four
+// watermill poison headers are stripped, and (b) a replay_count header is
+// incremented so a message that keeps failing is quarantined instead of
+// looping forever.
+//
+// Resume semantics: progress is tracked as committed offsets under a dedicated
+// consumer group (Options.Group), and an offset is committed only AFTER the
+// message is successfully republished. So a second run picks up where the last
+// one left off instead of re-replaying the whole topic, and a crash mid-run
+// re-replays only the uncommitted tail (at-least-once — safe because handlers
+// are idempotent). --since / --from-start override the resume point explicitly.
+package dlq
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/Shopify/sarama"
+	"github.com/ThreeDotsLabs/watermill"
+	watermillKafka "github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/kafka"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// ReplayCountKey counts how many times a message has been replayed out of a
+// DLQ. It is not a watermill key — we own it — and it is the loop guard: once
+// it reaches Options.MaxReplays the message is quarantined (left in the DLQ)
+// instead of replayed again.
+const ReplayCountKey = "replay_count"
+
+// DefaultGroup is the consumer group under which replay progress (committed
+// offsets) is tracked. Dedicated to this tool so it never collides with a real
+// consumer's group.
+const DefaultGroup = "dlq-replay-tool"
+
+// poisonKeys are the watermill metadata headers stripped before republish so
+// the replayed message is indistinguishable from a fresh one.
+var poisonKeys = []string{
+	middleware.ReasonForPoisonedKey,
+	middleware.PoisonedTopicKey,
+	middleware.PoisonedHandlerKey,
+	middleware.PoisonedSubscriberKey,
+}
+
+// Options controls a single replay run.
+type Options struct {
+	// SourceTopic is the DLQ topic to drain (e.g. "staging_events_dlq").
+	SourceTopic string
+	// TargetOverride, when set, routes every message to this topic instead of
+	// the per-message topic_poisoned header. Use only when the header is
+	// missing/wrong; normal replays leave it empty and route per message.
+	TargetOverride string
+	// Group is the consumer group that tracks committed-offset progress. Empty
+	// defaults to DefaultGroup. Change it only to run an independent replay
+	// stream over the same topic.
+	Group string
+	// SinceMs, when > 0, ignores the committed resume point and starts each
+	// partition at the first offset at or after this epoch-ms append time
+	// (bounds the replay to a specific incident window).
+	SinceMs int64
+	// FromStart ignores the committed resume point and re-drains each partition
+	// from its oldest retained offset. Mutually exclusive with SinceMs (SinceMs
+	// wins). Use to deliberately replay a topic in full again.
+	FromStart bool
+	// Max caps the number of messages replayed (0 = no cap). A safety valve.
+	Max int
+	// MaxReplays quarantines a message once its replay_count reaches this value
+	// (loop guard). Must be >= 1; defaults to 3.
+	MaxReplays int
+	// DryRun tallies and logs what would happen without producing anything and
+	// without committing any offset (so a later real run still sees everything).
+	DryRun bool
+	// idleTimeout stops draining a partition if no message arrives within this
+	// window before the snapshotted end offset is reached (guards against
+	// offset gaps from retention/compaction that would otherwise block).
+	idleTimeout time.Duration
+}
+
+// Summary is the outcome of a replay run.
+type Summary struct {
+	Scanned     int            // messages read from the DLQ
+	Replayed    int            // messages (re)published to a target topic
+	Skipped     int            // unroutable (no topic_poisoned and no override)
+	Quarantined int            // hit MaxReplays, left in place
+	ByTarget    map[string]int // replayed count per destination topic
+	ByReason    map[string]int // scanned count per (truncated) poison reason
+}
+
+// Replay drains opts.SourceTopic — resuming from the Group's committed offsets —
+// up to each partition's end offset at the moment the run starts (messages
+// appended mid-run are ignored) and routes each message back to its origin
+// topic. It returns a Summary even on a partial run.
+func Replay(ctx context.Context, cfg *config.Configuration, log *logger.Logger, opts Options) (*Summary, error) {
+	if opts.SourceTopic == "" {
+		return nil, fmt.Errorf("dlq replay: SourceTopic is required")
+	}
+	if opts.Group == "" {
+		opts.Group = DefaultGroup
+	}
+	if opts.MaxReplays < 1 {
+		opts.MaxReplays = 3
+	}
+	if opts.idleTimeout == 0 {
+		opts.idleTimeout = 15 * time.Second
+	}
+
+	sum := &Summary{ByTarget: map[string]int{}, ByReason: map[string]int{}}
+
+	saramaCfg := kafka.GetSaramaConfig(&cfg.Kafka)
+	// Leave AutoCommit ENABLED (its default). The commit-after-publish guarantee
+	// is enforced by only ever MarkOffset-ing a message after a successful
+	// Publish — autocommit can then only flush offsets for already-republished
+	// messages, and we also Commit() explicitly per partition for the tail.
+	// Do NOT disable autocommit: sarama only starts the offset manager's
+	// background loop when autocommit is on, and that loop is what lets
+	// partitionOffsetManager.Close() return — with it off, Close() deadlocks.
+
+	client, err := sarama.NewClient(cfg.Kafka.Brokers, saramaCfg)
+	if err != nil {
+		return sum, fmt.Errorf("connect kafka client: %w", err)
+	}
+	defer client.Close()
+
+	consumer, err := sarama.NewConsumerFromClient(client)
+	if err != nil {
+		return sum, fmt.Errorf("create consumer: %w", err)
+	}
+	defer consumer.Close()
+
+	offsetMgr, err := sarama.NewOffsetManagerFromClient(opts.Group, client)
+	if err != nil {
+		return sum, fmt.Errorf("create offset manager (group=%s): %w", opts.Group, err)
+	}
+	defer offsetMgr.Close()
+
+	// The publisher is created even in dry-run (cheap, and it validates broker
+	// auth up front) but Publish is only called on a real run.
+	var pub message.Publisher
+	if !opts.DryRun {
+		pub, err = newPublisher(cfg, log)
+		if err != nil {
+			return sum, fmt.Errorf("create publisher: %w", err)
+		}
+		defer pub.Close()
+	}
+
+	marshaler := watermillKafka.DefaultMarshaler{}
+
+	partitions, err := client.Partitions(opts.SourceTopic)
+	if err != nil {
+		return sum, fmt.Errorf("list partitions for %s: %w", opts.SourceTopic, err)
+	}
+
+	log.Info(ctx, "dlq replay: starting",
+		"source", opts.SourceTopic, "group", opts.Group,
+		"target_override", opts.TargetOverride, "partitions", len(partitions),
+		"dry_run", opts.DryRun, "from_start", opts.FromStart,
+		"since_ms", opts.SinceMs, "max", opts.Max, "max_replays", opts.MaxReplays)
+
+	for _, p := range partitions {
+		if opts.Max > 0 && sum.Replayed >= opts.Max {
+			break
+		}
+		if err := replayPartition(ctx, client, consumer, offsetMgr, marshaler, pub, log, opts, p, sum); err != nil {
+			// Return what we have so an operator can see partial progress and
+			// re-run — resume picks up from the committed offset.
+			return sum, fmt.Errorf("partition %d: %w", p, err)
+		}
+	}
+
+	log.Info(ctx, "dlq replay: done",
+		"scanned", sum.Scanned, "replayed", sum.Replayed,
+		"skipped", sum.Skipped, "quarantined", sum.Quarantined,
+		"by_target", sum.ByTarget)
+	return sum, nil
+}
+
+// replayPartition resolves the start offset for one partition (resume point,
+// or a --since / --from-start override), drains it, and commits the resulting
+// progress. The offset is committed here — after the drain — and only ever
+// reflects messages that handleMessage has already republished/decided on.
+func replayPartition(
+	ctx context.Context,
+	client sarama.Client,
+	consumer sarama.Consumer,
+	offsetMgr sarama.OffsetManager,
+	marshaler watermillKafka.DefaultMarshaler,
+	pub message.Publisher,
+	log *logger.Logger,
+	opts Options,
+	partition int32,
+	sum *Summary,
+) error {
+	// Snapshot the end offset now so messages appended during the run are not
+	// consumed (a replay must terminate; a live-tailing one never would).
+	hwm, err := client.GetOffset(opts.SourceTopic, partition, sarama.OffsetNewest)
+	if err != nil {
+		return fmt.Errorf("get newest offset: %w", err)
+	}
+	oldest, err := client.GetOffset(opts.SourceTopic, partition, sarama.OffsetOldest)
+	if err != nil {
+		return fmt.Errorf("get oldest offset: %w", err)
+	}
+
+	pom, err := offsetMgr.ManagePartition(opts.SourceTopic, partition)
+	if err != nil {
+		return fmt.Errorf("manage partition offsets: %w", err)
+	}
+	// Close runs after Commit below (deferred, so it is last), flushing cleanly.
+	defer pom.Close()
+
+	start, hasWork, err := resolveStart(client, pom, opts, partition, oldest, hwm)
+	if err != nil {
+		return err
+	}
+	if !hasWork {
+		return nil
+	}
+
+	runErr := drainPartition(ctx, consumer, pom, marshaler, pub, log, opts, partition, start, hwm, sum)
+
+	// Flush the marks accumulated during the drain. Every mark is post-publish,
+	// so committing them is safe even when runErr != nil (a partial drain still
+	// advances the resume point past what it successfully replayed). No-op in
+	// dry-run, which never marks.
+	if !opts.DryRun {
+		offsetMgr.Commit()
+	}
+	return runErr
+}
+
+// resolveStart picks the offset to begin a partition from and reports whether
+// there is anything to do. Precedence: --since > --from-start > committed
+// resume point. The start is clamped into [oldest, hwm].
+func resolveStart(
+	client sarama.Client,
+	pom sarama.PartitionOffsetManager,
+	opts Options,
+	partition int32,
+	oldest, hwm int64,
+) (start int64, hasWork bool, err error) {
+	switch {
+	case opts.SinceMs > 0:
+		start, err = client.GetOffset(opts.SourceTopic, partition, opts.SinceMs)
+		if err != nil {
+			return 0, false, fmt.Errorf("get offset for since_ms: %w", err)
+		}
+		if start == -1 {
+			return 0, false, nil // nothing appended in-window on this partition
+		}
+	case opts.FromStart:
+		start = oldest
+	default:
+		// NextOffset returns the config's Initial (a negative sentinel) when
+		// this group has never committed for the partition — resume from oldest.
+		start, _ = pom.NextOffset()
+		if start < 0 {
+			start = oldest
+		}
+	}
+
+	if start < oldest {
+		start = oldest // a committed offset trimmed away by retention
+	}
+	if hwm == 0 || start >= hwm {
+		return 0, false, nil // empty partition, or resume point already at the end
+	}
+	return start, true, nil
+}
+
+// drainPartition consumes [start, hwm) and hands each message to handleMessage,
+// marking the offset after a successful republish so progress can be committed.
+func drainPartition(
+	ctx context.Context,
+	consumer sarama.Consumer,
+	pom sarama.PartitionOffsetManager,
+	marshaler watermillKafka.DefaultMarshaler,
+	pub message.Publisher,
+	log *logger.Logger,
+	opts Options,
+	partition int32,
+	start, hwm int64,
+	sum *Summary,
+) error {
+	pc, err := consumer.ConsumePartition(opts.SourceTopic, partition, start)
+	if err != nil {
+		return fmt.Errorf("consume partition: %w", err)
+	}
+	defer pc.Close()
+
+	for {
+		if opts.Max > 0 && sum.Replayed >= opts.Max {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(opts.idleTimeout):
+			// No message within the idle window although we haven't reached the
+			// end offset — treat as end-of-data (offset gaps from retention or
+			// compaction) rather than block forever.
+			log.Info(ctx, "dlq replay: idle timeout before end offset, stopping partition",
+				"partition", partition, "source", opts.SourceTopic)
+			return nil
+		case km := <-pc.Messages():
+			if km == nil {
+				return nil
+			}
+			if err := handleMessage(ctx, marshaler, pub, log, opts, km, sum); err != nil {
+				// Hard failure (e.g. publish error): stop without marking this
+				// offset so the message is retried from here on the next run.
+				return err
+			}
+			if !opts.DryRun {
+				// Terminal decision made (replayed, skipped, or quarantined) —
+				// advance the resume point past it.
+				pom.MarkOffset(km.Offset+1, "")
+			}
+			// Stop once we've consumed the last message that existed at start.
+			if km.Offset >= hwm-1 {
+				return nil
+			}
+		}
+	}
+}
+
+// handleMessage routes and (unless dry-run) republishes a single DLQ message.
+// It returns a non-nil error only for a hard failure that should stop the drain
+// (publish error); routable/skippable/quarantinable outcomes return nil so the
+// caller advances past them.
+func handleMessage(
+	ctx context.Context,
+	marshaler watermillKafka.DefaultMarshaler,
+	pub message.Publisher,
+	log *logger.Logger,
+	opts Options,
+	km *sarama.ConsumerMessage,
+	sum *Summary,
+) error {
+	sum.Scanned++
+
+	msg, err := marshaler.Unmarshal(km)
+	if err != nil {
+		// A message we cannot unmarshal cannot be safely re-emitted; count it as
+		// skipped and advance rather than aborting the whole drain.
+		log.Error(ctx, "dlq replay: unmarshal failed, skipping",
+			"error", err, "offset", km.Offset, "partition", km.Partition)
+		sum.Skipped++
+		return nil
+	}
+
+	reason := msg.Metadata.Get(middleware.ReasonForPoisonedKey)
+	sum.ByReason[truncate(reason, 80)]++
+
+	target := opts.TargetOverride
+	if target == "" {
+		target = msg.Metadata.Get(middleware.PoisonedTopicKey)
+	}
+	if target == "" {
+		log.Info(ctx, "dlq replay: message has no topic_poisoned and no override, skipping",
+			"uuid", msg.UUID, "offset", km.Offset)
+		sum.Skipped++
+		return nil
+	}
+
+	// Loop guard: quarantine anything that has already been replayed too often.
+	replayCount := parseCount(msg.Metadata.Get(ReplayCountKey))
+	if replayCount >= opts.MaxReplays {
+		log.Info(ctx, "dlq replay: message hit max replays, quarantining",
+			"uuid", msg.UUID, "replay_count", replayCount, "max_replays", opts.MaxReplays)
+		sum.Quarantined++
+		return nil
+	}
+
+	// Strip the watermill poison headers and stamp the incremented replay count
+	// so the republished message is indistinguishable from a fresh one (except
+	// for the loop-guard counter).
+	for _, k := range poisonKeys {
+		delete(msg.Metadata, k)
+	}
+	msg.Metadata.Set(ReplayCountKey, strconv.Itoa(replayCount+1))
+
+	if opts.DryRun {
+		sum.ByTarget[target]++
+		sum.Replayed++ // "would replay"
+		return nil
+	}
+
+	if err := pub.Publish(target, msg); err != nil {
+		return fmt.Errorf("publish to %s: %w", target, err)
+	}
+	sum.ByTarget[target]++
+	sum.Replayed++
+	return nil
+}
+
+// newPublisher mirrors router.createDLQPublisher: a keyless watermill kafka
+// publisher using the DefaultMarshaler, so replayed messages match the wire
+// format of every other flexprice producer.
+func newPublisher(cfg *config.Configuration, log *logger.Logger) (message.Publisher, error) {
+	saramaCfg := kafka.GetSaramaConfig(&cfg.Kafka)
+	if saramaCfg != nil {
+		saramaCfg.Producer.Return.Successes = true
+		saramaCfg.Producer.Return.Errors = true
+	}
+	return watermillKafka.NewPublisher(
+		watermillKafka.PublisherConfig{
+			Brokers:               cfg.Kafka.Brokers,
+			Marshaler:             watermillKafka.DefaultMarshaler{},
+			OverwriteSaramaConfig: saramaCfg,
+		},
+		watermill.NewStdLogger(false, false),
+	)
+}
+
+func parseCount(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+func truncate(s string, n int) string {
+	if s == "" {
+		return "(no reason)"
+	}
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/kafka/dlq/replay_test.go
+++ b/internal/kafka/dlq/replay_test.go
@@ -1,0 +1,34 @@
+package dlq
+
+import "testing"
+
+// parseCount underpins the loop guard: a mis-parse that returns a low number
+// would let a message replay forever, so pin the edge cases.
+func TestParseCount(t *testing.T) {
+	cases := map[string]int{
+		"":     0, // never replayed
+		"0":    0,
+		"2":    2,
+		"3":    3,
+		"-1":   0, // malformed -> treat as unreplayed, guard still trips at MaxReplays
+		"abc":  0,
+		"  1 ": 0, // not trimmed on purpose; strconv rejects -> 0
+	}
+	for in, want := range cases {
+		if got := parseCount(in); got != want {
+			t.Errorf("parseCount(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("", 5); got != "(no reason)" {
+		t.Errorf("empty reason = %q, want (no reason)", got)
+	}
+	if got := truncate("short", 80); got != "short" {
+		t.Errorf("short = %q, want short", got)
+	}
+	if got := truncate("abcdef", 3); got != "abc" {
+		t.Errorf("truncate len = %q, want abc", got)
+	}
+}


### PR DESCRIPTION
Replaces the ad-hoc bastion + Python replay we run by hand each incident with a first-class, self-serve command.

- internal/kafka/dlq: reusable Replay() that drains a poison-queue topic and routes each message back to its topic_poisoned header (watermill's own constant — no hard-coded topic map to drift). Republishes via watermill DefaultMarshaler so messages are byte-identical to fresh ones.
- Resumable, commit-after-publish: progress tracked as committed offsets under a dedicated consumer group (--group, default dlq-replay-tool), committed only after a successful republish. A re-run resumes where it left off instead of re-replaying the whole topic; a crash re-does only the uncommitted tail (at-least-once — safe given idempotent handlers). --from-start / --since override the resume point; --dry-run commits nothing.
- Loop guard: increments a replay_count header, quarantines at --max-replays so a message can't re-poison forever during an ongoing outage.
- --dry-run prints routing + poison-reason histogram; --max caps volume.
- cmd/dlq: thin cobra wrapper mirroring cmd/migrate; config/auth from FLEXPRICE_* env, so it runs in-cluster as a K8s Job under the consumer's Kafka auth (no bastion, no short-lived tokens).
- Makefile dlq-replay target + README (resume + safety model documented).

Passes go build/vet/test + the loglint merge gate. Deploy manifest (K8s Job) lands in the infrastructure repo separately.

Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to replay dead-letter queue messages to their original or specified topics.
  * Supports dry runs, resume from offsets, start-time overrides, replay limits, timeouts, and replay-count quarantine.
  * Provides replay summaries by destination and poison reason.
  * Added a convenient `make dlq-replay` command with input validation.

* **Documentation**
  * Added usage guidance, safety controls, configuration details, and Kubernetes deployment instructions for DLQ replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->