### PR TITLE
fix(svix): Idempotency key for webhook delivery

### DIFF
--- a/internal/svix/client.go
+++ b/internal/svix/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/httpclient"
 	"github.com/flexprice/flexprice/internal/tracing"
+	"github.com/samber/lo"
 	svix "github.com/svix/svix-webhooks/go"
 	"github.com/svix/svix-webhooks/go/models"
 )
@@ -119,7 +120,7 @@ func (c *Client) GetDashboardURL(ctx context.Context, applicationID string) (url
 
 // SendMessage sends a webhook message to the given application.
 // Returns the Svix message id on success (empty string when Svix is disabled or the app doesn't exist).
-func (c *Client) SendMessage(ctx context.Context, applicationID string, eventType string, payload interface{}) (string, error) {
+func (c *Client) SendMessage(ctx context.Context, applicationID, eventID, eventType string, payload interface{}) (string, error) {
 	if !c.enabled || c.client == nil {
 		return "", nil
 	}
@@ -156,11 +157,14 @@ func (c *Client) SendMessage(ctx context.Context, applicationID string, eventTyp
 		}
 	}
 
+	idempotencyKey := fmt.Sprintf("%s_%s", eventID, eventType)
 	payloadMap["event_type"] = eventType
 	out, err := c.client.Message.Create(ctx, applicationID, models.MessageIn{
 		EventType: eventType,
 		Payload:   payloadMap,
-	}, &svix.MessageCreateOptions{})
+	}, &svix.MessageCreateOptions{
+		IdempotencyKey: lo.ToPtr(idempotencyKey),
+	})
 	if err != nil {
 		if err.Error() == "application not found" {
 			return "", nil

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -112,27 +112,25 @@ func (h *handler) DeliverWebhook(ctx context.Context, event *types.WebhookEvent)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, event.EnvironmentID)
 	ctx = context.WithValue(ctx, types.CtxUserID, event.UserID)
 
-	messageUUID := types.GenerateUUID()
+	eventID := event.ID
 	h.logger.Debug(ctx, "delivering webhook synchronously",
-		"message_uuid", messageUUID,
+		"event_id", eventID,
 		"event_name", event.EventName,
 		"tenant_id", event.TenantID,
-		"event_id", event.ID,
 	)
 
 	var deliveryErr error
 	if h.config.Svix.Enabled {
-		deliveryErr = h.deliverSvix(ctx, event, messageUUID)
+		deliveryErr = h.deliverSvix(ctx, event, eventID)
 	} else {
-		deliveryErr = h.deliverNative(ctx, event, messageUUID)
+		deliveryErr = h.deliverNative(ctx, event, eventID)
 	}
 	if deliveryErr != nil {
 		h.logger.Error(ctx, "failed to deliver webhook synchronously",
 			"error", deliveryErr,
-			"event_id", event.ID,
+			"event_id", eventID,
 			"event_name", event.EventName,
 			"tenant_id", event.TenantID,
-			"message_uuid", messageUUID,
 		)
 		if h.systemEventRepo != nil && event.ID != "" {
 			if dbErr := h.systemEventRepo.OnFailed(ctx, event.ID, deliveryErr.Error()); dbErr != nil {
@@ -240,7 +238,7 @@ func (h *handler) processMessage(ctx context.Context, msg *message.Message) erro
 }
 
 // deliverSvix sends a webhook via Svix.
-func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, messageUUID string) error {
+func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, eventID string) error {
 	appID, err := h.svixClient.GetOrCreateApplication(ctx, event.TenantID, event.EnvironmentID)
 	if err != nil {
 		if err.Error() == "application not found" {
@@ -293,7 +291,7 @@ func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, me
 		return err
 	}
 
-	svixOut, err := h.svixClient.SendMessage(ctx, appID, event.EventName, json.RawMessage(webHookPayload))
+	svixOut, err := h.svixClient.SendMessage(ctx, appID, eventID, event.EventName, json.RawMessage(webHookPayload))
 	if err != nil {
 		return err
 	}
@@ -314,7 +312,7 @@ func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, me
 	}
 
 	h.logger.Info(ctx, "webhook sent successfully via Svix",
-		"message_uuid", messageUUID,
+		"event_id", eventID,
 		"tenant_id", event.TenantID,
 		"event", event.EventName,
 	)
@@ -323,7 +321,7 @@ func (h *handler) deliverSvix(ctx context.Context, event *types.WebhookEvent, me
 }
 
 // deliverNative sends a webhook to the configured HTTP endpoint.
-func (h *handler) deliverNative(ctx context.Context, event *types.WebhookEvent, messageUUID string) error {
+func (h *handler) deliverNative(ctx context.Context, event *types.WebhookEvent, eventID string) error {
 	tenantCfg, ok := h.config.TenantConfig(event.TenantID)
 	if !ok {
 		return ierr.NewError("native webhook is not configured for this tenant").
@@ -376,7 +374,7 @@ func (h *handler) deliverNative(ctx context.Context, event *types.WebhookEvent, 
 	}
 
 	h.logger.Info(ctx, "webhook sent successfully",
-		"message_uuid", messageUUID,
+		"event_id", eventID,
 		"tenant_id", event.TenantID,
 		"event", event.EventName,
 		"status_code", resp.StatusCode,


### PR DESCRIPTION
## **CodeAnt-AI Description**
Prevent duplicate webhook deliveries when the same event is retried

### What Changed
- Webhook delivery now uses the event’s stable ID and event type as the Svix idempotency key
- Retried deliveries of the same event are recognized as the same message instead of creating duplicates
- Synchronous and queued deliveries use consistent event identifiers in delivery tracking and logs

### Impact
`✅ Fewer duplicate webhook deliveries`
`✅ Safer webhook retries`
`✅ Consistent event delivery tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook delivery reliability by preventing duplicate message creation when the same event is retried.
  * Webhook messages now consistently use the original event ID, providing stable identification across deliveries.
  * Delivery logs now reference the event’s existing ID for clearer troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->