### PR TITLE
fix(task-import): close SSRF via caller-supplied file_url

### DIFF
--- a/internal/ee/service/file_processor.go
+++ b/internal/ee/service/file_processor.go
@@ -41,18 +41,19 @@ type FileProcessor struct {
 // Default settings:
 // - MaxMemoryFileSize: 10MB (files smaller than this are processed in memory)
 // - MaxFileSize: 1GB (maximum file size allowed)
-func NewFileProcessor(client httpclient.Client, logger *logger.Logger) *FileProcessor {
+func NewFileProcessor(logger *logger.Logger) *FileProcessor {
+	streamingProcessor := NewStreamingProcessor(logger)
+
 	// Configure retryable HTTP client
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3
 	retryClient.RetryWaitMin = 1 * time.Second
 	retryClient.RetryWaitMax = 30 * time.Second
 	retryClient.Logger = logger.GetRetryableHTTPLogger()
-	// Instrument outbound file downloads for SigNoz External API Monitoring.
-	retryClient.HTTPClient.Transport = httpclient.OtelTransport(retryClient.HTTPClient.Transport)
+	retryClient.HTTPClient.Transport = streamingProcessor.Transport
 
 	return &FileProcessor{
-		StreamingProcessor: NewStreamingProcessor(client, logger),
+		StreamingProcessor: streamingProcessor,
 		ProviderRegistry:   NewFileProviderRegistry(),
 		CSVProcessor:       NewCSVProcessor(logger),
 		JSONProcessor:      NewJSONProcessor(logger),
@@ -171,7 +172,7 @@ func (fp *FileProcessor) DownloadFileStream(ctx context.Context, t *task.Task) (
 	// Make the request with extended timeout for large file downloads
 	httpClient := &http.Client{
 		Timeout:   10 * time.Minute, // Extended timeout for large file downloads
-		Transport: httpclient.OtelTransport(nil),
+		Transport: fp.Transport,
 	}
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
@@ -237,7 +238,7 @@ func (fp *FileProcessor) GetFileSize(ctx context.Context, t *task.Task) (int64, 
 
 	httpClient := &http.Client{
 		Timeout:   30 * time.Second, // Shorter timeout for HEAD requests
-		Transport: httpclient.OtelTransport(nil),
+		Transport: fp.Transport,
 	}
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {

--- a/internal/ee/service/file_processor_test.go
+++ b/internal/ee/service/file_processor_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/task"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+func newTestFileProcessor(t *testing.T) *FileProcessor {
+	t.Helper()
+	cfg := config.GetDefaultConfig()
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("failed to build logger: %v", err)
+	}
+	// DownloadFile/DownloadFileStream/GetFileSize each issue a single
+	// request (fp.Client.Send or a plain http.Client.Do) -- no
+	// retryablehttp.Client is involved, so no retry-backoff tuning is
+	// needed here (contrast with streaming_processor_test.go, which does
+	// exercise RetryClient).
+	return NewFileProcessor(log)
+}
+
+func newLoopbackServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("a,b\n1,2\n"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFileProcessor_DownloadFile_BlocksLoopback(t *testing.T) {
+	srv := newLoopbackServer(t)
+	fp := newTestFileProcessor(t)
+	tsk := &task.Task{FileURL: srv.URL + "/file.csv"}
+
+	if _, err := fp.DownloadFile(context.Background(), tsk); err == nil {
+		t.Fatal("expected DownloadFile to a loopback address to be blocked, got nil error")
+	}
+}
+
+func TestFileProcessor_DownloadFileStream_BlocksLoopback(t *testing.T) {
+	srv := newLoopbackServer(t)
+	fp := newTestFileProcessor(t)
+	tsk := &task.Task{FileURL: srv.URL + "/file.csv"}
+
+	if _, err := fp.DownloadFileStream(context.Background(), tsk); err == nil {
+		t.Fatal("expected DownloadFileStream to a loopback address to be blocked, got nil error")
+	}
+}
+
+func TestFileProcessor_GetFileSize_BlocksLoopback(t *testing.T) {
+	srv := newLoopbackServer(t)
+	fp := newTestFileProcessor(t)
+	tsk := &task.Task{FileURL: srv.URL + "/file.csv"}
+
+	if _, err := fp.GetFileSize(context.Background(), tsk); err == nil {
+		t.Fatal("expected GetFileSize to a loopback address to be blocked, got nil error")
+	}
+}

--- a/internal/ee/service/file_processor_test.go
+++ b/internal/ee/service/file_processor_test.go
@@ -18,11 +18,6 @@ func newTestFileProcessor(t *testing.T) *FileProcessor {
 	if err != nil {
 		t.Fatalf("failed to build logger: %v", err)
 	}
-	// DownloadFile/DownloadFileStream/GetFileSize each issue a single
-	// request (fp.Client.Send or a plain http.Client.Do) -- no
-	// retryablehttp.Client is involved, so no retry-backoff tuning is
-	// needed here (contrast with streaming_processor_test.go, which does
-	// exercise RetryClient).
 	return NewFileProcessor(log)
 }
 

--- a/internal/ee/service/file_provider.go
+++ b/internal/ee/service/file_provider.go
@@ -197,6 +197,9 @@ func parseAllowedURL(fileURL string) (*url.URL, error) {
 	if !allowedSchemes[strings.ToLower(u.Scheme)] {
 		return nil, fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", u.Scheme)
 	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("URL must include a host")
+	}
 	return u, nil
 }
 
@@ -258,7 +261,7 @@ func (r *FileProviderRegistry) GetProvider(fileURL string) FileProvider {
 	if matchesHost(host, "drive.google.com") {
 		return r.providers[FileProviderTypeGoogleDrive]
 	}
-	if matchesHost(host, "amazonaws.com") || strings.Contains(host, "s3.") {
+	if isS3Host(host) {
 		return r.providers[FileProviderTypeS3]
 	}
 	if matchesHost(host, "onedrive.live.com") || matchesHost(host, "1drv.ms") {
@@ -278,4 +281,20 @@ func (r *FileProviderRegistry) GetProvider(fileURL string) FileProvider {
 // matchesHost reports whether host equals domain or is a subdomain of it.
 func matchesHost(host, domain string) bool {
 	return host == domain || strings.HasSuffix(host, "."+domain)
+}
+
+// isS3Host reports whether host is an S3 endpoint, e.g. "s3.amazonaws.com",
+// "s3.us-east-1.amazonaws.com", or "my-bucket.s3.amazonaws.com" -- not just
+// any *.amazonaws.com service (ec2, lambda, ...) or an unrelated domain that
+// happens to contain "s3.".
+func isS3Host(host string) bool {
+	if !matchesHost(host, "amazonaws.com") {
+		return false
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "s3" || strings.HasPrefix(label, "s3-") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ee/service/file_provider.go
+++ b/internal/ee/service/file_provider.go
@@ -10,7 +10,7 @@
 //
 // Example usage:
 //
-//	processor := NewFileProcessor(httpClient, logger)
+//	processor := NewFileProcessor(logger)
 //	content, err := processor.DownloadFile(ctx, &task.Task{FileURL: "https://drive.google.com/file/d/123/view"})
 //	if err != nil {
 //	    // Handle error - simple error message, no complex error objects
@@ -56,9 +56,8 @@ const (
 type DirectURLProvider struct{}
 
 func (p *DirectURLProvider) GetDownloadURL(ctx context.Context, fileURL string) (string, error) {
-	// Validate URL
-	_, err := url.Parse(fileURL)
-	if err != nil {
+	// Validate URL and restrict to http/https
+	if _, err := parseAllowedURL(fileURL); err != nil {
 		return "", ierr.WithError(err).
 			WithHint("Invalid URL").
 			Mark(ierr.ErrValidation)
@@ -107,8 +106,7 @@ type S3Provider struct{}
 func (p *S3Provider) GetDownloadURL(ctx context.Context, fileURL string) (string, error) {
 	// S3 URLs are typically already in the correct format for direct download
 	// but we can add presigned URL logic here if needed
-	_, err := url.Parse(fileURL)
-	if err != nil {
+	if _, err := parseAllowedURL(fileURL); err != nil {
 		return "", ierr.WithError(err).
 			WithHint("Invalid S3 URL").
 			Mark(ierr.ErrValidation)
@@ -151,8 +149,7 @@ func (p *DropboxProvider) GetDownloadURL(ctx context.Context, fileURL string) (s
 		fileURL += "?dl=1"
 	}
 
-	_, err := url.Parse(fileURL)
-	if err != nil {
+	if _, err := parseAllowedURL(fileURL); err != nil {
 		return "", ierr.WithError(err).
 			WithHint("Invalid Dropbox URL").
 			Mark(ierr.ErrValidation)
@@ -176,8 +173,7 @@ func (p *GitHubProvider) GetDownloadURL(ctx context.Context, fileURL string) (st
 		fileURL = strings.Replace(fileURL, "/blob/", "/", 1)
 	}
 
-	_, err := url.Parse(fileURL)
-	if err != nil {
+	if _, err := parseAllowedURL(fileURL); err != nil {
 		return "", ierr.WithError(err).
 			WithHint("Invalid GitHub URL").
 			Mark(ierr.ErrValidation)
@@ -187,6 +183,23 @@ func (p *GitHubProvider) GetDownloadURL(ctx context.Context, fileURL string) (st
 
 func (p *GitHubProvider) GetProviderName() FileProviderType {
 	return FileProviderTypeGitHub
+}
+
+// allowedSchemes restricts outbound file fetches to http/https, rejecting
+// schemes like file://, ftp://, or gopher:// that could be used to reach
+// non-HTTP resources.
+var allowedSchemes = map[string]bool{"http": true, "https": true}
+
+// parseAllowedURL parses fileURL and ensures its scheme is http or https.
+func parseAllowedURL(fileURL string) (*url.URL, error) {
+	u, err := url.Parse(fileURL)
+	if err != nil {
+		return nil, err
+	}
+	if !allowedSchemes[strings.ToLower(u.Scheme)] {
+		return nil, fmt.Errorf("unsupported URL scheme %q: only http and https are allowed", u.Scheme)
+	}
+	return u, nil
 }
 
 // extractOneDriveFileID extracts file ID from OneDrive URL
@@ -237,23 +250,35 @@ func (r *FileProviderRegistry) RegisterProvider(provider FileProvider) {
 
 // GetProvider returns the appropriate provider for a given URL
 func (r *FileProviderRegistry) GetProvider(fileURL string) FileProvider {
-	// Check for specific providers based on URL patterns
-	if strings.Contains(fileURL, "drive.google.com") {
+	host := ""
+	if u, err := url.Parse(fileURL); err == nil {
+		host = strings.ToLower(u.Hostname())
+	}
+
+	// Check for specific providers based on the parsed hostname (not the raw
+	// URL string) so a value like "https://evil.com/?x=drive.google.com" or
+	// "https://drive.google.com.evil.com" can't be misclassified.
+	if matchesHost(host, "drive.google.com") {
 		return r.providers[FileProviderTypeGoogleDrive]
 	}
-	if strings.Contains(fileURL, "amazonaws.com") || strings.Contains(fileURL, "s3.") {
+	if matchesHost(host, "amazonaws.com") || strings.Contains(host, "s3.") {
 		return r.providers[FileProviderTypeS3]
 	}
-	if strings.Contains(fileURL, "onedrive.live.com") || strings.Contains(fileURL, "1drv.ms") {
+	if matchesHost(host, "onedrive.live.com") || matchesHost(host, "1drv.ms") {
 		return r.providers[FileProviderTypeOneDrive]
 	}
-	if strings.Contains(fileURL, "dropbox.com") {
+	if matchesHost(host, "dropbox.com") {
 		return r.providers[FileProviderTypeDropbox]
 	}
-	if strings.Contains(fileURL, "github.com") {
+	if matchesHost(host, "github.com") {
 		return r.providers[FileProviderTypeGitHub]
 	}
 
 	// Default to direct URL provider
 	return r.providers[FileProviderTypeDirect]
+}
+
+// matchesHost reports whether host equals domain or is a subdomain of it.
+func matchesHost(host, domain string) bool {
+	return host == domain || strings.HasSuffix(host, "."+domain)
 }

--- a/internal/ee/service/file_provider.go
+++ b/internal/ee/service/file_provider.go
@@ -185,9 +185,7 @@ func (p *GitHubProvider) GetProviderName() FileProviderType {
 	return FileProviderTypeGitHub
 }
 
-// allowedSchemes restricts outbound file fetches to http/https, rejecting
-// schemes like file://, ftp://, or gopher:// that could be used to reach
-// non-HTTP resources.
+// allowedSchemes restricts outbound file fetches to http/https.
 var allowedSchemes = map[string]bool{"http": true, "https": true}
 
 // parseAllowedURL parses fileURL and ensures its scheme is http or https.
@@ -255,9 +253,8 @@ func (r *FileProviderRegistry) GetProvider(fileURL string) FileProvider {
 		host = strings.ToLower(u.Hostname())
 	}
 
-	// Check for specific providers based on the parsed hostname (not the raw
-	// URL string) so a value like "https://evil.com/?x=drive.google.com" or
-	// "https://drive.google.com.evil.com" can't be misclassified.
+	// Match on the parsed hostname, not the raw URL, so a value like
+	// "evil.com/?x=drive.google.com" can't be misclassified.
 	if matchesHost(host, "drive.google.com") {
 		return r.providers[FileProviderTypeGoogleDrive]
 	}

--- a/internal/ee/service/file_provider_test.go
+++ b/internal/ee/service/file_provider_test.go
@@ -1,0 +1,53 @@
+package service
+
+import "testing"
+
+func TestParseAllowedURL_Scheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"http allowed", "http://example.com/file.csv", false},
+		{"https allowed", "https://example.com/file.csv", false},
+		{"file scheme rejected", "file:///etc/passwd", true},
+		{"ftp scheme rejected", "ftp://example.com/file.csv", true},
+		{"gopher scheme rejected", "gopher://example.com/file.csv", true},
+		{"no scheme rejected", "example.com/file.csv", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAllowedURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseAllowedURL(%q) error = %v, wantErr %v", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFileProviderRegistry_GetProvider(t *testing.T) {
+	registry := NewFileProviderRegistry()
+
+	tests := []struct {
+		name string
+		url  string
+		want FileProviderType
+	}{
+		{"google drive", "https://drive.google.com/file/d/abc123/view", FileProviderTypeGoogleDrive},
+		{"s3", "https://my-bucket.s3.amazonaws.com/file.csv", FileProviderTypeS3},
+		{"onedrive", "https://onedrive.live.com/download?cid=1", FileProviderTypeOneDrive},
+		{"dropbox", "https://www.dropbox.com/s/abc/file.csv", FileProviderTypeDropbox},
+		{"github", "https://github.com/user/repo/blob/main/file.csv", FileProviderTypeGitHub},
+		{"direct url", "https://example.com/file.csv", FileProviderTypeDirect},
+		{"spoofed host in query is not misclassified", "https://evil.com/?x=drive.google.com", FileProviderTypeDirect},
+		{"spoofed host as suffix is not misclassified", "https://drive.google.com.evil.com/file.csv", FileProviderTypeDirect},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := registry.GetProvider(tt.url)
+			if got.GetProviderName() != tt.want {
+				t.Errorf("GetProvider(%q) = %v, want %v", tt.url, got.GetProviderName(), tt.want)
+			}
+		})
+	}
+}

--- a/internal/ee/service/file_provider_test.go
+++ b/internal/ee/service/file_provider_test.go
@@ -14,6 +14,8 @@ func TestParseAllowedURL_Scheme(t *testing.T) {
 		{"ftp scheme rejected", "ftp://example.com/file.csv", true},
 		{"gopher scheme rejected", "gopher://example.com/file.csv", true},
 		{"no scheme rejected", "example.com/file.csv", true},
+		{"empty host rejected", "http://", true},
+		{"opaque http rejected", "http:opaque", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -41,6 +43,9 @@ func TestFileProviderRegistry_GetProvider(t *testing.T) {
 		{"direct url", "https://example.com/file.csv", FileProviderTypeDirect},
 		{"spoofed host in query is not misclassified", "https://evil.com/?x=drive.google.com", FileProviderTypeDirect},
 		{"spoofed host as suffix is not misclassified", "https://drive.google.com.evil.com/file.csv", FileProviderTypeDirect},
+		{"s3 with region", "https://s3.us-east-1.amazonaws.com/my-bucket/file.csv", FileProviderTypeS3},
+		{"non-s3 aws service is not misclassified as s3", "https://ec2.amazonaws.com/file.csv", FileProviderTypeDirect},
+		{"non-s3 domain containing s3. substring is not misclassified", "https://not-s3.example.com/file.csv", FileProviderTypeDirect},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/ee/service/streaming_processor.go
+++ b/internal/ee/service/streaming_processor.go
@@ -25,6 +25,7 @@ import (
 // StreamingProcessor handles streaming processing of large files
 type StreamingProcessor struct {
 	Client           httpclient.Client
+	Transport        http.RoundTripper // SSRF-safe, Otel-instrumented; shared by FileProcessor's ad-hoc clients
 	Logger           *logger.Logger
 	ProviderRegistry *FileProviderRegistry
 	CSVProcessor     *CSVProcessor
@@ -32,19 +33,25 @@ type StreamingProcessor struct {
 	RetryClient      *retryablehttp.Client
 }
 
-// NewStreamingProcessor creates a new streaming processor
-func NewStreamingProcessor(client httpclient.Client, logger *logger.Logger) *StreamingProcessor {
+// NewStreamingProcessor creates a new streaming processor. file_url is
+// caller-supplied, so every outbound download goes through a shared
+// SSRF-safe transport that blocks connections to loopback/link-local/
+// private/unspecified/multicast addresses -- see httpclient.SSRFSafeTransport.
+func NewStreamingProcessor(logger *logger.Logger) *StreamingProcessor {
+	base := httpclient.SSRFSafeTransport()
+	transport := httpclient.OtelTransport(base)
+
 	// Configure retryable HTTP client
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3
 	retryClient.RetryWaitMin = 1 * time.Second
 	retryClient.RetryWaitMax = 30 * time.Second
 	retryClient.Logger = logger.GetRetryableHTTPLogger()
-	// Instrument outbound file downloads for SigNoz External API Monitoring.
-	retryClient.HTTPClient.Transport = httpclient.OtelTransport(retryClient.HTTPClient.Transport)
+	retryClient.HTTPClient.Transport = transport
 
 	return &StreamingProcessor{
-		Client:           client,
+		Client:           httpclient.NewClientWithConfig(httpclient.ClientConfig{Transport: base}),
+		Transport:        transport,
 		Logger:           logger,
 		ProviderRegistry: NewFileProviderRegistry(),
 		RetryClient:      retryClient,

--- a/internal/ee/service/streaming_processor.go
+++ b/internal/ee/service/streaming_processor.go
@@ -34,9 +34,7 @@ type StreamingProcessor struct {
 }
 
 // NewStreamingProcessor creates a new streaming processor. file_url is
-// caller-supplied, so every outbound download goes through a shared
-// SSRF-safe transport that blocks connections to loopback/link-local/
-// private/unspecified/multicast addresses -- see httpclient.SSRFSafeTransport.
+// caller-supplied, so downloads go through httpclient.SSRFSafeTransport.
 func NewStreamingProcessor(logger *logger.Logger) *StreamingProcessor {
 	base := httpclient.SSRFSafeTransport()
 	transport := httpclient.OtelTransport(base)

--- a/internal/ee/service/streaming_processor_test.go
+++ b/internal/ee/service/streaming_processor_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/task"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+func TestStreamingProcessor_DownloadFileStream_BlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := config.GetDefaultConfig()
+	log, err := logger.NewLogger(cfg)
+	if err != nil {
+		t.Fatalf("failed to build logger: %v", err)
+	}
+
+	sp := NewStreamingProcessor(log)
+	sp.RetryClient.RetryMax = 0 // keep the test fast; the guard applies per attempt regardless of retries
+
+	tsk := &task.Task{FileURL: srv.URL + "/file.csv"}
+	if _, err := sp.downloadFileStream(context.Background(), tsk); err == nil {
+		t.Fatal("expected downloadFileStream to a loopback address to be blocked, got nil error")
+	}
+}

--- a/internal/ee/service/task.go
+++ b/internal/ee/service/task.go
@@ -40,7 +40,7 @@ func NewTaskService(
 ) TaskService {
 	return &taskService{
 		ServiceParams: serviceParams,
-		fileProcessor: NewFileProcessor(serviceParams.Client, serviceParams.Logger),
+		fileProcessor: NewFileProcessor(serviceParams.Logger),
 	}
 }
 

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -33,6 +33,9 @@ type Client interface {
 // ClientConfig holds configuration for the HTTP client
 type ClientConfig struct {
 	Timeout time.Duration
+	// Transport overrides the base (pre-instrumentation) transport used by
+	// the client. Nil preserves the default (http.DefaultTransport).
+	Transport http.RoundTripper
 }
 
 // NewClientWithConfig creates a new DefaultClient with custom configuration
@@ -45,7 +48,7 @@ func NewClientWithConfig(config ClientConfig) Client {
 	return &DefaultClient{
 		client: &http.Client{
 			Timeout:   timeout,
-			Transport: OtelTransport(nil),
+			Transport: OtelTransport(config.Transport),
 		},
 	}
 }

--- a/internal/httpclient/otel_test.go
+++ b/internal/httpclient/otel_test.go
@@ -65,6 +65,20 @@ func TestNewClientWithConfig_IsInstrumented(t *testing.T) {
 	}
 }
 
+type stubTransport struct{}
+
+func (stubTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, nil }
+
+func TestNewClientWithConfig_CustomTransport(t *testing.T) {
+	c, ok := NewClientWithConfig(ClientConfig{Transport: stubTransport{}}).(*DefaultClient)
+	if !ok {
+		t.Fatal("NewClientWithConfig did not return *DefaultClient")
+	}
+	if _, ok := c.client.Transport.(*otelhttp.Transport); !ok {
+		t.Fatalf("expected otel-wrapped transport, got %T", c.client.Transport)
+	}
+}
+
 // TestSend_RecordsClientSpan verifies that an outbound request through the
 // instrumented client produces exactly one CLIENT-kind span carrying the HTTP
 // semantic attributes that SigNoz External API Monitoring relies on, and that

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -8,11 +8,8 @@ import (
 	"time"
 )
 
-// IsPublicIP reports whether ip is a globally routable address -- i.e. not
-// loopback, link-local (including the 169.254.169.254 cloud metadata
-// address), private (RFC1918/RFC4193), unspecified, or multicast. It
-// correctly handles IPv4-mapped IPv6 forms since net.IP's classifiers
-// normalize via To4() internally.
+// IsPublicIP reports whether ip is globally routable (not loopback,
+// link-local incl. 169.254.169.254, private, unspecified, or multicast).
 func IsPublicIP(ip net.IP) bool {
 	switch {
 	case ip.IsLoopback(),
@@ -26,11 +23,8 @@ func IsPublicIP(ip net.IP) bool {
 	return true
 }
 
-// controlBlockNonPublic is a net.Dialer.Control callback. The Go runtime
-// invokes it on the actual resolved address immediately before the TCP
-// connect() syscall -- for the initial connection, every redirect hop, and
-// every candidate IP a hostname resolves to -- so validating here can't be
-// bypassed by a check-then-connect DNS-rebinding race.
+// controlBlockNonPublic runs on the resolved IP right before connect(), for
+// every dial including redirects -- so it can't be bypassed by DNS rebinding.
 func controlBlockNonPublic(_ string, address string, _ syscall.RawConn) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
@@ -49,9 +43,8 @@ func controlBlockNonPublic(_ string, address string, _ syscall.RawConn) error {
 	return nil
 }
 
-// SSRFSafeTransport returns an *http.Transport that refuses to connect to
-// non-public IP addresses. Use it as the base transport (wrapped with
-// OtelTransport) for any HTTP client that fetches a caller-supplied URL.
+// SSRFSafeTransport blocks connections to non-public IPs. Use as the base
+// transport (wrapped with OtelTransport) for clients fetching caller URLs.
 func SSRFSafeTransport() *http.Transport {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -11,7 +11,11 @@ import (
 // nonPublicNets covers reserved ranges net.IP's classifiers don't: "this
 // network" (0.0.0.0/8), RFC6598 shared address space (CGNAT), RFC5737/
 // RFC3849 documentation ranges, RFC2544 benchmarking, Class E reserved
-// space, and the limited broadcast address.
+// space, the limited broadcast address, and the RFC6052 local-use NAT64
+// prefix. The local-use prefix is blocked outright rather than unwrapped
+// like the well-known 64:ff9b::/96 prefix below: its /48 embedding splits
+// the IPv4 payload around a reserved byte, so decoding it is unnecessary
+// complexity for a prefix that isn't globally routable anyway.
 var nonPublicNets = mustParseCIDRs(
 	"0.0.0.0/8",
 	"100.64.0.0/10",
@@ -22,6 +26,7 @@ var nonPublicNets = mustParseCIDRs(
 	"240.0.0.0/4",
 	"255.255.255.255/32",
 	"2001:db8::/32",
+	"64:ff9b:1::/48",
 )
 
 // nat64Net and sixToFourNet are IPv6 transition mechanisms (RFC6052,
@@ -90,18 +95,21 @@ func IsPublicIP(ip net.IP) bool {
 // controlBlockNonPublic runs on the resolved IP right before connect(), for
 // every dial including redirects -- so it can't be bypassed by DNS rebinding.
 func controlBlockNonPublic(_ string, address string, _ syscall.RawConn) error {
+	// Error strings deliberately omit the address/IP: they flow into logs and
+	// traces, and echoing back attacker-supplied targets would let a caller
+	// enumerate internal network addressing.
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
-		return fmt.Errorf("ssrf guard: invalid address %q: %w", address, err)
+		return fmt.Errorf("ssrf guard: invalid address")
 	}
 
 	ip := net.ParseIP(host)
 	if ip == nil {
-		return fmt.Errorf("ssrf guard: unable to parse resolved address %q", host)
+		return fmt.Errorf("ssrf guard: unable to parse resolved address")
 	}
 
 	if !IsPublicIP(ip) {
-		return fmt.Errorf("ssrf guard: connections to %s are not allowed", ip.String())
+		return fmt.Errorf("ssrf guard: connection blocked to non-public address")
 	}
 
 	return nil

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -8,17 +8,30 @@ import (
 	"time"
 )
 
-// nonPublicNets covers reserved ranges net.IP's classifiers don't: RFC6598
-// shared address space (CGNAT), RFC5737/RFC3849 documentation ranges,
-// RFC2544 benchmarking, and the limited broadcast address.
+// nonPublicNets covers reserved ranges net.IP's classifiers don't: "this
+// network" (0.0.0.0/8), RFC6598 shared address space (CGNAT), RFC5737/
+// RFC3849 documentation ranges, RFC2544 benchmarking, Class E reserved
+// space, and the limited broadcast address.
 var nonPublicNets = mustParseCIDRs(
+	"0.0.0.0/8",
 	"100.64.0.0/10",
 	"192.0.2.0/24",
 	"198.51.100.0/24",
 	"203.0.113.0/24",
 	"198.18.0.0/15",
+	"240.0.0.0/4",
 	"255.255.255.255/32",
 	"2001:db8::/32",
+)
+
+// nat64Net and sixToFourNet are IPv6 transition mechanisms (RFC6052,
+// RFC3056) that embed an IPv4 address in the low/mid bits. IsPublicIP
+// unwraps and re-validates the embedded address so an attacker can't use
+// either encoding to smuggle a non-public IPv4 address past the checks
+// above, which only inspect the IPv6 bytes directly.
+var (
+	nat64Net     = mustParseCIDRs("64:ff9b::/96")[0]
+	sixToFourNet = mustParseCIDRs("2002::/16")[0]
 )
 
 func mustParseCIDRs(cidrs ...string) []*net.IPNet {
@@ -33,9 +46,26 @@ func mustParseCIDRs(cidrs ...string) []*net.IPNet {
 	return nets
 }
 
+// embeddedV4 returns the IPv4 address embedded in a NAT64 or 6to4 address,
+// or nil if ip is neither.
+func embeddedV4(ip net.IP) net.IP {
+	ip16 := ip.To16()
+	if ip16 == nil || ip.To4() != nil {
+		return nil
+	}
+	switch {
+	case nat64Net.Contains(ip):
+		return net.IP(ip16[12:16])
+	case sixToFourNet.Contains(ip):
+		return net.IP(ip16[2:6])
+	}
+	return nil
+}
+
 // IsPublicIP reports whether ip is globally routable (not loopback,
-// link-local incl. 169.254.169.254, private, unspecified, multicast, or
-// one of the reserved ranges in nonPublicNets).
+// link-local incl. 169.254.169.254, private, unspecified, multicast, one of
+// the reserved ranges in nonPublicNets, or a NAT64/6to4 encoding of a
+// non-public IPv4 address).
 func IsPublicIP(ip net.IP) bool {
 	switch {
 	case ip.IsLoopback(),
@@ -50,6 +80,9 @@ func IsPublicIP(ip net.IP) bool {
 		if n.Contains(ip) {
 			return false
 		}
+	}
+	if v4 := embeddedV4(ip); v4 != nil {
+		return IsPublicIP(v4)
 	}
 	return true
 }

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -54,5 +54,8 @@ func SSRFSafeTransport() *http.Transport {
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DialContext = dialer.DialContext
+	// Disable env-configured proxying: routing through a proxy would make the
+	// dial guard validate the proxy's IP, not the caller-supplied destination.
+	transport.Proxy = nil
 	return transport
 }

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -8,8 +8,34 @@ import (
 	"time"
 )
 
+// nonPublicNets covers reserved ranges net.IP's classifiers don't: RFC6598
+// shared address space (CGNAT), RFC5737/RFC3849 documentation ranges,
+// RFC2544 benchmarking, and the limited broadcast address.
+var nonPublicNets = mustParseCIDRs(
+	"100.64.0.0/10",
+	"192.0.2.0/24",
+	"198.51.100.0/24",
+	"203.0.113.0/24",
+	"198.18.0.0/15",
+	"255.255.255.255/32",
+	"2001:db8::/32",
+)
+
+func mustParseCIDRs(cidrs ...string) []*net.IPNet {
+	nets := make([]*net.IPNet, len(cidrs))
+	for i, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(err)
+		}
+		nets[i] = n
+	}
+	return nets
+}
+
 // IsPublicIP reports whether ip is globally routable (not loopback,
-// link-local incl. 169.254.169.254, private, unspecified, or multicast).
+// link-local incl. 169.254.169.254, private, unspecified, multicast, or
+// one of the reserved ranges in nonPublicNets).
 func IsPublicIP(ip net.IP) bool {
 	switch {
 	case ip.IsLoopback(),
@@ -19,6 +45,11 @@ func IsPublicIP(ip net.IP) bool {
 		ip.IsUnspecified(),
 		ip.IsMulticast():
 		return false
+	}
+	for _, n := range nonPublicNets {
+		if n.Contains(ip) {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/httpclient/ssrf.go
+++ b/internal/httpclient/ssrf.go
@@ -1,0 +1,65 @@
+package httpclient
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// IsPublicIP reports whether ip is a globally routable address -- i.e. not
+// loopback, link-local (including the 169.254.169.254 cloud metadata
+// address), private (RFC1918/RFC4193), unspecified, or multicast. It
+// correctly handles IPv4-mapped IPv6 forms since net.IP's classifiers
+// normalize via To4() internally.
+func IsPublicIP(ip net.IP) bool {
+	switch {
+	case ip.IsLoopback(),
+		ip.IsLinkLocalUnicast(),
+		ip.IsLinkLocalMulticast(),
+		ip.IsPrivate(),
+		ip.IsUnspecified(),
+		ip.IsMulticast():
+		return false
+	}
+	return true
+}
+
+// controlBlockNonPublic is a net.Dialer.Control callback. The Go runtime
+// invokes it on the actual resolved address immediately before the TCP
+// connect() syscall -- for the initial connection, every redirect hop, and
+// every candidate IP a hostname resolves to -- so validating here can't be
+// bypassed by a check-then-connect DNS-rebinding race.
+func controlBlockNonPublic(_ string, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("ssrf guard: invalid address %q: %w", address, err)
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("ssrf guard: unable to parse resolved address %q", host)
+	}
+
+	if !IsPublicIP(ip) {
+		return fmt.Errorf("ssrf guard: connections to %s are not allowed", ip.String())
+	}
+
+	return nil
+}
+
+// SSRFSafeTransport returns an *http.Transport that refuses to connect to
+// non-public IP addresses. Use it as the base transport (wrapped with
+// OtelTransport) for any HTTP client that fetches a caller-supplied URL.
+func SSRFSafeTransport() *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   controlBlockNonPublic,
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = dialer.DialContext
+	return transport
+}

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -36,6 +37,8 @@ func TestIsPublicIP(t *testing.T) {
 		{"class E reserved", "240.0.0.1", false},
 		{"nat64-encoded metadata IP", "64:ff9b::a9fe:a9fe", false},
 		{"nat64-encoded public IP", "64:ff9b::0808:0808", true},
+		{"nat64 local-use /48 metadata-embedding address", "64:ff9b:1:a9:fea9:fe00::", false},
+		{"nat64 local-use /48 public-looking address", "64:ff9b:1::0808:0808", false},
 		{"6to4-encoded loopback", "2002:7f00:1::", false},
 		{"6to4-encoded public IP", "2002:0808:0808::", true},
 		{"public v4", "8.8.8.8", true},
@@ -66,6 +69,16 @@ func TestSSRFSafeTransport_IgnoresProxyEnv(t *testing.T) {
 
 	if SSRFSafeTransport().Proxy != nil {
 		t.Fatal("expected SSRFSafeTransport to disable proxying so the dial guard always sees the real destination")
+	}
+}
+
+func TestControlBlockNonPublic_ErrorDoesNotLeakAddress(t *testing.T) {
+	err := controlBlockNonPublic("tcp", "127.0.0.1:80", nil)
+	if err == nil {
+		t.Fatal("expected loopback address to be blocked")
+	}
+	if strings.Contains(err.Error(), "127.0.0.1") {
+		t.Errorf("error must not leak the resolved address, got: %v", err)
 	}
 }
 

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -25,6 +25,13 @@ func TestIsPublicIP(t *testing.T) {
 		{"unspecified v6", "::", false},
 		{"multicast v4", "224.0.0.1", false},
 		{"ipv4-mapped loopback", "::ffff:127.0.0.1", false},
+		{"shared address space (CGNAT)", "100.64.0.1", false},
+		{"documentation TEST-NET-1", "192.0.2.1", false},
+		{"documentation TEST-NET-2", "198.51.100.1", false},
+		{"documentation TEST-NET-3", "203.0.113.1", false},
+		{"benchmarking", "198.18.0.1", false},
+		{"limited broadcast", "255.255.255.255", false},
+		{"ipv6 documentation", "2001:db8::1", false},
 		{"public v4", "8.8.8.8", true},
 		{"public v6", "2606:4700:4700::1111", true},
 	}

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -1,0 +1,56 @@
+package httpclient
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsPublicIP(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"loopback v4", "127.0.0.1", false},
+		{"loopback v6", "::1", false},
+		{"link-local metadata", "169.254.169.254", false},
+		{"link-local v6", "fe80::1", false},
+		{"private 10/8", "10.0.0.5", false},
+		{"private 172.16/12", "172.16.5.5", false},
+		{"private 192.168/16", "192.168.1.1", false},
+		{"unique local v6", "fc00::1", false},
+		{"unspecified v4", "0.0.0.0", false},
+		{"unspecified v6", "::", false},
+		{"multicast v4", "224.0.0.1", false},
+		{"ipv4-mapped loopback", "::ffff:127.0.0.1", false},
+		{"public v4", "8.8.8.8", true},
+		{"public v6", "2606:4700:4700::1111", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %q", tt.ip)
+			}
+			if got := IsPublicIP(ip); got != tt.want {
+				t.Errorf("IsPublicIP(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSRFSafeTransport_BlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: SSRFSafeTransport()}
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected request to loopback test server to be blocked, got nil error")
+	}
+}

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -32,6 +32,12 @@ func TestIsPublicIP(t *testing.T) {
 		{"benchmarking", "198.18.0.1", false},
 		{"limited broadcast", "255.255.255.255", false},
 		{"ipv6 documentation", "2001:db8::1", false},
+		{"this-network 0/8", "0.1.2.3", false},
+		{"class E reserved", "240.0.0.1", false},
+		{"nat64-encoded metadata IP", "64:ff9b::a9fe:a9fe", false},
+		{"nat64-encoded public IP", "64:ff9b::0808:0808", true},
+		{"6to4-encoded loopback", "2002:7f00:1::", false},
+		{"6to4-encoded public IP", "2002:0808:0808::", true},
 		{"public v4", "8.8.8.8", true},
 		{"public v6", "2606:4700:4700::1111", true},
 	}

--- a/internal/httpclient/ssrf_test.go
+++ b/internal/httpclient/ssrf_test.go
@@ -42,6 +42,20 @@ func TestIsPublicIP(t *testing.T) {
 	}
 }
 
+func TestSSRFSafeTransport_IgnoresProxyEnv(t *testing.T) {
+	// http.DefaultTransport (which SSRFSafeTransport clones) defaults Proxy to
+	// ProxyFromEnvironment. If left in place, an HTTP_PROXY/HTTPS_PROXY env var
+	// would make the dial guard validate only the proxy's IP while the proxy
+	// itself forwards to whatever internal address the caller-supplied URL
+	// names -- bypassing the guard entirely.
+	t.Setenv("HTTP_PROXY", "http://127.0.0.1:9")
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9")
+
+	if SSRFSafeTransport().Proxy != nil {
+		t.Fatal("expected SSRFSafeTransport to disable proxying so the dial guard always sees the real destination")
+	}
+}
+
 func TestSSRFSafeTransport_BlocksLoopback(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## **User description**
## Summary

Closes SFX-0203-F05 / VAPT 6.2 (HIGH) — SSRF via the caller-supplied `file_url` on task import. All four HTTP clients that fetch a task's `file_url` (`FileProcessor.Client`, its two ad-hoc streaming/size-check clients, and `StreamingProcessor.RetryClient`) now share a hardened transport that blocks outbound connections to non-public IPs.

- **`internal/httpclient/ssrf.go`**: `SSRFSafeTransport()` installs a `net.Dialer.Control` hook that validates the actual resolved IP right before `connect()` — for the initial request, every redirect hop, and every candidate address a hostname resolves to — so it can't be bypassed by a check-then-connect DNS-rebinding race. Blocks loopback, link-local (incl. `169.254.169.254` cloud metadata), private (RFC1918/RFC4193), unspecified, and multicast addresses.
- **`internal/httpclient/client.go`**: `ClientConfig` gains an optional `Transport` override (additive, no behavior change for existing callers).
- **`internal/ee/service/file_provider.go`**: restricts `file_url` to `http`/`https` schemes, and fixes `FileProviderRegistry.GetProvider` to match on the parsed hostname instead of substring-matching the raw URL (closes the `evil.com/?x=drive.google.com` misclassification the finding called out).
- **`internal/ee/service/streaming_processor.go` / `file_processor.go` / `task.go`**: wire the hardened transport through all four download paths; `NewFileProcessor`/`NewStreamingProcessor` now build it internally instead of taking an external client.

Scope: only the file-download path is hardened. The shared `httpclient.Client` used by Stripe/HubSpot/Nomod/Whop/Azure Marketplace/Gemini integrations is untouched, since those hit fixed, known-safe hosts.

Design spec and implementation plan (not committed — gitignored under `docs/superpowers/`) walked through the same reasoning in more depth if useful for review context.

## Test plan

- [x] New table-driven tests for `IsPublicIP` (loopback, `169.254.169.254`, RFC1918 x3, IPv6 loopback/ULA, unspecified, multicast, public)
- [x] `httptest.Server`-backed test proving `SSRFSafeTransport()` refuses to connect to a loopback test server
- [x] End-to-end tests proving `FileProcessor.DownloadFile`/`DownloadFileStream`/`GetFileSize` and `StreamingProcessor.downloadFileStream` (the actual production path via `ProcessTaskWithStreaming`) all reject a loopback `file_url`
- [x] Table-driven tests for scheme validation and corrected provider hostname matching (incl. spoofing cases)
- [x] Full `internal/ee/service` suite passes, including `TestTaskService`, confirming the existing mock-client test wiring is unaffected
- [x] `go build`, `go vet` clean; one pre-existing, unrelated `TestWalletService` failure confirmed present on `develop` before this branch (context-cancellation test, untouched by this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened protection against unsafe network requests, including loopback, private, reserved, and other non-public addresses.
  * Reduced risks from proxy settings and hostname-based network bypasses.
  * Restricted file providers to valid HTTP and HTTPS URLs.
  * Improved provider detection to prevent misleading or unrelated URLs from being misidentified.
  * Preserved request tracing when using custom network transports.
  * Prevented streaming downloads and file-size requests from accessing unsafe local endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Block unsafe task file downloads and validate caller-supplied URLs

### What Changed
- Task imports now allow file downloads only from HTTP and HTTPS URLs with a valid host.
- Downloads, streaming requests, size checks, redirects, retries, and provider fetches reject loopback, private, link-local, reserved, and other non-public network addresses.
- Proxy environment settings can no longer bypass the network-address checks.
- File provider detection now uses the actual hostname, preventing lookalike domains and query parameters from being treated as trusted providers.
- Added coverage for unsafe addresses, URL validation, provider spoofing, proxy bypasses, and all file-download paths.

### Impact
`✅ Blocked access to cloud metadata and private network services`
`✅ Safer task imports from caller-supplied URLs`
`✅ Fewer incorrect provider classifications`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
