### PR TITLE
feat(wallet-balance): Add timeout buffer for cached balance

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2549,6 +2549,66 @@ const docTemplate = `{
                 }
             }
         },
+        "/customers/external/{external_id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns all subscriptions for a customer looked up by external_id, with line-item meters and entitlements attached (no pagination).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Customers"
+                ],
+                "summary": "Get subscriptions for customer by external ID",
+                "operationId": "getSubscriptionsForCustomer",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Customer External ID",
+                        "name": "external_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated fields to expand: subscription_line_items, subscription_line_items.meters, entitlements, plan, customer",
+                        "name": "expand",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ListSubscriptionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "read"
+            }
+        },
         "/customers/search": {
             "post": {
                 "security": [
@@ -3606,7 +3666,10 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Use when fetching Hugging Face inference usage or billing data (e.g. for HF-specific reporting or reconciliation).",
+                "description": "Use when fetching Hugging Face inference usage or billing data (e.g. for HF-specific reporting or reconciliation). Reads the meter-usage pipeline.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -3615,11 +3678,69 @@ const docTemplate = `{
                 ],
                 "summary": "Get Hugging Face inference data",
                 "operationId": "getHuggingfaceInferenceData",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GetHuggingFaceBillingDataRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/GetHuggingFaceBillingDataResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/events/lookup": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Use when debugging a specific event (e.g. why it failed or how it was aggregated). Reads the meter-usage pipeline; includes processing status and step-by-step debug tracker when unprocessed. Uses ?id= query param because event IDs can contain \"/\".",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Get event",
+                "operationId": "getEvent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Event ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/GetEventByIDResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
@@ -3780,53 +3901,6 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Resource not found",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Server error",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/events/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Use when debugging a specific event (e.g. why it failed or how it was aggregated). Includes processing status and debug info.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Events"
-                ],
-                "summary": "Get event",
-                "operationId": "getEvent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Event ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/GetEventByIDResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
@@ -4737,6 +4811,12 @@ const docTemplate = `{
                         "collectionFormat": "csv",
                         "description": "Group usage breakdown by specified fields (e.g., source, feature_id, properties.org_id)",
                         "name": "group_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated related fields to include. Supports 'tax_applied.tax_rate' to attach rate details to each applied tax.",
+                        "name": "expand",
                         "in": "query"
                     }
                 ],
@@ -12880,6 +12960,12 @@ const docTemplate = `{
             "properties": {
                 "create_subscription_params": {
                     "$ref": "#/definitions/types.CreateSubscriptionParams"
+                },
+                "modify_subscription_params": {
+                    "$ref": "#/definitions/types.ModifySubscriptionParams"
+                },
+                "wallet_topup_params": {
+                    "$ref": "#/definitions/types.WalletTopupParams"
                 }
             }
         },
@@ -13185,6 +13271,37 @@ const docTemplate = `{
                 }
             }
         },
+        "AWSMarketplaceAgreement": {
+            "type": "object",
+            "required": [
+                "customer_aws_account_id",
+                "dimension",
+                "license_arn",
+                "product_code"
+            ],
+            "properties": {
+                "concurrent_agreements": {
+                    "description": "if true, ProductCode is omitted when reporting",
+                    "type": "boolean"
+                },
+                "customer_aws_account_id": {
+                    "description": "-\u003e BatchMeterUsage's CustomerAWSAccountId",
+                    "type": "string"
+                },
+                "dimension": {
+                    "description": "-\u003e BatchMeterUsage's Dimension (always \"usage_fee\" in the cents model)",
+                    "type": "string"
+                },
+                "license_arn": {
+                    "description": "-\u003e BatchMeterUsage's LicenseArn; identifies the buyer's agreement",
+                    "type": "string"
+                },
+                "product_code": {
+                    "description": "-\u003e BatchMeterUsage's ProductCode (omitted when ConcurrentAgreements)",
+                    "type": "string"
+                }
+            }
+        },
         "ActivateDraftSubscriptionRequest": {
             "type": "object",
             "required": [
@@ -13221,6 +13338,13 @@ const docTemplate = `{
                     "type": "object",
                     "additionalProperties": true
                 },
+                "override_line_items": {
+                    "description": "OverrideLineItems allows overriding price/quantity/billing model for specific addon prices",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/OverrideLineItemRequest"
+                    }
+                },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
                 },
@@ -13254,6 +13378,13 @@ const docTemplate = `{
                 "metadata": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "override_line_items": {
+                    "description": "OverrideLineItems allows overriding price/quantity/billing model for specific addon prices",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/OverrideLineItemRequest"
+                    }
                 },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
@@ -13418,6 +13549,15 @@ const docTemplate = `{
         "AggregatedEntitlement": {
             "type": "object",
             "properties": {
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
+                "buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AggregatedEntitlementBucket"
+                    }
+                },
                 "config_values": {
                     "type": "array",
                     "items": {
@@ -13442,6 +13582,32 @@ const docTemplate = `{
                 },
                 "usage_reset_period": {
                     "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
+                }
+            }
+        },
+        "AggregatedEntitlementBucket": {
+            "type": "object",
+            "properties": {
+                "entitlement_id": {
+                    "type": "string"
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                },
+                "grant_quota": {
+                    "type": "string"
+                },
+                "source_entity_id": {
+                    "type": "string"
+                },
+                "usage_limit": {
+                    "type": "integer"
                 }
             }
         },
@@ -13587,6 +13753,33 @@ const docTemplate = `{
                 },
                 "status": {
                     "$ref": "#/definitions/types.DebugTrackerStatus"
+                }
+            }
+        },
+        "AzureMarketplaceAgreement": {
+            "type": "object",
+            "required": [
+                "beneficiary_account_id",
+                "dimension",
+                "plan_id",
+                "resource_id"
+            ],
+            "properties": {
+                "beneficiary_account_id": {
+                    "description": "writes the customer mapping; not read in the report payload",
+                    "type": "string"
+                },
+                "dimension": {
+                    "description": "-\u003e usageEvent's dimension (always \"usage_fee\" in the cents model)",
+                    "type": "string"
+                },
+                "plan_id": {
+                    "description": "-\u003e usageEvent's planId; Azure's plan id, distinct from the request's top-level PlanID",
+                    "type": "string"
+                },
+                "resource_id": {
+                    "description": "-\u003e usageEvent's resourceId; the Azure SaaS subscription id",
+                    "type": "string"
                 }
             }
         },
@@ -13991,6 +14184,38 @@ const docTemplate = `{
                 "ChangedSubscriptionActionCreated",
                 "ChangedSubscriptionActionUpdated"
             ]
+        },
+        "CheckoutParams": {
+            "type": "object",
+            "required": [
+                "payment_provider"
+            ],
+            "properties": {
+                "cancel_url": {
+                    "type": "string"
+                },
+                "failure_url": {
+                    "type": "string"
+                },
+                "idempotency_key": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "payment_provider": {
+                    "$ref": "#/definitions/types.CheckoutPaymentProvider"
+                },
+                "payment_provider_config": {
+                    "$ref": "#/definitions/types.CheckoutPaymentProviderConfig"
+                },
+                "success_url": {
+                    "type": "string"
+                }
+            }
         },
         "CheckoutSessionResponse": {
             "type": "object",
@@ -15147,6 +15372,10 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 255
                 },
+                "onboarding_workflow_name": {
+                    "description": "onboarding_workflow_name is given if a custom onboarding workflow is to be triggered for this customer",
+                    "type": "string"
+                },
                 "skip_onboarding_workflow": {
                     "description": "skip_onboarding_workflow when true, prevents the customer onboarding workflow from being triggered\nThis is used internally when a customer is created via a workflow to prevent infinite loops\nDefault: false",
                     "type": "boolean"
@@ -15171,6 +15400,9 @@ const docTemplate = `{
                 "feature_type"
             ],
             "properties": {
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
                 "config_value": {
                     "type": "object",
                     "additionalProperties": true
@@ -15189,6 +15421,23 @@ const docTemplate = `{
                 },
                 "feature_type": {
                     "$ref": "#/definitions/types.FeatureType"
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "description": "Grant config — optional. All-or-nothing; see entitlement.validateGrantConfig.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                        }
+                    ]
+                },
+                "grant_quota": {
+                    "type": "string"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -17119,6 +17368,9 @@ const docTemplate = `{
                 "addon": {
                     "$ref": "#/definitions/AddonResponse"
                 },
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
                 "config_value": {
                     "type": "object",
                     "additionalProperties": true
@@ -17152,6 +17404,23 @@ const docTemplate = `{
                 },
                 "feature_type": {
                     "$ref": "#/definitions/types.FeatureType"
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "description": "Grant config; all-or-nothing set (see validateGrantConfig). Presence of a\ngrant config turns the entitlement into a time-boxed bucket source.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                        }
+                    ]
+                },
+                "grant_quota": {
+                    "type": "number"
                 },
                 "id": {
                     "type": "string"
@@ -17342,6 +17611,9 @@ const docTemplate = `{
                 "type"
             ],
             "properties": {
+                "checkout": {
+                    "$ref": "#/definitions/CheckoutParams"
+                },
                 "coupon_params": {
                     "$ref": "#/definitions/SubModifyCouponParams"
                 },
@@ -17502,6 +17774,33 @@ const docTemplate = `{
                 }
             }
         },
+        "GCPMarketplaceAgreement": {
+            "type": "object",
+            "required": [
+                "account_id",
+                "metric_name",
+                "service_name",
+                "usage_reporting_id"
+            ],
+            "properties": {
+                "account_id": {
+                    "description": "writes the customer mapping; not read in the report payload",
+                    "type": "string"
+                },
+                "metric_name": {
+                    "description": "-\u003e services.report's metricName (always \"{service_name}/usage_fee\")",
+                    "type": "string"
+                },
+                "service_name": {
+                    "description": "-\u003e services.report URL's service_name; identifies the product",
+                    "type": "string"
+                },
+                "usage_reporting_id": {
+                    "description": "-\u003e services.report's consumerId; identifies the buyer",
+                    "type": "string"
+                }
+            }
+        },
         "GetCostAnalyticsRequest": {
             "type": "object",
             "properties": {
@@ -17526,12 +17825,26 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "include_children": {
+                    "description": "IncludeChildren, when true and ExternalCustomerID belongs to a parent\ncustomer, aggregates every inherited-child customer's usage into the\nrevenue and cost totals. Default (false) restricts the query to the\ncustomer's own usage — mirrors the meter-usage analytics contract.",
+                    "type": "boolean"
+                },
                 "limit": {
                     "description": "Pagination",
                     "type": "integer"
                 },
                 "offset": {
                     "type": "integer"
+                },
+                "property_filters": {
+                    "description": "Property filters to filter the events by the keys in ` + "`" + `properties` + "`" + ` field of the event",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "start_time": {
                     "description": "Time range fields (optional - defaults to last 7 days if not provided)",
@@ -17701,6 +18014,21 @@ const docTemplate = `{
                 },
                 "total_count": {
                     "type": "integer"
+                }
+            }
+        },
+        "GetHuggingFaceBillingDataRequest": {
+            "type": "object",
+            "required": [
+                "requestIds"
+            ],
+            "properties": {
+                "requestIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -18122,6 +18450,21 @@ const docTemplate = `{
                 "GroupedInvoicingActionAdd",
                 "GroupedInvoicingActionRemove"
             ]
+        },
+        "GroupedInvoicingChildRequest": {
+            "type": "object",
+            "required": [
+                "external_customer_id",
+                "plan_id"
+            ],
+            "properties": {
+                "external_customer_id": {
+                    "type": "string"
+                },
+                "plan_id": {
+                    "type": "string"
+                }
+            }
         },
         "IngestEventRequest": {
             "type": "object",
@@ -18707,8 +19050,7 @@ const docTemplate = `{
         "LineItemQuantityChange": {
             "type": "object",
             "required": [
-                "id",
-                "quantity"
+                "id"
             ],
             "properties": {
                 "effective_date": {
@@ -19142,6 +19484,9 @@ const docTemplate = `{
                 },
                 "destination_type": {
                     "$ref": "#/definitions/types.PaymentDestinationType"
+                },
+                "environment_id": {
+                    "type": "string"
                 },
                 "error_message": {
                     "type": "string"
@@ -19656,40 +20001,49 @@ const docTemplate = `{
         "RegisterMarketplaceAgreementRequest": {
             "type": "object",
             "required": [
-                "customer_aws_account_id",
                 "customer_id",
-                "dimension",
-                "license_arn",
                 "plan_id",
-                "product_code",
                 "provider",
                 "subscription_id"
             ],
             "properties": {
-                "concurrent_agreements": {
-                    "type": "boolean"
+                "aws": {
+                    "description": "required iff Provider == aws_marketplace",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/AWSMarketplaceAgreement"
+                        }
+                    ]
                 },
-                "customer_aws_account_id": {
-                    "type": "string"
+                "azure": {
+                    "description": "required iff Provider == azure_marketplace",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/AzureMarketplaceAgreement"
+                        }
+                    ]
                 },
                 "customer_id": {
                     "type": "string"
                 },
-                "dimension": {
-                    "type": "string"
-                },
-                "license_arn": {
-                    "type": "string"
+                "gcp": {
+                    "description": "required iff Provider == gcp_marketplace",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/GCPMarketplaceAgreement"
+                        }
+                    ]
                 },
                 "plan_id": {
                     "type": "string"
                 },
-                "product_code": {
-                    "type": "string"
-                },
                 "provider": {
-                    "description": "e.g. \"aws\"",
-                    "type": "string"
+                    "description": "\"aws_marketplace\" | \"gcp_marketplace\" | \"azure_marketplace\"",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.SecretProvider"
+                        }
+                    ]
                 },
                 "subscription_id": {
                     "type": "string"
@@ -20314,6 +20668,13 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "grouped_invoicing_children_to_create": {
+                    "description": "grouped_invoicing_children_to_create creates new grouped_invoicing children under this parent",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GroupedInvoicingChildRequest"
+                    }
+                },
                 "invoicing_customer_external_id": {
                     "description": "InvoicingCustomerExternalID sets a different billing recipient (external ID).\nRequired for delegated; rejected for inherited; optional for others.",
                     "type": "string"
@@ -20428,6 +20789,14 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "meter": {
+                    "description": "Meter is populated when the caller adds \"meters\" to a subscription-scoped\nexpand string alongside \"subscription_line_items\". Only usage line items\n(PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/meter.Meter"
+                        }
+                    ]
+                },
                 "meter_display_name": {
                     "type": "string"
                 },
@@ -20486,6 +20855,14 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/ChangedResources"
+                        }
+                    ]
+                },
+                "checkout_session": {
+                    "description": "CheckoutSession is set on pay-first execute when payment must be collected\nbefore line-item changes apply. Reuses CheckoutSessionResponse (payment_action\nat session root). Omitted for pay-later and preview.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/CheckoutSessionResponse"
                         }
                     ]
                 },
@@ -20821,6 +21198,13 @@ const docTemplate = `{
                 "end_date": {
                     "description": "EndDate is the end date of the subscription",
                     "type": "string"
+                },
+                "entitlements": {
+                    "description": "Entitlements is populated only when the caller adds \"entitlements\" to\nthe search filter's expand string. Each entry is a feature with its\naggregated entitlement info (same shape as CustomerEntitlementsResponse.Features).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AggregatedFeature"
+                    }
                 },
                 "environment_id": {
                     "description": "EnvironmentID is the environment identifier for the subscription",
@@ -21759,9 +22143,21 @@ const docTemplate = `{
                     "description": "amount is the amount in the currency of the wallet to be added\nNOTE: this is not the number of credits to add, but the amount in the currency\namount = credits_to_add * conversion_rate\nif both amount and credits_to_add are provided, amount will be ignored\nex if the wallet has a conversion_rate of 2 then adding an amount of\n10 USD in the wallet wil add 5 credits in the wallet",
                     "type": "string"
                 },
+                "bonus_credits_expiry_date_utc": {
+                    "description": "bonus_credits_expiry_date_utc is the expiry (UTC, full precision) applied to the bonus\ncredits transaction. Independent of expiry_date_utc, which governs the purchase credits.\nOnly honored when bonus credits are actually granted (explicit BonusCreditsToAdd or slab).",
+                    "type": "string"
+                },
                 "bonus_credits_to_add": {
                     "description": "bonus_credits_to_add is an explicit override for the bonus credits granted alongside this\npurchase. When nil/omitted, the bonus is resolved from the tenant's\nbonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is\nused as-is, skipping slab resolution. To grant no bonus, omit this field entirely.",
                     "type": "string"
+                },
+                "checkout": {
+                    "description": "checkout opts into pay-first hosted checkout for PURCHASED_CREDIT_INVOICED top-ups.\nWhen set, credits are applied only after checkout payment succeeds.\nOmit for today's pay-later / auto-complete behavior.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/CheckoutParams"
+                        }
+                    ]
                 },
                 "credits_to_add": {
                     "description": "credits_to_add is the number of credits to add to the wallet",
@@ -21774,6 +22170,9 @@ const docTemplate = `{
                 "expiry_date_utc": {
                     "description": "expiry_date_utc is the expiry date in UTC timezone\nex 2025-01-01 00:00:00 UTC",
                     "type": "string"
+                },
+                "force_sync_invoice": {
+                    "type": "boolean"
                 },
                 "idempotency_key": {
                     "description": "idempotency_key is a unique key for the transaction",
@@ -21799,6 +22198,14 @@ const docTemplate = `{
         "TopUpWalletResponse": {
             "type": "object",
             "properties": {
+                "checkout_session": {
+                    "description": "CheckoutSession is set when pay-first checkout was requested on top-up.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/CheckoutSessionResponse"
+                        }
+                    ]
+                },
                 "invoice_id": {
                     "description": "Invoice ID if an invoice was created (only for PURCHASED_CREDIT_INVOICED)",
                     "type": "string"
@@ -22023,9 +22430,28 @@ const docTemplate = `{
         "UpdateEntitlementRequest": {
             "type": "object",
             "properties": {
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
+                "clear_grant_config": {
+                    "description": "Grant config — nil fields leave the current value alone.\nClearGrantConfig=true wipes the whole grant config (back to a legacy entitlement).",
+                    "type": "boolean"
+                },
                 "config_value": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                },
+                "grant_quota": {
+                    "type": "string"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -23181,20 +23607,6 @@ const docTemplate = `{
                 "ErrCodeNotImplemented"
             ]
         },
-        "errors.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "$ref": "#/definitions/errors.ErrorCode"
-                },
-                "http_status_code": {
-                    "type": "integer"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
         "Addon": {
             "type": "object",
             "properties": {
@@ -23508,808 +23920,16 @@ const docTemplate = `{
                 }
             }
         },
-        "types.Bucket": {
+        "errors.ErrorResponse": {
             "type": "object",
             "properties": {
-                "hour": {
-                    "type": "integer",
-                    "maximum": 24,
-                    "minimum": 0
+                "code": {
+                    "$ref": "#/definitions/errors.ErrorCode"
                 },
-                "minute": {
-                    "type": "integer",
-                    "maximum": 59,
-                    "minimum": 0
-                }
-            }
-        },
-        "types.Value": {
-            "type": "object",
-            "properties": {
-                "array": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "http_status_code": {
+                    "type": "integer"
                 },
-                "boolean": {
-                    "type": "boolean"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "number": {
-                    "type": "number"
-                },
-                "string": {
-                    "type": "string"
-                }
-            }
-        },
-        "group.Group": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "entity_type": {
-                    "$ref": "#/definitions/types.GroupEntityType"
-                },
-                "environment_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "lookup_key": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "invoice.InvoiceLineItem": {
-            "type": "object",
-            "properties": {
-                "adjusted_entitlement_quantity": {
-                    "description": "adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.\nNil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity.",
-                    "type": "string"
-                },
-                "amount": {
-                    "type": "string"
-                },
-                "commitment_info": {
-                    "$ref": "#/definitions/types.CommitmentInfo"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "customer_id": {
-                    "type": "string"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "entity_id": {
-                    "type": "string"
-                },
-                "entity_type": {
-                    "type": "string"
-                },
-                "environment_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "invoice_id": {
-                    "type": "string"
-                },
-                "invoice_level_discount": {
-                    "description": "invoice_level_discount is the discount amount in invoice currency applied to all line items on the invoice.",
-                    "type": "string"
-                },
-                "line_item_discount": {
-                    "description": "line_item_discount is the discount amount in invoice currency applied directly to this line item.",
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/types.Metadata"
-                },
-                "meter_display_name": {
-                    "type": "string"
-                },
-                "meter_id": {
-                    "type": "string"
-                },
-                "period_end": {
-                    "type": "string"
-                },
-                "period_start": {
-                    "type": "string"
-                },
-                "plan_display_name": {
-                    "type": "string"
-                },
-                "prepaid_credits_applied": {
-                    "description": "prepaid_credits_applied is the amount in invoice currency reduced from this line item due to prepaid credits application.",
-                    "type": "string"
-                },
-                "price_id": {
-                    "type": "string"
-                },
-                "price_type": {
-                    "type": "string"
-                },
-                "price_unit": {
-                    "type": "string"
-                },
-                "price_unit_amount": {
-                    "type": "string"
-                },
-                "price_unit_id": {
-                    "type": "string"
-                },
-                "quantity": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "type": "string"
-                },
-                "subscription_line_item_id": {
-                    "description": "sub_line_item_id links this invoice line item to the subscription_line_item that generated it.",
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "meter.Aggregation": {
-            "type": "object",
-            "properties": {
-                "bucket_size": {
-                    "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.WindowSize"
-                        }
-                    ]
-                },
-                "expression": {
-                    "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).",
-                    "type": "string"
-                },
-                "field": {
-                    "description": "Field is the key in $event.properties on which the aggregation is to be applied\nFor ex if the aggregation type is sum for API usage, the field could be \"duration_ms\"\nIgnored when Expression is set.",
-                    "type": "string"
-                },
-                "group_by": {
-                    "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total.",
-                    "type": "string"
-                },
-                "multiplier": {
-                    "description": "Multiplier is the multiplier for the aggregation\nFor ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000\nto scale up by a factor of 1000. If not provided, it will be null.",
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AggregationType"
-                }
-            }
-        },
-        "meter.Filter": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Key is the key for the filter from $event.properties\nCurrently we support only first level keys in the properties and not nested keys",
-                    "type": "string"
-                },
-                "values": {
-                    "description": "Values are the possible values for the filter to be considered for the meter\nFor ex \"model_name\" could have values \"o1-mini\", \"gpt-4o\" etc",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "meter.Meter": {
-            "type": "object",
-            "properties": {
-                "aggregation": {
-                    "description": "Aggregation defines the aggregation type and field for the meter\nIt is used to aggregate the events into a single value for calculating the usage",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/meter.Aggregation"
-                        }
-                    ]
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the meter",
-                    "type": "string"
-                },
-                "event_name": {
-                    "description": "EventName is the unique identifier for the event that this meter is tracking\nIt is a mandatory field in the events table and hence being used as the primary matching field\nWe can have multiple meters tracking the same event but with different filters and aggregation",
-                    "type": "string"
-                },
-                "filters": {
-                    "description": "Filters define the criteria for the meter to be applied on the events before aggregation\nIt also defines the possible values on which later the charges will be applied",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/meter.Filter"
-                    }
-                },
-                "id": {
-                    "description": "ID is the unique identifier for the meter",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Name is the display name of the meter",
-                    "type": "string"
-                },
-                "reset_usage": {
-                    "description": "ResetUsage defines whether the usage should be reset periodically or not\nFor ex meters tracking total storage used do not get reset but meters tracking\ntotal API requests do.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.ResetUsage"
-                        }
-                    ]
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.TemporalWorkflowResult": {
-            "type": "object",
-            "properties": {
                 "message": {
-                    "type": "string"
-                },
-                "run_id": {
-                    "type": "string"
-                },
-                "workflow_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "price.JSONBFilters": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "price.JSONBMetadata": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
-        "price.JSONBTransformQuantity": {
-            "type": "object",
-            "properties": {
-                "divide_by": {
-                    "description": "Divide quantity by this number",
-                    "type": "integer"
-                },
-                "round": {
-                    "description": "up or down",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.RoundType"
-                        }
-                    ]
-                }
-            }
-        },
-        "price.Price": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50",
-                    "type": "string"
-                },
-                "billing_cadence": {
-                    "$ref": "#/definitions/types.BillingCadence"
-                },
-                "billing_model": {
-                    "$ref": "#/definitions/types.BillingModel"
-                },
-                "billing_period": {
-                    "$ref": "#/definitions/types.BillingPeriod"
-                },
-                "billing_period_count": {
-                    "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
-                    "type": "integer",
-                    "default": 1
-                },
-                "conversion_rate": {
-                    "description": "ConversionRate is the conversion rate of the price unit to the fiat currency",
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "currency": {
-                    "description": "Currency 3 digit ISO currency code in lowercase ex usd, eur, gbp",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "Description of the price",
-                    "type": "string"
-                },
-                "display_amount": {
-                    "description": "DisplayAmount is the formatted amount with currency symbol\nFor USD: $12.50",
-                    "type": "string"
-                },
-                "display_name": {
-                    "description": "DisplayName is the name of the price",
-                    "type": "string"
-                },
-                "display_price_unit_amount": {
-                    "description": "DisplayPriceUnitAmount is the formatted amount of the price unit",
-                    "type": "string"
-                },
-                "end_date": {
-                    "description": "EndDate is the end date of the price",
-                    "type": "string"
-                },
-                "entity_id": {
-                    "description": "EntityID holds the value of the \"entity_id\" field.",
-                    "type": "string"
-                },
-                "entity_type": {
-                    "description": "EntityType holds the value of the \"entity_type\" field.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.PriceEntityType"
-                        }
-                    ]
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the price",
-                    "type": "string"
-                },
-                "group_id": {
-                    "description": "GroupID references the group this price belongs to",
-                    "type": "string"
-                },
-                "id": {
-                    "description": "ID uuid identifier for the price",
-                    "type": "string"
-                },
-                "invoice_cadence": {
-                    "$ref": "#/definitions/types.InvoiceCadence"
-                },
-                "lookup_key": {
-                    "description": "LookupKey used for looking up the price in the database",
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/price.JSONBMetadata"
-                },
-                "meter_id": {
-                    "description": "MeterID is the id of the meter for usage based pricing",
-                    "type": "string"
-                },
-                "min_quantity": {
-                    "description": "MinQuantity is the minimum quantity of the price",
-                    "type": "string",
-                    "x-nullable": true
-                },
-                "parent_price_id": {
-                    "description": "ParentPriceID references the root price (always set for price lineage tracking)",
-                    "type": "string"
-                },
-                "price_unit": {
-                    "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')",
-                    "type": "string"
-                },
-                "price_unit_amount": {
-                    "description": "PriceUnitAmount is the amount of the price unit",
-                    "type": "string"
-                },
-                "price_unit_id": {
-                    "description": "PriceUnitID is the id of the price unit (for CUSTOM type)",
-                    "type": "string"
-                },
-                "price_unit_tiers": {
-                    "description": "PriceUnitTiers are the tiers for the price unit when BillingModel is TIERED",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/price.PriceTier"
-                    }
-                },
-                "price_unit_type": {
-                    "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.PriceUnitType"
-                        }
-                    ]
-                },
-                "sequence": {
-                    "description": "Sequence is the monotonic stamp bumped on every state change that\nsubscription line items need to react to. Read by the plan-price sync;\nset by the database (DEFAULT nextval) on create and by the price\nrepository on termination / compatibility-affecting edits.",
-                    "type": "integer"
-                },
-                "start_date": {
-                    "description": "StartDate is the start date of the price",
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "tier_mode": {
-                    "$ref": "#/definitions/types.BillingTier"
-                },
-                "tiers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/price.PriceTier"
-                    }
-                },
-                "transform_quantity": {
-                    "$ref": "#/definitions/price.JSONBTransformQuantity"
-                },
-                "trial_period_days": {
-                    "description": "TrialPeriodDays is the number of days for the trial period\nNote: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)",
-                    "type": "integer"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.PriceType"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "price.PriceTier": {
-            "type": "object",
-            "properties": {
-                "flat_amount": {
-                    "description": "flat_amount is the flat amount for the given tier (optional)\nApplied on top of unit_amount*quantity. Useful for cases like \"2.7$ + 5c\"",
-                    "type": "string"
-                },
-                "unit_amount": {
-                    "description": "unit_amount is the amount per unit for the given tier",
-                    "type": "string"
-                },
-                "up_to": {
-                    "description": "up_to is the quantity up to which this tier applies. It is null for the last tier.\nIMPORTANT: Tier boundaries are INCLUSIVE.\n- If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier\n- This behavior is consistent across both VOLUME and SLAB tier modes",
-                    "type": "integer"
-                }
-            }
-        },
-        "price.TransformQuantity": {
-            "type": "object",
-            "properties": {
-                "divide_by": {
-                    "description": "Divide quantity by this number",
-                    "type": "integer"
-                },
-                "round": {
-                    "description": "up or down",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.RoundType"
-                        }
-                    ]
-                }
-            }
-        },
-        "subscription.SubscriptionLineItem": {
-            "type": "object",
-            "properties": {
-                "addon_association_id": {
-                    "type": "string"
-                },
-                "billing_period": {
-                    "$ref": "#/definitions/types.BillingPeriod"
-                },
-                "billing_period_count": {
-                    "description": "from price at create; default 1",
-                    "type": "integer"
-                },
-                "commitment_amount": {
-                    "description": "Commitment fields",
-                    "type": "string"
-                },
-                "commitment_duration": {
-                    "$ref": "#/definitions/types.BillingPeriod"
-                },
-                "commitment_overage_factor": {
-                    "type": "string"
-                },
-                "commitment_quantity": {
-                    "type": "string"
-                },
-                "commitment_time_buckets": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.TimeOfDayBucket"
-                    }
-                },
-                "commitment_true_up_enabled": {
-                    "type": "boolean"
-                },
-                "commitment_type": {
-                    "$ref": "#/definitions/types.CommitmentType"
-                },
-                "commitment_windowed": {
-                    "type": "boolean"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "customer_id": {
-                    "type": "string"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "end_date": {
-                    "type": "string"
-                },
-                "entity_id": {
-                    "type": "string"
-                },
-                "entity_type": {
-                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
-                },
-                "environment_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "invoice_cadence": {
-                    "$ref": "#/definitions/types.InvoiceCadence"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "meter_display_name": {
-                    "type": "string"
-                },
-                "meter_id": {
-                    "type": "string"
-                },
-                "plan_display_name": {
-                    "type": "string"
-                },
-                "price": {
-                    "$ref": "#/definitions/price.Price"
-                },
-                "price_id": {
-                    "type": "string"
-                },
-                "price_type": {
-                    "$ref": "#/definitions/types.PriceType"
-                },
-                "price_unit": {
-                    "type": "string"
-                },
-                "price_unit_id": {
-                    "type": "string"
-                },
-                "quantity": {
-                    "type": "string"
-                },
-                "start_date": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "type": "string"
-                },
-                "subscription_phase_id": {
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "subscription.SubscriptionPause": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the pause",
-                    "type": "string"
-                },
-                "id": {
-                    "description": "ID is the unique identifier for the subscription pause",
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/types.Metadata"
-                },
-                "original_period_end": {
-                    "description": "OriginalPeriodEnd is the end of the billing period when the pause was created",
-                    "type": "string"
-                },
-                "original_period_start": {
-                    "description": "OriginalPeriodStart is the start of the billing period when the pause was created",
-                    "type": "string"
-                },
-                "pause_end": {
-                    "description": "PauseEnd is when the pause will end (null for indefinite)",
-                    "type": "string"
-                },
-                "pause_mode": {
-                    "$ref": "#/definitions/types.PauseMode"
-                },
-                "pause_start": {
-                    "description": "PauseStart is when the pause actually started",
-                    "type": "string"
-                },
-                "pause_status": {
-                    "$ref": "#/definitions/types.PauseStatus"
-                },
-                "reason": {
-                    "description": "Reason is the reason for pausing",
-                    "type": "string"
-                },
-                "resume_mode": {
-                    "$ref": "#/definitions/types.ResumeMode"
-                },
-                "resumed_at": {
-                    "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "description": "SubscriptionID is the identifier for the subscription",
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "subscription.SubscriptionPhase": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "end_date": {
-                    "description": "EndDate is when the phase ends (nil if phase is still active or indefinite)",
-                    "type": "string"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the phase",
-                    "type": "string"
-                },
-                "id": {
-                    "description": "ID is the unique identifier for the subscription phase",
-                    "type": "string"
-                },
-                "metadata": {
-                    "description": "Metadata contains additional key-value pairs",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Metadata"
-                        }
-                    ]
-                },
-                "start_date": {
-                    "description": "StartDate is when the phase starts",
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "description": "SubscriptionID is the identifier for the subscription",
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
                     "type": "string"
                 }
             }
@@ -24453,14 +24073,16 @@ const docTemplate = `{
                 "feature",
                 "subscription",
                 "subscription_line_item",
-                "group"
+                "group",
+                "entitlement_grant"
             ],
             "x-enum-varnames": [
                 "AlertEntityTypeWallet",
                 "AlertEntityTypeFeature",
                 "AlertEntityTypeSubscription",
                 "AlertEntityTypeSubscriptionLineItem",
-                "AlertEntityTypeGroup"
+                "AlertEntityTypeGroup",
+                "AlertEntityTypeEntitlementGrant"
             ]
         },
         "types.AlertInfo": {
@@ -24555,79 +24177,6 @@ const docTemplate = `{
                 }
             }
         },
-        "types.AlertSettingsFilter": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "end_time": {
-                    "type": "string"
-                },
-                "entity_id": {
-                    "type": "string"
-                },
-                "entity_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "entity_type": {
-                    "$ref": "#/definitions/types.AlertEntityType"
-                },
-                "expand": {
-                    "type": "string"
-                },
-                "filters": {
-                    "description": "filters allows complex filtering based on multiple fields",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.FilterCondition"
-                    }
-                },
-                "limit": {
-                    "type": "integer",
-                    "maximum": 1000,
-                    "minimum": 1
-                },
-                "offset": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "order": {
-                    "type": "string",
-                    "enum": [
-                        "asc",
-                        "desc"
-                    ]
-                },
-                "parent_entity_id": {
-                    "type": "string"
-                },
-                "parent_entity_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "parent_entity_type": {
-                    "$ref": "#/definitions/types.AlertEntityType"
-                },
-                "sort": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.SortCondition"
-                    }
-                },
-                "start_time": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                }
-            }
-        },
         "types.AlertState": {
             "type": "string",
             "enum": [
@@ -24662,7 +24211,9 @@ const docTemplate = `{
                 "feature_wallet_balance",
                 "subscription_spend",
                 "subscription_line_item_spend",
-                "subscription_group_spend"
+                "subscription_group_spend",
+                "entitlement_grant_threshold",
+                "entitlement_grant_exhausted"
             ],
             "x-enum-varnames": [
                 "AlertTypeLowOngoingBalance",
@@ -24670,7 +24221,9 @@ const docTemplate = `{
                 "AlertTypeFeatureWalletBalance",
                 "AlertTypeSubscriptionSpend",
                 "AlertTypeSubscriptionLineItemSpend",
-                "AlertTypeSubscriptionGroupSpend"
+                "AlertTypeSubscriptionGroupSpend",
+                "AlertTypeEntitlementGrantThreshold",
+                "AlertTypeEntitlementGrantExhausted"
             ]
         },
         "types.ApplicationStatus": {
@@ -24695,6 +24248,14 @@ const docTemplate = `{
             "properties": {
                 "amount": {
                     "type": "number"
+                },
+                "cooldown": {
+                    "description": "Cooldown is an optional cooloff after a successful auto top-up before another may run.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.Duration"
+                        }
+                    ]
                 },
                 "enabled": {
                     "type": "boolean"
@@ -24772,6 +24333,21 @@ const docTemplate = `{
                 "BILLING_TIER_SLAB"
             ]
         },
+        "types.Bucket": {
+            "type": "object",
+            "properties": {
+                "hour": {
+                    "type": "integer",
+                    "maximum": 24,
+                    "minimum": 0
+                },
+                "minute": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            }
+        },
         "types.CancelImmediatelyInvoicePolicy": {
             "type": "string",
             "enum": [
@@ -24799,10 +24375,14 @@ const docTemplate = `{
         "types.CheckoutAction": {
             "type": "string",
             "enum": [
-                "create_subscription"
+                "create_subscription",
+                "modify_subscription",
+                "wallet_topup"
             ],
             "x-enum-varnames": [
-                "CheckoutActionCreateSubscription"
+                "CheckoutActionCreateSubscription",
+                "CheckoutActionModifySubscription",
+                "CheckoutActionWalletTopup"
             ]
         },
         "types.CheckoutConfiguration": {
@@ -24810,6 +24390,12 @@ const docTemplate = `{
             "properties": {
                 "create_subscription_params": {
                     "$ref": "#/definitions/types.CreateSubscriptionParams"
+                },
+                "modify_subscription_params": {
+                    "$ref": "#/definitions/types.ModifySubscriptionParams"
+                },
+                "wallet_topup_params": {
+                    "$ref": "#/definitions/types.WalletTopupParams"
                 }
             }
         },
@@ -24821,20 +24407,6 @@ const docTemplate = `{
             "x-enum-varnames": [
                 "CheckoutPaymentProviderRazorpay"
             ]
-        },
-        "types.CheckoutPaymentProviderConfig": {
-            "type": "object",
-            "properties": {
-                "collection_method": {
-                    "$ref": "#/definitions/types.CollectionMethod"
-                },
-                "max_mandate_limit": {
-                    "type": "string"
-                },
-                "payment_method": {
-                    "$ref": "#/definitions/types.PaymentMethodType"
-                }
-            }
         },
         "types.CheckoutStatus": {
             "type": "string",
@@ -25273,6 +24845,23 @@ const docTemplate = `{
                 "DebugTrackerStatusAttributed"
             ]
         },
+        "types.Duration": {
+            "type": "object",
+            "enum": [
+                3600000000000
+            ],
+            "properties": {
+                "unit": {
+                    "$ref": "#/definitions/types.DurationUnit"
+                },
+                "value": {
+                    "type": "integer"
+                }
+            },
+            "x-enum-varnames": [
+                "EntitlementGrantMinDuration"
+            ]
+        },
         "types.EntitlementEntityType": {
             "type": "string",
             "enum": [
@@ -25319,6 +24908,10 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/types.FilterCondition"
                     }
+                },
+                "has_grant_config": {
+                    "description": "HasGrantConfig filters on grant-config presence (grant_quota set or not).",
+                    "type": "boolean"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -25949,26 +25542,6 @@ const docTemplate = `{
                 "InvoiceTypeCredit"
             ]
         },
-        "types.ListResponse-dto_WalletResponse": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/WalletResponse"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/types.PaginationResponse"
-                }
-            }
-        },
-        "types.Metadata": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
         "types.PaginationResponse": {
             "type": "object",
             "properties": {
@@ -26430,17 +26003,6 @@ const docTemplate = `{
                 }
             }
         },
-        "types.RejectedEventReason": {
-            "type": "string",
-            "enum": [
-                "no_meter_for_event_name",
-                "no_matching_meter"
-            ],
-            "x-enum-varnames": [
-                "RejectedEventReasonNoMeterForName",
-                "RejectedEventReasonNoMatchingMeter"
-            ]
-        },
         "types.ReportingUnit": {
             "type": "object",
             "properties": {
@@ -26683,7 +26245,9 @@ const docTemplate = `{
                 "paddle",
                 "whop",
                 "tabs",
-                "aws_marketplace"
+                "aws_marketplace",
+                "gcp_marketplace",
+                "azure_marketplace"
             ],
             "x-enum-comments": {
                 "SecretProviderS3": "supports multiple connections per environment"
@@ -26702,7 +26266,9 @@ const docTemplate = `{
                 "SecretProviderPaddle",
                 "SecretProviderWhop",
                 "SecretProviderTabs",
-                "SecretProviderAWSMarketplace"
+                "SecretProviderAWSMarketplace",
+                "SecretProviderGCPMarketplace",
+                "SecretProviderAzureMarketplace"
             ]
         },
         "types.SecretType": {
@@ -26888,8 +26454,12 @@ const docTemplate = `{
                     "description": "TrialEndDueLTE, when set, restricts to subscriptions with trial_end not nil and trial_end \u003c= trial_end_due_lte.\nUse with subscription_status trialing for trial-end cron processing.",
                     "type": "string"
                 },
+                "with_coupon_associations": {
+                    "description": "WithCouponAssociations eager-loads coupon associations and their coupons.\n\nKept separate from WithLineItems because the coupon_associations table has no\nindex leading with subscription_id, so Ent's edge load degrades to a full table\nscan. Only set it when the response actually surfaces the associations; the\nservice layer back-fills it from expand=\"coupon_associations\".",
+                    "type": "boolean"
+                },
                 "with_line_items": {
-                    "description": "WithLineItems includes line items in the response",
+                    "description": "WithLineItems includes line items in the response.\n\nDeprecated: use expand=\"subscription_line_items\" instead. Retained for\nbackwards compatibility and for internal callers that need to force-disable\nline item loading (set to false). The service layer ORs this with the\nexpand check before invoking the repository.",
                     "type": "boolean"
                 }
             }
@@ -27067,6 +26637,14 @@ const docTemplate = `{
         "types.SyncConfig": {
             "type": "object",
             "properties": {
+                "aws_marketplace": {
+                    "description": "AWSMarketplace connection metadata",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.AWSMarketplaceSyncConfig"
+                        }
+                    ]
+                },
                 "customer": {
                     "$ref": "#/definitions/types.EntitySyncConfig"
                 },
@@ -27375,6 +26953,29 @@ const docTemplate = `{
                 "UserTypeServiceAccount"
             ]
         },
+        "types.Value": {
+            "type": "object",
+            "properties": {
+                "array": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "boolean": {
+                    "type": "boolean"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "number"
+                },
+                "string": {
+                    "type": "string"
+                }
+            }
+        },
         "types.WalletConfig": {
             "type": "object",
             "properties": {
@@ -27606,6 +27207,7 @@ const docTemplate = `{
                 "subscription.line_item_spend.threshold_recovered",
                 "subscription.group_spend.threshold_reached",
                 "subscription.group_spend.threshold_recovered",
+                "entitlement.grant.exhausted",
                 "subscription.renewal.due",
                 "invoice.communication.triggered",
                 "credit_note.created",
@@ -27663,6 +27265,7 @@ const docTemplate = `{
                 "WebhookEventSubscriptionLineItemSpendThresholdRecovered",
                 "WebhookEventSubscriptionGroupSpendThresholdReached",
                 "WebhookEventSubscriptionGroupSpendThresholdRecovered",
+                "WebhookEventEntitlementGrantExhausted",
                 "WebhookEventSubscriptionRenewalDue",
                 "WebhookEventInvoiceCommunicationTriggered",
                 "WebhookEventCreditNoteCreated",
@@ -27765,6 +27368,1000 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "workflow_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "group.Group": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "$ref": "#/definitions/types.GroupEntityType"
+                },
+                "environment_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lookup_key": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "invoice.InvoiceLineItem": {
+            "type": "object",
+            "properties": {
+                "adjusted_entitlement_quantity": {
+                    "description": "adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.\nNil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity.",
+                    "type": "string"
+                },
+                "amount": {
+                    "type": "string"
+                },
+                "commitment_info": {
+                    "$ref": "#/definitions/types.CommitmentInfo"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "customer_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "type": "string"
+                },
+                "environment_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "invoice_id": {
+                    "type": "string"
+                },
+                "invoice_level_discount": {
+                    "description": "invoice_level_discount is the discount amount in invoice currency applied to all line items on the invoice.",
+                    "type": "string"
+                },
+                "line_item_discount": {
+                    "description": "line_item_discount is the discount amount in invoice currency applied directly to this line item.",
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/types.Metadata"
+                },
+                "meter_display_name": {
+                    "type": "string"
+                },
+                "meter_id": {
+                    "type": "string"
+                },
+                "period_end": {
+                    "type": "string"
+                },
+                "period_start": {
+                    "type": "string"
+                },
+                "plan_display_name": {
+                    "type": "string"
+                },
+                "prepaid_credits_applied": {
+                    "description": "prepaid_credits_applied is the amount in invoice currency reduced from this line item due to prepaid credits application.",
+                    "type": "string"
+                },
+                "price_id": {
+                    "type": "string"
+                },
+                "price_type": {
+                    "type": "string"
+                },
+                "price_unit": {
+                    "type": "string"
+                },
+                "price_unit_amount": {
+                    "type": "string"
+                },
+                "price_unit_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "type": "string"
+                },
+                "subscription_line_item_id": {
+                    "description": "sub_line_item_id links this invoice line item to the subscription_line_item that generated it.",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "meter.Aggregation": {
+            "type": "object",
+            "properties": {
+                "bucket_size": {
+                    "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.WindowSize"
+                        }
+                    ]
+                },
+                "expression": {
+                    "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).",
+                    "type": "string"
+                },
+                "field": {
+                    "description": "Field is the key in $event.properties on which the aggregation is to be applied\nFor ex if the aggregation type is sum for API usage, the field could be \"duration_ms\"\nIgnored when Expression is set.",
+                    "type": "string"
+                },
+                "group_by": {
+                    "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total.",
+                    "type": "string"
+                },
+                "multiplier": {
+                    "description": "Multiplier is the multiplier for the aggregation\nFor ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000\nto scale up by a factor of 1000. If not provided, it will be null.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/types.AggregationType"
+                }
+            }
+        },
+        "meter.Filter": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Key is the key for the filter from $event.properties\nCurrently we support only first level keys in the properties and not nested keys",
+                    "type": "string"
+                },
+                "values": {
+                    "description": "Values are the possible values for the filter to be considered for the meter\nFor ex \"model_name\" could have values \"o1-mini\", \"gpt-4o\" etc",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "meter.Meter": {
+            "type": "object",
+            "properties": {
+                "aggregation": {
+                    "description": "Aggregation defines the aggregation type and field for the meter\nIt is used to aggregate the events into a single value for calculating the usage",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/meter.Aggregation"
+                        }
+                    ]
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the meter",
+                    "type": "string"
+                },
+                "event_name": {
+                    "description": "EventName is the unique identifier for the event that this meter is tracking\nIt is a mandatory field in the events table and hence being used as the primary matching field\nWe can have multiple meters tracking the same event but with different filters and aggregation",
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "Filters define the criteria for the meter to be applied on the events before aggregation\nIt also defines the possible values on which later the charges will be applied",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meter.Filter"
+                    }
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the meter",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the display name of the meter",
+                    "type": "string"
+                },
+                "reset_usage": {
+                    "description": "ResetUsage defines whether the usage should be reset periodically or not\nFor ex meters tracking total storage used do not get reset but meters tracking\ntotal API requests do.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ResetUsage"
+                        }
+                    ]
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TemporalWorkflowResult": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "run_id": {
+                    "type": "string"
+                },
+                "workflow_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "price.JSONBFilters": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "price.JSONBMetadata": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "price.JSONBTransformQuantity": {
+            "type": "object",
+            "properties": {
+                "divide_by": {
+                    "description": "Divide quantity by this number",
+                    "type": "integer"
+                },
+                "round": {
+                    "description": "up or down",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.RoundType"
+                        }
+                    ]
+                }
+            }
+        },
+        "price.Price": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50",
+                    "type": "string"
+                },
+                "billing_cadence": {
+                    "$ref": "#/definitions/types.BillingCadence"
+                },
+                "billing_model": {
+                    "$ref": "#/definitions/types.BillingModel"
+                },
+                "billing_period": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                },
+                "billing_period_count": {
+                    "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
+                    "type": "integer",
+                    "default": 1
+                },
+                "conversion_rate": {
+                    "description": "ConversionRate is the conversion rate of the price unit to the fiat currency",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "description": "Currency 3 digit ISO currency code in lowercase ex usd, eur, gbp",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Description of the price",
+                    "type": "string"
+                },
+                "display_amount": {
+                    "description": "DisplayAmount is the formatted amount with currency symbol\nFor USD: $12.50",
+                    "type": "string"
+                },
+                "display_name": {
+                    "description": "DisplayName is the name of the price",
+                    "type": "string"
+                },
+                "display_price_unit_amount": {
+                    "description": "DisplayPriceUnitAmount is the formatted amount of the price unit",
+                    "type": "string"
+                },
+                "end_date": {
+                    "description": "EndDate is the end date of the price",
+                    "type": "string"
+                },
+                "entity_id": {
+                    "description": "EntityID holds the value of the \"entity_id\" field.",
+                    "type": "string"
+                },
+                "entity_type": {
+                    "description": "EntityType holds the value of the \"entity_type\" field.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PriceEntityType"
+                        }
+                    ]
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the price",
+                    "type": "string"
+                },
+                "group_id": {
+                    "description": "GroupID references the group this price belongs to",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID uuid identifier for the price",
+                    "type": "string"
+                },
+                "invoice_cadence": {
+                    "$ref": "#/definitions/types.InvoiceCadence"
+                },
+                "lookup_key": {
+                    "description": "LookupKey used for looking up the price in the database",
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/price.JSONBMetadata"
+                },
+                "meter_id": {
+                    "description": "MeterID is the id of the meter for usage based pricing",
+                    "type": "string"
+                },
+                "min_quantity": {
+                    "description": "MinQuantity is the minimum quantity of the price",
+                    "type": "string",
+                    "x-nullable": true
+                },
+                "parent_price_id": {
+                    "description": "ParentPriceID references the root price (always set for price lineage tracking)",
+                    "type": "string"
+                },
+                "price_unit": {
+                    "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')",
+                    "type": "string"
+                },
+                "price_unit_amount": {
+                    "description": "PriceUnitAmount is the amount of the price unit",
+                    "type": "string"
+                },
+                "price_unit_id": {
+                    "description": "PriceUnitID is the id of the price unit (for CUSTOM type)",
+                    "type": "string"
+                },
+                "price_unit_tiers": {
+                    "description": "PriceUnitTiers are the tiers for the price unit when BillingModel is TIERED",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/price.PriceTier"
+                    }
+                },
+                "price_unit_type": {
+                    "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PriceUnitType"
+                        }
+                    ]
+                },
+                "sequence": {
+                    "description": "Sequence is the monotonic stamp bumped on every state change that\nsubscription line items need to react to. Read by the plan-price sync;\nset by the database (DEFAULT nextval) on create and by the price\nrepository on termination / compatibility-affecting edits.",
+                    "type": "integer"
+                },
+                "start_date": {
+                    "description": "StartDate is the start date of the price",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "tier_mode": {
+                    "$ref": "#/definitions/types.BillingTier"
+                },
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/price.PriceTier"
+                    }
+                },
+                "transform_quantity": {
+                    "$ref": "#/definitions/price.JSONBTransformQuantity"
+                },
+                "trial_period_days": {
+                    "description": "TrialPeriodDays is the number of days for the trial period\nNote: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)",
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/types.PriceType"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "price.PriceTier": {
+            "type": "object",
+            "properties": {
+                "flat_amount": {
+                    "description": "flat_amount is the flat amount for the given tier (optional)\nApplied on top of unit_amount*quantity. Useful for cases like \"2.7$ + 5c\"",
+                    "type": "string"
+                },
+                "unit_amount": {
+                    "description": "unit_amount is the amount per unit for the given tier",
+                    "type": "string"
+                },
+                "up_to": {
+                    "description": "up_to is the quantity up to which this tier applies. It is null for the last tier.\nIMPORTANT: Tier boundaries are INCLUSIVE.\n- If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier\n- This behavior is consistent across both VOLUME and SLAB tier modes",
+                    "type": "integer"
+                }
+            }
+        },
+        "price.TransformQuantity": {
+            "type": "object",
+            "properties": {
+                "divide_by": {
+                    "description": "Divide quantity by this number",
+                    "type": "integer"
+                },
+                "round": {
+                    "description": "up or down",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.RoundType"
+                        }
+                    ]
+                }
+            }
+        },
+        "subscription.SubscriptionLineItem": {
+            "type": "object",
+            "properties": {
+                "addon_association_id": {
+                    "type": "string"
+                },
+                "billing_period": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                },
+                "billing_period_count": {
+                    "description": "from price at create; default 1",
+                    "type": "integer"
+                },
+                "commitment_amount": {
+                    "description": "Commitment fields",
+                    "type": "string"
+                },
+                "commitment_duration": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                },
+                "commitment_overage_factor": {
+                    "type": "string"
+                },
+                "commitment_quantity": {
+                    "type": "string"
+                },
+                "commitment_time_buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.TimeOfDayBucket"
+                    }
+                },
+                "commitment_true_up_enabled": {
+                    "type": "boolean"
+                },
+                "commitment_type": {
+                    "$ref": "#/definitions/types.CommitmentType"
+                },
+                "commitment_windowed": {
+                    "type": "boolean"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "customer_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "end_date": {
+                    "type": "string"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
+                },
+                "environment_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "invoice_cadence": {
+                    "$ref": "#/definitions/types.InvoiceCadence"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "meter": {
+                    "description": "Meter is populated when the caller adds \"meters\" to a subscription-scoped\nexpand string alongside \"subscription_line_items\". Only usage line items\n(PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/meter.Meter"
+                        }
+                    ]
+                },
+                "meter_display_name": {
+                    "type": "string"
+                },
+                "meter_id": {
+                    "type": "string"
+                },
+                "plan_display_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "$ref": "#/definitions/price.Price"
+                },
+                "price_id": {
+                    "type": "string"
+                },
+                "price_type": {
+                    "$ref": "#/definitions/types.PriceType"
+                },
+                "price_unit": {
+                    "type": "string"
+                },
+                "price_unit_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "type": "string"
+                },
+                "subscription_phase_id": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "subscription.SubscriptionPause": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the pause",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the subscription pause",
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/types.Metadata"
+                },
+                "original_period_end": {
+                    "description": "OriginalPeriodEnd is the end of the billing period when the pause was created",
+                    "type": "string"
+                },
+                "original_period_start": {
+                    "description": "OriginalPeriodStart is the start of the billing period when the pause was created",
+                    "type": "string"
+                },
+                "pause_end": {
+                    "description": "PauseEnd is when the pause will end (null for indefinite)",
+                    "type": "string"
+                },
+                "pause_mode": {
+                    "$ref": "#/definitions/types.PauseMode"
+                },
+                "pause_start": {
+                    "description": "PauseStart is when the pause actually started",
+                    "type": "string"
+                },
+                "pause_status": {
+                    "$ref": "#/definitions/types.PauseStatus"
+                },
+                "reason": {
+                    "description": "Reason is the reason for pausing",
+                    "type": "string"
+                },
+                "resume_mode": {
+                    "$ref": "#/definitions/types.ResumeMode"
+                },
+                "resumed_at": {
+                    "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "description": "SubscriptionID is the identifier for the subscription",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "subscription.SubscriptionPhase": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "end_date": {
+                    "description": "EndDate is when the phase ends (nil if phase is still active or indefinite)",
+                    "type": "string"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the phase",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the subscription phase",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Metadata contains additional key-value pairs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.Metadata"
+                        }
+                    ]
+                },
+                "start_date": {
+                    "description": "StartDate is when the phase starts",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "description": "SubscriptionID is the identifier for the subscription",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.AWSMarketplaceSyncConfig": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.AlertSettingsFilter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "entity_type": {
+                    "$ref": "#/definitions/types.AlertEntityType"
+                },
+                "expand": {
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "filters allows complex filtering based on multiple fields",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.FilterCondition"
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "maximum": 1000,
+                    "minimum": 1
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "order": {
+                    "type": "string",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ]
+                },
+                "parent_entity_id": {
+                    "type": "string"
+                },
+                "parent_entity_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "parent_entity_type": {
+                    "$ref": "#/definitions/types.AlertEntityType"
+                },
+                "sort": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.SortCondition"
+                    }
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                }
+            }
+        },
+        "types.CheckoutPaymentProviderConfig": {
+            "type": "object",
+            "properties": {
+                "collection_method": {
+                    "$ref": "#/definitions/types.CollectionMethod"
+                },
+                "max_mandate_limit": {
+                    "type": "string"
+                },
+                "payment_method": {
+                    "$ref": "#/definitions/types.PaymentMethodType"
+                }
+            }
+        },
+        "types.DurationUnit": {
+            "type": "string",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day"
+            ],
+            "x-enum-varnames": [
+                "DurationUnitSecond",
+                "DurationUnitMinute",
+                "DurationUnitHour",
+                "DurationUnitDay"
+            ]
+        },
+        "types.EntitlementAggregationMode": {
+            "type": "string",
+            "enum": [
+                "additive",
+                "parallel"
+            ],
+            "x-enum-varnames": [
+                "EntitlementAggregationModeAdditive",
+                "EntitlementAggregationModeParallel"
+            ]
+        },
+        "types.EntitlementGrantDurationUnit": {
+            "type": "string",
+            "enum": [
+                "hour",
+                "day",
+                "week"
+            ],
+            "x-enum-varnames": [
+                "EntitlementGrantDurationUnitHour",
+                "EntitlementGrantDurationUnitDay",
+                "EntitlementGrantDurationUnitWeek"
+            ]
+        },
+        "types.EntitlementGrantMeasure": {
+            "type": "string",
+            "enum": [
+                "quantity",
+                "amount"
+            ],
+            "x-enum-varnames": [
+                "EntitlementGrantMeasureQuantity",
+                "EntitlementGrantMeasureAmount"
+            ]
+        },
+        "types.ListResponse-dto_WalletResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/WalletResponse"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/types.PaginationResponse"
+                }
+            }
+        },
+        "types.Metadata": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "types.ModifySubscriptionLineItem": {
+            "type": "object",
+            "properties": {
+                "effective_date": {
+                    "type": "string"
+                },
+                "line_item_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.ModifySubscriptionParams": {
+            "type": "object",
+            "properties": {
+                "line_item_modifications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ModifySubscriptionLineItem"
+                    }
+                },
+                "subscription_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.RejectedEventReason": {
+            "type": "string",
+            "enum": [
+                "no_meter_for_event_name",
+                "no_matching_meter"
+            ],
+            "x-enum-varnames": [
+                "RejectedEventReasonNoMeterForName",
+                "RejectedEventReasonNoMatchingMeter"
+            ]
+        },
+        "types.WalletTopupParams": {
+            "type": "object",
+            "required": [
+                "wallet_id"
+            ],
+            "properties": {
+                "wallet_id": {
+                    "type": "string"
+                },
+                "wallet_transaction_id": {
                     "type": "string"
                 }
             }
@@ -27975,6 +28572,9 @@ const docTemplate = `{
         "webhookDto.TransactionUpdatedWebhookPayload": {
             "type": "object",
             "properties": {
+                "customer": {
+                    "$ref": "#/definitions/CustomerResponse"
+                },
                 "event_type": {
                     "$ref": "#/definitions/types.WebhookEventName"
                 },
@@ -27989,6 +28589,9 @@ const docTemplate = `{
         "webhookDto.TransactionWebhookPayload": {
             "type": "object",
             "properties": {
+                "customer": {
+                    "$ref": "#/definitions/CustomerResponse"
+                },
                 "event_type": {
                     "$ref": "#/definitions/types.WebhookEventName"
                 },

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -3112,6 +3112,83 @@
         ]
       }
     },
+    "/customers/external/{external_id}/subscriptions": {
+      "get": {
+        "tags": [
+          "Customers"
+        ],
+        "summary": "Get subscriptions for customer by external ID",
+        "description": "Returns all subscriptions for a customer looked up by external_id, with line-item meters and entitlements attached (no pagination).",
+        "operationId": "getSubscriptionsForCustomer",
+        "parameters": [
+          {
+            "name": "external_id",
+            "in": "path",
+            "description": "Customer External ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "description": "Comma-separated fields to expand: subscription_line_items, subscription_line_items.meters, entitlements, plan, customer",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSubscriptionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "x-scope": "read"
+      }
+    },
     "/customers/search": {
       "post": {
         "tags": [
@@ -4361,8 +4438,19 @@
           "Events"
         ],
         "summary": "Get Hugging Face inference data",
-        "description": "Use when fetching Hugging Face inference usage or billing data (e.g. for HF-specific reporting or reconciliation).",
+        "description": "Use when fetching Hugging Face inference usage or billing data (e.g. for HF-specific reporting or reconciliation). Reads the meter-usage pipeline.",
         "operationId": "getHuggingfaceInferenceData",
+        "requestBody": {
+          "description": "Request body",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetHuggingFaceBillingDataRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -4370,6 +4458,65 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetHuggingFaceBillingDataResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "x-codegen-request-body-name": "request"
+      }
+    },
+    "/events/lookup": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "summary": "Get event",
+        "description": "Use when debugging a specific event (e.g. why it failed or how it was aggregated). Reads the meter-usage pipeline; includes processing status and step-by-step debug tracker when unprocessed. Uses ?id= query param because event IDs can contain \"/\".",
+        "operationId": "getEvent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "description": "Event ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetEventByIDResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
                 }
               }
             }
@@ -4577,64 +4724,6 @@
           }
         ],
         "x-codegen-request-body-name": "request"
-      }
-    },
-    "/events/{id}": {
-      "get": {
-        "tags": [
-          "Events"
-        ],
-        "summary": "Get event",
-        "description": "Use when debugging a specific event (e.g. why it failed or how it was aggregated). Includes processing status and debug info.",
-        "operationId": "getEvent",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Event ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetEventByIDResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/errors.ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/errors.ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ]
       }
     },
     "/features": {
@@ -5682,6 +5771,14 @@
               "items": {
                 "type": "string"
               }
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "description": "Comma-separated related fields to include. Supports 'tax_applied.tax_rate' to attach rate details to each applied tax.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -15059,6 +15156,12 @@
         "properties": {
           "create_subscription_params": {
             "$ref": "#/components/schemas/types.CreateSubscriptionParams"
+          },
+          "modify_subscription_params": {
+            "$ref": "#/components/schemas/types.ModifySubscriptionParams"
+          },
+          "wallet_topup_params": {
+            "$ref": "#/components/schemas/types.WalletTopupParams"
           }
         }
       },
@@ -15354,6 +15457,37 @@
           }
         }
       },
+      "AWSMarketplaceAgreement": {
+        "required": [
+          "customer_aws_account_id",
+          "dimension",
+          "license_arn",
+          "product_code"
+        ],
+        "type": "object",
+        "properties": {
+          "concurrent_agreements": {
+            "type": "boolean",
+            "description": "if true, ProductCode is omitted when reporting"
+          },
+          "customer_aws_account_id": {
+            "type": "string",
+            "description": "-> BatchMeterUsage's CustomerAWSAccountId"
+          },
+          "dimension": {
+            "type": "string",
+            "description": "-> BatchMeterUsage's Dimension (always \"usage_fee\" in the cents model)"
+          },
+          "license_arn": {
+            "type": "string",
+            "description": "-> BatchMeterUsage's LicenseArn; identifies the buyer's agreement"
+          },
+          "product_code": {
+            "type": "string",
+            "description": "-> BatchMeterUsage's ProductCode (omitted when ConcurrentAgreements)"
+          }
+        }
+      },
       "ActivateDraftSubscriptionRequest": {
         "required": [
           "start_date"
@@ -15391,6 +15525,13 @@
             "type": "object",
             "additionalProperties": true
           },
+          "override_line_items": {
+            "type": "array",
+            "description": "OverrideLineItems allows overriding price/quantity/billing model for specific addon prices",
+            "items": {
+              "$ref": "#/components/schemas/OverrideLineItemRequest"
+            }
+          },
           "proration_behavior": {
             "$ref": "#/components/schemas/types.ProrationBehavior"
           },
@@ -15425,6 +15566,13 @@
           "metadata": {
             "type": "object",
             "additionalProperties": true
+          },
+          "override_line_items": {
+            "type": "array",
+            "description": "OverrideLineItems allows overriding price/quantity/billing model for specific addon prices",
+            "items": {
+              "$ref": "#/components/schemas/OverrideLineItemRequest"
+            }
           },
           "proration_behavior": {
             "$ref": "#/components/schemas/types.ProrationBehavior"
@@ -15597,6 +15745,15 @@
       "AggregatedEntitlement": {
         "type": "object",
         "properties": {
+          "aggregation_mode": {
+            "$ref": "#/components/schemas/types.EntitlementAggregationMode"
+          },
+          "buckets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AggregatedEntitlementBucket"
+            }
+          },
           "config_values": {
             "type": "array",
             "items": {
@@ -15623,6 +15780,32 @@
           },
           "usage_reset_period": {
             "$ref": "#/components/schemas/types.EntitlementUsageResetPeriod"
+          }
+        }
+      },
+      "AggregatedEntitlementBucket": {
+        "type": "object",
+        "properties": {
+          "entitlement_id": {
+            "type": "string"
+          },
+          "grant_duration_unit": {
+            "$ref": "#/components/schemas/types.EntitlementGrantDurationUnit"
+          },
+          "grant_duration_value": {
+            "type": "integer"
+          },
+          "grant_measure": {
+            "$ref": "#/components/schemas/types.EntitlementGrantMeasure"
+          },
+          "grant_quota": {
+            "type": "string"
+          },
+          "source_entity_id": {
+            "type": "string"
+          },
+          "usage_limit": {
+            "type": "integer"
           }
         }
       },
@@ -15767,6 +15950,33 @@
           },
           "status": {
             "$ref": "#/components/schemas/types.DebugTrackerStatus"
+          }
+        }
+      },
+      "AzureMarketplaceAgreement": {
+        "required": [
+          "beneficiary_account_id",
+          "dimension",
+          "plan_id",
+          "resource_id"
+        ],
+        "type": "object",
+        "properties": {
+          "beneficiary_account_id": {
+            "type": "string",
+            "description": "writes the customer mapping; not read in the report payload"
+          },
+          "dimension": {
+            "type": "string",
+            "description": "-> usageEvent's dimension (always \"usage_fee\" in the cents model)"
+          },
+          "plan_id": {
+            "type": "string",
+            "description": "-> usageEvent's planId; Azure's plan id, distinct from the request's top-level PlanID"
+          },
+          "resource_id": {
+            "type": "string",
+            "description": "-> usageEvent's resourceId; the Azure SaaS subscription id"
           }
         }
       },
@@ -16113,6 +16323,38 @@
           "ChangedSubscriptionActionCreated",
           "ChangedSubscriptionActionUpdated"
         ]
+      },
+      "CheckoutParams": {
+        "required": [
+          "payment_provider"
+        ],
+        "type": "object",
+        "properties": {
+          "cancel_url": {
+            "type": "string"
+          },
+          "failure_url": {
+            "type": "string"
+          },
+          "idempotency_key": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "payment_provider": {
+            "$ref": "#/components/schemas/types.CheckoutPaymentProvider"
+          },
+          "payment_provider_config": {
+            "$ref": "#/components/schemas/types.CheckoutPaymentProviderConfig"
+          },
+          "success_url": {
+            "type": "string"
+          }
+        }
       },
       "CheckoutSessionResponse": {
         "type": "object",
@@ -17187,6 +17429,10 @@
             "type": "string",
             "description": "name is the full name or company name of the customer"
           },
+          "onboarding_workflow_name": {
+            "type": "string",
+            "description": "onboarding_workflow_name is given if a custom onboarding workflow is to be triggered for this customer"
+          },
           "skip_onboarding_workflow": {
             "type": "boolean",
             "description": "skip_onboarding_workflow when true, prevents the customer onboarding workflow from being triggered\nThis is used internally when a customer is created via a workflow to prevent infinite loops\nDefault: false"
@@ -17212,6 +17458,9 @@
         ],
         "type": "object",
         "properties": {
+          "aggregation_mode": {
+            "$ref": "#/components/schemas/types.EntitlementAggregationMode"
+          },
           "config_value": {
             "type": "object",
             "additionalProperties": true
@@ -17231,6 +17480,18 @@
           },
           "feature_type": {
             "$ref": "#/components/schemas/types.FeatureType"
+          },
+          "grant_duration_unit": {
+            "$ref": "#/components/schemas/types.EntitlementGrantDurationUnit"
+          },
+          "grant_duration_value": {
+            "type": "integer"
+          },
+          "grant_measure": {
+            "$ref": "#/components/schemas/types.EntitlementGrantMeasure"
+          },
+          "grant_quota": {
+            "type": "string"
           },
           "is_enabled": {
             "type": "boolean"
@@ -19031,6 +19292,9 @@
           "addon": {
             "$ref": "#/components/schemas/AddonResponse"
           },
+          "aggregation_mode": {
+            "$ref": "#/components/schemas/types.EntitlementAggregationMode"
+          },
           "config_value": {
             "type": "object",
             "additionalProperties": true
@@ -19066,6 +19330,18 @@
           },
           "feature_type": {
             "$ref": "#/components/schemas/types.FeatureType"
+          },
+          "grant_duration_unit": {
+            "$ref": "#/components/schemas/types.EntitlementGrantDurationUnit"
+          },
+          "grant_duration_value": {
+            "type": "integer"
+          },
+          "grant_measure": {
+            "$ref": "#/components/schemas/types.EntitlementGrantMeasure"
+          },
+          "grant_quota": {
+            "type": "number"
           },
           "id": {
             "type": "string"
@@ -19260,6 +19536,9 @@
         ],
         "type": "object",
         "properties": {
+          "checkout": {
+            "$ref": "#/components/schemas/CheckoutParams"
+          },
           "coupon_params": {
             "$ref": "#/components/schemas/SubModifyCouponParams"
           },
@@ -19419,6 +19698,33 @@
           }
         }
       },
+      "GCPMarketplaceAgreement": {
+        "required": [
+          "account_id",
+          "metric_name",
+          "service_name",
+          "usage_reporting_id"
+        ],
+        "type": "object",
+        "properties": {
+          "account_id": {
+            "type": "string",
+            "description": "writes the customer mapping; not read in the report payload"
+          },
+          "metric_name": {
+            "type": "string",
+            "description": "-> services.report's metricName (always \"{service_name}/usage_fee\")"
+          },
+          "service_name": {
+            "type": "string",
+            "description": "-> services.report URL's service_name; identifies the product"
+          },
+          "usage_reporting_id": {
+            "type": "string",
+            "description": "-> services.report's consumerId; identifies the buyer"
+          }
+        }
+      },
       "GetCostAnalyticsRequest": {
         "type": "object",
         "properties": {
@@ -19444,12 +19750,26 @@
               "type": "string"
             }
           },
+          "include_children": {
+            "type": "boolean",
+            "description": "IncludeChildren, when true and ExternalCustomerID belongs to a parent\ncustomer, aggregates every inherited-child customer's usage into the\nrevenue and cost totals. Default (false) restricts the query to the\ncustomer's own usage \u2014 mirrors the meter-usage analytics contract."
+          },
           "limit": {
             "type": "integer",
             "description": "Pagination"
           },
           "offset": {
             "type": "integer"
+          },
+          "property_filters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Property filters to filter the events by the keys in `properties` field of the event"
           },
           "start_time": {
             "type": "string",
@@ -19624,6 +19944,21 @@
           },
           "total_count": {
             "type": "integer"
+          }
+        }
+      },
+      "GetHuggingFaceBillingDataRequest": {
+        "required": [
+          "requestIds"
+        ],
+        "type": "object",
+        "properties": {
+          "requestIds": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -20049,6 +20384,21 @@
           "GroupedInvoicingActionAdd",
           "GroupedInvoicingActionRemove"
         ]
+      },
+      "GroupedInvoicingChildRequest": {
+        "required": [
+          "external_customer_id",
+          "plan_id"
+        ],
+        "type": "object",
+        "properties": {
+          "external_customer_id": {
+            "type": "string"
+          },
+          "plan_id": {
+            "type": "string"
+          }
+        }
       },
       "IngestEventRequest": {
         "required": [
@@ -20610,8 +20960,7 @@
       },
       "LineItemQuantityChange": {
         "required": [
-          "id",
-          "quantity"
+          "id"
         ],
         "type": "object",
         "properties": {
@@ -21044,6 +21393,9 @@
           },
           "destination_type": {
             "$ref": "#/components/schemas/types.PaymentDestinationType"
+          },
+          "environment_id": {
+            "type": "string"
           },
           "error_message": {
             "type": "string"
@@ -21562,41 +21914,30 @@
       },
       "RegisterMarketplaceAgreementRequest": {
         "required": [
-          "customer_aws_account_id",
           "customer_id",
-          "dimension",
-          "license_arn",
           "plan_id",
-          "product_code",
           "provider",
           "subscription_id"
         ],
         "type": "object",
         "properties": {
-          "concurrent_agreements": {
-            "type": "boolean"
+          "aws": {
+            "$ref": "#/components/schemas/AWSMarketplaceAgreement"
           },
-          "customer_aws_account_id": {
-            "type": "string"
+          "azure": {
+            "$ref": "#/components/schemas/AzureMarketplaceAgreement"
           },
           "customer_id": {
             "type": "string"
           },
-          "dimension": {
-            "type": "string"
-          },
-          "license_arn": {
-            "type": "string"
+          "gcp": {
+            "$ref": "#/components/schemas/GCPMarketplaceAgreement"
           },
           "plan_id": {
             "type": "string"
           },
-          "product_code": {
-            "type": "string"
-          },
           "provider": {
-            "type": "string",
-            "description": "e.g. \"aws\""
+            "$ref": "#/components/schemas/types.SecretProvider"
           },
           "subscription_id": {
             "type": "string"
@@ -22117,6 +22458,13 @@
               "type": "string"
             }
           },
+          "grouped_invoicing_children_to_create": {
+            "type": "array",
+            "description": "grouped_invoicing_children_to_create creates new grouped_invoicing children under this parent",
+            "items": {
+              "$ref": "#/components/schemas/GroupedInvoicingChildRequest"
+            }
+          },
           "invoicing_customer_external_id": {
             "type": "string",
             "description": "InvoicingCustomerExternalID sets a different billing recipient (external ID).\nRequired for delegated; rejected for inherited; optional for others."
@@ -22233,6 +22581,9 @@
               "type": "string"
             }
           },
+          "meter": {
+            "$ref": "#/components/schemas/meter.Meter"
+          },
           "meter_display_name": {
             "type": "string"
           },
@@ -22290,6 +22641,9 @@
         "properties": {
           "changed_resources": {
             "$ref": "#/components/schemas/ChangedResources"
+          },
+          "checkout_session": {
+            "$ref": "#/components/schemas/CheckoutSessionResponse"
           },
           "subscription": {
             "$ref": "#/components/schemas/SubscriptionResponse"
@@ -22617,6 +22971,13 @@
             "type": "string",
             "description": "EndDate is the end date of the subscription",
             "format": "date-time"
+          },
+          "entitlements": {
+            "type": "array",
+            "description": "Entitlements is populated only when the caller adds \"entitlements\" to\nthe search filter's expand string. Each entry is a feature with its\naggregated entitlement info (same shape as CustomerEntitlementsResponse.Features).",
+            "items": {
+              "$ref": "#/components/schemas/AggregatedFeature"
+            }
           },
           "environment_id": {
             "type": "string",
@@ -23532,9 +23893,16 @@
             "type": "string",
             "description": "amount is the amount in the currency of the wallet to be added\nNOTE: this is not the number of credits to add, but the amount in the currency\namount = credits_to_add * conversion_rate\nif both amount and credits_to_add are provided, amount will be ignored\nex if the wallet has a conversion_rate of 2 then adding an amount of\n10 USD in the wallet wil add 5 credits in the wallet"
           },
+          "bonus_credits_expiry_date_utc": {
+            "type": "string",
+            "description": "bonus_credits_expiry_date_utc is the expiry (UTC, full precision) applied to the bonus\ncredits transaction. Independent of expiry_date_utc, which governs the purchase credits.\nOnly honored when bonus credits are actually granted (explicit BonusCreditsToAdd or slab)."
+          },
           "bonus_credits_to_add": {
             "type": "string",
             "description": "bonus_credits_to_add is an explicit override for the bonus credits granted alongside this\npurchase. When nil/omitted, the bonus is resolved from the tenant's\nbonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is\nused as-is, skipping slab resolution. To grant no bonus, omit this field entirely."
+          },
+          "checkout": {
+            "$ref": "#/components/schemas/CheckoutParams"
           },
           "credits_to_add": {
             "type": "string",
@@ -23547,6 +23915,9 @@
           "expiry_date_utc": {
             "type": "string",
             "description": "expiry_date_utc is the expiry date in UTC timezone\nex 2025-01-01 00:00:00 UTC"
+          },
+          "force_sync_invoice": {
+            "type": "boolean"
           },
           "idempotency_key": {
             "type": "string",
@@ -23567,6 +23938,9 @@
       "TopUpWalletResponse": {
         "type": "object",
         "properties": {
+          "checkout_session": {
+            "$ref": "#/components/schemas/CheckoutSessionResponse"
+          },
           "invoice_id": {
             "type": "string",
             "description": "Invoice ID if an invoice was created (only for PURCHASED_CREDIT_INVOICED)"
@@ -23786,9 +24160,28 @@
       "UpdateEntitlementRequest": {
         "type": "object",
         "properties": {
+          "aggregation_mode": {
+            "$ref": "#/components/schemas/types.EntitlementAggregationMode"
+          },
+          "clear_grant_config": {
+            "type": "boolean",
+            "description": "Grant config \u2014 nil fields leave the current value alone.\nClearGrantConfig=true wipes the whole grant config (back to a legacy entitlement)."
+          },
           "config_value": {
             "type": "object",
             "additionalProperties": true
+          },
+          "grant_duration_unit": {
+            "$ref": "#/components/schemas/types.EntitlementGrantDurationUnit"
+          },
+          "grant_duration_value": {
+            "type": "integer"
+          },
+          "grant_measure": {
+            "$ref": "#/components/schemas/types.EntitlementGrantMeasure"
+          },
+          "grant_quota": {
+            "type": "string"
           },
           "is_enabled": {
             "type": "boolean"
@@ -24881,21 +25274,6 @@
         ],
         "x-speakeasy-name-override": "ErrorCode"
       },
-      "errors.ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "$ref": "#/components/schemas/errors.ErrorCode"
-          },
-          "http_status_code": {
-            "type": "integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "x-speakeasy-name-override": "ErrorResponse"
-      },
       "Addon": {
         "type": "object",
         "properties": {
@@ -25214,799 +25592,20 @@
           }
         }
       },
-      "types.Bucket": {
+      "errors.ErrorResponse": {
         "type": "object",
         "properties": {
-          "hour": {
-            "maximum": 24,
-            "minimum": 0,
+          "code": {
+            "$ref": "#/components/schemas/errors.ErrorCode"
+          },
+          "http_status_code": {
             "type": "integer"
           },
-          "minute": {
-            "maximum": 59,
-            "minimum": 0,
-            "type": "integer"
-          }
-        },
-        "x-speakeasy-name-override": "Bucket"
-      },
-      "types.Value": {
-        "type": "object",
-        "properties": {
-          "array": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "boolean": {
-            "type": "boolean"
-          },
-          "date": {
-            "type": "string"
-          },
-          "number": {
-            "type": "number"
-          },
-          "string": {
-            "type": "string"
-          }
-        },
-        "x-speakeasy-name-override": "Value"
-      },
-      "group.Group": {
-        "type": "object",
-        "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "entity_type": {
-            "$ref": "#/components/schemas/types.GroupEntityType"
-          },
-          "environment_id": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "lookup_key": {
-            "type": "string"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "name": {
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
-      },
-      "invoice.InvoiceLineItem": {
-        "type": "object",
-        "properties": {
-          "adjusted_entitlement_quantity": {
-            "type": "string",
-            "description": "adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.\nNil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity."
-          },
-          "amount": {
-            "type": "string"
-          },
-          "commitment_info": {
-            "$ref": "#/components/schemas/types.CommitmentInfo"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "currency": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "entity_id": {
-            "type": "string"
-          },
-          "entity_type": {
-            "type": "string"
-          },
-          "environment_id": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "invoice_id": {
-            "type": "string"
-          },
-          "invoice_level_discount": {
-            "type": "string",
-            "description": "invoice_level_discount is the discount amount in invoice currency applied to all line items on the invoice."
-          },
-          "line_item_discount": {
-            "type": "string",
-            "description": "line_item_discount is the discount amount in invoice currency applied directly to this line item."
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/types.Metadata"
-          },
-          "meter_display_name": {
-            "type": "string"
-          },
-          "meter_id": {
-            "type": "string"
-          },
-          "period_end": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "period_start": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "plan_display_name": {
-            "type": "string"
-          },
-          "prepaid_credits_applied": {
-            "type": "string",
-            "description": "prepaid_credits_applied is the amount in invoice currency reduced from this line item due to prepaid credits application."
-          },
-          "price_id": {
-            "type": "string"
-          },
-          "price_type": {
-            "type": "string"
-          },
-          "price_unit": {
-            "type": "string"
-          },
-          "price_unit_amount": {
-            "type": "string"
-          },
-          "price_unit_id": {
-            "type": "string"
-          },
-          "quantity": {
-            "type": "string"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "subscription_id": {
-            "type": "string"
-          },
-          "subscription_line_item_id": {
-            "type": "string",
-            "description": "sub_line_item_id links this invoice line item to the subscription_line_item that generated it."
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
-      },
-      "meter.Aggregation": {
-        "type": "object",
-        "properties": {
-          "bucket_size": {
-            "$ref": "#/components/schemas/types.WindowSize"
-          },
-          "expression": {
-            "type": "string",
-            "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel)."
-          },
-          "field": {
-            "type": "string",
-            "description": "Field is the key in $event.properties on which the aggregation is to be applied\nFor ex if the aggregation type is sum for API usage, the field could be \"duration_ms\"\nIgnored when Expression is set."
-          },
-          "group_by": {
-            "type": "string",
-            "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total."
-          },
-          "multiplier": {
-            "type": "string",
-            "description": "Multiplier is the multiplier for the aggregation\nFor ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000\nto scale up by a factor of 1000. If not provided, it will be null."
-          },
-          "type": {
-            "$ref": "#/components/schemas/types.AggregationType"
-          }
-        }
-      },
-      "meter.Filter": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "Key is the key for the filter from $event.properties\nCurrently we support only first level keys in the properties and not nested keys"
-          },
-          "values": {
-            "type": "array",
-            "description": "Values are the possible values for the filter to be considered for the meter\nFor ex \"model_name\" could have values \"o1-mini\", \"gpt-4o\" etc",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "meter.Meter": {
-        "type": "object",
-        "properties": {
-          "aggregation": {
-            "$ref": "#/components/schemas/meter.Aggregation"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "environment_id": {
-            "type": "string",
-            "description": "EnvironmentID is the environment identifier for the meter"
-          },
-          "event_name": {
-            "type": "string",
-            "description": "EventName is the unique identifier for the event that this meter is tracking\nIt is a mandatory field in the events table and hence being used as the primary matching field\nWe can have multiple meters tracking the same event but with different filters and aggregation"
-          },
-          "filters": {
-            "type": "array",
-            "description": "Filters define the criteria for the meter to be applied on the events before aggregation\nIt also defines the possible values on which later the charges will be applied",
-            "items": {
-              "$ref": "#/components/schemas/meter.Filter"
-            }
-          },
-          "id": {
-            "type": "string",
-            "description": "ID is the unique identifier for the meter"
-          },
-          "name": {
-            "type": "string",
-            "description": "Name is the display name of the meter"
-          },
-          "reset_usage": {
-            "$ref": "#/components/schemas/types.ResetUsage"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
-      },
-      "models.TemporalWorkflowResult": {
-        "type": "object",
-        "properties": {
           "message": {
             "type": "string"
-          },
-          "run_id": {
-            "type": "string"
-          },
-          "workflow_id": {
-            "type": "string"
           }
-        }
-      },
-      "price.JSONBFilters": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "price.JSONBMetadata": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "price.JSONBTransformQuantity": {
-        "type": "object",
-        "properties": {
-          "divide_by": {
-            "type": "integer",
-            "description": "Divide quantity by this number"
-          },
-          "round": {
-            "$ref": "#/components/schemas/types.RoundType"
-          }
-        }
-      },
-      "price.Price": {
-        "type": "object",
-        "properties": {
-          "amount": {
-            "type": "string",
-            "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50"
-          },
-          "billing_cadence": {
-            "$ref": "#/components/schemas/types.BillingCadence"
-          },
-          "billing_model": {
-            "$ref": "#/components/schemas/types.BillingModel"
-          },
-          "billing_period": {
-            "$ref": "#/components/schemas/types.BillingPeriod"
-          },
-          "billing_period_count": {
-            "type": "integer",
-            "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12"
-          },
-          "conversion_rate": {
-            "type": "string",
-            "description": "ConversionRate is the conversion rate of the price unit to the fiat currency"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "currency": {
-            "type": "string",
-            "description": "Currency 3 digit ISO currency code in lowercase ex usd, eur, gbp"
-          },
-          "description": {
-            "type": "string",
-            "description": "Description of the price"
-          },
-          "display_amount": {
-            "type": "string",
-            "description": "DisplayAmount is the formatted amount with currency symbol\nFor USD: $12.50"
-          },
-          "display_name": {
-            "type": "string",
-            "description": "DisplayName is the name of the price"
-          },
-          "display_price_unit_amount": {
-            "type": "string",
-            "description": "DisplayPriceUnitAmount is the formatted amount of the price unit"
-          },
-          "end_date": {
-            "type": "string",
-            "description": "EndDate is the end date of the price",
-            "format": "date-time"
-          },
-          "entity_id": {
-            "type": "string",
-            "description": "EntityID holds the value of the \"entity_id\" field."
-          },
-          "entity_type": {
-            "$ref": "#/components/schemas/types.PriceEntityType"
-          },
-          "environment_id": {
-            "type": "string",
-            "description": "EnvironmentID is the environment identifier for the price"
-          },
-          "group_id": {
-            "type": "string",
-            "description": "GroupID references the group this price belongs to"
-          },
-          "id": {
-            "type": "string",
-            "description": "ID uuid identifier for the price"
-          },
-          "invoice_cadence": {
-            "$ref": "#/components/schemas/types.InvoiceCadence"
-          },
-          "lookup_key": {
-            "type": "string",
-            "description": "LookupKey used for looking up the price in the database"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/price.JSONBMetadata"
-          },
-          "meter_id": {
-            "type": "string",
-            "description": "MeterID is the id of the meter for usage based pricing"
-          },
-          "min_quantity": {
-            "type": "string",
-            "description": "MinQuantity is the minimum quantity of the price",
-            "nullable": true
-          },
-          "parent_price_id": {
-            "type": "string",
-            "description": "ParentPriceID references the root price (always set for price lineage tracking)"
-          },
-          "price_unit": {
-            "type": "string",
-            "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')"
-          },
-          "price_unit_amount": {
-            "type": "string",
-            "description": "PriceUnitAmount is the amount of the price unit"
-          },
-          "price_unit_id": {
-            "type": "string",
-            "description": "PriceUnitID is the id of the price unit (for CUSTOM type)"
-          },
-          "price_unit_tiers": {
-            "type": "array",
-            "description": "PriceUnitTiers are the tiers for the price unit when BillingModel is TIERED",
-            "items": {
-              "$ref": "#/components/schemas/price.PriceTier"
-            }
-          },
-          "price_unit_type": {
-            "$ref": "#/components/schemas/types.PriceUnitType"
-          },
-          "sequence": {
-            "type": "integer",
-            "description": "Sequence is the monotonic stamp bumped on every state change that\nsubscription line items need to react to. Read by the plan-price sync;\nset by the database (DEFAULT nextval) on create and by the price\nrepository on termination / compatibility-affecting edits."
-          },
-          "start_date": {
-            "type": "string",
-            "description": "StartDate is the start date of the price",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "tier_mode": {
-            "$ref": "#/components/schemas/types.BillingTier"
-          },
-          "tiers": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/price.PriceTier"
-            }
-          },
-          "transform_quantity": {
-            "$ref": "#/components/schemas/price.JSONBTransformQuantity"
-          },
-          "trial_period_days": {
-            "type": "integer",
-            "description": "TrialPeriodDays is the number of days for the trial period\nNote: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)"
-          },
-          "type": {
-            "$ref": "#/components/schemas/types.PriceType"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
-      },
-      "price.PriceTier": {
-        "type": "object",
-        "properties": {
-          "flat_amount": {
-            "type": "string",
-            "description": "flat_amount is the flat amount for the given tier (optional)\nApplied on top of unit_amount*quantity. Useful for cases like \"2.7$ + 5c\""
-          },
-          "unit_amount": {
-            "type": "string",
-            "description": "unit_amount is the amount per unit for the given tier"
-          },
-          "up_to": {
-            "type": "integer",
-            "description": "up_to is the quantity up to which this tier applies. It is null for the last tier.\nIMPORTANT: Tier boundaries are INCLUSIVE.\n- If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier\n- This behavior is consistent across both VOLUME and SLAB tier modes"
-          }
-        }
-      },
-      "price.TransformQuantity": {
-        "type": "object",
-        "properties": {
-          "divide_by": {
-            "type": "integer",
-            "description": "Divide quantity by this number"
-          },
-          "round": {
-            "$ref": "#/components/schemas/types.RoundType"
-          }
-        }
-      },
-      "subscription.SubscriptionLineItem": {
-        "type": "object",
-        "properties": {
-          "addon_association_id": {
-            "type": "string"
-          },
-          "billing_period": {
-            "$ref": "#/components/schemas/types.BillingPeriod"
-          },
-          "billing_period_count": {
-            "type": "integer",
-            "description": "from price at create; default 1"
-          },
-          "commitment_amount": {
-            "type": "string",
-            "description": "Commitment fields"
-          },
-          "commitment_duration": {
-            "$ref": "#/components/schemas/types.BillingPeriod"
-          },
-          "commitment_overage_factor": {
-            "type": "string"
-          },
-          "commitment_quantity": {
-            "type": "string"
-          },
-          "commitment_time_buckets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/types.TimeOfDayBucket"
-            }
-          },
-          "commitment_true_up_enabled": {
-            "type": "boolean"
-          },
-          "commitment_type": {
-            "$ref": "#/components/schemas/types.CommitmentType"
-          },
-          "commitment_windowed": {
-            "type": "boolean"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "currency": {
-            "type": "string"
-          },
-          "customer_id": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "end_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "entity_id": {
-            "type": "string"
-          },
-          "entity_type": {
-            "$ref": "#/components/schemas/types.SubscriptionLineItemEntityType"
-          },
-          "environment_id": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "invoice_cadence": {
-            "$ref": "#/components/schemas/types.InvoiceCadence"
-          },
-          "metadata": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "meter_display_name": {
-            "type": "string"
-          },
-          "meter_id": {
-            "type": "string"
-          },
-          "plan_display_name": {
-            "type": "string"
-          },
-          "price": {
-            "$ref": "#/components/schemas/price.Price"
-          },
-          "price_id": {
-            "type": "string"
-          },
-          "price_type": {
-            "$ref": "#/components/schemas/types.PriceType"
-          },
-          "price_unit": {
-            "type": "string"
-          },
-          "price_unit_id": {
-            "type": "string"
-          },
-          "quantity": {
-            "type": "string"
-          },
-          "start_date": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "subscription_id": {
-            "type": "string"
-          },
-          "subscription_phase_id": {
-            "type": "string"
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
-      },
-      "subscription.SubscriptionPause": {
-        "type": "object",
-        "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "environment_id": {
-            "type": "string",
-            "description": "EnvironmentID is the environment identifier for the pause"
-          },
-          "id": {
-            "type": "string",
-            "description": "ID is the unique identifier for the subscription pause"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/types.Metadata"
-          },
-          "original_period_end": {
-            "type": "string",
-            "description": "OriginalPeriodEnd is the end of the billing period when the pause was created",
-            "format": "date-time"
-          },
-          "original_period_start": {
-            "type": "string",
-            "description": "OriginalPeriodStart is the start of the billing period when the pause was created",
-            "format": "date-time"
-          },
-          "pause_end": {
-            "type": "string",
-            "description": "PauseEnd is when the pause will end (null for indefinite)",
-            "format": "date-time"
-          },
-          "pause_mode": {
-            "$ref": "#/components/schemas/types.PauseMode"
-          },
-          "pause_start": {
-            "type": "string",
-            "description": "PauseStart is when the pause actually started",
-            "format": "date-time"
-          },
-          "pause_status": {
-            "$ref": "#/components/schemas/types.PauseStatus"
-          },
-          "reason": {
-            "type": "string",
-            "description": "Reason is the reason for pausing"
-          },
-          "resume_mode": {
-            "$ref": "#/components/schemas/types.ResumeMode"
-          },
-          "resumed_at": {
-            "type": "string",
-            "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "subscription_id": {
-            "type": "string",
-            "description": "SubscriptionID is the identifier for the subscription"
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
-      },
-      "subscription.SubscriptionPhase": {
-        "type": "object",
-        "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "end_date": {
-            "type": "string",
-            "description": "EndDate is when the phase ends (nil if phase is still active or indefinite)",
-            "format": "date-time"
-          },
-          "environment_id": {
-            "type": "string",
-            "description": "EnvironmentID is the environment identifier for the phase"
-          },
-          "id": {
-            "type": "string",
-            "description": "ID is the unique identifier for the subscription phase"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/types.Metadata"
-          },
-          "start_date": {
-            "type": "string",
-            "description": "StartDate is when the phase starts",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          },
-          "subscription_id": {
-            "type": "string",
-            "description": "SubscriptionID is the identifier for the subscription"
-          },
-          "tenant_id": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          }
-        }
+        },
+        "x-speakeasy-name-override": "ErrorResponse"
       },
       "types.AddonAssociationEntityType": {
         "type": "string",
@@ -26155,14 +25754,16 @@
           "feature",
           "subscription",
           "subscription_line_item",
-          "group"
+          "group",
+          "entitlement_grant"
         ],
         "x-enum-varnames": [
           "AlertEntityTypeWallet",
           "AlertEntityTypeFeature",
           "AlertEntityTypeSubscription",
           "AlertEntityTypeSubscriptionLineItem",
-          "AlertEntityTypeGroup"
+          "AlertEntityTypeGroup",
+          "AlertEntityTypeEntitlementGrant"
         ],
         "x-speakeasy-name-override": "AlertEntityType"
       },
@@ -26264,82 +25865,6 @@
         },
         "x-speakeasy-name-override": "AlertSettings"
       },
-      "types.AlertSettingsFilter": {
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "type": "boolean"
-          },
-          "end_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "entity_id": {
-            "type": "string"
-          },
-          "entity_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "entity_type": {
-            "$ref": "#/components/schemas/types.AlertEntityType"
-          },
-          "expand": {
-            "type": "string"
-          },
-          "filters": {
-            "type": "array",
-            "description": "filters allows complex filtering based on multiple fields",
-            "items": {
-              "$ref": "#/components/schemas/types.FilterCondition"
-            }
-          },
-          "limit": {
-            "maximum": 1000,
-            "minimum": 1,
-            "type": "integer"
-          },
-          "offset": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "order": {
-            "type": "string",
-            "enum": [
-              "asc",
-              "desc"
-            ]
-          },
-          "parent_entity_id": {
-            "type": "string"
-          },
-          "parent_entity_ids": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "parent_entity_type": {
-            "$ref": "#/components/schemas/types.AlertEntityType"
-          },
-          "sort": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/types.SortCondition"
-            }
-          },
-          "start_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "status": {
-            "$ref": "#/components/schemas/types.Status"
-          }
-        },
-        "x-speakeasy-name-override": "AlertSettingsFilter"
-      },
       "types.AlertState": {
         "type": "string",
         "enum": [
@@ -26376,7 +25901,9 @@
           "feature_wallet_balance",
           "subscription_spend",
           "subscription_line_item_spend",
-          "subscription_group_spend"
+          "subscription_group_spend",
+          "entitlement_grant_threshold",
+          "entitlement_grant_exhausted"
         ],
         "x-enum-varnames": [
           "AlertTypeLowOngoingBalance",
@@ -26384,7 +25911,9 @@
           "AlertTypeFeatureWalletBalance",
           "AlertTypeSubscriptionSpend",
           "AlertTypeSubscriptionLineItemSpend",
-          "AlertTypeSubscriptionGroupSpend"
+          "AlertTypeSubscriptionGroupSpend",
+          "AlertTypeEntitlementGrantThreshold",
+          "AlertTypeEntitlementGrantExhausted"
         ],
         "x-speakeasy-name-override": "AlertType"
       },
@@ -26411,6 +25940,9 @@
         "properties": {
           "amount": {
             "type": "number"
+          },
+          "cooldown": {
+            "$ref": "#/components/schemas/types.Duration"
           },
           "enabled": {
             "type": "boolean"
@@ -26494,6 +26026,22 @@
         ],
         "x-speakeasy-name-override": "BillingTier"
       },
+      "types.Bucket": {
+        "type": "object",
+        "properties": {
+          "hour": {
+            "maximum": 24,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "minute": {
+            "maximum": 59,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "x-speakeasy-name-override": "Bucket"
+      },
       "types.CancelImmediatelyInvoicePolicy": {
         "type": "string",
         "enum": [
@@ -26523,10 +26071,14 @@
       "types.CheckoutAction": {
         "type": "string",
         "enum": [
-          "create_subscription"
+          "create_subscription",
+          "modify_subscription",
+          "wallet_topup"
         ],
         "x-enum-varnames": [
-          "CheckoutActionCreateSubscription"
+          "CheckoutActionCreateSubscription",
+          "CheckoutActionModifySubscription",
+          "CheckoutActionWalletTopup"
         ],
         "x-speakeasy-name-override": "CheckoutAction"
       },
@@ -26535,6 +26087,12 @@
         "properties": {
           "create_subscription_params": {
             "$ref": "#/components/schemas/types.CreateSubscriptionParams"
+          },
+          "modify_subscription_params": {
+            "$ref": "#/components/schemas/types.ModifySubscriptionParams"
+          },
+          "wallet_topup_params": {
+            "$ref": "#/components/schemas/types.WalletTopupParams"
           }
         },
         "x-speakeasy-name-override": "CheckoutConfiguration"
@@ -26548,21 +26106,6 @@
           "CheckoutPaymentProviderRazorpay"
         ],
         "x-speakeasy-name-override": "CheckoutPaymentProvider"
-      },
-      "types.CheckoutPaymentProviderConfig": {
-        "type": "object",
-        "properties": {
-          "collection_method": {
-            "$ref": "#/components/schemas/types.CollectionMethod"
-          },
-          "max_mandate_limit": {
-            "type": "string"
-          },
-          "payment_method": {
-            "$ref": "#/components/schemas/types.PaymentMethodType"
-          }
-        },
-        "x-speakeasy-name-override": "CheckoutPaymentProviderConfig"
       },
       "types.CheckoutStatus": {
         "type": "string",
@@ -27027,6 +26570,24 @@
         ],
         "x-speakeasy-name-override": "DebugTrackerStatus"
       },
+      "types.Duration": {
+        "type": "object",
+        "properties": {
+          "unit": {
+            "$ref": "#/components/schemas/types.DurationUnit"
+          },
+          "value": {
+            "type": "integer"
+          }
+        },
+        "enum": [
+          "3600000000000"
+        ],
+        "x-enum-varnames": [
+          "EntitlementGrantMinDuration"
+        ],
+        "x-speakeasy-name-override": "Duration"
+      },
       "types.EntitlementEntityType": {
         "type": "string",
         "enum": [
@@ -27075,6 +26636,10 @@
             "items": {
               "$ref": "#/components/schemas/types.FilterCondition"
             }
+          },
+          "has_grant_config": {
+            "type": "boolean",
+            "description": "HasGrantConfig filters on grant-config presence (grant_quota set or not)."
           },
           "is_enabled": {
             "type": "boolean"
@@ -27716,28 +27281,6 @@
         ],
         "x-speakeasy-name-override": "InvoiceType"
       },
-      "types.ListResponse-dto_WalletResponse": {
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/WalletResponse"
-            }
-          },
-          "pagination": {
-            "$ref": "#/components/schemas/types.PaginationResponse"
-          }
-        },
-        "x-speakeasy-name-override": "ListResponse-dto_WalletResponse"
-      },
-      "types.Metadata": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        },
-        "x-speakeasy-name-override": "Metadata"
-      },
       "types.PaginationResponse": {
         "type": "object",
         "properties": {
@@ -28224,18 +27767,6 @@
         },
         "x-speakeasy-name-override": "QueryFilter"
       },
-      "types.RejectedEventReason": {
-        "type": "string",
-        "enum": [
-          "no_meter_for_event_name",
-          "no_matching_meter"
-        ],
-        "x-enum-varnames": [
-          "RejectedEventReasonNoMeterForName",
-          "RejectedEventReasonNoMatchingMeter"
-        ],
-        "x-speakeasy-name-override": "RejectedEventReason"
-      },
       "types.ReportingUnit": {
         "type": "object",
         "properties": {
@@ -28470,7 +28001,9 @@
           "paddle",
           "whop",
           "tabs",
-          "aws_marketplace"
+          "aws_marketplace",
+          "gcp_marketplace",
+          "azure_marketplace"
         ],
         "x-enum-comments": {
           "SecretProviderS3": "supports multiple connections per environment"
@@ -28489,7 +28022,9 @@
           "SecretProviderPaddle",
           "SecretProviderWhop",
           "SecretProviderTabs",
-          "SecretProviderAWSMarketplace"
+          "SecretProviderAWSMarketplace",
+          "SecretProviderGCPMarketplace",
+          "SecretProviderAzureMarketplace"
         ],
         "x-speakeasy-name-override": "SecretProvider"
       },
@@ -28685,9 +28220,13 @@
             "description": "TrialEndDueLTE, when set, restricts to subscriptions with trial_end not nil and trial_end <= trial_end_due_lte.\nUse with subscription_status trialing for trial-end cron processing.",
             "format": "date-time"
           },
+          "with_coupon_associations": {
+            "type": "boolean",
+            "description": "WithCouponAssociations eager-loads coupon associations and their coupons.\n\nKept separate from WithLineItems because the coupon_associations table has no\nindex leading with subscription_id, so Ent's edge load degrades to a full table\nscan. Only set it when the response actually surfaces the associations; the\nservice layer back-fills it from expand=\"coupon_associations\"."
+          },
           "with_line_items": {
             "type": "boolean",
-            "description": "WithLineItems includes line items in the response"
+            "description": "WithLineItems includes line items in the response.\n\nDeprecated: use expand=\"subscription_line_items\" instead. Retained for\nbackwards compatibility and for internal callers that need to force-disable\nline item loading (set to false). The service layer ORs this with the\nexpand check before invoking the repository."
           }
         },
         "x-speakeasy-name-override": "SubscriptionFilter"
@@ -28873,6 +28412,9 @@
       "types.SyncConfig": {
         "type": "object",
         "properties": {
+          "aws_marketplace": {
+            "$ref": "#/components/schemas/types.AWSMarketplaceSyncConfig"
+          },
           "customer": {
             "$ref": "#/components/schemas/types.EntitySyncConfig"
           },
@@ -29166,6 +28708,30 @@
         ],
         "x-speakeasy-name-override": "UserType"
       },
+      "types.Value": {
+        "type": "object",
+        "properties": {
+          "array": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "boolean": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string"
+          },
+          "number": {
+            "type": "number"
+          },
+          "string": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-name-override": "Value"
+      },
       "types.WalletConfig": {
         "type": "object",
         "properties": {
@@ -29406,6 +28972,7 @@
           "subscription.line_item_spend.threshold_recovered",
           "subscription.group_spend.threshold_reached",
           "subscription.group_spend.threshold_recovered",
+          "entitlement.grant.exhausted",
           "subscription.renewal.due",
           "invoice.communication.triggered",
           "credit_note.created",
@@ -29463,6 +29030,7 @@
           "WebhookEventSubscriptionLineItemSpendThresholdRecovered",
           "WebhookEventSubscriptionGroupSpendThresholdReached",
           "WebhookEventSubscriptionGroupSpendThresholdRecovered",
+          "WebhookEventEntitlementGrantExhausted",
           "WebhookEventSubscriptionRenewalDue",
           "WebhookEventInvoiceCommunicationTriggered",
           "WebhookEventCreditNoteCreated",
@@ -29573,6 +29141,997 @@
           }
         },
         "x-speakeasy-name-override": "WorkflowExecutionFilter"
+      },
+      "group.Group": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "entity_type": {
+            "$ref": "#/components/schemas/types.GroupEntityType"
+          },
+          "environment_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lookup_key": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "invoice.InvoiceLineItem": {
+        "type": "object",
+        "properties": {
+          "adjusted_entitlement_quantity": {
+            "type": "string",
+            "description": "adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.\nNil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity."
+          },
+          "amount": {
+            "type": "string"
+          },
+          "commitment_info": {
+            "$ref": "#/components/schemas/types.CommitmentInfo"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "entity_type": {
+            "type": "string"
+          },
+          "environment_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "invoice_id": {
+            "type": "string"
+          },
+          "invoice_level_discount": {
+            "type": "string",
+            "description": "invoice_level_discount is the discount amount in invoice currency applied to all line items on the invoice."
+          },
+          "line_item_discount": {
+            "type": "string",
+            "description": "line_item_discount is the discount amount in invoice currency applied directly to this line item."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/types.Metadata"
+          },
+          "meter_display_name": {
+            "type": "string"
+          },
+          "meter_id": {
+            "type": "string"
+          },
+          "period_end": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "period_start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "plan_display_name": {
+            "type": "string"
+          },
+          "prepaid_credits_applied": {
+            "type": "string",
+            "description": "prepaid_credits_applied is the amount in invoice currency reduced from this line item due to prepaid credits application."
+          },
+          "price_id": {
+            "type": "string"
+          },
+          "price_type": {
+            "type": "string"
+          },
+          "price_unit": {
+            "type": "string"
+          },
+          "price_unit_amount": {
+            "type": "string"
+          },
+          "price_unit_id": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "subscription_id": {
+            "type": "string"
+          },
+          "subscription_line_item_id": {
+            "type": "string",
+            "description": "sub_line_item_id links this invoice line item to the subscription_line_item that generated it."
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "meter.Aggregation": {
+        "type": "object",
+        "properties": {
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
+          },
+          "expression": {
+            "type": "string",
+            "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel)."
+          },
+          "field": {
+            "type": "string",
+            "description": "Field is the key in $event.properties on which the aggregation is to be applied\nFor ex if the aggregation type is sum for API usage, the field could be \"duration_ms\"\nIgnored when Expression is set."
+          },
+          "group_by": {
+            "type": "string",
+            "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total."
+          },
+          "multiplier": {
+            "type": "string",
+            "description": "Multiplier is the multiplier for the aggregation\nFor ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000\nto scale up by a factor of 1000. If not provided, it will be null."
+          },
+          "type": {
+            "$ref": "#/components/schemas/types.AggregationType"
+          }
+        }
+      },
+      "meter.Filter": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Key is the key for the filter from $event.properties\nCurrently we support only first level keys in the properties and not nested keys"
+          },
+          "values": {
+            "type": "array",
+            "description": "Values are the possible values for the filter to be considered for the meter\nFor ex \"model_name\" could have values \"o1-mini\", \"gpt-4o\" etc",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "meter.Meter": {
+        "type": "object",
+        "properties": {
+          "aggregation": {
+            "$ref": "#/components/schemas/meter.Aggregation"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "environment_id": {
+            "type": "string",
+            "description": "EnvironmentID is the environment identifier for the meter"
+          },
+          "event_name": {
+            "type": "string",
+            "description": "EventName is the unique identifier for the event that this meter is tracking\nIt is a mandatory field in the events table and hence being used as the primary matching field\nWe can have multiple meters tracking the same event but with different filters and aggregation"
+          },
+          "filters": {
+            "type": "array",
+            "description": "Filters define the criteria for the meter to be applied on the events before aggregation\nIt also defines the possible values on which later the charges will be applied",
+            "items": {
+              "$ref": "#/components/schemas/meter.Filter"
+            }
+          },
+          "id": {
+            "type": "string",
+            "description": "ID is the unique identifier for the meter"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name is the display name of the meter"
+          },
+          "reset_usage": {
+            "$ref": "#/components/schemas/types.ResetUsage"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "models.TemporalWorkflowResult": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "workflow_id": {
+            "type": "string"
+          }
+        }
+      },
+      "price.JSONBFilters": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "price.JSONBMetadata": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "price.JSONBTransformQuantity": {
+        "type": "object",
+        "properties": {
+          "divide_by": {
+            "type": "integer",
+            "description": "Divide quantity by this number"
+          },
+          "round": {
+            "$ref": "#/components/schemas/types.RoundType"
+          }
+        }
+      },
+      "price.Price": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "string",
+            "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50"
+          },
+          "billing_cadence": {
+            "$ref": "#/components/schemas/types.BillingCadence"
+          },
+          "billing_model": {
+            "$ref": "#/components/schemas/types.BillingModel"
+          },
+          "billing_period": {
+            "$ref": "#/components/schemas/types.BillingPeriod"
+          },
+          "billing_period_count": {
+            "type": "integer",
+            "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12"
+          },
+          "conversion_rate": {
+            "type": "string",
+            "description": "ConversionRate is the conversion rate of the price unit to the fiat currency"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string",
+            "description": "Currency 3 digit ISO currency code in lowercase ex usd, eur, gbp"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the price"
+          },
+          "display_amount": {
+            "type": "string",
+            "description": "DisplayAmount is the formatted amount with currency symbol\nFor USD: $12.50"
+          },
+          "display_name": {
+            "type": "string",
+            "description": "DisplayName is the name of the price"
+          },
+          "display_price_unit_amount": {
+            "type": "string",
+            "description": "DisplayPriceUnitAmount is the formatted amount of the price unit"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "EndDate is the end date of the price",
+            "format": "date-time"
+          },
+          "entity_id": {
+            "type": "string",
+            "description": "EntityID holds the value of the \"entity_id\" field."
+          },
+          "entity_type": {
+            "$ref": "#/components/schemas/types.PriceEntityType"
+          },
+          "environment_id": {
+            "type": "string",
+            "description": "EnvironmentID is the environment identifier for the price"
+          },
+          "group_id": {
+            "type": "string",
+            "description": "GroupID references the group this price belongs to"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID uuid identifier for the price"
+          },
+          "invoice_cadence": {
+            "$ref": "#/components/schemas/types.InvoiceCadence"
+          },
+          "lookup_key": {
+            "type": "string",
+            "description": "LookupKey used for looking up the price in the database"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/price.JSONBMetadata"
+          },
+          "meter_id": {
+            "type": "string",
+            "description": "MeterID is the id of the meter for usage based pricing"
+          },
+          "min_quantity": {
+            "type": "string",
+            "description": "MinQuantity is the minimum quantity of the price",
+            "nullable": true
+          },
+          "parent_price_id": {
+            "type": "string",
+            "description": "ParentPriceID references the root price (always set for price lineage tracking)"
+          },
+          "price_unit": {
+            "type": "string",
+            "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')"
+          },
+          "price_unit_amount": {
+            "type": "string",
+            "description": "PriceUnitAmount is the amount of the price unit"
+          },
+          "price_unit_id": {
+            "type": "string",
+            "description": "PriceUnitID is the id of the price unit (for CUSTOM type)"
+          },
+          "price_unit_tiers": {
+            "type": "array",
+            "description": "PriceUnitTiers are the tiers for the price unit when BillingModel is TIERED",
+            "items": {
+              "$ref": "#/components/schemas/price.PriceTier"
+            }
+          },
+          "price_unit_type": {
+            "$ref": "#/components/schemas/types.PriceUnitType"
+          },
+          "sequence": {
+            "type": "integer",
+            "description": "Sequence is the monotonic stamp bumped on every state change that\nsubscription line items need to react to. Read by the plan-price sync;\nset by the database (DEFAULT nextval) on create and by the price\nrepository on termination / compatibility-affecting edits."
+          },
+          "start_date": {
+            "type": "string",
+            "description": "StartDate is the start date of the price",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "tier_mode": {
+            "$ref": "#/components/schemas/types.BillingTier"
+          },
+          "tiers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/price.PriceTier"
+            }
+          },
+          "transform_quantity": {
+            "$ref": "#/components/schemas/price.JSONBTransformQuantity"
+          },
+          "trial_period_days": {
+            "type": "integer",
+            "description": "TrialPeriodDays is the number of days for the trial period\nNote: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)"
+          },
+          "type": {
+            "$ref": "#/components/schemas/types.PriceType"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "price.PriceTier": {
+        "type": "object",
+        "properties": {
+          "flat_amount": {
+            "type": "string",
+            "description": "flat_amount is the flat amount for the given tier (optional)\nApplied on top of unit_amount*quantity. Useful for cases like \"2.7$ + 5c\""
+          },
+          "unit_amount": {
+            "type": "string",
+            "description": "unit_amount is the amount per unit for the given tier"
+          },
+          "up_to": {
+            "type": "integer",
+            "description": "up_to is the quantity up to which this tier applies. It is null for the last tier.\nIMPORTANT: Tier boundaries are INCLUSIVE.\n- If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier\n- This behavior is consistent across both VOLUME and SLAB tier modes"
+          }
+        }
+      },
+      "price.TransformQuantity": {
+        "type": "object",
+        "properties": {
+          "divide_by": {
+            "type": "integer",
+            "description": "Divide quantity by this number"
+          },
+          "round": {
+            "$ref": "#/components/schemas/types.RoundType"
+          }
+        }
+      },
+      "subscription.SubscriptionLineItem": {
+        "type": "object",
+        "properties": {
+          "addon_association_id": {
+            "type": "string"
+          },
+          "billing_period": {
+            "$ref": "#/components/schemas/types.BillingPeriod"
+          },
+          "billing_period_count": {
+            "type": "integer",
+            "description": "from price at create; default 1"
+          },
+          "commitment_amount": {
+            "type": "string",
+            "description": "Commitment fields"
+          },
+          "commitment_duration": {
+            "$ref": "#/components/schemas/types.BillingPeriod"
+          },
+          "commitment_overage_factor": {
+            "type": "string"
+          },
+          "commitment_quantity": {
+            "type": "string"
+          },
+          "commitment_time_buckets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.TimeOfDayBucket"
+            }
+          },
+          "commitment_true_up_enabled": {
+            "type": "boolean"
+          },
+          "commitment_type": {
+            "$ref": "#/components/schemas/types.CommitmentType"
+          },
+          "commitment_windowed": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "customer_id": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "entity_type": {
+            "$ref": "#/components/schemas/types.SubscriptionLineItemEntityType"
+          },
+          "environment_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "invoice_cadence": {
+            "$ref": "#/components/schemas/types.InvoiceCadence"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "meter": {
+            "$ref": "#/components/schemas/meter.Meter"
+          },
+          "meter_display_name": {
+            "type": "string"
+          },
+          "meter_id": {
+            "type": "string"
+          },
+          "plan_display_name": {
+            "type": "string"
+          },
+          "price": {
+            "$ref": "#/components/schemas/price.Price"
+          },
+          "price_id": {
+            "type": "string"
+          },
+          "price_type": {
+            "$ref": "#/components/schemas/types.PriceType"
+          },
+          "price_unit": {
+            "type": "string"
+          },
+          "price_unit_id": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "subscription_id": {
+            "type": "string"
+          },
+          "subscription_phase_id": {
+            "type": "string"
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "subscription.SubscriptionPause": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "environment_id": {
+            "type": "string",
+            "description": "EnvironmentID is the environment identifier for the pause"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID is the unique identifier for the subscription pause"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/types.Metadata"
+          },
+          "original_period_end": {
+            "type": "string",
+            "description": "OriginalPeriodEnd is the end of the billing period when the pause was created",
+            "format": "date-time"
+          },
+          "original_period_start": {
+            "type": "string",
+            "description": "OriginalPeriodStart is the start of the billing period when the pause was created",
+            "format": "date-time"
+          },
+          "pause_end": {
+            "type": "string",
+            "description": "PauseEnd is when the pause will end (null for indefinite)",
+            "format": "date-time"
+          },
+          "pause_mode": {
+            "$ref": "#/components/schemas/types.PauseMode"
+          },
+          "pause_start": {
+            "type": "string",
+            "description": "PauseStart is when the pause actually started",
+            "format": "date-time"
+          },
+          "pause_status": {
+            "$ref": "#/components/schemas/types.PauseStatus"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason is the reason for pausing"
+          },
+          "resume_mode": {
+            "$ref": "#/components/schemas/types.ResumeMode"
+          },
+          "resumed_at": {
+            "type": "string",
+            "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "subscription_id": {
+            "type": "string",
+            "description": "SubscriptionID is the identifier for the subscription"
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "subscription.SubscriptionPhase": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "end_date": {
+            "type": "string",
+            "description": "EndDate is when the phase ends (nil if phase is still active or indefinite)",
+            "format": "date-time"
+          },
+          "environment_id": {
+            "type": "string",
+            "description": "EnvironmentID is the environment identifier for the phase"
+          },
+          "id": {
+            "type": "string",
+            "description": "ID is the unique identifier for the subscription phase"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/types.Metadata"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "StartDate is when the phase starts",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          },
+          "subscription_id": {
+            "type": "string",
+            "description": "SubscriptionID is the identifier for the subscription"
+          },
+          "tenant_id": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "types.AWSMarketplaceSyncConfig": {
+        "type": "object",
+        "properties": {
+          "region": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-name-override": "AWSMarketplaceSyncConfig"
+      },
+      "types.AlertSettingsFilter": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "entity_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "entity_type": {
+            "$ref": "#/components/schemas/types.AlertEntityType"
+          },
+          "expand": {
+            "type": "string"
+          },
+          "filters": {
+            "type": "array",
+            "description": "filters allows complex filtering based on multiple fields",
+            "items": {
+              "$ref": "#/components/schemas/types.FilterCondition"
+            }
+          },
+          "limit": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "offset": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          },
+          "parent_entity_id": {
+            "type": "string"
+          },
+          "parent_entity_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "parent_entity_type": {
+            "$ref": "#/components/schemas/types.AlertEntityType"
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.SortCondition"
+            }
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/components/schemas/types.Status"
+          }
+        },
+        "x-speakeasy-name-override": "AlertSettingsFilter"
+      },
+      "types.CheckoutPaymentProviderConfig": {
+        "type": "object",
+        "properties": {
+          "collection_method": {
+            "$ref": "#/components/schemas/types.CollectionMethod"
+          },
+          "max_mandate_limit": {
+            "type": "string"
+          },
+          "payment_method": {
+            "$ref": "#/components/schemas/types.PaymentMethodType"
+          }
+        },
+        "x-speakeasy-name-override": "CheckoutPaymentProviderConfig"
+      },
+      "types.DurationUnit": {
+        "type": "string",
+        "enum": [
+          "second",
+          "minute",
+          "hour",
+          "day"
+        ],
+        "x-enum-varnames": [
+          "DurationUnitSecond",
+          "DurationUnitMinute",
+          "DurationUnitHour",
+          "DurationUnitDay"
+        ],
+        "x-speakeasy-name-override": "DurationUnit"
+      },
+      "types.EntitlementAggregationMode": {
+        "type": "string",
+        "enum": [
+          "additive",
+          "parallel"
+        ],
+        "x-enum-varnames": [
+          "EntitlementAggregationModeAdditive",
+          "EntitlementAggregationModeParallel"
+        ],
+        "x-speakeasy-name-override": "EntitlementAggregationMode"
+      },
+      "types.EntitlementGrantDurationUnit": {
+        "type": "string",
+        "enum": [
+          "hour",
+          "day",
+          "week"
+        ],
+        "x-enum-varnames": [
+          "EntitlementGrantDurationUnitHour",
+          "EntitlementGrantDurationUnitDay",
+          "EntitlementGrantDurationUnitWeek"
+        ],
+        "x-speakeasy-name-override": "EntitlementGrantDurationUnit"
+      },
+      "types.EntitlementGrantMeasure": {
+        "type": "string",
+        "enum": [
+          "quantity",
+          "amount"
+        ],
+        "x-enum-varnames": [
+          "EntitlementGrantMeasureQuantity",
+          "EntitlementGrantMeasureAmount"
+        ],
+        "x-speakeasy-name-override": "EntitlementGrantMeasure"
+      },
+      "types.ListResponse-dto_WalletResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WalletResponse"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/types.PaginationResponse"
+          }
+        },
+        "x-speakeasy-name-override": "ListResponse-dto_WalletResponse"
+      },
+      "types.Metadata": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "x-speakeasy-name-override": "Metadata"
+      },
+      "types.ModifySubscriptionLineItem": {
+        "type": "object",
+        "properties": {
+          "effective_date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "line_item_id": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-name-override": "ModifySubscriptionLineItem"
+      },
+      "types.ModifySubscriptionParams": {
+        "type": "object",
+        "properties": {
+          "line_item_modifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.ModifySubscriptionLineItem"
+            }
+          },
+          "subscription_id": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-name-override": "ModifySubscriptionParams"
+      },
+      "types.RejectedEventReason": {
+        "type": "string",
+        "enum": [
+          "no_meter_for_event_name",
+          "no_matching_meter"
+        ],
+        "x-enum-varnames": [
+          "RejectedEventReasonNoMeterForName",
+          "RejectedEventReasonNoMatchingMeter"
+        ],
+        "x-speakeasy-name-override": "RejectedEventReason"
+      },
+      "types.WalletTopupParams": {
+        "required": [
+          "wallet_id"
+        ],
+        "type": "object",
+        "properties": {
+          "wallet_id": {
+            "type": "string"
+          },
+          "wallet_transaction_id": {
+            "type": "string"
+          }
+        },
+        "x-speakeasy-name-override": "WalletTopupParams"
       },
       "webhookDto.AlertWebhookPayload": {
         "type": "object",
@@ -29781,6 +30340,9 @@
       "webhookDto.TransactionUpdatedWebhookPayload": {
         "type": "object",
         "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/CustomerResponse"
+          },
           "event_type": {
             "$ref": "#/components/schemas/types.WebhookEventName"
           },
@@ -29795,6 +30357,9 @@
       "webhookDto.TransactionWebhookPayload": {
         "type": "object",
         "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/CustomerResponse"
+          },
           "event_type": {
             "$ref": "#/components/schemas/types.WebhookEventName"
           },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2545,6 +2545,66 @@
                 }
             }
         },
+        "/customers/external/{external_id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Returns all subscriptions for a customer looked up by external_id, with line-item meters and entitlements attached (no pagination).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Customers"
+                ],
+                "summary": "Get subscriptions for customer by external ID",
+                "operationId": "getSubscriptionsForCustomer",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Customer External ID",
+                        "name": "external_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated fields to expand: subscription_line_items, subscription_line_items.meters, entitlements, plan, customer",
+                        "name": "expand",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ListSubscriptionsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource not found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "read"
+            }
+        },
         "/customers/search": {
             "post": {
                 "security": [
@@ -3602,7 +3662,10 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Use when fetching Hugging Face inference usage or billing data (e.g. for HF-specific reporting or reconciliation).",
+                "description": "Use when fetching Hugging Face inference usage or billing data (e.g. for HF-specific reporting or reconciliation). Reads the meter-usage pipeline.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -3611,11 +3674,69 @@
                 ],
                 "summary": "Get Hugging Face inference data",
                 "operationId": "getHuggingfaceInferenceData",
+                "parameters": [
+                    {
+                        "description": "Request body",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GetHuggingFaceBillingDataRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/GetHuggingFaceBillingDataResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/events/lookup": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Use when debugging a specific event (e.g. why it failed or how it was aggregated). Reads the meter-usage pipeline; includes processing status and step-by-step debug tracker when unprocessed. Uses ?id= query param because event IDs can contain \"/\".",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Events"
+                ],
+                "summary": "Get event",
+                "operationId": "getEvent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Event ID",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/GetEventByIDResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
                         }
                     },
                     "500": {
@@ -3776,53 +3897,6 @@
                     },
                     "404": {
                         "description": "Resource not found",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Server error",
-                        "schema": {
-                            "$ref": "#/definitions/errors.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/events/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "ApiKeyAuth": []
-                    }
-                ],
-                "description": "Use when debugging a specific event (e.g. why it failed or how it was aggregated). Includes processing status and debug info.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Events"
-                ],
-                "summary": "Get event",
-                "operationId": "getEvent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Event ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/GetEventByIDResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/errors.ErrorResponse"
                         }
@@ -4733,6 +4807,12 @@
                         "collectionFormat": "csv",
                         "description": "Group usage breakdown by specified fields (e.g., source, feature_id, properties.org_id)",
                         "name": "group_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Comma-separated related fields to include. Supports 'tax_applied.tax_rate' to attach rate details to each applied tax.",
+                        "name": "expand",
                         "in": "query"
                     }
                 ],
@@ -12876,6 +12956,12 @@
             "properties": {
                 "create_subscription_params": {
                     "$ref": "#/definitions/types.CreateSubscriptionParams"
+                },
+                "modify_subscription_params": {
+                    "$ref": "#/definitions/types.ModifySubscriptionParams"
+                },
+                "wallet_topup_params": {
+                    "$ref": "#/definitions/types.WalletTopupParams"
                 }
             }
         },
@@ -13165,6 +13251,37 @@
                 }
             }
         },
+        "AWSMarketplaceAgreement": {
+            "type": "object",
+            "required": [
+                "customer_aws_account_id",
+                "dimension",
+                "license_arn",
+                "product_code"
+            ],
+            "properties": {
+                "concurrent_agreements": {
+                    "description": "if true, ProductCode is omitted when reporting",
+                    "type": "boolean"
+                },
+                "customer_aws_account_id": {
+                    "description": "-\u003e BatchMeterUsage's CustomerAWSAccountId",
+                    "type": "string"
+                },
+                "dimension": {
+                    "description": "-\u003e BatchMeterUsage's Dimension (always \"usage_fee\" in the cents model)",
+                    "type": "string"
+                },
+                "license_arn": {
+                    "description": "-\u003e BatchMeterUsage's LicenseArn; identifies the buyer's agreement",
+                    "type": "string"
+                },
+                "product_code": {
+                    "description": "-\u003e BatchMeterUsage's ProductCode (omitted when ConcurrentAgreements)",
+                    "type": "string"
+                }
+            }
+        },
         "ActivateDraftSubscriptionRequest": {
             "type": "object",
             "required": [
@@ -13201,6 +13318,13 @@
                     "type": "object",
                     "additionalProperties": true
                 },
+                "override_line_items": {
+                    "description": "OverrideLineItems allows overriding price/quantity/billing model for specific addon prices",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/OverrideLineItemRequest"
+                    }
+                },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
                 },
@@ -13234,6 +13358,13 @@
                 "metadata": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "override_line_items": {
+                    "description": "OverrideLineItems allows overriding price/quantity/billing model for specific addon prices",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/OverrideLineItemRequest"
+                    }
                 },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
@@ -13398,6 +13529,15 @@
         "AggregatedEntitlement": {
             "type": "object",
             "properties": {
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
+                "buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AggregatedEntitlementBucket"
+                    }
+                },
                 "config_values": {
                     "type": "array",
                     "items": {
@@ -13422,6 +13562,32 @@
                 },
                 "usage_reset_period": {
                     "$ref": "#/definitions/types.EntitlementUsageResetPeriod"
+                }
+            }
+        },
+        "AggregatedEntitlementBucket": {
+            "type": "object",
+            "properties": {
+                "entitlement_id": {
+                    "type": "string"
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                },
+                "grant_quota": {
+                    "type": "string"
+                },
+                "source_entity_id": {
+                    "type": "string"
+                },
+                "usage_limit": {
+                    "type": "integer"
                 }
             }
         },
@@ -13563,6 +13729,33 @@
                 },
                 "status": {
                     "$ref": "#/definitions/types.DebugTrackerStatus"
+                }
+            }
+        },
+        "AzureMarketplaceAgreement": {
+            "type": "object",
+            "required": [
+                "beneficiary_account_id",
+                "dimension",
+                "plan_id",
+                "resource_id"
+            ],
+            "properties": {
+                "beneficiary_account_id": {
+                    "description": "writes the customer mapping; not read in the report payload",
+                    "type": "string"
+                },
+                "dimension": {
+                    "description": "-\u003e usageEvent's dimension (always \"usage_fee\" in the cents model)",
+                    "type": "string"
+                },
+                "plan_id": {
+                    "description": "-\u003e usageEvent's planId; Azure's plan id, distinct from the request's top-level PlanID",
+                    "type": "string"
+                },
+                "resource_id": {
+                    "description": "-\u003e usageEvent's resourceId; the Azure SaaS subscription id",
+                    "type": "string"
                 }
             }
         },
@@ -13915,6 +14108,38 @@
                 "ChangedSubscriptionActionCreated",
                 "ChangedSubscriptionActionUpdated"
             ]
+        },
+        "CheckoutParams": {
+            "type": "object",
+            "required": [
+                "payment_provider"
+            ],
+            "properties": {
+                "cancel_url": {
+                    "type": "string"
+                },
+                "failure_url": {
+                    "type": "string"
+                },
+                "idempotency_key": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "payment_provider": {
+                    "$ref": "#/definitions/types.CheckoutPaymentProvider"
+                },
+                "payment_provider_config": {
+                    "$ref": "#/definitions/types.CheckoutPaymentProviderConfig"
+                },
+                "success_url": {
+                    "type": "string"
+                }
+            }
         },
         "CheckoutSessionResponse": {
             "type": "object",
@@ -14995,6 +15220,10 @@
                     "type": "string",
                     "maxLength": 255
                 },
+                "onboarding_workflow_name": {
+                    "description": "onboarding_workflow_name is given if a custom onboarding workflow is to be triggered for this customer",
+                    "type": "string"
+                },
                 "skip_onboarding_workflow": {
                     "description": "skip_onboarding_workflow when true, prevents the customer onboarding workflow from being triggered\nThis is used internally when a customer is created via a workflow to prevent infinite loops\nDefault: false",
                     "type": "boolean"
@@ -15019,6 +15248,9 @@
                 "feature_type"
             ],
             "properties": {
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
                 "config_value": {
                     "type": "object",
                     "additionalProperties": true
@@ -15037,6 +15269,19 @@
                 },
                 "feature_type": {
                     "$ref": "#/definitions/types.FeatureType"
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "description": "Grant config — optional. All-or-nothing; see entitlement.validateGrantConfig.",
+                    "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                },
+                "grant_quota": {
+                    "type": "string"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -16839,6 +17084,9 @@
                 "addon": {
                     "$ref": "#/definitions/AddonResponse"
                 },
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
                 "config_value": {
                     "type": "object",
                     "additionalProperties": true
@@ -16872,6 +17120,19 @@
                 },
                 "feature_type": {
                     "$ref": "#/definitions/types.FeatureType"
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "description": "Grant config; all-or-nothing set (see validateGrantConfig). Presence of a\ngrant config turns the entitlement into a time-boxed bucket source.",
+                    "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                },
+                "grant_quota": {
+                    "type": "number"
                 },
                 "id": {
                     "type": "string"
@@ -17062,6 +17323,9 @@
                 "type"
             ],
             "properties": {
+                "checkout": {
+                    "$ref": "#/definitions/CheckoutParams"
+                },
                 "coupon_params": {
                     "$ref": "#/definitions/SubModifyCouponParams"
                 },
@@ -17218,6 +17482,33 @@
                 }
             }
         },
+        "GCPMarketplaceAgreement": {
+            "type": "object",
+            "required": [
+                "account_id",
+                "metric_name",
+                "service_name",
+                "usage_reporting_id"
+            ],
+            "properties": {
+                "account_id": {
+                    "description": "writes the customer mapping; not read in the report payload",
+                    "type": "string"
+                },
+                "metric_name": {
+                    "description": "-\u003e services.report's metricName (always \"{service_name}/usage_fee\")",
+                    "type": "string"
+                },
+                "service_name": {
+                    "description": "-\u003e services.report URL's service_name; identifies the product",
+                    "type": "string"
+                },
+                "usage_reporting_id": {
+                    "description": "-\u003e services.report's consumerId; identifies the buyer",
+                    "type": "string"
+                }
+            }
+        },
         "GetCostAnalyticsRequest": {
             "type": "object",
             "properties": {
@@ -17242,12 +17533,26 @@
                         "type": "string"
                     }
                 },
+                "include_children": {
+                    "description": "IncludeChildren, when true and ExternalCustomerID belongs to a parent\ncustomer, aggregates every inherited-child customer's usage into the\nrevenue and cost totals. Default (false) restricts the query to the\ncustomer's own usage — mirrors the meter-usage analytics contract.",
+                    "type": "boolean"
+                },
                 "limit": {
                     "description": "Pagination",
                     "type": "integer"
                 },
                 "offset": {
                     "type": "integer"
+                },
+                "property_filters": {
+                    "description": "Property filters to filter the events by the keys in `properties` field of the event",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "start_time": {
                     "description": "Time range fields (optional - defaults to last 7 days if not provided)",
@@ -17417,6 +17722,21 @@
                 },
                 "total_count": {
                     "type": "integer"
+                }
+            }
+        },
+        "GetHuggingFaceBillingDataRequest": {
+            "type": "object",
+            "required": [
+                "requestIds"
+            ],
+            "properties": {
+                "requestIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -17830,6 +18150,21 @@
                 "GroupedInvoicingActionAdd",
                 "GroupedInvoicingActionRemove"
             ]
+        },
+        "GroupedInvoicingChildRequest": {
+            "type": "object",
+            "required": [
+                "external_customer_id",
+                "plan_id"
+            ],
+            "properties": {
+                "external_customer_id": {
+                    "type": "string"
+                },
+                "plan_id": {
+                    "type": "string"
+                }
+            }
         },
         "IngestEventRequest": {
             "type": "object",
@@ -18383,8 +18718,7 @@
         "LineItemQuantityChange": {
             "type": "object",
             "required": [
-                "id",
-                "quantity"
+                "id"
             ],
             "properties": {
                 "effective_date": {
@@ -18810,6 +19144,9 @@
                 },
                 "destination_type": {
                     "$ref": "#/definitions/types.PaymentDestinationType"
+                },
+                "environment_id": {
+                    "type": "string"
                 },
                 "error_message": {
                     "type": "string"
@@ -19316,40 +19653,33 @@
         "RegisterMarketplaceAgreementRequest": {
             "type": "object",
             "required": [
-                "customer_aws_account_id",
                 "customer_id",
-                "dimension",
-                "license_arn",
                 "plan_id",
-                "product_code",
                 "provider",
                 "subscription_id"
             ],
             "properties": {
-                "concurrent_agreements": {
-                    "type": "boolean"
+                "aws": {
+                    "description": "required iff Provider == aws_marketplace",
+                    "$ref": "#/definitions/AWSMarketplaceAgreement"
                 },
-                "customer_aws_account_id": {
-                    "type": "string"
+                "azure": {
+                    "description": "required iff Provider == azure_marketplace",
+                    "$ref": "#/definitions/AzureMarketplaceAgreement"
                 },
                 "customer_id": {
                     "type": "string"
                 },
-                "dimension": {
-                    "type": "string"
-                },
-                "license_arn": {
-                    "type": "string"
+                "gcp": {
+                    "description": "required iff Provider == gcp_marketplace",
+                    "$ref": "#/definitions/GCPMarketplaceAgreement"
                 },
                 "plan_id": {
                     "type": "string"
                 },
-                "product_code": {
-                    "type": "string"
-                },
                 "provider": {
-                    "description": "e.g. \"aws\"",
-                    "type": "string"
+                    "description": "\"aws_marketplace\" | \"gcp_marketplace\" | \"azure_marketplace\"",
+                    "$ref": "#/definitions/types.SecretProvider"
                 },
                 "subscription_id": {
                     "type": "string"
@@ -19882,6 +20212,13 @@
                         "type": "string"
                     }
                 },
+                "grouped_invoicing_children_to_create": {
+                    "description": "grouped_invoicing_children_to_create creates new grouped_invoicing children under this parent",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/GroupedInvoicingChildRequest"
+                    }
+                },
                 "invoicing_customer_external_id": {
                     "description": "InvoicingCustomerExternalID sets a different billing recipient (external ID).\nRequired for delegated; rejected for inherited; optional for others.",
                     "type": "string"
@@ -19996,6 +20333,10 @@
                         "type": "string"
                     }
                 },
+                "meter": {
+                    "description": "Meter is populated when the caller adds \"meters\" to a subscription-scoped\nexpand string alongside \"subscription_line_items\". Only usage line items\n(PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.",
+                    "$ref": "#/definitions/meter.Meter"
+                },
                 "meter_display_name": {
                     "type": "string"
                 },
@@ -20052,6 +20393,10 @@
                 "changed_resources": {
                     "description": "All resources created or mutated as a result of this modification.",
                     "$ref": "#/definitions/ChangedResources"
+                },
+                "checkout_session": {
+                    "description": "CheckoutSession is set on pay-first execute when payment must be collected\nbefore line-item changes apply. Reuses CheckoutSessionResponse (payment_action\nat session root). Omitted for pay-later and preview.",
+                    "$ref": "#/definitions/CheckoutSessionResponse"
                 },
                 "subscription": {
                     "description": "The subscription after the modification.",
@@ -20369,6 +20714,13 @@
                 "end_date": {
                     "description": "EndDate is the end date of the subscription",
                     "type": "string"
+                },
+                "entitlements": {
+                    "description": "Entitlements is populated only when the caller adds \"entitlements\" to\nthe search filter's expand string. Each entry is a feature with its\naggregated entitlement info (same shape as CustomerEntitlementsResponse.Features).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AggregatedFeature"
+                    }
                 },
                 "environment_id": {
                     "description": "EnvironmentID is the environment identifier for the subscription",
@@ -21255,9 +21607,17 @@
                     "description": "amount is the amount in the currency of the wallet to be added\nNOTE: this is not the number of credits to add, but the amount in the currency\namount = credits_to_add * conversion_rate\nif both amount and credits_to_add are provided, amount will be ignored\nex if the wallet has a conversion_rate of 2 then adding an amount of\n10 USD in the wallet wil add 5 credits in the wallet",
                     "type": "string"
                 },
+                "bonus_credits_expiry_date_utc": {
+                    "description": "bonus_credits_expiry_date_utc is the expiry (UTC, full precision) applied to the bonus\ncredits transaction. Independent of expiry_date_utc, which governs the purchase credits.\nOnly honored when bonus credits are actually granted (explicit BonusCreditsToAdd or slab).",
+                    "type": "string"
+                },
                 "bonus_credits_to_add": {
                     "description": "bonus_credits_to_add is an explicit override for the bonus credits granted alongside this\npurchase. When nil/omitted, the bonus is resolved from the tenant's\nbonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is\nused as-is, skipping slab resolution. To grant no bonus, omit this field entirely.",
                     "type": "string"
+                },
+                "checkout": {
+                    "description": "checkout opts into pay-first hosted checkout for PURCHASED_CREDIT_INVOICED top-ups.\nWhen set, credits are applied only after checkout payment succeeds.\nOmit for today's pay-later / auto-complete behavior.",
+                    "$ref": "#/definitions/CheckoutParams"
                 },
                 "credits_to_add": {
                     "description": "credits_to_add is the number of credits to add to the wallet",
@@ -21270,6 +21630,9 @@
                 "expiry_date_utc": {
                     "description": "expiry_date_utc is the expiry date in UTC timezone\nex 2025-01-01 00:00:00 UTC",
                     "type": "string"
+                },
+                "force_sync_invoice": {
+                    "type": "boolean"
                 },
                 "idempotency_key": {
                     "description": "idempotency_key is a unique key for the transaction",
@@ -21291,6 +21654,10 @@
         "TopUpWalletResponse": {
             "type": "object",
             "properties": {
+                "checkout_session": {
+                    "description": "CheckoutSession is set when pay-first checkout was requested on top-up.",
+                    "$ref": "#/definitions/CheckoutSessionResponse"
+                },
                 "invoice_id": {
                     "description": "Invoice ID if an invoice was created (only for PURCHASED_CREDIT_INVOICED)",
                     "type": "string"
@@ -21507,9 +21874,28 @@
         "UpdateEntitlementRequest": {
             "type": "object",
             "properties": {
+                "aggregation_mode": {
+                    "$ref": "#/definitions/types.EntitlementAggregationMode"
+                },
+                "clear_grant_config": {
+                    "description": "Grant config — nil fields leave the current value alone.\nClearGrantConfig=true wipes the whole grant config (back to a legacy entitlement).",
+                    "type": "boolean"
+                },
                 "config_value": {
                     "type": "object",
                     "additionalProperties": true
+                },
+                "grant_duration_unit": {
+                    "$ref": "#/definitions/types.EntitlementGrantDurationUnit"
+                },
+                "grant_duration_value": {
+                    "type": "integer"
+                },
+                "grant_measure": {
+                    "$ref": "#/definitions/types.EntitlementGrantMeasure"
+                },
+                "grant_quota": {
+                    "type": "string"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -22601,20 +22987,6 @@
                 "ErrCodeNotImplemented"
             ]
         },
-        "errors.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "$ref": "#/definitions/errors.ErrorCode"
-                },
-                "http_status_code": {
-                    "type": "integer"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
         "Addon": {
             "type": "object",
             "properties": {
@@ -22924,776 +23296,16 @@
                 }
             }
         },
-        "types.Bucket": {
+        "errors.ErrorResponse": {
             "type": "object",
             "properties": {
-                "hour": {
-                    "type": "integer",
-                    "maximum": 24,
-                    "minimum": 0
+                "code": {
+                    "$ref": "#/definitions/errors.ErrorCode"
                 },
-                "minute": {
-                    "type": "integer",
-                    "maximum": 59,
-                    "minimum": 0
-                }
-            }
-        },
-        "types.Value": {
-            "type": "object",
-            "properties": {
-                "array": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "http_status_code": {
+                    "type": "integer"
                 },
-                "boolean": {
-                    "type": "boolean"
-                },
-                "date": {
-                    "type": "string"
-                },
-                "number": {
-                    "type": "number"
-                },
-                "string": {
-                    "type": "string"
-                }
-            }
-        },
-        "group.Group": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "entity_type": {
-                    "$ref": "#/definitions/types.GroupEntityType"
-                },
-                "environment_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "lookup_key": {
-                    "type": "string"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "invoice.InvoiceLineItem": {
-            "type": "object",
-            "properties": {
-                "adjusted_entitlement_quantity": {
-                    "description": "adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.\nNil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity.",
-                    "type": "string"
-                },
-                "amount": {
-                    "type": "string"
-                },
-                "commitment_info": {
-                    "$ref": "#/definitions/types.CommitmentInfo"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "customer_id": {
-                    "type": "string"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "entity_id": {
-                    "type": "string"
-                },
-                "entity_type": {
-                    "type": "string"
-                },
-                "environment_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "invoice_id": {
-                    "type": "string"
-                },
-                "invoice_level_discount": {
-                    "description": "invoice_level_discount is the discount amount in invoice currency applied to all line items on the invoice.",
-                    "type": "string"
-                },
-                "line_item_discount": {
-                    "description": "line_item_discount is the discount amount in invoice currency applied directly to this line item.",
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/types.Metadata"
-                },
-                "meter_display_name": {
-                    "type": "string"
-                },
-                "meter_id": {
-                    "type": "string"
-                },
-                "period_end": {
-                    "type": "string"
-                },
-                "period_start": {
-                    "type": "string"
-                },
-                "plan_display_name": {
-                    "type": "string"
-                },
-                "prepaid_credits_applied": {
-                    "description": "prepaid_credits_applied is the amount in invoice currency reduced from this line item due to prepaid credits application.",
-                    "type": "string"
-                },
-                "price_id": {
-                    "type": "string"
-                },
-                "price_type": {
-                    "type": "string"
-                },
-                "price_unit": {
-                    "type": "string"
-                },
-                "price_unit_amount": {
-                    "type": "string"
-                },
-                "price_unit_id": {
-                    "type": "string"
-                },
-                "quantity": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "type": "string"
-                },
-                "subscription_line_item_id": {
-                    "description": "sub_line_item_id links this invoice line item to the subscription_line_item that generated it.",
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "meter.Aggregation": {
-            "type": "object",
-            "properties": {
-                "bucket_size": {
-                    "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
-                    "$ref": "#/definitions/types.WindowSize"
-                },
-                "expression": {
-                    "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).",
-                    "type": "string"
-                },
-                "field": {
-                    "description": "Field is the key in $event.properties on which the aggregation is to be applied\nFor ex if the aggregation type is sum for API usage, the field could be \"duration_ms\"\nIgnored when Expression is set.",
-                    "type": "string"
-                },
-                "group_by": {
-                    "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total.",
-                    "type": "string"
-                },
-                "multiplier": {
-                    "description": "Multiplier is the multiplier for the aggregation\nFor ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000\nto scale up by a factor of 1000. If not provided, it will be null.",
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.AggregationType"
-                }
-            }
-        },
-        "meter.Filter": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "description": "Key is the key for the filter from $event.properties\nCurrently we support only first level keys in the properties and not nested keys",
-                    "type": "string"
-                },
-                "values": {
-                    "description": "Values are the possible values for the filter to be considered for the meter\nFor ex \"model_name\" could have values \"o1-mini\", \"gpt-4o\" etc",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "meter.Meter": {
-            "type": "object",
-            "properties": {
-                "aggregation": {
-                    "description": "Aggregation defines the aggregation type and field for the meter\nIt is used to aggregate the events into a single value for calculating the usage",
-                    "$ref": "#/definitions/meter.Aggregation"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the meter",
-                    "type": "string"
-                },
-                "event_name": {
-                    "description": "EventName is the unique identifier for the event that this meter is tracking\nIt is a mandatory field in the events table and hence being used as the primary matching field\nWe can have multiple meters tracking the same event but with different filters and aggregation",
-                    "type": "string"
-                },
-                "filters": {
-                    "description": "Filters define the criteria for the meter to be applied on the events before aggregation\nIt also defines the possible values on which later the charges will be applied",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/meter.Filter"
-                    }
-                },
-                "id": {
-                    "description": "ID is the unique identifier for the meter",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "Name is the display name of the meter",
-                    "type": "string"
-                },
-                "reset_usage": {
-                    "description": "ResetUsage defines whether the usage should be reset periodically or not\nFor ex meters tracking total storage used do not get reset but meters tracking\ntotal API requests do.",
-                    "$ref": "#/definitions/types.ResetUsage"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "models.TemporalWorkflowResult": {
-            "type": "object",
-            "properties": {
                 "message": {
-                    "type": "string"
-                },
-                "run_id": {
-                    "type": "string"
-                },
-                "workflow_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "price.JSONBFilters": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                }
-            }
-        },
-        "price.JSONBMetadata": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
-        "price.JSONBTransformQuantity": {
-            "type": "object",
-            "properties": {
-                "divide_by": {
-                    "description": "Divide quantity by this number",
-                    "type": "integer"
-                },
-                "round": {
-                    "description": "up or down",
-                    "$ref": "#/definitions/types.RoundType"
-                }
-            }
-        },
-        "price.Price": {
-            "type": "object",
-            "properties": {
-                "amount": {
-                    "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50",
-                    "type": "string"
-                },
-                "billing_cadence": {
-                    "$ref": "#/definitions/types.BillingCadence"
-                },
-                "billing_model": {
-                    "$ref": "#/definitions/types.BillingModel"
-                },
-                "billing_period": {
-                    "$ref": "#/definitions/types.BillingPeriod"
-                },
-                "billing_period_count": {
-                    "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
-                    "type": "integer",
-                    "default": 1
-                },
-                "conversion_rate": {
-                    "description": "ConversionRate is the conversion rate of the price unit to the fiat currency",
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "currency": {
-                    "description": "Currency 3 digit ISO currency code in lowercase ex usd, eur, gbp",
-                    "type": "string"
-                },
-                "description": {
-                    "description": "Description of the price",
-                    "type": "string"
-                },
-                "display_amount": {
-                    "description": "DisplayAmount is the formatted amount with currency symbol\nFor USD: $12.50",
-                    "type": "string"
-                },
-                "display_name": {
-                    "description": "DisplayName is the name of the price",
-                    "type": "string"
-                },
-                "display_price_unit_amount": {
-                    "description": "DisplayPriceUnitAmount is the formatted amount of the price unit",
-                    "type": "string"
-                },
-                "end_date": {
-                    "description": "EndDate is the end date of the price",
-                    "type": "string"
-                },
-                "entity_id": {
-                    "description": "EntityID holds the value of the \"entity_id\" field.",
-                    "type": "string"
-                },
-                "entity_type": {
-                    "description": "EntityType holds the value of the \"entity_type\" field.",
-                    "$ref": "#/definitions/types.PriceEntityType"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the price",
-                    "type": "string"
-                },
-                "group_id": {
-                    "description": "GroupID references the group this price belongs to",
-                    "type": "string"
-                },
-                "id": {
-                    "description": "ID uuid identifier for the price",
-                    "type": "string"
-                },
-                "invoice_cadence": {
-                    "$ref": "#/definitions/types.InvoiceCadence"
-                },
-                "lookup_key": {
-                    "description": "LookupKey used for looking up the price in the database",
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/price.JSONBMetadata"
-                },
-                "meter_id": {
-                    "description": "MeterID is the id of the meter for usage based pricing",
-                    "type": "string"
-                },
-                "min_quantity": {
-                    "description": "MinQuantity is the minimum quantity of the price",
-                    "type": "string",
-                    "x-nullable": true
-                },
-                "parent_price_id": {
-                    "description": "ParentPriceID references the root price (always set for price lineage tracking)",
-                    "type": "string"
-                },
-                "price_unit": {
-                    "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')",
-                    "type": "string"
-                },
-                "price_unit_amount": {
-                    "description": "PriceUnitAmount is the amount of the price unit",
-                    "type": "string"
-                },
-                "price_unit_id": {
-                    "description": "PriceUnitID is the id of the price unit (for CUSTOM type)",
-                    "type": "string"
-                },
-                "price_unit_tiers": {
-                    "description": "PriceUnitTiers are the tiers for the price unit when BillingModel is TIERED",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/price.PriceTier"
-                    }
-                },
-                "price_unit_type": {
-                    "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
-                    "$ref": "#/definitions/types.PriceUnitType"
-                },
-                "sequence": {
-                    "description": "Sequence is the monotonic stamp bumped on every state change that\nsubscription line items need to react to. Read by the plan-price sync;\nset by the database (DEFAULT nextval) on create and by the price\nrepository on termination / compatibility-affecting edits.",
-                    "type": "integer"
-                },
-                "start_date": {
-                    "description": "StartDate is the start date of the price",
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "tier_mode": {
-                    "$ref": "#/definitions/types.BillingTier"
-                },
-                "tiers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/price.PriceTier"
-                    }
-                },
-                "transform_quantity": {
-                    "$ref": "#/definitions/price.JSONBTransformQuantity"
-                },
-                "trial_period_days": {
-                    "description": "TrialPeriodDays is the number of days for the trial period\nNote: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)",
-                    "type": "integer"
-                },
-                "type": {
-                    "$ref": "#/definitions/types.PriceType"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "price.PriceTier": {
-            "type": "object",
-            "properties": {
-                "flat_amount": {
-                    "description": "flat_amount is the flat amount for the given tier (optional)\nApplied on top of unit_amount*quantity. Useful for cases like \"2.7$ + 5c\"",
-                    "type": "string"
-                },
-                "unit_amount": {
-                    "description": "unit_amount is the amount per unit for the given tier",
-                    "type": "string"
-                },
-                "up_to": {
-                    "description": "up_to is the quantity up to which this tier applies. It is null for the last tier.\nIMPORTANT: Tier boundaries are INCLUSIVE.\n- If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier\n- This behavior is consistent across both VOLUME and SLAB tier modes",
-                    "type": "integer"
-                }
-            }
-        },
-        "price.TransformQuantity": {
-            "type": "object",
-            "properties": {
-                "divide_by": {
-                    "description": "Divide quantity by this number",
-                    "type": "integer"
-                },
-                "round": {
-                    "description": "up or down",
-                    "$ref": "#/definitions/types.RoundType"
-                }
-            }
-        },
-        "subscription.SubscriptionLineItem": {
-            "type": "object",
-            "properties": {
-                "addon_association_id": {
-                    "type": "string"
-                },
-                "billing_period": {
-                    "$ref": "#/definitions/types.BillingPeriod"
-                },
-                "billing_period_count": {
-                    "description": "from price at create; default 1",
-                    "type": "integer"
-                },
-                "commitment_amount": {
-                    "description": "Commitment fields",
-                    "type": "string"
-                },
-                "commitment_duration": {
-                    "$ref": "#/definitions/types.BillingPeriod"
-                },
-                "commitment_overage_factor": {
-                    "type": "string"
-                },
-                "commitment_quantity": {
-                    "type": "string"
-                },
-                "commitment_time_buckets": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.TimeOfDayBucket"
-                    }
-                },
-                "commitment_true_up_enabled": {
-                    "type": "boolean"
-                },
-                "commitment_type": {
-                    "$ref": "#/definitions/types.CommitmentType"
-                },
-                "commitment_windowed": {
-                    "type": "boolean"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "currency": {
-                    "type": "string"
-                },
-                "customer_id": {
-                    "type": "string"
-                },
-                "display_name": {
-                    "type": "string"
-                },
-                "end_date": {
-                    "type": "string"
-                },
-                "entity_id": {
-                    "type": "string"
-                },
-                "entity_type": {
-                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
-                },
-                "environment_id": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "invoice_cadence": {
-                    "$ref": "#/definitions/types.InvoiceCadence"
-                },
-                "metadata": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "meter_display_name": {
-                    "type": "string"
-                },
-                "meter_id": {
-                    "type": "string"
-                },
-                "plan_display_name": {
-                    "type": "string"
-                },
-                "price": {
-                    "$ref": "#/definitions/price.Price"
-                },
-                "price_id": {
-                    "type": "string"
-                },
-                "price_type": {
-                    "$ref": "#/definitions/types.PriceType"
-                },
-                "price_unit": {
-                    "type": "string"
-                },
-                "price_unit_id": {
-                    "type": "string"
-                },
-                "quantity": {
-                    "type": "string"
-                },
-                "start_date": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "type": "string"
-                },
-                "subscription_phase_id": {
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "subscription.SubscriptionPause": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the pause",
-                    "type": "string"
-                },
-                "id": {
-                    "description": "ID is the unique identifier for the subscription pause",
-                    "type": "string"
-                },
-                "metadata": {
-                    "$ref": "#/definitions/types.Metadata"
-                },
-                "original_period_end": {
-                    "description": "OriginalPeriodEnd is the end of the billing period when the pause was created",
-                    "type": "string"
-                },
-                "original_period_start": {
-                    "description": "OriginalPeriodStart is the start of the billing period when the pause was created",
-                    "type": "string"
-                },
-                "pause_end": {
-                    "description": "PauseEnd is when the pause will end (null for indefinite)",
-                    "type": "string"
-                },
-                "pause_mode": {
-                    "$ref": "#/definitions/types.PauseMode"
-                },
-                "pause_start": {
-                    "description": "PauseStart is when the pause actually started",
-                    "type": "string"
-                },
-                "pause_status": {
-                    "$ref": "#/definitions/types.PauseStatus"
-                },
-                "reason": {
-                    "description": "Reason is the reason for pausing",
-                    "type": "string"
-                },
-                "resume_mode": {
-                    "$ref": "#/definitions/types.ResumeMode"
-                },
-                "resumed_at": {
-                    "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "description": "SubscriptionID is the identifier for the subscription",
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
-                    "type": "string"
-                }
-            }
-        },
-        "subscription.SubscriptionPhase": {
-            "type": "object",
-            "properties": {
-                "created_at": {
-                    "type": "string"
-                },
-                "created_by": {
-                    "type": "string"
-                },
-                "end_date": {
-                    "description": "EndDate is when the phase ends (nil if phase is still active or indefinite)",
-                    "type": "string"
-                },
-                "environment_id": {
-                    "description": "EnvironmentID is the environment identifier for the phase",
-                    "type": "string"
-                },
-                "id": {
-                    "description": "ID is the unique identifier for the subscription phase",
-                    "type": "string"
-                },
-                "metadata": {
-                    "description": "Metadata contains additional key-value pairs",
-                    "$ref": "#/definitions/types.Metadata"
-                },
-                "start_date": {
-                    "description": "StartDate is when the phase starts",
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                },
-                "subscription_id": {
-                    "description": "SubscriptionID is the identifier for the subscription",
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                },
-                "updated_by": {
                     "type": "string"
                 }
             }
@@ -23837,14 +23449,16 @@
                 "feature",
                 "subscription",
                 "subscription_line_item",
-                "group"
+                "group",
+                "entitlement_grant"
             ],
             "x-enum-varnames": [
                 "AlertEntityTypeWallet",
                 "AlertEntityTypeFeature",
                 "AlertEntityTypeSubscription",
                 "AlertEntityTypeSubscriptionLineItem",
-                "AlertEntityTypeGroup"
+                "AlertEntityTypeGroup",
+                "AlertEntityTypeEntitlementGrant"
             ]
         },
         "types.AlertInfo": {
@@ -23939,79 +23553,6 @@
                 }
             }
         },
-        "types.AlertSettingsFilter": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "end_time": {
-                    "type": "string"
-                },
-                "entity_id": {
-                    "type": "string"
-                },
-                "entity_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "entity_type": {
-                    "$ref": "#/definitions/types.AlertEntityType"
-                },
-                "expand": {
-                    "type": "string"
-                },
-                "filters": {
-                    "description": "filters allows complex filtering based on multiple fields",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.FilterCondition"
-                    }
-                },
-                "limit": {
-                    "type": "integer",
-                    "maximum": 1000,
-                    "minimum": 1
-                },
-                "offset": {
-                    "type": "integer",
-                    "minimum": 0
-                },
-                "order": {
-                    "type": "string",
-                    "enum": [
-                        "asc",
-                        "desc"
-                    ]
-                },
-                "parent_entity_id": {
-                    "type": "string"
-                },
-                "parent_entity_ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "parent_entity_type": {
-                    "$ref": "#/definitions/types.AlertEntityType"
-                },
-                "sort": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.SortCondition"
-                    }
-                },
-                "start_time": {
-                    "type": "string"
-                },
-                "status": {
-                    "$ref": "#/definitions/types.Status"
-                }
-            }
-        },
         "types.AlertState": {
             "type": "string",
             "enum": [
@@ -24046,7 +23587,9 @@
                 "feature_wallet_balance",
                 "subscription_spend",
                 "subscription_line_item_spend",
-                "subscription_group_spend"
+                "subscription_group_spend",
+                "entitlement_grant_threshold",
+                "entitlement_grant_exhausted"
             ],
             "x-enum-varnames": [
                 "AlertTypeLowOngoingBalance",
@@ -24054,7 +23597,9 @@
                 "AlertTypeFeatureWalletBalance",
                 "AlertTypeSubscriptionSpend",
                 "AlertTypeSubscriptionLineItemSpend",
-                "AlertTypeSubscriptionGroupSpend"
+                "AlertTypeSubscriptionGroupSpend",
+                "AlertTypeEntitlementGrantThreshold",
+                "AlertTypeEntitlementGrantExhausted"
             ]
         },
         "types.ApplicationStatus": {
@@ -24079,6 +23624,10 @@
             "properties": {
                 "amount": {
                     "type": "number"
+                },
+                "cooldown": {
+                    "description": "Cooldown is an optional cooloff after a successful auto top-up before another may run.",
+                    "$ref": "#/definitions/types.Duration"
                 },
                 "enabled": {
                     "type": "boolean"
@@ -24156,6 +23705,21 @@
                 "BILLING_TIER_SLAB"
             ]
         },
+        "types.Bucket": {
+            "type": "object",
+            "properties": {
+                "hour": {
+                    "type": "integer",
+                    "maximum": 24,
+                    "minimum": 0
+                },
+                "minute": {
+                    "type": "integer",
+                    "maximum": 59,
+                    "minimum": 0
+                }
+            }
+        },
         "types.CancelImmediatelyInvoicePolicy": {
             "type": "string",
             "enum": [
@@ -24183,10 +23747,14 @@
         "types.CheckoutAction": {
             "type": "string",
             "enum": [
-                "create_subscription"
+                "create_subscription",
+                "modify_subscription",
+                "wallet_topup"
             ],
             "x-enum-varnames": [
-                "CheckoutActionCreateSubscription"
+                "CheckoutActionCreateSubscription",
+                "CheckoutActionModifySubscription",
+                "CheckoutActionWalletTopup"
             ]
         },
         "types.CheckoutConfiguration": {
@@ -24194,6 +23762,12 @@
             "properties": {
                 "create_subscription_params": {
                     "$ref": "#/definitions/types.CreateSubscriptionParams"
+                },
+                "modify_subscription_params": {
+                    "$ref": "#/definitions/types.ModifySubscriptionParams"
+                },
+                "wallet_topup_params": {
+                    "$ref": "#/definitions/types.WalletTopupParams"
                 }
             }
         },
@@ -24205,20 +23779,6 @@
             "x-enum-varnames": [
                 "CheckoutPaymentProviderRazorpay"
             ]
-        },
-        "types.CheckoutPaymentProviderConfig": {
-            "type": "object",
-            "properties": {
-                "collection_method": {
-                    "$ref": "#/definitions/types.CollectionMethod"
-                },
-                "max_mandate_limit": {
-                    "type": "string"
-                },
-                "payment_method": {
-                    "$ref": "#/definitions/types.PaymentMethodType"
-                }
-            }
         },
         "types.CheckoutStatus": {
             "type": "string",
@@ -24657,6 +24217,23 @@
                 "DebugTrackerStatusAttributed"
             ]
         },
+        "types.Duration": {
+            "type": "object",
+            "enum": [
+                3600000000000
+            ],
+            "properties": {
+                "unit": {
+                    "$ref": "#/definitions/types.DurationUnit"
+                },
+                "value": {
+                    "type": "integer"
+                }
+            },
+            "x-enum-varnames": [
+                "EntitlementGrantMinDuration"
+            ]
+        },
         "types.EntitlementEntityType": {
             "type": "string",
             "enum": [
@@ -24703,6 +24280,10 @@
                     "items": {
                         "$ref": "#/definitions/types.FilterCondition"
                     }
+                },
+                "has_grant_config": {
+                    "description": "HasGrantConfig filters on grant-config presence (grant_quota set or not).",
+                    "type": "boolean"
                 },
                 "is_enabled": {
                     "type": "boolean"
@@ -25317,26 +24898,6 @@
                 "InvoiceTypeCredit"
             ]
         },
-        "types.ListResponse-dto_WalletResponse": {
-            "type": "object",
-            "properties": {
-                "items": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/WalletResponse"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/types.PaginationResponse"
-                }
-            }
-        },
-        "types.Metadata": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            }
-        },
         "types.PaginationResponse": {
             "type": "object",
             "properties": {
@@ -25798,17 +25359,6 @@
                 }
             }
         },
-        "types.RejectedEventReason": {
-            "type": "string",
-            "enum": [
-                "no_meter_for_event_name",
-                "no_matching_meter"
-            ],
-            "x-enum-varnames": [
-                "RejectedEventReasonNoMeterForName",
-                "RejectedEventReasonNoMatchingMeter"
-            ]
-        },
         "types.ReportingUnit": {
             "type": "object",
             "properties": {
@@ -26035,7 +25585,9 @@
                 "paddle",
                 "whop",
                 "tabs",
-                "aws_marketplace"
+                "aws_marketplace",
+                "gcp_marketplace",
+                "azure_marketplace"
             ],
             "x-enum-comments": {
                 "SecretProviderS3": "supports multiple connections per environment"
@@ -26054,7 +25606,9 @@
                 "SecretProviderPaddle",
                 "SecretProviderWhop",
                 "SecretProviderTabs",
-                "SecretProviderAWSMarketplace"
+                "SecretProviderAWSMarketplace",
+                "SecretProviderGCPMarketplace",
+                "SecretProviderAzureMarketplace"
             ]
         },
         "types.SecretType": {
@@ -26240,8 +25794,12 @@
                     "description": "TrialEndDueLTE, when set, restricts to subscriptions with trial_end not nil and trial_end \u003c= trial_end_due_lte.\nUse with subscription_status trialing for trial-end cron processing.",
                     "type": "string"
                 },
+                "with_coupon_associations": {
+                    "description": "WithCouponAssociations eager-loads coupon associations and their coupons.\n\nKept separate from WithLineItems because the coupon_associations table has no\nindex leading with subscription_id, so Ent's edge load degrades to a full table\nscan. Only set it when the response actually surfaces the associations; the\nservice layer back-fills it from expand=\"coupon_associations\".",
+                    "type": "boolean"
+                },
                 "with_line_items": {
-                    "description": "WithLineItems includes line items in the response",
+                    "description": "WithLineItems includes line items in the response.\n\nDeprecated: use expand=\"subscription_line_items\" instead. Retained for\nbackwards compatibility and for internal callers that need to force-disable\nline item loading (set to false). The service layer ORs this with the\nexpand check before invoking the repository.",
                     "type": "boolean"
                 }
             }
@@ -26419,6 +25977,10 @@
         "types.SyncConfig": {
             "type": "object",
             "properties": {
+                "aws_marketplace": {
+                    "description": "AWSMarketplace connection metadata",
+                    "$ref": "#/definitions/types.AWSMarketplaceSyncConfig"
+                },
                 "customer": {
                     "$ref": "#/definitions/types.EntitySyncConfig"
                 },
@@ -26703,6 +26265,29 @@
                 "UserTypeServiceAccount"
             ]
         },
+        "types.Value": {
+            "type": "object",
+            "properties": {
+                "array": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "boolean": {
+                    "type": "boolean"
+                },
+                "date": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "number"
+                },
+                "string": {
+                    "type": "string"
+                }
+            }
+        },
         "types.WalletConfig": {
             "type": "object",
             "properties": {
@@ -26934,6 +26519,7 @@
                 "subscription.line_item_spend.threshold_recovered",
                 "subscription.group_spend.threshold_reached",
                 "subscription.group_spend.threshold_recovered",
+                "entitlement.grant.exhausted",
                 "subscription.renewal.due",
                 "invoice.communication.triggered",
                 "credit_note.created",
@@ -26991,6 +26577,7 @@
                 "WebhookEventSubscriptionLineItemSpendThresholdRecovered",
                 "WebhookEventSubscriptionGroupSpendThresholdReached",
                 "WebhookEventSubscriptionGroupSpendThresholdRecovered",
+                "WebhookEventEntitlementGrantExhausted",
                 "WebhookEventSubscriptionRenewalDue",
                 "WebhookEventInvoiceCommunicationTriggered",
                 "WebhookEventCreditNoteCreated",
@@ -27093,6 +26680,964 @@
                     "type": "string"
                 },
                 "workflow_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "group.Group": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "$ref": "#/definitions/types.GroupEntityType"
+                },
+                "environment_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lookup_key": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "invoice.InvoiceLineItem": {
+            "type": "object",
+            "properties": {
+                "adjusted_entitlement_quantity": {
+                    "description": "adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.\nNil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity.",
+                    "type": "string"
+                },
+                "amount": {
+                    "type": "string"
+                },
+                "commitment_info": {
+                    "$ref": "#/definitions/types.CommitmentInfo"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "customer_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "type": "string"
+                },
+                "environment_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "invoice_id": {
+                    "type": "string"
+                },
+                "invoice_level_discount": {
+                    "description": "invoice_level_discount is the discount amount in invoice currency applied to all line items on the invoice.",
+                    "type": "string"
+                },
+                "line_item_discount": {
+                    "description": "line_item_discount is the discount amount in invoice currency applied directly to this line item.",
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/types.Metadata"
+                },
+                "meter_display_name": {
+                    "type": "string"
+                },
+                "meter_id": {
+                    "type": "string"
+                },
+                "period_end": {
+                    "type": "string"
+                },
+                "period_start": {
+                    "type": "string"
+                },
+                "plan_display_name": {
+                    "type": "string"
+                },
+                "prepaid_credits_applied": {
+                    "description": "prepaid_credits_applied is the amount in invoice currency reduced from this line item due to prepaid credits application.",
+                    "type": "string"
+                },
+                "price_id": {
+                    "type": "string"
+                },
+                "price_type": {
+                    "type": "string"
+                },
+                "price_unit": {
+                    "type": "string"
+                },
+                "price_unit_amount": {
+                    "type": "string"
+                },
+                "price_unit_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "type": "string"
+                },
+                "subscription_line_item_id": {
+                    "description": "sub_line_item_id links this invoice line item to the subscription_line_item that generated it.",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "meter.Aggregation": {
+            "type": "object",
+            "properties": {
+                "bucket_size": {
+                    "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
+                    "$ref": "#/definitions/types.WindowSize"
+                },
+                "expression": {
+                    "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).",
+                    "type": "string"
+                },
+                "field": {
+                    "description": "Field is the key in $event.properties on which the aggregation is to be applied\nFor ex if the aggregation type is sum for API usage, the field could be \"duration_ms\"\nIgnored when Expression is set.",
+                    "type": "string"
+                },
+                "group_by": {
+                    "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total.",
+                    "type": "string"
+                },
+                "multiplier": {
+                    "description": "Multiplier is the multiplier for the aggregation\nFor ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000\nto scale up by a factor of 1000. If not provided, it will be null.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/types.AggregationType"
+                }
+            }
+        },
+        "meter.Filter": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Key is the key for the filter from $event.properties\nCurrently we support only first level keys in the properties and not nested keys",
+                    "type": "string"
+                },
+                "values": {
+                    "description": "Values are the possible values for the filter to be considered for the meter\nFor ex \"model_name\" could have values \"o1-mini\", \"gpt-4o\" etc",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "meter.Meter": {
+            "type": "object",
+            "properties": {
+                "aggregation": {
+                    "description": "Aggregation defines the aggregation type and field for the meter\nIt is used to aggregate the events into a single value for calculating the usage",
+                    "$ref": "#/definitions/meter.Aggregation"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the meter",
+                    "type": "string"
+                },
+                "event_name": {
+                    "description": "EventName is the unique identifier for the event that this meter is tracking\nIt is a mandatory field in the events table and hence being used as the primary matching field\nWe can have multiple meters tracking the same event but with different filters and aggregation",
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "Filters define the criteria for the meter to be applied on the events before aggregation\nIt also defines the possible values on which later the charges will be applied",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/meter.Filter"
+                    }
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the meter",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the display name of the meter",
+                    "type": "string"
+                },
+                "reset_usage": {
+                    "description": "ResetUsage defines whether the usage should be reset periodically or not\nFor ex meters tracking total storage used do not get reset but meters tracking\ntotal API requests do.",
+                    "$ref": "#/definitions/types.ResetUsage"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TemporalWorkflowResult": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "run_id": {
+                    "type": "string"
+                },
+                "workflow_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "price.JSONBFilters": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        "price.JSONBMetadata": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "price.JSONBTransformQuantity": {
+            "type": "object",
+            "properties": {
+                "divide_by": {
+                    "description": "Divide quantity by this number",
+                    "type": "integer"
+                },
+                "round": {
+                    "description": "up or down",
+                    "$ref": "#/definitions/types.RoundType"
+                }
+            }
+        },
+        "price.Price": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "description": "Amount stored in main currency units (e.g., dollars, not cents)\nFor USD: 12.50 means $12.50",
+                    "type": "string"
+                },
+                "billing_cadence": {
+                    "$ref": "#/definitions/types.BillingCadence"
+                },
+                "billing_model": {
+                    "$ref": "#/definitions/types.BillingModel"
+                },
+                "billing_period": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                },
+                "billing_period_count": {
+                    "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
+                    "type": "integer",
+                    "default": 1
+                },
+                "conversion_rate": {
+                    "description": "ConversionRate is the conversion rate of the price unit to the fiat currency",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "description": "Currency 3 digit ISO currency code in lowercase ex usd, eur, gbp",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Description of the price",
+                    "type": "string"
+                },
+                "display_amount": {
+                    "description": "DisplayAmount is the formatted amount with currency symbol\nFor USD: $12.50",
+                    "type": "string"
+                },
+                "display_name": {
+                    "description": "DisplayName is the name of the price",
+                    "type": "string"
+                },
+                "display_price_unit_amount": {
+                    "description": "DisplayPriceUnitAmount is the formatted amount of the price unit",
+                    "type": "string"
+                },
+                "end_date": {
+                    "description": "EndDate is the end date of the price",
+                    "type": "string"
+                },
+                "entity_id": {
+                    "description": "EntityID holds the value of the \"entity_id\" field.",
+                    "type": "string"
+                },
+                "entity_type": {
+                    "description": "EntityType holds the value of the \"entity_type\" field.",
+                    "$ref": "#/definitions/types.PriceEntityType"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the price",
+                    "type": "string"
+                },
+                "group_id": {
+                    "description": "GroupID references the group this price belongs to",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID uuid identifier for the price",
+                    "type": "string"
+                },
+                "invoice_cadence": {
+                    "$ref": "#/definitions/types.InvoiceCadence"
+                },
+                "lookup_key": {
+                    "description": "LookupKey used for looking up the price in the database",
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/price.JSONBMetadata"
+                },
+                "meter_id": {
+                    "description": "MeterID is the id of the meter for usage based pricing",
+                    "type": "string"
+                },
+                "min_quantity": {
+                    "description": "MinQuantity is the minimum quantity of the price",
+                    "type": "string",
+                    "x-nullable": true
+                },
+                "parent_price_id": {
+                    "description": "ParentPriceID references the root price (always set for price lineage tracking)",
+                    "type": "string"
+                },
+                "price_unit": {
+                    "description": "PriceUnit is the code of the price unit (e.g., 'btc', 'eth')",
+                    "type": "string"
+                },
+                "price_unit_amount": {
+                    "description": "PriceUnitAmount is the amount of the price unit",
+                    "type": "string"
+                },
+                "price_unit_id": {
+                    "description": "PriceUnitID is the id of the price unit (for CUSTOM type)",
+                    "type": "string"
+                },
+                "price_unit_tiers": {
+                    "description": "PriceUnitTiers are the tiers for the price unit when BillingModel is TIERED",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/price.PriceTier"
+                    }
+                },
+                "price_unit_type": {
+                    "description": "PriceUnitType is the type of the price unit (FIAT, CUSTOM)",
+                    "$ref": "#/definitions/types.PriceUnitType"
+                },
+                "sequence": {
+                    "description": "Sequence is the monotonic stamp bumped on every state change that\nsubscription line items need to react to. Read by the plan-price sync;\nset by the database (DEFAULT nextval) on create and by the price\nrepository on termination / compatibility-affecting edits.",
+                    "type": "integer"
+                },
+                "start_date": {
+                    "description": "StartDate is the start date of the price",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "tier_mode": {
+                    "$ref": "#/definitions/types.BillingTier"
+                },
+                "tiers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/price.PriceTier"
+                    }
+                },
+                "transform_quantity": {
+                    "$ref": "#/definitions/price.JSONBTransformQuantity"
+                },
+                "trial_period_days": {
+                    "description": "TrialPeriodDays is the number of days for the trial period\nNote: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)",
+                    "type": "integer"
+                },
+                "type": {
+                    "$ref": "#/definitions/types.PriceType"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "price.PriceTier": {
+            "type": "object",
+            "properties": {
+                "flat_amount": {
+                    "description": "flat_amount is the flat amount for the given tier (optional)\nApplied on top of unit_amount*quantity. Useful for cases like \"2.7$ + 5c\"",
+                    "type": "string"
+                },
+                "unit_amount": {
+                    "description": "unit_amount is the amount per unit for the given tier",
+                    "type": "string"
+                },
+                "up_to": {
+                    "description": "up_to is the quantity up to which this tier applies. It is null for the last tier.\nIMPORTANT: Tier boundaries are INCLUSIVE.\n- If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier\n- This behavior is consistent across both VOLUME and SLAB tier modes",
+                    "type": "integer"
+                }
+            }
+        },
+        "price.TransformQuantity": {
+            "type": "object",
+            "properties": {
+                "divide_by": {
+                    "description": "Divide quantity by this number",
+                    "type": "integer"
+                },
+                "round": {
+                    "description": "up or down",
+                    "$ref": "#/definitions/types.RoundType"
+                }
+            }
+        },
+        "subscription.SubscriptionLineItem": {
+            "type": "object",
+            "properties": {
+                "addon_association_id": {
+                    "type": "string"
+                },
+                "billing_period": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                },
+                "billing_period_count": {
+                    "description": "from price at create; default 1",
+                    "type": "integer"
+                },
+                "commitment_amount": {
+                    "description": "Commitment fields",
+                    "type": "string"
+                },
+                "commitment_duration": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                },
+                "commitment_overage_factor": {
+                    "type": "string"
+                },
+                "commitment_quantity": {
+                    "type": "string"
+                },
+                "commitment_time_buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.TimeOfDayBucket"
+                    }
+                },
+                "commitment_true_up_enabled": {
+                    "type": "boolean"
+                },
+                "commitment_type": {
+                    "$ref": "#/definitions/types.CommitmentType"
+                },
+                "commitment_windowed": {
+                    "type": "boolean"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "currency": {
+                    "type": "string"
+                },
+                "customer_id": {
+                    "type": "string"
+                },
+                "display_name": {
+                    "type": "string"
+                },
+                "end_date": {
+                    "type": "string"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_type": {
+                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
+                },
+                "environment_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "invoice_cadence": {
+                    "$ref": "#/definitions/types.InvoiceCadence"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "meter": {
+                    "description": "Meter is populated when the caller adds \"meters\" to a subscription-scoped\nexpand string alongside \"subscription_line_items\". Only usage line items\n(PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.",
+                    "$ref": "#/definitions/meter.Meter"
+                },
+                "meter_display_name": {
+                    "type": "string"
+                },
+                "meter_id": {
+                    "type": "string"
+                },
+                "plan_display_name": {
+                    "type": "string"
+                },
+                "price": {
+                    "$ref": "#/definitions/price.Price"
+                },
+                "price_id": {
+                    "type": "string"
+                },
+                "price_type": {
+                    "$ref": "#/definitions/types.PriceType"
+                },
+                "price_unit": {
+                    "type": "string"
+                },
+                "price_unit_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "type": "string"
+                },
+                "subscription_phase_id": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "subscription.SubscriptionPause": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the pause",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the subscription pause",
+                    "type": "string"
+                },
+                "metadata": {
+                    "$ref": "#/definitions/types.Metadata"
+                },
+                "original_period_end": {
+                    "description": "OriginalPeriodEnd is the end of the billing period when the pause was created",
+                    "type": "string"
+                },
+                "original_period_start": {
+                    "description": "OriginalPeriodStart is the start of the billing period when the pause was created",
+                    "type": "string"
+                },
+                "pause_end": {
+                    "description": "PauseEnd is when the pause will end (null for indefinite)",
+                    "type": "string"
+                },
+                "pause_mode": {
+                    "$ref": "#/definitions/types.PauseMode"
+                },
+                "pause_start": {
+                    "description": "PauseStart is when the pause actually started",
+                    "type": "string"
+                },
+                "pause_status": {
+                    "$ref": "#/definitions/types.PauseStatus"
+                },
+                "reason": {
+                    "description": "Reason is the reason for pausing",
+                    "type": "string"
+                },
+                "resume_mode": {
+                    "$ref": "#/definitions/types.ResumeMode"
+                },
+                "resumed_at": {
+                    "description": "ResumedAt is when the pause was actually ended (if manually resumed)",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "description": "SubscriptionID is the identifier for the subscription",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "subscription.SubscriptionPhase": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "end_date": {
+                    "description": "EndDate is when the phase ends (nil if phase is still active or indefinite)",
+                    "type": "string"
+                },
+                "environment_id": {
+                    "description": "EnvironmentID is the environment identifier for the phase",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "ID is the unique identifier for the subscription phase",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "Metadata contains additional key-value pairs",
+                    "$ref": "#/definitions/types.Metadata"
+                },
+                "start_date": {
+                    "description": "StartDate is when the phase starts",
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                },
+                "subscription_id": {
+                    "description": "SubscriptionID is the identifier for the subscription",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.AWSMarketplaceSyncConfig": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.AlertSettingsFilter": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "end_time": {
+                    "type": "string"
+                },
+                "entity_id": {
+                    "type": "string"
+                },
+                "entity_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "entity_type": {
+                    "$ref": "#/definitions/types.AlertEntityType"
+                },
+                "expand": {
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "filters allows complex filtering based on multiple fields",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.FilterCondition"
+                    }
+                },
+                "limit": {
+                    "type": "integer",
+                    "maximum": 1000,
+                    "minimum": 1
+                },
+                "offset": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "order": {
+                    "type": "string",
+                    "enum": [
+                        "asc",
+                        "desc"
+                    ]
+                },
+                "parent_entity_id": {
+                    "type": "string"
+                },
+                "parent_entity_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "parent_entity_type": {
+                    "$ref": "#/definitions/types.AlertEntityType"
+                },
+                "sort": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.SortCondition"
+                    }
+                },
+                "start_time": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/types.Status"
+                }
+            }
+        },
+        "types.CheckoutPaymentProviderConfig": {
+            "type": "object",
+            "properties": {
+                "collection_method": {
+                    "$ref": "#/definitions/types.CollectionMethod"
+                },
+                "max_mandate_limit": {
+                    "type": "string"
+                },
+                "payment_method": {
+                    "$ref": "#/definitions/types.PaymentMethodType"
+                }
+            }
+        },
+        "types.DurationUnit": {
+            "type": "string",
+            "enum": [
+                "second",
+                "minute",
+                "hour",
+                "day"
+            ],
+            "x-enum-varnames": [
+                "DurationUnitSecond",
+                "DurationUnitMinute",
+                "DurationUnitHour",
+                "DurationUnitDay"
+            ]
+        },
+        "types.EntitlementAggregationMode": {
+            "type": "string",
+            "enum": [
+                "additive",
+                "parallel"
+            ],
+            "x-enum-varnames": [
+                "EntitlementAggregationModeAdditive",
+                "EntitlementAggregationModeParallel"
+            ]
+        },
+        "types.EntitlementGrantDurationUnit": {
+            "type": "string",
+            "enum": [
+                "hour",
+                "day",
+                "week"
+            ],
+            "x-enum-varnames": [
+                "EntitlementGrantDurationUnitHour",
+                "EntitlementGrantDurationUnitDay",
+                "EntitlementGrantDurationUnitWeek"
+            ]
+        },
+        "types.EntitlementGrantMeasure": {
+            "type": "string",
+            "enum": [
+                "quantity",
+                "amount"
+            ],
+            "x-enum-varnames": [
+                "EntitlementGrantMeasureQuantity",
+                "EntitlementGrantMeasureAmount"
+            ]
+        },
+        "types.ListResponse-dto_WalletResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/WalletResponse"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/types.PaginationResponse"
+                }
+            }
+        },
+        "types.Metadata": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "types.ModifySubscriptionLineItem": {
+            "type": "object",
+            "properties": {
+                "effective_date": {
+                    "type": "string"
+                },
+                "line_item_id": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.ModifySubscriptionParams": {
+            "type": "object",
+            "properties": {
+                "line_item_modifications": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.ModifySubscriptionLineItem"
+                    }
+                },
+                "subscription_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.RejectedEventReason": {
+            "type": "string",
+            "enum": [
+                "no_meter_for_event_name",
+                "no_matching_meter"
+            ],
+            "x-enum-varnames": [
+                "RejectedEventReasonNoMeterForName",
+                "RejectedEventReasonNoMatchingMeter"
+            ]
+        },
+        "types.WalletTopupParams": {
+            "type": "object",
+            "required": [
+                "wallet_id"
+            ],
+            "properties": {
+                "wallet_id": {
+                    "type": "string"
+                },
+                "wallet_transaction_id": {
                     "type": "string"
                 }
             }
@@ -27303,6 +27848,9 @@
         "webhookDto.TransactionUpdatedWebhookPayload": {
             "type": "object",
             "properties": {
+                "customer": {
+                    "$ref": "#/definitions/CustomerResponse"
+                },
                 "event_type": {
                     "$ref": "#/definitions/types.WebhookEventName"
                 },
@@ -27317,6 +27865,9 @@
         "webhookDto.TransactionWebhookPayload": {
             "type": "object",
             "properties": {
+                "customer": {
+                    "$ref": "#/definitions/CustomerResponse"
+                },
                 "event_type": {
                     "$ref": "#/definitions/types.WebhookEventName"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -185,6 +185,10 @@ definitions:
     properties:
       create_subscription_params:
         $ref: '#/definitions/types.CreateSubscriptionParams'
+      modify_subscription_params:
+        $ref: '#/definitions/types.ModifySubscriptionParams'
+      wallet_topup_params:
+        $ref: '#/definitions/types.WalletTopupParams'
     type: object
   checkout.JSONBCheckoutPaymentProviderConfig:
     properties:
@@ -395,6 +399,30 @@ definitions:
       updated_by:
         type: string
     type: object
+  AWSMarketplaceAgreement:
+    properties:
+      concurrent_agreements:
+        description: if true, ProductCode is omitted when reporting
+        type: boolean
+      customer_aws_account_id:
+        description: -> BatchMeterUsage's CustomerAWSAccountId
+        type: string
+      dimension:
+        description: -> BatchMeterUsage's Dimension (always "usage_fee" in the cents
+          model)
+        type: string
+      license_arn:
+        description: -> BatchMeterUsage's LicenseArn; identifies the buyer's agreement
+        type: string
+      product_code:
+        description: -> BatchMeterUsage's ProductCode (omitted when ConcurrentAgreements)
+        type: string
+    required:
+    - customer_aws_account_id
+    - dimension
+    - license_arn
+    - product_code
+    type: object
   ActivateDraftSubscriptionRequest:
     properties:
       start_date:
@@ -418,6 +446,12 @@ definitions:
       metadata:
         additionalProperties: true
         type: object
+      override_line_items:
+        description: OverrideLineItems allows overriding price/quantity/billing model
+          for specific addon prices
+        items:
+          $ref: '#/definitions/OverrideLineItemRequest'
+        type: array
       proration_behavior:
         $ref: '#/definitions/types.ProrationBehavior'
       start_date:
@@ -443,6 +477,12 @@ definitions:
       metadata:
         additionalProperties: true
         type: object
+      override_line_items:
+        description: OverrideLineItems allows overriding price/quantity/billing model
+          for specific addon prices
+        items:
+          $ref: '#/definitions/OverrideLineItemRequest'
+        type: array
       proration_behavior:
         $ref: '#/definitions/types.ProrationBehavior'
       start_date:
@@ -555,6 +595,12 @@ definitions:
     type: object
   AggregatedEntitlement:
     properties:
+      aggregation_mode:
+        $ref: '#/definitions/types.EntitlementAggregationMode'
+      buckets:
+        items:
+          $ref: '#/definitions/AggregatedEntitlementBucket'
+        type: array
       config_values:
         items:
           additionalProperties: {}
@@ -572,6 +618,23 @@ definitions:
         type: integer
       usage_reset_period:
         $ref: '#/definitions/types.EntitlementUsageResetPeriod'
+    type: object
+  AggregatedEntitlementBucket:
+    properties:
+      entitlement_id:
+        type: string
+      grant_duration_unit:
+        $ref: '#/definitions/types.EntitlementGrantDurationUnit'
+      grant_duration_value:
+        type: integer
+      grant_measure:
+        $ref: '#/definitions/types.EntitlementGrantMeasure'
+      grant_quota:
+        type: string
+      source_entity_id:
+        type: string
+      usage_limit:
+        type: integer
     type: object
   AggregatedFeature:
     properties:
@@ -666,6 +729,27 @@ definitions:
         $ref: '#/definitions/MeterUsageAttribution'
       status:
         $ref: '#/definitions/types.DebugTrackerStatus'
+    type: object
+  AzureMarketplaceAgreement:
+    properties:
+      beneficiary_account_id:
+        description: writes the customer mapping; not read in the report payload
+        type: string
+      dimension:
+        description: -> usageEvent's dimension (always "usage_fee" in the cents model)
+        type: string
+      plan_id:
+        description: -> usageEvent's planId; Azure's plan id, distinct from the request's
+          top-level PlanID
+        type: string
+      resource_id:
+        description: -> usageEvent's resourceId; the Azure SaaS subscription id
+        type: string
+    required:
+    - beneficiary_account_id
+    - dimension
+    - plan_id
+    - resource_id
     type: object
   BillingCycleInfo:
     properties:
@@ -941,6 +1025,27 @@ definitions:
     x-enum-varnames:
     - ChangedSubscriptionActionCreated
     - ChangedSubscriptionActionUpdated
+  CheckoutParams:
+    properties:
+      cancel_url:
+        type: string
+      failure_url:
+        type: string
+      idempotency_key:
+        type: string
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
+      payment_provider:
+        $ref: '#/definitions/types.CheckoutPaymentProvider'
+      payment_provider_config:
+        $ref: '#/definitions/types.CheckoutPaymentProviderConfig'
+      success_url:
+        type: string
+    required:
+    - payment_provider
+    type: object
   CheckoutSessionResponse:
     properties:
       action:
@@ -1770,6 +1875,10 @@ definitions:
         description: name is the full name or company name of the customer
         maxLength: 255
         type: string
+      onboarding_workflow_name:
+        description: onboarding_workflow_name is given if a custom onboarding workflow
+          is to be triggered for this customer
+        type: string
       skip_onboarding_workflow:
         description: |-
           skip_onboarding_workflow when true, prevents the customer onboarding workflow from being triggered
@@ -1793,6 +1902,8 @@ definitions:
     type: object
   CreateEntitlementRequest:
     properties:
+      aggregation_mode:
+        $ref: '#/definitions/types.EntitlementAggregationMode'
       config_value:
         additionalProperties: true
         type: object
@@ -1806,6 +1917,16 @@ definitions:
         type: string
       feature_type:
         $ref: '#/definitions/types.FeatureType'
+      grant_duration_unit:
+        $ref: '#/definitions/types.EntitlementGrantDurationUnit'
+      grant_duration_value:
+        type: integer
+      grant_measure:
+        allOf:
+        - $ref: '#/definitions/types.EntitlementGrantMeasure'
+        description: Grant config — optional. All-or-nothing; see entitlement.validateGrantConfig.
+      grant_quota:
+        type: string
       is_enabled:
         type: boolean
       is_soft_limit:
@@ -3287,6 +3408,8 @@ definitions:
     properties:
       addon:
         $ref: '#/definitions/AddonResponse'
+      aggregation_mode:
+        $ref: '#/definitions/types.EntitlementAggregationMode'
       config_value:
         additionalProperties: true
         type: object
@@ -3310,6 +3433,18 @@ definitions:
         type: string
       feature_type:
         $ref: '#/definitions/types.FeatureType'
+      grant_duration_unit:
+        $ref: '#/definitions/types.EntitlementGrantDurationUnit'
+      grant_duration_value:
+        type: integer
+      grant_measure:
+        allOf:
+        - $ref: '#/definitions/types.EntitlementGrantMeasure'
+        description: |-
+          Grant config; all-or-nothing set (see validateGrantConfig). Presence of a
+          grant config turns the entitlement into a time-boxed bucket source.
+      grant_quota:
+        type: number
       id:
         type: string
       is_enabled:
@@ -3435,6 +3570,8 @@ definitions:
     type: object
   ExecuteSubscriptionModifyRequest:
     properties:
+      checkout:
+        $ref: '#/definitions/CheckoutParams'
       coupon_params:
         $ref: '#/definitions/SubModifyCouponParams'
       grouped_invoicing_params:
@@ -3542,6 +3679,26 @@ definitions:
       usage_percent:
         type: string
     type: object
+  GCPMarketplaceAgreement:
+    properties:
+      account_id:
+        description: writes the customer mapping; not read in the report payload
+        type: string
+      metric_name:
+        description: -> services.report's metricName (always "{service_name}/usage_fee")
+        type: string
+      service_name:
+        description: -> services.report URL's service_name; identifies the product
+        type: string
+      usage_reporting_id:
+        description: -> services.report's consumerId; identifies the buyer
+        type: string
+    required:
+    - account_id
+    - metric_name
+    - service_name
+    - usage_reporting_id
+    type: object
   GetCostAnalyticsRequest:
     properties:
       end_time:
@@ -3559,11 +3716,26 @@ definitions:
         items:
           type: string
         type: array
+      include_children:
+        description: |-
+          IncludeChildren, when true and ExternalCustomerID belongs to a parent
+          customer, aggregates every inherited-child customer's usage into the
+          revenue and cost totals. Default (false) restricts the query to the
+          customer's own usage — mirrors the meter-usage analytics contract.
+        type: boolean
       limit:
         description: Pagination
         type: integer
       offset:
         type: integer
+      property_filters:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        description: Property filters to filter the events by the keys in `properties`
+          field of the event
+        type: object
       start_time:
         description: Time range fields (optional - defaults to last 7 days if not
           provided)
@@ -3691,6 +3863,16 @@ definitions:
         type: integer
       total_count:
         type: integer
+    type: object
+  GetHuggingFaceBillingDataRequest:
+    properties:
+      requestIds:
+        items:
+          type: string
+        minItems: 1
+        type: array
+    required:
+    - requestIds
     type: object
   GetHuggingFaceBillingDataResponse:
     properties:
@@ -4032,6 +4214,16 @@ definitions:
     x-enum-varnames:
     - GroupedInvoicingActionAdd
     - GroupedInvoicingActionRemove
+  GroupedInvoicingChildRequest:
+    properties:
+      external_customer_id:
+        type: string
+      plan_id:
+        type: string
+    required:
+    - external_customer_id
+    - plan_id
+    type: object
   IngestEventRequest:
     properties:
       customer_id:
@@ -4500,7 +4692,6 @@ definitions:
         type: string
     required:
     - id
-    - quantity
     type: object
   LinkIntegrationMappingRequest:
     properties:
@@ -4788,6 +4979,8 @@ definitions:
         type: string
       destination_type:
         $ref: '#/definitions/types.PaymentDestinationType'
+      environment_id:
+        type: string
       error_message:
         type: string
       failed_at:
@@ -5154,32 +5347,31 @@ definitions:
     type: object
   RegisterMarketplaceAgreementRequest:
     properties:
-      concurrent_agreements:
-        type: boolean
-      customer_aws_account_id:
-        type: string
+      aws:
+        allOf:
+        - $ref: '#/definitions/AWSMarketplaceAgreement'
+        description: required iff Provider == aws_marketplace
+      azure:
+        allOf:
+        - $ref: '#/definitions/AzureMarketplaceAgreement'
+        description: required iff Provider == azure_marketplace
       customer_id:
         type: string
-      dimension:
-        type: string
-      license_arn:
-        type: string
+      gcp:
+        allOf:
+        - $ref: '#/definitions/GCPMarketplaceAgreement'
+        description: required iff Provider == gcp_marketplace
       plan_id:
         type: string
-      product_code:
-        type: string
       provider:
-        description: e.g. "aws"
-        type: string
+        allOf:
+        - $ref: '#/definitions/types.SecretProvider'
+        description: '"aws_marketplace" | "gcp_marketplace" | "azure_marketplace"'
       subscription_id:
         type: string
     required:
-    - customer_aws_account_id
     - customer_id
-    - dimension
-    - license_arn
     - plan_id
-    - product_code
     - provider
     - subscription_id
     type: object
@@ -5614,6 +5806,12 @@ definitions:
         items:
           type: string
         type: array
+      grouped_invoicing_children_to_create:
+        description: grouped_invoicing_children_to_create creates new grouped_invoicing
+          children under this parent
+        items:
+          $ref: '#/definitions/GroupedInvoicingChildRequest'
+        type: array
       invoicing_customer_external_id:
         description: |-
           InvoicingCustomerExternalID sets a different billing recipient (external ID).
@@ -5697,6 +5895,13 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      meter:
+        allOf:
+        - $ref: '#/definitions/meter.Meter'
+        description: |-
+          Meter is populated when the caller adds "meters" to a subscription-scoped
+          expand string alongside "subscription_line_items". Only usage line items
+          (PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.
       meter_display_name:
         type: string
       meter_id:
@@ -5736,6 +5941,13 @@ definitions:
         allOf:
         - $ref: '#/definitions/ChangedResources'
         description: All resources created or mutated as a result of this modification.
+      checkout_session:
+        allOf:
+        - $ref: '#/definitions/CheckoutSessionResponse'
+        description: |-
+          CheckoutSession is set on pay-first execute when payment must be collected
+          before line-item changes apply. Reuses CheckoutSessionResponse (payment_action
+          at session root). Omitted for pay-later and preview.
       subscription:
         allOf:
         - $ref: '#/definitions/SubscriptionResponse'
@@ -5994,6 +6206,14 @@ definitions:
       end_date:
         description: EndDate is the end date of the subscription
         type: string
+      entitlements:
+        description: |-
+          Entitlements is populated only when the caller adds "entitlements" to
+          the search filter's expand string. Each entry is a feature with its
+          aggregated entitlement info (same shape as CustomerEntitlementsResponse.Features).
+        items:
+          $ref: '#/definitions/AggregatedFeature'
+        type: array
       environment_id:
         description: EnvironmentID is the environment identifier for the subscription
         type: string
@@ -6682,6 +6902,12 @@ definitions:
           ex if the wallet has a conversion_rate of 2 then adding an amount of
           10 USD in the wallet wil add 5 credits in the wallet
         type: string
+      bonus_credits_expiry_date_utc:
+        description: |-
+          bonus_credits_expiry_date_utc is the expiry (UTC, full precision) applied to the bonus
+          credits transaction. Independent of expiry_date_utc, which governs the purchase credits.
+          Only honored when bonus credits are actually granted (explicit BonusCreditsToAdd or slab).
+        type: string
       bonus_credits_to_add:
         description: |-
           bonus_credits_to_add is an explicit override for the bonus credits granted alongside this
@@ -6689,6 +6915,13 @@ definitions:
           bonus_credits_topup_config slabs (if enabled). When set, it must be greater than 0 and is
           used as-is, skipping slab resolution. To grant no bonus, omit this field entirely.
         type: string
+      checkout:
+        allOf:
+        - $ref: '#/definitions/CheckoutParams'
+        description: |-
+          checkout opts into pay-first hosted checkout for PURCHASED_CREDIT_INVOICED top-ups.
+          When set, credits are applied only after checkout payment succeeds.
+          Omit for today's pay-later / auto-complete behavior.
       credits_to_add:
         description: credits_to_add is the number of credits to add to the wallet
         type: string
@@ -6700,6 +6933,8 @@ definitions:
           expiry_date_utc is the expiry date in UTC timezone
           ex 2025-01-01 00:00:00 UTC
         type: string
+      force_sync_invoice:
+        type: boolean
       idempotency_key:
         description: idempotency_key is a unique key for the transaction
         type: string
@@ -6721,6 +6956,11 @@ definitions:
     type: object
   TopUpWalletResponse:
     properties:
+      checkout_session:
+        allOf:
+        - $ref: '#/definitions/CheckoutSessionResponse'
+        description: CheckoutSession is set when pay-first checkout was requested
+          on top-up.
       invoice_id:
         description: Invoice ID if an invoice was created (only for PURCHASED_CREDIT_INVOICED)
         type: string
@@ -6885,9 +7125,24 @@ definitions:
     type: object
   UpdateEntitlementRequest:
     properties:
+      aggregation_mode:
+        $ref: '#/definitions/types.EntitlementAggregationMode'
+      clear_grant_config:
+        description: |-
+          Grant config — nil fields leave the current value alone.
+          ClearGrantConfig=true wipes the whole grant config (back to a legacy entitlement).
+        type: boolean
       config_value:
         additionalProperties: true
         type: object
+      grant_duration_unit:
+        $ref: '#/definitions/types.EntitlementGrantDurationUnit'
+      grant_duration_value:
+        type: integer
+      grant_measure:
+        $ref: '#/definitions/types.EntitlementGrantMeasure'
+      grant_quota:
+        type: string
       is_enabled:
         type: boolean
       is_soft_limit:
@@ -7712,15 +7967,6 @@ definitions:
     - ErrCodeServiceUnavailable
     - ErrCodeTooManyRequests
     - ErrCodeNotImplemented
-  errors.ErrorResponse:
-    properties:
-      code:
-        $ref: '#/definitions/errors.ErrorCode'
-      http_status_code:
-        type: integer
-      message:
-        type: string
-    type: object
   Addon:
     properties:
       created_at:
@@ -7937,606 +8183,13 @@ definitions:
       updated_by:
         type: string
     type: object
-  types.Bucket:
+  errors.ErrorResponse:
     properties:
-      hour:
-        maximum: 24
-        minimum: 0
+      code:
+        $ref: '#/definitions/errors.ErrorCode'
+      http_status_code:
         type: integer
-      minute:
-        maximum: 59
-        minimum: 0
-        type: integer
-    type: object
-  types.Value:
-    properties:
-      array:
-        items:
-          type: string
-        type: array
-      boolean:
-        type: boolean
-      date:
-        type: string
-      number:
-        type: number
-      string:
-        type: string
-    type: object
-  group.Group:
-    properties:
-      created_at:
-        type: string
-      created_by:
-        type: string
-      entity_type:
-        $ref: '#/definitions/types.GroupEntityType'
-      environment_id:
-        type: string
-      id:
-        type: string
-      lookup_key:
-        type: string
-      metadata:
-        additionalProperties:
-          type: string
-        type: object
-      name:
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-      tenant_id:
-        type: string
-      updated_at:
-        type: string
-      updated_by:
-        type: string
-    type: object
-  invoice.InvoiceLineItem:
-    properties:
-      adjusted_entitlement_quantity:
-        description: |-
-          adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.
-          Nil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity.
-        type: string
-      amount:
-        type: string
-      commitment_info:
-        $ref: '#/definitions/types.CommitmentInfo'
-      created_at:
-        type: string
-      created_by:
-        type: string
-      currency:
-        type: string
-      customer_id:
-        type: string
-      display_name:
-        type: string
-      entity_id:
-        type: string
-      entity_type:
-        type: string
-      environment_id:
-        type: string
-      id:
-        type: string
-      invoice_id:
-        type: string
-      invoice_level_discount:
-        description: invoice_level_discount is the discount amount in invoice currency
-          applied to all line items on the invoice.
-        type: string
-      line_item_discount:
-        description: line_item_discount is the discount amount in invoice currency
-          applied directly to this line item.
-        type: string
-      metadata:
-        $ref: '#/definitions/types.Metadata'
-      meter_display_name:
-        type: string
-      meter_id:
-        type: string
-      period_end:
-        type: string
-      period_start:
-        type: string
-      plan_display_name:
-        type: string
-      prepaid_credits_applied:
-        description: prepaid_credits_applied is the amount in invoice currency reduced
-          from this line item due to prepaid credits application.
-        type: string
-      price_id:
-        type: string
-      price_type:
-        type: string
-      price_unit:
-        type: string
-      price_unit_amount:
-        type: string
-      price_unit_id:
-        type: string
-      quantity:
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-      subscription_id:
-        type: string
-      subscription_line_item_id:
-        description: sub_line_item_id links this invoice line item to the subscription_line_item
-          that generated it.
-        type: string
-      tenant_id:
-        type: string
-      updated_at:
-        type: string
-      updated_by:
-        type: string
-    type: object
-  meter.Aggregation:
-    properties:
-      bucket_size:
-        allOf:
-        - $ref: '#/definitions/types.WindowSize'
-        description: |-
-          BucketSize is used only for MAX aggregation when windowed aggregation is needed
-          It defines the size of time windows to calculate max values within
-      expression:
-        description: |-
-          Expression is an optional CEL expression to compute per-event quantity from event.properties.
-          When set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).
-        type: string
-      field:
-        description: |-
-          Field is the key in $event.properties on which the aggregation is to be applied
-          For ex if the aggregation type is sum for API usage, the field could be "duration_ms"
-          Ignored when Expression is set.
-        type: string
-      group_by:
-        description: |-
-          GroupBy is the property name in event.properties to group by before aggregating.
-          Currently only supported for MAX aggregation with bucket_size.
-          When set, aggregation is applied per unique value of this property within each bucket,
-          then the per-group results are summed to produce the bucket total.
-        type: string
-      multiplier:
-        description: |-
-          Multiplier is the multiplier for the aggregation
-          For ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000
-          to scale up by a factor of 1000. If not provided, it will be null.
-        type: string
-      type:
-        $ref: '#/definitions/types.AggregationType'
-    type: object
-  meter.Filter:
-    properties:
-      key:
-        description: |-
-          Key is the key for the filter from $event.properties
-          Currently we support only first level keys in the properties and not nested keys
-        type: string
-      values:
-        description: |-
-          Values are the possible values for the filter to be considered for the meter
-          For ex "model_name" could have values "o1-mini", "gpt-4o" etc
-        items:
-          type: string
-        type: array
-    type: object
-  meter.Meter:
-    properties:
-      aggregation:
-        allOf:
-        - $ref: '#/definitions/meter.Aggregation'
-        description: |-
-          Aggregation defines the aggregation type and field for the meter
-          It is used to aggregate the events into a single value for calculating the usage
-      created_at:
-        type: string
-      created_by:
-        type: string
-      environment_id:
-        description: EnvironmentID is the environment identifier for the meter
-        type: string
-      event_name:
-        description: |-
-          EventName is the unique identifier for the event that this meter is tracking
-          It is a mandatory field in the events table and hence being used as the primary matching field
-          We can have multiple meters tracking the same event but with different filters and aggregation
-        type: string
-      filters:
-        description: |-
-          Filters define the criteria for the meter to be applied on the events before aggregation
-          It also defines the possible values on which later the charges will be applied
-        items:
-          $ref: '#/definitions/meter.Filter'
-        type: array
-      id:
-        description: ID is the unique identifier for the meter
-        type: string
-      name:
-        description: Name is the display name of the meter
-        type: string
-      reset_usage:
-        allOf:
-        - $ref: '#/definitions/types.ResetUsage'
-        description: |-
-          ResetUsage defines whether the usage should be reset periodically or not
-          For ex meters tracking total storage used do not get reset but meters tracking
-          total API requests do.
-      status:
-        $ref: '#/definitions/types.Status'
-      tenant_id:
-        type: string
-      updated_at:
-        type: string
-      updated_by:
-        type: string
-    type: object
-  models.TemporalWorkflowResult:
-    properties:
       message:
-        type: string
-      run_id:
-        type: string
-      workflow_id:
-        type: string
-    type: object
-  price.JSONBFilters:
-    additionalProperties:
-      items:
-        type: string
-      type: array
-    type: object
-  price.JSONBMetadata:
-    additionalProperties:
-      type: string
-    type: object
-  price.JSONBTransformQuantity:
-    properties:
-      divide_by:
-        description: Divide quantity by this number
-        type: integer
-      round:
-        allOf:
-        - $ref: '#/definitions/types.RoundType'
-        description: up or down
-    type: object
-  price.Price:
-    properties:
-      amount:
-        description: |-
-          Amount stored in main currency units (e.g., dollars, not cents)
-          For USD: 12.50 means $12.50
-        type: string
-      billing_cadence:
-        $ref: '#/definitions/types.BillingCadence'
-      billing_model:
-        $ref: '#/definitions/types.BillingModel'
-      billing_period:
-        $ref: '#/definitions/types.BillingPeriod'
-      billing_period_count:
-        default: 1
-        description: BillingPeriodCount is the count of the billing period ex 1, 3,
-          6, 12
-        type: integer
-      conversion_rate:
-        description: ConversionRate is the conversion rate of the price unit to the
-          fiat currency
-        type: string
-      created_at:
-        type: string
-      created_by:
-        type: string
-      currency:
-        description: Currency 3 digit ISO currency code in lowercase ex usd, eur,
-          gbp
-        type: string
-      description:
-        description: Description of the price
-        type: string
-      display_amount:
-        description: |-
-          DisplayAmount is the formatted amount with currency symbol
-          For USD: $12.50
-        type: string
-      display_name:
-        description: DisplayName is the name of the price
-        type: string
-      display_price_unit_amount:
-        description: DisplayPriceUnitAmount is the formatted amount of the price unit
-        type: string
-      end_date:
-        description: EndDate is the end date of the price
-        type: string
-      entity_id:
-        description: EntityID holds the value of the "entity_id" field.
-        type: string
-      entity_type:
-        allOf:
-        - $ref: '#/definitions/types.PriceEntityType'
-        description: EntityType holds the value of the "entity_type" field.
-      environment_id:
-        description: EnvironmentID is the environment identifier for the price
-        type: string
-      group_id:
-        description: GroupID references the group this price belongs to
-        type: string
-      id:
-        description: ID uuid identifier for the price
-        type: string
-      invoice_cadence:
-        $ref: '#/definitions/types.InvoiceCadence'
-      lookup_key:
-        description: LookupKey used for looking up the price in the database
-        type: string
-      metadata:
-        $ref: '#/definitions/price.JSONBMetadata'
-      meter_id:
-        description: MeterID is the id of the meter for usage based pricing
-        type: string
-      min_quantity:
-        description: MinQuantity is the minimum quantity of the price
-        type: string
-        x-nullable: true
-      parent_price_id:
-        description: ParentPriceID references the root price (always set for price
-          lineage tracking)
-        type: string
-      price_unit:
-        description: PriceUnit is the code of the price unit (e.g., 'btc', 'eth')
-        type: string
-      price_unit_amount:
-        description: PriceUnitAmount is the amount of the price unit
-        type: string
-      price_unit_id:
-        description: PriceUnitID is the id of the price unit (for CUSTOM type)
-        type: string
-      price_unit_tiers:
-        description: PriceUnitTiers are the tiers for the price unit when BillingModel
-          is TIERED
-        items:
-          $ref: '#/definitions/price.PriceTier'
-        type: array
-      price_unit_type:
-        allOf:
-        - $ref: '#/definitions/types.PriceUnitType'
-        description: PriceUnitType is the type of the price unit (FIAT, CUSTOM)
-      sequence:
-        description: |-
-          Sequence is the monotonic stamp bumped on every state change that
-          subscription line items need to react to. Read by the plan-price sync;
-          set by the database (DEFAULT nextval) on create and by the price
-          repository on termination / compatibility-affecting edits.
-        type: integer
-      start_date:
-        description: StartDate is the start date of the price
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-      tenant_id:
-        type: string
-      tier_mode:
-        $ref: '#/definitions/types.BillingTier'
-      tiers:
-        items:
-          $ref: '#/definitions/price.PriceTier'
-        type: array
-      transform_quantity:
-        $ref: '#/definitions/price.JSONBTransformQuantity'
-      trial_period_days:
-        description: |-
-          TrialPeriodDays is the number of days for the trial period
-          Note: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)
-        type: integer
-      type:
-        $ref: '#/definitions/types.PriceType'
-      updated_at:
-        type: string
-      updated_by:
-        type: string
-    type: object
-  price.PriceTier:
-    properties:
-      flat_amount:
-        description: |-
-          flat_amount is the flat amount for the given tier (optional)
-          Applied on top of unit_amount*quantity. Useful for cases like "2.7$ + 5c"
-        type: string
-      unit_amount:
-        description: unit_amount is the amount per unit for the given tier
-        type: string
-      up_to:
-        description: |-
-          up_to is the quantity up to which this tier applies. It is null for the last tier.
-          IMPORTANT: Tier boundaries are INCLUSIVE.
-          - If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier
-          - This behavior is consistent across both VOLUME and SLAB tier modes
-        type: integer
-    type: object
-  price.TransformQuantity:
-    properties:
-      divide_by:
-        description: Divide quantity by this number
-        type: integer
-      round:
-        allOf:
-        - $ref: '#/definitions/types.RoundType'
-        description: up or down
-    type: object
-  subscription.SubscriptionLineItem:
-    properties:
-      addon_association_id:
-        type: string
-      billing_period:
-        $ref: '#/definitions/types.BillingPeriod'
-      billing_period_count:
-        description: from price at create; default 1
-        type: integer
-      commitment_amount:
-        description: Commitment fields
-        type: string
-      commitment_duration:
-        $ref: '#/definitions/types.BillingPeriod'
-      commitment_overage_factor:
-        type: string
-      commitment_quantity:
-        type: string
-      commitment_time_buckets:
-        items:
-          $ref: '#/definitions/types.TimeOfDayBucket'
-        type: array
-      commitment_true_up_enabled:
-        type: boolean
-      commitment_type:
-        $ref: '#/definitions/types.CommitmentType'
-      commitment_windowed:
-        type: boolean
-      created_at:
-        type: string
-      created_by:
-        type: string
-      currency:
-        type: string
-      customer_id:
-        type: string
-      display_name:
-        type: string
-      end_date:
-        type: string
-      entity_id:
-        type: string
-      entity_type:
-        $ref: '#/definitions/types.SubscriptionLineItemEntityType'
-      environment_id:
-        type: string
-      id:
-        type: string
-      invoice_cadence:
-        $ref: '#/definitions/types.InvoiceCadence'
-      metadata:
-        additionalProperties:
-          type: string
-        type: object
-      meter_display_name:
-        type: string
-      meter_id:
-        type: string
-      plan_display_name:
-        type: string
-      price:
-        $ref: '#/definitions/price.Price'
-      price_id:
-        type: string
-      price_type:
-        $ref: '#/definitions/types.PriceType'
-      price_unit:
-        type: string
-      price_unit_id:
-        type: string
-      quantity:
-        type: string
-      start_date:
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-      subscription_id:
-        type: string
-      subscription_phase_id:
-        type: string
-      tenant_id:
-        type: string
-      updated_at:
-        type: string
-      updated_by:
-        type: string
-    type: object
-  subscription.SubscriptionPause:
-    properties:
-      created_at:
-        type: string
-      created_by:
-        type: string
-      environment_id:
-        description: EnvironmentID is the environment identifier for the pause
-        type: string
-      id:
-        description: ID is the unique identifier for the subscription pause
-        type: string
-      metadata:
-        $ref: '#/definitions/types.Metadata'
-      original_period_end:
-        description: OriginalPeriodEnd is the end of the billing period when the pause
-          was created
-        type: string
-      original_period_start:
-        description: OriginalPeriodStart is the start of the billing period when the
-          pause was created
-        type: string
-      pause_end:
-        description: PauseEnd is when the pause will end (null for indefinite)
-        type: string
-      pause_mode:
-        $ref: '#/definitions/types.PauseMode'
-      pause_start:
-        description: PauseStart is when the pause actually started
-        type: string
-      pause_status:
-        $ref: '#/definitions/types.PauseStatus'
-      reason:
-        description: Reason is the reason for pausing
-        type: string
-      resume_mode:
-        $ref: '#/definitions/types.ResumeMode'
-      resumed_at:
-        description: ResumedAt is when the pause was actually ended (if manually resumed)
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-      subscription_id:
-        description: SubscriptionID is the identifier for the subscription
-        type: string
-      tenant_id:
-        type: string
-      updated_at:
-        type: string
-      updated_by:
-        type: string
-    type: object
-  subscription.SubscriptionPhase:
-    properties:
-      created_at:
-        type: string
-      created_by:
-        type: string
-      end_date:
-        description: EndDate is when the phase ends (nil if phase is still active
-          or indefinite)
-        type: string
-      environment_id:
-        description: EnvironmentID is the environment identifier for the phase
-        type: string
-      id:
-        description: ID is the unique identifier for the subscription phase
-        type: string
-      metadata:
-        allOf:
-        - $ref: '#/definitions/types.Metadata'
-        description: Metadata contains additional key-value pairs
-      start_date:
-        description: StartDate is when the phase starts
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-      subscription_id:
-        description: SubscriptionID is the identifier for the subscription
-        type: string
-      tenant_id:
-        type: string
-      updated_at:
-        type: string
-      updated_by:
         type: string
     type: object
   types.AddonAssociationEntityType:
@@ -8644,6 +8297,7 @@ definitions:
     - subscription
     - subscription_line_item
     - group
+    - entitlement_grant
     type: string
     x-enum-varnames:
     - AlertEntityTypeWallet
@@ -8651,6 +8305,7 @@ definitions:
     - AlertEntityTypeSubscription
     - AlertEntityTypeSubscriptionLineItem
     - AlertEntityTypeGroup
+    - AlertEntityTypeEntitlementGrant
   types.AlertInfo:
     properties:
       alert_settings:
@@ -8713,56 +8368,6 @@ definitions:
       warning:
         $ref: '#/definitions/types.AlertThreshold'
     type: object
-  types.AlertSettingsFilter:
-    properties:
-      enabled:
-        type: boolean
-      end_time:
-        type: string
-      entity_id:
-        type: string
-      entity_ids:
-        items:
-          type: string
-        type: array
-      entity_type:
-        $ref: '#/definitions/types.AlertEntityType'
-      expand:
-        type: string
-      filters:
-        description: filters allows complex filtering based on multiple fields
-        items:
-          $ref: '#/definitions/types.FilterCondition'
-        type: array
-      limit:
-        maximum: 1000
-        minimum: 1
-        type: integer
-      offset:
-        minimum: 0
-        type: integer
-      order:
-        enum:
-        - asc
-        - desc
-        type: string
-      parent_entity_id:
-        type: string
-      parent_entity_ids:
-        items:
-          type: string
-        type: array
-      parent_entity_type:
-        $ref: '#/definitions/types.AlertEntityType'
-      sort:
-        items:
-          $ref: '#/definitions/types.SortCondition'
-        type: array
-      start_time:
-        type: string
-      status:
-        $ref: '#/definitions/types.Status'
-    type: object
   types.AlertState:
     enum:
     - ok
@@ -8790,6 +8395,8 @@ definitions:
     - subscription_spend
     - subscription_line_item_spend
     - subscription_group_spend
+    - entitlement_grant_threshold
+    - entitlement_grant_exhausted
     type: string
     x-enum-varnames:
     - AlertTypeLowOngoingBalance
@@ -8798,6 +8405,8 @@ definitions:
     - AlertTypeSubscriptionSpend
     - AlertTypeSubscriptionLineItemSpend
     - AlertTypeSubscriptionGroupSpend
+    - AlertTypeEntitlementGrantThreshold
+    - AlertTypeEntitlementGrantExhausted
   types.ApplicationStatus:
     enum:
     - applied
@@ -8816,6 +8425,11 @@ definitions:
     properties:
       amount:
         type: number
+      cooldown:
+        allOf:
+        - $ref: '#/definitions/types.Duration'
+        description: Cooldown is an optional cooloff after a successful auto top-up
+          before another may run.
       enabled:
         type: boolean
       invoicing:
@@ -8873,6 +8487,17 @@ definitions:
     x-enum-varnames:
     - BILLING_TIER_VOLUME
     - BILLING_TIER_SLAB
+  types.Bucket:
+    properties:
+      hour:
+        maximum: 24
+        minimum: 0
+        type: integer
+      minute:
+        maximum: 59
+        minimum: 0
+        type: integer
+    type: object
   types.CancelImmediatelyInvoicePolicy:
     enum:
     - generate_invoice
@@ -8894,13 +8519,21 @@ definitions:
   types.CheckoutAction:
     enum:
     - create_subscription
+    - modify_subscription
+    - wallet_topup
     type: string
     x-enum-varnames:
     - CheckoutActionCreateSubscription
+    - CheckoutActionModifySubscription
+    - CheckoutActionWalletTopup
   types.CheckoutConfiguration:
     properties:
       create_subscription_params:
         $ref: '#/definitions/types.CreateSubscriptionParams'
+      modify_subscription_params:
+        $ref: '#/definitions/types.ModifySubscriptionParams'
+      wallet_topup_params:
+        $ref: '#/definitions/types.WalletTopupParams'
     type: object
   types.CheckoutPaymentProvider:
     enum:
@@ -8908,15 +8541,6 @@ definitions:
     type: string
     x-enum-varnames:
     - CheckoutPaymentProviderRazorpay
-  types.CheckoutPaymentProviderConfig:
-    properties:
-      collection_method:
-        $ref: '#/definitions/types.CollectionMethod'
-      max_mandate_limit:
-        type: string
-      payment_method:
-        $ref: '#/definitions/types.PaymentMethodType'
-    type: object
   types.CheckoutStatus:
     enum:
     - initiated
@@ -9238,6 +8862,17 @@ definitions:
     - DebugTrackerStatusError
     - DebugTrackerStatusProcessing
     - DebugTrackerStatusAttributed
+  types.Duration:
+    enum:
+    - 3600000000000
+    properties:
+      unit:
+        $ref: '#/definitions/types.DurationUnit'
+      value:
+        type: integer
+    type: object
+    x-enum-varnames:
+    - EntitlementGrantMinDuration
   types.EntitlementEntityType:
     enum:
     - PLAN
@@ -9271,6 +8906,10 @@ definitions:
         items:
           $ref: '#/definitions/types.FilterCondition'
         type: array
+      has_grant_config:
+        description: HasGrantConfig filters on grant-config presence (grant_quota
+          set or not).
+        type: boolean
       is_enabled:
         type: boolean
       limit:
@@ -9756,19 +9395,6 @@ definitions:
     - InvoiceTypeSubscription
     - InvoiceTypeOneOff
     - InvoiceTypeCredit
-  types.ListResponse-dto_WalletResponse:
-    properties:
-      items:
-        items:
-          $ref: '#/definitions/WalletResponse'
-        type: array
-      pagination:
-        $ref: '#/definitions/types.PaginationResponse'
-    type: object
-  types.Metadata:
-    additionalProperties:
-      type: string
-    type: object
   types.PaginationResponse:
     properties:
       limit:
@@ -10109,14 +9735,6 @@ definitions:
       status:
         $ref: '#/definitions/types.Status'
     type: object
-  types.RejectedEventReason:
-    enum:
-    - no_meter_for_event_name
-    - no_matching_meter
-    type: string
-    x-enum-varnames:
-    - RejectedEventReasonNoMeterForName
-    - RejectedEventReasonNoMatchingMeter
   types.ReportingUnit:
     properties:
       conversion_rate:
@@ -10298,6 +9916,8 @@ definitions:
     - whop
     - tabs
     - aws_marketplace
+    - gcp_marketplace
+    - azure_marketplace
     type: string
     x-enum-comments:
       SecretProviderS3: supports multiple connections per environment
@@ -10316,6 +9936,8 @@ definitions:
     - SecretProviderWhop
     - SecretProviderTabs
     - SecretProviderAWSMarketplace
+    - SecretProviderGCPMarketplace
+    - SecretProviderAzureMarketplace
   types.SecretType:
     enum:
     - private_key
@@ -10453,8 +10075,23 @@ definitions:
           TrialEndDueLTE, when set, restricts to subscriptions with trial_end not nil and trial_end <= trial_end_due_lte.
           Use with subscription_status trialing for trial-end cron processing.
         type: string
+      with_coupon_associations:
+        description: |-
+          WithCouponAssociations eager-loads coupon associations and their coupons.
+
+          Kept separate from WithLineItems because the coupon_associations table has no
+          index leading with subscription_id, so Ent's edge load degrades to a full table
+          scan. Only set it when the response actually surfaces the associations; the
+          service layer back-fills it from expand="coupon_associations".
+        type: boolean
       with_line_items:
-        description: WithLineItems includes line items in the response
+        description: |-
+          WithLineItems includes line items in the response.
+
+          Deprecated: use expand="subscription_line_items" instead. Retained for
+          backwards compatibility and for internal callers that need to force-disable
+          line item loading (set to false). The service layer ORs this with the
+          expand check before invoking the repository.
         type: boolean
     type: object
   types.SubscriptionLineItemEntityType:
@@ -10582,6 +10219,10 @@ definitions:
     - SubscriptionTypeGroupedInvoicing
   types.SyncConfig:
     properties:
+      aws_marketplace:
+        allOf:
+        - $ref: '#/definitions/types.AWSMarketplaceSyncConfig'
+        description: AWSMarketplace connection metadata
       customer:
         $ref: '#/definitions/types.EntitySyncConfig'
       deal:
@@ -10803,6 +10444,21 @@ definitions:
     x-enum-varnames:
     - UserTypeUser
     - UserTypeServiceAccount
+  types.Value:
+    properties:
+      array:
+        items:
+          type: string
+        type: array
+      boolean:
+        type: boolean
+      date:
+        type: string
+      number:
+        type: number
+      string:
+        type: string
+    type: object
   types.WalletConfig:
     properties:
       allowed_price_types:
@@ -10982,6 +10638,7 @@ definitions:
     - subscription.line_item_spend.threshold_recovered
     - subscription.group_spend.threshold_reached
     - subscription.group_spend.threshold_recovered
+    - entitlement.grant.exhausted
     - subscription.renewal.due
     - invoice.communication.triggered
     - credit_note.created
@@ -11039,6 +10696,7 @@ definitions:
     - WebhookEventSubscriptionLineItemSpendThresholdRecovered
     - WebhookEventSubscriptionGroupSpendThresholdReached
     - WebhookEventSubscriptionGroupSpendThresholdRecovered
+    - WebhookEventEntitlementGrantExhausted
     - WebhookEventSubscriptionRenewalDue
     - WebhookEventInvoiceCommunicationTriggered
     - WebhookEventCreditNoteCreated
@@ -11120,6 +10778,739 @@ definitions:
         type: string
       workflow_type:
         type: string
+    type: object
+  group.Group:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      entity_type:
+        $ref: '#/definitions/types.GroupEntityType'
+      environment_id:
+        type: string
+      id:
+        type: string
+      lookup_key:
+        type: string
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
+      name:
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  invoice.InvoiceLineItem:
+    properties:
+      adjusted_entitlement_quantity:
+        description: |-
+          adjusted_entitlement_quantity is the entitlement-covered portion deducted from raw usage.
+          Nil when no entitlement was applied. Raw usage = Quantity + AdjustedEntitlementQuantity.
+        type: string
+      amount:
+        type: string
+      commitment_info:
+        $ref: '#/definitions/types.CommitmentInfo'
+      created_at:
+        type: string
+      created_by:
+        type: string
+      currency:
+        type: string
+      customer_id:
+        type: string
+      display_name:
+        type: string
+      entity_id:
+        type: string
+      entity_type:
+        type: string
+      environment_id:
+        type: string
+      id:
+        type: string
+      invoice_id:
+        type: string
+      invoice_level_discount:
+        description: invoice_level_discount is the discount amount in invoice currency
+          applied to all line items on the invoice.
+        type: string
+      line_item_discount:
+        description: line_item_discount is the discount amount in invoice currency
+          applied directly to this line item.
+        type: string
+      metadata:
+        $ref: '#/definitions/types.Metadata'
+      meter_display_name:
+        type: string
+      meter_id:
+        type: string
+      period_end:
+        type: string
+      period_start:
+        type: string
+      plan_display_name:
+        type: string
+      prepaid_credits_applied:
+        description: prepaid_credits_applied is the amount in invoice currency reduced
+          from this line item due to prepaid credits application.
+        type: string
+      price_id:
+        type: string
+      price_type:
+        type: string
+      price_unit:
+        type: string
+      price_unit_amount:
+        type: string
+      price_unit_id:
+        type: string
+      quantity:
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+      subscription_id:
+        type: string
+      subscription_line_item_id:
+        description: sub_line_item_id links this invoice line item to the subscription_line_item
+          that generated it.
+        type: string
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  meter.Aggregation:
+    properties:
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize is used only for MAX aggregation when windowed aggregation is needed
+          It defines the size of time windows to calculate max values within
+      expression:
+        description: |-
+          Expression is an optional CEL expression to compute per-event quantity from event.properties.
+          When set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).
+        type: string
+      field:
+        description: |-
+          Field is the key in $event.properties on which the aggregation is to be applied
+          For ex if the aggregation type is sum for API usage, the field could be "duration_ms"
+          Ignored when Expression is set.
+        type: string
+      group_by:
+        description: |-
+          GroupBy is the property name in event.properties to group by before aggregating.
+          Currently only supported for MAX aggregation with bucket_size.
+          When set, aggregation is applied per unique value of this property within each bucket,
+          then the per-group results are summed to produce the bucket total.
+        type: string
+      multiplier:
+        description: |-
+          Multiplier is the multiplier for the aggregation
+          For ex if the aggregation type is sum_with_multiplier for API usage, the multiplier could be 1000
+          to scale up by a factor of 1000. If not provided, it will be null.
+        type: string
+      type:
+        $ref: '#/definitions/types.AggregationType'
+    type: object
+  meter.Filter:
+    properties:
+      key:
+        description: |-
+          Key is the key for the filter from $event.properties
+          Currently we support only first level keys in the properties and not nested keys
+        type: string
+      values:
+        description: |-
+          Values are the possible values for the filter to be considered for the meter
+          For ex "model_name" could have values "o1-mini", "gpt-4o" etc
+        items:
+          type: string
+        type: array
+    type: object
+  meter.Meter:
+    properties:
+      aggregation:
+        allOf:
+        - $ref: '#/definitions/meter.Aggregation'
+        description: |-
+          Aggregation defines the aggregation type and field for the meter
+          It is used to aggregate the events into a single value for calculating the usage
+      created_at:
+        type: string
+      created_by:
+        type: string
+      environment_id:
+        description: EnvironmentID is the environment identifier for the meter
+        type: string
+      event_name:
+        description: |-
+          EventName is the unique identifier for the event that this meter is tracking
+          It is a mandatory field in the events table and hence being used as the primary matching field
+          We can have multiple meters tracking the same event but with different filters and aggregation
+        type: string
+      filters:
+        description: |-
+          Filters define the criteria for the meter to be applied on the events before aggregation
+          It also defines the possible values on which later the charges will be applied
+        items:
+          $ref: '#/definitions/meter.Filter'
+        type: array
+      id:
+        description: ID is the unique identifier for the meter
+        type: string
+      name:
+        description: Name is the display name of the meter
+        type: string
+      reset_usage:
+        allOf:
+        - $ref: '#/definitions/types.ResetUsage'
+        description: |-
+          ResetUsage defines whether the usage should be reset periodically or not
+          For ex meters tracking total storage used do not get reset but meters tracking
+          total API requests do.
+      status:
+        $ref: '#/definitions/types.Status'
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  models.TemporalWorkflowResult:
+    properties:
+      message:
+        type: string
+      run_id:
+        type: string
+      workflow_id:
+        type: string
+    type: object
+  price.JSONBFilters:
+    additionalProperties:
+      items:
+        type: string
+      type: array
+    type: object
+  price.JSONBMetadata:
+    additionalProperties:
+      type: string
+    type: object
+  price.JSONBTransformQuantity:
+    properties:
+      divide_by:
+        description: Divide quantity by this number
+        type: integer
+      round:
+        allOf:
+        - $ref: '#/definitions/types.RoundType'
+        description: up or down
+    type: object
+  price.Price:
+    properties:
+      amount:
+        description: |-
+          Amount stored in main currency units (e.g., dollars, not cents)
+          For USD: 12.50 means $12.50
+        type: string
+      billing_cadence:
+        $ref: '#/definitions/types.BillingCadence'
+      billing_model:
+        $ref: '#/definitions/types.BillingModel'
+      billing_period:
+        $ref: '#/definitions/types.BillingPeriod'
+      billing_period_count:
+        default: 1
+        description: BillingPeriodCount is the count of the billing period ex 1, 3,
+          6, 12
+        type: integer
+      conversion_rate:
+        description: ConversionRate is the conversion rate of the price unit to the
+          fiat currency
+        type: string
+      created_at:
+        type: string
+      created_by:
+        type: string
+      currency:
+        description: Currency 3 digit ISO currency code in lowercase ex usd, eur,
+          gbp
+        type: string
+      description:
+        description: Description of the price
+        type: string
+      display_amount:
+        description: |-
+          DisplayAmount is the formatted amount with currency symbol
+          For USD: $12.50
+        type: string
+      display_name:
+        description: DisplayName is the name of the price
+        type: string
+      display_price_unit_amount:
+        description: DisplayPriceUnitAmount is the formatted amount of the price unit
+        type: string
+      end_date:
+        description: EndDate is the end date of the price
+        type: string
+      entity_id:
+        description: EntityID holds the value of the "entity_id" field.
+        type: string
+      entity_type:
+        allOf:
+        - $ref: '#/definitions/types.PriceEntityType'
+        description: EntityType holds the value of the "entity_type" field.
+      environment_id:
+        description: EnvironmentID is the environment identifier for the price
+        type: string
+      group_id:
+        description: GroupID references the group this price belongs to
+        type: string
+      id:
+        description: ID uuid identifier for the price
+        type: string
+      invoice_cadence:
+        $ref: '#/definitions/types.InvoiceCadence'
+      lookup_key:
+        description: LookupKey used for looking up the price in the database
+        type: string
+      metadata:
+        $ref: '#/definitions/price.JSONBMetadata'
+      meter_id:
+        description: MeterID is the id of the meter for usage based pricing
+        type: string
+      min_quantity:
+        description: MinQuantity is the minimum quantity of the price
+        type: string
+        x-nullable: true
+      parent_price_id:
+        description: ParentPriceID references the root price (always set for price
+          lineage tracking)
+        type: string
+      price_unit:
+        description: PriceUnit is the code of the price unit (e.g., 'btc', 'eth')
+        type: string
+      price_unit_amount:
+        description: PriceUnitAmount is the amount of the price unit
+        type: string
+      price_unit_id:
+        description: PriceUnitID is the id of the price unit (for CUSTOM type)
+        type: string
+      price_unit_tiers:
+        description: PriceUnitTiers are the tiers for the price unit when BillingModel
+          is TIERED
+        items:
+          $ref: '#/definitions/price.PriceTier'
+        type: array
+      price_unit_type:
+        allOf:
+        - $ref: '#/definitions/types.PriceUnitType'
+        description: PriceUnitType is the type of the price unit (FIAT, CUSTOM)
+      sequence:
+        description: |-
+          Sequence is the monotonic stamp bumped on every state change that
+          subscription line items need to react to. Read by the plan-price sync;
+          set by the database (DEFAULT nextval) on create and by the price
+          repository on termination / compatibility-affecting edits.
+        type: integer
+      start_date:
+        description: StartDate is the start date of the price
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+      tenant_id:
+        type: string
+      tier_mode:
+        $ref: '#/definitions/types.BillingTier'
+      tiers:
+        items:
+          $ref: '#/definitions/price.PriceTier'
+        type: array
+      transform_quantity:
+        $ref: '#/definitions/price.JSONBTransformQuantity'
+      trial_period_days:
+        description: |-
+          TrialPeriodDays is the number of days for the trial period
+          Note: This is only applicable for recurring prices (BILLING_CADENCE_RECURRING)
+        type: integer
+      type:
+        $ref: '#/definitions/types.PriceType'
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  price.PriceTier:
+    properties:
+      flat_amount:
+        description: |-
+          flat_amount is the flat amount for the given tier (optional)
+          Applied on top of unit_amount*quantity. Useful for cases like "2.7$ + 5c"
+        type: string
+      unit_amount:
+        description: unit_amount is the amount per unit for the given tier
+        type: string
+      up_to:
+        description: |-
+          up_to is the quantity up to which this tier applies. It is null for the last tier.
+          IMPORTANT: Tier boundaries are INCLUSIVE.
+          - If up_to is 1000, then quantity less than or equal to 1000 belongs to this tier
+          - This behavior is consistent across both VOLUME and SLAB tier modes
+        type: integer
+    type: object
+  price.TransformQuantity:
+    properties:
+      divide_by:
+        description: Divide quantity by this number
+        type: integer
+      round:
+        allOf:
+        - $ref: '#/definitions/types.RoundType'
+        description: up or down
+    type: object
+  subscription.SubscriptionLineItem:
+    properties:
+      addon_association_id:
+        type: string
+      billing_period:
+        $ref: '#/definitions/types.BillingPeriod'
+      billing_period_count:
+        description: from price at create; default 1
+        type: integer
+      commitment_amount:
+        description: Commitment fields
+        type: string
+      commitment_duration:
+        $ref: '#/definitions/types.BillingPeriod'
+      commitment_overage_factor:
+        type: string
+      commitment_quantity:
+        type: string
+      commitment_time_buckets:
+        items:
+          $ref: '#/definitions/types.TimeOfDayBucket'
+        type: array
+      commitment_true_up_enabled:
+        type: boolean
+      commitment_type:
+        $ref: '#/definitions/types.CommitmentType'
+      commitment_windowed:
+        type: boolean
+      created_at:
+        type: string
+      created_by:
+        type: string
+      currency:
+        type: string
+      customer_id:
+        type: string
+      display_name:
+        type: string
+      end_date:
+        type: string
+      entity_id:
+        type: string
+      entity_type:
+        $ref: '#/definitions/types.SubscriptionLineItemEntityType'
+      environment_id:
+        type: string
+      id:
+        type: string
+      invoice_cadence:
+        $ref: '#/definitions/types.InvoiceCadence'
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
+      meter:
+        allOf:
+        - $ref: '#/definitions/meter.Meter'
+        description: |-
+          Meter is populated when the caller adds "meters" to a subscription-scoped
+          expand string alongside "subscription_line_items". Only usage line items
+          (PriceType == USAGE with a non-empty MeterID) will have a non-nil Meter.
+      meter_display_name:
+        type: string
+      meter_id:
+        type: string
+      plan_display_name:
+        type: string
+      price:
+        $ref: '#/definitions/price.Price'
+      price_id:
+        type: string
+      price_type:
+        $ref: '#/definitions/types.PriceType'
+      price_unit:
+        type: string
+      price_unit_id:
+        type: string
+      quantity:
+        type: string
+      start_date:
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+      subscription_id:
+        type: string
+      subscription_phase_id:
+        type: string
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  subscription.SubscriptionPause:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      environment_id:
+        description: EnvironmentID is the environment identifier for the pause
+        type: string
+      id:
+        description: ID is the unique identifier for the subscription pause
+        type: string
+      metadata:
+        $ref: '#/definitions/types.Metadata'
+      original_period_end:
+        description: OriginalPeriodEnd is the end of the billing period when the pause
+          was created
+        type: string
+      original_period_start:
+        description: OriginalPeriodStart is the start of the billing period when the
+          pause was created
+        type: string
+      pause_end:
+        description: PauseEnd is when the pause will end (null for indefinite)
+        type: string
+      pause_mode:
+        $ref: '#/definitions/types.PauseMode'
+      pause_start:
+        description: PauseStart is when the pause actually started
+        type: string
+      pause_status:
+        $ref: '#/definitions/types.PauseStatus'
+      reason:
+        description: Reason is the reason for pausing
+        type: string
+      resume_mode:
+        $ref: '#/definitions/types.ResumeMode'
+      resumed_at:
+        description: ResumedAt is when the pause was actually ended (if manually resumed)
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+      subscription_id:
+        description: SubscriptionID is the identifier for the subscription
+        type: string
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  subscription.SubscriptionPhase:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      end_date:
+        description: EndDate is when the phase ends (nil if phase is still active
+          or indefinite)
+        type: string
+      environment_id:
+        description: EnvironmentID is the environment identifier for the phase
+        type: string
+      id:
+        description: ID is the unique identifier for the subscription phase
+        type: string
+      metadata:
+        allOf:
+        - $ref: '#/definitions/types.Metadata'
+        description: Metadata contains additional key-value pairs
+      start_date:
+        description: StartDate is when the phase starts
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+      subscription_id:
+        description: SubscriptionID is the identifier for the subscription
+        type: string
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      updated_by:
+        type: string
+    type: object
+  types.AWSMarketplaceSyncConfig:
+    properties:
+      region:
+        type: string
+    type: object
+  types.AlertSettingsFilter:
+    properties:
+      enabled:
+        type: boolean
+      end_time:
+        type: string
+      entity_id:
+        type: string
+      entity_ids:
+        items:
+          type: string
+        type: array
+      entity_type:
+        $ref: '#/definitions/types.AlertEntityType'
+      expand:
+        type: string
+      filters:
+        description: filters allows complex filtering based on multiple fields
+        items:
+          $ref: '#/definitions/types.FilterCondition'
+        type: array
+      limit:
+        maximum: 1000
+        minimum: 1
+        type: integer
+      offset:
+        minimum: 0
+        type: integer
+      order:
+        enum:
+        - asc
+        - desc
+        type: string
+      parent_entity_id:
+        type: string
+      parent_entity_ids:
+        items:
+          type: string
+        type: array
+      parent_entity_type:
+        $ref: '#/definitions/types.AlertEntityType'
+      sort:
+        items:
+          $ref: '#/definitions/types.SortCondition'
+        type: array
+      start_time:
+        type: string
+      status:
+        $ref: '#/definitions/types.Status'
+    type: object
+  types.CheckoutPaymentProviderConfig:
+    properties:
+      collection_method:
+        $ref: '#/definitions/types.CollectionMethod'
+      max_mandate_limit:
+        type: string
+      payment_method:
+        $ref: '#/definitions/types.PaymentMethodType'
+    type: object
+  types.DurationUnit:
+    enum:
+    - second
+    - minute
+    - hour
+    - day
+    type: string
+    x-enum-varnames:
+    - DurationUnitSecond
+    - DurationUnitMinute
+    - DurationUnitHour
+    - DurationUnitDay
+  types.EntitlementAggregationMode:
+    enum:
+    - additive
+    - parallel
+    type: string
+    x-enum-varnames:
+    - EntitlementAggregationModeAdditive
+    - EntitlementAggregationModeParallel
+  types.EntitlementGrantDurationUnit:
+    enum:
+    - hour
+    - day
+    - week
+    type: string
+    x-enum-varnames:
+    - EntitlementGrantDurationUnitHour
+    - EntitlementGrantDurationUnitDay
+    - EntitlementGrantDurationUnitWeek
+  types.EntitlementGrantMeasure:
+    enum:
+    - quantity
+    - amount
+    type: string
+    x-enum-varnames:
+    - EntitlementGrantMeasureQuantity
+    - EntitlementGrantMeasureAmount
+  types.ListResponse-dto_WalletResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/WalletResponse'
+        type: array
+      pagination:
+        $ref: '#/definitions/types.PaginationResponse'
+    type: object
+  types.Metadata:
+    additionalProperties:
+      type: string
+    type: object
+  types.ModifySubscriptionLineItem:
+    properties:
+      effective_date:
+        type: string
+      line_item_id:
+        type: string
+      quantity:
+        type: string
+    type: object
+  types.ModifySubscriptionParams:
+    properties:
+      line_item_modifications:
+        items:
+          $ref: '#/definitions/types.ModifySubscriptionLineItem'
+        type: array
+      subscription_id:
+        type: string
+    type: object
+  types.RejectedEventReason:
+    enum:
+    - no_meter_for_event_name
+    - no_matching_meter
+    type: string
+    x-enum-varnames:
+    - RejectedEventReasonNoMeterForName
+    - RejectedEventReasonNoMatchingMeter
+  types.WalletTopupParams:
+    properties:
+      wallet_id:
+        type: string
+      wallet_transaction_id:
+        type: string
+    required:
+    - wallet_id
     type: object
   webhookDto.AlertWebhookPayload:
     properties:
@@ -11254,6 +11645,8 @@ definitions:
     type: object
   webhookDto.TransactionUpdatedWebhookPayload:
     properties:
+      customer:
+        $ref: '#/definitions/CustomerResponse'
       event_type:
         $ref: '#/definitions/types.WebhookEventName'
       updated_transaction:
@@ -11263,6 +11656,8 @@ definitions:
     type: object
   webhookDto.TransactionWebhookPayload:
     properties:
+      customer:
+        $ref: '#/definitions/CustomerResponse'
       event_type:
         $ref: '#/definitions/types.WebhookEventName'
       transaction:
@@ -13159,6 +13554,47 @@ paths:
       summary: Get customer entitlements by external ID
       tags:
       - Customers
+  /customers/external/{external_id}/subscriptions:
+    get:
+      description: Returns all subscriptions for a customer looked up by external_id,
+        with line-item meters and entitlements attached (no pagination).
+      operationId: getSubscriptionsForCustomer
+      parameters:
+      - description: Customer External ID
+        in: path
+        name: external_id
+        required: true
+        type: string
+      - description: 'Comma-separated fields to expand: subscription_line_items, subscription_line_items.meters,
+          entitlements, plan, customer'
+        in: query
+        name: expand
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListSubscriptionsResponse'
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Resource not found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Server error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get subscriptions for customer by external ID
+      tags:
+      - Customers
+      x-scope: read
   /customers/search:
     post:
       consumes:
@@ -13587,37 +14023,6 @@ paths:
       summary: Ingest event
       tags:
       - Events
-  /events/{id}:
-    get:
-      description: Use when debugging a specific event (e.g. why it failed or how
-        it was aggregated). Includes processing status and debug info.
-      operationId: getEvent
-      parameters:
-      - description: Event ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/GetEventByIDResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/errors.ErrorResponse'
-        "500":
-          description: Server error
-          schema:
-            $ref: '#/definitions/errors.ErrorResponse'
-      security:
-      - ApiKeyAuth: []
-      summary: Get event
-      tags:
-      - Events
   /events/analytics:
     post:
       consumes:
@@ -13690,9 +14095,19 @@ paths:
       - Events
   /events/huggingface-inference:
     post:
+      consumes:
+      - application/json
       description: Use when fetching Hugging Face inference usage or billing data
-        (e.g. for HF-specific reporting or reconciliation).
+        (e.g. for HF-specific reporting or reconciliation). Reads the meter-usage
+        pipeline.
       operationId: getHuggingfaceInferenceData
+      parameters:
+      - description: Request body
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/GetHuggingFaceBillingDataRequest'
       produces:
       - application/json
       responses:
@@ -13707,6 +14122,39 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Get Hugging Face inference data
+      tags:
+      - Events
+  /events/lookup:
+    get:
+      description: Use when debugging a specific event (e.g. why it failed or how
+        it was aggregated). Reads the meter-usage pipeline; includes processing status
+        and step-by-step debug tracker when unprocessed. Uses ?id= query param because
+        event IDs can contain "/".
+      operationId: getEvent
+      parameters:
+      - description: Event ID
+        in: query
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/GetEventByIDResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Server error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Get event
       tags:
       - Events
   /events/query:
@@ -14337,6 +14785,11 @@ paths:
           type: string
         name: group_by
         type: array
+      - description: Comma-separated related fields to include. Supports 'tax_applied.tax_rate'
+          to attach rate details to each applied tax.
+        in: query
+        name: expand
+        type: string
       produces:
       - application/json
       responses:

--- a/ent/schema/price.go
+++ b/ent/schema/price.go
@@ -307,5 +307,11 @@ func (Price) Indexes() []ent.Index {
 		// To get "what changed since the sub's last synced_price_sequence"
 		index.Fields("tenant_id", "environment_id", "entity_id", "entity_type", "sequence").
 			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
+		// Covers the subscription-scoped override NOT EXISTS in the plan-price sync
+		// discovery CTE (plan_price_sync_v2.go), which probes by
+		// (entity_id = sub_id, entity_type = 'SUBSCRIPTION', parent_price_id = plan_price_id).
+		// Scoped to SUBSCRIPTION-scoped published rows to keep the index small.
+		index.Fields("tenant_id", "environment_id", "entity_id", "parent_price_id").
+			Annotations(entsql.IndexWhere("(((status)::text = 'published'::text) AND ((entity_type)::text = 'SUBSCRIPTION'::text))")),
 	}
 }

--- a/ent/schema/subscription.go
+++ b/ent/schema/subscription.go
@@ -250,7 +250,10 @@ func (Subscription) Indexes() []ent.Index {
 		// For billing period updates
 		index.Fields("tenant_id", "environment_id", "current_period_end", "subscription_status", "status"),
 		// Drives the plan-price sync's "which subs are behind?" lookup.
-		index.Fields("tenant_id", "environment_id", "plan_id", "synced_price_sequence").
+		// `id` is included so the discovery CTE's `ORDER BY synced_price_sequence, id LIMIT N`
+		// can be served as an index range scan that stops after N rows, instead of
+		// a Top-N sort over the full stale-sub set (see plan_price_sync_v2.go).
+		index.Fields("tenant_id", "environment_id", "plan_id", "synced_price_sequence", "id").
 			Annotations(entsql.IndexWhere(
 				"(((status)::text = 'published'::text) AND ((subscription_type)::text = ANY (ARRAY[('standalone'::character varying)::text, ('delegated_invoicing'::character varying)::text, ('parent'::character varying)::text, ('grouped_invoicing'::character varying)::text])))")),
 	}

--- a/ent/schema/subscription_line_item.go
+++ b/ent/schema/subscription_line_item.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -217,5 +218,12 @@ func (SubscriptionLineItem) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "meter_id", "status"),
 		index.Fields("start_date", "end_date"),
 		index.Fields("subscription_id", "status"),
+		// Covers the "line item already exists?" NOT EXISTS guard in the plan-price
+		// sync discovery CTE (plan_price_sync_v2.go): keyed on (subscription_id,
+		// price_id, entity_type) so the probe with entity_type='plan' is index-only.
+		// entity_type is a trailing key column (not in the partial predicate) so this
+		// index also serves lookups for entity_type='addon' and 'subscription'.
+		index.Fields("tenant_id", "environment_id", "subscription_id", "price_id", "entity_type").
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 	}
 }

--- a/internal/api/dto/addon.go
+++ b/internal/api/dto/addon.go
@@ -84,6 +84,9 @@ type AddAddonToSubscriptionRequest struct {
 	// LineItemCommitments allows setting commitment configuration per addon line item (keyed by price_id)
 	LineItemCommitments map[string]*LineItemCommitmentConfig `json:"line_item_commitments,omitempty" validate:"omitempty,dive"`
 
+	// OverrideLineItems allows overriding price/quantity/billing model for specific addon prices
+	OverrideLineItems []OverrideLineItemRequest `json:"override_line_items,omitempty" validate:"omitempty,dive"`
+
 	// SkipEntityValidation is used to skip the entitlement check for the addon
 	// This is used to add an addon to a subscription without checking the entitlement compatibility
 	// This is used when we are adding an addon to a subscription that already has an active instance of the addon
@@ -132,6 +135,10 @@ func (r *AddAddonToSubscriptionRequest) Validate() error {
 	}
 
 	if err := validateLineItemCommitments(r.LineItemCommitments); err != nil {
+		return err
+	}
+
+	if err := validateNoDuplicateOverridePriceIDs(r.OverrideLineItems); err != nil {
 		return err
 	}
 

--- a/internal/api/dto/addon_test.go
+++ b/internal/api/dto/addon_test.go
@@ -1,0 +1,41 @@
+package dto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+func TestAddAddonToSubscriptionRequest_Validate_RejectsDuplicateOverridePriceIDs(t *testing.T) {
+	req := &AddAddonToSubscriptionRequest{
+		AddonID: "addon_123",
+		OverrideLineItems: []OverrideLineItemRequest{
+			{PriceID: "price_1", Amount: lo.ToPtr(decimal.NewFromInt(10))},
+			{PriceID: "price_1", Amount: lo.ToPtr(decimal.NewFromInt(20))},
+		},
+	}
+
+	err := req.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for duplicate override price_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate price_id in override line items") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddAddonToSubscriptionRequest_Validate_AcceptsDistinctOverridePriceIDs(t *testing.T) {
+	req := &AddAddonToSubscriptionRequest{
+		AddonID: "addon_123",
+		OverrideLineItems: []OverrideLineItemRequest{
+			{PriceID: "price_1", Amount: lo.ToPtr(decimal.NewFromInt(10))},
+			{PriceID: "price_2", Amount: lo.ToPtr(decimal.NewFromInt(20))},
+		},
+	}
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -471,20 +471,8 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		return err
 	}
 
-	if len(c.OverrideLineItems) > 0 {
-		priceIDsSeen := make(map[string]bool)
-		for i, override := range c.OverrideLineItems {
-			if priceIDsSeen[override.PriceID] {
-				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
-					WithHint("Each price can only be overridden once per subscription").
-					WithReportableDetails(map[string]interface{}{
-						"price_id": override.PriceID,
-						"index":    i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-			priceIDsSeen[override.PriceID] = true
-		}
+	if err := validateNoDuplicateOverridePriceIDs(c.OverrideLineItems); err != nil {
+		return err
 	}
 
 	const maxLineItems = 100

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -479,6 +479,108 @@ type SubscriptionCreationConfig struct {
 	Phases []SubscriptionPhaseCreateRequest `json:"phases,omitempty" validate:"omitempty,dive"`
 }
 
+// Validate validates the self-contained fields of SubscriptionCreationConfig — checks that
+// only ever need this struct's own fields, independent of the parent request's type,
+// billing status, or proration settings. Used by both CreateSubscriptionRequest.Validate()
+// and (transitively, via CreateSubscriptionRequest's own promoted fields) grouped-invoicing
+// child requests.
+func (c *SubscriptionCreationConfig) Validate() error {
+	// Validate commitment amount and overage factor
+	if c.CommitmentAmount != nil && c.CommitmentAmount.LessThan(decimal.Zero) {
+		return ierr.NewError("commitment_amount must be non-negative").
+			WithHint("Commitment amount must be greater than or equal to 0").
+			WithReportableDetails(map[string]interface{}{
+				"commitment_amount": *c.CommitmentAmount,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if c.OverageFactor != nil && c.OverageFactor.LessThan(decimal.NewFromInt(1)) {
+		return ierr.NewError("overage_factor must be at least 1.0").
+			WithHint("Overage factor must be greater than or equal to 1.0").
+			WithReportableDetails(map[string]interface{}{
+				"overage_factor": *c.OverageFactor,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	// Validate credit grants if provided
+	if len(c.CreditGrants) > 0 {
+		for i, grant := range c.CreditGrants {
+			// Force scope to SUBSCRIPTION for all grants added this way
+			if grant.Scope != types.CreditGrantScopeSubscription {
+				return ierr.NewError("invalid credit grant scope").
+					WithHint("Credit grants created with a subscription must have SUBSCRIPTION scope").
+					WithReportableDetails(map[string]interface{}{
+						"grant_scope": grant.Scope,
+						"grant_index": i,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		}
+	}
+
+	// taxrate overrides validation
+	if len(c.TaxRateOverrides) > 0 {
+		for _, taxRateOverride := range c.TaxRateOverrides {
+			if err := taxRateOverride.Validate(); err != nil {
+				return ierr.NewError("invalid tax rate override").
+					WithHint("Tax rate override validation failed").
+					WithReportableDetails(map[string]interface{}{
+						"error":             err.Error(),
+						"tax_rate_override": taxRateOverride,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		}
+	}
+
+	// Validate line item commitments if provided
+	if err := validateLineItemCommitments(c.LineItemCommitments); err != nil {
+		return err
+	}
+
+	// Validate override line items if provided
+	if len(c.OverrideLineItems) > 0 {
+		priceIDsSeen := make(map[string]bool)
+		for i, override := range c.OverrideLineItems {
+			// Check for duplicate price IDs
+			if priceIDsSeen[override.PriceID] {
+				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
+					WithHint("Each price can only be overridden once per subscription").
+					WithReportableDetails(map[string]interface{}{
+						"price_id": override.PriceID,
+						"index":    i,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+			priceIDsSeen[override.PriceID] = true
+		}
+	}
+
+	// Validate line_items if provided (each must have exactly one of price_id or price)
+	const maxLineItems = 100
+	if len(c.LineItems) > maxLineItems {
+		return ierr.NewError("line_items exceeds maximum allowed").
+			WithHint(fmt.Sprintf("At most %d line items can be added at subscription creation", maxLineItems)).
+			WithReportableDetails(map[string]interface{}{
+				"count": len(c.LineItems),
+				"max":   maxLineItems,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	for i, item := range c.LineItems {
+		if err := item.Validate(nil, nil); err != nil {
+			return ierr.WithError(err).
+				WithHint(fmt.Sprintf("Line item validation failed at index %d", i)).
+				WithReportableDetails(map[string]interface{}{"line_item_index": i}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	return nil
+}
+
 type CreateSubscriptionRequest struct {
 	// ID is an optional pre-generated subscription ID for internal use only.
 	// This exists as a temporary patch to allow Paddle entity mapping to be created
@@ -1046,98 +1148,8 @@ func (r *CreateSubscriptionRequest) Validate() error {
 		}
 	}
 
-	// Validate commitment amount and overage factor
-	if r.CommitmentAmount != nil && r.CommitmentAmount.LessThan(decimal.Zero) {
-		return ierr.NewError("commitment_amount must be non-negative").
-			WithHint("Commitment amount must be greater than or equal to 0").
-			WithReportableDetails(map[string]interface{}{
-				"commitment_amount": *r.CommitmentAmount,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-
-	if r.OverageFactor != nil && r.OverageFactor.LessThan(decimal.NewFromInt(1)) {
-		return ierr.NewError("overage_factor must be at least 1.0").
-			WithHint("Overage factor must be greater than or equal to 1.0").
-			WithReportableDetails(map[string]interface{}{
-				"overage_factor": *r.OverageFactor,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-
-	// Validate credit grants if provided
-	if len(r.CreditGrants) > 0 {
-		for i, grant := range r.CreditGrants {
-
-			// Force scope to SUBSCRIPTION for all grants added this way
-			if grant.Scope != types.CreditGrantScopeSubscription {
-				return ierr.NewError("invalid credit grant scope").
-					WithHint("Credit grants created with a subscription must have SUBSCRIPTION scope").
-					WithReportableDetails(map[string]interface{}{
-						"grant_scope": grant.Scope,
-						"grant_index": i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-		}
-	}
-
-	// taxrate overrides validation
-	if len(r.TaxRateOverrides) > 0 {
-		for _, taxRateOverride := range r.TaxRateOverrides {
-			if err := taxRateOverride.Validate(); err != nil {
-				return ierr.NewError("invalid tax rate override").
-					WithHint("Tax rate override validation failed").
-					WithReportableDetails(map[string]interface{}{
-						"error":             err.Error(),
-						"tax_rate_override": taxRateOverride,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-		}
-	}
-
-	// Validate line item commitments if provided
-	if err := validateLineItemCommitments(r.LineItemCommitments); err != nil {
+	if err := r.SubscriptionCreationConfig.Validate(); err != nil {
 		return err
-	}
-
-	// Validate override line items if provided
-	if len(r.OverrideLineItems) > 0 {
-		priceIDsSeen := make(map[string]bool)
-		for i, override := range r.OverrideLineItems {
-			// Check for duplicate price IDs
-			if priceIDsSeen[override.PriceID] {
-				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
-					WithHint("Each price can only be overridden once per subscription").
-					WithReportableDetails(map[string]interface{}{
-						"price_id": override.PriceID,
-						"index":    i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-			priceIDsSeen[override.PriceID] = true
-		}
-	}
-
-	// Validate line_items if provided (each must have exactly one of price_id or price)
-	const maxLineItems = 100
-	if len(r.LineItems) > maxLineItems {
-		return ierr.NewError("line_items exceeds maximum allowed").
-			WithHint(fmt.Sprintf("At most %d line items can be added at subscription creation", maxLineItems)).
-			WithReportableDetails(map[string]interface{}{
-				"count": len(r.LineItems),
-				"max":   maxLineItems,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-	for i, item := range r.LineItems {
-		if err := item.Validate(nil, nil); err != nil {
-			return ierr.WithError(err).
-				WithHint(fmt.Sprintf("Line item validation failed at index %d", i)).
-				WithReportableDetails(map[string]interface{}{"line_item_index": i}).
-				Mark(ierr.ErrValidation)
-		}
 	}
 
 	// Validate phases continuity if provided

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -154,8 +154,7 @@ func validateLineItemCommitments(commitments map[string]*LineItemCommitmentConfi
 	return nil
 }
 
-// validateNoDuplicateOverridePriceIDs rejects override line items that target the same
-// price more than once — each price can only be overridden once per request.
+// validateNoDuplicateOverridePriceIDs rejects overrides that repeat the same price_id.
 func validateNoDuplicateOverridePriceIDs(overrides []OverrideLineItemRequest) error {
 	if len(overrides) == 0 {
 		return nil

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -16,7 +16,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// SubscriptionPhaseCreateRequest represents the request to create a subscription phase
 type SubscriptionPhaseCreateRequest struct {
 	StartDate time.Time  `json:"start_date" validate:"required"`
 	EndDate   *time.Time `json:"end_date,omitempty"`
@@ -30,18 +29,15 @@ type SubscriptionPhaseCreateRequest struct {
 	// Deprecated: use SubscriptionCoupons instead.
 	LineItemCoupons map[string][]string `json:"line_item_coupons,omitempty"`
 
-	// OverrideLineItems allows customizing specific prices for this phase
-	// If not provided, phase will use the same line items as the subscription (plan prices)
+	// OverrideLineItems overrides specific plan prices for this phase.
 	OverrideLineItems []OverrideLineItemRequest `json:"override_line_items,omitempty" validate:"omitempty,dive"`
 
-	// LineItems are extra line items to add during this phase, primarily one-time charges.
-	// Each item's start_date defaults to the phase's start_date when not provided.
+	// LineItems are extra (non-plan) line items for this phase; start_date defaults to phase start.
 	LineItems []CreateSubscriptionLineItemRequest `json:"line_items,omitempty" validate:"omitempty,dive"`
 
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
-// Validate validates the SubscriptionPhaseCreateRequest
 func (r *SubscriptionPhaseCreateRequest) Validate() error {
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
@@ -53,9 +49,7 @@ func (r *SubscriptionPhaseCreateRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Validate each nested line item (price/price_id presence, date ordering, etc.)
-	// Price and subscription context are not available here; full business-rule
-	// validation is deferred to createPhaseExtraLineItems in the service layer.
+	// Full business-rule validation (price context, dates) is deferred to the service layer.
 	for i, li := range r.LineItems {
 		if err := li.Validate(nil, nil); err != nil {
 			return ierr.NewErrorf("invalid line_item at index %d: %s", i, err.Error()).
@@ -66,8 +60,6 @@ func (r *SubscriptionPhaseCreateRequest) Validate() error {
 
 	return nil
 }
-
-// ToSubscriptionPhase converts the request to a domain SubscriptionPhase
 
 func (r *SubscriptionPhaseCreateRequest) ToSubscriptionPhase(ctx context.Context, subscriptionID string) *subscription.SubscriptionPhase {
 	return &subscription.SubscriptionPhase{
@@ -81,44 +73,26 @@ func (r *SubscriptionPhaseCreateRequest) ToSubscriptionPhase(ctx context.Context
 	}
 }
 
-// LineItemCommitmentConfig represents commitment configuration for a line item
 type LineItemCommitmentConfig struct {
-	// CommitmentAmount is the minimum amount committed for this line item
-	CommitmentAmount *decimal.Decimal `json:"commitment_amount,omitempty"`
-
-	// CommitmentQuantity is the minimum quantity committed for this line item
-	CommitmentQuantity *decimal.Decimal `json:"commitment_quantity,omitempty"`
-
-	// CommitmentType specifies whether commitment is based on amount or quantity
-	CommitmentType types.CommitmentType `json:"commitment_type,omitempty"`
-
-	// OverageFactor is a multiplier applied to usage beyond the commitment
+	CommitmentAmount   *decimal.Decimal     `json:"commitment_amount,omitempty"`
+	CommitmentQuantity *decimal.Decimal     `json:"commitment_quantity,omitempty"`
+	CommitmentType     types.CommitmentType `json:"commitment_type,omitempty"`
+	// OverageFactor is a multiplier on usage beyond commitment; 1.0 = base rate.
 	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty"`
-
-	// EnableTrueUp determines if true-up fee should be applied when usage is below commitment
+	// EnableTrueUp charges the shortfall when usage is below commitment.
 	EnableTrueUp *bool `json:"enable_true_up,omitempty"`
-
-	// IsWindowCommitment determines if commitment is applied per window (e.g., per day) rather than per billing period
+	// IsWindowCommitment applies commitment per window (e.g. per day) rather than per billing period.
 	IsWindowCommitment *bool `json:"is_window_commitment,omitempty"`
-
-	// CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)
+	// CommitmentDuration allows a different period than billing (e.g. ANNUAL commitment on MONTHLY billing).
 	CommitmentDuration *types.BillingPeriod `json:"commitment_duration,omitempty"`
-
-	// CommitmentTimeBuckets defines per-bucket commitment + inline price for
-	// windows whose start UTC hour falls within each configured bucket. Each
-	// bucket carries its own price (materialized by the service). Requires
-	// IsWindowCommitment=true.
+	// CommitmentTimeBuckets scopes commitment to specific UTC-hour windows; requires IsWindowCommitment=true.
 	CommitmentTimeBuckets []CommitmentBucketRequest `json:"commitment_time_buckets,omitempty"`
 }
 
-// ToDomainBuckets maps the config's bucket requests to domain buckets (IDs +
-// commitment fields, empty PriceIDs); the service materializes a price per
-// bucket and fills in the PriceIDs.
 func (c *LineItemCommitmentConfig) ToDomainBuckets() types.TimeOfDayBuckets {
 	return bucketRequestsToDomain(c.CommitmentTimeBuckets)
 }
 
-// validateLineItemCommitments validates a map of price_id -> commitment configuration.
 func validateLineItemCommitments(commitments map[string]*LineItemCommitmentConfig) error {
 	if len(commitments) == 0 {
 		return nil
@@ -154,18 +128,15 @@ func validateLineItemCommitments(commitments map[string]*LineItemCommitmentConfi
 	return nil
 }
 
-// Validate validates the line item commitment configuration
 func (c *LineItemCommitmentConfig) Validate() error {
 	hasAmountCommitment := c.CommitmentAmount != nil && c.CommitmentAmount.GreaterThan(decimal.Zero)
 	hasQuantityCommitment := c.CommitmentQuantity != nil && c.CommitmentQuantity.GreaterThan(decimal.Zero)
 	hasCommitment := hasAmountCommitment || hasQuantityCommitment
 
 	if !hasCommitment {
-		// No commitment configured, nothing to validate
 		return nil
 	}
 
-	// Rule 1: Cannot set both commitment_amount and commitment_quantity
 	if hasAmountCommitment && hasQuantityCommitment {
 		return ierr.NewError("cannot set both commitment_amount and commitment_quantity").
 			WithHint("Specify either commitment_amount or commitment_quantity, not both").
@@ -176,7 +147,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 2: Commitment type must be valid and match the provided field
 	if c.CommitmentType != "" && !c.CommitmentType.Validate() {
 		return ierr.NewError("invalid commitment_type").
 			WithHint("Commitment type must be either 'amount' or 'quantity'").
@@ -186,7 +156,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Auto-set commitment type if not provided
 	if c.CommitmentType == "" {
 		if hasAmountCommitment {
 			c.CommitmentType = types.COMMITMENT_TYPE_AMOUNT
@@ -194,7 +163,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			c.CommitmentType = types.COMMITMENT_TYPE_QUANTITY
 		}
 	} else {
-		// Validate commitment type matches the provided field
 		if hasAmountCommitment && c.CommitmentType != types.COMMITMENT_TYPE_AMOUNT {
 			return ierr.NewError("commitment_type mismatch").
 				WithHint("When commitment_amount is set, commitment_type must be 'amount'").
@@ -216,8 +184,7 @@ func (c *LineItemCommitmentConfig) Validate() error {
 		}
 	}
 
-	// Rule 3: Overage factor is required and must be at least 1.0 when commitment is set.
-	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
+	// overage_factor is required; 1.0 means usage beyond commitment bills at the base rate.
 	if c.OverageFactor == nil {
 		return ierr.NewError("overage_factor is required when commitment is set").
 			WithHint("Specify an overage_factor of 1.0 or greater").
@@ -233,7 +200,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 4: Validate commitment values are positive
 	if hasAmountCommitment && c.CommitmentAmount.IsNegative() {
 		return ierr.NewError("commitment_amount must be non-negative").
 			WithHint("Commitment amount cannot be negative").
@@ -252,8 +218,6 @@ func (c *LineItemCommitmentConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 5: commitment_time_buckets only constrains the per-window application
-	// path — it has no meaning without is_window_commitment=true.
 	if len(c.CommitmentTimeBuckets) > 0 {
 		if c.IsWindowCommitment == nil || !*c.IsWindowCommitment {
 			return ierr.NewError("commitment_time_buckets requires is_window_commitment=true").
@@ -268,9 +232,7 @@ func (c *LineItemCommitmentConfig) Validate() error {
 	return nil
 }
 
-// SubscriptionCouponRequest represents a coupon to be applied to a subscription
-// If LineItemID is provided, the coupon is applied to that specific line item
-// If LineItemID is omitted, the coupon is applied at the subscription level
+// SubscriptionCouponRequest applies a coupon at subscription level or to a specific line item.
 type SubscriptionCouponRequest struct {
 	CouponID            string     `json:"coupon_id" validate:"required"`
 	StartDate           time.Time  `json:"start_date" validate:"required"`
@@ -279,14 +241,11 @@ type SubscriptionCouponRequest struct {
 	SubscriptionPhaseID *string    `json:"subscription_phase_id,omitempty"`
 }
 
-// Validate validates the SubscriptionCouponRequest
 func (r *SubscriptionCouponRequest) Validate() error {
-
 	if err := validator.ValidateRequest(r); err != nil {
 		return err
 	}
 
-	// Validate date range if EndDate is provided
 	if r.EndDate != nil {
 		if r.EndDate.Before(r.StartDate) {
 			return ierr.NewError("end_date cannot be before start_date").
@@ -298,21 +257,15 @@ func (r *SubscriptionCouponRequest) Validate() error {
 	return nil
 }
 
-// SubscriptionCouponInput is the preferred coupon attachment request.
-// Identifies a coupon by human-readable code (never internal ID).
-// Optionally targets a specific subscription line item via price_id.
+// SubscriptionCouponInput is the preferred coupon attachment request (by coupon_code, not ID).
+// Optionally targets a specific line item via price_id; omit for subscription-level.
 type SubscriptionCouponInput struct {
-	// CouponCode is the coupon's human-readable code (case-insensitive). Required.
-	CouponCode string `json:"coupon_code" validate:"required"`
-	// StartDate is when the coupon starts; defaults to subscription/phase StartDate.
-	StartDate *time.Time `json:"start_date,omitempty"`
-	// EndDate is when the coupon ends; overrides duration_in_periods calculation.
-	EndDate *time.Time `json:"end_date,omitempty"`
-	// PriceID is the price ID of the line item to target; omit for subscription-level.
-	PriceID *string `json:"price_id,omitempty"`
+	CouponCode string     `json:"coupon_code" validate:"required"`
+	StartDate  *time.Time `json:"start_date,omitempty"`
+	EndDate    *time.Time `json:"end_date,omitempty"`
+	PriceID    *string    `json:"price_id,omitempty"`
 }
 
-// Validate validates SubscriptionCouponInput.
 func (r *SubscriptionCouponInput) Validate() error {
 	if r.CouponCode == "" {
 		return ierr.NewError("coupon_code is required").
@@ -326,95 +279,79 @@ func (r *SubscriptionCouponInput) Validate() error {
 	return nil
 }
 
-// GroupedInvoicingChildRequest creates one grouped_invoicing child under the parent in the same request.
-// Billing period, cycle, anchor, currency, and start_date are inherited from the parent;
-// everything in SubscriptionCreationConfig is independently configurable per child.
+// GroupedInvoicingChildRequest creates a grouped_invoicing child inline with the parent request.
+// Billing schedule fields (period, cycle, anchor, currency, start_date) are inherited from the parent.
 type GroupedInvoicingChildRequest struct {
 	PlanID             string `json:"plan_id" validate:"required"`
 	ExternalCustomerID string `json:"external_customer_id" validate:"required"`
 	SubscriptionCreationConfig
 }
 
-// SubscriptionInheritanceConfig groups all hierarchy and invoicing-routing fields for
-// subscription creation.
+// SubscriptionInheritanceConfig holds all customer-hierarchy and invoicing-routing fields.
 type SubscriptionInheritanceConfig struct {
-	// ExternalCustomerIDsToInheritSubscription: child customer external IDs for which
-	// inherited skeleton subscriptions will be created. Only valid for parent behavior.
+	// ExternalCustomerIDsToInheritSubscription creates inherited skeleton subscriptions for child customers. Parent only.
 	ExternalCustomerIDsToInheritSubscription []string `json:"external_customer_ids_to_inherit_subscription,omitempty"`
 
-	// ParentSubscriptionID links this subscription to an existing parent.
-	// Required for inherited and grouped_invoicing; rejected for standalone, delegated, parent.
+	// ParentSubscriptionID links to an existing parent. Required for inherited/grouped_invoicing; rejected for standalone/delegated/parent.
 	ParentSubscriptionID string `json:"parent_subscription_id,omitempty"`
 
-	// InvoicingCustomerExternalID sets a different billing recipient (external ID).
-	// Required for delegated; rejected for inherited; optional for others.
+	// InvoicingCustomerExternalID routes invoices to a different customer. Required for delegated; rejected for inherited.
 	InvoicingCustomerExternalID *string `json:"invoicing_customer_external_id,omitempty"`
 
-	// SubscriptionsIDsForGroupedInvoicing: existing standalone subscription IDs to convert to
-	// grouped_invoicing under this parent at creation time. Only valid for parent behavior.
+	// SubscriptionsIDsForGroupedInvoicing converts existing standalone subscriptions to grouped_invoicing under this parent. Parent only.
 	SubscriptionsIDsForGroupedInvoicing []string `json:"subscriptions_ids_for_grouped_invoicing,omitempty"`
 
-	// grouped_invoicing_children_to_create creates new grouped_invoicing children under this parent
 	GroupedInvoicingChildrenToCreate []GroupedInvoicingChildRequest `json:"grouped_invoicing_children_to_create,omitempty" validate:"omitempty,dive"`
 }
 
-// Validate enforces mutual-exclusivity constraints between inheritance fields.
 func (c *SubscriptionInheritanceConfig) Validate() error {
 	if c == nil {
 		return nil
 	}
 
-	// Cannot combine explicit parent link with "create inherited children".
 	if c.ParentSubscriptionID != "" && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set parent_subscription_id together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either a parent subscription link or child customers to inherit, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Cannot delegate invoicing while also creating inherited children.
 	if c.InvoicingCustomerExternalID != nil && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set invoicing_customer_external_id together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either invoicing_customer_external_id or external_customer_ids_to_inherit_subscription, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing conversions only make sense when creating a parent (no parent link).
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && c.ParentSubscriptionID != "" {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with parent_subscription_id").
 			WithHint("subscriptions_ids_for_grouped_invoicing can only be used when creating a parent subscription").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing conversions cannot be combined with delegated invoicing.
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && c.InvoicingCustomerExternalID != nil {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with invoicing_customer_external_id").
 			WithHint("Use either grouped invoicing conversion or delegated invoicing, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing conversions cannot be combined with inherited child creation.
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 && len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
 		return ierr.NewError("cannot set subscriptions_ids_for_grouped_invoicing together with external_customer_ids_to_inherit_subscription").
 			WithHint("Use either grouped invoicing conversion or inherited child creation, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Grouped invoicing inline-child creation cannot be combined with existing-subscription conversion.
 	if len(c.GroupedInvoicingChildrenToCreate) > 0 && len(c.SubscriptionsIDsForGroupedInvoicing) > 0 {
 		return ierr.NewError("cannot set grouped_invoicing_children_to_create together with subscriptions_ids_for_grouped_invoicing").
 			WithHint("Use either inline child creation or existing-subscription conversion, not both").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Inline children require creating a parent, not attaching under an existing parent.
-	// InvoicingCustomerExternalID is allowed (delegated payer for seat fees).
+	// InvoicingCustomerExternalID is still allowed here (delegated payer for seat fees).
 	if len(c.GroupedInvoicingChildrenToCreate) > 0 && c.ParentSubscriptionID != "" {
 		return ierr.NewError("cannot set grouped_invoicing_children_to_create together with parent_subscription_id").
 			WithHint("grouped_invoicing_children_to_create can only be used when creating a parent subscription").
 			Mark(ierr.ErrValidation)
 	}
 
-	// Validate that no element in SubscriptionsIDsForGroupedInvoicing is empty.
 	for i, id := range c.SubscriptionsIDsForGroupedInvoicing {
 		if id == "" {
 			return ierr.NewError("subscriptions_ids_for_grouped_invoicing cannot contain empty values").
@@ -426,32 +363,21 @@ func (c *SubscriptionInheritanceConfig) Validate() error {
 	return nil
 }
 
-// SubscriptionCreationConfig groups every optional, per-subscription configuration field
-// that can be set at creation time, beyond plan/customer/billing-schedule. It is embedded
-// in both CreateSubscriptionRequest (top-level subscription creation) and
-// GroupedInvoicingChildRequest (inline grouped-invoicing child creation), so both use
-// identical JSON field names and identical validation.
+// SubscriptionCreationConfig holds optional configuration shared by CreateSubscriptionRequest and
+// GroupedInvoicingChildRequest, using identical JSON fields and validation for both.
 type SubscriptionCreationConfig struct {
-	// TrialPeriodDays: nil = inherit trial length from plan recurring-fixed prices (must be uniform).
-	// 0 = explicitly no trial (overrides catalog). >0 = override duration in days.
+	// TrialPeriodDays: nil = inherit from plan prices, 0 = no trial, >0 = override in days.
 	TrialPeriodDays *int `json:"trial_period_days,omitempty"`
 
-	// Credit grants to be applied when subscription is created
 	CreditGrants []CreateCreditGrantRequest `json:"credit_grants,omitempty"`
 
-	// CommitmentAmount is the minimum amount a customer commits to paying for a billing period
 	CommitmentAmount *decimal.Decimal `json:"commitment_amount,omitempty" swaggertype:"string"`
 
-	// CommitmentDuration is the time frame of the commitment (e.g., ANNUAL commitment on MONTHLY billing)
+	// CommitmentDuration allows a different commitment period than billing (e.g. ANNUAL on MONTHLY).
 	CommitmentDuration *types.BillingPeriod `json:"commitment_duration,omitempty"`
 
-	// OverageFactor is a multiplier applied to usage beyond the commitment amount
-	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty" swaggertype:"string"`
-
-	// Enable Commitment True Up Fee
-	EnableTrueUp bool `json:"enable_true_up"`
-
-	// tax_rate_overrides is the tax rate overrides to be applied to the subscription
+	OverageFactor    *decimal.Decimal   `json:"overage_factor,omitempty" swaggertype:"string"`
+	EnableTrueUp     bool               `json:"enable_true_up"`
 	TaxRateOverrides []*TaxRateOverride `json:"tax_rate_overrides,omitempty"`
 
 	// SubscriptionCoupons is the preferred way to attach coupons at creation.
@@ -464,30 +390,19 @@ type SubscriptionCreationConfig struct {
 	// Deprecated: use SubscriptionCoupons instead.
 	LineItemCoupons map[string][]string `json:"line_item_coupons,omitempty"`
 
-	// LineItemCommitments allows setting commitment configuration per line item (keyed by price_id)
+	// LineItemCommitments sets per-line-item commitment config, keyed by price_id.
 	LineItemCommitments map[string]*LineItemCommitmentConfig `json:"line_item_commitments,omitempty" validate:"omitempty,dive"`
 
-	// OverrideLineItems allows customizing specific prices for this subscription
-	OverrideLineItems []OverrideLineItemRequest `json:"override_line_items,omitempty" validate:"omitempty,dive"`
-	// OverrideEntitlements allows customizing specific entitlements for this subscription
-	OverrideEntitlements []OverrideEntitlementRequest `json:"override_entitlements,omitempty" validate:"omitempty,dive"`
-	// Addons represents addons to be added to the subscription during creation
-	Addons []AddAddonToSubscriptionRequest `json:"addons,omitempty" validate:"omitempty,dive"`
-
-	// LineItems are extra line items to add at creation (each with price_id or price), in addition to plan prices
+	// OverrideLineItems overrides specific plan prices for this subscription.
+	OverrideLineItems    []OverrideLineItemRequest       `json:"override_line_items,omitempty" validate:"omitempty,dive"`
+	OverrideEntitlements []OverrideEntitlementRequest    `json:"override_entitlements,omitempty" validate:"omitempty,dive"`
+	Addons               []AddAddonToSubscriptionRequest `json:"addons,omitempty" validate:"omitempty,dive"`
+	// LineItems are extra (non-plan) line items added at creation.
 	LineItems []CreateSubscriptionLineItemRequest `json:"line_items,omitempty" validate:"omitempty,dive"`
-
-	// Phases represents subscription phases to be created with the subscription
-	Phases []SubscriptionPhaseCreateRequest `json:"phases,omitempty" validate:"omitempty,dive"`
+	Phases    []SubscriptionPhaseCreateRequest    `json:"phases,omitempty" validate:"omitempty,dive"`
 }
 
-// Validate validates the self-contained fields of SubscriptionCreationConfig — checks that
-// only ever need this struct's own fields, independent of the parent request's type,
-// billing status, or proration settings. Used by both CreateSubscriptionRequest.Validate()
-// and (transitively, via CreateSubscriptionRequest's own promoted fields) grouped-invoicing
-// child requests.
 func (c *SubscriptionCreationConfig) Validate() error {
-	// Validate commitment amount and overage factor
 	if c.CommitmentAmount != nil && c.CommitmentAmount.LessThan(decimal.Zero) {
 		return ierr.NewError("commitment_amount must be non-negative").
 			WithHint("Commitment amount must be greater than or equal to 0").
@@ -506,10 +421,9 @@ func (c *SubscriptionCreationConfig) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// Validate credit grants if provided
 	if len(c.CreditGrants) > 0 {
 		for i, grant := range c.CreditGrants {
-			// Force scope to SUBSCRIPTION for all grants added this way
+			// Grants created with a subscription must have SUBSCRIPTION scope.
 			if grant.Scope != types.CreditGrantScopeSubscription {
 				return ierr.NewError("invalid credit grant scope").
 					WithHint("Credit grants created with a subscription must have SUBSCRIPTION scope").
@@ -522,7 +436,6 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		}
 	}
 
-	// taxrate overrides validation
 	if len(c.TaxRateOverrides) > 0 {
 		for _, taxRateOverride := range c.TaxRateOverrides {
 			if err := taxRateOverride.Validate(); err != nil {
@@ -537,16 +450,13 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		}
 	}
 
-	// Validate line item commitments if provided
 	if err := validateLineItemCommitments(c.LineItemCommitments); err != nil {
 		return err
 	}
 
-	// Validate override line items if provided
 	if len(c.OverrideLineItems) > 0 {
 		priceIDsSeen := make(map[string]bool)
 		for i, override := range c.OverrideLineItems {
-			// Check for duplicate price IDs
 			if priceIDsSeen[override.PriceID] {
 				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
 					WithHint("Each price can only be overridden once per subscription").
@@ -560,7 +470,6 @@ func (c *SubscriptionCreationConfig) Validate() error {
 		}
 	}
 
-	// Validate line_items if provided (each must have exactly one of price_id or price)
 	const maxLineItems = 100
 	if len(c.LineItems) > maxLineItems {
 		return ierr.NewError("line_items exceeds maximum allowed").
@@ -584,19 +493,12 @@ func (c *SubscriptionCreationConfig) Validate() error {
 }
 
 type CreateSubscriptionRequest struct {
-	// ID is an optional pre-generated subscription ID for internal use only.
-	// This exists as a temporary patch to allow Paddle entity mapping to be created
-	// before the subscription row is written, so both share the same transaction.
+	// ID is pre-generated for internal use (e.g. Paddle mapping before write). Never from external JSON.
 	// TODO: Remove once plan-change integration carryover is handled generically.
-	// Never populated from external JSON.
 	ID string `json:"-"`
 
-	// customer_id is the flexprice customer id
-	// and it is prioritized over external_customer_id in case both are provided.
-	CustomerID string `json:"customer_id"`
-
-	// external_customer_id is the customer id in your DB
-	// and must be same as what you provided as external_id while creating the customer in flexprice.
+	// CustomerID takes priority over ExternalCustomerID when both are provided.
+	CustomerID         string `json:"customer_id"`
 	ExternalCustomerID string `json:"external_customer_id"`
 
 	PlanID    string     `json:"plan_id" validate:"required"`
@@ -605,7 +507,7 @@ type CreateSubscriptionRequest struct {
 	StartDate *time.Time `json:"start_date,omitempty"`
 	EndDate   *time.Time `json:"end_date,omitempty"`
 
-	// TrialStart/TrialEnd are for internal integrations only (e.g. Stripe sync); not accepted from public JSON.
+	// TrialStart/TrialEnd are for internal integrations (e.g. Stripe sync); not accepted from public JSON.
 	TrialStart *time.Time `json:"-"`
 	TrialEnd   *time.Time `json:"-"`
 
@@ -614,89 +516,52 @@ type CreateSubscriptionRequest struct {
 	BillingPeriodCount int                  `json:"billing_period_count" default:"1"`
 	Metadata           map[string]string    `json:"metadata,omitempty"`
 
-	// BillingCycle is the cycle of the billing anchor.
-	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
-	// If not set, the default value is anniversary. Possible values are anniversary and calendar.
-	// Anniversary billing means the billing anchor will be the start date of the subscription.
-	// Calendar billing means the billing anchor will be the appropriate date based on the billing period.
-	// For example, if the billing period is month and the start date is 2025-04-15 then in case of
-	// calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
+	// BillingCycle controls the billing anchor. anniversary = start_date; calendar = period boundary
+	// (e.g. monthly with start 2025-04-15 → calendar anchor is 2025-05-01).
 	BillingCycle types.BillingCycle `json:"billing_cycle"`
 
-	// Payment behavior configuration
-	PaymentBehavior        *types.PaymentBehavior `json:"payment_behavior,omitempty"`
-	GatewayPaymentMethodID *string                `json:"gateway_payment_method_id,omitempty"`
-
-	// collection_method determines how invoices are collected
-	// "default_incomplete" - subscription waits for payment confirmation before activation
-	// "send_invoice" - subscription activates immediately, invoice is sent for payment
-	CollectionMethod *types.CollectionMethod `json:"collection_method,omitempty"`
-
-	// ProrationBehavior controls how proration is handled.
-	// If not set, the default value is none. Possible values are create_prorations and none.
-	// create_prorations means the proration will be calculated and applied.
-	// none means the proration will not be calculated.
-	// This is IGNORED when the billing cycle is anniversary.
+	PaymentBehavior        *types.PaymentBehavior  `json:"payment_behavior,omitempty"`
+	GatewayPaymentMethodID *string                 `json:"gateway_payment_method_id,omitempty"`
+	CollectionMethod       *types.CollectionMethod `json:"collection_method,omitempty"`
+	// ProrationBehavior: create_prorations or none (default). Ignored for anniversary billing.
 	ProrationBehavior types.ProrationBehavior `json:"proration_behavior,omitempty"`
-
-	// Timezone of the customer.
-	// If not set, the default value is UTC.
-	Timezone string `json:"timezone" validate:"omitempty,timezone"`
-
-	// BillingAnchor overrides the derived billing anchor when billing_cycle is anniversary.
-	// For monthly billing, the day-of-month (and time-of-day) define cycle boundaries: if start_date
-	// is before that day in the month, the first billing period ends on the next occurrence of that
-	// day in the same month (a shorter first period); subsequent periods follow the usual interval.
+	Timezone          string                  `json:"timezone" validate:"omitempty,timezone"`
+	// BillingAnchor overrides the derived anchor for anniversary billing. For monthly billing,
+	// the day-of-month defines cycle boundaries (shorter first period if start is before that day).
 	BillingAnchor *time.Time `json:"billing_anchor,omitempty"`
 
-	// Workflow
 	Workflow *types.TemporalWorkflowType `json:"-"`
 
-	// SubscriptionStatus determines the initial status of the subscription
-	// If set to "draft", the subscription will be created as a draft (skips invoice creation and payment processing)
+	// SubscriptionStatus: set to "draft" to skip invoice creation and payment on create.
 	SubscriptionStatus types.SubscriptionStatus `json:"subscription_status,omitempty"`
+	PaymentTerms       *types.PaymentTerms      `json:"payment_terms,omitempty"`
 
-	// PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end
-	PaymentTerms *types.PaymentTerms `json:"payment_terms,omitempty"`
-
-	// AutoInvoiceThreshold is the usage amount (in subscription currency) that triggers
-	// an intermediate invoice mid-period. Set once at creation; cannot be changed later.
-	// Allowed only when the subscription resolves to type standalone (no parent hierarchy rows).
-	// Plan line items must be usage-based only (no fixed or other non-usage plan prices).
-	// Nil means auto invoice threshold billing is disabled for this subscription.
+	// AutoInvoiceThreshold triggers a mid-period invoice when usage (in subscription currency) exceeds this amount.
+	// Standalone subscriptions only; all plan prices must be usage-based. Immutable after creation.
 	AutoInvoiceThreshold *decimal.Decimal `json:"auto_invoice_threshold,omitempty" swaggertype:"string"`
 
-	// Inheritance groups all customer-hierarchy fields.
-	// When provided with at least one child ID, the subscription becomes a PARENT type.
+	// Inheritance groups customer-hierarchy fields; providing child IDs makes this a PARENT subscription.
 	Inheritance *SubscriptionInheritanceConfig `json:"inheritance,omitempty"`
 
 	// SubscriptionType is set internally by the service layer.
 	SubscriptionType types.SubscriptionType `json:"-"`
 
-	// OpeningInvoiceAdjustmentAmount is internal: proration/cancel credit to net the new subscription's first (opening) invoice (e.g. CancelSubscriptionResponse.TotalCreditAmount on immediate plan change). Not in public JSON.
+	// OpeningInvoiceAdjustmentAmount nets the opening invoice against a proration/cancel credit (e.g. on plan change). Internal only.
 	OpeningInvoiceAdjustmentAmount *decimal.Decimal `json:"-"`
 
-	// SubscriptionCreationConfig holds every optional configuration field shared with
-	// GroupedInvoicingChildRequest (overrides, extra line items, coupons, taxes,
-	// commitments, trial, credit grants, entitlement overrides, addons, phases).
 	SubscriptionCreationConfig
 }
 
-// AddAddonRequest is used by body-based endpoint /subscriptions/addon
 type AddAddonRequest struct {
 	SubscriptionID                string `json:"subscription_id" validate:"required"`
 	AddAddonToSubscriptionRequest `json:",inline"`
 }
 
-// RemoveAddonRequest is used by body-based endpoint /subscriptions/addon (DELETE)
 type RemoveAddonRequest struct {
 	AddonAssociationID string                  `json:"addon_association_id" validate:"required"`
 	Reason             string                  `json:"reason,omitempty"`
 	ProrationBehavior  types.ProrationBehavior `json:"proration_behavior,omitempty"`
-	// EffectiveDate is the date the cancellation takes effect.
-	// When nil the addon is cancelled at the end of the current period.
-	// When provided it must fall within [CurrentPeriodStart, CurrentPeriodEnd]; mid-period
-	// values combined with create_prorations will issue a wallet credit for unused time.
+	// EffectiveDate defaults to period end when nil; mid-period with create_prorations issues a wallet credit.
 	EffectiveDate *time.Time `json:"effective_date,omitempty"`
 }
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -327,10 +327,12 @@ func (r *SubscriptionCouponInput) Validate() error {
 }
 
 // GroupedInvoicingChildRequest creates one grouped_invoicing child under the parent in the same request.
-// Billing period, cycle, anchor, currency, and start_date are inherited from the parent.
+// Billing period, cycle, anchor, currency, and start_date are inherited from the parent;
+// everything in SubscriptionCreationConfig is independently configurable per child.
 type GroupedInvoicingChildRequest struct {
 	PlanID             string `json:"plan_id" validate:"required"`
 	ExternalCustomerID string `json:"external_customer_id" validate:"required"`
+	SubscriptionCreationConfig
 }
 
 // SubscriptionInheritanceConfig groups all hierarchy and invoicing-routing fields for

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -424,49 +424,15 @@ func (c *SubscriptionInheritanceConfig) Validate() error {
 	return nil
 }
 
-type CreateSubscriptionRequest struct {
-	// ID is an optional pre-generated subscription ID for internal use only.
-	// This exists as a temporary patch to allow Paddle entity mapping to be created
-	// before the subscription row is written, so both share the same transaction.
-	// TODO: Remove once plan-change integration carryover is handled generically.
-	// Never populated from external JSON.
-	ID string `json:"-"`
-
-	// customer_id is the flexprice customer id
-	// and it is prioritized over external_customer_id in case both are provided.
-	CustomerID string `json:"customer_id"`
-
-	// external_customer_id is the customer id in your DB
-	// and must be same as what you provided as external_id while creating the customer in flexprice.
-	ExternalCustomerID string `json:"external_customer_id"`
-
-	PlanID    string     `json:"plan_id" validate:"required"`
-	Currency  string     `json:"currency" validate:"required,len=3"`
-	LookupKey string     `json:"lookup_key"`
-	StartDate *time.Time `json:"start_date,omitempty"`
-	EndDate   *time.Time `json:"end_date,omitempty"`
-
+// SubscriptionCreationConfig groups every optional, per-subscription configuration field
+// that can be set at creation time, beyond plan/customer/billing-schedule. It is embedded
+// in both CreateSubscriptionRequest (top-level subscription creation) and
+// GroupedInvoicingChildRequest (inline grouped-invoicing child creation), so both use
+// identical JSON field names and identical validation.
+type SubscriptionCreationConfig struct {
 	// TrialPeriodDays: nil = inherit trial length from plan recurring-fixed prices (must be uniform).
 	// 0 = explicitly no trial (overrides catalog). >0 = override duration in days.
 	TrialPeriodDays *int `json:"trial_period_days,omitempty"`
-
-	// TrialStart/TrialEnd are for internal integrations only (e.g. Stripe sync); not accepted from public JSON.
-	TrialStart *time.Time `json:"-"`
-	TrialEnd   *time.Time `json:"-"`
-
-	BillingCadence     types.BillingCadence `json:"-"`
-	BillingPeriod      types.BillingPeriod  `json:"billing_period" validate:"required"`
-	BillingPeriodCount int                  `json:"billing_period_count" default:"1"`
-	Metadata           map[string]string    `json:"metadata,omitempty"`
-
-	// BillingCycle is the cycle of the billing anchor.
-	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
-	// If not set, the default value is anniversary. Possible values are anniversary and calendar.
-	// Anniversary billing means the billing anchor will be the start date of the subscription.
-	// Calendar billing means the billing anchor will be the appropriate date based on the billing period.
-	// For example, if the billing period is month and the start date is 2025-04-15 then in case of
-	// calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
-	BillingCycle types.BillingCycle `json:"billing_cycle"`
 
 	// Credit grants to be applied when subscription is created
 	CreditGrants []CreateCreditGrantRequest `json:"credit_grants,omitempty"`
@@ -480,7 +446,10 @@ type CreateSubscriptionRequest struct {
 	// OverageFactor is a multiplier applied to usage beyond the commitment amount
 	OverageFactor *decimal.Decimal `json:"overage_factor,omitempty" swaggertype:"string"`
 
-	// tax_rate_overrides is the tax rate overrides	to be applied to the subscription
+	// Enable Commitment True Up Fee
+	EnableTrueUp bool `json:"enable_true_up"`
+
+	// tax_rate_overrides is the tax rate overrides to be applied to the subscription
 	TaxRateOverrides []*TaxRateOverride `json:"tax_rate_overrides,omitempty"`
 
 	// SubscriptionCoupons is the preferred way to attach coupons at creation.
@@ -508,6 +477,47 @@ type CreateSubscriptionRequest struct {
 
 	// Phases represents subscription phases to be created with the subscription
 	Phases []SubscriptionPhaseCreateRequest `json:"phases,omitempty" validate:"omitempty,dive"`
+}
+
+type CreateSubscriptionRequest struct {
+	// ID is an optional pre-generated subscription ID for internal use only.
+	// This exists as a temporary patch to allow Paddle entity mapping to be created
+	// before the subscription row is written, so both share the same transaction.
+	// TODO: Remove once plan-change integration carryover is handled generically.
+	// Never populated from external JSON.
+	ID string `json:"-"`
+
+	// customer_id is the flexprice customer id
+	// and it is prioritized over external_customer_id in case both are provided.
+	CustomerID string `json:"customer_id"`
+
+	// external_customer_id is the customer id in your DB
+	// and must be same as what you provided as external_id while creating the customer in flexprice.
+	ExternalCustomerID string `json:"external_customer_id"`
+
+	PlanID    string     `json:"plan_id" validate:"required"`
+	Currency  string     `json:"currency" validate:"required,len=3"`
+	LookupKey string     `json:"lookup_key"`
+	StartDate *time.Time `json:"start_date,omitempty"`
+	EndDate   *time.Time `json:"end_date,omitempty"`
+
+	// TrialStart/TrialEnd are for internal integrations only (e.g. Stripe sync); not accepted from public JSON.
+	TrialStart *time.Time `json:"-"`
+	TrialEnd   *time.Time `json:"-"`
+
+	BillingCadence     types.BillingCadence `json:"-"`
+	BillingPeriod      types.BillingPeriod  `json:"billing_period" validate:"required"`
+	BillingPeriodCount int                  `json:"billing_period_count" default:"1"`
+	Metadata           map[string]string    `json:"metadata,omitempty"`
+
+	// BillingCycle is the cycle of the billing anchor.
+	// This is used to determine the billing date for the subscription (i.e set the billing anchor)
+	// If not set, the default value is anniversary. Possible values are anniversary and calendar.
+	// Anniversary billing means the billing anchor will be the start date of the subscription.
+	// Calendar billing means the billing anchor will be the appropriate date based on the billing period.
+	// For example, if the billing period is month and the start date is 2025-04-15 then in case of
+	// calendar billing the billing anchor will be 2025-05-01 vs 2025-04-15 for anniversary billing.
+	BillingCycle types.BillingCycle `json:"billing_cycle"`
 
 	// Payment behavior configuration
 	PaymentBehavior        *types.PaymentBehavior `json:"payment_behavior,omitempty"`
@@ -545,9 +555,6 @@ type CreateSubscriptionRequest struct {
 	// PaymentTerms (e.g. 15 NET, 30 NET) used to compute invoice due date from period end
 	PaymentTerms *types.PaymentTerms `json:"payment_terms,omitempty"`
 
-	// Enable Commitment True Up Fee
-	EnableTrueUp bool `json:"enable_true_up"`
-
 	// AutoInvoiceThreshold is the usage amount (in subscription currency) that triggers
 	// an intermediate invoice mid-period. Set once at creation; cannot be changed later.
 	// Allowed only when the subscription resolves to type standalone (no parent hierarchy rows).
@@ -564,6 +571,11 @@ type CreateSubscriptionRequest struct {
 
 	// OpeningInvoiceAdjustmentAmount is internal: proration/cancel credit to net the new subscription's first (opening) invoice (e.g. CancelSubscriptionResponse.TotalCreditAmount on immediate plan change). Not in public JSON.
 	OpeningInvoiceAdjustmentAmount *decimal.Decimal `json:"-"`
+
+	// SubscriptionCreationConfig holds every optional configuration field shared with
+	// GroupedInvoicingChildRequest (overrides, extra line items, coupons, taxes,
+	// commitments, trial, credit grants, entitlement overrides, addons, phases).
+	SubscriptionCreationConfig
 }
 
 // AddAddonRequest is used by body-based endpoint /subscriptions/addon

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -154,6 +154,29 @@ func validateLineItemCommitments(commitments map[string]*LineItemCommitmentConfi
 	return nil
 }
 
+// validateNoDuplicateOverridePriceIDs rejects override line items that target the same
+// price more than once — each price can only be overridden once per request.
+func validateNoDuplicateOverridePriceIDs(overrides []OverrideLineItemRequest) error {
+	if len(overrides) == 0 {
+		return nil
+	}
+
+	priceIDsSeen := make(map[string]bool)
+	for i, override := range overrides {
+		if priceIDsSeen[override.PriceID] {
+			return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
+				WithHint("Each price can only be overridden once per subscription").
+				WithReportableDetails(map[string]interface{}{
+					"price_id": override.PriceID,
+					"index":    i,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+		priceIDsSeen[override.PriceID] = true
+	}
+	return nil
+}
+
 // Validate validates the line item commitment configuration
 func (c *LineItemCommitmentConfig) Validate() error {
 	hasAmountCommitment := c.CommitmentAmount != nil && c.CommitmentAmount.GreaterThan(decimal.Zero)
@@ -1091,21 +1114,8 @@ func (r *CreateSubscriptionRequest) Validate() error {
 	}
 
 	// Validate override line items if provided
-	if len(r.OverrideLineItems) > 0 {
-		priceIDsSeen := make(map[string]bool)
-		for i, override := range r.OverrideLineItems {
-			// Check for duplicate price IDs
-			if priceIDsSeen[override.PriceID] {
-				return ierr.NewError(fmt.Sprintf("duplicate price_id in override line items at index %d", i)).
-					WithHint("Each price can only be overridden once per subscription").
-					WithReportableDetails(map[string]interface{}{
-						"price_id": override.PriceID,
-						"index":    i,
-					}).
-					Mark(ierr.ErrValidation)
-			}
-			priceIDsSeen[override.PriceID] = true
-		}
+	if err := validateNoDuplicateOverridePriceIDs(r.OverrideLineItems); err != nil {
+		return err
 	}
 
 	// Validate line_items if provided (each must have exactly one of price_id or price)

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -74,7 +74,7 @@ func (s *billingService) CalculateMeterUsageCharges(
 	}
 
 	subscriptionService := NewSubscriptionService(s.ServiceParams)
-	aggregatedEntitlements, err := subscriptionService.GetAggregatedSubscriptionEntitlements(ctx, sub.ID, nil)
+	aggregatedEntitlements, err := subscriptionService.GetAggregatedSubscriptionEntitlementsForSubscription(ctx, sub, nil)
 	if err != nil {
 		return nil, decimal.Zero, err
 	}

--- a/internal/ee/service/line_item_proration.go
+++ b/internal/ee/service/line_item_proration.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/idempotency"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 )
@@ -30,7 +32,7 @@ type LineItemProrationRequest struct {
 	EffectiveDate  time.Time
 	Behavior       types.ProrationBehavior
 	Reason         string // shown in wallet credit description
-	IdempotencyKey string // required when Behavior == create_prorations and credits may be issued
+	IdempotencyKey string
 }
 
 // LineItemProrationSummary is returned by Compute and used internally by Apply.
@@ -145,7 +147,7 @@ func (s *lineItemProrationService) Apply(ctx context.Context, req LineItemProrat
 
 	if summary.TotalChargeAmount.GreaterThan(decimal.Zero) && len(summary.ChargeLineItems) > 0 {
 		invoiceSvc := NewInvoiceService(s.params)
-		if err := s.settleCharge(ctx, sub, summary, req.EffectiveDate, invoiceSvc); err != nil {
+		if err := s.settleCharge(ctx, sub, summary, req.EffectiveDate, prorationChargeInvoiceKey(req), invoiceSvc); err != nil {
 			return err
 		}
 	}
@@ -259,12 +261,31 @@ func (s *lineItemProrationService) buildChargeLineItem(
 	}
 }
 
+func prorationChargeInvoiceKey(req LineItemProrationRequest) string {
+	source := req.IdempotencyKey
+	if source == "" {
+		ids := make([]string, 0, len(req.Entries))
+		for _, entry := range req.Entries {
+			ids = append(ids, entry.LineItem.ID)
+		}
+		sort.Strings(ids)
+		source = strings.Join(ids, ",")
+	}
+
+	return idempotency.NewGenerator().GenerateKey(idempotency.ScopeProrationCharge, map[string]interface{}{
+		"subscription_id": req.Subscription.ID,
+		"effective_date":  req.EffectiveDate.UTC().Format(time.RFC3339Nano),
+		"source":          source,
+	})
+}
+
 // settleCharge creates a one-off invoice for the aggregated charge amount.
 func (s *lineItemProrationService) settleCharge(
 	ctx context.Context,
 	sub *subscription.Subscription,
 	summary *LineItemProrationSummary,
 	effectiveDate time.Time,
+	idempotencyKey string,
 	invoiceSvc InvoiceService,
 ) error {
 	billingCustomer := sub.GetInvoicingCustomerID()
@@ -284,6 +305,7 @@ func (s *lineItemProrationService) settleCharge(
 		PeriodEnd:      &periodEnd,
 		BillingPeriod:  &billingPeriod,
 		LineItems:      summary.ChargeLineItems,
+		IdempotencyKey: &idempotencyKey,
 	})
 	if err != nil {
 		s.params.Logger.Error(ctx, "failed to create proration charge invoice", "error", err)

--- a/internal/ee/service/line_item_proration.go
+++ b/internal/ee/service/line_item_proration.go
@@ -267,6 +267,7 @@ func prorationChargeInvoiceKey(req LineItemProrationRequest) string {
 		ids := make([]string, 0, len(req.Entries))
 		for _, entry := range req.Entries {
 			ids = append(ids, entry.LineItem.ID)
+			ids = append(ids, string(entry.Action))
 		}
 		sort.Strings(ids)
 		source = strings.Join(ids, ",")

--- a/internal/ee/service/line_item_proration_test.go
+++ b/internal/ee/service/line_item_proration_test.go
@@ -148,7 +148,7 @@ func (s *LineItemProrationServiceSuite) setupTestData() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		SubscriptionStatus: types.SubscriptionStatusActive,
-		Timezone:   "UTC",
+		Timezone:           "UTC",
 		BaseModel:          types.GetDefaultBaseModel(ctx),
 	}
 	s.NoError(s.GetStores().SubscriptionRepo.Create(ctx, s.td.sub))
@@ -476,6 +476,112 @@ func (s *LineItemProrationServiceSuite) TestApply_AddItem_CreatesOneOffInvoice()
 	s.Equal(types.InvoiceTypeOneOff, inv.InvoiceType)
 	s.True(inv.AmountDue.GreaterThan(decimal.Zero),
 		"invoice amount must be positive, got %s", inv.AmountDue)
+}
+
+// TestApply_TwoChangesSameEffectiveDate_BillSeparately guards the under-billing
+// regression: two mid-period changes on one subscription sharing an effective date
+// used to collide on the auto-generated invoice idempotency key (subscription +
+// billing reason + period truncated to the minute), so the second was rejected as a
+// duplicate and silently never billed. Only the caller's key distinguishes them.
+func (s *LineItemProrationServiceSuite) TestApply_TwoChangesSameEffectiveDate_BillSeparately() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	secondPrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(35),
+		Currency:           "usd",
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, secondPrice))
+
+	secondLineItem := &subscription.SubscriptionLineItem{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID: s.td.sub.ID,
+		CustomerID:     s.td.sub.CustomerID,
+		PriceID:        secondPrice.ID,
+		PriceType:      types.PRICE_TYPE_FIXED,
+		Quantity:       decimal.NewFromInt(1),
+		Currency:       "usd",
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: types.InvoiceCadenceAdvance,
+		StartDate:      effectiveDate,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, secondLineItem))
+
+	applyAdd := func(lineItem *subscription.SubscriptionLineItem, p *price.Price, key string) error {
+		return s.svc.Apply(ctx, LineItemProrationRequest{
+			Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+			EffectiveDate:  effectiveDate,
+			Behavior:       types.ProrationBehaviorCreateProrations,
+			IdempotencyKey: key,
+			Entries: []LineItemProrationEntry{{
+				LineItem:    lineItem,
+				Price:       p,
+				Action:      types.ProrationActionAddItem,
+				NewQuantity: lineItem.Quantity,
+			}},
+		})
+	}
+
+	s.NoError(applyAdd(s.td.lineItem, s.td.fixedPrice, "addon_add_assoc_one"))
+	s.NoError(applyAdd(secondLineItem, secondPrice, "addon_add_assoc_two"),
+		"a second change with the same effective date must still be billed")
+
+	invoices, err := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(err)
+	s.Require().Len(invoices, 2, "each change must produce its own proration invoice")
+
+	keys := make(map[string]struct{}, len(invoices))
+	total := decimal.Zero
+	for _, inv := range invoices {
+		s.Require().NotNil(inv.IdempotencyKey, "proration invoice must carry an idempotency key")
+		keys[*inv.IdempotencyKey] = struct{}{}
+		s.True(inv.AmountDue.GreaterThan(decimal.Zero))
+		total = total.Add(inv.AmountDue)
+	}
+	s.Len(keys, 2, "proration invoices must have distinct idempotency keys")
+
+	// $20 and $35 prorated over the same remaining window (2/3 of the period).
+	expected, _ := decimal.NewFromString("36.66")
+	s.True(total.Equal(expected), "expected %s billed across both invoices, got %s", expected, total)
+}
+
+// TestApply_SameChangeTwice_IsIdempotent verifies the flip side: replaying the exact
+// same change must not produce a second invoice.
+func (s *LineItemProrationServiceSuite) TestApply_SameChangeTwice_IsIdempotent() {
+	ctx := s.GetContext()
+	effectiveDate := time.Date(2026, 4, 11, 0, 0, 0, 0, time.UTC)
+
+	req := LineItemProrationRequest{
+		Subscription:   s.subCopyWithPeriod(s.td.periodStart, s.td.periodEnd),
+		EffectiveDate:  effectiveDate,
+		Behavior:       types.ProrationBehaviorCreateProrations,
+		IdempotencyKey: "addon_add_assoc_replayed",
+		Entries: []LineItemProrationEntry{{
+			LineItem:    s.td.lineItem,
+			Price:       s.td.fixedPrice,
+			Action:      types.ProrationActionAddItem,
+			NewQuantity: s.td.lineItem.Quantity,
+		}},
+	}
+
+	s.NoError(s.svc.Apply(ctx, req))
+	_ = s.svc.Apply(ctx, req)
+
+	invoices, err := s.GetStores().InvoiceRepo.List(ctx, &types.InvoiceFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.NoError(err)
+	s.Len(invoices, 1, "replaying the same change must not double-bill")
 }
 
 // ─── Apply – credit (wallet top-up) ──────────────────────────────────────────

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -621,7 +621,7 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 		missingPairs, subIDsInPage, listErr := s.PlanPriceSyncRepo.ListPlanLineItemsToCreateV2(ctx, planpricesync.ListPlanLineItemsToCreateV2Params{
 			PlanID:    planID,
 			TargetSeq: targetSeq,
-			Limit:     1000,
+			Limit:     2000,
 		})
 		if listErr != nil {
 			return nil, listErr
@@ -672,10 +672,10 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 				lineItems = append(lineItems, createPlanLineItem(ctx, sub, price, plan))
 			}
 
-			// Page size is 1000 subs but each sub can match multiple prices,
+			// Page size is 2000 subs but each sub can match multiple prices,
 			// so total line items per page can exceed a sensible single-
 			// statement insert size. Chunk the bulk insert.
-			const bulkInsertBatchSize = 2000
+			const bulkInsertBatchSize = 1500
 			for i := 0; i < len(lineItems); i += bulkInsertBatchSize {
 				end := min(i+bulkInsertBatchSize, len(lineItems))
 				batch := lineItems[i:end]

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -621,7 +621,7 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 		missingPairs, subIDsInPage, listErr := s.PlanPriceSyncRepo.ListPlanLineItemsToCreateV2(ctx, planpricesync.ListPlanLineItemsToCreateV2Params{
 			PlanID:    planID,
 			TargetSeq: targetSeq,
-			Limit:     5000,
+			Limit:     10000,
 		})
 		if listErr != nil {
 			return nil, listErr
@@ -672,7 +672,7 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 				lineItems = append(lineItems, createPlanLineItem(ctx, sub, price, plan))
 			}
 
-			// Page size is 5000 subs but each sub can match multiple prices,
+			// Page size is 10000 subs but each sub can match multiple prices,
 			// so total line items per page can exceed a sensible single-
 			// statement insert size. Chunk the bulk insert.
 			const bulkInsertBatchSize = 1500

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -621,7 +621,7 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 		missingPairs, subIDsInPage, listErr := s.PlanPriceSyncRepo.ListPlanLineItemsToCreateV2(ctx, planpricesync.ListPlanLineItemsToCreateV2Params{
 			PlanID:    planID,
 			TargetSeq: targetSeq,
-			Limit:     10000,
+			Limit:     2000,
 		})
 		if listErr != nil {
 			return nil, listErr

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -621,7 +621,7 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 		missingPairs, subIDsInPage, listErr := s.PlanPriceSyncRepo.ListPlanLineItemsToCreateV2(ctx, planpricesync.ListPlanLineItemsToCreateV2Params{
 			PlanID:    planID,
 			TargetSeq: targetSeq,
-			Limit:     2000,
+			Limit:     5000,
 		})
 		if listErr != nil {
 			return nil, listErr
@@ -672,7 +672,7 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 				lineItems = append(lineItems, createPlanLineItem(ctx, sub, price, plan))
 			}
 
-			// Page size is 2000 subs but each sub can match multiple prices,
+			// Page size is 5000 subs but each sub can match multiple prices,
 			// so total line items per page can exceed a sensible single-
 			// statement insert size. Chunk the bulk insert.
 			const bulkInsertBatchSize = 1500

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -6680,27 +6680,17 @@ func (s *subscriptionService) filterOverriddenEntitlements(
 	return finalEntitlements
 }
 
-// GetAggregatedSubscriptionEntitlements retrieves and aggregates all entitlements for a subscription
+// GetAggregatedSubscriptionEntitlementsForSubscription retrieves and aggregates all entitlements for a subscription
 // and returns them in a structured response format with aggregated features
-func (s *subscriptionService) GetAggregatedSubscriptionEntitlements(ctx context.Context, subscriptionID string, req *dto.GetSubscriptionEntitlementsRequest) (*dto.SubscriptionEntitlementsResponse, error) {
-	// Validate request if provided
-	if req != nil {
-		if err := req.Validate(); err != nil {
-			return nil, err
-		}
-	} else {
-		// Initialize with empty request if none provided
-		req = &dto.GetSubscriptionEntitlementsRequest{}
-	}
-
-	// Get the subscription
-	sub, err := s.SubRepo.Get(ctx, subscriptionID)
-	if err != nil {
-		return nil, err
+func (s *subscriptionService) GetAggregatedSubscriptionEntitlementsForSubscription(ctx context.Context, sub *subscription.Subscription, req *dto.GetSubscriptionEntitlementsRequest) (*dto.SubscriptionEntitlementsResponse, error) {
+	if sub == nil {
+		return nil, ierr.NewError("subscription is required").
+			WithHint("A subscription must be provided to resolve entitlements").
+			Mark(ierr.ErrValidation)
 	}
 
 	// Get all entitlements for the subscription
-	entitlements, err := s.GetSubscriptionEntitlements(ctx, subscriptionID)
+	entitlements, err := s.GetSubscriptionEntitlementsForSubscription(ctx, sub)
 	if err != nil {
 		return nil, err
 	}
@@ -6720,26 +6710,48 @@ func (s *subscriptionService) GetAggregatedSubscriptionEntitlements(ctx context.
 	billingService := NewBillingService(s.ServiceParams)
 	aggregatedFeatures := billingService.AggregateEntitlements(&dto.AggregateEntitlementsParams{
 		Entitlements:   entitlements,
-		SubscriptionID: subscriptionID,
+		SubscriptionID: sub.ID,
 	})
 
 	// Ensure subscription ID is set in all sources
 	for _, feature := range aggregatedFeatures {
 		for _, source := range feature.Sources {
 			if source.SubscriptionID == "" {
-				source.SubscriptionID = subscriptionID
+				source.SubscriptionID = sub.ID
 			}
 		}
 	}
 
 	// Build final response
 	response := &dto.SubscriptionEntitlementsResponse{
-		SubscriptionID: subscriptionID,
+		SubscriptionID: sub.ID,
 		PlanID:         sub.PlanID,
 		Features:       aggregatedFeatures,
 	}
 
 	return response, nil
+}
+
+// GetAggregatedSubscriptionEntitlements retrieves and aggregates all entitlements for a subscription
+// and returns them in a structured response format with aggregated features
+func (s *subscriptionService) GetAggregatedSubscriptionEntitlements(ctx context.Context, subscriptionID string, req *dto.GetSubscriptionEntitlementsRequest) (*dto.SubscriptionEntitlementsResponse, error) {
+	// Validate request if provided
+	if req != nil {
+		if err := req.Validate(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Initialize with empty request if none provided
+		req = &dto.GetSubscriptionEntitlementsRequest{}
+	}
+
+	// Get the subscription
+	sub, err := s.SubRepo.Get(ctx, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetAggregatedSubscriptionEntitlementsForSubscription(ctx, sub, req)
 }
 
 // ProcessSubscriptionEntitlementOverrides creates subscription-scoped entitlement overrides

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4852,14 +4852,6 @@ func (s *subscriptionService) addAddonToSubscription(
 		lineItems = append(lineItems, lineItem)
 	}
 
-	// Must run after commitments above (keyed by line item ID, so they survive the
-	// PriceID mutation here) and before the transaction (CreatePrice persists directly).
-	if len(req.OverrideLineItems) > 0 {
-		if err := s.ProcessSubscriptionPriceOverrides(ctx, sub, req.OverrideLineItems, lineItems, priceMap); err != nil {
-			return nil, err
-		}
-	}
-
 	// Ensure subscription-level and line-item-level commitments don't conflict
 	originalLineItems := sub.LineItems
 	sub.LineItems = lo.Flatten([][]*subscription.SubscriptionLineItem{originalLineItems, lineItems})
@@ -4870,6 +4862,12 @@ func (s *subscriptionService) addAddonToSubscription(
 	}
 
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
+		if len(req.OverrideLineItems) > 0 {
+			if err := s.ProcessSubscriptionPriceOverrides(ctx, sub, req.OverrideLineItems, lineItems, priceMap); err != nil {
+				return err
+			}
+		}
+
 		// Create subscription addon association
 		err = s.AddonAssociationRepo.Create(ctx, addonAssociation)
 		if err != nil {

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4797,6 +4797,12 @@ func (s *subscriptionService) addAddonToSubscription(
 		return nil, err
 	}
 
+	// Price map for override processing, keyed by price ID (same pattern createSubscription uses)
+	priceMap := make(map[string]*dto.PriceResponse, len(validPrices))
+	for _, p := range validPrices {
+		priceMap[p.Price.ID] = p
+	}
+
 	// Create subscription addon association
 	addonAssociation := req.ToAddonAssociation(
 		ctx,
@@ -4844,6 +4850,16 @@ func (s *subscriptionService) addAddonToSubscription(
 			lineItemBucketCfgs[lineItem.ID] = cfg
 		}
 		lineItems = append(lineItems, lineItem)
+	}
+
+	// Process price overrides — must run after commitments are applied above (bucket
+	// configs are keyed by line item ID, not price ID, so they survive the PriceID
+	// mutation this performs) and before the transaction below (it persists its own
+	// subscription-scoped Price rows directly via priceService.CreatePrice).
+	if len(req.OverrideLineItems) > 0 {
+		if err := s.ProcessSubscriptionPriceOverrides(ctx, sub, req.OverrideLineItems, lineItems, priceMap); err != nil {
+			return nil, err
+		}
 	}
 
 	// Ensure subscription-level and line-item-level commitments don't conflict

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7689,12 +7689,15 @@ func (s *subscriptionService) createInheritedSubscriptions(ctx context.Context, 
 
 // createGroupedInvoicingChildren creates each child spec as a brand-new grouped_invoicing
 // subscription under parent, inside the caller's existing transaction. Each child's own opening
-// invoice is suppressed (see the invoice-generation gate in createSubscriptionCore); its period-1
-// charges are folded into the parent's own opening invoice instead. Calls createSubscriptionCore
+// invoice is suppressed (see the invoice-generation gate in createSubscription); its period-1
+// charges are folded into the parent's own opening invoice instead. Calls createSubscription
 // directly (not the public CreateSubscription): it must reuse the caller's already-open
 // transaction and must not fire the child's own post-transaction side effects (webhook,
 // HubSpot/Paddle sync) — only the parent's single post-tx block should run, once, after
-// everything commits.
+// everything commits. Every field in the child's SubscriptionCreationConfig (overrides, extra
+// line items, coupons, taxes, commitments, trial, credit grants, entitlement overrides, addons,
+// phases) is copied through as-is and validated/applied by the same createSubscription call the
+// parent uses — no separate handling needed here.
 func (s *subscriptionService) createGroupedInvoicingChildren(
 	ctx context.Context,
 	parent *subscription.Subscription,
@@ -7702,15 +7705,28 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 ) error {
 	for _, c := range childRequests {
 		startDate := parent.StartDate
+
+		// BillingAnchor is only ever valid alongside BillingCycle == anniversary (enforced in
+		// CreateSubscriptionRequest.Validate()). Since BillingCycle is always inherited from the
+		// parent below, only pass the anchor through when that inherited cycle is anniversary —
+		// otherwise a calendar-cycle child would fail validation on a non-nil anchor pointer.
+		var billingAnchor *time.Time
+		if parent.BillingCycle == types.BillingCycleAnniversary {
+			anchor := parent.BillingAnchor
+			billingAnchor = &anchor
+		}
+
 		childReq := dto.CreateSubscriptionRequest{
-			ExternalCustomerID: c.ExternalCustomerID,
-			PlanID:             c.PlanID,
-			Currency:           parent.Currency,
-			StartDate:          &startDate,
-			BillingPeriod:      parent.BillingPeriod,
-			BillingPeriodCount: parent.BillingPeriodCount,
-			BillingCycle:       parent.BillingCycle,
-			SubscriptionType:   types.SubscriptionTypeGroupedInvoicing,
+			ExternalCustomerID:         c.ExternalCustomerID,
+			PlanID:                     c.PlanID,
+			Currency:                   parent.Currency,
+			StartDate:                  &startDate,
+			BillingPeriod:              parent.BillingPeriod,
+			BillingPeriodCount:         parent.BillingPeriodCount,
+			BillingCycle:               parent.BillingCycle,
+			BillingAnchor:              billingAnchor,
+			SubscriptionType:           types.SubscriptionTypeGroupedInvoicing,
+			SubscriptionCreationConfig: c.SubscriptionCreationConfig,
 			Inheritance: &dto.SubscriptionInheritanceConfig{
 				ParentSubscriptionID: parent.ID,
 			},

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7687,17 +7687,9 @@ func (s *subscriptionService) createInheritedSubscriptions(ctx context.Context, 
 	return nil
 }
 
-// createGroupedInvoicingChildren creates each child spec as a brand-new grouped_invoicing
-// subscription under parent, inside the caller's existing transaction. Each child's own opening
-// invoice is suppressed (see the invoice-generation gate in createSubscription); its period-1
-// charges are folded into the parent's own opening invoice instead. Calls createSubscription
-// directly (not the public CreateSubscription): it must reuse the caller's already-open
-// transaction and must not fire the child's own post-transaction side effects (webhook,
-// HubSpot/Paddle sync) — only the parent's single post-tx block should run, once, after
-// everything commits. Every field in the child's SubscriptionCreationConfig (overrides, extra
-// line items, coupons, taxes, commitments, trial, credit grants, entitlement overrides, addons,
-// phases) is copied through as-is and validated/applied by the same createSubscription call the
-// parent uses — no separate handling needed here.
+// createGroupedInvoicingChildren creates grouped_invoicing child subscriptions inside the caller's
+// transaction. Children suppress their own opening invoice (charges fold into the parent's);
+// post-tx side effects (webhooks, HubSpot/Paddle sync) run only from the parent's block.
 func (s *subscriptionService) createGroupedInvoicingChildren(
 	ctx context.Context,
 	parent *subscription.Subscription,
@@ -7706,10 +7698,7 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 	for _, c := range childRequests {
 		startDate := parent.StartDate
 
-		// BillingAnchor is only ever valid alongside BillingCycle == anniversary (enforced in
-		// CreateSubscriptionRequest.Validate()). Since BillingCycle is always inherited from the
-		// parent below, only pass the anchor through when that inherited cycle is anniversary —
-		// otherwise a calendar-cycle child would fail validation on a non-nil anchor pointer.
+		// BillingAnchor is only valid for anniversary billing; pass nil for calendar to avoid validation failure.
 		var billingAnchor *time.Time
 		if parent.BillingCycle == types.BillingCycleAnniversary {
 			anchor := parent.BillingAnchor
@@ -7978,14 +7967,8 @@ func (s *subscriptionService) processAutoInvoiceThresholdSubscription(
 	return nil
 }
 
-// runPaddleSubscriptionSync synchronously bootstraps a Paddle subscription for the given
-// subscription. It is called inline from CreateSubscription so the checkout URL is available
-// in the response without a round-trip through Temporal. All errors are soft-fail: the
-// subscription has already been persisted, so we only log and continue.
-//
-// On success, EnsureSubscriptionSynced persists paddle checkout metadata; it is copied back
-// onto the caller's sub so the create response includes paddle_checkout_url and
-// paddle_transaction_id.
+// runPaddleSubscriptionSync bootstraps Paddle inline (not via Temporal) so checkout metadata is
+// available in the create response. Errors are soft-fail — subscription is already persisted.
 func (s *subscriptionService) runPaddleSubscriptionSync(ctx context.Context, sub *subscription.Subscription) {
 	if s.IntegrationFactory == nil {
 		return

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4899,10 +4899,12 @@ func (s *subscriptionService) addAddonToSubscription(
 
 	addProrationKey := fmt.Sprintf("addon_add_%s_%d", addonAssociation.ID, effectiveDate.Unix())
 	if err := s.applyAddonAddProration(ctx, sub, lineItems, effectiveDate, req.ProrationBehavior, addProrationKey); err != nil {
-		s.Logger.Info(ctx, "failed to create proration invoice for addon add; addon was persisted successfully",
+		s.Logger.Error(ctx, "failed to create proration invoice for addon add; addon was persisted and is UNBILLED for this period",
 			"error", err,
 			"association_id", addonAssociation.ID,
+			"addon_id", req.AddonID,
 			"subscription_id", sub.ID,
+			"effective_date", effectiveDate,
 			"idempotency_key", addProrationKey,
 		)
 	}
@@ -5322,9 +5324,10 @@ func (s *subscriptionService) RemoveAddonFromSubscription(ctx context.Context, r
 			association.ID, *effectiveEndDate,
 			req.ProrationBehavior, endReason,
 		); err != nil {
-			s.Logger.Info(ctx, "failed to issue proration credit for addon remove; removal was persisted successfully",
+			s.Logger.Error(ctx, "failed to issue proration credit for addon remove; removal was persisted and the credit is UNISSUED",
 				"error", err,
 				"association_id", association.ID,
+				"addon_id", association.AddonID,
 				"subscription_id", sub.ID,
 			)
 		}

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -6688,6 +6688,15 @@ func (s *subscriptionService) GetAggregatedSubscriptionEntitlementsForSubscripti
 			WithHint("A subscription must be provided to resolve entitlements").
 			Mark(ierr.ErrValidation)
 	}
+	// Validate request if provided
+	if req != nil {
+		if err := req.Validate(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Initialize with empty request if none provided
+		req = &dto.GetSubscriptionEntitlementsRequest{}
+	}
 
 	// Get all entitlements for the subscription
 	entitlements, err := s.GetSubscriptionEntitlementsForSubscription(ctx, sub)

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4852,10 +4852,8 @@ func (s *subscriptionService) addAddonToSubscription(
 		lineItems = append(lineItems, lineItem)
 	}
 
-	// Process price overrides — must run after commitments are applied above (bucket
-	// configs are keyed by line item ID, not price ID, so they survive the PriceID
-	// mutation this performs) and before the transaction below (it persists its own
-	// subscription-scoped Price rows directly via priceService.CreatePrice).
+	// Must run after commitments above (keyed by line item ID, so they survive the
+	// PriceID mutation here) and before the transaction (CreatePrice persists directly).
 	if len(req.OverrideLineItems) > 0 {
 		if err := s.ProcessSubscriptionPriceOverrides(ctx, sub, req.OverrideLineItems, lineItems, priceMap); err != nil {
 			return nil, err

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -866,12 +866,14 @@ func (s *subscriptionChangeService) createNewSubscription(
 		Metadata:           lo.Assign(currentSub.Metadata, req.Metadata),
 		ProrationBehavior:  req.ProrationBehavior,
 		Timezone:           currentSub.Timezone,
-		CommitmentAmount:   currentSub.CommitmentAmount,
-		OverageFactor:      currentSub.OverageFactor,
 		PaymentTerms:       currentSub.PaymentTerms,
 		Workflow:           lo.ToPtr(types.TemporalSubscriptionCreationWorkflow),
 		Inheritance:        inheritance,
-		TrialPeriodDays:    lo.ToPtr(0), // THIS IS IMPORTANT: we don't want to inherit the trial period days from the old subscription
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			CommitmentAmount: currentSub.CommitmentAmount,
+			OverageFactor:    currentSub.OverageFactor,
+			TrialPeriodDays:  lo.ToPtr(0), // THIS IS IMPORTANT: we don't want to inherit the trial period days from the old subscription
+		},
 	}
 
 	// When doing an immediate plan change, we cancel the old subscription with proration but

--- a/internal/ee/service/subscription_price_override_test.go
+++ b/internal/ee/service/subscription_price_override_test.go
@@ -32,11 +32,13 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			BillingCycle:       types.BillingCycleAnniversary,
-			OverrideLineItems: []dto.OverrideLineItemRequest{
-				{
-					PriceID:  "test_price_789",
-					Amount:   &overrideAmount,
-					Quantity: &overrideQuantity,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{
+					{
+						PriceID:  "test_price_789",
+						Amount:   &overrideAmount,
+						Quantity: &overrideQuantity,
+					},
 				},
 			},
 		}
@@ -151,14 +153,16 @@ func TestCreateSubscriptionWithPriceOverrides(t *testing.T) {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			BillingCycle:       types.BillingCycleAnniversary,
-			OverrideLineItems: []dto.OverrideLineItemRequest{
-				{
-					PriceID: "duplicate_price",
-					Amount:  &amount1,
-				},
-				{
-					PriceID: "duplicate_price", // Duplicate!
-					Amount:  &amount2,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{
+					{
+						PriceID: "duplicate_price",
+						Amount:  &amount1,
+					},
+					{
+						PriceID: "duplicate_price", // Duplicate!
+						Amount:  &amount2,
+					},
 				},
 			},
 		}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9044,13 +9044,22 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	ctx := s.GetContext()
 	seatPlan := s.setupSeatFeePlan()
 
+	// Create a separate plan as the entity for the onboarding fee so the price is NOT
+	// auto-included in seatPlan subscriptions, but the plan lookup in buildLineItemParamsForPrice succeeds.
+	onboardingPlan := &plan.Plan{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:      "Onboarding Plan T5",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, onboardingPlan))
+
 	onboardingFeeID := "price_onboarding_fee_child_t5"
 	onboardingFee := &price.Price{
 		ID:                 onboardingFeeID,
 		Amount:             decimal.NewFromInt(25),
 		Currency:           "usd",
 		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
-		EntityID:           seatPlan.ID,
+		EntityID:           onboardingPlan.ID,
 		Type:               types.PRICE_TYPE_FIXED,
 		BillingPeriod:      types.BILLING_PERIOD_ONETIME,
 		BillingPeriodCount: 1,

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9,15 +9,19 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addon"
+	"github.com/flexprice/flexprice/internal/domain/coupon"
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/settings"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
+	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
@@ -9134,4 +9138,503 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	for _, item := range parentItems {
 		s.NotEqual(onboardingFeeID, item.PriceID, "parent must not carry the child's extra line item")
 	}
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_SubscriptionCoupons() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	pct := decimal.NewFromInt(10)
+	couponID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON)
+	c := &coupon.Coupon{
+		ID:            couponID,
+		Name:          "Seat Coupon",
+		Type:          types.CouponTypePercentage,
+		Cadence:       types.CouponCadenceForever,
+		PercentageOff: &pct,
+		CouponCode:    lo.ToPtr(couponID),
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		BaseModel:     types.GetDefaultBaseModel(ctx),
+	}
+	c.Status = types.StatusPublished
+	s.Require().NoError(s.GetStores().CouponRepo.Create(ctx, c))
+
+	seatExternal := "ext_seat_coupon_t6"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Coupon",
+		Email:      "seatcoupon@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						SubscriptionCoupons: []dto.SubscriptionCouponInput{
+							{CouponCode: *c.CouponCode},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	assocFilter := &types.CouponAssociationFilter{
+		QueryFilter:     types.NewNoLimitQueryFilter(),
+		SubscriptionIDs: []string{children[0].ID},
+		CouponIDs:       []string{couponID},
+	}
+	assocs, err := s.GetStores().CouponAssociationRepo.List(ctx, assocFilter)
+	s.NoError(err)
+	s.Require().Len(assocs, 1, "expected the coupon to be associated with the child, not the parent")
+
+	parentAssocFilter := &types.CouponAssociationFilter{
+		QueryFilter:     types.NewNoLimitQueryFilter(),
+		SubscriptionIDs: []string{resp.ID},
+		CouponIDs:       []string{couponID},
+	}
+	parentAssocs, err := s.GetStores().CouponAssociationRepo.List(ctx, parentAssocFilter)
+	s.NoError(err)
+	s.Empty(parentAssocs, "parent must not carry the child's coupon association")
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_TaxRateOverrides() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	pct := decimal.NewFromInt(10)
+	taxCode := "seat_tax_t7a"
+	tr := &taxrate.TaxRate{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_TAX_RATE),
+		Name:            "Seat Tax Rate",
+		Code:            taxCode,
+		TaxRateStatus:   types.TaxRateStatusActive,
+		TaxRateType:     types.TaxRateTypePercentage,
+		PercentageValue: &pct,
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().TaxRateRepo.Create(ctx, tr))
+
+	seatExternal := "ext_seat_tax_t7a"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Tax",
+		Email:      "seattax@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						TaxRateOverrides: []*dto.TaxRateOverride{
+							{TaxRateCode: taxCode, Currency: "usd"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	taxFilter := &types.TaxAssociationFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		EntityType:  types.TaxRateEntityTypeSubscription,
+		EntityID:    children[0].ID,
+		TaxRateIDs:  []string{tr.ID},
+	}
+	assocs, err := s.GetStores().TaxAssociationRepo.List(ctx, taxFilter)
+	s.NoError(err)
+	s.Require().Len(assocs, 1, "expected the tax rate to be linked to the child")
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ExplicitCreditGrants() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_explicit_credit_t10"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Explicit Credit",
+		Email:      "seatexplicitcredit@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						CreditGrants: []dto.CreateCreditGrantRequest{
+							{
+								Name:           "Explicit Seat Credits",
+								Scope:          types.CreditGrantScopeSubscription,
+								Credits:        decimal.NewFromInt(250),
+								Cadence:        types.CreditGrantCadenceOneTime,
+								ExpirationType: types.CreditGrantExpiryTypeNever,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	wallets, err := s.GetStores().WalletRepo.GetWalletsByCustomerID(ctx, seat.ID)
+	s.NoError(err)
+	s.Require().Len(wallets, 1)
+	s.True(decimal.NewFromInt(250).Equal(wallets[0].Balance),
+		"expected seat wallet funded with the child's explicit 250 credits, got %s",
+		wallets[0].Balance.String())
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_OverrideEntitlements() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatFeature := &feature.Feature{
+		ID:        "feat_seat_override_t11",
+		Name:      "Seat Feature",
+		Type:      types.FeatureTypeMetered,
+		MeterID:   s.testData.meters.apiCalls.ID,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().FeatureRepo.Create(ctx, seatFeature))
+
+	planEntitlement := &entitlement.Entitlement{
+		ID:               "ent_seat_override_plan_t11",
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         seatPlan.ID,
+		FeatureID:        seatFeature.ID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       lo.ToPtr(int64(1000)),
+		UsageResetPeriod: types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, planEntitlement)
+	s.NoError(err)
+
+	seatExternal := "ext_seat_entitlement_override_t11"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Entitlement Override",
+		Email:      "seatentitlementoverride@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						OverrideEntitlements: []dto.OverrideEntitlementRequest{
+							{
+								EntitlementID: planEntitlement.ID,
+								UsageLimit:    lo.ToPtr(int64(50)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	entFilter := types.NewNoLimitEntitlementFilter()
+	entFilter.WithEntityIDs([]string{children[0].ID})
+	entFilter.WithEntityType(types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION)
+	childEntitlements, err := s.GetStores().EntitlementRepo.List(ctx, entFilter)
+	s.NoError(err)
+	s.Require().Len(childEntitlements, 1)
+	s.Equal(seatFeature.ID, childEntitlements[0].FeatureID)
+	s.Require().NotNil(childEntitlements[0].ParentEntitlementID)
+	s.Equal(planEntitlement.ID, *childEntitlements[0].ParentEntitlementID)
+	s.Require().NotNil(childEntitlements[0].UsageLimit)
+	s.Equal(int64(50), *childEntitlements[0].UsageLimit)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_Addons() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	addonID := "addon_seat_child_t12"
+	addonPriceID := "price_addon_seat_child_t12"
+
+	a := &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Seat Child Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().AddonRepo.Create(ctx, a))
+
+	p := &price.Price{
+		ID:                 addonPriceID,
+		Amount:             decimal.NewFromFloat(15),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+
+	seatExternal := "ext_seat_addon_t12"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Addon",
+		Email:      "seataddon@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						Addons: []dto.AddAddonToSubscriptionRequest{
+							{AddonID: addonID},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	assocFilter := types.NewNoLimitAddonAssociationFilter()
+	assocFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+	assocFilter.EntityIDs = []string{children[0].ID}
+	associations, err := s.GetStores().AddonAssociationRepo.List(ctx, assocFilter)
+	s.Require().NoError(err)
+	s.Require().Len(associations, 1)
+	s.Equal(addonID, associations[0].AddonID)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_Phases() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_phases_t13"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Phases",
+		Email:      "seatphases@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	phaseStart := s.testData.now.Truncate(time.Millisecond)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(phaseStart),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						Phases: []dto.SubscriptionPhaseCreateRequest{
+							{
+								StartDate: phaseStart,
+								Metadata:  map[string]string{"phase": "seat_single_phase"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	phaseFilter := types.NewNoLimitSubscriptionPhaseFilter()
+	phaseFilter.SubscriptionIDs = []string{children[0].ID}
+	phases, err := s.GetStores().SubscriptionPhaseRepo.List(ctx, phaseFilter)
+	s.NoError(err)
+	s.Require().Len(phases, 1, "expected the child to have its own phase record")
+	s.Equal("seat_single_phase", phases[0].Metadata["phase"])
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_RejectsDuplicateOverridePriceID() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	priceFilter := types.NewNoLimitPriceFilter()
+	priceFilter.EntityType = lo.ToPtr(types.PRICE_ENTITY_TYPE_PLAN)
+	priceFilter.EntityIDs = []string{seatPlan.ID}
+	seatPrices, err := s.GetStores().PriceRepo.List(ctx, priceFilter)
+	s.Require().NoError(err)
+	s.Require().Len(seatPrices, 1)
+	seatPriceID := seatPrices[0].ID
+
+	seatExternal := "ext_seat_dup_override_t14"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Dup Override",
+		Email:      "seatdupoverride@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						OverrideLineItems: []dto.OverrideLineItemRequest{
+							{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(60.00))},
+							{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(70.00))},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = s.service.CreateSubscription(ctx, req)
+	s.Error(err, "expected duplicate price_id in a child's override_line_items to be rejected")
+	s.Contains(err.Error(), "duplicate price_id in override line items")
 }

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8923,3 +8923,69 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 			"expected child %s line item amount 50, got %s", childID, amount.String())
 	}
 }
+
+// TestCreateSubscription_GroupedInvoicingChildrenToCreate_OverrideLineItems verifies a child
+// can override its own plan's price at creation, independent of the parent.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_OverrideLineItems() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	priceFilter := types.NewNoLimitPriceFilter()
+	priceFilter.EntityType = lo.ToPtr(types.PRICE_ENTITY_TYPE_PLAN)
+	priceFilter.EntityIDs = []string{seatPlan.ID}
+	seatPrices, err := s.GetStores().PriceRepo.List(ctx, priceFilter)
+	s.Require().NoError(err)
+	s.Require().Len(seatPrices, 1)
+	seatPriceID := seatPrices[0].ID
+
+	seatExternal := "ext_seat_override"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Override",
+		Email:      "seatoverride@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						OverrideLineItems: []dto.OverrideLineItemRequest{
+							{
+								PriceID: seatPriceID,
+								Amount:  lo.ToPtr(decimal.NewFromFloat(75.00)),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	s.verifyPriceOverridesCreated(ctx, children[0].ID,
+		[]dto.OverrideLineItemRequest{{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(75.00))}},
+		"child subscription must have its own subscription-scoped override price")
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -8989,3 +8989,140 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 		[]dto.OverrideLineItemRequest{{PriceID: seatPriceID, Amount: lo.ToPtr(decimal.NewFromFloat(75.00))}},
 		"child subscription must have its own subscription-scoped override price")
 }
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ChildInheritsParentBillingAnchor() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_anchor_t4"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Anchor",
+		Email:      "seatanchor@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	anchor := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		BillingAnchor:      lo.ToPtr(anchor),
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{PlanID: seatPlan.ID, ExternalCustomerID: seatExternal},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	parentSub, err := s.GetStores().SubscriptionRepo.Get(ctx, resp.ID)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	s.True(parentSub.BillingAnchor.Equal(children[0].BillingAnchor),
+		"expected child billing_anchor %s to equal parent billing_anchor %s",
+		children[0].BillingAnchor, parentSub.BillingAnchor)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_ExtraLineItems() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	onboardingFeeID := "price_onboarding_fee_child_t5"
+	onboardingFee := &price.Price{
+		ID:                 onboardingFeeID,
+		Amount:             decimal.NewFromInt(25),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           seatPlan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_ONETIME,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, onboardingFee))
+
+	seatExternal := "ext_seat_extra_line_item_t5"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Extra Line Item",
+		Email:      "seatextralineitem@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						LineItems: []dto.CreateSubscriptionLineItemRequest{
+							{PriceID: onboardingFeeID, Quantity: decimal.NewFromInt(1)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	liFilter.SubscriptionIDs = []string{children[0].ID}
+	items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+	s.NoError(err)
+
+	found := false
+	for _, item := range items {
+		if item.PriceID == onboardingFeeID {
+			found = true
+		}
+	}
+	s.True(found, "expected child subscription to carry the extra onboarding-fee line item, got %+v", items)
+
+	parentLiFilter := types.NewNoLimitSubscriptionLineItemFilter()
+	parentLiFilter.SubscriptionIDs = []string{resp.ID}
+	parentItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, parentLiFilter)
+	s.NoError(err)
+	for _, item := range parentItems {
+		s.NotEqual(onboardingFeeID, item.PriceID, "parent must not carry the child's extra line item")
+	}
+}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -366,6 +366,271 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionLineItemCommitments
 	})
 }
 
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionPriceOverrides() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	createFixedPriceAddon := func(addonID, priceID string, amount decimal.Decimal) {
+		a := &addon.Addon{
+			ID:          addonID,
+			LookupKey:   addonID,
+			Name:        "Test Addon",
+			Description: "Test Addon Description",
+			BaseModel:   types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(subService.AddonRepo.Create(ctx, a))
+
+		p := &price.Price{
+			ID:                 priceID,
+			Amount:             amount,
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+			EntityID:           addonID,
+			Type:               types.PRICE_TYPE_FIXED,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			InvoiceCadence:     types.InvoiceCadenceAdvance,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	}
+
+	createUsagePriceAddon := func(addonID, priceID, meterID string) {
+		a := &addon.Addon{
+			ID:          addonID,
+			LookupKey:   addonID,
+			Name:        "Test Addon",
+			Description: "Test Addon Description",
+			BaseModel:   types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(subService.AddonRepo.Create(ctx, a))
+
+		p := &price.Price{
+			ID:                 priceID,
+			Amount:             decimal.Zero,
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+			EntityID:           addonID,
+			Type:               types.PRICE_TYPE_USAGE,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			InvoiceCadence:     types.InvoiceCadenceArrear,
+			MeterID:            meterID,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	}
+
+	findLineItemByEntity := func(subID, addonID string) *subscription.SubscriptionLineItem {
+		filter := types.NewNoLimitSubscriptionLineItemFilter()
+		filter.SubscriptionIDs = []string{subID}
+		items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, filter)
+		s.NoError(err)
+		for _, it := range items {
+			if it.EntityType == types.SubscriptionLineItemEntityTypeAddon && it.EntityID == addonID {
+				return it
+			}
+		}
+		return nil
+	}
+
+	s.Run("overrides_amount_and_quantity_on_fixed_addon_price", func() {
+		addonID := "addon_override_amount_qty"
+		priceID := "price_addon_override_amount_qty"
+		createFixedPriceAddon(addonID, priceID, decimal.NewFromFloat(10.00))
+
+		now := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+			OverrideLineItems: []dto.OverrideLineItemRequest{
+				{
+					PriceID:  priceID,
+					Amount:   lo.ToPtr(decimal.NewFromFloat(25.00)),
+					Quantity: lo.ToPtr(decimal.NewFromInt(3)),
+				},
+			},
+		})
+		s.NoError(err)
+
+		li := findLineItemByEntity(s.testData.subscription.ID, addonID)
+		s.NotNil(li)
+		if li == nil {
+			return
+		}
+		s.NotEqual(priceID, li.PriceID, "line item should reference the overridden price, not the original")
+		s.True(li.Quantity.Equal(decimal.NewFromInt(3)))
+
+		overriddenPrice, err := s.GetStores().PriceRepo.Get(ctx, li.PriceID)
+		s.NoError(err)
+		s.True(overriddenPrice.Amount.Equal(decimal.NewFromFloat(25.00)))
+		s.Equal(priceID, overriddenPrice.ParentPriceID)
+		s.Equal(types.PRICE_ENTITY_TYPE_SUBSCRIPTION, overriddenPrice.EntityType)
+		s.Equal(s.testData.subscription.ID, overriddenPrice.EntityID)
+	})
+
+	s.Run("rejects_quantity_override_on_usage_based_addon_price", func() {
+		addonID := "addon_override_usage_qty_reject"
+		priceID := "price_addon_override_usage_qty_reject"
+		createUsagePriceAddon(addonID, priceID, s.testData.meters.apiCalls.ID)
+
+		now := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+			OverrideLineItems: []dto.OverrideLineItemRequest{
+				{
+					PriceID:  priceID,
+					Quantity: lo.ToPtr(decimal.NewFromInt(5)),
+				},
+			},
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "quantity cannot be set for usage-based prices")
+	})
+
+	s.Run("overrides_billing_model_to_tiered_on_addon_price", func() {
+		addonID := "addon_override_tiered"
+		priceID := "price_addon_override_tiered"
+		createFixedPriceAddon(addonID, priceID, decimal.NewFromFloat(10.00))
+
+		now := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+			OverrideLineItems: []dto.OverrideLineItemRequest{
+				{
+					PriceID:      priceID,
+					BillingModel: types.BILLING_MODEL_TIERED,
+					TierMode:     types.BILLING_TIER_VOLUME,
+					Tiers: []dto.CreatePriceTier{
+						{UpTo: lo.ToPtr(uint64(10)), UnitAmount: decimal.RequireFromString("5.00")},
+						{UpTo: nil, UnitAmount: decimal.RequireFromString("3.00")},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		li := findLineItemByEntity(s.testData.subscription.ID, addonID)
+		s.NotNil(li)
+		if li == nil {
+			return
+		}
+		overriddenPrice, err := s.GetStores().PriceRepo.Get(ctx, li.PriceID)
+		s.NoError(err)
+		s.Equal(types.BILLING_MODEL_TIERED, overriddenPrice.BillingModel)
+		s.Equal(types.BILLING_TIER_VOLUME, overriddenPrice.TierMode)
+		s.Len(overriddenPrice.Tiers, 2)
+	})
+
+	s.Run("rejects_override_price_id_not_belonging_to_addon", func() {
+		addonID := "addon_override_invalid_price"
+		priceID := "price_addon_override_invalid_price"
+		createFixedPriceAddon(addonID, priceID, decimal.NewFromFloat(10.00))
+
+		now := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+			OverrideLineItems: []dto.OverrideLineItemRequest{
+				{
+					PriceID: s.testData.prices.fixedMonthly.ID, // belongs to the plan, not this addon
+					Amount:  lo.ToPtr(decimal.NewFromFloat(15.00)),
+				},
+			},
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "price not found in plan")
+	})
+
+	s.Run("rejects_duplicate_override_price_id", func() {
+		addonID := "addon_override_dup"
+		priceID := "price_addon_override_dup"
+		createFixedPriceAddon(addonID, priceID, decimal.NewFromFloat(10.00))
+
+		now := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+			OverrideLineItems: []dto.OverrideLineItemRequest{
+				{PriceID: priceID, Amount: lo.ToPtr(decimal.NewFromFloat(15.00))},
+				{PriceID: priceID, Amount: lo.ToPtr(decimal.NewFromFloat(20.00))},
+			},
+		})
+		s.Error(err)
+		s.Contains(err.Error(), "duplicate price_id in override line items")
+	})
+
+	s.Run("no_overrides_behaves_as_before", func() {
+		addonID := "addon_no_override_regression"
+		priceID := "price_addon_no_override_regression"
+		createFixedPriceAddon(addonID, priceID, decimal.NewFromFloat(10.00))
+
+		now := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+		})
+		s.NoError(err)
+
+		li := findLineItemByEntity(s.testData.subscription.ID, addonID)
+		s.NotNil(li)
+		if li == nil {
+			return
+		}
+		s.Equal(priceID, li.PriceID, "line item should still reference the original addon price when no overrides are given")
+	})
+
+	s.Run("commitment_and_override_on_same_price_both_apply", func() {
+		addonID := "addon_override_with_commitment"
+		priceID := "price_addon_override_with_commitment"
+		createUsagePriceAddon(addonID, priceID, s.testData.meters.apiCalls.ID)
+
+		now := time.Now().UTC()
+		commitmentAmount := decimal.NewFromFloat(25)
+		overageFactor := decimal.NewFromFloat(2)
+
+		_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+			AddonID:   addonID,
+			StartDate: &now,
+			LineItemCommitments: map[string]*dto.LineItemCommitmentConfig{
+				priceID: {
+					CommitmentAmount: &commitmentAmount,
+					OverageFactor:    &overageFactor,
+				},
+			},
+			OverrideLineItems: []dto.OverrideLineItemRequest{
+				{
+					PriceID:      priceID,
+					TierMode:     types.BILLING_TIER_SLAB,
+					BillingModel: types.BILLING_MODEL_TIERED,
+					Tiers: []dto.CreatePriceTier{
+						{UpTo: lo.ToPtr(uint64(1000)), UnitAmount: decimal.RequireFromString("0.02")},
+						{UpTo: nil, UnitAmount: decimal.RequireFromString("0.01")},
+					},
+				},
+			},
+		})
+		s.NoError(err)
+
+		li := findLineItemByEntity(s.testData.subscription.ID, addonID)
+		s.NotNil(li)
+		if li == nil {
+			return
+		}
+		s.NotEqual(priceID, li.PriceID, "commitment line item should still get its price overridden")
+		s.NotNil(li.CommitmentAmount)
+		s.True(li.CommitmentAmount.Equal(commitmentAmount), "commitment config must survive the price override")
+
+		overriddenPrice, err := s.GetStores().PriceRepo.Get(ctx, li.PriceID)
+		s.NoError(err)
+		s.Equal(types.BILLING_MODEL_TIERED, overriddenPrice.BillingModel)
+	})
+}
+
 func (s *SubscriptionServiceSuite) SetupTest() {
 	s.BaseServiceTestSuite.SetupTest()
 	s.ClearStores() // Clear all stores before each test for isolation

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -9140,6 +9140,121 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildr
 	}
 }
 
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_Commitment() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_commitment_t8"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Commitment",
+		Email:      "seatcommitment@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	commitmentAmount := decimal.NewFromInt(200)
+	overageFactor := decimal.NewFromFloat(1.5)
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						CommitmentAmount:   &commitmentAmount,
+						CommitmentDuration: lo.ToPtr(types.BILLING_PERIOD_ANNUAL),
+						OverageFactor:      &overageFactor,
+						EnableTrueUp:       true,
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	child, err := s.GetStores().SubscriptionRepo.Get(ctx, children[0].ID)
+	s.NoError(err)
+	s.Require().NotNil(child.CommitmentAmount)
+	s.True(commitmentAmount.Equal(*child.CommitmentAmount))
+	s.Require().NotNil(child.CommitmentDuration)
+	s.Equal(types.BILLING_PERIOD_ANNUAL, *child.CommitmentDuration)
+	s.Require().NotNil(child.OverageFactor)
+	s.True(overageFactor.Equal(*child.OverageFactor))
+	s.True(child.EnableTrueUp)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_TrialPeriodDays() {
+	ctx := s.GetContext()
+	seatPlan := s.setupSeatFeePlan()
+
+	seatExternal := "ext_seat_trial_t9"
+	seat := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: seatExternal,
+		Name:       "Seat Trial",
+		Email:      "seattrial@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, seat))
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             seatPlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
+		Inheritance: &dto.SubscriptionInheritanceConfig{
+			GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+				{
+					PlanID:             seatPlan.ID,
+					ExternalCustomerID: seatExternal,
+					SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+						TrialPeriodDays: lo.ToPtr(14),
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.NoError(err)
+
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{resp.ID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(ctx, filter)
+	s.NoError(err)
+	s.Require().Len(children, 1)
+
+	child, err := s.GetStores().SubscriptionRepo.Get(ctx, children[0].ID)
+	s.NoError(err)
+	s.Require().NotNil(child.TrialStart)
+	s.Require().NotNil(child.TrialEnd)
+	s.Equal(child.TrialStart.AddDate(0, 0, 14), *child.TrialEnd)
+}
+
 func (s *SubscriptionServiceSuite) TestCreateSubscription_GroupedInvoicingChildrenToCreate_SubscriptionCoupons() {
 	ctx := s.GetContext()
 	seatPlan := s.setupSeatFeePlan()

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -2004,9 +2004,11 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems() {
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		BillingCycle:       types.BillingCycleAnniversary,
-		LineItems: []dto.CreateSubscriptionLineItemRequest{
-			{PriceID: planPriceID},
-			{Price: inlinePriceReq},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			LineItems: []dto.CreateSubscriptionLineItemRequest{
+				{PriceID: planPriceID},
+				{Price: inlinePriceReq},
+			},
 		},
 	}
 
@@ -2097,17 +2099,19 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems_Validatio
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			req := dto.CreateSubscriptionRequest{
-				CustomerID:         s.testData.customer.ID,
-				PlanID:             s.testData.plan.ID,
-				StartDate:          &start,
-				EndDate:            &end,
-				Currency:           "usd",
-				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-				BillingPeriodCount: 1,
-				BillingCycle:       types.BillingCycleAnniversary,
-				LineItems:          tt.lineItems,
-			}
+		req := dto.CreateSubscriptionRequest{
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			StartDate:          &start,
+			EndDate:            &end,
+			Currency:           "usd",
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingCycle:       types.BillingCycleAnniversary,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				LineItems: tt.lineItems,
+			},
+		}
 			_, err := s.service.CreateSubscription(ctx, req)
 			s.Error(err)
 			s.Contains(err.Error(), tt.wantErrCont)
@@ -2172,37 +2176,39 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_LineItemWithBuckets_Ma
 		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 		BillingPeriodCount: 1,
 		BillingCycle:       types.BillingCycleAnniversary,
-		// Add a line item with CommitmentTimeBuckets — this goes through AddSubscriptionLineItem
-		// which calls resolveBucketPrices inside the transaction.
-		LineItems: []dto.CreateSubscriptionLineItemRequest{
-			{
-				PriceID:                 usagePriceForBucketSub.ID,
-				SkipEntitlementCheck:    true,
-				CommitmentAmount:        &commitmentAmount,
-				CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
-				CommitmentOverageFactor: &overageFactor,
-				CommitmentWindowed:      true,
-				CommitmentTimeBuckets: []dto.CommitmentBucketRequest{
-					{
-						Start: types.Bucket{Hour: 9, Minute: 0},
-						End:   types.Bucket{Hour: 17, Minute: 0},
-						Price: &dto.CreatePriceRequest{
-							Amount:               lo.ToPtr(bucketPriceAmount),
-							Currency:             "usd",
-							EntityType:           types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
-							Type:                 types.PRICE_TYPE_FIXED,
-							PriceUnitType:        types.PRICE_UNIT_TYPE_FIAT,
-							BillingPeriod:        types.BILLING_PERIOD_MONTHLY,
-							BillingPeriodCount:   1,
-							BillingModel:         types.BILLING_MODEL_FLAT_FEE,
-							InvoiceCadence:       types.InvoiceCadenceAdvance,
-							LookupKey:            "sub_create_bucket_price",
-							SkipEntityValidation: true,
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			// Add a line item with CommitmentTimeBuckets — this goes through AddSubscriptionLineItem
+			// which calls resolveBucketPrices inside the transaction.
+			LineItems: []dto.CreateSubscriptionLineItemRequest{
+				{
+					PriceID:                 usagePriceForBucketSub.ID,
+					SkipEntitlementCheck:    true,
+					CommitmentAmount:        &commitmentAmount,
+					CommitmentType:          types.COMMITMENT_TYPE_AMOUNT,
+					CommitmentOverageFactor: &overageFactor,
+					CommitmentWindowed:      true,
+					CommitmentTimeBuckets: []dto.CommitmentBucketRequest{
+						{
+							Start: types.Bucket{Hour: 9, Minute: 0},
+							End:   types.Bucket{Hour: 17, Minute: 0},
+							Price: &dto.CreatePriceRequest{
+								Amount:               lo.ToPtr(bucketPriceAmount),
+								Currency:             "usd",
+								EntityType:           types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
+								Type:                 types.PRICE_TYPE_FIXED,
+								PriceUnitType:        types.PRICE_UNIT_TYPE_FIAT,
+								BillingPeriod:        types.BILLING_PERIOD_MONTHLY,
+								BillingPeriodCount:   1,
+								BillingModel:         types.BILLING_MODEL_FLAT_FEE,
+								InvoiceCadence:       types.InvoiceCadenceAdvance,
+								LookupKey:            "sub_create_bucket_price",
+								SkipEntityValidation: true,
+							},
+							CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
+							CommitmentValue: decimal.NewFromInt(300),
+							OverageFactor:   lo.ToPtr(decimal.NewFromFloat(1.5)),
+							TrueUpEnabled:   true,
 						},
-						CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
-						CommitmentValue: decimal.NewFromInt(300),
-						OverageFactor:   lo.ToPtr(decimal.NewFromFloat(1.5)),
-						TrueUpEnabled:   true,
 					},
 				},
 			},
@@ -6464,15 +6470,17 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithPriceOverrides() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			// Create subscription request with overrides
-			req := dto.CreateSubscriptionRequest{
-				CustomerID:         s.testData.customer.ID,
-				PlanID:             s.testData.plan.ID,
-				Currency:           "usd",
-				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-				BillingPeriodCount: 1,
-				BillingCycle:       types.BillingCycleAnniversary,
-				OverrideLineItems:  tc.overrideLineItems,
-			}
+		req := dto.CreateSubscriptionRequest{
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			Currency:           "usd",
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingCycle:       types.BillingCycleAnniversary,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: tc.overrideLineItems,
+			},
+		}
 
 			// Create subscription
 			resp, err := s.service.CreateSubscription(s.GetContext(), req)
@@ -6991,17 +6999,19 @@ func (s *SubscriptionServiceSuite) TestPriceOverrideIntegration() {
 			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
 			BillingPeriodCount: 1,
 			BillingCycle:       types.BillingCycleAnniversary,
-			OverrideLineItems: []dto.OverrideLineItemRequest{
-				{
-					PriceID:      s.testData.prices.fixedMonthly.ID,
-					Amount:       lo.ToPtr(decimal.NewFromFloat(75.00)),
-					BillingModel: types.BILLING_MODEL_TIERED,
-					TierMode:     types.BILLING_TIER_VOLUME,
-					Tiers: []dto.CreatePriceTier{
-						{UpTo: lo.ToPtr(uint64(100)), UnitAmount: decimal.RequireFromString("0.50")},
-						{UpTo: nil, UnitAmount: decimal.RequireFromString("0.25")},
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{
+					{
+						PriceID:      s.testData.prices.fixedMonthly.ID,
+						Amount:       lo.ToPtr(decimal.NewFromFloat(75.00)),
+						BillingModel: types.BILLING_MODEL_TIERED,
+						TierMode:     types.BILLING_TIER_VOLUME,
+						Tiers: []dto.CreatePriceTier{
+							{UpTo: lo.ToPtr(uint64(100)), UnitAmount: decimal.RequireFromString("0.50")},
+							{UpTo: nil, UnitAmount: decimal.RequireFromString("0.25")},
+						},
+						Quantity: lo.ToPtr(decimal.NewFromInt(2)),
 					},
-					Quantity: lo.ToPtr(decimal.NewFromInt(2)),
 				},
 			},
 		}
@@ -7045,15 +7055,17 @@ func (s *SubscriptionServiceSuite) TestPriceOverrideIntegration() {
 		subscriptionIDs := make([]string, len(overrideScenarios))
 
 		for i, override := range overrideScenarios {
-			req := dto.CreateSubscriptionRequest{
-				CustomerID:         s.testData.customer.ID,
-				PlanID:             s.testData.plan.ID,
-				Currency:           "usd",
-				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-				BillingPeriodCount: 1,
-				BillingCycle:       types.BillingCycleAnniversary,
-				OverrideLineItems:  []dto.OverrideLineItemRequest{override},
-			}
+		req := dto.CreateSubscriptionRequest{
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			Currency:           "usd",
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingCycle:       types.BillingCycleAnniversary,
+			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+				OverrideLineItems: []dto.OverrideLineItemRequest{override},
+			},
+		}
 
 			resp, err := s.service.CreateSubscription(s.GetContext(), req)
 			s.NoError(err, "Failed to create subscription %d with overrides", i+1)
@@ -7912,8 +7924,10 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_DraftWithAddons() {
 		BillingCycle:       types.BillingCycleAnniversary,
 		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
 		SubscriptionStatus: types.SubscriptionStatusDraft,
-		Addons: []dto.AddAddonToSubscriptionRequest{
-			{AddonID: addonID},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			Addons: []dto.AddAddonToSubscriptionRequest{
+				{AddonID: addonID},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -7982,8 +7996,10 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_WithAddons_Date
 		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
 		PaymentBehavior:    lo.ToPtr(types.PaymentBehaviorDefaultActive),
 		SubscriptionStatus: types.SubscriptionStatusDraft,
-		Addons: []dto.AddAddonToSubscriptionRequest{
-			{AddonID: addonID},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			Addons: []dto.AddAddonToSubscriptionRequest{
+				{AddonID: addonID},
+			},
 		},
 	})
 	s.Require().NoError(err)
@@ -8049,8 +8065,10 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_OnetimeAddon_En
 		CollectionMethod:   lo.ToPtr(types.CollectionMethodSendInvoice),
 		PaymentBehavior:    lo.ToPtr(types.PaymentBehaviorDefaultActive),
 		SubscriptionStatus: types.SubscriptionStatusDraft,
-		Addons: []dto.AddAddonToSubscriptionRequest{
-			{AddonID: addonID, Cadence: types.AddonCadenceOnetime},
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			Addons: []dto.AddAddonToSubscriptionRequest{
+				{AddonID: addonID, Cadence: types.AddonCadenceOnetime},
+			},
 		},
 	})
 	s.Require().NoError(err)

--- a/internal/ee/service/subscription_trial_test.go
+++ b/internal/ee/service/subscription_trial_test.go
@@ -62,14 +62,14 @@ func TestSetCreateSubscriptionTrialWindow_RequestOverrideDays(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	sub := &subscription.Subscription{StartDate: start}
 	seven := 7
-	req := &dto.CreateSubscriptionRequest{TrialPeriodDays: &seven}
+	req := &dto.CreateSubscriptionRequest{SubscriptionCreationConfig: dto.SubscriptionCreationConfig{TrialPeriodDays: &seven}}
 	err := setCreateSubscriptionTrialWindow(req, sub, nil)
 	require.NoError(t, err)
 	assert.Equal(t, start, *sub.TrialStart)
 	assert.Equal(t, start.AddDate(0, 0, 7), *sub.TrialEnd)
 
 	zero := 0
-	req2 := &dto.CreateSubscriptionRequest{TrialPeriodDays: &zero}
+	req2 := &dto.CreateSubscriptionRequest{SubscriptionCreationConfig: dto.SubscriptionCreationConfig{TrialPeriodDays: &zero}}
 	sub2 := &subscription.Subscription{StartDate: start}
 	err2 := setCreateSubscriptionTrialWindow(req2, sub2, []*dto.PriceResponse{
 		{Price: &price.Price{BillingCadence: types.BILLING_CADENCE_RECURRING, Type: types.PRICE_TYPE_FIXED, TrialPeriodDays: 14}},
@@ -167,7 +167,7 @@ func TestSetCreateSubscriptionTrialWindow_ZeroClears(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	sub := &subscription.Subscription{StartDate: start, TrialStart: &start, TrialEnd: &start}
 	z := 0
-	req := &dto.CreateSubscriptionRequest{TrialPeriodDays: &z}
+	req := &dto.CreateSubscriptionRequest{SubscriptionCreationConfig: dto.SubscriptionCreationConfig{TrialPeriodDays: &z}}
 	prices := []*dto.PriceResponse{
 		{Price: &price.Price{BillingCadence: types.BILLING_CADENCE_RECURRING, Type: types.PRICE_TYPE_FIXED, TrialPeriodDays: 14}},
 	}

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -2980,14 +2980,12 @@ func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string)
 		if err != nil {
 			// Parent context was canceled or its deadline exceeded, the caller
 			// has given up, so propagate instead of serving stale cached data.
-			if ctx.Err() != nil {
-				s.Logger.Error(ctx, "wallet balance computation timed out",
-					"wallet_id", walletID,
-					"tenant_id", types.GetTenantID(ctx),
-					"environment_id", types.GetEnvironmentID(ctx),
-					"endpoint", "real_time",
-					"error", err.Error(),
-				)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				message := "wallet balance computation canceled"
+				if ctxErr == context.DeadlineExceeded {
+					message = "wallet balance computation timed out"
+				}
+				s.Logger.Error(ctx, message, "wallet_id", walletID, "error", err.Error())
 				return nil, err
 			}
 			s.Logger.Error(ctx, "wallet balance fallback to cache",
@@ -3215,14 +3213,12 @@ func (s *walletService) GetWalletBalanceFromCache(ctx context.Context, walletID 
 		if err != nil {
 			// Parent context was canceled or its deadline exceeded, the caller
 			// has given up, so propagate instead of serving stale cached data.
-			if ctx.Err() != nil {
-				s.Logger.Error(ctx, "wallet balance computation timed out",
-					"wallet_id", walletID,
-					"tenant_id", types.GetTenantID(ctx),
-					"environment_id", types.GetEnvironmentID(ctx),
-					"endpoint", "real_time",
-					"error", err.Error(),
-				)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				message := "wallet balance computation canceled"
+				if ctxErr == context.DeadlineExceeded {
+					message = "wallet balance computation timed out"
+				}
+				s.Logger.Error(ctx, message, "wallet_id", walletID, "error", err.Error())
 				return nil, err
 			}
 			s.Logger.Error(ctx, "wallet balance fallback to cache",

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -2968,9 +2968,9 @@ func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string)
 		var timeoutDuration time.Duration
 		currentTimeout, ok := ctx.Deadline()
 		if ok && !currentTimeout.IsZero() && time.Until(currentTimeout) < s.computeBalanceTimeout {
-			timeoutDuration = time.Until(currentTimeout)
+			timeoutDuration = time.Until(currentTimeout) - (100 * time.Millisecond)
 		} else {
-			timeoutDuration = s.computeBalanceTimeout
+			timeoutDuration = s.computeBalanceTimeout - (100 * time.Millisecond)
 		}
 
 		computeCtx, cancel := context.WithTimeout(ctx, timeoutDuration)
@@ -2981,6 +2981,13 @@ func (s *walletService) GetWalletBalanceV2(ctx context.Context, walletID string)
 			// Parent context was canceled or its deadline exceeded, the caller
 			// has given up, so propagate instead of serving stale cached data.
 			if ctx.Err() != nil {
+				s.Logger.Error(ctx, "wallet balance computation timed out",
+					"wallet_id", walletID,
+					"tenant_id", types.GetTenantID(ctx),
+					"environment_id", types.GetEnvironmentID(ctx),
+					"endpoint", "real_time",
+					"error", err.Error(),
+				)
 				return nil, err
 			}
 			s.Logger.Error(ctx, "wallet balance fallback to cache",
@@ -3076,7 +3083,7 @@ func (s *walletService) computeRealtimeBalanceDefault(ctx context.Context, w *wa
 				Source:         string(types.UsageSourceWallet),
 			}
 
-			usage, err := subscriptionService.GetMeterUsageBySubscription(ctx, usageReq)
+			usage, err := subscriptionService.GetMeterUsageForSubscription(ctx, sub, usageReq)
 			if err != nil {
 				return nil, err
 			}
@@ -3196,9 +3203,9 @@ func (s *walletService) GetWalletBalanceFromCache(ctx context.Context, walletID 
 		var timeoutDuration time.Duration
 		currentTimeout, ok := ctx.Deadline()
 		if ok && !currentTimeout.IsZero() && time.Until(currentTimeout) < s.computeBalanceTimeout {
-			timeoutDuration = time.Until(currentTimeout)
+			timeoutDuration = time.Until(currentTimeout) - (100 * time.Millisecond)
 		} else {
-			timeoutDuration = s.computeBalanceTimeout
+			timeoutDuration = s.computeBalanceTimeout - (100 * time.Millisecond)
 		}
 
 		computeCtx, cancel := context.WithTimeout(ctx, timeoutDuration)
@@ -3209,6 +3216,13 @@ func (s *walletService) GetWalletBalanceFromCache(ctx context.Context, walletID 
 			// Parent context was canceled or its deadline exceeded, the caller
 			// has given up, so propagate instead of serving stale cached data.
 			if ctx.Err() != nil {
+				s.Logger.Error(ctx, "wallet balance computation timed out",
+					"wallet_id", walletID,
+					"tenant_id", types.GetTenantID(ctx),
+					"environment_id", types.GetEnvironmentID(ctx),
+					"endpoint", "real_time",
+					"error", err.Error(),
+				)
 				return nil, err
 			}
 			s.Logger.Error(ctx, "wallet balance fallback to cache",

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -966,6 +966,9 @@ func (m *mockSubscriptionService) GetMeterUsageForSubscription(ctx context.Conte
 func (m *mockSubscriptionService) GetSubscriptionEntitlements(ctx context.Context, subscriptionID string) ([]*apidto.EntitlementResponse, error) {
 	return nil, nil
 }
+func (m *mockSubscriptionService) GetAggregatedSubscriptionEntitlementsForSubscription(ctx context.Context, sub *subscription.Subscription, req *apidto.GetSubscriptionEntitlementsRequest) (*apidto.SubscriptionEntitlementsResponse, error) {
+	return nil, nil
+}
 func (m *mockSubscriptionService) GetSubscriptionEntitlementsForSubscription(ctx context.Context, sub *subscription.Subscription) ([]*apidto.EntitlementResponse, error) {
 	return nil, nil
 }

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -145,6 +145,7 @@ type SubscriptionService interface {
 
 	GetSubscriptionEntitlementsForSubscription(ctx context.Context, sub *subscription.Subscription) ([]*dto.EntitlementResponse, error)
 
+	GetAggregatedSubscriptionEntitlementsForSubscription(ctx context.Context, sub *subscription.Subscription, req *dto.GetSubscriptionEntitlementsRequest) (*dto.SubscriptionEntitlementsResponse, error)
 	GetAggregatedSubscriptionEntitlements(ctx context.Context, subscriptionID string, req *dto.GetSubscriptionEntitlementsRequest) (*dto.SubscriptionEntitlementsResponse, error)
 
 	// List all tenant subscriptions

--- a/internal/repository/ent/coupon_association.go
+++ b/internal/repository/ent/coupon_association.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	entsql "entgo.io/ent/dialect/sql"
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/couponassociation"
 	"github.com/flexprice/flexprice/ent/predicate"
@@ -113,8 +114,19 @@ func applyActiveOnlyFilter(query CouponAssociationQuery, activePeriodStart, acti
 				couponassociation.EndDateGTE(periodStart),
 				couponassociation.EndDateIsNil(),
 			),
+			couponassociation.Or(
+				couponassociation.EndDateIsNil(),
+				predicate.CouponAssociation(excludeZeroDurationCouponAssociations),
+			),
 		),
 	)
+}
+
+func excludeZeroDurationCouponAssociations(selector *entsql.Selector) {
+	selector.Where(entsql.ColumnsNEQ(
+		selector.C(couponassociation.FieldStartDate),
+		selector.C(couponassociation.FieldEndDate),
+	))
 }
 
 // applyEntityQueryOptions applies entity-specific filters from CouponAssociationFilter

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -235,14 +235,14 @@ func (r *meterRepository) GetMatchingMetersByEventName(ctx context.Context, even
 
 	if cached, found := r.cache.ForceCacheGet(ctx, cacheKey); found {
 		meters, ok := cache.UnmarshalCacheValue[[]*domainMeter.Meter](cached)
-		if !ok {
-			return nil, ierr.WithError(ierr.ErrInternal).
-				WithMessage("failed to unmarshal meters from cache").
-				WithHint("Failed to unmarshal meters from cache").
-				WithReportableDetails(map[string]any{"cache_key": cacheKey}).
-				Mark(ierr.ErrInternal)
+		if ok {
+			return *meters, nil
 		}
-		return *meters, nil
+		r.logger.Info(ctx, "failed to unmarshal meters from cache, treating as miss",
+			"cache_key", cacheKey,
+			"event_name", eventName,
+		)
+		r.cache.ForceCacheDelete(ctx, cacheKey)
 	}
 
 	filter := types.NewNoLimitMeterFilter()

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -233,10 +233,16 @@ func (r *meterRepository) GetMatchingMetersByEventName(ctx context.Context, even
 	eventName = strings.TrimSpace(eventName)
 	cacheKey := cache.GenerateKey(ctx, cache.PrefixMeter, "event_name", eventName)
 
-	if cached, found := r.cache.Get(ctx, cacheKey); found {
-		if meters, ok := cached.([]*domainMeter.Meter); ok {
-			return meters, nil
+	if cached, found := r.cache.ForceCacheGet(ctx, cacheKey); found {
+		meters, ok := cache.UnmarshalCacheValue[[]*domainMeter.Meter](cached)
+		if !ok {
+			return nil, ierr.WithError(ierr.ErrInternal).
+				WithMessage("failed to unmarshal meters from cache").
+				WithHint("Failed to unmarshal meters from cache").
+				WithReportableDetails(map[string]any{"cache_key": cacheKey}).
+				Mark(ierr.ErrInternal)
 		}
+		return *meters, nil
 	}
 
 	filter := types.NewNoLimitMeterFilter()
@@ -248,7 +254,7 @@ func (r *meterRepository) GetMatchingMetersByEventName(ctx context.Context, even
 		return nil, err
 	}
 	if len(meters) > 0 {
-		r.cache.Set(ctx, cacheKey, meters, matchingMetersByEventNameCacheTTL)
+		r.cache.ForceCacheSet(ctx, cacheKey, meters, matchingMetersByEventNameCacheTTL)
 	}
 	return meters, nil
 }

--- a/internal/repository/ent/plan_price_sync_v2.go
+++ b/internal/repository/ent/plan_price_sync_v2.go
@@ -102,7 +102,10 @@ func (r *planPriceSyncRepository) ListPlanLineItemsToCreateV2(
 			  AND subscription_status IN ('%s','%s', '%s', '%s')
 			  AND subscription_type IN (%s)
 			  AND synced_price_sequence < $4
-			ORDER BY id
+			-- Order matches the (plan_id, synced_price_sequence, id) partial index key so
+			-- LIMIT $5 becomes an index range scan that stops after $5 rows instead of a
+			-- Top-N sort over every stale sub in the plan.
+			ORDER BY synced_price_sequence, id
 			LIMIT $5
 		),
 		plan_prices AS (

--- a/internal/temporal/workflows/price_sync_v2_workflow.go
+++ b/internal/temporal/workflows/price_sync_v2_workflow.go
@@ -34,7 +34,7 @@ func PriceSyncV2Workflow(ctx workflow.Context, in models.PriceSyncWorkflowInput)
 	}
 
 	ao := workflow.ActivityOptions{
-		StartToCloseTimeout: time.Hour * 3,
+		StartToCloseTimeout: time.Hour * 2,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:    time.Second,
 			BackoffCoefficient: 2.0,

--- a/internal/temporal/workflows/price_sync_v2_workflow.go
+++ b/internal/temporal/workflows/price_sync_v2_workflow.go
@@ -34,7 +34,7 @@ func PriceSyncV2Workflow(ctx workflow.Context, in models.PriceSyncWorkflowInput)
 	}
 
 	ao := workflow.ActivityOptions{
-		StartToCloseTimeout: time.Hour * 1,
+		StartToCloseTimeout: time.Hour * 3,
 		RetryPolicy: &temporal.RetryPolicy{
 			InitialInterval:    time.Second,
 			BackoffCoefficient: 2.0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prepaid balance calculations when cached data is used.
  * Added clearer timeout handling for balance requests while preserving fallback behavior for other errors.
  * Improved subscription entitlement aggregation during usage-charge and balance calculations.
  * Improved prepaid balance accuracy by retrieving the latest applicable usage information during realtime calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->