### PR TITLE
feat(costsheet): enhance CRUD operations to be scoped by tenant and environment

### DIFF
--- a/internal/ee/service/costsheet.go
+++ b/internal/ee/service/costsheet.go
@@ -238,11 +238,13 @@ func (s *costsheetService) UpdateCostsheet(ctx context.Context, id string, req d
 		// Update the costsheet
 		req.UpdateCostsheet(costsheet, ctx)
 
-		// Save the updated costsheet
+		// Save the updated costsheet. The repository already classifies this error
+		// (not-found, validation, or database) — propagate it as-is rather than
+		// re-marking it, since Mark() adds a mark on top instead of replacing one,
+		// which would make ResolveError's classification pick between two matching
+		// sentinels non-deterministically.
 		if err := s.CostSheetRepo.Update(ctx, costsheet); err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to update costsheet").
-				Mark(ierr.ErrDatabase)
+			return err
 		}
 
 		return nil
@@ -266,28 +268,14 @@ func (s *costsheetService) DeleteCostsheet(ctx context.Context, id string) (*dto
 			Mark(ierr.ErrValidation)
 	}
 
-	existing, err := s.CostSheetRepo.GetByID(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	if existing.Status == types.StatusDeleted {
-		return nil, ierr.NewError("costsheet is already archived").
-			WithHint("This costsheet has already been archived").
-			WithReportableDetails(map[string]any{
-				"id":     id,
-				"status": existing.Status,
-			}).
-			Mark(ierr.ErrValidation)
-	}
-
-	// Start a transaction to delete costsheet
-	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
-		// Soft delete the costsheet
+	// The "already deleted" check lives in the repository, not here: reading the
+	// status before the transaction would race with a concurrent delete (both
+	// requests could read "active" and both report success). CostSheetRepo.Delete
+	// makes the status transition atomic and returns a validation error if it
+	// lost the race, or if the costsheet was already deleted.
+	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
 		if err := s.CostSheetRepo.Delete(ctx, id); err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to archive costsheet").
-				Mark(ierr.ErrDatabase)
+			return err
 		}
 		return nil
 	})

--- a/internal/ee/service/costsheet.go
+++ b/internal/ee/service/costsheet.go
@@ -266,12 +266,27 @@ func (s *costsheetService) DeleteCostsheet(ctx context.Context, id string) (*dto
 			Mark(ierr.ErrValidation)
 	}
 
+	existing, err := s.CostSheetRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing.Status == types.StatusDeleted {
+		return nil, ierr.NewError("costsheet is already archived").
+			WithHint("This costsheet has already been archived").
+			WithReportableDetails(map[string]any{
+				"id":     id,
+				"status": existing.Status,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
 	// Start a transaction to delete costsheet
-	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
+	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 		// Soft delete the costsheet
 		if err := s.CostSheetRepo.Delete(ctx, id); err != nil {
 			return ierr.WithError(err).
-				WithHint("Failed to delete costsheet").
+				WithHint("Failed to archive costsheet").
 				Mark(ierr.ErrDatabase)
 		}
 		return nil

--- a/internal/repository/ent/costsheet.go
+++ b/internal/repository/ent/costsheet.go
@@ -327,13 +327,16 @@ func (r *costsheetRepository) Update(ctx context.Context, cs *domainCostsheet.Co
 
 // Delete soft deletes a costsheet record by setting its status to deleted, scoped to the tenant and environment in ctx.
 // The tenant/environment predicates are always applied (never conditionally skipped) so that a
-// request with incomplete auth context fails closed instead of widening the delete scope.
+// request with incomplete auth context fails closed instead of widening the delete scope. The
+// StatusNEQ guard makes the transition atomic: only a costsheet that isn't already deleted gets
+// flipped, so two concurrent deletes can't both read "active" and both report success.
 func (r *costsheetRepository) Delete(ctx context.Context, id string) error {
 	deleteQuery := r.client.Writer(ctx).Costsheet.Update().
 		Where(
 			costsheet.ID(id),
 			costsheet.TenantID(types.GetTenantID(ctx)),
 			costsheet.EnvironmentID(types.GetEnvironmentID(ctx)),
+			costsheet.StatusNEQ(string(types.StatusDeleted)),
 		).
 		SetStatus(string(types.StatusDeleted)).
 		SetUpdatedAt(time.Now().UTC())
@@ -354,10 +357,35 @@ func (r *costsheetRepository) Delete(ctx context.Context, id string) error {
 	}
 
 	if affected == 0 {
-		return ierr.NewError("costsheet not found").
-			WithHint("No costsheet found with the provided ID").
+		// affected == 0 means either the costsheet doesn't exist (or isn't in this
+		// tenant/environment), or the StatusNEQ guard excluded it because it was
+		// already deleted (possibly by a concurrent request that won the race).
+		// Disambiguate with one cheap existence check ignoring status (only on
+		// this already-failed path, not the common-case success path).
+		exists, existErr := r.client.Reader(ctx).Costsheet.Query().
+			Where(
+				costsheet.ID(id),
+				costsheet.TenantID(types.GetTenantID(ctx)),
+				costsheet.EnvironmentID(types.GetEnvironmentID(ctx)),
+			).
+			Exist(ctx)
+		if existErr != nil {
+			r.logger.Error(ctx, "Failed to delete costsheet", "error", existErr, "costsheet_id", id)
+			return ierr.WithError(existErr).
+				WithHint("Failed to delete costsheet").
+				Mark(ierr.ErrDatabase)
+		}
+		if !exists {
+			return ierr.NewError("costsheet not found").
+				WithHint("No costsheet found with the provided ID").
+				WithReportableDetails(map[string]any{"id": id}).
+				Mark(ierr.ErrNotFound)
+		}
+
+		return ierr.NewError("costsheet is already deleted").
+			WithHint("This costsheet has already been deleted").
 			WithReportableDetails(map[string]any{"id": id}).
-			Mark(ierr.ErrNotFound)
+			Mark(ierr.ErrValidation)
 	}
 
 	r.logger.Info(ctx, "Deleted costsheet", "costsheet_id", id)

--- a/internal/repository/ent/costsheet.go
+++ b/internal/repository/ent/costsheet.go
@@ -71,9 +71,22 @@ func (r *costsheetRepository) Create(ctx context.Context, costsheet *domainCosts
 	return nil
 }
 
-// GetByID retrieves a costsheet record by its ID.
+// GetByID retrieves a costsheet record by its ID, scoped to the tenant and environment in ctx.
 func (r *costsheetRepository) GetByID(ctx context.Context, id string) (*domainCostsheet.Costsheet, error) {
-	entCostsheet, err := r.client.Reader(ctx).Costsheet.Get(ctx, id)
+	query := r.client.Reader(ctx).Costsheet.Query().
+		Where(costsheet.ID(id))
+
+	// Apply tenant and environment from context
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	if tenantID != "" {
+		query = query.Where(costsheet.TenantID(tenantID))
+	}
+	if environmentID != "" {
+		query = query.Where(costsheet.EnvironmentID(environmentID))
+	}
+
+	entCostsheet, err := query.Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, ierr.NewError("costsheet not found").
@@ -263,11 +276,24 @@ func (r *costsheetRepository) Count(ctx context.Context, filter *domainCostsheet
 	return int64(count), nil
 }
 
-// Update updates an existing costsheet record.
-func (r *costsheetRepository) Update(ctx context.Context, costsheet *domainCostsheet.Costsheet) error {
-	entCostsheet := r.domainToEnt(costsheet)
+// Update updates an existing costsheet record, scoped to the tenant and environment in ctx.
+func (r *costsheetRepository) Update(ctx context.Context, cs *domainCostsheet.Costsheet) error {
+	entCostsheet := r.domainToEnt(cs)
 
-	updateQuery := r.client.Writer(ctx).Costsheet.UpdateOneID(entCostsheet.ID).
+	updateQuery := r.client.Writer(ctx).Costsheet.Update().
+		Where(costsheet.ID(entCostsheet.ID))
+
+	// Apply tenant and environment from context
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	if tenantID != "" {
+		updateQuery = updateQuery.Where(costsheet.TenantID(tenantID))
+	}
+	if environmentID != "" {
+		updateQuery = updateQuery.Where(costsheet.EnvironmentID(environmentID))
+	}
+
+	updateQuery = updateQuery.
 		SetName(entCostsheet.Name).
 		SetStatus(entCostsheet.Status).
 		SetUpdatedAt(entCostsheet.UpdatedAt).
@@ -284,31 +310,51 @@ func (r *costsheetRepository) Update(ctx context.Context, costsheet *domainCosts
 		updateQuery.SetMetadata(entCostsheet.Metadata)
 	}
 
-	err := updateQuery.Exec(ctx)
+	affected, err := updateQuery.Save(ctx)
 
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return ierr.NewError("costsheet not found").
 				WithHint("No costsheet found with the provided ID").
-				WithReportableDetails(map[string]any{"id": costsheet.ID}).
+				WithReportableDetails(map[string]any{"id": cs.ID}).
 				Mark(ierr.ErrNotFound)
 		}
-		r.logger.Error(ctx, "Failed to update costsheet", "error", err, "costsheet_id", costsheet.ID)
+		r.logger.Error(ctx, "Failed to update costsheet", "error", err, "costsheet_id", cs.ID)
 		return ierr.WithError(err).
 			WithHint("Failed to update costsheet").
 			Mark(ierr.ErrDatabase)
 	}
 
-	r.logger.Info(ctx, "Updated costsheet", "costsheet_id", costsheet.ID, "name", costsheet.Name)
+	if affected == 0 {
+		return ierr.NewError("costsheet not found").
+			WithHint("No costsheet found with the provided ID").
+			WithReportableDetails(map[string]any{"id": cs.ID}).
+			Mark(ierr.ErrNotFound)
+	}
+
+	r.logger.Info(ctx, "Updated costsheet", "costsheet_id", cs.ID, "name", cs.Name)
 	return nil
 }
 
-// Delete soft deletes a costsheet record by setting its status to deleted.
+// Delete soft deletes a costsheet record by setting its status to deleted, scoped to the tenant and environment in ctx.
 func (r *costsheetRepository) Delete(ctx context.Context, id string) error {
-	err := r.client.Writer(ctx).Costsheet.UpdateOneID(id).
+	deleteQuery := r.client.Writer(ctx).Costsheet.Update().
+		Where(costsheet.ID(id))
+
+	// Apply tenant and environment from context
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+	if tenantID != "" {
+		deleteQuery = deleteQuery.Where(costsheet.TenantID(tenantID))
+	}
+	if environmentID != "" {
+		deleteQuery = deleteQuery.Where(costsheet.EnvironmentID(environmentID))
+	}
+
+	affected, err := deleteQuery.
 		SetStatus(string(types.StatusDeleted)).
 		SetUpdatedAt(time.Now().UTC()).
-		Exec(ctx)
+		Save(ctx)
 
 	if err != nil {
 		if ent.IsNotFound(err) {
@@ -321,6 +367,13 @@ func (r *costsheetRepository) Delete(ctx context.Context, id string) error {
 		return ierr.WithError(err).
 			WithHint("Failed to delete costsheet").
 			Mark(ierr.ErrDatabase)
+	}
+
+	if affected == 0 {
+		return ierr.NewError("costsheet not found").
+			WithHint("No costsheet found with the provided ID").
+			WithReportableDetails(map[string]any{"id": id}).
+			Mark(ierr.ErrNotFound)
 	}
 
 	r.logger.Info(ctx, "Deleted costsheet", "costsheet_id", id)

--- a/internal/repository/ent/costsheet.go
+++ b/internal/repository/ent/costsheet.go
@@ -72,21 +72,16 @@ func (r *costsheetRepository) Create(ctx context.Context, costsheet *domainCosts
 }
 
 // GetByID retrieves a costsheet record by its ID, scoped to the tenant and environment in ctx.
+// The tenant/environment predicates are always applied (never conditionally skipped) so that a
+// request with incomplete auth context fails closed instead of widening the lookup scope.
 func (r *costsheetRepository) GetByID(ctx context.Context, id string) (*domainCostsheet.Costsheet, error) {
-	query := r.client.Reader(ctx).Costsheet.Query().
-		Where(costsheet.ID(id))
-
-	// Apply tenant and environment from context
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-	if tenantID != "" {
-		query = query.Where(costsheet.TenantID(tenantID))
-	}
-	if environmentID != "" {
-		query = query.Where(costsheet.EnvironmentID(environmentID))
-	}
-
-	entCostsheet, err := query.Only(ctx)
+	entCostsheet, err := r.client.Reader(ctx).Costsheet.Query().
+		Where(
+			costsheet.ID(id),
+			costsheet.TenantID(types.GetTenantID(ctx)),
+			costsheet.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
+		Only(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, ierr.NewError("costsheet not found").
@@ -277,23 +272,17 @@ func (r *costsheetRepository) Count(ctx context.Context, filter *domainCostsheet
 }
 
 // Update updates an existing costsheet record, scoped to the tenant and environment in ctx.
+// The tenant/environment predicates are always applied (never conditionally skipped) so that a
+// request with incomplete auth context fails closed instead of widening the update scope.
 func (r *costsheetRepository) Update(ctx context.Context, cs *domainCostsheet.Costsheet) error {
 	entCostsheet := r.domainToEnt(cs)
 
 	updateQuery := r.client.Writer(ctx).Costsheet.Update().
-		Where(costsheet.ID(entCostsheet.ID))
-
-	// Apply tenant and environment from context
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-	if tenantID != "" {
-		updateQuery = updateQuery.Where(costsheet.TenantID(tenantID))
-	}
-	if environmentID != "" {
-		updateQuery = updateQuery.Where(costsheet.EnvironmentID(environmentID))
-	}
-
-	updateQuery = updateQuery.
+		Where(
+			costsheet.ID(entCostsheet.ID),
+			costsheet.TenantID(types.GetTenantID(ctx)),
+			costsheet.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		SetName(entCostsheet.Name).
 		SetStatus(entCostsheet.Status).
 		SetUpdatedAt(entCostsheet.UpdatedAt).
@@ -337,24 +326,19 @@ func (r *costsheetRepository) Update(ctx context.Context, cs *domainCostsheet.Co
 }
 
 // Delete soft deletes a costsheet record by setting its status to deleted, scoped to the tenant and environment in ctx.
+// The tenant/environment predicates are always applied (never conditionally skipped) so that a
+// request with incomplete auth context fails closed instead of widening the delete scope.
 func (r *costsheetRepository) Delete(ctx context.Context, id string) error {
 	deleteQuery := r.client.Writer(ctx).Costsheet.Update().
-		Where(costsheet.ID(id))
-
-	// Apply tenant and environment from context
-	tenantID := types.GetTenantID(ctx)
-	environmentID := types.GetEnvironmentID(ctx)
-	if tenantID != "" {
-		deleteQuery = deleteQuery.Where(costsheet.TenantID(tenantID))
-	}
-	if environmentID != "" {
-		deleteQuery = deleteQuery.Where(costsheet.EnvironmentID(environmentID))
-	}
-
-	affected, err := deleteQuery.
+		Where(
+			costsheet.ID(id),
+			costsheet.TenantID(types.GetTenantID(ctx)),
+			costsheet.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		SetStatus(string(types.StatusDeleted)).
-		SetUpdatedAt(time.Now().UTC()).
-		Save(ctx)
+		SetUpdatedAt(time.Now().UTC())
+
+	affected, err := deleteQuery.Save(ctx)
 
 	if err != nil {
 		if ent.IsNotFound(err) {


### PR DESCRIPTION
## **CodeAnt-AI Description**
Scope costsheet reads and changes to the active tenant and environment

### What Changed
- Fetching a costsheet by ID now only returns a record belonging to the tenant and environment in the request context
- Updating or deleting a costsheet now applies the same tenant and environment boundaries
- Updates and deletes that do not match a scoped record now return a clear not-found error instead of reporting success

### Impact
`✅ Prevents cross-tenant costsheet access`
`✅ Prevents cross-environment updates and deletes`
`✅ Clearer not-found results for out-of-scope records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cost sheet retrieval, updates, and archiving now respect the active tenant and environment context.
  * Operations fail safely when the required context is incomplete.
  * Updates and archiving return a not-found result when no matching cost sheet exists.
  * Archiving is prevented for cost sheets that have already been archived, including concurrent or repeated attempts, with a clear status message.
  * Existing database error handling and logging remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->