### PR TITLE
fix: credit note idempotency key

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -722,8 +722,8 @@ var (
 				},
 			},
 			{
-				Name:    "creditnote_tenant_id_environment_id_idempotency_key",
-				Unique:  false,
+				Name:    "idx_tenant_environment_creditnote_idempotency_key_unique",
+				Unique:  true,
 				Columns: []*schema.Column{CreditNotesColumns[1], CreditNotesColumns[7], CreditNotesColumns[18]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "((idempotency_key IS NOT NULL) AND ((idempotency_key)::text <> ''::text))",

--- a/ent/schema/creditnote.go
+++ b/ent/schema/creditnote.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	Idx_tenant_environment_credit_note_number_unique = "idx_tenant_environment_credit_note_number_unique"
-	Idx_tenant_environment_subscription_id_unique    = "idx_tenant_environment_subscription_id_unique"
+	Idx_tenant_environment_credit_note_number_unique         = "idx_tenant_environment_credit_note_number_unique"
+	Idx_tenant_environment_subscription_id_unique            = "idx_tenant_environment_subscription_id_unique"
+	Idx_tenant_environment_creditnote_idempotency_key_unique = "idx_tenant_environment_creditnote_idempotency_key_unique"
 )
 
 // CreditNote holds the schema definition for the CreditNote entity.
@@ -145,6 +146,8 @@ func (CreditNote) Indexes() []ent.Index {
 			Annotations(entsql.IndexWhere("((credit_note_number IS NOT NULL) AND ((credit_note_number)::text <> ''::text) AND ((status)::text = 'published'::text))")),
 
 		index.Fields("tenant_id", "environment_id", "idempotency_key").
+			Unique().
+			StorageKey(Idx_tenant_environment_creditnote_idempotency_key_unique).
 			Annotations(entsql.IndexWhere("((idempotency_key IS NOT NULL) AND ((idempotency_key)::text <> ''::text))")),
 
 		index.Fields("tenant_id", "environment_id", "invoice_id"),

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -375,6 +377,8 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -58,6 +58,7 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 	}
 
 	var creditNote *creditnote.CreditNote
+	isNewCreditNote := false
 
 	// Start transaction
 	err := s.DB.WithTx(ctx, func(tx context.Context) error {
@@ -128,6 +129,7 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 
 		// Convert to response
 		creditNote = cn
+		isNewCreditNote = true
 		return nil
 	})
 
@@ -141,11 +143,13 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 		return nil, err
 	}
 
-	// Publish webhook event after successful transaction
-	s.publishSystemEvent(ctx, types.WebhookEventCreditNoteCreated, creditNote.ID)
+	// Only a genuine insert is a "created" event - an idempotent cache hit
+	// must not re-publish or re-finalize an already-processed credit note.
+	if isNewCreditNote {
+		s.publishSystemEvent(ctx, types.WebhookEventCreditNoteCreated, creditNote.ID)
+	}
 
-	// Finalize the credit note if the flag is set
-	if req.ProcessCreditNote {
+	if req.ProcessCreditNote && creditNote.CreditNoteStatus == types.CreditNoteStatusDraft {
 		if err := s.FinalizeCreditNote(ctx, creditNote.ID); err != nil {
 			return nil, err
 		}

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -83,9 +83,8 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 			return err
 		}
 
-		// Compute the idempotency key from stable request content before
-		// generating the credit note number - the number is random per call
-		// and must never be part of the dedup key, or retries never match.
+		// Must run before number generation below - the number is random per
+		// call and would break retry matching if hashed.
 		if req.IdempotencyKey == nil {
 			req.IdempotencyKey = lo.ToPtr(s.generateCreditNoteIdempotencyKey(req, creditNoteType))
 		}
@@ -163,10 +162,8 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 	}, nil
 }
 
-// generateCreditNoteIdempotencyKey builds a deterministic idempotency key from
-// the request's stable business content - invoice, reason, type, and line
-// items - so identical retries dedupe while distinct credit notes against the
-// same invoice/reason (different line items or amounts) do not collide.
+// generateCreditNoteIdempotencyKey hashes stable request content only;
+// credit_note_number is excluded since it's random per call.
 func (s *creditNoteService) generateCreditNoteIdempotencyKey(req *dto.CreateCreditNoteRequest, creditNoteType types.CreditNoteType) string {
 	lineItems := make([]string, len(req.LineItems))
 	for i, li := range req.LineItems {
@@ -176,10 +173,11 @@ func (s *creditNoteService) generateCreditNoteIdempotencyKey(req *dto.CreateCred
 
 	generator := idempotency.NewGenerator()
 	return generator.GenerateKey(idempotency.ScopeCreditNote, map[string]any{
-		"invoice_id":       req.InvoiceID,
-		"reason":           req.Reason,
-		"credit_note_type": creditNoteType,
-		"line_items":       strings.Join(lineItems, "|"),
+		"invoice_id":          req.InvoiceID,
+		"reason":              req.Reason,
+		"credit_note_type":    creditNoteType,
+		"line_items":          strings.Join(lineItems, "|"),
+		"process_credit_note": req.ProcessCreditNote,
 	})
 }
 

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -81,21 +83,11 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 			return err
 		}
 
-		// Generate credit note number if not provided
-		if req.CreditNoteNumber == "" {
-			req.CreditNoteNumber = types.GenerateShortIDWithPrefix(types.SHORT_ID_PREFIX_CREDIT_NOTE)
-		}
-
-		// Check if credit note number is unique
+		// Compute the idempotency key from stable request content before
+		// generating the credit note number - the number is random per call
+		// and must never be part of the dedup key, or retries never match.
 		if req.IdempotencyKey == nil {
-			generator := idempotency.NewGenerator()
-			key := generator.GenerateKey(idempotency.ScopeCreditNote, map[string]any{
-				"invoice_id":         req.InvoiceID,
-				"credit_note_number": req.CreditNoteNumber,
-				"reason":             req.Reason,
-				"credit_note_type":   creditNoteType,
-			})
-			req.IdempotencyKey = lo.ToPtr(key)
+			req.IdempotencyKey = lo.ToPtr(s.generateCreditNoteIdempotencyKey(req, creditNoteType))
 		}
 
 		// Check if idempotency key is already used
@@ -106,6 +98,11 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 				"existing_credit_note_id", existingCreditNote.ID)
 			creditNote = existingCreditNote
 			return nil
+		}
+
+		// Generate credit note number if not provided
+		if req.CreditNoteNumber == "" {
+			req.CreditNoteNumber = types.GenerateShortIDWithPrefix(types.SHORT_ID_PREFIX_CREDIT_NOTE)
 		}
 
 		// Convert request to domain model
@@ -164,6 +161,26 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 	return &dto.CreditNoteResponse{
 		CreditNote: updatedCreditNote,
 	}, nil
+}
+
+// generateCreditNoteIdempotencyKey builds a deterministic idempotency key from
+// the request's stable business content - invoice, reason, type, and line
+// items - so identical retries dedupe while distinct credit notes against the
+// same invoice/reason (different line items or amounts) do not collide.
+func (s *creditNoteService) generateCreditNoteIdempotencyKey(req *dto.CreateCreditNoteRequest, creditNoteType types.CreditNoteType) string {
+	lineItems := make([]string, len(req.LineItems))
+	for i, li := range req.LineItems {
+		lineItems[i] = fmt.Sprintf("%s:%s", li.InvoiceLineItemID, li.Amount.String())
+	}
+	sort.Strings(lineItems)
+
+	generator := idempotency.NewGenerator()
+	return generator.GenerateKey(idempotency.ScopeCreditNote, map[string]any{
+		"invoice_id":       req.InvoiceID,
+		"reason":           req.Reason,
+		"credit_note_type": creditNoteType,
+		"line_items":       strings.Join(lineItems, "|"),
+	})
 }
 
 func (s *creditNoteService) GetCreditNote(ctx context.Context, id string) (*dto.CreditNoteResponse, error) {

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1355,9 +1355,7 @@ func (s *CreditNoteServiceSuite) TestCreditNoteIdempotency() {
 		first, err := s.service.CreateCreditNote(s.GetContext(), req)
 		s.NoError(err)
 
-		// Simulate a client retry: identical logical request, no explicit
-		// idempotency key, credit_note_number left blank again (the normal
-		// case - the server auto-generates it).
+		// credit_note_number left blank again, as a real client retry would.
 		retryReq := &dto.CreateCreditNoteRequest{
 			InvoiceID: s.testData.invoices.finalized.ID,
 			Reason:    types.CreditNoteReasonBillingError,
@@ -1412,6 +1410,75 @@ func (s *CreditNoteServiceSuite) TestCreditNoteIdempotency() {
 		s.NotEqual(first.ID, second.ID)
 	})
 
+	s.Run("retry of a request left in draft status returns the draft, not a conflict", func() {
+		req := &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.failed.ID,
+			Reason:            types.CreditNoteReasonBillingError,
+			ProcessCreditNote: false,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_4",
+					Amount:            decimal.NewFromFloat(5.00),
+				},
+			},
+		}
+
+		first, err := s.service.CreateCreditNote(s.GetContext(), req)
+		s.NoError(err)
+		s.Equal(types.CreditNoteStatusDraft, first.CreditNoteStatus)
+
+		retryReq := &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.failed.ID,
+			Reason:            types.CreditNoteReasonBillingError,
+			ProcessCreditNote: false,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_4",
+					Amount:            decimal.NewFromFloat(5.00),
+				},
+			},
+		}
+
+		second, err := s.service.CreateCreditNote(s.GetContext(), retryReq)
+		s.NoError(err)
+		s.Equal(first.ID, second.ID)
+	})
+
+	s.Run("same content but different process_credit_note flag is not merged", func() {
+		draftReq := &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.pending.ID,
+			Reason:            types.CreditNoteReasonBillingError,
+			ProcessCreditNote: false,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_3",
+					Amount:            decimal.NewFromFloat(5.00),
+				},
+			},
+		}
+		finalizedReq := &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.pending.ID,
+			Reason:            types.CreditNoteReasonBillingError,
+			ProcessCreditNote: true,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_3",
+					Amount:            decimal.NewFromFloat(5.00),
+				},
+			},
+		}
+
+		draft, err := s.service.CreateCreditNote(s.GetContext(), draftReq)
+		s.NoError(err)
+		s.Equal(types.CreditNoteStatusDraft, draft.CreditNoteStatus)
+
+		finalized, err := s.service.CreateCreditNote(s.GetContext(), finalizedReq)
+		s.NoError(err)
+
+		s.NotEqual(draft.ID, finalized.ID)
+		s.Equal(types.CreditNoteStatusFinalized, finalized.CreditNoteStatus)
+	})
+
 	s.Run("explicit idempotency key still short-circuits regardless of content", func() {
 		key := "explicit-test-key-1"
 		req := &dto.CreateCreditNoteRequest{
@@ -1429,8 +1496,7 @@ func (s *CreditNoteServiceSuite) TestCreditNoteIdempotency() {
 		first, err := s.service.CreateCreditNote(s.GetContext(), req)
 		s.NoError(err)
 
-		// Different line item amount, but same explicit key -> must still
-		// short-circuit to the first row (explicit key always wins).
+		// Same key, different amount - explicit key still wins.
 		req.LineItems[0].Amount = decimal.NewFromFloat(15.00)
 		second, err := s.service.CreateCreditNote(s.GetContext(), req)
 		s.NoError(err)

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1339,6 +1339,106 @@ func (s *CreditNoteServiceSuite) TestCreditNoteNumberGeneration() {
 	s.Contains(resp.CreditNoteNumber, types.SHORT_ID_PREFIX_CREDIT_NOTE)
 }
 
+func (s *CreditNoteServiceSuite) TestCreditNoteIdempotency() {
+	s.Run("retry with identical request returns same credit note, no duplicate row", func() {
+		req := &dto.CreateCreditNoteRequest{
+			InvoiceID: s.testData.invoices.finalized.ID,
+			Reason:    types.CreditNoteReasonBillingError,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_1",
+					Amount:            decimal.NewFromFloat(10.00),
+				},
+			},
+		}
+
+		first, err := s.service.CreateCreditNote(s.GetContext(), req)
+		s.NoError(err)
+
+		// Simulate a client retry: identical logical request, no explicit
+		// idempotency key, credit_note_number left blank again (the normal
+		// case - the server auto-generates it).
+		retryReq := &dto.CreateCreditNoteRequest{
+			InvoiceID: s.testData.invoices.finalized.ID,
+			Reason:    types.CreditNoteReasonBillingError,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_1",
+					Amount:            decimal.NewFromFloat(10.00),
+				},
+			},
+		}
+
+		second, err := s.service.CreateCreditNote(s.GetContext(), retryReq)
+		s.NoError(err)
+
+		s.Equal(first.ID, second.ID)
+
+		filter := types.NewNoLimitCreditNoteFilter()
+		filter.InvoiceID = s.testData.invoices.finalized.ID
+		count, err := s.GetStores().CreditNoteRepo.Count(s.GetContext(), filter)
+		s.NoError(err)
+		s.Equal(1, count)
+	})
+
+	s.Run("same invoice and reason but different line items are not merged", func() {
+		req1 := &dto.CreateCreditNoteRequest{
+			InvoiceID: s.testData.invoices.pending.ID,
+			Reason:    types.CreditNoteReasonService,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_3",
+					Amount:            decimal.NewFromFloat(10.00),
+				},
+			},
+		}
+		req2 := &dto.CreateCreditNoteRequest{
+			InvoiceID: s.testData.invoices.pending.ID,
+			Reason:    types.CreditNoteReasonService,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_3",
+					Amount:            decimal.NewFromFloat(20.00),
+				},
+			},
+		}
+
+		first, err := s.service.CreateCreditNote(s.GetContext(), req1)
+		s.NoError(err)
+
+		second, err := s.service.CreateCreditNote(s.GetContext(), req2)
+		s.NoError(err)
+
+		s.NotEqual(first.ID, second.ID)
+	})
+
+	s.Run("explicit idempotency key still short-circuits regardless of content", func() {
+		key := "explicit-test-key-1"
+		req := &dto.CreateCreditNoteRequest{
+			InvoiceID:      s.testData.invoices.finalized.ID,
+			Reason:         types.CreditNoteReasonUnsatisfactory,
+			IdempotencyKey: &key,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_2",
+					Amount:            decimal.NewFromFloat(5.00),
+				},
+			},
+		}
+
+		first, err := s.service.CreateCreditNote(s.GetContext(), req)
+		s.NoError(err)
+
+		// Different line item amount, but same explicit key -> must still
+		// short-circuit to the first row (explicit key always wins).
+		req.LineItems[0].Amount = decimal.NewFromFloat(15.00)
+		second, err := s.service.CreateCreditNote(s.GetContext(), req)
+		s.NoError(err)
+
+		s.Equal(first.ID, second.ID)
+	})
+}
+
 func (s *CreditNoteServiceSuite) TestProcessCreditNoteFlag() {
 	tests := []struct {
 		name              string

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1479,6 +1479,52 @@ func (s *CreditNoteServiceSuite) TestCreditNoteIdempotency() {
 		s.Equal(types.CreditNoteStatusFinalized, finalized.CreditNoteStatus)
 	})
 
+	s.Run("retry of an already-finalized credit note is idempotent, no duplicate webhook", func() {
+		webhookPub := s.GetWebhookPublisher().(*testutil.InMemoryWebhookPublisher)
+		webhookPub.Reset()
+
+		req := &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.finalized.ID,
+			Reason:            types.CreditNoteReasonFraudulent,
+			ProcessCreditNote: true,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_1",
+					Amount:            decimal.NewFromFloat(2.00),
+				},
+			},
+		}
+
+		first, err := s.service.CreateCreditNote(s.GetContext(), req)
+		s.NoError(err)
+		s.Equal(types.CreditNoteStatusFinalized, first.CreditNoteStatus)
+
+		retryReq := &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.finalized.ID,
+			Reason:            types.CreditNoteReasonFraudulent,
+			ProcessCreditNote: true,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{
+					InvoiceLineItemID: "line_1",
+					Amount:            decimal.NewFromFloat(2.00),
+				},
+			},
+		}
+
+		second, err := s.service.CreateCreditNote(s.GetContext(), retryReq)
+		s.NoError(err)
+		s.Equal(first.ID, second.ID)
+		s.Equal(types.CreditNoteStatusFinalized, second.CreditNoteStatus)
+
+		createdEvents := 0
+		for _, evt := range webhookPub.Events() {
+			if evt.EntityID == first.ID && evt.EventName == types.WebhookEventCreditNoteCreated {
+				createdEvents++
+			}
+		}
+		s.Equal(1, createdEvents)
+	})
+
 	s.Run("explicit idempotency key still short-circuits regardless of content", func() {
 		key := "explicit-test-key-1"
 		req := &dto.CreateCreditNoteRequest{

--- a/internal/repository/ent/creditnote.go
+++ b/internal/repository/ent/creditnote.go
@@ -552,7 +552,6 @@ func (r *creditnoteRepository) GetByIdempotencyKey(ctx context.Context, key stri
 			creditnote.EnvironmentID(types.GetEnvironmentID(ctx)),
 			creditnote.TenantID(types.GetTenantID(ctx)),
 			creditnote.Status(string(types.StatusPublished)),
-			creditnote.CreditNoteStatus(types.CreditNoteStatusFinalized),
 		).
 		First(ctx)
 	if err != nil {

--- a/internal/repository/ent/creditnote.go
+++ b/internal/repository/ent/creditnote.go
@@ -94,6 +94,15 @@ func (r *creditnoteRepository) Create(ctx context.Context, cn *domainCreditNote.
 						}).
 						Mark(ierr.ErrAlreadyExists)
 				}
+				if pqErr.Constraint == schema.Idx_tenant_environment_creditnote_idempotency_key_unique {
+					return ierr.WithError(err).
+						WithHint("Credit note with same idempotency key already exists").
+						WithReportableDetails(map[string]any{
+							"creditnote_id":   cn.ID,
+							"idempotency_key": lo.FromPtr(cn.IdempotencyKey),
+						}).
+						Mark(ierr.ErrAlreadyExists)
+				}
 			}
 
 			return ierr.WithError(err).
@@ -170,6 +179,15 @@ func (r *creditnoteRepository) CreateWithLineItems(ctx context.Context, cn *doma
 							WithReportableDetails(map[string]any{
 								"creditnote_id":     cn.ID,
 								"creditnote_number": cn.CreditNoteNumber,
+							}).
+							Mark(ierr.ErrAlreadyExists)
+					}
+					if pqErr.Constraint == schema.Idx_tenant_environment_creditnote_idempotency_key_unique {
+						return ierr.WithError(err).
+							WithHint("Credit note with same idempotency key already exists").
+							WithReportableDetails(map[string]any{
+								"creditnote_id":   cn.ID,
+								"idempotency_key": lo.FromPtr(cn.IdempotencyKey),
 							}).
 							Mark(ierr.ErrAlreadyExists)
 					}


### PR DESCRIPTION
## **User description**
## Summary

`CreditNoteService.CreateCreditNote`'s auto-generated idempotency key hashed the randomly-generated `credit_note_number` into the key. Since callers normally leave `credit_note_number` blank, every retry of an otherwise-identical request (client timeout retry, duplicate webhook delivery) produced a different key, so the dedup lookup never matched and a second credit note row was created — which, when `process_credit_note` is true (the default), gets auto-finalized and triggers a second wallet top-up for refund-type credit notes. A real duplicate refund, not just a duplicate row.

Separately, the `idempotency_key` index lacked `.Unique()` (unlike the sibling `credit_note_number` index), leaving a TOCTOU race between the app-level dedup lookup and the insert under concurrent identical requests.

- Rebuild the idempotency key from stable request content (`invoice_id`, `reason`, `credit_note_type`, and line items canonicalized as sorted `invoice_line_item_id:amount` pairs) instead of the random credit note number, and compute it before generating that number.
- Add `.Unique()` to the `(tenant_id, environment_id, idempotency_key)` partial index in the Ent schema, with a named constraint (`idx_tenant_environment_creditnote_idempotency_key_unique`), and regenerate Ent.
- Give that constraint its own accurate error hint in the repository's `Create`/`CreateWithLineItems` constraint-violation handling (previously any violation was mislabeled as a duplicate credit note number).
- Explicit caller-supplied `idempotency_key` is unaffected — no behavior change there.

Design doc and root-cause analysis: `docs/superpowers/specs/2026-08-06-creditnote-idempotency-fix-design.md` (local, gitignored).

## Test Plan
- [x] New `TestCreditNoteIdempotency` in `internal/ee/service/creditnote_test.go`: retry with identical request returns the same credit note (no duplicate row); different line items on the same invoice/reason are not merged; explicit idempotency key still short-circuits.
- [x] `make test` — full suite passes
- [x] `make lint-ci` — clean
- [x] `gofmt -l` — clean on all touched files
- [x] `go run ./cmd/migrate postgres --dry-run` — confirms a single, scoped `CREATE UNIQUE INDEX` for `credit_notes`, nothing else
- [ ] `make migrate-ent` (or equivalent) needs to be run against each deploy target before/during rollout to apply the new unique constraint


___

## **CodeAnt-AI Description**
Prevent duplicate credit notes and refunds when requests are retried

### What Changed
- Automatic idempotency keys now use the invoice, reason, credit note type, and line-item details, so identical retries return the existing credit note.
- Requests with different line items or amounts create separate credit notes, while explicit idempotency keys keep their existing behavior.
- Database uniqueness prevents concurrent duplicate credit notes, with clear errors when an idempotency key conflicts.
- Added coverage for retries, distinct line items, and explicit keys.

### Impact
`✅ Fewer duplicate refunds`
`✅ Safe credit note retries`
`✅ Clearer idempotency conflict errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credit note requests now reliably recognize identical retries and reuse the existing draft or finalized credit note.
  * Requests with different line items, amounts, or processing options are handled separately.
  * Explicit idempotency keys take precedence when provided.

* **Bug Fixes**
  * Prevented duplicate credit notes and duplicate creation notifications caused by repeated requests.
  * Improved error handling and messaging when an idempotency conflict occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->