### PR TITLE
feat(helm): support custom labels per component

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
+++ b/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
@@ -37,6 +37,11 @@ FlexPrice app release.
   immutable on Deployments, so changing these values stays `helm upgrade`-safe.
   Rendering with default values is byte-identical to 1.1.0.
 
+  The selector-owned keys (`app.kubernetes.io/name`, `/instance`, `/component`)
+  cannot be overridden from these values. Setting them is silently ignored
+  rather than producing pods that no longer match their own Deployment selector,
+  Service, PDB, and NetworkPolicy.
+
 ## [1.1.0] - 2026-06-11
 
 ### Added

--- a/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
+++ b/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
@@ -9,6 +9,34 @@ Chart versions are independent of the application (`appVersion`) version —
 `Chart.yaml#version` bumps on every chart change, `appVersion` follows the
 FlexPrice app release.
 
+## [1.2.0] - 2026-08-05
+
+### Added
+- Custom labels per component. Every workload block (`api`, `consumer`,
+  `worker`, `frontend`) now accepts:
+  - `<component>.labels` — extra labels on that component's Kubernetes objects
+    (Deployment, Service, HPA, PDB, Ingress, ServiceAccount).
+  - `<component>.podLabels` — extra labels on that component's pods only.
+- Global `podLabels`, applied to every FlexPrice pod. Per-component
+  `podLabels` merge on top of it.
+- The pre-existing global `labels` value is now documented in `values.yaml`.
+
+  Intended for log shippers (Filebeat/ELK, Fluent Bit, Datadog) that enrich from
+  pod metadata, so operators no longer have to fork the templates to add an
+  index or team label:
+
+  ```yaml
+  podLabels:
+    logging.company.io/index: flexprice
+  api:
+    podLabels:
+      logging.company.io/index: flexprice-api
+  ```
+
+  Labels are never added to `spec.selector.matchLabels` — selectors are
+  immutable on Deployments, so changing these values stays `helm upgrade`-safe.
+  Rendering with default values is byte-identical to 1.1.0.
+
 ## [1.1.0] - 2026-06-11
 
 ### Added

--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/README.md
+++ b/internal/ee/infrastructure/helm/flexprice/README.md
@@ -585,6 +585,48 @@ Passwords are injected once in Step 1 as a Kubernetes Secret (`<release>-secrets
 
 ---
 
+## Custom labels
+
+The chart applies labels at three scopes. All default to `{}`, so the rendered
+output with default values is unchanged from chart 1.1.0.
+
+| Value | Applies to |
+|---|---|
+| `labels` | Every Kubernetes object the chart renders |
+| `podLabels` | Every FlexPrice pod (api, consumer, worker, frontend) |
+| `<component>.labels` | That component's objects — Deployment, Service, HPA, PDB, Ingress, ServiceAccount |
+| `<component>.podLabels` | That component's pods only |
+
+`<component>` is one of `api`, `consumer`, `worker`, `frontend`. Per-component
+values merge on top of the global ones and win on key collisions.
+
+The common case is tagging pods for a log shipper (Filebeat/ELK, Fluent Bit,
+Datadog), all of which enrich log records from pod metadata:
+
+```yaml
+# Everything lands in one index...
+podLabels:
+  logging.company.io/index: flexprice
+
+# ...except the API, which gets its own.
+api:
+  podLabels:
+    logging.company.io/index: flexprice-api
+  labels:
+    company.io/tier: edge
+```
+
+### Selectors are never touched
+
+These labels are deliberately excluded from `spec.selector.matchLabels` on
+Deployments and from Service `spec.selector`. Deployment selectors are immutable
+in the Kubernetes API: if a user-supplied label ended up there, the next
+`helm upgrade` would fail with `field is immutable` and the release would need to
+be deleted and reinstalled. Object labels and pod labels are both mutable —
+changing `podLabels` triggers an ordinary rolling update.
+
+---
+
 ## Node groups (EKS)
 
 This Helm chart deploys workloads onto existing nodes — it does **not** create node groups. Node groups are AWS EC2 Auto Scaling Groups registered with EKS and must be provisioned before `helm install`.

--- a/internal/ee/infrastructure/helm/flexprice/README.md
+++ b/internal/ee/infrastructure/helm/flexprice/README.md
@@ -616,6 +616,15 @@ api:
     company.io/tier: edge
 ```
 
+### Reserved keys
+
+`app.kubernetes.io/name`, `app.kubernetes.io/instance`, and
+`app.kubernetes.io/component` are owned by the chart and cannot be set through
+`labels` or `podLabels`. The chart emits them last, so a value supplied for one
+of these keys is silently discarded. This is deliberate: overriding them on a pod
+would leave it unmatched by its own Deployment selector, Service, PDB, and
+NetworkPolicy.
+
 ### Selectors are never touched
 
 These labels are deliberately excluded from `spec.selector.matchLabels` on

--- a/internal/ee/infrastructure/helm/flexprice/README.md
+++ b/internal/ee/infrastructure/helm/flexprice/README.md
@@ -592,13 +592,18 @@ output with default values is unchanged from chart 1.1.0.
 
 | Value | Applies to |
 |---|---|
-| `labels` | Every Kubernetes object the chart renders |
+| `labels` | Every object this chart renders itself — app workloads, in-cluster ClickHouse/Kafka/Redis, the migration and bootstrap Jobs |
 | `podLabels` | Every FlexPrice pod (api, consumer, worker, frontend) |
 | `<component>.labels` | That component's objects — Deployment, Service, HPA, PDB, Ingress, ServiceAccount |
 | `<component>.podLabels` | That component's pods only |
 
 `<component>` is one of `api`, `consumer`, `worker`, `frontend`. Per-component
 values merge on top of the global ones and win on key collisions.
+
+Resources created by the bundled **subcharts** (Bitnami PostgreSQL, Kafka, Redis
+and Temporal) are outside this chart's templates, so `labels` does not reach
+them. Use each subchart's own mechanism instead — for the Bitnami charts that is
+`postgresql.commonLabels`, `kafka.commonLabels`, and so on.
 
 The common case is tagging pods for a log shipper (Filebeat/ELK, Fluent Bit,
 Datadog), all of which enrich log records from pod metadata:

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -58,10 +58,14 @@ Object labels for a component's Kubernetes resources (Deployment, Service, HPA,
 PDB, Ingress, ServiceAccount, ...).
 Usage: include "flexprice.componentLabels" (dict "ctx" . "component" "api")
 
-Emits the common labels, the component label, and finally any operator-supplied
-labels from `.Values.<component>.labels`. Chart-owned keys win over user keys is
-NOT the behavior here — user keys are emitted last so an operator can override
-e.g. app.kubernetes.io/version if they really mean to.
+Emits the common labels, then operator-supplied labels from
+`.Values.<component>.labels`, then the component key.
+
+The component key goes last so it can't be overridden from values — several
+resources (PDB, NetworkPolicy, Service) build selectors from it, and a Service
+whose object labels disagree with the pods it targets is a debugging trap. The
+remaining common labels stay overridable, so an operator who really wants their
+own `app.kubernetes.io/version` can still set it.
 
 Never use this for `spec.selector.matchLabels`: selectors are immutable on
 Deployments and StatefulSets, so a user adding a label would break every
@@ -74,32 +78,39 @@ subsequent `helm upgrade` with "field is immutable". Selectors stay on
        so resolve the component block with `index` and guard it being unset. */ -}}
 {{- $cfg := index $ctx.Values .component | default dict -}}
 {{ include "flexprice.labels" $ctx }}
-app.kubernetes.io/component: {{ .component }}
 {{- with (get $cfg "labels") }}
-{{ toYaml . }}
-{{- end }}
+{{- toYaml . | nindent 0 }}
+{{ end }}
+app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
 Pod template labels for a component.
 Usage: include "flexprice.componentPodLabels" (dict "ctx" . "component" "api")
 
-Selector labels + component, then global `.Values.podLabels`, then
-`.Values.<component>.podLabels`. Pod labels are mutable, so adding one here only
+Global `.Values.podLabels`, then `.Values.<component>.podLabels`, and finally the
+selector labels + component key. Pod labels are mutable, so adding one here only
 triggers a normal rolling update. This is the hook log shippers (Filebeat/ELK,
 Fluent Bit, Datadog) should target, since they enrich from pod metadata.
+
+The selector-owned keys (app.kubernetes.io/name, /instance, /component) are
+emitted LAST on purpose. YAML resolves duplicate keys to the final occurrence, so
+this makes them impossible to override from values: a user who sets
+`podLabels.app.kubernetes.io/component` gets their value silently discarded
+rather than a pod that no longer matches its own Deployment selector, Service,
+PDB, and NetworkPolicy. Reordering these lines reintroduces that bug.
 */}}
 {{- define "flexprice.componentPodLabels" -}}
 {{- $ctx := .ctx -}}
 {{- $cfg := index $ctx.Values .component | default dict -}}
-{{ include "flexprice.selectorLabels" $ctx }}
-app.kubernetes.io/component: {{ .component }}
 {{- with $ctx.Values.podLabels }}
-{{ toYaml . }}
-{{- end }}
+{{- toYaml . | nindent 0 }}
+{{ end }}
 {{- with (get $cfg "podLabels") }}
-{{ toYaml . }}
-{{- end }}
+{{- toYaml . | nindent 0 }}
+{{ end }}
+{{- include "flexprice.selectorLabels" $ctx }}
+app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -54,6 +54,55 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Object labels for a component's Kubernetes resources (Deployment, Service, HPA,
+PDB, Ingress, ServiceAccount, ...).
+Usage: include "flexprice.componentLabels" (dict "ctx" . "component" "api")
+
+Emits the common labels, the component label, and finally any operator-supplied
+labels from `.Values.<component>.labels`. Chart-owned keys win over user keys is
+NOT the behavior here — user keys are emitted last so an operator can override
+e.g. app.kubernetes.io/version if they really mean to.
+
+Never use this for `spec.selector.matchLabels`: selectors are immutable on
+Deployments and StatefulSets, so a user adding a label would break every
+subsequent `helm upgrade` with "field is immutable". Selectors stay on
+`flexprice.selectorLabels` + the component key.
+*/}}
+{{- define "flexprice.componentLabels" -}}
+{{- $ctx := .ctx -}}
+{{- /* `dig` can't walk .Values (chartutil.Values, not map[string]interface{}),
+       so resolve the component block with `index` and guard it being unset. */ -}}
+{{- $cfg := index $ctx.Values .component | default dict -}}
+{{ include "flexprice.labels" $ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- with (get $cfg "labels") }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod template labels for a component.
+Usage: include "flexprice.componentPodLabels" (dict "ctx" . "component" "api")
+
+Selector labels + component, then global `.Values.podLabels`, then
+`.Values.<component>.podLabels`. Pod labels are mutable, so adding one here only
+triggers a normal rolling update. This is the hook log shippers (Filebeat/ELK,
+Fluent Bit, Datadog) should target, since they enrich from pod metadata.
+*/}}
+{{- define "flexprice.componentPodLabels" -}}
+{{- $ctx := .ctx -}}
+{{- $cfg := index $ctx.Values .component | default dict -}}
+{{ include "flexprice.selectorLabels" $ctx }}
+app.kubernetes.io/component: {{ .component }}
+{{- with $ctx.Values.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- with (get $cfg "podLabels") }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Default ServiceAccount name (shared across components when per-workload SAs are off).
 */}}
 {{- define "flexprice.serviceAccountName" -}}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
@@ -4,8 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "flexprice.fullname" . }}-api
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
 spec:
   replicas: {{ .Values.api.replicaCount }}
   {{- with .Values.api.strategy }}
@@ -27,8 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "flexprice.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: api
+        {{- include "flexprice.componentPodLabels" (dict "ctx" . "component" "api") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
@@ -4,8 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "flexprice.fullname" . }}-consumer
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: consumer
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "consumer") | nindent 4 }}
 spec:
   replicas: {{ .Values.consumer.replicaCount }}
   {{- with .Values.consumer.strategy }}
@@ -27,8 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "flexprice.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: consumer
+        {{- include "flexprice.componentPodLabels" (dict "ctx" . "component" "consumer") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-frontend.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-frontend.yaml
@@ -4,8 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "flexprice.fullname" . }}-frontend
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: frontend
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
 spec:
   replicas: {{ .Values.frontend.replicaCount }}
   selector:
@@ -15,8 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "flexprice.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: frontend
+        {{- include "flexprice.componentPodLabels" (dict "ctx" . "component" "frontend") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -89,8 +87,7 @@ kind: Service
 metadata:
   name: {{ include "flexprice.fullname" . }}-frontend
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: frontend
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
 spec:
   type: ClusterIP
   ports:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
@@ -4,8 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "flexprice.fullname" . }}-worker
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "worker") | nindent 4 }}
 spec:
   replicas: {{ .Values.worker.replicaCount }}
   {{- with .Values.worker.strategy }}
@@ -27,8 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "flexprice.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: worker
+        {{- include "flexprice.componentPodLabels" (dict "ctx" . "component" "worker") | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/ingress.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/ingress.yaml
@@ -4,8 +4,7 @@ kind: Ingress
 metadata:
   name: {{ include "flexprice.fullname" . }}-api
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -47,8 +46,7 @@ kind: Ingress
 metadata:
   name: {{ include "flexprice.fullname" . }}-frontend
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: frontend
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
   {{- with .Values.frontendIngress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/service.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/service.yaml
@@ -4,8 +4,7 @@ kind: Service
 metadata:
   name: {{ include "flexprice.fullname" . }}-api
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/serviceaccount.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/serviceaccount.yaml
@@ -11,8 +11,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "flexprice.componentServiceAccountName" (dict "ctx" $ "component" $component) }}
   labels:
-    {{- include "flexprice.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: {{ $component }}
+    {{- include "flexprice.componentLabels" (dict "ctx" $ "component" $component) | nindent 4 }}
   {{- $compAnnotations := dig "components" $component "annotations" dict $.Values.serviceAccount }}
   {{- $effective := merge (dict) $compAnnotations $.Values.serviceAccount.annotations }}
   {{- if $effective }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-api.yaml
@@ -4,8 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "flexprice.fullname" . }}-api
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-consumer.yaml
@@ -4,8 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "flexprice.fullname" . }}-consumer
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: consumer
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "consumer") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-frontend.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-frontend.yaml
@@ -4,8 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "flexprice.fullname" . }}-frontend
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: frontend
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-worker.yaml
@@ -4,8 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "flexprice.fullname" . }}-worker
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "worker") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -15,8 +15,7 @@ kind: ScaledObject
 metadata:
   name: {{ include "flexprice.fullname" . }}-consumer
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: consumer
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "consumer") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-api.yaml
@@ -4,8 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "flexprice.fullname" . }}-api
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
 spec:
   {{- if .Values.api.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.api.podDisruptionBudget.minAvailable }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-consumer.yaml
@@ -4,8 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "flexprice.fullname" . }}-consumer
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: consumer
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "consumer") | nindent 4 }}
 spec:
   {{- if .Values.consumer.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.consumer.podDisruptionBudget.minAvailable }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-frontend.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-frontend.yaml
@@ -4,8 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "flexprice.fullname" . }}-frontend
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: frontend
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "frontend") | nindent 4 }}
 spec:
   {{- if .Values.frontend.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.frontend.podDisruptionBudget.minAvailable }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/reliability/pdb-worker.yaml
@@ -4,8 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "flexprice.fullname" . }}-worker
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "worker") | nindent 4 }}
 spec:
   {{- if .Values.worker.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.worker.podDisruptionBudget.minAvailable }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/security/networkpolicy.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/security/networkpolicy.yaml
@@ -18,8 +18,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ include "flexprice.fullname" . }}-api
   labels:
-    {{- include "flexprice.labels" . | nindent 4 }}
-    app.kubernetes.io/component: api
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -144,6 +144,13 @@ securityContext:
 api:
   enabled: true
   replicaCount: 1
+  # Extra labels for this component's Kubernetes objects (Deployment, Service,
+  # HPA, PDB, Ingress, ServiceAccount). Merged on top of the global `labels`.
+  # Not applied to spec.selector.matchLabels — selectors are immutable.
+  labels: {}
+  # Extra labels for this component's pods only. Merged on top of the global
+  # `podLabels`. This is what log shippers (Filebeat/ELK, Fluent Bit) read.
+  podLabels: {}
   resources:
     requests:
       cpu: "500m"
@@ -184,6 +191,13 @@ api:
 consumer:
   enabled: true
   replicaCount: 1
+  # Extra labels for this component's Kubernetes objects (Deployment, Service,
+  # HPA, PDB, Ingress, ServiceAccount). Merged on top of the global `labels`.
+  # Not applied to spec.selector.matchLabels — selectors are immutable.
+  labels: {}
+  # Extra labels for this component's pods only. Merged on top of the global
+  # `podLabels`. This is what log shippers (Filebeat/ELK, Fluent Bit) read.
+  podLabels: {}
   # Consumer-only env overrides (rendered after the shared flexprice.env, so these
   # win for duplicate keys). For settings that differ on the consumer vs api/worker —
   # e.g. FLEXPRICE_CACHE_ENABLED (cache enabled on the consumer only).
@@ -245,6 +259,13 @@ consumer:
 worker:
   enabled: true
   replicaCount: 1
+  # Extra labels for this component's Kubernetes objects (Deployment, Service,
+  # HPA, PDB, Ingress, ServiceAccount). Merged on top of the global `labels`.
+  # Not applied to spec.selector.matchLabels — selectors are immutable.
+  labels: {}
+  # Extra labels for this component's pods only. Merged on top of the global
+  # `podLabels`. This is what log shippers (Filebeat/ELK, Fluent Bit) read.
+  podLabels: {}
   resources:
     requests:
       cpu: "375m"
@@ -299,6 +320,13 @@ ingress:
 frontend:
   enabled: false
   replicaCount: 1
+  # Extra labels for this component's Kubernetes objects (Deployment, Service,
+  # HPA, PDB, Ingress, ServiceAccount). Merged on top of the global `labels`.
+  # Not applied to spec.selector.matchLabels — selectors are immutable.
+  labels: {}
+  # Extra labels for this component's pods only. Merged on top of the global
+  # `podLabels`. This is what log shippers (Filebeat/ELK, Fluent Bit) read.
+  podLabels: {}
   image:
     repository: flexprice-frontend
     tag: "local"
@@ -1032,6 +1060,13 @@ envAccess:
 # Pod annotations
 podAnnotations: {}
 
+# Pod labels applied to every flexprice pod (api, consumer, worker, frontend).
+# Per-component additions go under `<component>.podLabels`.
+# Example — tag pods for an ELK ingest pipeline:
+#   podLabels:
+#     logging.company.io/index: flexprice
+podLabels: {}
+
 # ---------------------------------------------------------------------------
 # Node placement — nodeSelector, tolerations, affinity
 # ---------------------------------------------------------------------------
@@ -1150,7 +1185,10 @@ extraVolumeMounts: []
 # - name: extra-volume
 #   mountPath: /extra
 
-# Resource labels
+# Labels applied to every Kubernetes object the chart renders.
+# Per-component additions go under `<component>.labels`.
+# Never lands on spec.selector.matchLabels — those are immutable on
+# Deployments, so changing this value stays upgrade-safe.
 labels: {}
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## **User description**
## What

Adds custom label support to the Helm chart, per component.

Requested so labels used by ELK (and any other pod-metadata-driven log shipper) can be set from `values.yaml` instead of forking or patching the templates.

Each workload block — `api`, `consumer`, `worker`, `frontend` — now accepts:

| Value | Applies to |
|---|---|
| `labels` (global) | Every object the chart renders |
| `podLabels` (global) | Every FlexPrice pod |
| `<component>.labels` | That component's Deployment, Service, HPA, PDB, Ingress, ServiceAccount |
| `<component>.podLabels` | That component's pods only |

Per-component values merge on top of the global ones and win on key collisions. `labels` already existed but was undocumented; it's now described in `values.yaml`.

```yaml
podLabels:
  logging.company.io/index: flexprice

api:
  podLabels:
    logging.company.io/index: flexprice-api
  labels:
    company.io/tier: edge
```

## How

Two new helpers in `_helpers.tpl` — `flexprice.componentLabels` and `flexprice.componentPodLabels` — replace the open-coded `flexprice.labels` + `app.kubernetes.io/component` pairs at every app call site.

They resolve the component block with `index` rather than `dig`, because `dig` cannot walk `.Values` (it's `chartutil.Values`, not `map[string]interface{}`) and fails with `interface conversion: interface {} is common.Values`.

## Selectors are deliberately untouched

User labels never reach `spec.selector.matchLabels` on Deployments or `spec.selector` on Services. Deployment selectors are immutable in the API — a user-supplied label there would break the next `helm upgrade` with `field is immutable` and force a delete/reinstall of the release. Object labels and pod labels are both mutable; changing `podLabels` triggers an ordinary rolling update.

## Scope

App components only. Infra subcharts (postgres, kafka, redis, temporal, clickhouse) and one-shot jobs (migration, temporal bootstrap) are unchanged — those have their own subchart label mechanisms.

## Verification

- `helm template` output is **byte-identical** to the base commit under default values, `values-local.yaml`, and `values-prod.example.yaml` (all defaults are `{}`).
- `helm lint` passes on all three value files (same matrix as `helm-validate.yml`).
- Rendered with labels set and confirmed via parsed YAML: object labels land on Deployment/Service/HPA/PDB/ServiceAccount; pod labels land on the pod template only; `matchLabels` contains just name/instance/component; per-component `podLabels` correctly override the global value while other components inherit it.

Chart version bumped `1.1.0` → `1.2.0` (additive, backward compatible), with a `CHANGELOG.md` entry and a README section.


___

## **CodeAnt-AI Description**
Add upgrade-safe custom labels for each FlexPrice component

### What Changed
- Operators can set labels for each component’s Kubernetes resources and separate labels for its pods across API, consumer, worker, and frontend workloads.
- Global labels apply to all rendered resources or pods, while component-specific values override matching global labels.
- Pod labels can identify workloads for ELK, Fluent Bit, Datadog, and other metadata-based log shippers.
- Custom labels stay out of Kubernetes selectors, so changing them remains safe during Helm upgrades and triggers normal pod rollouts when pod labels change.
- Documents the new settings and updates the chart to version 1.2.0.

### Impact
`✅ Component-specific log routing`
`✅ Upgrade-safe label changes`
`✅ Targeted workload ownership and cost tags`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable global labels and pod labels for Kubernetes resources.
  - Added component-specific labels and pod labels for API, consumer, worker, and frontend components.
  - Applied labels consistently across deployments, services, ingress, autoscaling, reliability, and security resources.
  - Pod labels support combined global and component-specific configuration.

- **Bug Fixes**
  - Preserved immutable deployment and service selectors when custom labels are configured.

- **Documentation**
  - Added configuration guidance, precedence rules, examples, and compatibility notes.
  - Updated the Helm chart to version 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->