### PR TITLE
feat(addon): addon proration for credit grants

### DIFF
--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -46,8 +46,7 @@ type CreateCreditGrantRequest struct {
 	TopupConversionRate *decimal.Decimal `json:"topup_conversion_rate,omitempty" swaggertype:"string"`
 
 	// FirstPeriodProration, when set, scales the first application's credits to the
-	// portion of the billing period the grant actually covers. Server-computed only:
-	// json:"-" keeps API clients from supplying their own coefficient.
+	// portion of the billing period the grant actually covers.
 	FirstPeriodProration *FirstPeriodProration `json:"-"`
 }
 

--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -44,6 +44,30 @@ type CreateCreditGrantRequest struct {
 	// ex if topup_conversion_rate is 2, then 1 USD = 0.5 credits
 	// ex if topup_conversion_rate is 0.5, then 1 USD = 2 credits
 	TopupConversionRate *decimal.Decimal `json:"topup_conversion_rate,omitempty" swaggertype:"string"`
+
+	// FirstPeriodProration, when set, scales the first application's credits to the
+	// portion of the billing period the grant actually covers. Server-computed only:
+	// json:"-" keeps API clients from supplying their own coefficient.
+	FirstPeriodProration *FirstPeriodProration `json:"-"`
+}
+
+// FirstPeriodProration describes the billing period a mid-cycle grant lands in.
+// It is consumed once, when the first credit grant application is created, and is
+// deliberately never persisted on the grant: every later period is a whole period
+// and must grant the full amount.
+type FirstPeriodProration struct {
+	// PeriodStart/PeriodEnd bound the subscription billing period containing the grant.
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+
+	// ProrationDate is when coverage begins, e.g. the addon attach date.
+	ProrationDate time.Time
+
+	Timezone string
+	Strategy types.ProrationStrategy
+
+	// Source labels the trigger in audit metadata, e.g. "addon_attach".
+	Source string
 }
 
 // UpdateCreditGrantRequest represents the request to update an existing credit grant
@@ -399,6 +423,7 @@ type CreateCreditGrantApplicationRequest struct {
 	ApplicationReason               types.CreditGrantApplicationReason `json:"application_reason"`
 	SubscriptionStatusAtApplication types.SubscriptionStatus           `json:"subscription_status_at_application"`
 	IdempotencyKey                  string                             `json:"idempotency_key"`
+	Metadata                        types.Metadata                     `json:"metadata,omitempty"`
 }
 
 // Validate validates the create credit grant application request
@@ -461,6 +486,7 @@ func (r *CreateCreditGrantApplicationRequest) ToCreditGrantApplication(ctx conte
 		SubscriptionStatusAtApplication: r.SubscriptionStatusAtApplication,
 		Credits:                         r.Credits,
 		IdempotencyKey:                  r.IdempotencyKey,
+		Metadata:                        r.Metadata,
 		RetryCount:                      0,
 		FailureReason:                   nil,
 		EnvironmentID:                   types.GetEnvironmentID(ctx),

--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -62,7 +62,6 @@ type FirstPeriodProration struct {
 	// ProrationDate is when coverage begins, e.g. the addon attach date.
 	ProrationDate time.Time
 
-	Timezone string
 	Strategy types.ProrationStrategy
 
 	// Source labels the trigger in audit metadata, e.g. "addon_attach".

--- a/internal/domain/proration/creditgrant_proration.go
+++ b/internal/domain/proration/creditgrant_proration.go
@@ -1,0 +1,96 @@
+package proration
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+)
+
+// creditGrantCreditsScale matches the numeric(20,8) precision of
+// credit_grant_applications.credits.
+const creditGrantCreditsScale = 8
+
+// CreditGrantProrationParams describes the window a credit grant's first
+// application covers relative to the full billing period it sits in.
+type CreditGrantProrationParams struct {
+	// PeriodStart/PeriodEnd bound the full billing period (the denominator).
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+
+	// ProrationDate is where coverage actually begins (the numerator start).
+	ProrationDate time.Time
+
+	Timezone        string
+	Strategy        types.ProrationStrategy
+	OriginalCredits decimal.Decimal
+}
+
+// CreditGrantProrationResult carries the scaled credits plus the inputs that
+// produced them, so callers can record an audit trail.
+type CreditGrantProrationResult struct {
+	Coefficient     decimal.Decimal
+	ProratedCredits decimal.Decimal
+	OriginalCredits decimal.Decimal
+
+	PeriodStart   time.Time
+	PeriodEnd     time.Time
+	ProrationDate time.Time
+	Strategy      types.ProrationStrategy
+}
+
+// CalculateCreditGrantProration scales OriginalCredits by the fraction of the
+// billing period remaining at ProrationDate.
+//
+// Unlike price proration this returns a quantity rather than money, but it must
+// use the same coefficient so granted credits and the invoiced stub cover the
+// identical window.
+func CalculateCreditGrantProration(params CreditGrantProrationParams) (*CreditGrantProrationResult, error) {
+	strategy := params.Strategy
+	if strategy == "" {
+		strategy = types.StrategySecondBased
+	}
+
+	// Timezone is validated at the API boundary; fall back to UTC rather than
+	// failing, matching types.loadTimezone.
+	loc, err := time.LoadLocation(types.ResolveTimezone(params.Timezone))
+	if err != nil {
+		loc = time.UTC
+	}
+
+	coefficient, err := calculateProrationCoefficient(
+		params.PeriodStart,
+		params.PeriodEnd,
+		params.ProrationDate,
+		loc,
+		strategy,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CreditGrantProrationResult{
+		Coefficient:     coefficient,
+		ProratedCredits: params.OriginalCredits.Mul(coefficient).Round(creditGrantCreditsScale),
+		OriginalCredits: params.OriginalCredits,
+		PeriodStart:     params.PeriodStart,
+		PeriodEnd:       params.PeriodEnd,
+		ProrationDate:   params.ProrationDate,
+		Strategy:        strategy,
+	}, nil
+}
+
+// AuditMetadata renders the calculation as string pairs for storage on the
+// credit grant application and the resulting wallet transaction.
+func (r *CreditGrantProrationResult) AuditMetadata(source string) types.Metadata {
+	return types.Metadata{
+		"proration_applied":          "true",
+		"proration_coefficient":      r.Coefficient.String(),
+		"proration_original_credits": r.OriginalCredits.String(),
+		"proration_period_start":     r.PeriodStart.UTC().Format(time.RFC3339),
+		"proration_period_end":       r.PeriodEnd.UTC().Format(time.RFC3339),
+		"proration_date":             r.ProrationDate.UTC().Format(time.RFC3339),
+		"proration_strategy":         string(r.Strategy),
+		"proration_source":           source,
+	}
+}

--- a/internal/domain/proration/creditgrant_proration.go
+++ b/internal/domain/proration/creditgrant_proration.go
@@ -21,7 +21,6 @@ type CreditGrantProrationParams struct {
 	// ProrationDate is where coverage actually begins (the numerator start).
 	ProrationDate time.Time
 
-	Timezone        string
 	Strategy        types.ProrationStrategy
 	OriginalCredits decimal.Decimal
 }
@@ -47,18 +46,11 @@ func CalculateCreditGrantProration(params CreditGrantProrationParams) (*CreditGr
 		strategy = types.StrategySecondBased
 	}
 
-	// Timezone is validated at the API boundary; fall back to UTC rather than
-	// failing, matching types.loadTimezone.
-	loc, err := time.LoadLocation(types.ResolveTimezone(params.Timezone))
-	if err != nil {
-		loc = time.UTC
-	}
-
 	coefficient, err := calculateProrationCoefficient(
 		params.PeriodStart,
 		params.PeriodEnd,
 		params.ProrationDate,
-		loc,
+		time.UTC,
 		strategy,
 	)
 	if err != nil {

--- a/internal/domain/proration/creditgrant_proration.go
+++ b/internal/domain/proration/creditgrant_proration.go
@@ -7,9 +7,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// creditGrantCreditsScale matches the numeric(20,8) precision of
-// credit_grant_applications.credits.
-const creditGrantCreditsScale = 8
+const creditGrantCreditsScale = 2
 
 // CreditGrantProrationParams describes the window a credit grant's first
 // application covers relative to the full billing period it sits in.
@@ -41,10 +39,6 @@ type CreditGrantProrationResult struct {
 
 // CalculateCreditGrantProration scales OriginalCredits by the fraction of the
 // billing period remaining at ProrationDate.
-//
-// Unlike price proration this returns a quantity rather than money, but it must
-// use the same coefficient so granted credits and the invoiced stub cover the
-// identical window.
 func CalculateCreditGrantProration(params CreditGrantProrationParams) (*CreditGrantProrationResult, error) {
 	strategy := params.Strategy
 	if strategy == "" {

--- a/internal/domain/proration/creditgrant_proration.go
+++ b/internal/domain/proration/creditgrant_proration.go
@@ -7,7 +7,9 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-const creditGrantCreditsScale = 2
+// creditGrantCreditsScale matches the numeric(20,8) precision of
+// credit_grant_applications.credits.
+const creditGrantCreditsScale = 8
 
 // CreditGrantProrationParams describes the window a credit grant's first
 // application covers relative to the full billing period it sits in.

--- a/internal/domain/proration/creditgrant_proration_test.go
+++ b/internal/domain/proration/creditgrant_proration_test.go
@@ -1,0 +1,185 @@
+package proration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateCreditGrantProration(t *testing.T) {
+	jan1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb1 := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name            string
+		periodStart     time.Time
+		periodEnd       time.Time
+		prorationDate   time.Time
+		timezone        string
+		strategy        types.ProrationStrategy
+		credits         decimal.Decimal
+		wantCoefficient string
+		wantCredits     string
+	}{
+		{
+			name:            "mid period grants the remaining fraction",
+			periodStart:     jan1,
+			periodEnd:       feb1,
+			prorationDate:   time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC),
+			strategy:        types.StrategySecondBased,
+			credits:         decimal.NewFromInt(100),
+			wantCoefficient: "0.3870967741935484",
+			wantCredits:     "38.70967742",
+		},
+		{
+			name:          "exactly on period start grants everything",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: jan1,
+			strategy:      types.StrategySecondBased,
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "100",
+		},
+		{
+			name:          "exactly on period end grants nothing",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: feb1,
+			strategy:      types.StrategySecondBased,
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "0",
+		},
+		{
+			name:          "past period end clamps to zero rather than going negative",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC),
+			strategy:      types.StrategySecondBased,
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "0",
+		},
+		{
+			name:          "empty timezone falls back to UTC instead of erroring",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC),
+			timezone:      "",
+			strategy:      types.StrategySecondBased,
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "50",
+		},
+		{
+			name:          "non-UTC timezone is accepted",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC),
+			timezone:      "Asia/Kolkata",
+			strategy:      types.StrategySecondBased,
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "50",
+		},
+		{
+			name:          "defaults to second based when strategy is unset",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC),
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "50",
+		},
+		{
+			name:          "day based crossing a DST boundary",
+			periodStart:   time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			periodEnd:     time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+			prorationDate: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			timezone:      "America/New_York",
+			strategy:      types.StrategyDayBased,
+			credits:       decimal.NewFromInt(100),
+			wantCredits:   "100",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CalculateCreditGrantProration(CreditGrantProrationParams{
+				PeriodStart:     tt.periodStart,
+				PeriodEnd:       tt.periodEnd,
+				ProrationDate:   tt.prorationDate,
+				Timezone:        tt.timezone,
+				Strategy:        tt.strategy,
+				OriginalCredits: tt.credits,
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantCredits, got.ProratedCredits.String())
+			assert.Equal(t, tt.credits.String(), got.OriginalCredits.String())
+			if tt.wantCoefficient != "" {
+				assert.Equal(t, tt.wantCoefficient, got.Coefficient.String())
+			}
+		})
+	}
+}
+
+func TestCalculateCreditGrantProration_InvalidPeriod(t *testing.T) {
+	start := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := CalculateCreditGrantProration(CreditGrantProrationParams{
+		PeriodStart:     start,
+		PeriodEnd:       start.AddDate(0, -1, 0),
+		ProrationDate:   start,
+		Strategy:        types.StrategySecondBased,
+		OriginalCredits: decimal.NewFromInt(100),
+	})
+
+	assert.Error(t, err)
+}
+
+// The credit stub and the invoiced price stub must cover the same window, so both
+// must derive from the same coefficient.
+func TestCalculateCreditGrantProration_MatchesPriceProrationCoefficient(t *testing.T) {
+	periodStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	prorationDate := time.Date(2025, 1, 20, 8, 30, 0, 0, time.UTC)
+
+	want, err := calculateProrationCoefficient(
+		periodStart, periodEnd, prorationDate, time.UTC, types.StrategySecondBased,
+	)
+	require.NoError(t, err)
+
+	got, err := CalculateCreditGrantProration(CreditGrantProrationParams{
+		PeriodStart:     periodStart,
+		PeriodEnd:       periodEnd,
+		ProrationDate:   prorationDate,
+		Strategy:        types.StrategySecondBased,
+		OriginalCredits: decimal.NewFromInt(100),
+	})
+	require.NoError(t, err)
+
+	assert.True(t, want.Equal(got.Coefficient),
+		"credit grant coefficient %s must equal price proration coefficient %s",
+		got.Coefficient, want)
+}
+
+func TestCreditGrantProrationResult_AuditMetadata(t *testing.T) {
+	res, err := CalculateCreditGrantProration(CreditGrantProrationParams{
+		PeriodStart:     time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:       time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+		ProrationDate:   time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC),
+		Strategy:        types.StrategySecondBased,
+		OriginalCredits: decimal.NewFromInt(100),
+	})
+	require.NoError(t, err)
+
+	md := res.AuditMetadata("addon_attach")
+
+	assert.Equal(t, "true", md["proration_applied"])
+	assert.Equal(t, "100", md["proration_original_credits"])
+	assert.Equal(t, "addon_attach", md["proration_source"])
+	assert.Equal(t, string(types.StrategySecondBased), md["proration_strategy"])
+	assert.Equal(t, "2025-01-01T00:00:00Z", md["proration_period_start"])
+	assert.Equal(t, "2025-02-01T00:00:00Z", md["proration_period_end"])
+	assert.Equal(t, "2025-01-20T00:00:00Z", md["proration_date"])
+}

--- a/internal/domain/proration/creditgrant_proration_test.go
+++ b/internal/domain/proration/creditgrant_proration_test.go
@@ -19,7 +19,6 @@ func TestCalculateCreditGrantProration(t *testing.T) {
 		periodStart     time.Time
 		periodEnd       time.Time
 		prorationDate   time.Time
-		timezone        string
 		strategy        types.ProrationStrategy
 		credits         decimal.Decimal
 		wantCoefficient string
@@ -75,21 +74,10 @@ func TestCalculateCreditGrantProration(t *testing.T) {
 			wantCredits:   "0",
 		},
 		{
-			name:          "empty timezone falls back to UTC instead of erroring",
+			name:          "mid period halves the credits",
 			periodStart:   jan1,
 			periodEnd:     feb1,
 			prorationDate: time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC),
-			timezone:      "",
-			strategy:      types.StrategySecondBased,
-			credits:       decimal.NewFromInt(100),
-			wantCredits:   "50",
-		},
-		{
-			name:          "non-UTC timezone is accepted",
-			periodStart:   jan1,
-			periodEnd:     feb1,
-			prorationDate: time.Date(2025, 1, 16, 12, 0, 0, 0, time.UTC),
-			timezone:      "Asia/Kolkata",
 			strategy:      types.StrategySecondBased,
 			credits:       decimal.NewFromInt(100),
 			wantCredits:   "50",
@@ -103,11 +91,10 @@ func TestCalculateCreditGrantProration(t *testing.T) {
 			wantCredits:   "50",
 		},
 		{
-			name:          "day based crossing a DST boundary",
+			name:          "day based at period start grants everything",
 			periodStart:   time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
 			periodEnd:     time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
 			prorationDate: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
-			timezone:      "America/New_York",
 			strategy:      types.StrategyDayBased,
 			credits:       decimal.NewFromInt(100),
 			wantCredits:   "100",
@@ -120,7 +107,6 @@ func TestCalculateCreditGrantProration(t *testing.T) {
 				PeriodStart:     tt.periodStart,
 				PeriodEnd:       tt.periodEnd,
 				ProrationDate:   tt.prorationDate,
-				Timezone:        tt.timezone,
 				Strategy:        tt.strategy,
 				OriginalCredits: tt.credits,
 			})

--- a/internal/domain/proration/creditgrant_proration_test.go
+++ b/internal/domain/proration/creditgrant_proration_test.go
@@ -33,7 +33,7 @@ func TestCalculateCreditGrantProration(t *testing.T) {
 			strategy:        types.StrategySecondBased,
 			credits:         decimal.NewFromInt(100),
 			wantCoefficient: "0.3870967741935484",
-			wantCredits:     "38.70967742",
+			wantCredits:     "38.71",
 		},
 		{
 			name:          "exactly on period start grants everything",

--- a/internal/domain/proration/creditgrant_proration_test.go
+++ b/internal/domain/proration/creditgrant_proration_test.go
@@ -33,7 +33,19 @@ func TestCalculateCreditGrantProration(t *testing.T) {
 			strategy:        types.StrategySecondBased,
 			credits:         decimal.NewFromInt(100),
 			wantCoefficient: "0.3870967741935484",
-			wantCredits:     "38.71",
+			wantCredits:     "38.70967742",
+		},
+		{
+			// A zero-credit application fails the wallet top-up, which rolls back the
+			// transaction that would have created the next period — so a stub must never
+			// round down to nothing.
+			name:          "a stub of a few seconds still grants something",
+			periodStart:   jan1,
+			periodEnd:     feb1,
+			prorationDate: feb1.Add(-30 * time.Second),
+			strategy:      types.StrategySecondBased,
+			credits:       decimal.NewFromInt(1),
+			wantCredits:   "0.0000112",
 		},
 		{
 			name:          "exactly on period start grants everything",

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -1312,8 +1312,8 @@ func (s *creditGrantService) cancelFutureGrantApplications(ctx context.Context, 
 			types.ApplicationStatusPending,
 			types.ApplicationStatusFailed,
 		},
-		ScheduledAfter: &effectiveDate,
-		QueryFilter:    types.NewNoLimitQueryFilter(),
+		ScheduledFrom: &effectiveDate,
+		QueryFilter:   types.NewNoLimitQueryFilter(),
 	}
 
 	applications, err := s.CreditGrantApplicationRepo.List(ctx, pendingFilter)

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -333,7 +333,6 @@ func (s *creditGrantService) InitializeCreditGrantWorkflow(
 			PeriodStart:     prorationCfg.PeriodStart,
 			PeriodEnd:       prorationCfg.PeriodEnd,
 			ProrationDate:   prorationCfg.ProrationDate,
-			Timezone:        prorationCfg.Timezone,
 			Strategy:        prorationCfg.Strategy,
 			OriginalCredits: cg.Credits,
 		})
@@ -754,17 +753,11 @@ func (s *creditGrantService) applyCreditGrantToWallet(ctx context.Context, grant
 		}
 	}
 
-	// Prepare top-up request
-	topupMetadata := map[string]string{
+	topupMetadata := lo.Assign(map[string]string{
 		"grant_id":        grant.ID,
 		"subscription_id": subscription.ID,
 		"cga_id":          cga.ID,
-	}
-	// Carry any proration audit trail onto the wallet transaction so a prorated
-	// top-up explains itself without joining back to the application.
-	for k, v := range cga.Metadata {
-		topupMetadata[k] = v
-	}
+	}, cga.Metadata)
 
 	topupReq := &dto.TopUpWalletRequest{
 		CreditsToAdd:      cga.Credits,

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	domainCreditGrantApplication "github.com/flexprice/flexprice/internal/domain/creditgrantapplication"
+	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/idempotency"
@@ -265,7 +266,7 @@ func (s *creditGrantService) CreateCreditGrant(ctx context.Context, req dto.Crea
 
 	// Initialize workflow
 	if cg.Scope == types.CreditGrantScopeSubscription {
-		cg, err = s.InitializeCreditGrantWorkflow(ctx, lo.FromPtr(cg))
+		cg, err = s.initializeCreditGrantWorkflow(ctx, lo.FromPtr(cg), req.FirstPeriodProration)
 		if err != nil {
 			return nil, err
 		}
@@ -276,6 +277,18 @@ func (s *creditGrantService) CreateCreditGrant(ctx context.Context, req dto.Crea
 }
 
 func (s *creditGrantService) InitializeCreditGrantWorkflow(ctx context.Context, cg creditgrant.CreditGrant) (*creditgrant.CreditGrant, error) {
+	return s.initializeCreditGrantWorkflow(ctx, cg, nil)
+}
+
+// initializeCreditGrantWorkflow creates the grant's first application. When
+// prorationCfg is set, that first application covers only part of a billing period
+// and its credits are scaled accordingly; later periods are whole and always grant
+// the full amount, which is why the config is never persisted on the grant.
+func (s *creditGrantService) initializeCreditGrantWorkflow(
+	ctx context.Context,
+	cg creditgrant.CreditGrant,
+	prorationCfg *dto.FirstPeriodProration,
+) (*creditgrant.CreditGrant, error) {
 
 	// 3. Calculate period for the first application
 	periodStart := lo.FromPtr(cg.StartDate)
@@ -292,13 +305,21 @@ func (s *creditGrantService) InitializeCreditGrantWorkflow(ctx context.Context, 
 	}
 
 	if cg.Cadence == types.CreditGrantCadenceRecurring {
-		var err error
-		var calculatedPeriodEnd time.Time
-		_, calculatedPeriodEnd, err = CalculateNextCreditGrantPeriod(cg, periodStart, subscription.Timezone)
-		if err != nil {
-			return nil, err
+		if prorationCfg != nil {
+			// A prorated grant's first period is deliberately short: it ends where the
+			// subscription's billing period does. It is set directly rather than derived
+			// from the anchor because NextBillingDate has no short-first-period rule for
+			// annual cycles, and overshoots when the period spans multiple weeks.
+			periodEnd = lo.ToPtr(prorationCfg.PeriodEnd)
+		} else {
+			var err error
+			var calculatedPeriodEnd time.Time
+			_, calculatedPeriodEnd, err = CalculateNextCreditGrantPeriod(cg, periodStart, subscription.Timezone)
+			if err != nil {
+				return nil, err
+			}
+			periodEnd = lo.ToPtr(calculatedPeriodEnd)
 		}
-		periodEnd = lo.ToPtr(calculatedPeriodEnd)
 	}
 
 	// 5. Create the first CGA record in Pending status
@@ -309,6 +330,34 @@ func (s *creditGrantService) InitializeCreditGrantWorkflow(ctx context.Context, 
 		applicationReason = types.ApplicationReasonOnetimeCreditGrant
 	}
 
+	credits := cg.Credits
+	var prorationMetadata types.Metadata
+	if prorationCfg != nil {
+		result, err := proration.CalculateCreditGrantProration(proration.CreditGrantProrationParams{
+			PeriodStart:     prorationCfg.PeriodStart,
+			PeriodEnd:       prorationCfg.PeriodEnd,
+			ProrationDate:   prorationCfg.ProrationDate,
+			Timezone:        prorationCfg.Timezone,
+			Strategy:        prorationCfg.Strategy,
+			OriginalCredits: cg.Credits,
+		})
+		if err != nil {
+			return nil, err
+		}
+		credits = result.ProratedCredits
+		prorationMetadata = result.AuditMetadata(prorationCfg.Source)
+
+		s.Logger.Info(ctx, "prorating first credit grant application",
+			"grant_id", cg.ID,
+			"subscription_id", lo.FromPtr(cg.SubscriptionID),
+			"coefficient", result.Coefficient.String(),
+			"original_credits", cg.Credits.String(),
+			"prorated_credits", credits.String())
+	}
+
+	// The idempotency key stays keyed on (grant, period) only. Folding the amount in
+	// would let a future change to the coefficient mint a second application for a
+	// period that was already granted.
 	cgaReq := dto.CreateCreditGrantApplicationRequest{
 		CreditGrantID:                   cg.ID,
 		SubscriptionID:                  lo.FromPtr(cg.SubscriptionID),
@@ -316,9 +365,10 @@ func (s *creditGrantService) InitializeCreditGrantWorkflow(ctx context.Context, 
 		PeriodStart:                     periodStart,
 		PeriodEnd:                       periodEnd,
 		ApplicationReason:               applicationReason,
-		Credits:                         cg.Credits,
+		Credits:                         credits,
 		SubscriptionStatusAtApplication: subscription.SubscriptionStatus,
 		IdempotencyKey:                  s.generateIdempotencyKey(lo.ToPtr(cg), lo.ToPtr(periodStart), periodEnd),
+		Metadata:                        prorationMetadata,
 	}
 
 	if err := cgaReq.Validate(); err != nil {
@@ -331,8 +381,11 @@ func (s *creditGrantService) InitializeCreditGrantWorkflow(ctx context.Context, 
 		return nil, err
 	}
 
-	// 6. Eager application: if the grant is due now or in the past, process it immediately
-	if cg.CreditGrantAnchor.Before(time.Now()) || cg.CreditGrantAnchor.Equal(time.Now()) {
+	// 6. Eager application: if the application is due now or in the past, process it
+	// immediately. Keyed on ScheduledFor rather than the anchor — the anchor is a cycle
+	// reference and may legitimately sit in the future (a prorated grant anchors on the
+	// period boundary it aligns to), which would otherwise defer the credits to the cron.
+	if !cga.ScheduledFor.After(time.Now()) {
 		// Use a background context or a sub-context to avoid blocking the main creation if processing fails
 		// Though for initialization, we might want it to be synchronous if it fails due to validation
 		if err := s.processCatchUpApplications(ctx, cga); err != nil {
@@ -711,17 +764,24 @@ func (s *creditGrantService) applyCreditGrantToWallet(ctx context.Context, grant
 	}
 
 	// Prepare top-up request
+	topupMetadata := map[string]string{
+		"grant_id":        grant.ID,
+		"subscription_id": subscription.ID,
+		"cga_id":          cga.ID,
+	}
+	// Carry any proration audit trail onto the wallet transaction so a prorated
+	// top-up explains itself without joining back to the application.
+	for k, v := range cga.Metadata {
+		topupMetadata[k] = v
+	}
+
 	topupReq := &dto.TopUpWalletRequest{
 		CreditsToAdd:      cga.Credits,
 		TransactionReason: types.TransactionReasonSubscriptionCredit,
 		ExpiryDateUTC:     expiryDate,
 		Priority:          grant.Priority,
 		IdempotencyKey:    lo.ToPtr(cga.ID),
-		Metadata: map[string]string{
-			"grant_id":        grant.ID,
-			"subscription_id": subscription.ID,
-			"cga_id":          cga.ID,
-		},
+		Metadata:          topupMetadata,
 	}
 
 	var nextCGA *domainCreditGrantApplication.CreditGrantApplication

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -49,7 +49,7 @@ type CreditGrantService interface {
 
 	// InitializeCreditGrantWorkflow initializes the workflow for a credit grant
 	// This creates the first CGA and triggers eager application if applicable
-	InitializeCreditGrantWorkflow(ctx context.Context, cg creditgrant.CreditGrant) (*creditgrant.CreditGrant, error)
+	InitializeCreditGrantWorkflow(ctx context.Context, cg creditgrant.CreditGrant, prorationCfg *dto.FirstPeriodProration) (*creditgrant.CreditGrant, error)
 
 	// ProcessCreditGrantApplication processes a single credit grant application
 	// Use this to manually trigger processing of a pending/failed application
@@ -266,7 +266,7 @@ func (s *creditGrantService) CreateCreditGrant(ctx context.Context, req dto.Crea
 
 	// Initialize workflow
 	if cg.Scope == types.CreditGrantScopeSubscription {
-		cg, err = s.initializeCreditGrantWorkflow(ctx, lo.FromPtr(cg), req.FirstPeriodProration)
+		cg, err = s.InitializeCreditGrantWorkflow(ctx, lo.FromPtr(cg), req.FirstPeriodProration)
 		if err != nil {
 			return nil, err
 		}
@@ -276,15 +276,11 @@ func (s *creditGrantService) CreateCreditGrant(ctx context.Context, req dto.Crea
 	return response, nil
 }
 
-func (s *creditGrantService) InitializeCreditGrantWorkflow(ctx context.Context, cg creditgrant.CreditGrant) (*creditgrant.CreditGrant, error) {
-	return s.initializeCreditGrantWorkflow(ctx, cg, nil)
-}
-
 // initializeCreditGrantWorkflow creates the grant's first application. When
 // prorationCfg is set, that first application covers only part of a billing period
 // and its credits are scaled accordingly; later periods are whole and always grant
 // the full amount, which is why the config is never persisted on the grant.
-func (s *creditGrantService) initializeCreditGrantWorkflow(
+func (s *creditGrantService) InitializeCreditGrantWorkflow(
 	ctx context.Context,
 	cg creditgrant.CreditGrant,
 	prorationCfg *dto.FirstPeriodProration,
@@ -355,9 +351,6 @@ func (s *creditGrantService) initializeCreditGrantWorkflow(
 			"prorated_credits", credits.String())
 	}
 
-	// The idempotency key stays keyed on (grant, period) only. Folding the amount in
-	// would let a future change to the coefficient mint a second application for a
-	// period that was already granted.
 	cgaReq := dto.CreateCreditGrantApplicationRequest{
 		CreditGrantID:                   cg.ID,
 		SubscriptionID:                  lo.FromPtr(cg.SubscriptionID),
@@ -382,9 +375,7 @@ func (s *creditGrantService) initializeCreditGrantWorkflow(
 	}
 
 	// 6. Eager application: if the application is due now or in the past, process it
-	// immediately. Keyed on ScheduledFor rather than the anchor — the anchor is a cycle
-	// reference and may legitimately sit in the future (a prorated grant anchors on the
-	// period boundary it aligns to), which would otherwise defer the credits to the cron.
+	// immediately.
 	if !cga.ScheduledFor.After(time.Now()) {
 		// Use a background context or a sub-context to avoid blocking the main creation if processing fails
 		// Though for initialization, we might want it to be synchronous if it fails due to validation

--- a/internal/ee/service/creditgrant_test.go
+++ b/internal/ee/service/creditgrant_test.go
@@ -897,7 +897,7 @@ func (s *CreditGrantServiceTestSuite) TestDeleteCreditGrant_OnlyCancelsApplicati
 
 	gotAtCutoff, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), atCutoffApp.ID)
 	s.NoError(err)
-	s.Equal(types.ApplicationStatusPending, gotAtCutoff.ApplicationStatus, "application scheduled exactly at the effective date must remain untouched (strictly-after cutoff)")
+	s.Equal(types.ApplicationStatusCancelled, gotAtCutoff.ApplicationStatus, "application scheduled exactly at the effective date must be cancelled (inclusive cutoff)")
 
 	gotAfter, err := s.GetStores().CreditGrantApplicationRepo.Get(s.GetContext(), afterApp.ID)
 	s.NoError(err)

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1601,6 +1601,7 @@ func (s *subscriptionService) addonCreditGrantProration(
 		ProrationDate: startDate,
 		Timezone:      sub.Timezone,
 		Strategy:      types.StrategySecondBased,
+		Source:        "addon_attach",
 	}
 }
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1523,31 +1523,6 @@ func (s *subscriptionService) handleCreditGrants(
 	return s.handleCreditGrantsWithStart(ctx, subscription, creditGrantRequests, startDate, nil, nil)
 }
 
-// creditGrantMatchesBillingCycle reports whether a grant recurs on the same rhythm as
-// the subscription's billing cycle. Snapping a grant to a billing boundary is only
-// meaningful when the two coincide: a monthly grant on an annual subscription is
-// supposed to keep recurring monthly inside the billing period, not stretch to it.
-func creditGrantMatchesBillingCycle(
-	sub *subscription.Subscription,
-	grantReq dto.CreateCreditGrantRequest,
-) bool {
-	if grantReq.Period == nil {
-		return false
-	}
-
-	grantPeriod, err := types.GetBillingPeriodFromCreditGrantPeriod(lo.FromPtr(grantReq.Period))
-	if err != nil {
-		return false
-	}
-
-	grantPeriodCount := 1
-	if grantReq.PeriodCount != nil {
-		grantPeriodCount = lo.FromPtr(grantReq.PeriodCount)
-	}
-
-	return grantPeriod == sub.BillingPeriod && grantPeriodCount == sub.BillingPeriodCount
-}
-
 // addonCreditGrantProration resolves the billing period containing startDate so a
 // mid-cycle grant can be scaled to the part of that period it actually covers.
 // Returns nil when proration does not apply, in which case the grant keeps its full
@@ -1599,7 +1574,6 @@ func (s *subscriptionService) addonCreditGrantProration(
 		PeriodStart:   p.Start,
 		PeriodEnd:     p.End,
 		ProrationDate: startDate,
-		Timezone:      sub.Timezone,
 		Strategy:      types.StrategySecondBased,
 		Source:        "addon_attach",
 	}
@@ -1682,11 +1656,25 @@ func (s *subscriptionService) handleCreditGrantsWithStart(
 		// Use subscription start date as the anchor for the credit grant chain
 		grantReq.CreditGrantAnchor = lo.ToPtr(startDate)
 
-		// Prorating a mid-cycle grant only makes sense for a recurring allowance; a
-		// onetime grant is a fixed lump with no period to scale against.
+		// Prorating a mid-cycle grant only makes sense for a recurring allowance that
+		// shares the subscription's billing rhythm; a onetime grant is a fixed lump,
+		// and a monthly grant on an annual subscription should keep recurring monthly
+		// rather than stretch to the billing period.
+		grantPeriod := types.BillingPeriod("")
+		if grantReq.Period != nil {
+			period, err := types.GetBillingPeriodFromCreditGrantPeriod(lo.FromPtr(grantReq.Period))
+			if err != nil {
+				s.Logger.Error(ctx, "failed to get billing period from credit grant period",
+					"subscription_id", subscription.ID,
+					"credit_grant_period", grantReq.Period,
+					"error", err)
+			}
+			grantPeriod = period
+		}
+
 		if prorationCfg != nil &&
 			grantReq.Cadence == types.CreditGrantCadenceRecurring &&
-			creditGrantMatchesBillingCycle(subscription, grantReq) {
+			grantPeriod == subscription.BillingPeriod {
 			// Anchor on the subscription's period boundary rather than the attach date, so
 			// every period after the short first one lands on an invoicing boundary instead
 			// of drifting. Chaining stays correct because createNextPeriodApplication feeds

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1601,7 +1601,6 @@ func (s *subscriptionService) addonCreditGrantProration(
 		ProrationDate: startDate,
 		Timezone:      sub.Timezone,
 		Strategy:      types.StrategySecondBased,
-		Source:        "addon_attach",
 	}
 }
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -1520,7 +1520,89 @@ func (s *subscriptionService) handleCreditGrants(
 	if subscription.TrialEnd != nil {
 		startDate = lo.FromPtr(subscription.TrialEnd)
 	}
-	return s.handleCreditGrantsWithStart(ctx, subscription, creditGrantRequests, startDate, nil)
+	return s.handleCreditGrantsWithStart(ctx, subscription, creditGrantRequests, startDate, nil, nil)
+}
+
+// creditGrantMatchesBillingCycle reports whether a grant recurs on the same rhythm as
+// the subscription's billing cycle. Snapping a grant to a billing boundary is only
+// meaningful when the two coincide: a monthly grant on an annual subscription is
+// supposed to keep recurring monthly inside the billing period, not stretch to it.
+func creditGrantMatchesBillingCycle(
+	sub *subscription.Subscription,
+	grantReq dto.CreateCreditGrantRequest,
+) bool {
+	if grantReq.Period == nil {
+		return false
+	}
+
+	grantPeriod, err := types.GetBillingPeriodFromCreditGrantPeriod(lo.FromPtr(grantReq.Period))
+	if err != nil {
+		return false
+	}
+
+	grantPeriodCount := 1
+	if grantReq.PeriodCount != nil {
+		grantPeriodCount = lo.FromPtr(grantReq.PeriodCount)
+	}
+
+	return grantPeriod == sub.BillingPeriod && grantPeriodCount == sub.BillingPeriodCount
+}
+
+// addonCreditGrantProration resolves the billing period containing startDate so a
+// mid-cycle grant can be scaled to the part of that period it actually covers.
+// Returns nil when proration does not apply, in which case the grant keeps its full
+// credits and its natural anchoring.
+//
+// Never returns an error: proration is an enhancement to the attach, so an
+// unresolvable period downgrades to today's behaviour instead of rejecting the addon.
+func (s *subscriptionService) addonCreditGrantProration(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	startDate time.Time,
+	behavior types.ProrationBehavior,
+) *dto.FirstPeriodProration {
+	if behavior != types.ProrationBehaviorCreateProrations {
+		return nil
+	}
+
+	p, err := types.FindPeriodForDate(&types.FindPeriodForDateParams{
+		Target:           startDate,
+		KnownPeriodStart: sub.CurrentPeriodStart,
+		KnownPeriodEnd:   sub.CurrentPeriodEnd,
+		Anchor:           sub.BillingAnchor,
+		PeriodCount:      sub.BillingPeriodCount,
+		BillingPeriod:    sub.BillingPeriod,
+		Timezone:         sub.Timezone,
+	})
+	if err != nil {
+		// FindPeriodForDate only walks forward, so a start date in an already-closed
+		// period cannot be resolved. Grant in full rather than blocking the attach.
+		s.Logger.Info(ctx, "skipping credit grant proration; could not resolve billing period for addon start",
+			"subscription_id", sub.ID,
+			"start_date", startDate,
+			"current_period_start", sub.CurrentPeriodStart,
+			"error", err.Error())
+		return nil
+	}
+
+	if !startDate.After(p.Start) {
+		return nil
+	}
+
+	// A grant anchored past the subscription end fails CreateCreditGrant validation,
+	// and the grant would be capped to that end anyway.
+	if sub.EndDate != nil && p.End.After(lo.FromPtr(sub.EndDate)) {
+		return nil
+	}
+
+	return &dto.FirstPeriodProration{
+		PeriodStart:   p.Start,
+		PeriodEnd:     p.End,
+		ProrationDate: startDate,
+		Timezone:      sub.Timezone,
+		Strategy:      types.StrategySecondBased,
+		Source:        "addon_attach",
+	}
 }
 
 // handleCreditGrantsWithStart materializes the given credit grant requests onto the
@@ -1533,6 +1615,7 @@ func (s *subscriptionService) handleCreditGrantsWithStart(
 	creditGrantRequests []dto.CreateCreditGrantRequest,
 	startDate time.Time,
 	endDateOverride *time.Time,
+	prorationCfg *dto.FirstPeriodProration,
 ) error {
 	if len(creditGrantRequests) == 0 {
 		return nil
@@ -1598,6 +1681,19 @@ func (s *subscriptionService) handleCreditGrantsWithStart(
 
 		// Use subscription start date as the anchor for the credit grant chain
 		grantReq.CreditGrantAnchor = lo.ToPtr(startDate)
+
+		// Prorating a mid-cycle grant only makes sense for a recurring allowance; a
+		// onetime grant is a fixed lump with no period to scale against.
+		if prorationCfg != nil &&
+			grantReq.Cadence == types.CreditGrantCadenceRecurring &&
+			creditGrantMatchesBillingCycle(subscription, grantReq) {
+			// Anchor on the subscription's period boundary rather than the attach date, so
+			// every period after the short first one lands on an invoicing boundary instead
+			// of drifting. Chaining stays correct because createNextPeriodApplication feeds
+			// each period end back in as the next period start, matching this anchor.
+			grantReq.CreditGrantAnchor = lo.ToPtr(prorationCfg.PeriodEnd)
+			grantReq.FirstPeriodProration = prorationCfg
+		}
 
 		// Create credit grant: this now triggers initializeCreditGrantWorkflow
 		// which handles creation, anchor calculation, and eager application
@@ -4861,6 +4957,8 @@ func (s *subscriptionService) addAddonToSubscription(
 		return nil, err
 	}
 
+	creditGrantProration := s.addonCreditGrantProration(ctx, sub, addonRequestedStart, req.ProrationBehavior)
+
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 		if len(req.OverrideLineItems) > 0 {
 			if err := s.ProcessSubscriptionPriceOverrides(ctx, sub, req.OverrideLineItems, lineItems, priceMap); err != nil {
@@ -4891,7 +4989,7 @@ func (s *subscriptionService) addAddonToSubscription(
 		// Materialize the addon's credit grants (if any) onto the subscription,
 		// anchored at the addon attach date so mid-cycle grants apply immediately.
 		// Kept in-transaction so grant application is atomic with the addon attach.
-		if err := s.materializeAddonCreditGrants(ctx, sub, req.AddonID, addonRequestedStart, addonAssociation.EndDate); err != nil {
+		if err := s.materializeAddonCreditGrants(ctx, sub, req.AddonID, addonRequestedStart, addonAssociation.EndDate, creditGrantProration); err != nil {
 			return err
 		}
 
@@ -4934,6 +5032,7 @@ func (s *subscriptionService) materializeAddonCreditGrants(
 	addonID string,
 	startDate time.Time,
 	addonEndDate *time.Time,
+	prorationCfg *dto.FirstPeriodProration,
 ) error {
 	creditGrantService := NewCreditGrantService(s.ServiceParams)
 	addonGrants, err := creditGrantService.GetCreditGrantsByAddon(ctx, addonID)
@@ -4970,7 +5069,7 @@ func (s *subscriptionService) materializeAddonCreditGrants(
 		})
 	}
 
-	return s.handleCreditGrantsWithStart(ctx, sub, requests, startDate, addonEndDate)
+	return s.handleCreditGrantsWithStart(ctx, sub, requests, startDate, addonEndDate, prorationCfg)
 }
 
 // validateEntitlementCompatibility checks if addon entitlements are compatible with existing subscription entitlements

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -395,7 +395,6 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_ProratesFirstCredi
 		PeriodStart:     sub.CurrentPeriodStart,
 		PeriodEnd:       sub.CurrentPeriodEnd,
 		ProrationDate:   now,
-		Timezone:        sub.Timezone,
 		Strategy:        types.StrategySecondBased,
 		OriginalCredits: decimal.NewFromInt(100),
 	})
@@ -2745,19 +2744,19 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems_Validatio
 
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-		req := dto.CreateSubscriptionRequest{
-			CustomerID:         s.testData.customer.ID,
-			PlanID:             s.testData.plan.ID,
-			StartDate:          &start,
-			EndDate:            &end,
-			Currency:           "usd",
-			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-			BillingPeriodCount: 1,
-			BillingCycle:       types.BillingCycleAnniversary,
-			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
-				LineItems: tt.lineItems,
-			},
-		}
+			req := dto.CreateSubscriptionRequest{
+				CustomerID:         s.testData.customer.ID,
+				PlanID:             s.testData.plan.ID,
+				StartDate:          &start,
+				EndDate:            &end,
+				Currency:           "usd",
+				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+				BillingPeriodCount: 1,
+				BillingCycle:       types.BillingCycleAnniversary,
+				SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+					LineItems: tt.lineItems,
+				},
+			}
 			_, err := s.service.CreateSubscription(ctx, req)
 			s.Error(err)
 			s.Contains(err.Error(), tt.wantErrCont)
@@ -7116,17 +7115,17 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithPriceOverrides() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			// Create subscription request with overrides
-		req := dto.CreateSubscriptionRequest{
-			CustomerID:         s.testData.customer.ID,
-			PlanID:             s.testData.plan.ID,
-			Currency:           "usd",
-			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-			BillingPeriodCount: 1,
-			BillingCycle:       types.BillingCycleAnniversary,
-			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
-				OverrideLineItems: tc.overrideLineItems,
-			},
-		}
+			req := dto.CreateSubscriptionRequest{
+				CustomerID:         s.testData.customer.ID,
+				PlanID:             s.testData.plan.ID,
+				Currency:           "usd",
+				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+				BillingPeriodCount: 1,
+				BillingCycle:       types.BillingCycleAnniversary,
+				SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+					OverrideLineItems: tc.overrideLineItems,
+				},
+			}
 
 			// Create subscription
 			resp, err := s.service.CreateSubscription(s.GetContext(), req)
@@ -7701,17 +7700,17 @@ func (s *SubscriptionServiceSuite) TestPriceOverrideIntegration() {
 		subscriptionIDs := make([]string, len(overrideScenarios))
 
 		for i, override := range overrideScenarios {
-		req := dto.CreateSubscriptionRequest{
-			CustomerID:         s.testData.customer.ID,
-			PlanID:             s.testData.plan.ID,
-			Currency:           "usd",
-			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
-			BillingPeriodCount: 1,
-			BillingCycle:       types.BillingCycleAnniversary,
-			SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
-				OverrideLineItems: []dto.OverrideLineItemRequest{override},
-			},
-		}
+			req := dto.CreateSubscriptionRequest{
+				CustomerID:         s.testData.customer.ID,
+				PlanID:             s.testData.plan.ID,
+				Currency:           "usd",
+				BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+				BillingPeriodCount: 1,
+				BillingCycle:       types.BillingCycleAnniversary,
+				SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+					OverrideLineItems: []dto.OverrideLineItemRequest{override},
+				},
+			}
 
 			resp, err := s.service.CreateSubscription(s.GetContext(), req)
 			s.NoError(err, "Failed to create subscription %d with overrides", i+1)

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -408,7 +408,6 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_ProratesFirstCredi
 	s.Equal(expected.ProratedCredits.String(), app.Credits.String())
 	s.Equal("true", app.Metadata["proration_applied"])
 	s.Equal("100", app.Metadata["proration_original_credits"])
-	s.Equal("addon_attach", app.Metadata["proration_source"])
 
 	// Computing the right amount is worthless if the credits never reach the wallet.
 	// Re-anchoring puts the anchor in the future, so the eager-apply gate must key off

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/addon"
 	"github.com/flexprice/flexprice/internal/domain/coupon"
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
+	"github.com/flexprice/flexprice/internal/domain/creditgrantapplication"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entitlement"
 	"github.com/flexprice/flexprice/internal/domain/events"
@@ -19,6 +20,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/proration"
 	"github.com/flexprice/flexprice/internal/domain/settings"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
@@ -242,6 +244,382 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_OnetimeAddonCapsGr
 	s.NotNil(materialized.EndDate, "addon-sourced grant must have a bounded end date")
 	s.WithinDuration(expectedEnd, lo.FromPtr(materialized.EndDate), time.Second,
 		"grant end date must equal the addon association end date, not the subscription end")
+}
+
+// setupCreditGrantAddon registers an addon carrying a single credit grant template
+// plus a price, and gives the customer a wallet for the grant to land in.
+func (s *SubscriptionServiceSuite) setupCreditGrantAddon(
+	addonID string,
+	credits int64,
+	cadence types.CreditGrantCadence,
+) {
+	s.setupCreditGrantAddonFull(addonID, credits, cadence, types.CREDIT_GRANT_PERIOD_MONTHLY)
+}
+
+// setupCreditGrantAddonWithPeriod registers a recurring grant on a non-monthly period.
+func (s *SubscriptionServiceSuite) setupCreditGrantAddonWithPeriod(
+	addonID string,
+	credits int64,
+	period types.CreditGrantPeriod,
+) {
+	s.setupCreditGrantAddonFull(addonID, credits, types.CreditGrantCadenceRecurring, period)
+}
+
+func (s *SubscriptionServiceSuite) setupCreditGrantAddonFull(
+	addonID string,
+	credits int64,
+	cadence types.CreditGrantCadence,
+	period types.CreditGrantPeriod,
+) {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	s.NoError(subService.AddonRepo.Create(ctx, &addon.Addon{
+		ID:        addonID,
+		LookupKey: addonID,
+		Name:      "Credit Addon",
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}))
+
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, &price.Price{
+		ID:                 "price_" + addonID,
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+		EntityID:           addonID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meters.apiCalls.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}))
+
+	s.NoError(s.GetStores().WalletRepo.CreateWallet(ctx, &wallet.Wallet{
+		ID:                  "wallet_" + addonID,
+		CustomerID:          s.testData.customer.ID,
+		Name:                "Test Wallet",
+		Currency:            "usd",
+		WalletStatus:        types.WalletStatusActive,
+		ConversionRate:      decimal.NewFromInt(1),
+		TopupConversionRate: decimal.NewFromInt(1),
+		BaseModel:           types.GetDefaultBaseModel(ctx),
+	}))
+
+	req := dto.CreateCreditGrantRequest{
+		Name:           "Addon Credits",
+		Scope:          types.CreditGrantScopeAddon,
+		AddonID:        &addonID,
+		Credits:        decimal.NewFromInt(credits),
+		Cadence:        cadence,
+		ExpirationType: types.CreditGrantExpiryTypeBillingCycle,
+		Priority:       lo.ToPtr(1),
+	}
+	if cadence == types.CreditGrantCadenceRecurring {
+		req.Period = lo.ToPtr(period)
+		req.PeriodCount = lo.ToPtr(1)
+	}
+
+	_, err := NewCreditGrantService(subService.ServiceParams).CreateCreditGrant(ctx, req)
+	s.NoError(err)
+}
+
+// materializedAddonGrant returns the SUBSCRIPTION-scoped grant cloned from addonID.
+func (s *SubscriptionServiceSuite) materializedAddonGrant(addonID string) *creditgrant.CreditGrant {
+	subService := s.service.(*subscriptionService)
+	filter := types.NewNoLimitCreditGrantFilter()
+	filter.SubscriptionIDs = []string{s.testData.subscription.ID}
+	grants, err := subService.CreditGrantRepo.List(s.GetContext(), filter)
+	s.NoError(err)
+
+	for _, g := range grants {
+		if g.AddonID != nil && *g.AddonID == addonID && g.Scope == types.CreditGrantScopeSubscription {
+			return g
+		}
+	}
+	return nil
+}
+
+// firstApplicationFor returns the earliest application created for a grant.
+func (s *SubscriptionServiceSuite) firstApplicationFor(grantID string) *creditgrantapplication.CreditGrantApplication {
+	subService := s.service.(*subscriptionService)
+	apps, err := subService.CreditGrantApplicationRepo.List(s.GetContext(), &types.CreditGrantApplicationFilter{
+		CreditGrantIDs: []string{grantID},
+		QueryFilter:    types.NewNoLimitQueryFilter(),
+	})
+	s.NoError(err)
+
+	var first *creditgrantapplication.CreditGrantApplication
+	for _, a := range apps {
+		if first == nil || a.PeriodStart.Before(first.PeriodStart) {
+			first = a
+		}
+	}
+	return first
+}
+
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_ProratesFirstCreditGrantApplication() {
+	ctx := s.GetContext()
+	sub := s.testData.subscription
+	now := s.testData.now
+
+	addonID := "addon_cg_prorate"
+	s.setupCreditGrantAddon(addonID, 100, types.CreditGrantCadenceRecurring)
+
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &now,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	})
+	s.NoError(err)
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+
+	// Re-anchoring onto the subscription's period boundary is what makes the grant
+	// chain align with invoicing instead of drifting from the attach date.
+	s.WithinDuration(sub.CurrentPeriodEnd, lo.FromPtr(grant.CreditGrantAnchor), time.Second)
+
+	// The first application must end where the subscription period ends, not a full
+	// period after the attach date.
+	firstApp := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(firstApp)
+	s.Require().NotNil(firstApp.PeriodEnd)
+	s.WithinDuration(sub.CurrentPeriodEnd, lo.FromPtr(firstApp.PeriodEnd), time.Second)
+
+	// The fixture's period is [now-24h, now+6d) and the addon attaches at `now`,
+	// leaving 6 of 7 days.
+	expected, err := proration.CalculateCreditGrantProration(proration.CreditGrantProrationParams{
+		PeriodStart:     sub.CurrentPeriodStart,
+		PeriodEnd:       sub.CurrentPeriodEnd,
+		ProrationDate:   now,
+		Timezone:        sub.Timezone,
+		Strategy:        types.StrategySecondBased,
+		OriginalCredits: decimal.NewFromInt(100),
+	})
+	s.NoError(err)
+	s.True(expected.ProratedCredits.LessThan(decimal.NewFromInt(100)),
+		"sanity: a mid-period attach must yield less than the full grant")
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Equal(expected.ProratedCredits.String(), app.Credits.String())
+	s.Equal("true", app.Metadata["proration_applied"])
+	s.Equal("100", app.Metadata["proration_original_credits"])
+	s.Equal("addon_attach", app.Metadata["proration_source"])
+
+	// Computing the right amount is worthless if the credits never reach the wallet.
+	// Re-anchoring puts the anchor in the future, so the eager-apply gate must key off
+	// the application's schedule rather than the anchor.
+	s.Equal(types.ApplicationStatusApplied, app.ApplicationStatus,
+		"credits must land at attach time, not wait for the 15-minute cron")
+	s.assertWalletToppedUpBy(grant.ID, expected.ProratedCredits.String())
+}
+
+// assertWalletToppedUpBy checks a wallet transaction carrying the grant's provenance
+// actually credited the expected amount.
+func (s *SubscriptionServiceSuite) assertWalletToppedUpBy(grantID, credits string) {
+	subService := s.service.(*subscriptionService)
+	txns, err := subService.WalletRepo.ListAllWalletTransactions(
+		s.GetContext(), types.NewNoLimitWalletTransactionFilter())
+	s.Require().NoError(err)
+	for _, t := range txns {
+		if t.Metadata != nil && t.Metadata["grant_id"] == grantID {
+			s.Equal(credits, t.CreditAmount.String(), "wallet top-up amount")
+			return
+		}
+	}
+	s.Failf("no wallet top-up found", "no transaction carrying grant_id=%s", grantID)
+}
+
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_ProrationBehaviorNoneGrantsFullCredits() {
+	ctx := s.GetContext()
+	now := s.testData.now
+
+	addonID := "addon_cg_no_prorate"
+	s.setupCreditGrantAddon(addonID, 100, types.CreditGrantCadenceRecurring)
+
+	_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &now,
+		ProrationBehavior: types.ProrationBehaviorNone,
+	})
+	s.NoError(err)
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+	s.WithinDuration(now, lo.FromPtr(grant.CreditGrantAnchor), time.Second,
+		"opting out of proration must leave the attach-date anchoring untouched")
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Equal("100", app.Credits.String())
+	s.Empty(app.Metadata["proration_applied"])
+}
+
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_OnetimeGrantNotProrated() {
+	ctx := s.GetContext()
+	now := s.testData.now
+
+	addonID := "addon_cg_onetime"
+	s.setupCreditGrantAddon(addonID, 100, types.CreditGrantCadenceOneTime)
+
+	_, err := s.service.AddAddonToSubscription(ctx, s.testData.subscription.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &now,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	})
+	s.NoError(err)
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+
+	// A onetime grant is a fixed lump, not a per-period allowance, so it keeps both
+	// its full credits and its attach-date anchoring.
+	s.WithinDuration(now, lo.FromPtr(grant.CreditGrantAnchor), time.Second)
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Equal("100", app.Credits.String())
+	s.Empty(app.Metadata["proration_applied"])
+}
+
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_AttachOnPeriodStartGrantsFullCredits() {
+	ctx := s.GetContext()
+	sub := s.testData.subscription
+	periodStart := sub.CurrentPeriodStart
+
+	addonID := "addon_cg_boundary"
+	s.setupCreditGrantAddon(addonID, 100, types.CreditGrantCadenceRecurring)
+
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &periodStart,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	})
+	s.NoError(err)
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Equal("100", app.Credits.String(),
+		"attaching exactly on a period boundary covers the whole period")
+	s.Empty(app.Metadata["proration_applied"])
+}
+
+// A grant recurring on a different rhythm than the billing cycle keeps its own
+// cadence: snapping a monthly allowance to an annual boundary would stretch the
+// first period across the whole year.
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_GrantPeriodMismatchNotRealigned() {
+	ctx := s.GetContext()
+	sub := s.testData.subscription
+	now := s.testData.now
+
+	sub.BillingPeriod = types.BILLING_PERIOD_ANNUAL
+	sub.CurrentPeriodEnd = sub.CurrentPeriodStart.AddDate(1, 0, 0)
+	s.NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	addonID := "addon_cg_period_mismatch"
+	s.setupCreditGrantAddon(addonID, 100, types.CreditGrantCadenceRecurring)
+
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &now,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	})
+	s.NoError(err)
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+	s.WithinDuration(now, lo.FromPtr(grant.CreditGrantAnchor), time.Second,
+		"a monthly grant on an annual subscription keeps its attach-date anchoring")
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Equal("100", app.Credits.String())
+	s.Empty(app.Metadata["proration_applied"])
+}
+
+// NextBillingDate has no short-first-period rule for annual cycles, so the first
+// period end must be pinned to the subscription boundary rather than derived.
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_AnnualCycleFirstPeriodEndsOnBoundary() {
+	ctx := s.GetContext()
+	sub := s.testData.subscription
+
+	// Period spans a calendar year boundary and the addon attaches on the far side
+	// of it — the case where deriving the end from an anchor overshoots by a year.
+	sub.BillingPeriod = types.BILLING_PERIOD_ANNUAL
+	sub.CurrentPeriodStart = time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+	sub.CurrentPeriodEnd = time.Date(2026, 3, 10, 0, 0, 0, 0, time.UTC)
+	sub.BillingAnchor = sub.CurrentPeriodStart
+	sub.StartDate = sub.CurrentPeriodStart
+	s.NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	attach := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+
+	addonID := "addon_cg_annual"
+	s.setupCreditGrantAddonWithPeriod(addonID, 100, types.CREDIT_GRANT_PERIOD_ANNUAL)
+
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &attach,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	})
+	s.NoError(err)
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Require().NotNil(app.PeriodEnd)
+	s.WithinDuration(sub.CurrentPeriodEnd, lo.FromPtr(app.PeriodEnd), time.Second,
+		"first period must end at the subscription boundary, not a year later")
+}
+
+// FindPeriodForDate only walks forward, so an attach dated into an already-closed
+// period cannot be resolved. Proration must degrade to full credits rather than
+// rejecting the attach outright.
+func (s *SubscriptionServiceSuite) TestAddAddonToSubscription_BackdatedAttachStillSucceeds() {
+	ctx := s.GetContext()
+	sub := s.testData.subscription
+	now := s.testData.now
+
+	sub.BillingPeriod = types.BILLING_PERIOD_MONTHLY
+	sub.StartDate = now.AddDate(0, -3, 0)
+	sub.BillingAnchor = sub.StartDate
+	sub.CurrentPeriodStart = now.AddDate(0, -1, 0)
+	sub.CurrentPeriodEnd = now.AddDate(0, 0, 5)
+	s.NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	addonID := "addon_cg_backdated"
+	s.setupCreditGrantAddon(addonID, 100, types.CreditGrantCadenceRecurring)
+
+	backdated := now.AddDate(0, -2, 0).Add(72 * time.Hour)
+	_, err := s.service.AddAddonToSubscription(ctx, sub.ID, &dto.AddAddonToSubscriptionRequest{
+		AddonID:           addonID,
+		Cadence:           types.AddonCadenceRecurring,
+		StartDate:         &backdated,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+	})
+	s.NoError(err, "an unresolvable period must not fail the addon attach")
+
+	grant := s.materializedAddonGrant(addonID)
+	s.Require().NotNil(grant)
+
+	app := s.firstApplicationFor(grant.ID)
+	s.Require().NotNil(app)
+	s.Equal("100", app.Credits.String())
+	s.Empty(app.Metadata["proration_applied"])
 }
 
 func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionLineItemCommitments() {

--- a/internal/repository/ent/creditgrantapplication.go
+++ b/internal/repository/ent/creditgrantapplication.go
@@ -516,8 +516,8 @@ func (o CreditGrantApplicationQueryOptions) applyEntityQueryOptions(_ context.Co
 		query = query.Where(cga.ScheduledFor(*f.ScheduledFor))
 	}
 
-	if f.ScheduledAfter != nil {
-		query = query.Where(cga.ScheduledForGT(lo.FromPtr(f.ScheduledAfter)))
+	if f.ScheduledFrom != nil {
+		query = query.Where(cga.ScheduledForGTE(lo.FromPtr(f.ScheduledFrom)))
 	}
 
 	if f.AppliedAt != nil {

--- a/internal/testutil/inmemory_creditgrantapplication_store.go
+++ b/internal/testutil/inmemory_creditgrantapplication_store.go
@@ -196,8 +196,8 @@ func creditGrantApplicationFilterFn(ctx context.Context, cga *creditgrantapplica
 		return false
 	}
 
-	// Check scheduled after filter (strictly after, matching the Ent repository's ScheduledForGT)
-	if f.ScheduledAfter != nil && !cga.ScheduledFor.After(*f.ScheduledAfter) {
+	// Check scheduled from filter (at or after, matching the Ent repository's ScheduledForGTE)
+	if f.ScheduledFrom != nil && cga.ScheduledFor.Before(*f.ScheduledFrom) {
 		return false
 	}
 

--- a/internal/types/creditgrantapplication.go
+++ b/internal/types/creditgrantapplication.go
@@ -114,7 +114,7 @@ type CreditGrantApplicationFilter struct {
 	ScheduledFor        *time.Time          `json:"scheduled_for,omitempty" form:"scheduled_for" validate:"omitempty"`
 	AppliedAt           *time.Time          `json:"applied_at,omitempty" form:"applied_at" validate:"omitempty"`
 	ApplicationStatuses []ApplicationStatus `json:"application_statuses,omitempty" form:"application_statuses" validate:"omitempty"`
-	ScheduledAfter      *time.Time          `json:"scheduled_after,omitempty" form:"scheduled_after" validate:"omitempty"`
+	ScheduledFrom       *time.Time          `json:"scheduled_from,omitempty" form:"scheduled_from" validate:"omitempty"`
 }
 
 // NewCreditGrantApplicationFilter creates a new CreditGrantApplicationFilter with default values


### PR DESCRIPTION
## **User description**
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-period proration for recurring credit grants attached mid-billing period.
  * Proration accounts for billing periods, time zones, daylight saving changes, and configurable strategies.
  * Added optional metadata support for credit-grant applications and wallet top-ups.
  * Subsequent grant cycles retain full credit amounts and follow billing-period boundaries.

* **Bug Fixes**
  * Improved handling of boundary dates, mismatched billing cadences, one-time grants, and backdated attachments with safe fallback behavior.
  * Applications scheduled on the effective cancellation date are now canceled as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prorate the first recurring credit grant when an addon starts mid-cycle

### What Changed
- Recurring addon grants now provide credits only for the remaining portion of the current subscription billing period.
- The first prorated period ends at the subscription billing boundary; later recurring grants provide the full credit amount on the regular schedule.
- One-time grants, period-mismatched grants, period-start attachments, and opted-out proration continue to receive full credits.
- Proration details are saved with the credit application and wallet transaction for traceability.
- Addon attachments still succeed with full credits when the billing period cannot be resolved.
- Applications scheduled on the cancellation date are now canceled.

### Impact
`✅ Accurate mid-cycle addon credits`
`✅ Full credits on subsequent grant cycles`
`✅ Reliable backdated and boundary-date addon attachments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
