### PR TITLE
fix(clickhouse): support HTTP wire protocol

### DIFF
--- a/internal/config/clickhouse_config_test.go
+++ b/internal/config/clickhouse_config_test.go
@@ -2,7 +2,42 @@ package config
 
 import (
 	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
 )
+
+// An unset protocol must keep resolving to Native: every deployment predating the
+// field relies on that, and the failure mode of getting it wrong (native client on
+// an HTTP port) is an opaque "[handshake] unexpected packet [72] from server".
+func TestClickHouseConfig_GetClientOptions_Protocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		want     clickhouse.Protocol
+	}{
+		{"unset defaults to native", "", clickhouse.Native},
+		{"explicit native", "native", clickhouse.Native},
+		{"http", "http", clickhouse.HTTP},
+		{"http is case-insensitive", "HTTP", clickhouse.HTTP},
+		{"unrecognised falls back to native", "grpc", clickhouse.Native},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := ClickHouseConfig{
+				Address:        "127.0.0.1:9000",
+				Username:       "u",
+				Password:       "p",
+				Database:       "d",
+				MaxMemoryUsage: 50,
+				Protocol:       tt.protocol,
+			}
+			if got := c.GetClientOptions().Protocol; got != tt.want {
+				t.Errorf("Protocol: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestClickHouseConfig_GetClientOptions_MaxMemoryUsage(t *testing.T) {
 	// Hardcoded limit: 50 GB

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -280,7 +280,16 @@ type ClickHouseConfig struct {
 	// environments whose ClickHouse serves a self-signed certificate (equivalent to
 	// SSL=true with SSL_MODE=NONE); it removes MITM protection, so leave it false
 	// everywhere else and trust the CA instead.
-	TLSSkipVerify  bool   `mapstructure:"tls_skip_verify"`
+	TLSSkipVerify bool `mapstructure:"tls_skip_verify"`
+	// Protocol selects the ClickHouse wire protocol: "native" (default) or "http".
+	// The two protocols listen on different ports and are not interchangeable — a
+	// native client pointed at an HTTP port fails with
+	// "[handshake] unexpected packet [72] from server" (72 is 'H' of "HTTP/1.1").
+	// Ports: native 9000 / 9440 (TLS), http 8123 / 8443 (TLS). Set this to "http"
+	// when ClickHouse is only reachable through an HTTP(S) endpoint, e.g. behind a
+	// TLS-terminating load balancer that exposes 8443. Empty means native so
+	// existing deployments keep their current behaviour.
+	Protocol       string `mapstructure:"protocol" validate:"omitempty,oneof=native http"`
 	Username       string `mapstructure:"username" validate:"required"`
 	Password       string `mapstructure:"password" validate:"required"`
 	Database       string `mapstructure:"database" validate:"required"`
@@ -1049,6 +1058,16 @@ func GetDefaultConfig() *Configuration {
 	}
 }
 
+// protocol maps the configured protocol name onto the driver's enum. An unset or
+// unrecognised value yields clickhouse.Native, which is both the driver's zero
+// value and the behaviour every deployment had before this field existed.
+func (c ClickHouseConfig) protocol() clickhouse.Protocol {
+	if strings.EqualFold(c.Protocol, "http") {
+		return clickhouse.HTTP
+	}
+	return clickhouse.Native
+}
+
 func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 	options := &clickhouse.Options{
 		Addr: []string{c.Address},
@@ -1079,6 +1098,7 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 	if c.TLS {
 		options.TLS = &tls.Config{InsecureSkipVerify: c.TLSSkipVerify} // #nosec G402 -- opt-in, dev-only self-signed certs
 	}
+	options.Protocol = c.protocol()
 
 	maxMemoryUsageBytes := c.MaxMemoryUsage * int64(1024) * int64(1024) * int64(1024)
 	options.Settings = clickhouse.Settings{

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -105,6 +105,12 @@ clickhouse:
   address: 127.0.0.1:9000 # For local mode
   # Will be overridden by FLEXPRICE_CLICKHOUSE_ADDRESS env var in Docker
   tls: false
+  # Wire protocol: native (default) or http. The address port must match the
+  # protocol — native listens on 9000 (9440 with TLS), http on 8123 (8443 with
+  # TLS). A native client pointed at an HTTP port fails at connect with
+  # "[handshake] unexpected packet [72] from server". Use http when ClickHouse is
+  # only reachable via an HTTPS endpoint, e.g. behind a TLS-terminating LB.
+  protocol: native
   username: flexprice
   password: flexprice123
   database: flexprice


### PR DESCRIPTION
## **User description**
## Problem

The clickhouse-go client is always opened in **native** protocol mode: `GetClientOptions` never sets `Options.Protocol`, and the driver's zero value is `clickhouse.Native`.

Deployments whose ClickHouse is only reachable over HTTP(S) — for example behind a TLS-terminating load balancer exposing `8443` — fail every query and insert at connect time:

```
failed to bulk insert meter usage: [handshake] unexpected packet [72] from server
```

`72` is `H`, the first byte of the server's `HTTP/1.1` response to what the driver expected to be a native handshake. The error surfaces per-query in both the consumer and the API, not at boot, so it presents as a total ClickHouse outage rather than a misconfiguration.

## Change

Adds a `clickhouse.protocol` setting (`native` | `http`), bound from `FLEXPRICE_CLICKHOUSE_PROTOCOL`.

An unset or unrecognised value resolves to `Native` — both the driver's zero value and the behaviour of every deployment predating this field — so the change is backward compatible.

The env var binds through the reflective autobind, so no Helm template change is needed: migrated environments pass it as a plain key under `.Values.env`.

## Port / protocol matrix

The address port must match the protocol; they are not interchangeable.

| Protocol | plaintext | TLS |
|---|---|---|
| native | 9000 | 9440 |
| http | 8123 | 8443 |

All current flexprice environments run native (9000, or 9440 for the TLS ones) and are unaffected by this change.

## Testing

- Table test over the protocol mapping, including the unset-defaults-to-native case that guards backward compatibility, and case-insensitivity.
- `go build`, `go test ./internal/config/...`, `go vet` all pass.
- Verified out-of-band that `FLEXPRICE_CLICKHOUSE_PROTOCOL=http` binds correctly through `NewConfig()` via the reflective autobind.


___

## **CodeAnt-AI Description**
Support ClickHouse deployments reachable through HTTP or HTTPS

### What Changed
- ClickHouse can now use the HTTP wire protocol when configured with `clickhouse.protocol: http`
- Native protocol remains the default, preserving existing deployments
- Protocol names are case-insensitive, and invalid values fall back to native
- Configuration documents the required port combinations for native and HTTP connections

### Impact
`✅ ClickHouse works through HTTP(S) endpoints`
`✅ Fewer connection failures caused by protocol mismatches`
`✅ Existing native deployments remain unchanged`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ClickHouse connection protocols: native or HTTP.
  * Native protocol remains the default, with support for HTTP and HTTPS endpoint configurations.
  * Added validation and configuration guidance for protocol and port selection.

* **Tests**
  * Added coverage for default, explicit, case-insensitive, and unsupported protocol values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->