### PR TITLE
fix(billing): Decimal precision

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -1798,6 +1798,64 @@ type SubscriptionUsageByMetersResponse struct {
 	// BucketedUsageResult holds per-bucket usage data for bucketed meters (MAX/SUM with bucket_size).
 	// Populated by GetMeterUsageBySubscription so CalculateMeterUsageCharges doesn't re-query ClickHouse.
 	BucketedUsageResult *events.AggregationResult `json:"-"`
+
+	// Exact carriers for billing math. JSON amount/quantity remain float64 for API
+	// compatibility; invoice calculation must use AmountDecimal/QuantityDecimal so
+	// values never round-trip through float64 (can flip currency rounding at boundaries).
+	amountExact      decimal.Decimal
+	hasAmountExact   bool
+	quantityExact    decimal.Decimal
+	hasQuantityExact bool
+}
+
+// SetAmountDecimal stores the billing amount exactly and mirrors float64 for the API.
+func (c *SubscriptionUsageByMetersResponse) SetAmountDecimal(amount decimal.Decimal) {
+	if c == nil {
+		return
+	}
+	c.amountExact = amount
+	c.hasAmountExact = true
+	c.Amount = amount.InexactFloat64()
+}
+
+// SetAmountWithCurrencyPrecision rounds to currency precision, then SetAmountDecimal.
+func (c *SubscriptionUsageByMetersResponse) SetAmountWithCurrencyPrecision(amount decimal.Decimal, currency string) {
+	if c == nil {
+		return
+	}
+	c.SetAmountDecimal(types.RoundToCurrencyPrecision(amount, currency))
+}
+
+// AmountDecimal returns the exact billing amount when set; otherwise reconstructs from the API float.
+func (c *SubscriptionUsageByMetersResponse) AmountDecimal() decimal.Decimal {
+	if c == nil {
+		return decimal.Zero
+	}
+	if c.hasAmountExact {
+		return c.amountExact
+	}
+	return decimal.NewFromFloat(c.Amount)
+}
+
+// SetQuantityDecimal stores the billing quantity exactly and mirrors float64 for the API.
+func (c *SubscriptionUsageByMetersResponse) SetQuantityDecimal(quantity decimal.Decimal) {
+	if c == nil {
+		return
+	}
+	c.quantityExact = quantity
+	c.hasQuantityExact = true
+	c.Quantity = quantity.InexactFloat64()
+}
+
+// QuantityDecimal returns the exact billing quantity when set; otherwise reconstructs from the API float.
+func (c *SubscriptionUsageByMetersResponse) QuantityDecimal() decimal.Decimal {
+	if c == nil {
+		return decimal.Zero
+	}
+	if c.hasQuantityExact {
+		return c.quantityExact
+	}
+	return decimal.NewFromFloat(c.Quantity)
 }
 
 type SubscriptionUpdatePeriodResponse struct {

--- a/internal/api/dto/subscription_amount_decimal_test.go
+++ b/internal/api/dto/subscription_amount_decimal_test.go
@@ -1,0 +1,40 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// Near half-up boundaries, float64 round-trips can flip the final cent.
+// AmountDecimal must preserve the exact decimal used for billing.
+func TestSubscriptionUsageByMetersResponse_AmountDecimalPreservesRoundingBoundary(t *testing.T) {
+	boundary := decimal.RequireFromString("0.014999999999999999")
+
+	viaFloat := decimal.NewFromFloat(boundary.InexactFloat64()).Round(2)
+	if !viaFloat.Equal(decimal.RequireFromString("0.02")) {
+		t.Fatalf("precondition: expected float round-trip to flip to 0.02, got %s", viaFloat)
+	}
+
+	charge := &SubscriptionUsageByMetersResponse{}
+	charge.SetAmountDecimal(boundary)
+	got := charge.AmountDecimal().Round(2)
+	want := decimal.RequireFromString("0.01")
+	if !got.Equal(want) {
+		t.Fatalf("AmountDecimal().Round(2)=%s, want %s (float Amount=%v)", got, want, charge.Amount)
+	}
+}
+
+func TestSubscriptionUsageByMetersResponse_QuantityDecimalPreservesHighPrecision(t *testing.T) {
+	q := decimal.RequireFromString("1234567.890123456789")
+	viaFloat := decimal.NewFromFloat(q.InexactFloat64())
+	if viaFloat.Equal(q) {
+		t.Fatalf("precondition: expected quantity float round-trip loss")
+	}
+
+	charge := &SubscriptionUsageByMetersResponse{}
+	charge.SetQuantityDecimal(q)
+	if !charge.QuantityDecimal().Equal(q) {
+		t.Fatalf("QuantityDecimal()=%s, want %s", charge.QuantityDecimal(), q)
+	}
+}

--- a/internal/domain/price/model.go
+++ b/internal/domain/price/model.go
@@ -235,16 +235,17 @@ func (p *Price) FormatAmountToStringWithPrecision() string {
 	return p.Amount.Round(config.Precision).String()
 }
 
-// FormatAmountToFloat64 formats the amount to float64
+// FormatAmountToFloat64 formats the amount to float64 for API responses.
+// Do not use the result as an input to further billing math — keep decimal.Decimal.
 func (p *Price) FormatAmountToFloat64() float64 {
 	return p.Amount.InexactFloat64()
 }
 
-// FormatAmountToFloat64WithPrecision formats the amount to float64
-// It rounds off the amount according to currency precision
+// FormatAmountToFloat64WithPrecision formats the amount to float64 for API responses.
+// It rounds to currency precision first. Do not feed the result back into billing math
+// via float→decimal conversion; use FormatAmountWithPrecision / decimal throughout.
 func (p *Price) FormatAmountToFloat64WithPrecision() float64 {
-	config := types.GetCurrencyConfig(p.Currency)
-	return p.Amount.Round(config.Precision).InexactFloat64()
+	return FormatAmountToFloat64WithPrecision(p.Amount, p.Currency)
 }
 
 // GetDisplayAmount returns the amount in the currency ex $12.00
@@ -297,10 +298,16 @@ func FormatAmountToStringWithPrecision(amount decimal.Decimal, currency string) 
 	return amount.Round(config.Precision).String()
 }
 
-// FormatAmountToFloat64WithPrecision formats the amount to float64
-// It rounds off the amount according to currency precision
+// FormatAmountWithPrecision rounds amount to the currency's decimal places.
+func FormatAmountWithPrecision(amount decimal.Decimal, currency string) decimal.Decimal {
+	return amount.Round(types.GetCurrencyPrecision(currency))
+}
+
+// FormatAmountToFloat64WithPrecision formats a currency-rounded amount for API/JSON float fields.
+// Billing calculations must keep decimal.Decimal end-to-end; converting through float64 can
+// change currency rounding at boundaries (e.g. 0.014999… → 0.02 instead of 0.01).
 func FormatAmountToFloat64WithPrecision(amount decimal.Decimal, currency string) float64 {
-	return amount.Round(types.GetCurrencyPrecision(currency)).InexactFloat64()
+	return FormatAmountWithPrecision(amount, currency).InexactFloat64()
 }
 
 // PriceTransform is the quantity transformation in case of PACKAGE billing model

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -81,7 +81,6 @@ type BillingService interface {
 
 	// GetCustomerUsageSummary returns usage summaries for a customer's features.
 	GetCustomerUsageSummary(ctx context.Context, customerID string, req *dto.GetCustomerUsageSummaryRequest) (*dto.CustomerUsageSummaryResponse, error)
-
 }
 
 type billingService struct {
@@ -499,7 +498,7 @@ func (s *billingService) CalculateUsageCharges(
 
 		// Process each matching charge individually (normal and overage charges)
 		for _, matchingCharge := range matchingCharges {
-			quantityForCalculation := decimal.NewFromFloat(matchingCharge.Quantity)
+			quantityForCalculation := matchingCharge.QuantityDecimal()
 			matchingEntitlement, entitlementOk := entitlementsByMeterID[item.MeterID]
 			var entitlementAdjustedQty *decimal.Decimal
 
@@ -537,8 +536,8 @@ func (s *billingService) CalculateUsageCharges(
 				}
 
 				cost := calculateBucketedMeterCost(ctx, priceService, matchingCharge.Price, usageResult, hasGroupBy)
-				matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(cost.Amount, matchingCharge.Price.Currency)
-				matchingCharge.Quantity = cost.Quantity.InexactFloat64()
+				matchingCharge.SetAmountWithCurrencyPrecision(cost.Amount, matchingCharge.Price.Currency)
+				matchingCharge.SetQuantityDecimal(cost.Quantity)
 				quantityForCalculation = cost.Quantity
 			}
 
@@ -558,7 +557,7 @@ func (s *billingService) CalculateUsageCharges(
 						quantityForCalculation = adjustedQuantity
 						if matchingCharge.Price != nil {
 							adjustedAmount := priceService.CalculateCost(ctx, matchingCharge.Price, quantityForCalculation)
-							matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(adjustedAmount, matchingCharge.Price.Currency)
+							matchingCharge.SetAmountWithCurrencyPrecision(adjustedAmount, matchingCharge.Price.Currency)
 						}
 						adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
 						entitlementAdjustedQty = &adj
@@ -566,7 +565,7 @@ func (s *billingService) CalculateUsageCharges(
 				} else {
 					// Unlimited entitlement → zero cost
 					quantityForCalculation = decimal.Zero
-					matchingCharge.Amount = 0
+					matchingCharge.SetAmountDecimal(decimal.Zero)
 					entitlementAdjustedQty = lo.ToPtr(decimal.Max(rawQtyBeforeEntitlement, decimal.Zero))
 				}
 			}
@@ -587,7 +586,7 @@ func (s *billingService) CalculateUsageCharges(
 					if (matchingEntitlement.UsageResetPeriod) == types.EntitlementUsageResetPeriod(sub.BillingPeriod) {
 
 						usageAllowed := decimal.NewFromFloat(float64(*matchingEntitlement.UsageLimit))
-						adjustedQuantity := decimal.NewFromFloat(matchingCharge.Quantity).Sub(usageAllowed)
+						adjustedQuantity := matchingCharge.QuantityDecimal().Sub(usageAllowed)
 						quantityForCalculation = decimal.Max(adjustedQuantity, decimal.Zero)
 						adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
 						entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
@@ -728,7 +727,7 @@ func (s *billingService) CalculateUsageCharges(
 						entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
 					} else {
 						usageAllowed := decimal.NewFromFloat(float64(*matchingEntitlement.UsageLimit))
-						adjustedQuantity := decimal.NewFromFloat(matchingCharge.Quantity).Sub(usageAllowed)
+						adjustedQuantity := matchingCharge.QuantityDecimal().Sub(usageAllowed)
 						quantityForCalculation = decimal.Max(adjustedQuantity, decimal.Zero)
 						adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
 						entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
@@ -738,12 +737,12 @@ func (s *billingService) CalculateUsageCharges(
 					if matchingCharge.Price != nil {
 						// For regular pricing, use standard cost calculation
 						adjustedAmount := priceService.CalculateCost(ctx, matchingCharge.Price, quantityForCalculation)
-						matchingCharge.Amount = adjustedAmount.InexactFloat64()
+						matchingCharge.SetAmountDecimal(adjustedAmount)
 					}
 				} else {
 					// unlimited usage allowed, so we set the usage quantity for calculation to 0
 					quantityForCalculation = decimal.Zero
-					matchingCharge.Amount = 0
+					matchingCharge.SetAmountDecimal(decimal.Zero)
 					entitlementAdjustedQty = lo.ToPtr(decimal.Max(rawQtyBeforeEntitlement, decimal.Zero))
 				}
 			}
@@ -751,7 +750,7 @@ func (s *billingService) CalculateUsageCharges(
 			// use the full quantity and calculate the amount normally
 
 			// Add the amount to total usage cost
-			lineItemAmount := decimal.NewFromFloat(matchingCharge.Amount)
+			lineItemAmount := matchingCharge.AmountDecimal()
 
 			// Store commitment info separately
 			var commitmentInfo *types.CommitmentInfo
@@ -820,7 +819,7 @@ func (s *billingService) CalculateUsageCharges(
 						}
 
 						lineItemAmount = adjustedAmount
-						matchingCharge.Amount = adjustedAmount.InexactFloat64()
+						matchingCharge.SetAmountDecimal(adjustedAmount)
 						commitmentInfo = info
 					} else {
 						// Non-window commitment: apply to aggregated usage cost
@@ -831,7 +830,7 @@ func (s *billingService) CalculateUsageCharges(
 						}
 
 						lineItemAmount = adjustedAmount
-						matchingCharge.Amount = adjustedAmount.InexactFloat64()
+						matchingCharge.SetAmountDecimal(adjustedAmount)
 						commitmentInfo = info
 					}
 				}
@@ -1127,7 +1126,6 @@ func (s *billingService) fillBucketedValuesForWindowedCommitment(
 	}
 	return bucketedValues, bucketStarts
 }
-
 
 func (s *billingService) CalculateAllCharges(
 	ctx context.Context,
@@ -2639,7 +2637,7 @@ func (s *billingService) GetCustomerUsageSummary(ctx context.Context, customerID
 				resetPeriod := featureUsageResetPeriodMap[featureID]
 				if resetPeriod.String() == sub.BillingPeriod.String() {
 					currentUsage := usageByFeature[featureID]
-					usageByFeature[featureID] = currentUsage.Add(decimal.NewFromFloat(charge.Quantity))
+					usageByFeature[featureID] = currentUsage.Add(charge.QuantityDecimal())
 				} else if resetPeriod == types.ENTITLEMENT_USAGE_RESET_PERIOD_DAILY {
 					// Handle daily reset features: get today's usage from daily windows
 					meterID := featureMeterMap[featureID]

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -542,6 +542,7 @@ func (s *billingService) applyMeterUsageCommitment(
 		if err != nil {
 			return decimal.Zero, nil, err
 		}
+		adjustedAmount = types.RoundToCurrencyPrecision(adjustedAmount, matchingCharge.Price.Currency)
 		matchingCharge.SetAmountDecimal(adjustedAmount)
 		return adjustedAmount, info, nil
 	}
@@ -575,6 +576,7 @@ func (s *billingService) applyMeterUsageCommitment(
 	if err != nil {
 		return decimal.Zero, nil, err
 	}
+	adjustedAmount = types.RoundToCurrencyPrecision(adjustedAmount, matchingCharge.Price.Currency)
 	matchingCharge.SetAmountDecimal(adjustedAmount)
 	return adjustedAmount, info, nil
 }

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/meter"
-	priceDomain "github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/priceunit"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -165,7 +164,7 @@ func (s *billingService) CalculateMeterUsageCharges(
 		var cumulativePreferredCharge bool // true once a non-overage charge has set the fields above
 
 		for _, matchingCharge := range matchingCharges {
-			quantityForCalculation := decimal.NewFromFloat(matchingCharge.Quantity)
+			quantityForCalculation := matchingCharge.QuantityDecimal()
 
 			// 1. Bucketed meter cost — use pre-fetched result or fallback to direct query
 			var cachedBucketedUsageResult *events.AggregationResult
@@ -181,8 +180,8 @@ func (s *billingService) CalculateMeterUsageCharges(
 
 				hasGroupBy := m.IsBucketedMaxMeter() && m.Aggregation.GroupBy != ""
 				cost := calculateBucketedMeterCost(ctx, priceService, matchingCharge.Price, usageResult, hasGroupBy)
-				matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(cost.Amount, matchingCharge.Price.Currency)
-				matchingCharge.Quantity = cost.Quantity.InexactFloat64()
+				matchingCharge.SetAmountWithCurrencyPrecision(cost.Amount, matchingCharge.Price.Currency)
+				matchingCharge.SetQuantityDecimal(cost.Quantity)
 				quantityForCalculation = cost.Quantity
 			}
 
@@ -207,7 +206,7 @@ func (s *billingService) CalculateMeterUsageCharges(
 				// already updated matchingCharge (Amount/Quantity). For the
 				// pricer, use the grant-derived quantity; amount-lane grants
 				// return zero here on purpose (already priced).
-				quantityForCalculation = decimal.NewFromFloat(matchingCharge.Quantity)
+				quantityForCalculation = matchingCharge.QuantityDecimal()
 				if grantResult.Measure == types.EntitlementGrantMeasureQuantity {
 					adj := rawQtyBeforeEntitlement.Sub(quantityForCalculation)
 					entitlementAdjustedQty = lo.ToPtr(decimal.Max(adj, decimal.Zero))
@@ -225,10 +224,10 @@ func (s *billingService) CalculateMeterUsageCharges(
 			case !matchingCharge.IsOverage && !m.IsBucketedMaxMeter() && !m.IsBucketedSumMeter() && matchingCharge.Price != nil:
 				// No grant, no entitlement — recalculate cost for non-bucketed meters.
 				adjustedAmount := priceService.CalculateCost(ctx, matchingCharge.Price, quantityForCalculation)
-				matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(adjustedAmount, matchingCharge.Price.Currency)
+				matchingCharge.SetAmountWithCurrencyPrecision(adjustedAmount, matchingCharge.Price.Currency)
 			}
 
-			lineItemAmount := decimal.NewFromFloat(matchingCharge.Amount)
+			lineItemAmount := matchingCharge.AmountDecimal()
 
 			// 3. Cumulative commitment — accumulate into ONE combined entry per line
 			// item (appended after the charge loop below), not one per charge.
@@ -396,7 +395,7 @@ func (s *billingService) adjustMeterUsageEntitlement(
 	priceService PriceService,
 	querySource types.UsageSource,
 ) (decimal.Decimal, error) {
-	quantity := decimal.NewFromFloat(matchingCharge.Quantity)
+	quantity := matchingCharge.QuantityDecimal()
 
 	// Bucketed meters: simple limit subtraction
 	if m.IsBucketedMaxMeter() || m.IsBucketedSumMeter() {
@@ -404,18 +403,18 @@ func (s *billingService) adjustMeterUsageEntitlement(
 			allowed := decimal.NewFromFloat(float64(*ent.UsageLimit))
 			adjusted := decimal.Max(quantity.Sub(allowed), decimal.Zero)
 			if !adjusted.Equal(quantity) && matchingCharge.Price != nil {
-				matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(
+				matchingCharge.SetAmountWithCurrencyPrecision(
 					priceService.CalculateCost(ctx, matchingCharge.Price, adjusted), matchingCharge.Price.Currency)
 			}
 			return adjusted, nil
 		}
-		matchingCharge.Amount = 0
+		matchingCharge.SetAmountDecimal(decimal.Zero)
 		return decimal.Zero, nil
 	}
 
 	// Non-bucketed meters
 	if ent.UsageLimit == nil {
-		matchingCharge.Amount = 0
+		matchingCharge.SetAmountDecimal(decimal.Zero)
 		return decimal.Zero, nil
 	}
 
@@ -501,7 +500,7 @@ func (s *billingService) adjustMeterUsageEntitlement(
 	}
 
 	if matchingCharge.Price != nil {
-		matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(
+		matchingCharge.SetAmountWithCurrencyPrecision(
 			priceService.CalculateCost(ctx, matchingCharge.Price, adjusted), matchingCharge.Price.Currency)
 	}
 	return adjusted, nil
@@ -535,7 +534,7 @@ func (s *billingService) applyMeterUsageCommitment(
 	querySource types.UsageSource,
 	meterMap map[string]*meter.Meter,
 ) (decimal.Decimal, *types.CommitmentInfo, error) {
-	lineItemAmount := decimal.NewFromFloat(matchingCharge.Amount)
+	lineItemAmount := matchingCharge.AmountDecimal()
 	commitmentCalc := newCommitmentCalculator(s.Logger, priceService)
 
 	if !item.CommitmentWindowed {
@@ -543,7 +542,7 @@ func (s *billingService) applyMeterUsageCommitment(
 		if err != nil {
 			return decimal.Zero, nil, err
 		}
-		matchingCharge.Amount = adjustedAmount.InexactFloat64()
+		matchingCharge.SetAmountDecimal(adjustedAmount)
 		return adjustedAmount, info, nil
 	}
 
@@ -576,7 +575,7 @@ func (s *billingService) applyMeterUsageCommitment(
 	if err != nil {
 		return decimal.Zero, nil, err
 	}
-	matchingCharge.Amount = adjustedAmount.InexactFloat64()
+	matchingCharge.SetAmountDecimal(adjustedAmount)
 	return adjustedAmount, info, nil
 }
 

--- a/internal/ee/service/billing_meter_usage_grants.go
+++ b/internal/ee/service/billing_meter_usage_grants.go
@@ -139,21 +139,21 @@ func (s *billingService) adjustMeterUsageGrants(
 
 	switch measure {
 	case types.EntitlementGrantMeasureQuantity:
-		matchingCharge.Quantity = res.Overage.InexactFloat64()
+		matchingCharge.SetQuantityDecimal(res.Overage)
 		if matchingCharge.Price != nil {
 			cost := priceService.CalculateCost(ctx, matchingCharge.Price, res.Overage)
-			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(cost, matchingCharge.Price.Currency)
+			matchingCharge.SetAmountWithCurrencyPrecision(cost, matchingCharge.Price.Currency)
 		} else {
-			matchingCharge.Amount = 0
+			matchingCharge.SetAmountDecimal(decimal.Zero)
 		}
 	case types.EntitlementGrantMeasureAmount:
 		// Already money — zero the qty so aggregation doesn't double-count.
 		if matchingCharge.Price != nil {
-			matchingCharge.Amount = priceDomain.FormatAmountToFloat64WithPrecision(res.Overage, matchingCharge.Price.Currency)
+			matchingCharge.SetAmountWithCurrencyPrecision(res.Overage, matchingCharge.Price.Currency)
 		} else {
-			matchingCharge.Amount = res.Overage.InexactFloat64()
+			matchingCharge.SetAmountDecimal(res.Overage)
 		}
-		matchingCharge.Quantity = 0
+		matchingCharge.SetQuantityDecimal(decimal.Zero)
 	}
 	return res, true, nil
 }

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -2204,15 +2204,15 @@ func (s *meterUsageService) ConvertToBillingCharges(
 
 		charge := &dto.SubscriptionUsageByMetersResponse{
 			SubscriptionLineItemID: lu.LineItem.ID,
-			Amount:                 cost.InexactFloat64(),
 			Currency:               lu.Price.Currency,
-			DisplayAmount:          fmt.Sprintf("%.2f %s", cost.InexactFloat64(), lu.Price.Currency),
-			Quantity:               quantity.InexactFloat64(),
+			DisplayAmount:          price.GetDisplayAmountWithPrecision(cost, lu.Price.Currency),
 			FilterValues:           make(price.JSONBFilters),
 			MeterID:                lu.MeterID,
 			Price:                  lu.Price,
 			BucketedUsageResult:    lu.BucketedResult,
 		}
+		charge.SetAmountWithCurrencyPrecision(cost, lu.Price.Currency)
+		charge.SetQuantityDecimal(quantity)
 
 		if lu.Meter != nil {
 			charge.MeterDisplayName = lu.Meter.Name

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3100,7 +3100,7 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 			totalOverageAmount = totalOverageAmount.Add(overageAmountDecimal)
 
 			charge.SetAmountWithCurrencyPrecision(overageAmountDecimal, subscription.Currency)
-			charge.DisplayAmount = overageAmountDecimal.StringFixed(6)
+			charge.DisplayAmount = price.FormatAmountToStringWithPrecision(charge.AmountDecimal(), subscription.Currency)
 			charge.IsOverage = true
 			charge.OverageFactor = overageFactorFloat
 			response.Charges = append(response.Charges, charge)
@@ -6505,7 +6505,7 @@ func (s *subscriptionService) buildMeterUsageResponse(ctx context.Context, subMe
 			totalOverageAmount = totalOverageAmount.Add(overageAmountDecimal)
 
 			charge.SetAmountWithCurrencyPrecision(overageAmountDecimal, sub.Currency)
-			charge.DisplayAmount = overageAmountDecimal.StringFixed(6)
+			charge.DisplayAmount = price.GetDisplayAmountWithPrecision(charge.AmountDecimal(), sub.Currency)
 			charge.IsOverage = true
 			charge.OverageFactor = overageFactorFloat
 			finalCharges = append(finalCharges, charge)

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3031,12 +3031,12 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 
 		for _, charge := range usageOnlyCharges {
 			// Get charge amount as decimal for precise calculations
-			chargeAmount := decimal.NewFromFloat(charge.Amount)
+			chargeAmount := charge.AmountDecimal()
 			pricePerUnit := decimal.Zero
 			if charge.Price != nil && charge.Price.BillingModel == types.BILLING_MODEL_FLAT_FEE {
 				pricePerUnit = charge.Price.Amount
 			} else if charge.Quantity > 0 {
-				pricePerUnit = chargeAmount.Div(decimal.NewFromFloat(charge.Quantity))
+				pricePerUnit = chargeAmount.Div(charge.QuantityDecimal())
 			}
 
 			// Normal price covers all of this charge
@@ -3065,15 +3065,15 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 				// Create the normal charge
 				if normalQuantityDecimal.GreaterThan(decimal.Zero) {
 					normalCharge := *charge // Create a copy
-					normalCharge.Quantity = normalQuantityDecimal.InexactFloat64()
-					normalCharge.Amount = price.FormatAmountToFloat64WithPrecision(normalAmountDecimal, subscription.Currency)
+					normalCharge.SetQuantityDecimal(normalQuantityDecimal)
+					normalCharge.SetAmountWithCurrencyPrecision(normalAmountDecimal, subscription.Currency)
 					normalCharge.DisplayAmount = price.FormatAmountToStringWithPrecision(normalAmountDecimal, subscription.Currency)
 					normalCharge.IsOverage = false
 					response.Charges = append(response.Charges, &normalCharge)
 				}
 
 				// Calculate overage quantity and amount
-				overageQuantityDecimal := decimal.NewFromFloat(charge.Quantity).Sub(normalQuantityDecimal)
+				overageQuantityDecimal := charge.QuantityDecimal().Sub(normalQuantityDecimal)
 
 				// Create the overage charge only if there's actual overage
 				if overageQuantityDecimal.GreaterThan(decimal.Zero) {
@@ -3081,8 +3081,8 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 					totalOverageAmount = totalOverageAmount.Add(overageAmountDecimal)
 
 					overageCharge := *charge // Create a copy
-					overageCharge.Quantity = overageQuantityDecimal.InexactFloat64()
-					overageCharge.Amount = price.FormatAmountToFloat64WithPrecision(overageAmountDecimal, subscription.Currency)
+					overageCharge.SetQuantityDecimal(overageQuantityDecimal)
+					overageCharge.SetAmountWithCurrencyPrecision(overageAmountDecimal, subscription.Currency)
 					overageCharge.DisplayAmount = price.FormatAmountToStringWithPrecision(overageAmountDecimal, subscription.Currency)
 					overageCharge.IsOverage = true
 					overageCharge.OverageFactor = overageFactorFloat
@@ -3099,7 +3099,7 @@ func (s *subscriptionService) GetUsageBySubscription(ctx context.Context, req *d
 			overageAmountDecimal := chargeAmount.Mul(overageFactor)
 			totalOverageAmount = totalOverageAmount.Add(overageAmountDecimal)
 
-			charge.Amount = price.FormatAmountToFloat64WithPrecision(overageAmountDecimal, subscription.Currency)
+			charge.SetAmountWithCurrencyPrecision(overageAmountDecimal, subscription.Currency)
 			charge.DisplayAmount = overageAmountDecimal.StringFixed(6)
 			charge.IsOverage = true
 			charge.OverageFactor = overageFactorFloat
@@ -3889,17 +3889,16 @@ func createChargeResponse(priceObj *price.Price, quantity decimal.Decimal, cost 
 		return nil
 	}
 
-	finalAmount := price.FormatAmountToFloat64WithPrecision(cost, priceObj.Currency)
-
-	return &dto.SubscriptionUsageByMetersResponse{
-		Amount:           finalAmount,
+	charge := &dto.SubscriptionUsageByMetersResponse{
 		Currency:         priceObj.Currency,
 		DisplayAmount:    price.GetDisplayAmountWithPrecision(cost, priceObj.Currency),
-		Quantity:         quantity.InexactFloat64(),
 		MeterID:          priceObj.MeterID,
 		MeterDisplayName: meterDisplayName,
 		Price:            priceObj,
 	}
+	charge.SetAmountWithCurrencyPrecision(cost, priceObj.Currency)
+	charge.SetQuantityDecimal(quantity)
+	return charge
 }
 
 // filterValidPricesForSubscription filters prices that are valid for a subscription.
@@ -6452,12 +6451,12 @@ func (s *subscriptionService) buildMeterUsageResponse(ctx context.Context, subMe
 		totalOverageAmount := decimal.Zero
 
 		for _, charge := range usageOnlyCharges {
-			chargeAmount := decimal.NewFromFloat(charge.Amount)
+			chargeAmount := charge.AmountDecimal()
 			pricePerUnit := decimal.Zero
 			if charge.Price != nil && charge.Price.BillingModel == types.BILLING_MODEL_FLAT_FEE {
 				pricePerUnit = charge.Price.Amount
 			} else if charge.Quantity > 0 {
-				pricePerUnit = chargeAmount.Div(decimal.NewFromFloat(charge.Quantity))
+				pricePerUnit = chargeAmount.Div(charge.QuantityDecimal())
 			}
 
 			if remainingCommitment.GreaterThanOrEqual(chargeAmount) {
@@ -6476,21 +6475,21 @@ func (s *subscriptionService) buildMeterUsageResponse(ctx context.Context, subMe
 
 				if normalQuantityDecimal.GreaterThan(decimal.Zero) {
 					normalCharge := *charge
-					normalCharge.Quantity = normalQuantityDecimal.InexactFloat64()
-					normalCharge.Amount = price.FormatAmountToFloat64WithPrecision(normalAmountDecimal, sub.Currency)
+					normalCharge.SetQuantityDecimal(normalQuantityDecimal)
+					normalCharge.SetAmountWithCurrencyPrecision(normalAmountDecimal, sub.Currency)
 					normalCharge.DisplayAmount = price.FormatAmountToStringWithPrecision(normalAmountDecimal, sub.Currency)
 					normalCharge.IsOverage = false
 					finalCharges = append(finalCharges, &normalCharge)
 				}
 
-				overageQuantityDecimal := decimal.NewFromFloat(charge.Quantity).Sub(normalQuantityDecimal)
+				overageQuantityDecimal := charge.QuantityDecimal().Sub(normalQuantityDecimal)
 				if overageQuantityDecimal.GreaterThan(decimal.Zero) {
 					overageAmountDecimal := overageQuantityDecimal.Mul(pricePerUnit).Mul(overageFactor)
 					totalOverageAmount = totalOverageAmount.Add(overageAmountDecimal)
 
 					overageCharge := *charge
-					overageCharge.Quantity = overageQuantityDecimal.InexactFloat64()
-					overageCharge.Amount = price.FormatAmountToFloat64WithPrecision(overageAmountDecimal, sub.Currency)
+					overageCharge.SetQuantityDecimal(overageQuantityDecimal)
+					overageCharge.SetAmountWithCurrencyPrecision(overageAmountDecimal, sub.Currency)
 					overageCharge.DisplayAmount = price.GetDisplayAmountWithPrecision(overageAmountDecimal, sub.Currency)
 					overageCharge.IsOverage = true
 					overageCharge.OverageFactor = overageFactorFloat
@@ -6505,7 +6504,7 @@ func (s *subscriptionService) buildMeterUsageResponse(ctx context.Context, subMe
 			overageAmountDecimal := chargeAmount.Mul(overageFactor)
 			totalOverageAmount = totalOverageAmount.Add(overageAmountDecimal)
 
-			charge.Amount = price.FormatAmountToFloat64WithPrecision(overageAmountDecimal, sub.Currency)
+			charge.SetAmountWithCurrencyPrecision(overageAmountDecimal, sub.Currency)
 			charge.DisplayAmount = overageAmountDecimal.StringFixed(6)
 			charge.IsOverage = true
 			charge.OverageFactor = overageFactorFloat


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing accuracy by preserving exact usage quantities and charge amounts during calculations.
  * Applied currency-aware rounding consistently to usage charges, commitments, entitlements, grants, and overage calculations.
  * Prevented precision loss at billing boundaries, especially for high-precision quantities and fractional amounts.
  * Updated usage summaries and billing charges to display totals with more reliable currency precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Preserve exact decimal precision in billing calculations

### What Changed
- Billing now keeps exact usage quantities and amounts throughout entitlement, overage, commitment, and invoice calculations instead of converting through floating-point values.
- Currency amounts are rounded at the correct currency precision while API responses retain their existing numeric fields.
- High-precision usage quantities and values near cent-rounding boundaries no longer produce incorrect totals or charge splits.
- Added tests covering rounding-boundary amounts and high-precision quantities.

### Impact
`✅ Accurate currency rounding at billing boundaries`
`✅ Precise high-volume usage quantities`
`✅ Consistent commitment and overage totals`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
