### PR TITLE
feat(redis): support data-node ACL username (FLEXPRICE_REDIS_USERNAME)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -741,8 +741,10 @@ type CustomerPortalConfig struct {
 
 // RedisConfig holds configuration for Redis
 type RedisConfig struct {
-	Host      string        `mapstructure:"host" default:"localhost"`
-	Port      int           `mapstructure:"port" default:"6379"`
+	Host string `mapstructure:"host" default:"localhost"`
+	Port int    `mapstructure:"port" default:"6379"`
+	// Username is the data-node ACL user; leave empty for requirepass-style auth.
+	Username  string        `mapstructure:"username" default:""`
 	Password  string        `mapstructure:"password" default:""`
 	DB        int           `mapstructure:"db" default:"0"`
 	UseTLS    bool          `mapstructure:"use_tls" default:"false"`
@@ -758,8 +760,8 @@ type RedisConfig struct {
 
 	// Sentinel HA: a non-empty SentinelMasterName switches to Sentinel mode
 	// (ignores Host/Port/ClusterMode) and resolves the master via the quorum.
-	// SentinelAddrs are the sentinel endpoints, NOT the master. Password (above)
-	// auths the data nodes; SentinelUsername/Password auth the sentinels.
+	// SentinelAddrs are the sentinel endpoints, NOT the master. Username/Password
+	// (above) auth the data nodes; SentinelUsername/Password auth the sentinels.
 	SentinelMasterName string   `mapstructure:"sentinel_master_name" default:""`
 	SentinelAddrs      []string `mapstructure:"sentinel_addrs"`
 	SentinelUsername   string   `mapstructure:"sentinel_username" default:""`

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -464,6 +464,7 @@ customer_portal:
 redis:
   host: "localhost" # Redis server hostname
   port: 6379 # Redis server port
+  username: "" # Redis data-node ACL user (optional); FLEXPRICE_REDIS_USERNAME
   password: "" # Redis password (optional)
   db: 0 # Redis database number
   use_tls: false # Use TLS for Redis connection

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -51,14 +51,18 @@ func resolveRedisMode(c config.RedisConfig) (redisMode, error) {
 	}
 }
 
-// NewClient creates a Redis client in one of three modes (see resolveRedisMode):
-// Sentinel (HA/automatic failover), Cluster (sharded), or Standalone (single node).
-func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), config.Redis.Timeout)
-	defer cancel()
+// buildOptions maps config to go-redis options for the resolved topology. Pure
+// (no I/O) so the credential split — Username/Password to the data nodes,
+// SentinelUsername/SentinelPassword to the sentinels — is unit-testable without
+// a live Redis.
+func buildOptions(c config.RedisConfig) (*redis.UniversalOptions, redisMode, error) {
+	mode, err := resolveRedisMode(c)
+	if err != nil {
+		return nil, "", err
+	}
 
 	var tlsConfig *tls.Config
-	if config.Redis.UseTLS {
+	if c.UseTLS {
 		tlsConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true, // Required for AWS ElastiCache wildcard certificates
@@ -66,41 +70,53 @@ func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error
 	}
 
 	opts := &redis.UniversalOptions{
-		Password:     config.Redis.Password,
-		DB:           config.Redis.DB,
-		ReadTimeout:  config.Redis.Timeout,
-		WriteTimeout: config.Redis.Timeout,
-		PoolSize:     config.Redis.PoolSize,
+		Username:     c.Username,
+		Password:     c.Password,
+		DB:           c.DB,
+		ReadTimeout:  c.Timeout,
+		WriteTimeout: c.Timeout,
+		PoolSize:     c.PoolSize,
 		TLSConfig:    tlsConfig,
 	}
 
-	var rdb redis.UniversalClient
-	mode, err := resolveRedisMode(config.Redis)
-	if err != nil {
-		return nil, err
-	}
 	switch mode {
 	case modeSentinel, modeSentinelReplicaRead:
 		// Addrs are the sentinel endpoints; go-redis (via Failover()) discovers
 		// the master/replicas. resolveRedisMode has already ensured they're set.
-		opts.Addrs = config.Redis.SentinelAddrs
-		opts.MasterName = config.Redis.SentinelMasterName
-		opts.SentinelUsername = config.Redis.SentinelUsername
-		opts.SentinelPassword = config.Redis.SentinelPassword
-		if mode == modeSentinelReplicaRead {
-			// RouteByLatency: reads go to the lowest-latency node among
-			// master+replicas, writes to master. Read scaling, not sharding.
-			opts.RouteByLatency = true
-			rdb = redis.NewFailoverClusterClient(opts.Failover())
-		} else {
-			rdb = redis.NewFailoverClient(opts.Failover())
-		}
+		opts.Addrs = c.SentinelAddrs
+		opts.MasterName = c.SentinelMasterName
+		opts.SentinelUsername = c.SentinelUsername
+		opts.SentinelPassword = c.SentinelPassword
+		// RouteByLatency: reads go to the lowest-latency node among
+		// master+replicas, writes to master. Read scaling, not sharding.
+		opts.RouteByLatency = mode == modeSentinelReplicaRead
+	default: // modeCluster, modeStandalone
+		opts.Addrs = []string{fmt.Sprintf("%s:%d", c.Host, c.Port)}
+	}
+	return opts, mode, nil
+}
+
+// NewClient creates a Redis client in one of three modes (see resolveRedisMode):
+// Sentinel (HA/automatic failover), Cluster (sharded), or Standalone (single node).
+func NewClient(config *config.Configuration, log *logger.Logger) (*Client, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), config.Redis.Timeout)
+	defer cancel()
+
+	opts, mode, err := buildOptions(config.Redis)
+	if err != nil {
+		return nil, err
+	}
+
+	var rdb redis.UniversalClient
+	switch mode {
+	case modeSentinelReplicaRead:
+		rdb = redis.NewFailoverClusterClient(opts.Failover())
+	case modeSentinel:
+		rdb = redis.NewFailoverClient(opts.Failover())
 	case modeCluster:
-		opts.Addrs = []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)}
 		rdb = redis.NewClusterClient(opts.Cluster())
 	default: // modeStandalone
 		// UniversalOptions.Simple() routes to a standalone *redis.Client; DB index applies.
-		opts.Addrs = []string{fmt.Sprintf("%s:%d", config.Redis.Host, config.Redis.Port)}
 		rdb = redis.NewClient(opts.Simple())
 	}
 

--- a/internal/redis/client_test.go
+++ b/internal/redis/client_test.go
@@ -79,6 +79,79 @@ func TestResolveRedisMode(t *testing.T) {
 	}
 }
 
+// TestBuildOptions_CredentialSplit locks the two independent credential sets:
+// Username/Password auth the data nodes, SentinelUsername/SentinelPassword auth
+// the sentinels. Crossing them only fails against a real auth-enabled cluster.
+func TestBuildOptions_CredentialSplit(t *testing.T) {
+	cfg := config.RedisConfig{
+		Host:               "redis.internal",
+		Port:               6379,
+		Username:           "app-user",
+		Password:           "data-pw",
+		SentinelMasterName: "mymaster",
+		SentinelAddrs:      []string{"s1:26379"},
+		SentinelUsername:   "sentinel-user",
+		SentinelPassword:   "sentinel-pw",
+	}
+
+	opts, mode, err := buildOptions(cfg)
+	if err != nil {
+		t.Fatalf("buildOptions() unexpected error: %v", err)
+	}
+	if mode != modeSentinel {
+		t.Fatalf("mode = %q, want %q", mode, modeSentinel)
+	}
+	checks := []struct {
+		field, got, want string
+	}{
+		{"Username", opts.Username, "app-user"},
+		{"Password", opts.Password, "data-pw"},
+		{"SentinelUsername", opts.SentinelUsername, "sentinel-user"},
+		{"SentinelPassword", opts.SentinelPassword, "sentinel-pw"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("opts.%s = %q, want %q", c.field, c.got, c.want)
+		}
+	}
+
+	// Failover() is what actually reaches go-redis in Sentinel mode.
+	fo := opts.Failover()
+	if fo.Username != "app-user" || fo.Password != "data-pw" {
+		t.Errorf("Failover() data-node creds = %q/%q, want app-user/data-pw", fo.Username, fo.Password)
+	}
+	if fo.SentinelUsername != "sentinel-user" || fo.SentinelPassword != "sentinel-pw" {
+		t.Errorf("Failover() sentinel creds = %q/%q, want sentinel-user/sentinel-pw", fo.SentinelUsername, fo.SentinelPassword)
+	}
+}
+
+// TestBuildOptions_UsernameOptional guards backward compatibility: an unset
+// Username must stay empty so go-redis keeps using plain AUTH <password>.
+func TestBuildOptions_UsernameOptional(t *testing.T) {
+	modes := []struct {
+		name string
+		cfg  config.RedisConfig
+	}{
+		{"standalone", config.RedisConfig{Host: "h", Port: 6379, Password: "pw"}},
+		{"cluster", config.RedisConfig{Host: "h", Port: 6379, Password: "pw", ClusterMode: true}},
+		{"sentinel", config.RedisConfig{Password: "pw", SentinelMasterName: "m", SentinelAddrs: []string{"s1:26379"}}},
+	}
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			opts, _, err := buildOptions(m.cfg)
+			if err != nil {
+				t.Fatalf("buildOptions() unexpected error: %v", err)
+			}
+			if opts.Username != "" {
+				t.Errorf("opts.Username = %q, want empty (requirepass-style auth)", opts.Username)
+			}
+			if opts.Password != "pw" {
+				t.Errorf("opts.Password = %q, want %q", opts.Password, "pw")
+			}
+		})
+	}
+}
+
 // TestNewClient_SentinelMissingAddrsErrors verifies that a misconfigured Sentinel
 // setup fails loudly rather than panicking, hanging, or (worse) silently
 // connecting to go-redis's 127.0.0.1:26379 default when addrs are empty.


### PR DESCRIPTION
## **User description**
## Why

The Redis Sentinel work (#2354) shipped credentials for the **sentinels** (`FLEXPRICE_REDIS_SENTINEL_USERNAME` / `_SENTINEL_PASSWORD`) and a password for the **data nodes** (`FLEXPRICE_REDIS_PASSWORD`) — but no way to set a data-node *username*.

That covers servers using `requirepass` (password-only `AUTH` against the implicit `default` user). It does **not** cover Redis data nodes configured with **ACL users**, which is what our first Sentinel customer runs — they auth on the sentinels *and* on the data nodes, each with a username+password pair. Without this they simply cannot connect.

## What

Adds `RedisConfig.Username`, wired to `redis.UniversalOptions.Username`. The two credential sets are now fully expressible and independent:

| Target | Username | Password |
|---|---|---|
| Sentinels | `FLEXPRICE_REDIS_SENTINEL_USERNAME` | `FLEXPRICE_REDIS_SENTINEL_PASSWORD` |
| Data nodes | `FLEXPRICE_REDIS_USERNAME` **(new)** | `FLEXPRICE_REDIS_PASSWORD` |

Applies to **all three modes** (standalone, cluster, sentinel), not just Sentinel.

Option construction is extracted into a pure `buildOptions()` so the credential split is unit-testable without a live Redis — miswiring the two sets is the kind of bug that only surfaces at runtime against a customer's auth-enabled cluster.

## Backward compatibility

Defaults to empty. An empty `Username` leaves go-redis on plain `AUTH <password>` — **byte-identical behaviour for every existing deployment**. Nothing to set, nothing to migrate.

## Testing

- `TestBuildOptions_CredentialSplit` — data-node vs sentinel creds land in the right fields, asserted both on `UniversalOptions` and through `.Failover()` (what actually reaches go-redis in Sentinel mode).
- `TestBuildOptions_UsernameOptional` — unset username stays empty and the password still applies, across standalone / cluster / sentinel.
- Env binding verified against `NewConfig()`: `FLEXPRICE_REDIS_USERNAME` resolves via the reflection auto-bind, no hand-written `BindEnv` needed.
- `go test -race ./internal/redis/... ./internal/config/...` green; `make lint-ci` clean.

## Notes

- Branch is cut from `develop` (not `main`) because `develop` is currently 69 commits behind `main` — branching from `main` would have produced a bloated diff.
- The EE Helm chart does not template any `FLEXPRICE_REDIS_SENTINEL_*` vars either; chart-based deployments set both these and the sentinel vars via `extraEnv`. Adding first-class chart support for the whole Sentinel surface is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Redis username configuration for ACL-based authentication.
  * Added environment-variable support for configuring the Redis username.
  * Improved support for distinct credentials between Redis data nodes and Sentinel.

* **Bug Fixes**
  * Preserved authentication settings consistently across standalone, cluster, and Sentinel connection modes.
  * Ensured omitted usernames remain optional without affecting password-based authentication.
  * Improved consistency when applying Redis connection and authentication settings across supported deployment modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Support Redis ACL usernames for data-node authentication

### What Changed
- Redis connections can now use a separate data-node username through `FLEXPRICE_REDIS_USERNAME`
- Data-node credentials and Sentinel credentials remain independent in standalone, cluster, and Sentinel modes
- Leaving the username empty preserves password-only authentication for existing deployments
- Added configuration documentation and coverage for credential routing and backward compatibility

### Impact
`✅ Redis ACL user authentication`
`✅ Sentinel and data-node credentials stay separate`
`✅ Existing password-only Redis deployments continue to connect`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
