### PR TITLE
security: response security headers + bulk ingest cap (VAPT)

### DIFF
--- a/internal/api/dto/bulk_ingest_validate_test.go
+++ b/internal/api/dto/bulk_ingest_validate_test.go
@@ -1,0 +1,38 @@
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+)
+
+func TestBulkIngestEventRequestValidate(t *testing.T) {
+	mk := func(n int) *dto.BulkIngestEventRequest {
+		ev := make([]*dto.IngestEventRequest, n)
+		for i := range ev {
+			ev[i] = &dto.IngestEventRequest{
+				EventName:          "api_call",
+				ExternalCustomerID: "cust_1",
+			}
+		}
+		return &dto.BulkIngestEventRequest{Events: ev}
+	}
+	cases := []struct {
+		name    string
+		n       int
+		wantErr bool
+	}{
+		{"empty rejected", 0, true},
+		{"one ok", 1, false},
+		{"at cap ok", 1000, false},
+		{"over cap rejected", 1001, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := mk(c.n).Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("n=%d err=%v, wantErr=%v", c.n, err, c.wantErr)
+			}
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -91,6 +91,7 @@ func NewRouter(
 		middleware.DBWriterPinMiddleware,     // Per-request read-your-writes pin for DB routing
 		middleware.LoggingMiddleware(logger), // Use our standard logger for HTTP logging
 		middleware.CORSMiddleware,
+		middleware.SecurityHeadersMiddleware, // nosniff / frame-deny / referrer / CSP / permissions
 	)
 	// Tracing middleware creates the otelgin span per request (SigNoz / OTLP).
 	// Each handler is added separately because gin's Use signature is variadic

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -99,6 +99,11 @@ func (h *EventsHandler) BulkIngestEvent(c *gin.Context) {
 		return
 	}
 
+	if err := req.Validate(); err != nil {
+		c.Error(err)
+		return
+	}
+
 	err := h.eventService.BulkCreateEvents(ctx, &req)
 	if err != nil {
 		h.log.Error(c.Request.Context(), "Failed to bulk ingest events", "error", err)

--- a/internal/rest/middleware/security_headers.go
+++ b/internal/rest/middleware/security_headers.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// SecurityHeadersMiddleware sets response hardening headers.
+//
+// This is a JSON API: it serves no HTML and uses no cookie-based auth, so
+// Content-Security-Policy and X-Frame-Options carry little weight here. They
+// are set anyway because they cost nothing and the API host also answers
+// /swagger and /health, which a browser may render.
+//
+// X-Content-Type-Options is the one that matters: it stops a browser from
+// MIME-sniffing a JSON body into something executable if a response is ever
+// reflected somewhere that renders it.
+func SecurityHeadersMiddleware(c *gin.Context) {
+	h := c.Writer.Header()
+	h.Set("X-Content-Type-Options", "nosniff")
+	h.Set("X-Frame-Options", "DENY")
+	h.Set("Referrer-Policy", "no-referrer")
+	h.Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
+	h.Set("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+	c.Next()
+}

--- a/internal/rest/middleware/security_headers.go
+++ b/internal/rest/middleware/security_headers.go
@@ -6,10 +6,12 @@ import (
 
 // SecurityHeadersMiddleware sets response hardening headers.
 //
-// This is a JSON API: it serves no HTML and uses no cookie-based auth, so
-// Content-Security-Policy and X-Frame-Options carry little weight here. They
-// are set anyway because they cost nothing and the API host also answers
-// /swagger and /health, which a browser may render.
+// This is a JSON API: no route serves HTML (no c.HTML, no LoadHTMLGlob, no
+// static handler, and no Swagger UI is mounted — the router only populates
+// swagger.SwaggerInfo for spec generation), and auth is header-based rather
+// than cookie-based. Content-Security-Policy and X-Frame-Options therefore
+// constrain nothing that exists today; they are set as a guard in case an
+// HTML-rendering route is ever added.
 //
 // X-Content-Type-Options is the one that matters: it stops a browser from
 // MIME-sniffing a JSON body into something executable if a response is ever

--- a/internal/rest/middleware/security_headers_api_test.go
+++ b/internal/rest/middleware/security_headers_api_test.go
@@ -1,0 +1,55 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/rest/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+// Security headers must not alter API behaviour for programmatic clients.
+func TestSecurityHeadersDoNotAffectAPIClients(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.CORSMiddleware, middleware.SecurityHeadersMiddleware)
+	r.POST("/v1/events", func(c *gin.Context) { c.JSON(202, gin.H{"message": "accepted"}) })
+	r.OPTIONS("/v1/events", func(c *gin.Context) {})
+
+	t.Run("POST from SDK still succeeds", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/events", nil)
+		req.Header.Set("x-api-key", "sk_test")
+		req.Header.Set("User-Agent", "flexprice-go-sdk/1.0")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != 202 {
+			t.Fatalf("status = %d, want 202", w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); ct == "" {
+			t.Error("Content-Type missing — clients parse on this")
+		}
+	})
+
+	t.Run("CORS preflight still permissive", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/v1/events", nil)
+		req.Header.Set("Origin", "https://customer-dashboard.example.com")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("ACAO = %q, want * — browser clients would break", got)
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("preflight status = %d, want 200", w.Code)
+		}
+	})
+
+	t.Run("no request-side gating", func(t *testing.T) {
+		// No Origin, no User-Agent — a bare curl. Must still pass.
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/v1/events", nil))
+		if w.Code != 202 {
+			t.Errorf("bare client status = %d, want 202", w.Code)
+		}
+	})
+}

--- a/internal/rest/middleware/security_headers_api_test.go
+++ b/internal/rest/middleware/security_headers_api_test.go
@@ -3,6 +3,7 @@ package middleware_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/rest/middleware"
@@ -34,10 +35,18 @@ func TestSecurityHeadersDoNotAffectAPIClients(t *testing.T) {
 	t.Run("CORS preflight still permissive", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodOptions, "/v1/events", nil)
 		req.Header.Set("Origin", "https://customer-dashboard.example.com")
+		req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+		req.Header.Set("Access-Control-Request-Headers", "x-api-key, content-type")
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
 			t.Errorf("ACAO = %q, want * — browser clients would break", got)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodPost) {
+			t.Errorf("ACAM = %q, want it to include POST", got)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got != "*" {
+			t.Errorf("ACAH = %q, want * — x-api-key must be allowed", got)
 		}
 		if w.Code != http.StatusOK {
 			t.Errorf("preflight status = %d, want 200", w.Code)

--- a/internal/rest/middleware/security_headers_test.go
+++ b/internal/rest/middleware/security_headers_test.go
@@ -1,0 +1,36 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/rest/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.SecurityHeadersMiddleware)
+	r.GET("/health", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	want := map[string]string{
+		"X-Content-Type-Options":  "nosniff",
+		"X-Frame-Options":         "DENY",
+		"Referrer-Policy":         "no-referrer",
+		"Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'",
+		"Permissions-Policy":      "geolocation=(), microphone=(), camera=()",
+	}
+	for h, exp := range want {
+		if got := w.Header().Get(h); got != exp {
+			t.Errorf("%s = %q, want %q", h, got, exp)
+		}
+	}
+	if w.Code != 200 {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}


### PR DESCRIPTION
## **User description**
Two independent fixes from the August 2026 penetration tests. Both verified against the code on `develop`.

## 1. Response security headers — VAPT 6.6 (Atom Assurances, LOW)

Adds `SecurityHeadersMiddleware` to the global chain: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Content-Security-Policy`, `Permissions-Policy`.

**This cannot affect API clients.** All five are response headers interpreted only by browsers — curl, Go `net/http`, Python `requests`, and our SDKs ignore them. There is no request-side gating and CORS is untouched (`Access-Control-Allow-Origin` stays `*`).

Verified there is no HTML surface to constrain: no `c.HTML`, no `LoadHTMLGlob`, no `Static`, no swagger UI handler mounted. `nosniff` is the header that carries real weight here; the rest are set because they cost nothing.

`security_headers_api_test.go` covers the compatibility claim directly — SDK POST returns 202, CORS preflight still returns `*`, and a bare client with no `Origin`/`User-Agent` passes.

## 2. Bulk ingest cap — SFX-2026-0203-F11 (Secfox, MEDIUM)

`BulkIngestEvent` bound the request and called `BulkCreateEvents` without ever calling `req.Validate()`, so the existing `validate:"required,min=1,max=1000"` tag on `BulkIngestEventRequest.Events` never fired. The sibling `BulkIngestRawEvent` does call it.

`POST /v1/events/bulk` accepted an unbounded number of events per request. One line, matching the sibling handler.

### Scope limit

This bounds event **count** only. There is still no `http.MaxBytesReader` on the ingest path and no `ReadTimeout`/`WriteTimeout` on the server (`cmd/server/main.go` uses `r.Run()`), so a 1000-event request with large `Properties` maps is still unbounded. Those need traffic modelling before limits are picked — deliberately not in this PR.

## Verification

```
go build -mod=mod ./internal/rest/middleware/... ./internal/api/...   # clean
go test  -mod=mod ./internal/rest/middleware/... ./internal/api/dto/...  # ok, ok
gofmt -l <touched files>                                             # clean
```

`-mod=mod` is required: `develop` has pre-existing inconsistent vendoring (`go.mod` and `vendor/modules.txt` disagree on ~11 modules). That is present on pristine `develop` and unrelated to this PR, but it does mean `go build ./...` is not currently green on the branch.

Not verified at runtime against a deployed environment.


___

## **CodeAnt-AI Description**
**Add browser security protections and enforce the bulk event limit**

### What Changed
- API responses now include browser security headers that prevent MIME sniffing, framing, referrer leakage, and access to camera, microphone, and location features
- Bulk event ingestion now rejects empty requests and requests containing more than 1,000 events
- Existing API clients and permissive CORS behavior continue to work unchanged

### Impact
`✅ Fewer browser-based response security risks`
`✅ Prevented oversized bulk event submissions`
`✅ Uninterrupted SDK and cross-origin API access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added browser security headers to API responses without changing existing request behavior.
  * Preserved CORS preflight handling and compatibility for SDK, browser, and direct clients.

* **Bug Fixes**
  * Invalid bulk event requests are now rejected before processing.
  * Bulk ingestion enforces a maximum batch size of 1,000 events.

* **Tests**
  * Added coverage for bulk validation, security headers, health checks, and middleware compatibility across supported request types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->