### PR TITLE
feat(clickhouse): support TLS without certificate verification

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,14 +253,20 @@ type ClickHouseConfig struct {
 	// (clickhouse.go acquire() waits on a semaphore of MaxOpenConns slots for DialTimeout),
 	// so it cannot be tuned for pool pressure without also changing dial failover — see
 	// the ConnOpenInOrder note in GetClientOptions. Prefer raising MaxOpenConns instead.
-	DialTimeout    time.Duration `mapstructure:"dial_timeout"`
-	ReadTimeout    time.Duration `mapstructure:"read_timeout"`
-	Address        string        `mapstructure:"address" validate:"required"`
-	TLS            bool          `mapstructure:"tls"`
-	Username       string        `mapstructure:"username" validate:"required"`
-	Password       string        `mapstructure:"password" validate:"required"`
-	Database       string        `mapstructure:"database" validate:"required"`
-	MaxMemoryUsage int64         `mapstructure:"max_memory_usage" validate:"required"`
+	DialTimeout time.Duration `mapstructure:"dial_timeout"`
+	ReadTimeout time.Duration `mapstructure:"read_timeout"`
+	Address     string        `mapstructure:"address" validate:"required"`
+	TLS         bool          `mapstructure:"tls"`
+	// TLSSkipVerify disables server certificate and hostname verification on the
+	// TLS connection. It only takes effect when TLS is true. Intended for dev
+	// environments whose ClickHouse serves a self-signed certificate (equivalent to
+	// SSL=true with SSL_MODE=NONE); it removes MITM protection, so leave it false
+	// everywhere else and trust the CA instead.
+	TLSSkipVerify  bool   `mapstructure:"tls_skip_verify"`
+	Username       string `mapstructure:"username" validate:"required"`
+	Password       string `mapstructure:"password" validate:"required"`
+	Database       string `mapstructure:"database" validate:"required"`
+	MaxMemoryUsage int64  `mapstructure:"max_memory_usage" validate:"required"`
 }
 
 type LoggingConfig struct {
@@ -1051,7 +1057,7 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 		options.ReadTimeout = c.ReadTimeout
 	}
 	if c.TLS {
-		options.TLS = &tls.Config{}
+		options.TLS = &tls.Config{InsecureSkipVerify: c.TLSSkipVerify} // #nosec G402 -- opt-in, dev-only self-signed certs
 	}
 
 	maxMemoryUsageBytes := c.MaxMemoryUsage * int64(1024) * int64(1024) * int64(1024)

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -342,6 +342,8 @@ All service addresses are resolved via named templates above so this block stays
   value: {{ .Values.clickhouse.database | quote }}
 - name: FLEXPRICE_CLICKHOUSE_TLS
   value: {{ .Values.clickhouse.tls | quote }}
+- name: FLEXPRICE_CLICKHOUSE_TLS_SKIP_VERIFY
+  value: {{ .Values.clickhouse.tlsSkipVerify | default false | quote }}
 - name: FLEXPRICE_CLICKHOUSE_MAX_MEMORY_USAGE
   value: {{ .Values.clickhouse.maxMemoryUsageGB | default 90 | quote }}
 {{- /* ---- Kafka ---- */}}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -414,6 +414,12 @@ clickhouse:
 
   # Shared connection settings (used by all modes)
   tls: false
+  # Skip server certificate/hostname verification on the TLS connection. Only has
+  # an effect when tls is true. This is the "SSL on, SSL_MODE none" combination —
+  # use it for dev ClickHouse serving a self-signed cert with no CA to distribute.
+  # It removes MITM protection, so keep it false in staging/production and trust
+  # the issuing CA instead (mount the bundle and point SSL_CERT_FILE at it).
+  tlsSkipVerify: false
   username: "default"
   password: "" # Set via secret or secrets.existingSecret key: clickhouse-password
   database: "flexprice"


### PR DESCRIPTION
## Problem

`ClickHouseConfig` exposes a single `tls` boolean, which maps to an empty `tls.Config{}`:

```go
if c.TLS {
    options.TLS = &tls.Config{}
}
```

An empty `tls.Config` means Go defaults: full chain **and** hostname verification against the system trust store, always on. So only two states are reachable — plaintext, or TLS with mandatory verification.

There is no way to express *TLS transport on, certificate verification off* (the `SSL=true` / `SSL_MODE=NONE` combination). Dev environments backed by a self-signed ClickHouse certificate therefore cannot connect at all: the handshake fails with `x509: certificate signed by unknown authority`, and no setting bypasses it.

Postgres in the same struct already has `SSLMode`, so `require` / `verify-full` / `disable` all work there. ClickHouse never got the equivalent.

## Change

Adds `clickhouse.tls_skip_verify`, which sets `InsecureSkipVerify` on the client TLS config. It only takes effect when `tls` is true.

| Layer | Key |
|---|---|
| Config | `clickhouse.tls_skip_verify` |
| Env | `FLEXPRICE_CLICKHOUSE_TLS_SKIP_VERIFY` |
| Helm | `clickhouse.tlsSkipVerify` |

The env var binds automatically — `bindEnvs` reflects over `Configuration`, so no manual registration was needed.

Dev usage:

```yaml
clickhouse:
  tls: true
  tlsSkipVerify: true
```

## Backwards compatibility

Behaviour is unchanged for every existing deployment:

- `tls: false` → untouched code path.
- `tls: true`, `tlsSkipVerify` unset → `InsecureSkipVerify: false`, i.e. identical to the previous empty `tls.Config{}`.
- The template uses `| default false`, so charts rendered from older values files keep full verification.

## Security note

This disables MITM protection and is intended for dev only. The values.yaml comment and the struct doc comment both say so. For staging and production the right fix is to trust the issuing CA rather than skip verification — a follow-up can add an explicit CA-bundle path, mirroring the Kafka TLS configuration in #2422.

## Verification

- `go build -mod=mod ./internal/config/` — passes. (Plain `go build` fails on pre-existing inconsistent vendoring in the repo, unrelated to this change.)
- `gofmt` clean. The struct-tag realignment is why the diff is larger than the ~6 functional lines.
- `helm lint` — 0 charts failed.
- `helm template` with defaults → `FLEXPRICE_CLICKHOUSE_TLS_SKIP_VERIFY: "false"`.
- `helm template --set clickhouse.tls=true --set clickhouse.tlsSkipVerify=true` → `"true"`, rendered on all 5 workloads that consume the shared env helper.

## Out of scope

Two pre-existing gaps, untouched here, that will surface in the first genuinely TLS-only environment:

- The migration job shells `clickhouse-client` without `--secure` (`templates/jobs/migration.yaml`), so it fails against a TLS-only port even when the app connects fine.
- `standalone` / `altinity` modes hardcode `:9000`, so TLS is effectively `mode: external` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to skip ClickHouse TLS certificate and hostname verification when TLS is enabled.
  - Added Helm configuration support through `clickhouse.tlsSkipVerify`, defaulting to secure verification.

- **Configuration**
  - Exposed the TLS verification setting through the application’s configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->