### PR TITLE
fix(coupon): Enforce max redemption in on-off invoices

### DIFF
--- a/internal/ee/service/coupon_application.go
+++ b/internal/ee/service/coupon_application.go
@@ -346,12 +346,14 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 		// Deduped by coupon_id so a coupon that appears on both a line item and at
 		// invoice level (or twice at line-item level) counts as one redemption per
 		// invoice, matching the "one use of the code" semantic.
-		// Idempotency: skip increment if a CouponApplication for this
-		// (invoice_id, coupon_id) already exists — protects against ComputeInvoice
-		// retries after a failed FinalizeInvoice (line-item discounts get reset by
-		// reconcileLineItems but CouponApplication rows persist; without this,
-		// retries would over-count redemptions).
+		// Idempotency: skip increment AND persistence if a CouponApplication for
+		// this (invoice_id, coupon_id) already exists — protects against
+		// ComputeInvoice retries after a failed FinalizeInvoice (line-item
+		// discounts get reset by reconcileLineItems but CouponApplication rows
+		// persist; without this, retries would over-count redemptions and insert
+		// duplicate application rows).
 		seen := make(map[string]bool)
+		alreadyPersisted := make(map[string]bool)
 		for _, ca := range appliedCoupons {
 			if ca.CouponApplication.CouponAssociationID != "" {
 				continue
@@ -375,6 +377,7 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 				return countErr
 			}
 			if existing > 0 {
+				alreadyPersisted[couponID] = true
 				continue
 			}
 
@@ -387,8 +390,13 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 			}
 		}
 
-		// Persist coupon applications
+		// Persist coupon applications. Skip one-off entries whose (invoice_id,
+		// coupon_id) already has rows from a prior compute — otherwise a retry
+		// would insert duplicates.
 		for _, ca := range appliedCoupons {
+			if ca.CouponApplication.CouponAssociationID == "" && alreadyPersisted[ca.CouponApplication.CouponID] {
+				continue
+			}
 			if err := s.CouponApplicationRepo.Create(txCtx, ca.CouponApplication); err != nil {
 				s.Logger.Error(ctx, "failed to create coupon application",
 					"coupon_application_id", ca.CouponApplication.ID,

--- a/internal/ee/service/coupon_application.go
+++ b/internal/ee/service/coupon_application.go
@@ -340,6 +340,53 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 	totalDiscountAmount := totalLineItemDiscount.Add(totalInvoiceLevelDiscount)
 
 	err = s.DB.WithTx(ctx, func(txCtx context.Context) error {
+		// Enforce MaxRedemptions for one-off applications (nil CouponAssociationID).
+		// Subscription-attached coupons are already counted during createCouponAssociation;
+		// re-counting them here would multiply redemptions by number of invoices.
+		// Deduped by coupon_id so a coupon that appears on both a line item and at
+		// invoice level (or twice at line-item level) counts as one redemption per
+		// invoice, matching the "one use of the code" semantic.
+		// Idempotency: skip increment if a CouponApplication for this
+		// (invoice_id, coupon_id) already exists — protects against ComputeInvoice
+		// retries after a failed FinalizeInvoice (line-item discounts get reset by
+		// reconcileLineItems but CouponApplication rows persist; without this,
+		// retries would over-count redemptions).
+		seen := make(map[string]bool)
+		for _, ca := range appliedCoupons {
+			if ca.CouponApplication.CouponAssociationID != "" {
+				continue
+			}
+			couponID := ca.CouponApplication.CouponID
+			if seen[couponID] {
+				continue
+			}
+			seen[couponID] = true
+
+			existing, countErr := s.CouponApplicationRepo.Count(txCtx, &types.CouponApplicationFilter{
+				QueryFilter: types.NewNoLimitQueryFilter(),
+				InvoiceIDs:  []string{inv.ID},
+				CouponIDs:   []string{couponID},
+			})
+			if countErr != nil {
+				s.Logger.Error(txCtx, "failed to count existing coupon applications for redemption idempotency",
+					"error", countErr,
+					"invoice_id", inv.ID,
+					"coupon_id", couponID)
+				return countErr
+			}
+			if existing > 0 {
+				continue
+			}
+
+			if err := s.CouponRepo.IncrementRedemptions(txCtx, couponID, couponsMap[couponID].MaxRedemptions); err != nil {
+				s.Logger.Error(txCtx, "failed to increment coupon redemptions",
+					"error", err,
+					"invoice_id", inv.ID,
+					"coupon_id", couponID)
+				return err
+			}
+		}
+
 		// Persist coupon applications
 		for _, ca := range appliedCoupons {
 			if err := s.CouponApplicationRepo.Create(txCtx, ca.CouponApplication); err != nil {

--- a/internal/ee/service/coupon_application_test.go
+++ b/internal/ee/service/coupon_application_test.go
@@ -252,7 +252,10 @@ func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_SubscriptionAs
 // TestApplyCouponsToInvoice_RepeatedCompute_NoDoubleIncrement confirms
 // idempotency: if ComputeInvoice is retried on the same one-off Draft (e.g.
 // after a prior successful compute but failed finalize), the second apply
-// must not double-count the redemption.
+// must not double-count the redemption OR persist duplicate CouponApplication
+// rows. This is the persistence-level guard requested by review: the earlier
+// fix protected TotalRedemptions but the persistence loop was still inserting
+// new rows on every retry.
 func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_RepeatedCompute_NoDoubleIncrement() {
 	ctx := s.GetContext()
 
@@ -275,6 +278,13 @@ func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_RepeatedComput
 	s.Require().NoError(err)
 	s.Equal(1, afterFirst.TotalRedemptions)
 
+	appFilter := types.NewNoLimitCouponApplicationFilter()
+	appFilter.InvoiceIDs = []string{inv.ID}
+	appFilter.CouponIDs = []string{c.ID}
+	firstRows, err := s.GetStores().CouponApplicationRepo.List(ctx, appFilter)
+	s.Require().NoError(err)
+	s.Len(firstRows, 1, "first apply should persist exactly one CouponApplication")
+
 	// Second apply on same invoice (recompute retry). Reset the line-item
 	// discount as reconcileLineItems would; the CouponApplication row from
 	// the first apply persists.
@@ -290,4 +300,8 @@ func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_RepeatedComput
 	afterSecond, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
 	s.Require().NoError(err)
 	s.Equal(1, afterSecond.TotalRedemptions, "recompute of same invoice must not double-count redemption")
+
+	secondRows, err := s.GetStores().CouponApplicationRepo.List(ctx, appFilter)
+	s.Require().NoError(err)
+	s.Len(secondRows, 1, "recompute must not persist duplicate CouponApplication rows for the same (invoice, coupon)")
 }

--- a/internal/ee/service/coupon_application_test.go
+++ b/internal/ee/service/coupon_application_test.go
@@ -289,13 +289,15 @@ func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_RepeatedComput
 	// discount as reconcileLineItems would; the CouponApplication row from
 	// the first apply persists.
 	inv.LineItems[0].LineItemDiscount = decimal.Zero
-	_, err = s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+	recomputeRes, err := s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
 		Invoice: inv,
 		LineItemCoupons: []dto.InvoiceLineItemCoupon{
 			{LineItemID: priceID, CouponID: c.ID},
 		},
 	})
 	s.Require().NoError(err)
+	s.True(recomputeRes.TotalDiscountAmount.IsPositive(), "recompute must still apply the discount so the invoice total is correct after reconcileLineItems reset it")
+	s.True(inv.LineItems[0].LineItemDiscount.IsPositive(), "recompute must restore the line-item discount reset by reconcileLineItems")
 
 	afterSecond, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
 	s.Require().NoError(err)

--- a/internal/ee/service/coupon_application_test.go
+++ b/internal/ee/service/coupon_application_test.go
@@ -1,0 +1,293 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	coupon_domain "github.com/flexprice/flexprice/internal/domain/coupon"
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	invoice_domain "github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// CouponApplicationServiceSuite covers the VAPT-driven redemption enforcement
+// for ApplyCouponsToInvoice: one-off invoice applications must count against
+// MaxRedemptions, subscription-attached applications must not (already counted
+// at association time), and repeated compute of the same draft must not
+// double-count.
+type CouponApplicationServiceSuite struct {
+	testutil.BaseServiceTestSuite
+	service  CouponApplicationService
+	testData struct {
+		customer *customer.Customer
+	}
+}
+
+func TestCouponApplicationService(t *testing.T) {
+	suite.Run(t, new(CouponApplicationServiceSuite))
+}
+
+func (s *CouponApplicationServiceSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.service = NewCouponApplicationService(s.newServiceParams())
+	s.setupTestData()
+}
+
+func (s *CouponApplicationServiceSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+}
+
+func (s *CouponApplicationServiceSuite) newServiceParams() ServiceParams {
+	stores := s.GetStores()
+	return ServiceParams{
+		Logger:                   s.GetLogger(),
+		Config:                   s.GetConfig(),
+		DB:                       s.GetDB(),
+		SubRepo:                  stores.SubscriptionRepo,
+		SubscriptionLineItemRepo: stores.SubscriptionLineItemRepo,
+		PriceRepo:                stores.PriceRepo,
+		MeterRepo:                stores.MeterRepo,
+		CustomerRepo:             stores.CustomerRepo,
+		InvoiceRepo:              stores.InvoiceRepo,
+		InvoiceLineItemRepo:      stores.InvoiceLineItemRepo,
+		CouponRepo:               stores.CouponRepo,
+		CouponAssociationRepo:    stores.CouponAssociationRepo,
+		CouponApplicationRepo:    stores.CouponApplicationRepo,
+		EventPublisher:           s.GetPublisher(),
+		WebhookPublisher:         s.GetWebhookPublisher(),
+	}
+}
+
+func (s *CouponApplicationServiceSuite) setupTestData() {
+	ctx := s.GetContext()
+	s.testData.customer = &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: "ext_cust_coupon_app",
+		Name:       "Coupon Application Customer",
+		Email:      "coupon-app@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(ctx, s.testData.customer))
+}
+
+func (s *CouponApplicationServiceSuite) createPublishedCoupon(name string, maxRedemptions *int) *coupon_domain.Coupon {
+	ctx := s.GetContext()
+	pct := decimal.NewFromInt(10)
+	c := &coupon_domain.Coupon{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON),
+		Name:           name,
+		Type:           types.CouponTypePercentage,
+		Cadence:        types.CouponCadenceOnce,
+		PercentageOff:  &pct,
+		MaxRedemptions: maxRedemptions,
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	c.Status = types.StatusPublished
+	s.NoError(s.GetStores().CouponRepo.Create(ctx, c))
+	return c
+}
+
+func (s *CouponApplicationServiceSuite) createOneOffInvoiceWithLineItem(id string, priceID string, amount decimal.Decimal) *invoice_domain.Invoice {
+	ctx := s.GetContext()
+	li := &invoice_domain.InvoiceLineItem{
+		ID:                    types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE_LINE_ITEM),
+		CustomerID:            s.testData.customer.ID,
+		InvoiceID:             id,
+		PriceID:               lo.ToPtr(priceID),
+		Amount:                amount,
+		Currency:              "usd",
+		Quantity:              decimal.NewFromInt(1),
+		LineItemDiscount:      decimal.Zero,
+		InvoiceLevelDiscount:  decimal.Zero,
+		PrepaidCreditsApplied: decimal.Zero,
+		BaseModel:             types.GetDefaultBaseModel(ctx),
+	}
+	inv := &invoice_domain.Invoice{
+		ID:              id,
+		CustomerID:      s.testData.customer.ID,
+		Currency:        "usd",
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusDraft,
+		Subtotal:        amount,
+		Total:           amount,
+		AmountDue:       amount,
+		AmountRemaining: amount,
+		LineItems:       []*invoice_domain.InvoiceLineItem{li},
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.CreateWithLineItems(ctx, inv))
+	return inv
+}
+
+// TestApplyCouponsToInvoice_OneOff_IncrementsRedemption is the core VAPT fix:
+// applying a coupon to a one-off invoice must increment TotalRedemptions.
+// Before this fix, one-off invoices could apply a coupon unlimited times
+// without ever counting against MaxRedemptions (the counter was only bumped
+// during subscription association).
+func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_OneOff_IncrementsRedemption() {
+	ctx := s.GetContext()
+
+	maxRedemptions := 2
+	c := s.createPublishedCoupon("one-off limited", &maxRedemptions)
+
+	priceID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)
+
+	// First one-off apply: MUST increment TotalRedemptions from 0 to 1.
+	inv1 := s.createOneOffInvoiceWithLineItem(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE), priceID, decimal.NewFromInt(100))
+	res, err := s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv1,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID},
+		},
+	})
+	s.Require().NoError(err)
+	s.True(res.TotalDiscountAmount.IsPositive(), "discount should apply on first one-off use")
+
+	updated, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(1, updated.TotalRedemptions, "TotalRedemptions must be 1 after first one-off application")
+
+	// Second one-off apply: also increments. TotalRedemptions -> 2.
+	inv2 := s.createOneOffInvoiceWithLineItem(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE), priceID, decimal.NewFromInt(100))
+	_, err = s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv2,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID},
+		},
+	})
+	s.Require().NoError(err)
+	updated, err = s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(2, updated.TotalRedemptions, "TotalRedemptions must be 2 after second one-off application")
+
+	// Third one-off apply: MaxRedemptions=2 reached. couponService.ApplyDiscount
+	// rejects via coupon.IsValid() (existing check), so the coupon is silently
+	// skipped and no discount is applied. TotalRedemptions must stay at 2.
+	inv3 := s.createOneOffInvoiceWithLineItem(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE), priceID, decimal.NewFromInt(100))
+	res, err = s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv3,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID},
+		},
+	})
+	s.Require().NoError(err)
+	s.True(res.TotalDiscountAmount.IsZero(), "exhausted coupon must not discount the invoice")
+
+	filter := types.NewNoLimitCouponApplicationFilter()
+	filter.InvoiceIDs = []string{inv3.ID}
+	rows, err := s.GetStores().CouponApplicationRepo.List(ctx, filter)
+	s.Require().NoError(err)
+	s.Empty(rows, "exhausted coupon must not persist a CouponApplication row on inv3")
+
+	updated, err = s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(2, updated.TotalRedemptions, "TotalRedemptions must stay at 2 after exhausted apply")
+}
+
+// TestApplyCouponsToInvoice_SameCouponOnLineItemAndInvoice_CountsOnce confirms
+// that a coupon appearing in both line-item and invoice-level lists on the same
+// invoice counts as one redemption, not two.
+func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_SameCouponOnLineItemAndInvoice_CountsOnce() {
+	ctx := s.GetContext()
+
+	max := 5
+	c := s.createPublishedCoupon("dedup coupon", &max)
+
+	priceID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)
+	inv := s.createOneOffInvoiceWithLineItem(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE), priceID, decimal.NewFromInt(200))
+
+	_, err := s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID},
+		},
+		InvoiceCoupons: []dto.InvoiceCoupon{
+			{CouponID: c.ID},
+		},
+	})
+	s.Require().NoError(err)
+
+	updated, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(1, updated.TotalRedemptions, "same coupon on line-item + invoice-level = one redemption per invoice")
+}
+
+// TestApplyCouponsToInvoice_SubscriptionAssociation_NoIncrement confirms the
+// subscription path is unaffected: coupons carrying a CouponAssociationID were
+// already counted at association time and must not be re-counted per invoice.
+func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_SubscriptionAssociation_NoIncrement() {
+	ctx := s.GetContext()
+
+	c := s.createPublishedCoupon("sub-attached", nil)
+
+	// Simulate the association-time increment that ApplyCouponsToSubscription
+	// would have performed: bump TotalRedemptions to 1 before the invoice apply.
+	s.NoError(s.GetStores().CouponRepo.IncrementRedemptions(ctx, c.ID, nil))
+	before, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(1, before.TotalRedemptions)
+
+	priceID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)
+	inv := s.createOneOffInvoiceWithLineItem(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE), priceID, decimal.NewFromInt(100))
+
+	assocID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON_ASSOCIATION)
+	_, err = s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID, CouponAssociationID: &assocID},
+		},
+	})
+	s.Require().NoError(err)
+
+	after, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(1, after.TotalRedemptions, "subscription-attached apply must NOT re-increment redemptions")
+}
+
+// TestApplyCouponsToInvoice_RepeatedCompute_NoDoubleIncrement confirms
+// idempotency: if ComputeInvoice is retried on the same one-off Draft (e.g.
+// after a prior successful compute but failed finalize), the second apply
+// must not double-count the redemption.
+func (s *CouponApplicationServiceSuite) TestApplyCouponsToInvoice_RepeatedCompute_NoDoubleIncrement() {
+	ctx := s.GetContext()
+
+	max := 2
+	c := s.createPublishedCoupon("idempotent coupon", &max)
+
+	priceID := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE)
+	inv := s.createOneOffInvoiceWithLineItem(types.GenerateUUIDWithPrefix(types.UUID_PREFIX_INVOICE), priceID, decimal.NewFromInt(100))
+
+	// First apply.
+	_, err := s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID},
+		},
+	})
+	s.Require().NoError(err)
+
+	afterFirst, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(1, afterFirst.TotalRedemptions)
+
+	// Second apply on same invoice (recompute retry). Reset the line-item
+	// discount as reconcileLineItems would; the CouponApplication row from
+	// the first apply persists.
+	inv.LineItems[0].LineItemDiscount = decimal.Zero
+	_, err = s.service.ApplyCouponsToInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice: inv,
+		LineItemCoupons: []dto.InvoiceLineItemCoupon{
+			{LineItemID: priceID, CouponID: c.ID},
+		},
+	})
+	s.Require().NoError(err)
+
+	afterSecond, err := s.GetStores().CouponRepo.Get(ctx, c.ID)
+	s.Require().NoError(err)
+	s.Equal(1, afterSecond.TotalRedemptions, "recompute of same invoice must not double-count redemption")
+}


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-time coupon redemptions are now counted accurately when applied to invoices.
  * Duplicate coupon references on the same invoice no longer consume additional redemptions.
  * Subscription-linked coupons are excluded from one-time redemption counts.
  * Recomputing an invoice draft no longer causes repeated redemption increments.
  * Coupons stop being applied after reaching their maximum redemption limit.
  * Coupon application updates remain consistent when redemption tracking cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Enforce coupon redemption limits for one-off invoices

### What Changed
- One-off invoice coupon uses now count toward the coupon’s redemption limit
- Coupons stop applying after reaching the configured maximum, without creating an application record or increasing the count
- The same coupon used multiple times on one invoice counts as a single redemption
- Recomputing the same invoice does not create duplicate applications or count the redemption again
- Subscription-attached coupons continue to count only when associated, not once per invoice
- Added coverage for redemption limits, duplicate uses, subscription behavior, and invoice retry scenarios

### Impact
`✅ Enforced coupon redemption limits`
`✅ No duplicate redemptions during invoice retries`
`✅ Consistent coupon counts across invoice types`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
