### PR TITLE
fix(creditnote): lock invoice and re-check refund capacity on finalize/void

### DIFF
--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -409,22 +409,29 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 	// Store original status for logging
 	originalStatus := cn.CreditNoteStatus
 
-	// Recalculate before flipping status, so a failure never leaves the credit note half-voided.
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
 		if originalStatus == types.CreditNoteStatusFinalized {
 			// Lock to serialize against a concurrent finalize/void on the same invoice.
 			if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
 				return err
 			}
+		}
 
+		cn.CreditNoteStatus = types.CreditNoteStatusVoided
+		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {
+			return err
+		}
+
+		if originalStatus == types.CreditNoteStatusFinalized {
+			// Status must be persisted as Voided before this runs: RecalculateInvoiceAmounts
+			// sums all Finalized credit notes, and would otherwise still count this one.
 			invoiceService := NewInvoiceService(s.ServiceParams)
 			if err := invoiceService.RecalculateInvoiceAmounts(tx, cn.InvoiceID); err != nil {
 				return err
 			}
 		}
 
-		cn.CreditNoteStatus = types.CreditNoteStatusVoided
-		return s.CreditNoteRepo.Update(tx, cn)
+		return nil
 	})
 	if err != nil {
 		s.Logger.Error(ctx, "failed to void credit note",
@@ -486,11 +493,10 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 			return err
 		}
 
-		// Re-check capacity under the lock: another credit note may have consumed it since draft creation.
-		maxCreditableAmount, err := s.calculateMaxCreditableAmount(tx, lockedInv)
-		if err != nil {
-			return err
-		}
+		// Re-check capacity under the lock: another credit note may have consumed it since draft
+		// creation. Use cn's own type, not the invoice's current derived type, which may have
+		// drifted (e.g. payment succeeded after this draft was created as an adjustment).
+		maxCreditableAmount := s.calculateMaxCreditableAmount(tx, lockedInv, cn.CreditNoteType)
 		if cn.TotalAmount.GreaterThan(maxCreditableAmount) {
 			return ierr.NewError("credit amount exceeds available limit").
 				WithHintf(
@@ -636,11 +642,12 @@ func (s *creditNoteService) validateInvoiceEligibility(ctx context.Context, invo
 
 // validateCreditNoteAmounts validates credit note amounts and line items
 func (s *creditNoteService) validateCreditNoteAmounts(ctx context.Context, req *dto.CreateCreditNoteRequest, inv *invoice.Invoice) error {
-	// Determine the max creditable amount
-	maxCreditableAmount, err := s.calculateMaxCreditableAmount(ctx, inv)
+	creditNoteType, err := s.getCreditNoteType(inv)
 	if err != nil {
 		return err
 	}
+
+	maxCreditableAmount := s.calculateMaxCreditableAmount(ctx, inv, creditNoteType)
 
 	// Validate line items and calculate total amount
 	totalCreditNoteAmount, err := s.validateLineItems(req, inv)
@@ -650,9 +657,6 @@ func (s *creditNoteService) validateCreditNoteAmounts(ctx context.Context, req *
 
 	// Check if total amount exceeds max creditable amount
 	if totalCreditNoteAmount.GreaterThan(maxCreditableAmount) {
-		// Determine credit note type for better messaging
-		creditNoteType, _ := s.getCreditNoteType(inv)
-
 		var messageTemplate string
 		if creditNoteType == types.CreditNoteTypeRefund {
 			messageTemplate = "You can only refund up to %s for this invoice. You're trying to refund %s, but only %s is available based on payments received."
@@ -678,13 +682,8 @@ func (s *creditNoteService) validateCreditNoteAmounts(ctx context.Context, req *
 	return nil
 }
 
-// calculateMaxCreditableAmount calculates the maximum amount that can be credited using stored amounts
-func (s *creditNoteService) calculateMaxCreditableAmount(ctx context.Context, inv *invoice.Invoice) (decimal.Decimal, error) {
-	creditNoteType, err := s.getCreditNoteType(inv)
-	if err != nil {
-		return decimal.Zero, err
-	}
-
+// calculateMaxCreditableAmount calculates the maximum amount creditable for the given type, using stored amounts
+func (s *creditNoteService) calculateMaxCreditableAmount(ctx context.Context, inv *invoice.Invoice, creditNoteType types.CreditNoteType) decimal.Decimal {
 	// Calculate max creditable amount based on credit note type using stored amounts
 	var maxCreditableAmount decimal.Decimal
 	if creditNoteType == types.CreditNoteTypeRefund {
@@ -713,7 +712,7 @@ func (s *creditNoteService) calculateMaxCreditableAmount(ctx context.Context, in
 		"invoice_refunded_amount", inv.RefundedAmount,
 		"max_creditable_amount", maxCreditableAmount)
 
-	return maxCreditableAmount, nil
+	return maxCreditableAmount
 }
 
 // validateLineItems validates credit note line items against invoice line items

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -409,26 +409,37 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 	// Store original status for logging
 	originalStatus := cn.CreditNoteStatus
 
-	// Update credit note status to voided
-	cn.CreditNoteStatus = types.CreditNoteStatusVoided
+	// Update credit note status to voided, and — for a finalized credit note —
+	// lock the invoice and recalculate its amounts in the same transaction, so
+	// both writes commit or roll back together. The lock/recalculation runs
+	// before the status flip so a recalculation failure never leaves the credit
+	// note marked Voided.
+	err = s.DB.WithTx(ctx, func(tx context.Context) error {
+		if originalStatus == types.CreditNoteStatusFinalized {
+			// Lock the invoice row so a concurrent finalize/void on the same
+			// invoice cannot race this recalculation with a stale view of it.
+			if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
+				return err
+			}
 
-	if err := s.CreditNoteRepo.Update(ctx, cn); err != nil {
+			invoiceService := NewInvoiceService(s.ServiceParams)
+			if err := invoiceService.RecalculateInvoiceAmounts(tx, cn.InvoiceID); err != nil {
+				return err
+			}
+		}
+
+		cn.CreditNoteStatus = types.CreditNoteStatusVoided
+		return s.CreditNoteRepo.Update(tx, cn)
+	})
+	if err != nil {
+		s.Logger.Error(ctx, "failed to void credit note",
+			"error", err,
+			"credit_note_id", cn.ID,
+			"invoice_id", cn.InvoiceID)
 		return err
 	}
 
-	// Recalculate invoice amounts after credit note void
-	// This is needed to update the adjustment and refunded amounts
-	if originalStatus == types.CreditNoteStatusFinalized {
-		invoiceService := NewInvoiceService(s.ServiceParams)
-		if err := invoiceService.RecalculateInvoiceAmounts(ctx, cn.InvoiceID); err != nil {
-			s.Logger.Error(ctx, "failed to recalculate invoice amounts after credit note void",
-				"error", err,
-				"credit_note_id", cn.ID,
-				"invoice_id", cn.InvoiceID)
-		}
-	}
-
-	// Publish webhook event after successful update
+	// Publish webhook event after successful transaction
 	s.publishSystemEvent(ctx, types.WebhookEventCreditNoteUpdated, cn.ID)
 
 	s.Logger.Info(ctx, "credit note voided successfully",

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -474,7 +474,37 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 
 	// Process the credit note in transaction
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
-		// Update credit note status first
+		// Lock the invoice row first, before any write, so a concurrent finalize
+		// on the same invoice cannot race past the capacity re-check below with a
+		// stale view of refunded/adjusted amounts.
+		lockedInv, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID)
+		if err != nil {
+			return err
+		}
+
+		// Re-validate refund/adjustment capacity under the lock. The amount
+		// available may have shrunk since this credit note was drafted, if
+		// another credit note on the same invoice was finalized in the meantime.
+		maxCreditableAmount, err := s.calculateMaxCreditableAmount(tx, lockedInv)
+		if err != nil {
+			return err
+		}
+		if cn.TotalAmount.GreaterThan(maxCreditableAmount) {
+			return ierr.NewError("credit amount exceeds available limit").
+				WithHintf(
+					"This credit note is for %s, but only %s is currently available to credit against this invoice. Another credit note may have been finalized against it since this one was created.",
+					cn.TotalAmount, maxCreditableAmount,
+				).
+				WithReportableDetails(map[string]any{
+					"credit_note_id":   cn.ID,
+					"requested_amount": cn.TotalAmount,
+					"maximum_allowed":  maxCreditableAmount,
+					"invoice_id":       lockedInv.ID,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+
+		// Only now, having validated capacity under the lock, mutate anything.
 		cn.CreditNoteStatus = types.CreditNoteStatusFinalized
 		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {
 			return err
@@ -482,21 +512,15 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 
 		// Handle refund credit notes (wallet top-up logic)
 		if cn.CreditNoteType == types.CreditNoteTypeRefund {
-			// Get invoice using transaction context
-			inv, err := s.InvoiceRepo.Get(tx, cn.InvoiceID)
-			if err != nil {
-				return err
-			}
-
 			// Find or create wallet using transaction context
-			wallets, err := walletService.GetWalletsByCustomerID(tx, inv.CustomerID)
+			wallets, err := walletService.GetWalletsByCustomerID(tx, lockedInv.CustomerID)
 			if err != nil {
 				return err
 			}
 
 			var selectedWallet *dto.WalletResponse
 			for _, w := range wallets {
-				if types.IsMatchingCurrency(w.Currency, inv.Currency) {
+				if types.IsMatchingCurrency(w.Currency, lockedInv.Currency) {
 					selectedWallet = w
 					break
 				}
@@ -504,8 +528,8 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 			if selectedWallet == nil {
 				// Create new wallet using transaction context
 				walletReq := &dto.CreateWalletRequest{
-					CustomerID:     inv.CustomerID,
-					Currency:       inv.Currency,
+					CustomerID:     lockedInv.CustomerID,
+					Currency:       lockedInv.Currency,
 					ConversionRate: decimal.NewFromInt(1), // Set default conversion rate to avoid division by zero
 					WalletType:     types.WalletTypePrePaid,
 				}
@@ -531,24 +555,21 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 			}
 		}
 
-		// Recalculate invoice amounts after credit note finalization
-		// This is needed to update the adjustment and refunded amounts
-		inv, err := s.InvoiceRepo.Get(ctx, cn.InvoiceID)
-		if err != nil {
+		// Recalculate invoice amounts within the same transaction and using the
+		// locked invoice, so this write commits/rolls back atomically with the
+		// wallet top-up and credit note status change above.
+		if err := s.RecalculateInvoiceAmountsForCreditNote(tx, lockedInv, cn); err != nil {
 			return err
-		}
-
-		if err := s.RecalculateInvoiceAmountsForCreditNote(ctx, inv, cn); err != nil {
-			s.Logger.Error(ctx, "failed to recalculate invoice amounts after credit note finalization",
-				"error", err,
-				"credit_note_id", cn.ID,
-				"invoice_id", cn.InvoiceID)
 		}
 
 		return nil
 	})
 
 	if err != nil {
+		s.Logger.Error(ctx, "failed to finalize credit note",
+			"error", err,
+			"credit_note_id", cn.ID,
+			"invoice_id", cn.InvoiceID)
 		return err
 	}
 

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -410,12 +410,10 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 	originalStatus := cn.CreditNoteStatus
 
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
-		if originalStatus == types.CreditNoteStatusFinalized {
 			// Lock to serialize against a concurrent finalize/void on the same invoice.
 			if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
 				return err
 			}
-		}
 
 		cn.CreditNoteStatus = types.CreditNoteStatusVoided
 		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -409,15 +409,10 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 	// Store original status for logging
 	originalStatus := cn.CreditNoteStatus
 
-	// Update credit note status to voided, and — for a finalized credit note —
-	// lock the invoice and recalculate its amounts in the same transaction, so
-	// both writes commit or roll back together. The lock/recalculation runs
-	// before the status flip so a recalculation failure never leaves the credit
-	// note marked Voided.
+	// Recalculate before flipping status, so a failure never leaves the credit note half-voided.
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
 		if originalStatus == types.CreditNoteStatusFinalized {
-			// Lock the invoice row so a concurrent finalize/void on the same
-			// invoice cannot race this recalculation with a stale view of it.
+			// Lock to serialize against a concurrent finalize/void on the same invoice.
 			if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
 				return err
 			}
@@ -485,17 +480,13 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 
 	// Process the credit note in transaction
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
-		// Lock the invoice row first, before any write, so a concurrent finalize
-		// on the same invoice cannot race past the capacity re-check below with a
-		// stale view of refunded/adjusted amounts.
+		// Lock before any write so a concurrent finalize can't race the capacity check below.
 		lockedInv, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID)
 		if err != nil {
 			return err
 		}
 
-		// Re-validate refund/adjustment capacity under the lock. The amount
-		// available may have shrunk since this credit note was drafted, if
-		// another credit note on the same invoice was finalized in the meantime.
+		// Re-check capacity under the lock: another credit note may have consumed it since draft creation.
 		maxCreditableAmount, err := s.calculateMaxCreditableAmount(tx, lockedInv)
 		if err != nil {
 			return err
@@ -515,7 +506,6 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 				Mark(ierr.ErrValidation)
 		}
 
-		// Only now, having validated capacity under the lock, mutate anything.
 		cn.CreditNoteStatus = types.CreditNoteStatusFinalized
 		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {
 			return err
@@ -566,9 +556,7 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 			}
 		}
 
-		// Recalculate invoice amounts within the same transaction and using the
-		// locked invoice, so this write commits/rolls back atomically with the
-		// wallet top-up and credit note status change above.
+		// Same tx as the wallet top-up above, so both commit/roll back together.
 		if err := s.RecalculateInvoiceAmountsForCreditNote(tx, lockedInv, cn); err != nil {
 			return err
 		}

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -434,10 +434,14 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 		return nil
 	})
 	if err != nil {
-		s.Logger.Error(ctx, "failed to void credit note",
-			"error", err,
-			"credit_note_id", cn.ID,
-			"invoice_id", cn.InvoiceID)
+		if ierr.IsValidation(err) {
+			s.Logger.Info(ctx, "credit note void rejected", "error", err, "credit_note_id", cn.ID)
+		} else {
+			s.Logger.Error(ctx, "failed to void credit note",
+				"error", err,
+				"credit_note_id", cn.ID,
+				"invoice_id", cn.InvoiceID)
+		}
 		return err
 	}
 
@@ -449,6 +453,16 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 		"previous_status", originalStatus)
 
 	return nil
+}
+
+func creditNoteAlreadyProcessedError(status types.CreditNoteStatus) error {
+	return ierr.NewError("credit note already processed").
+		WithHintf("This credit note is %s and cannot be processed again. Only draft credit notes can be finalized.", status).
+		WithReportableDetails(map[string]any{
+			"current_status":  status,
+			"required_status": types.CreditNoteStatusDraft,
+		}).
+		Mark(ierr.ErrValidation)
 }
 
 func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) error {
@@ -464,13 +478,7 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 	}
 
 	if cn.CreditNoteStatus != types.CreditNoteStatusDraft {
-		return ierr.NewError("credit note already processed").
-			WithHintf("This credit note is %s and cannot be processed again. Only draft credit notes can be finalized.", cn.CreditNoteStatus).
-			WithReportableDetails(map[string]any{
-				"current_status":  cn.CreditNoteStatus,
-				"required_status": types.CreditNoteStatusDraft,
-			}).
-			Mark(ierr.ErrValidation)
+		return creditNoteAlreadyProcessedError(cn.CreditNoteStatus)
 	}
 
 	// Additional validation before processing
@@ -491,6 +499,16 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 		lockedInv, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID)
 		if err != nil {
 			return err
+		}
+
+		// Re-fetch under the lock: a concurrent finalize of this exact credit note may have
+		// already committed while this call was waiting on the invoice lock.
+		cn, err = s.CreditNoteRepo.Get(tx, cn.ID)
+		if err != nil {
+			return err
+		}
+		if cn.CreditNoteStatus != types.CreditNoteStatusDraft {
+			return creditNoteAlreadyProcessedError(cn.CreditNoteStatus)
 		}
 
 		// Re-check capacity under the lock: another credit note may have consumed it since draft
@@ -571,10 +589,14 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 	})
 
 	if err != nil {
-		s.Logger.Error(ctx, "failed to finalize credit note",
-			"error", err,
-			"credit_note_id", cn.ID,
-			"invoice_id", cn.InvoiceID)
+		if ierr.IsValidation(err) {
+			s.Logger.Info(ctx, "credit note finalize rejected", "error", err, "credit_note_id", cn.ID)
+		} else {
+			s.Logger.Error(ctx, "failed to finalize credit note",
+				"error", err,
+				"credit_note_id", cn.ID,
+				"invoice_id", cn.InvoiceID)
+		}
 		return err
 	}
 

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1129,6 +1129,11 @@ func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RefundCapacityRecheck() 
 
 	walletBefore, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallets.usd.ID)
 	s.NoError(err)
+	// Snapshot the balance as a plain value: the in-memory wallet store returns a
+	// live pointer (no cloning), and later top-ups mutate that same object's
+	// Balance field in place, so walletBefore.Balance itself is not a frozen
+	// snapshot once read later in this test.
+	balanceBefore := walletBefore.Balance
 
 	// Finalize the first: succeeds, refunds 100.00 into the USD wallet.
 	s.NoError(s.service.FinalizeCreditNote(s.GetContext(), first.ID))
@@ -1147,7 +1152,7 @@ func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RefundCapacityRecheck() 
 	// The wallet must reflect only the first refund, never a double refund.
 	walletAfter, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallets.usd.ID)
 	s.NoError(err)
-	expectedBalance := walletBefore.Balance.Add(decimal.NewFromFloat(100.00))
+	expectedBalance := balanceBefore.Add(decimal.NewFromFloat(100.00))
 	s.True(walletAfter.Balance.Equal(expectedBalance),
 		"expected wallet balance %s, got %s", expectedBalance, walletAfter.Balance)
 }

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1101,6 +1101,57 @@ func (s *CreditNoteServiceSuite) TestProcessDraftCreditNote() {
 	}
 }
 
+func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RefundCapacityRecheck() {
+	// Two drafts on the same invoice (AmountPaid=110.00, RefundedAmount=0.00 at
+	// creation time), each individually valid (100.00 <= 110.00 max), but their
+	// combined total (200.00) exceeds what the invoice can actually refund.
+	// Finalizing the first must succeed; finalizing the second must be rejected
+	// under the invoice lock instead of silently double-refunding the wallet.
+	draftReq := func() *dto.CreateCreditNoteRequest {
+		return &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.finalized.ID,
+			Reason:            types.CreditNoteReasonUnsatisfactory,
+			ProcessCreditNote: false,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{InvoiceLineItemID: "line_1", Amount: decimal.NewFromFloat(50.00)},
+				{InvoiceLineItemID: "line_2", Amount: decimal.NewFromFloat(50.00)},
+			},
+		}
+	}
+
+	first, err := s.service.CreateCreditNote(s.GetContext(), draftReq())
+	s.NoError(err)
+	s.Equal(types.CreditNoteStatusDraft, first.CreditNoteStatus)
+
+	second, err := s.service.CreateCreditNote(s.GetContext(), draftReq())
+	s.NoError(err)
+	s.Equal(types.CreditNoteStatusDraft, second.CreditNoteStatus)
+
+	walletBefore, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallets.usd.ID)
+	s.NoError(err)
+
+	// Finalize the first: succeeds, refunds 100.00 into the USD wallet.
+	s.NoError(s.service.FinalizeCreditNote(s.GetContext(), first.ID))
+
+	// Finalizing the second must now fail: only 10.00 (110.00 paid - 100.00
+	// already refunded) is available, but this credit note is for 100.00.
+	err = s.service.FinalizeCreditNote(s.GetContext(), second.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "credit amount exceeds available limit")
+
+	// The rejected credit note must stay Draft, not silently flip to Finalized.
+	secondAfter, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), second.ID)
+	s.NoError(err)
+	s.Equal(types.CreditNoteStatusDraft, secondAfter.CreditNoteStatus)
+
+	// The wallet must reflect only the first refund, never a double refund.
+	walletAfter, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallets.usd.ID)
+	s.NoError(err)
+	expectedBalance := walletBefore.Balance.Add(decimal.NewFromFloat(100.00))
+	s.True(walletAfter.Balance.Equal(expectedBalance),
+		"expected wallet balance %s, got %s", expectedBalance, walletAfter.Balance)
+}
+
 func (s *CreditNoteServiceSuite) TestMaxCreditableAmountValidation() {
 	// Create credit notes that exceed max creditable amount
 	tests := []struct {

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -976,9 +976,9 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote() {
 	}
 }
 
-func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailurePropagates() {
-	// Finalized ADJUSTMENT (refund type can't be voided) pointing at a missing invoice,
-	// standing in for the recalculation step failing.
+func (s *CreditNoteServiceSuite) TestVoidCreditNote_TransactionFailurePropagates() {
+	// Finalized ADJUSTMENT (refund type can't be voided) pointing at a missing invoice:
+	// fails at the GetForUpdate lock step, before recalculation itself ever runs.
 	brokenCN := &creditnote.CreditNote{
 		ID:               "cn_void_recalc_fail",
 		CustomerID:       s.testData.customer.ID,
@@ -997,7 +997,7 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailurePropagat
 	s.Error(err)
 	s.Contains(err.Error(), "not found")
 
-	// Status flip must not happen before the lock/recalculation succeeds.
+	// Status flip must not happen before the lock succeeds.
 	after, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), brokenCN.ID)
 	s.NoError(err)
 	s.Equal(types.CreditNoteStatusFinalized, after.CreditNoteStatus)
@@ -1171,6 +1171,43 @@ func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RefundCapacityRecheck() 
 	expectedBalance := balanceBefore.Add(decimal.NewFromFloat(100.00))
 	s.True(walletAfter.Balance.Equal(expectedBalance),
 		"expected wallet balance %s, got %s", expectedBalance, walletAfter.Balance)
+}
+
+func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_AdjustmentCapacityRecheck() {
+	// Same race as the refund case, but for ADJUSTMENT type, which has no wallet
+	// idempotency backstop against a double-applied recalculation.
+	draftReq := func() *dto.CreateCreditNoteRequest {
+		return &dto.CreateCreditNoteRequest{
+			InvoiceID:         s.testData.invoices.pending.ID,
+			Reason:            types.CreditNoteReasonBillingError,
+			ProcessCreditNote: false,
+			LineItems: []dto.CreateCreditNoteLineItemRequest{
+				{InvoiceLineItemID: "line_3", Amount: decimal.NewFromFloat(80.00)},
+			},
+		}
+	}
+
+	first, err := s.service.CreateCreditNote(s.GetContext(), draftReq())
+	s.NoError(err)
+	s.Equal(types.CreditNoteTypeAdjustment, first.CreditNoteType)
+
+	second, err := s.service.CreateCreditNote(s.GetContext(), draftReq())
+	s.NoError(err)
+
+	s.NoError(s.service.FinalizeCreditNote(s.GetContext(), first.ID))
+
+	err = s.service.FinalizeCreditNote(s.GetContext(), second.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "credit amount exceeds available limit")
+
+	secondAfter, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), second.ID)
+	s.NoError(err)
+	s.Equal(types.CreditNoteStatusDraft, secondAfter.CreditNoteStatus)
+
+	invAfter, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), s.testData.invoices.pending.ID)
+	s.NoError(err)
+	s.True(invAfter.AdjustmentAmount.Equal(decimal.NewFromFloat(80.00)),
+		"expected adjustment amount 80, got %s", invAfter.AdjustmentAmount)
 }
 
 func (s *CreditNoteServiceSuite) TestMaxCreditableAmountValidation() {

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -976,6 +976,38 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote() {
 	}
 }
 
+func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailurePropagates() {
+	// A finalized ADJUSTMENT credit note (refund-type finalized credit notes can
+	// never be voided, so this is the only status/type combination that reaches
+	// the invoice recalculation path) referencing an invoice that no longer
+	// exists — standing in for the recalculation step failing. Voiding it must
+	// surface that failure, not silently succeed while leaving the invoice
+	// unrecalculated.
+	brokenCN := &creditnote.CreditNote{
+		ID:               "cn_void_recalc_fail",
+		CustomerID:       s.testData.customer.ID,
+		InvoiceID:        "inv_does_not_exist",
+		CreditNoteNumber: "CN-VOID-FAIL-TEST",
+		CreditNoteStatus: types.CreditNoteStatusFinalized,
+		CreditNoteType:   types.CreditNoteTypeAdjustment,
+		Reason:           types.CreditNoteReasonBillingError,
+		Currency:         "USD",
+		TotalAmount:      decimal.NewFromFloat(10.00),
+		BaseModel:        types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CreditNoteRepo.CreateWithLineItems(s.GetContext(), brokenCN))
+
+	err := s.service.VoidCreditNote(s.GetContext(), brokenCN.ID)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+
+	// The credit note must remain Finalized: the status flip must never be
+	// attempted before the invoice lock/recalculation succeeds.
+	after, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), brokenCN.ID)
+	s.NoError(err)
+	s.Equal(types.CreditNoteStatusFinalized, after.CreditNoteStatus)
+}
+
 func (s *CreditNoteServiceSuite) TestProcessDraftCreditNote() {
 	// Create draft credit note manually in repository to test processing
 	// This bypasses the CreateCreditNote validation that automatically processes the credit note

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -977,12 +977,8 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote() {
 }
 
 func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailurePropagates() {
-	// A finalized ADJUSTMENT credit note (refund-type finalized credit notes can
-	// never be voided, so this is the only status/type combination that reaches
-	// the invoice recalculation path) referencing an invoice that no longer
-	// exists — standing in for the recalculation step failing. Voiding it must
-	// surface that failure, not silently succeed while leaving the invoice
-	// unrecalculated.
+	// Finalized ADJUSTMENT (refund type can't be voided) pointing at a missing invoice,
+	// standing in for the recalculation step failing.
 	brokenCN := &creditnote.CreditNote{
 		ID:               "cn_void_recalc_fail",
 		CustomerID:       s.testData.customer.ID,
@@ -1001,8 +997,7 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailurePropagat
 	s.Error(err)
 	s.Contains(err.Error(), "not found")
 
-	// The credit note must remain Finalized: the status flip must never be
-	// attempted before the invoice lock/recalculation succeeds.
+	// Status flip must not happen before the lock/recalculation succeeds.
 	after, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), brokenCN.ID)
 	s.NoError(err)
 	s.Equal(types.CreditNoteStatusFinalized, after.CreditNoteStatus)
@@ -1134,11 +1129,8 @@ func (s *CreditNoteServiceSuite) TestProcessDraftCreditNote() {
 }
 
 func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RefundCapacityRecheck() {
-	// Two drafts on the same invoice (AmountPaid=110.00, RefundedAmount=0.00 at
-	// creation time), each individually valid (100.00 <= 110.00 max), but their
-	// combined total (200.00) exceeds what the invoice can actually refund.
-	// Finalizing the first must succeed; finalizing the second must be rejected
-	// under the invoice lock instead of silently double-refunding the wallet.
+	// Two drafts, each individually valid (100 <= 110 max), whose combined total (200)
+	// exceeds what the invoice can actually refund.
 	draftReq := func() *dto.CreateCreditNoteRequest {
 		return &dto.CreateCreditNoteRequest{
 			InvoiceID:         s.testData.invoices.finalized.ID,
@@ -1161,27 +1153,19 @@ func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RefundCapacityRecheck() 
 
 	walletBefore, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallets.usd.ID)
 	s.NoError(err)
-	// Snapshot the balance as a plain value: the in-memory wallet store returns a
-	// live pointer (no cloning), and later top-ups mutate that same object's
-	// Balance field in place, so walletBefore.Balance itself is not a frozen
-	// snapshot once read later in this test.
+	// In-memory wallet store returns a live pointer, so snapshot the balance now.
 	balanceBefore := walletBefore.Balance
 
-	// Finalize the first: succeeds, refunds 100.00 into the USD wallet.
 	s.NoError(s.service.FinalizeCreditNote(s.GetContext(), first.ID))
 
-	// Finalizing the second must now fail: only 10.00 (110.00 paid - 100.00
-	// already refunded) is available, but this credit note is for 100.00.
 	err = s.service.FinalizeCreditNote(s.GetContext(), second.ID)
 	s.Error(err)
 	s.Contains(err.Error(), "credit amount exceeds available limit")
 
-	// The rejected credit note must stay Draft, not silently flip to Finalized.
 	secondAfter, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), second.ID)
 	s.NoError(err)
 	s.Equal(types.CreditNoteStatusDraft, secondAfter.CreditNoteStatus)
 
-	// The wallet must reflect only the first refund, never a double refund.
 	walletAfter, err := s.GetStores().WalletRepo.GetWalletByID(s.GetContext(), s.testData.wallets.usd.ID)
 	s.NoError(err)
 	expectedBalance := balanceBefore.Add(decimal.NewFromFloat(100.00))


### PR DESCRIPTION
## **User description**
## Summary
- Fixes SFX-0203-F02: `FinalizeCreditNote` only checked that the credit note's amount was positive and read the invoice twice without any row lock (one of those reads even used the outer, non-transactional context). Two draft credit notes on the same invoice, each individually valid, could both be finalized and both top up the customer's wallet before the invoice's refunded/adjusted amounts were updated.
- `FinalizeCreditNote` now locks the invoice via `GetForUpdate` before any write, re-runs the same max-creditable-amount check used at draft-creation time under that lock, and runs the invoice recalculation inside the same transaction as the wallet top-up.
- `VoidCreditNote` had the same shape of gap: it recalculated invoice amounts via an unguarded, unlocked call whose error was only logged. It now locks the invoice and recalculates inside a transaction, before flipping the credit note's status, and returns the error instead of swallowing it.

## Test Plan
- [x] Added `TestFinalizeCreditNote_RefundCapacityRecheck`: two individually-valid drafts on one invoice; first finalize succeeds, second is now rejected with "credit amount exceeds available limit" instead of double-refunding the wallet.
- [x] Added `TestVoidCreditNote_RecalculationFailurePropagates`: a finalized adjustment credit note referencing a missing invoice now surfaces the recalculation failure instead of silently succeeding.
- [x] `go test -race ./internal/ee/service/...` passes (one pre-existing, unrelated flaky test — `TestWalletService/TestGetWalletBalanceV2_SkipsFallbackOnClientDisconnect` — confirmed to fail identically on the base commit, before this change).
- [x] `go vet ./internal/ee/service/...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit note finalization and voiding reliability by ensuring invoice recalculations and wallet updates complete together.
  * Prevented credit notes from being finalized when available refund or adjustment capacity is insufficient.
  * Failures now stop processing cleanly and avoid unintended wallet refunds, invoice changes, or partial updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent duplicate credit note processing and keep invoice totals consistent

### What Changed
- Finalizing a credit note now rechecks the invoice’s remaining refund or adjustment capacity, so only credits that still fit can be processed.
- Concurrent finalizations are serialized, preventing multiple drafts from exceeding the invoice’s available credit.
- Wallet refunds and invoice total updates now succeed or roll back together.
- Voiding a finalized credit note updates its status before recalculating the invoice, and any failure is returned without leaving a partial void.
- Added coverage for refund and adjustment capacity limits, concurrent processing, and void failures.

### Impact
`✅ Prevented duplicate wallet refunds`
`✅ Accurate invoice refund and adjustment totals`
`✅ Clear errors when credit capacity is exhausted`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
