### PR TITLE
fix(creditnote): recalc invoice amounts inside the void/finalize transaction

### DIFF
--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -412,23 +412,34 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 	// Update credit note status to voided
 	cn.CreditNoteStatus = types.CreditNoteStatusVoided
 
-	if err := s.CreditNoteRepo.Update(ctx, cn); err != nil {
+	// Process the status update and invoice recalculation in a single transaction
+	// so a recalculation failure rolls back the status change too.
+	err = s.DB.WithTx(ctx, func(tx context.Context) error {
+		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {
+			return err
+		}
+
+		// Recalculate invoice amounts after credit note void
+		// This is needed to update the adjustment and refunded amounts
+		if originalStatus == types.CreditNoteStatusFinalized {
+			invoiceService := NewInvoiceService(s.ServiceParams)
+			if err := invoiceService.RecalculateInvoiceAmounts(tx, cn.InvoiceID); err != nil {
+				s.Logger.Error(ctx, "failed to recalculate invoice amounts after credit note void",
+					"error", err,
+					"credit_note_id", cn.ID,
+					"invoice_id", cn.InvoiceID)
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
 		return err
 	}
 
-	// Recalculate invoice amounts after credit note void
-	// This is needed to update the adjustment and refunded amounts
-	if originalStatus == types.CreditNoteStatusFinalized {
-		invoiceService := NewInvoiceService(s.ServiceParams)
-		if err := invoiceService.RecalculateInvoiceAmounts(ctx, cn.InvoiceID); err != nil {
-			s.Logger.Error(ctx, "failed to recalculate invoice amounts after credit note void",
-				"error", err,
-				"credit_note_id", cn.ID,
-				"invoice_id", cn.InvoiceID)
-		}
-	}
-
-	// Publish webhook event after successful update
+	// Publish webhook event after successful transaction
 	s.publishSystemEvent(ctx, types.WebhookEventCreditNoteUpdated, cn.ID)
 
 	s.Logger.Info(ctx, "credit note voided successfully",

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -544,16 +544,17 @@ func (s *creditNoteService) FinalizeCreditNote(ctx context.Context, id string) e
 
 		// Recalculate invoice amounts after credit note finalization
 		// This is needed to update the adjustment and refunded amounts
-		inv, err := s.InvoiceRepo.Get(ctx, cn.InvoiceID)
+		inv, err := s.InvoiceRepo.Get(tx, cn.InvoiceID)
 		if err != nil {
 			return err
 		}
 
-		if err := s.RecalculateInvoiceAmountsForCreditNote(ctx, inv, cn); err != nil {
+		if err := s.RecalculateInvoiceAmountsForCreditNote(tx, inv, cn); err != nil {
 			s.Logger.Error(ctx, "failed to recalculate invoice amounts after credit note finalization",
 				"error", err,
 				"credit_note_id", cn.ID,
 				"invoice_id", cn.InvoiceID)
+			return err
 		}
 
 		return nil

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -974,6 +975,68 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote() {
 			s.Equal(types.CreditNoteStatusVoided, resp.CreditNoteStatus)
 		})
 	}
+}
+
+// failOnUpdateInvoiceRepo wraps a real invoice.Repository and forces Update to
+// fail for one specific invoice ID, leaving every other method (including Get)
+// delegated to the real repo. This is the only way to make
+// RecalculateInvoiceAmountsForCreditNote's InvoiceRepo.Update call fail while
+// the earlier InvoiceRepo.Get call in FinalizeCreditNote still succeeds -
+// deleting the invoice out from under it fails the (already-correct) Get
+// instead of the (buggy, swallowed-error) recalculation step.
+type failOnUpdateInvoiceRepo struct {
+	invoice.Repository
+	failInvoiceID string
+}
+
+func (r *failOnUpdateInvoiceRepo) Update(ctx context.Context, inv *invoice.Invoice) error {
+	if inv.ID == r.failInvoiceID {
+		return errors.New("forced invoice update failure for test")
+	}
+	return r.Repository.Update(ctx, inv)
+}
+
+func (s *CreditNoteServiceSuite) TestFinalizeCreditNote_RecalculationFailureIsPropagated() {
+	cn := &creditnote.CreditNote{
+		ID:               "cn_finalize_recalc_fail_test",
+		CustomerID:       s.testData.customer.ID,
+		InvoiceID:        s.testData.invoices.pending.ID,
+		CreditNoteNumber: "CN-FINALIZE-RECALC-FAIL-TEST",
+		CreditNoteStatus: types.CreditNoteStatusDraft,
+		CreditNoteType:   types.CreditNoteTypeAdjustment,
+		Reason:           types.CreditNoteReasonBillingError,
+		Currency:         "USD",
+		TotalAmount:      decimal.NewFromFloat(10.00),
+		LineItems: []*creditnote.CreditNoteLineItem{
+			{
+				ID:          "finalize_recalc_fail_line_1",
+				DisplayName: "Adjustment for Product C",
+				Amount:      decimal.NewFromFloat(10.00),
+				Currency:    "USD",
+				BaseModel:   types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CreditNoteRepo.CreateWithLineItems(s.GetContext(), cn))
+
+	failingService := NewCreditNoteService(ServiceParams{
+		Logger:           s.GetLogger(),
+		DB:               s.GetDB(),
+		CreditNoteRepo:   s.GetStores().CreditNoteRepo,
+		InvoiceRepo:      &failOnUpdateInvoiceRepo{Repository: s.GetStores().InvoiceRepo, failInvoiceID: cn.InvoiceID},
+		WebhookPublisher: s.GetWebhookPublisher(),
+	})
+
+	// setupTestData's createTestWallets() already publishes webhooks via the same
+	// shared publisher, so assert no *new* webhook was published rather than empty.
+	webhookCountBefore := len(s.GetPublishedWebhooks())
+
+	err := failingService.FinalizeCreditNote(s.GetContext(), cn.ID)
+
+	s.Error(err)
+	s.Contains(err.Error(), "forced invoice update failure for test")
+	s.Len(s.GetPublishedWebhooks(), webhookCountBefore)
 }
 
 func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailureIsPropagated() {

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -978,12 +978,12 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote() {
 }
 
 // failOnUpdateInvoiceRepo wraps a real invoice.Repository and forces Update to
-// fail for one specific invoice ID, leaving every other method (including Get)
-// delegated to the real repo. This is the only way to make
+// fail for one specific invoice ID, leaving every other method (including
+// GetForUpdate) delegated to the real repo. This is the only way to make
 // RecalculateInvoiceAmountsForCreditNote's InvoiceRepo.Update call fail while
-// the earlier InvoiceRepo.Get call in FinalizeCreditNote still succeeds -
-// deleting the invoice out from under it fails the (already-correct) Get
-// instead of the (buggy, swallowed-error) recalculation step.
+// the earlier GetForUpdate in FinalizeCreditNote still succeeds — deleting the
+// invoice out from under it fails the (already-correct) lock instead of the
+// (buggy, swallowed-error) recalculation step.
 type failOnUpdateInvoiceRepo struct {
 	invoice.Repository
 	failInvoiceID string

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -976,6 +976,43 @@ func (s *CreditNoteServiceSuite) TestVoidCreditNote() {
 	}
 }
 
+func (s *CreditNoteServiceSuite) TestVoidCreditNote_RecalculationFailureIsPropagated() {
+	cn := &creditnote.CreditNote{
+		ID:               "cn_void_recalc_fail_test",
+		CustomerID:       s.testData.customer.ID,
+		InvoiceID:        s.testData.invoices.pending.ID,
+		CreditNoteNumber: "CN-VOID-RECALC-FAIL-TEST",
+		CreditNoteStatus: types.CreditNoteStatusFinalized,
+		CreditNoteType:   types.CreditNoteTypeAdjustment,
+		Reason:           types.CreditNoteReasonBillingError,
+		Currency:         "USD",
+		TotalAmount:      decimal.NewFromFloat(10.00),
+		LineItems: []*creditnote.CreditNoteLineItem{
+			{
+				ID:          "void_recalc_fail_line_1",
+				DisplayName: "Adjustment for Product C",
+				Amount:      decimal.NewFromFloat(10.00),
+				Currency:    "USD",
+				BaseModel:   types.GetDefaultBaseModel(s.GetContext()),
+			},
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CreditNoteRepo.CreateWithLineItems(s.GetContext(), cn))
+
+	// Delete the invoice out from under the credit note so invoice amount
+	// recalculation fails when VoidCreditNote tries to fetch it.
+	s.NoError(s.GetStores().InvoiceRepo.Delete(s.GetContext(), s.testData.invoices.pending.ID))
+
+	webhookCountBefore := len(s.GetPublishedWebhooks())
+
+	err := s.service.VoidCreditNote(s.GetContext(), cn.ID)
+
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+	s.Len(s.GetPublishedWebhooks(), webhookCountBefore)
+}
+
 func (s *CreditNoteServiceSuite) TestProcessDraftCreditNote() {
 	// Create draft credit note manually in repository to test processing
 	// This bypasses the CreateCreditNote validation that automatically processes the credit note


### PR DESCRIPTION
## **User description**
## Summary

Fixes SFX-0203-F08 (Secfox, MEDIUM): `VoidCreditNote` and `FinalizeCreditNote` updated the credit note status and recalculated the parent invoice's amounts as non-atomic writes, and silently swallowed recalculation errors — so a credit note could end up voided/finalized while the invoice's adjustment/refunded amounts stayed stale.

- `VoidCreditNote`: wraps the status update and `RecalculateInvoiceAmounts` call in `s.DB.WithTx`; a recalculation failure now rolls back the status change and returns the error to the caller (previously logged only, void still "succeeded").
- `FinalizeCreditNote`: the existing `WithTx` closure was calling `InvoiceRepo.Get` and `RecalculateInvoiceAmountsForCreditNote` with the outer, non-tx `ctx` instead of the tx-scoped `tx`, so recalculation actually ran outside the transaction despite appearances; both calls now use `tx`, and a recalculation failure now rolls back the status update and wallet top-up (for refund-type credit notes) instead of being logged and ignored.

## Test plan

- [x] Added `TestVoidCreditNote_RecalculationFailureIsPropagated` — deletes the invoice out from under a finalized credit note so recalculation fails; confirms `VoidCreditNote` now returns an error and no webhook is published (previously returned `nil` and published a webhook).
- [x] Added `TestFinalizeCreditNote_RecalculationFailureIsPropagated` — uses a decorator `InvoiceRepo` that forces `Update` to fail for one invoice ID (the initial `Get` already propagated correctly, so a plain delete doesn't exercise the actual swallowed-error bug); confirms `FinalizeCreditNote` now returns an error and no webhook is published.
- [x] `go test -v -race ./internal/ee/service -run TestCreditNoteService` — full suite passes, including existing `TestVoidCreditNote` and `TestProcessDraftCreditNote` (no regression).
- [x] `go vet ./internal/...`, `gofmt -l`, `make lint-ci` — all clean.
- [x] `make test` — one unrelated pre-existing failure (`TestGetWalletBalanceV2_SkipsFallbackOnClientDisconnect`), confirmed present on `develop` before this change and untouched by this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for credit-note finalization when invoice recalculation fails.
  * Verified that failures are correctly surfaced and no webhook is emitted when finalization cannot complete.
  * Improved confidence in error handling for credit-note processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make credit note finalization and voiding atomic when invoice recalculation fails

### What Changed
- Credit note status changes now roll back when updating the related invoice fails
- Finalization no longer completes a wallet refund or publishes a webhook after recalculation fails
- Added coverage for recalculation failures during credit note finalization and voiding

### Impact
`✅ No partially completed credit note operations`
`✅ Accurate invoice adjustment and refund amounts`
`✅ No misleading webhooks after failed finalization`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
