### PR TITLE
feat(plan-change): Generate invoice for arrear usge charges

### DIFF
--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -712,12 +712,18 @@ func (s *subscriptionChangeService) executeChange(
 	isTrialing := currentSub.SubscriptionStatus == types.SubscriptionStatusTrialing
 
 	// Cancel the old subscription (pass through proration_behavior so execute matches preview).
+	// Generate a cancel invoice so arrear usage in the old window is billed and can be
+	// debited from the prepaid wallet — otherwise pending usage drops out of ongoing
+	// balance when the old sub leaves the active set.
+	// SkipProrationWalletCredit: unused fixed-fee credit is netted onto the new
+	// subscription opening invoice instead of a wallet top-up.
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
-		CancellationType:          types.CancellationTypeImmediate,
-		Reason:                    "subscription_change",
-		ProrationBehavior:         req.ProrationBehavior,
-		SkipProrationWalletCredit: true, // we always skip the wallet credit refund since we will apply it as adjustment to the new subscription 1st invoice
+		CancellationType:               types.CancellationTypeImmediate,
+		Reason:                         "subscription_change",
+		ProrationBehavior:              req.ProrationBehavior,
+		SkipProrationWalletCredit:      true,
+		CancelImmediatelyInvoicePolicy: types.CancelImmediatelyInvoicePolicyGenerateInvoice,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -712,15 +712,20 @@ func (s *subscriptionChangeService) executeChange(
 	isTrialing := currentSub.SubscriptionStatus == types.SubscriptionStatusTrialing
 
 	// Cancel the old subscription (pass through proration_behavior so execute matches preview).
-	// Generate a cancel invoice so arrear usage in the old window is billed and can be debited from the prepaid wallet.
+	// Non-trial: generate a cancel invoice so arrear usage is billed and can debit prepaid wallet.
+	// Trial: skip invoice — nothing has been charged yet.
 	// SkipProrationWalletCredit: unused fixed-fee credit is netted onto the new subscription opening invoice instead of a wallet top-up.
+	cancelInvoicePolicy := types.CancelImmediatelyInvoicePolicyGenerateInvoice
+	if isTrialing {
+		cancelInvoicePolicy = types.CancelImmediatelyInvoicePolicySkip
+	}
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
 		CancellationType:               types.CancellationTypeImmediate,
 		Reason:                         "subscription_change",
 		ProrationBehavior:              req.ProrationBehavior,
 		SkipProrationWalletCredit:      true,
-		CancelImmediatelyInvoicePolicy: types.CancelImmediatelyInvoicePolicyGenerateInvoice,
+		CancelImmediatelyInvoicePolicy: cancelInvoicePolicy,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -712,11 +712,8 @@ func (s *subscriptionChangeService) executeChange(
 	isTrialing := currentSub.SubscriptionStatus == types.SubscriptionStatusTrialing
 
 	// Cancel the old subscription (pass through proration_behavior so execute matches preview).
-	// Generate a cancel invoice so arrear usage in the old window is billed and can be
-	// debited from the prepaid wallet — otherwise pending usage drops out of ongoing
-	// balance when the old sub leaves the active set.
-	// SkipProrationWalletCredit: unused fixed-fee credit is netted onto the new
-	// subscription opening invoice instead of a wallet top-up.
+	// Generate a cancel invoice so arrear usage in the old window is billed and can be debited from the prepaid wallet.
+	// SkipProrationWalletCredit: unused fixed-fee credit is netted onto the new subscription opening invoice instead of a wallet top-up.
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
 		CancellationType:               types.CancellationTypeImmediate,

--- a/internal/ee/service/subscription_change_test.go
+++ b/internal/ee/service/subscription_change_test.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/events"
 	invoicedomain "github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
@@ -49,7 +51,9 @@ func (s *SubscriptionChangeServiceTestSuite) setupServices() {
 		UserRepo:                     s.GetStores().UserRepo,
 		EventRepo:                    s.GetStores().EventRepo,
 		MeterRepo:                    s.GetStores().MeterRepo,
+		MeterUsageRepo:               s.GetStores().MeterUsageRepo,
 		PriceRepo:                    s.GetStores().PriceRepo,
+		PriceUnitRepo:                s.GetStores().PriceUnitRepo,
 		CustomerRepo:                 s.GetStores().CustomerRepo,
 		PlanRepo:                     s.GetStores().PlanRepo,
 		SubRepo:                      s.GetStores().SubscriptionRepo,
@@ -62,6 +66,7 @@ func (s *SubscriptionChangeServiceTestSuite) setupServices() {
 		InvoiceRepo:                  s.GetStores().InvoiceRepo,
 		FeatureRepo:                  s.GetStores().FeatureRepo,
 		EntitlementRepo:              s.GetStores().EntitlementRepo,
+		EntitlementGrantRepo:         s.GetStores().EntitlementGrantRepo,
 		PaymentRepo:                  s.GetStores().PaymentRepo,
 		SecretRepo:                   s.GetStores().SecretRepo,
 		EnvironmentRepo:              s.GetStores().EnvironmentRepo,
@@ -997,6 +1002,116 @@ func (s *SubscriptionChangeServiceTestSuite) TestFixedToUsagePlanTransition() {
 	assert.NotNil(s.T(), executeResponse)
 	assert.Equal(s.T(), usagePlan.ID, executeResponse.NewSubscription.PlanID)
 	assert.NotNil(s.T(), executeResponse.ProrationApplied)
+}
+
+// TestPlanChangeInvoicesCancelUsageAndDebitsPrepaidWallet verifies that an immediate
+// plan change raises a cancel invoice for arrear usage on the old subscription and
+// applies prepaid credits (wallet debit) so usage liability is not dropped.
+func (s *SubscriptionChangeServiceTestSuite) TestPlanChangeInvoicesCancelUsageAndDebitsPrepaidWallet() {
+	ctx := s.GetContext()
+
+	cust := s.createTestCustomer()
+	usagePlan, m := s.createUsageBasedPlan("Usage Source", decimal.Zero, decimal.NewFromInt(1))
+	targetPlan := s.createTestPlan("Target Fixed", decimal.NewFromInt(20))
+	sub := s.createTestSubscription(usagePlan.ID, cust.ID)
+
+	// Widen the cancel window and align line-item start so seeded usage is billable.
+	periodStart := time.Now().UTC().Add(-2 * time.Hour)
+	sub.CurrentPeriodStart = periodStart
+	require.NoError(s.T(), s.GetStores().SubscriptionRepo.Update(ctx, sub))
+	lineItems, err := s.GetStores().SubscriptionLineItemRepo.ListBySubscription(ctx, sub)
+	require.NoError(s.T(), err)
+	for _, li := range lineItems {
+		li.StartDate = periodStart
+		require.NoError(s.T(), s.GetStores().SubscriptionLineItemRepo.Update(ctx, li))
+	}
+	sub, _, err = s.GetStores().SubscriptionRepo.GetWithLineItems(ctx, sub.ID)
+	require.NoError(s.T(), err)
+
+	walletBalance := decimal.NewFromInt(100)
+	w := &walletdomain.Wallet{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET),
+		CustomerID:     cust.ID,
+		Currency:       "usd",
+		Balance:        walletBalance,
+		CreditBalance:  walletBalance,
+		ConversionRate: decimal.NewFromInt(1),
+		WalletStatus:   types.WalletStatusActive,
+		WalletType:     types.WalletTypePrePaid,
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	require.NoError(s.T(), s.GetStores().WalletRepo.CreateWallet(ctx, w))
+	require.NoError(s.T(), s.GetStores().WalletRepo.CreateTransaction(ctx, &walletdomain.Transaction{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_WALLET_TRANSACTION),
+		WalletID:         w.ID,
+		Type:             types.TransactionTypeCredit,
+		Amount:           walletBalance,
+		CreditAmount:     walletBalance,
+		CreditsAvailable: walletBalance,
+		TxStatus:         types.TransactionStatusCompleted,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}))
+
+	const usageQty int64 = 10
+	usageAmount := decimal.NewFromInt(usageQty) // $1/unit
+	ts := periodStart.Add(time.Hour)
+	records := make([]*events.MeterUsage, 0, usageQty)
+	for i := int64(0); i < usageQty; i++ {
+		id := types.GenerateUUIDWithPrefix("mu")
+		records = append(records, &events.MeterUsage{
+			Event: events.Event{
+				ID:                 id,
+				TenantID:           types.GetTenantID(ctx),
+				EnvironmentID:      types.GetEnvironmentID(ctx),
+				EventName:          m.EventName,
+				CustomerID:         cust.ID,
+				ExternalCustomerID: cust.ExternalID,
+				Timestamp:          ts,
+				IngestedAt:         ts,
+				Properties:         map[string]interface{}{},
+			},
+			MeterID:    m.ID,
+			QtyTotal:   decimal.NewFromInt(1),
+			UniqueHash: fmt.Sprintf("%s:%s", m.EventName, id),
+		})
+	}
+	require.NoError(s.T(), s.GetStores().MeterUsageRepo.BulkInsertMeterUsage(ctx, records))
+
+	req := s.createSubscriptionChangeRequest(targetPlan.ID, types.ProrationBehaviorNone)
+	execResp, err := s.subscriptionChangeService.ExecuteSubscriptionChange(ctx, sub.ID, req)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), execResp)
+	assert.Equal(s.T(), types.SubscriptionStatusCancelled, execResp.OldSubscription.Status)
+
+	oldInvoices := s.getInvoicesForSub(sub.ID)
+	var cancelInv *invoicedomain.Invoice
+	for _, inv := range oldInvoices {
+		if types.InvoiceBillingReason(inv.BillingReason) == types.InvoiceBillingReasonProration {
+			cancelInv = inv
+			break
+		}
+	}
+	require.NotNil(s.T(), cancelInv, "plan change should create a cancel invoice on the old subscription")
+	require.NotEmpty(s.T(), cancelInv.LineItems, "cancel invoice should include usage line items")
+
+	var usageLine *invoicedomain.InvoiceLineItem
+	for i := range cancelInv.LineItems {
+		li := cancelInv.LineItems[i]
+		if li.MeterID != nil && *li.MeterID == m.ID {
+			usageLine = li
+			break
+		}
+	}
+	require.NotNil(s.T(), usageLine, "cancel invoice must include a usage line for the meter")
+	assert.True(s.T(), usageAmount.Equal(usageLine.Amount),
+		"usage line amount: want %s, got %s", usageAmount, usageLine.Amount)
+
+	updatedWallet, err := s.GetStores().WalletRepo.GetWalletByID(ctx, w.ID)
+	require.NoError(s.T(), err)
+	expectedBalance := walletBalance.Sub(usageAmount)
+	assert.True(s.T(), expectedBalance.Equal(updatedWallet.Balance),
+		"prepaid wallet should be debited for cancel usage: want %s, got %s", expectedBalance, updatedWallet.Balance)
 }
 
 // // TC-012: Usage Plan to Fixed Plan Transition


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Immediate subscription changes now generate cancellation invoices for non-trialing usage-based charges while preserving requested proration behavior.
  * Trialing subscriptions no longer receive cancellation invoices during immediate plan changes.
  * Prepaid wallet credits are correctly debited and applied to the replacement subscription’s opening invoice when switching to fixed pricing.
  * Improved billing for arrears usage and fixed-fee credits during plan changes, ensuring accurate invoice totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Bill pending usage when subscriptions change immediately

### What Changed
- Immediate plan changes now generate a cancellation invoice for usage accrued on the old subscription before it ends
- Pending usage appears as usage line items on that invoice instead of being dropped
- Prepaid wallet balances are debited to cover the billed usage, while unused fixed-fee credits continue to apply to the replacement subscription’s opening invoice
- Added coverage for usage billing and prepaid wallet deductions during plan changes

### Impact
`✅ No lost usage charges during immediate plan changes`
`✅ Accurate prepaid wallet balances`
`✅ Clear usage charges on cancellation invoices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
