### PR TITLE
fix(coupon): enforce redemption limits on subscription modify path (VAPT)

### DIFF
--- a/internal/api/dto/coupon.go
+++ b/internal/api/dto/coupon.go
@@ -10,6 +10,11 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// MaxCouponRedemptionsLimit caps the max_redemptions a coupon may be created
+// with. Prevents impractically large limits that undermine business controls
+// (VAPT: no upper bound on max_redemptions).
+const MaxCouponRedemptionsLimit = 1_000_000
+
 // CreateCouponRequest represents the request to create a new coupon
 type CreateCouponRequest struct {
 	Name              string                  `json:"name" validate:"required"`
@@ -81,9 +86,13 @@ func (r *CreateCouponRequest) Validate() error {
 		}
 	}
 
-	if r.MaxRedemptions != nil && *r.MaxRedemptions <= 0 {
-		return ierr.NewError("max_redemptions must be greater than zero").
+	if r.MaxRedemptions != nil && (*r.MaxRedemptions <= 0 || *r.MaxRedemptions > MaxCouponRedemptionsLimit) {
+		return ierr.NewError("max_redemptions must be between 1 and 1000000").
 			WithHint("Please provide a valid maximum redemption count").
+			WithReportableDetails(map[string]interface{}{
+				"max_redemptions": *r.MaxRedemptions,
+				"limit":           MaxCouponRedemptionsLimit,
+			}).
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/api/dto/coupon_test.go
+++ b/internal/api/dto/coupon_test.go
@@ -1,0 +1,59 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseValidCouponRequest returns a minimal CreateCouponRequest that passes
+// Validate(), so tests can vary a single field in isolation.
+func baseValidCouponRequest() CreateCouponRequest {
+	pct := decimal.NewFromInt(10)
+	return CreateCouponRequest{
+		Name:          "Test Coupon",
+		Type:          types.CouponTypePercentage,
+		Cadence:       types.CouponCadenceOnce,
+		PercentageOff: &pct,
+	}
+}
+
+// TestCreateCouponRequest_MaxRedemptions covers the VAPT finding that
+// max_redemptions had no upper bound (impractically large values accepted).
+func TestCreateCouponRequest_MaxRedemptions(t *testing.T) {
+	cases := []struct {
+		name    string
+		max     *int
+		wantErr bool
+	}{
+		{name: "nil is allowed (unlimited)", max: nil, wantErr: false},
+		{name: "one is allowed", max: lo.ToPtr(1), wantErr: false},
+		{name: "at the limit is allowed", max: lo.ToPtr(MaxCouponRedemptionsLimit), wantErr: false},
+		{name: "zero is rejected", max: lo.ToPtr(0), wantErr: true},
+		{name: "negative is rejected", max: lo.ToPtr(-5), wantErr: true},
+		{name: "just over the limit is rejected", max: lo.ToPtr(MaxCouponRedemptionsLimit + 1), wantErr: true},
+		{name: "the VAPT value 100000000000 is rejected", max: lo.ToPtr(100_000_000_000), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := baseValidCouponRequest()
+			req.MaxRedemptions = tc.max
+			err := req.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMaxCouponRedemptionsLimit(t *testing.T) {
+	// Guard against accidental changes to the business cap.
+	assert.Equal(t, 1_000_000, MaxCouponRedemptionsLimit)
+}

--- a/internal/ee/service/subscription_modification_coupon.go
+++ b/internal/ee/service/subscription_modification_coupon.go
@@ -56,6 +56,15 @@ func (s *subscriptionModificationService) executeAddCoupon(
 	}
 	couponID := c.ID
 
+	// Enforce coupon redemption rules (max_redemptions, redeem_after,
+	// redeem_before, currency/cadence) before creating the association. Without
+	// this, the modify/execute path bypasses every restriction the create path
+	// enforces (VAPT: coupon limits/validity not enforced at redemption time).
+	validationService := NewCouponValidationService(sp)
+	if err := validationService.ValidateCoupon(ctx, *c, sub); err != nil {
+		return nil, err
+	}
+
 	// Resolve target: line-item level or subscription level.
 	var lineItemID *string
 	if params.SubscriptionLineItemID != nil {
@@ -122,7 +131,19 @@ func (s *subscriptionModificationService) executeAddCoupon(
 		BaseModel:              types.GetDefaultBaseModel(ctx),
 	}
 	if err := sp.DB.WithTx(ctx, func(txCtx context.Context) error {
-		return sp.CouponAssociationRepo.Create(txCtx, assoc)
+		if err := sp.CouponAssociationRepo.Create(txCtx, assoc); err != nil {
+			return err
+		}
+		// Atomically increment total_redemptions within the same transaction.
+		// The DB-level CAS in IncrementRedemptions (WHERE total_redemptions <
+		// max_redemptions) is the real limit guard — it closes the TOCTOU between
+		// the ValidateCoupon read above and this insert, and keeps the counter in
+		// sync so the create path's limit stays enforced too. c.MaxRedemptions is
+		// immutable coupon config, safe to reuse from the earlier read.
+		if err := sp.CouponRepo.IncrementRedemptions(txCtx, couponID, c.MaxRedemptions); err != nil {
+			return err
+		}
+		return nil
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/ee/service/subscription_modification_coupon_test.go
+++ b/internal/ee/service/subscription_modification_coupon_test.go
@@ -557,3 +557,121 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 		})
 	}
 }
+
+// createCouponWithLimits creates a published percentage-off coupon with the
+// given redemption controls, for the VAPT redemption-enforcement tests.
+func (s *SubscriptionModificationServiceSuite) createCouponWithLimits(
+	maxRedemptions *int,
+	totalRedemptions int,
+	redeemAfter, redeemBefore *time.Time,
+) *coupon_domain.Coupon {
+	ctx := s.GetContext()
+	pct := decimal.NewFromInt(10)
+	id := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON)
+	c := &coupon_domain.Coupon{
+		ID:               id,
+		Name:             "Limited Coupon",
+		Type:             types.CouponTypePercentage,
+		Cadence:          types.CouponCadenceForever,
+		PercentageOff:    &pct,
+		CouponCode:       lo.ToPtr(id),
+		MaxRedemptions:   maxRedemptions,
+		TotalRedemptions: totalRedemptions,
+		RedeemAfter:      redeemAfter,
+		RedeemBefore:     redeemBefore,
+		EnvironmentID:    types.GetEnvironmentID(ctx),
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	c.Status = types.StatusPublished
+	s.Require().NoError(s.GetStores().CouponRepo.Create(ctx, c))
+	return c
+}
+
+// TestCouponRedemptionEnforcement covers the VAPT finding that the
+// subscription modify/execute add-coupon path did not enforce max_redemptions,
+// redeem_after, or redeem_before, and never incremented total_redemptions.
+func (s *SubscriptionModificationServiceSuite) TestCouponRedemptionEnforcement() {
+	s.Run("max_redemptions already reached — add is rejected", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-max-reached")
+		sub := s.createActiveSub(cust.ID)
+		// max=2, already at 2 → limit reached.
+		c := s.createCouponWithLimits(lo.ToPtr(2), 2, nil, nil)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().Error(err, "coupon at max_redemptions must not be redeemable")
+
+		// No association should have been created.
+		assocs, listErr := s.GetStores().CouponAssociationRepo.List(ctx, &types.CouponAssociationFilter{
+			QueryFilter:     types.NewNoLimitQueryFilter(),
+			SubscriptionIDs: []string{sub.ID},
+			CouponIDs:       []string{c.ID},
+		})
+		s.Require().NoError(listErr)
+		s.Len(assocs, 0)
+	})
+
+	s.Run("redeem_after in the future — add is rejected", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-not-yet-valid")
+		sub := s.createActiveSub(cust.ID)
+		future := s.GetNow().Add(72 * time.Hour)
+		c := s.createCouponWithLimits(nil, 0, &future, nil)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().Error(err, "coupon before its redeem_after must not be redeemable")
+	})
+
+	s.Run("redeem_before in the past — add is rejected", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-expired")
+		sub := s.createActiveSub(cust.ID)
+		past := s.GetNow().Add(-72 * time.Hour)
+		c := s.createCouponWithLimits(nil, 0, nil, &past)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().Error(err, "coupon past its redeem_before must not be redeemable")
+	})
+
+	s.Run("successful add increments total_redemptions", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-increments")
+		sub := s.createActiveSub(cust.ID)
+		c := s.createCouponWithLimits(lo.ToPtr(5), 0, nil, nil)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().NoError(err)
+
+		updated, getErr := s.GetStores().CouponRepo.Get(ctx, c.ID)
+		s.Require().NoError(getErr)
+		s.Equal(1, updated.TotalRedemptions, "total_redemptions must be incremented on redemption")
+	})
+}


### PR DESCRIPTION
## **User description**
## What

Closes two VAPT findings on coupon redemption.

### Finding 3 (MEDIUM) — max_redemptions / redeem_before / redeem_after not enforced at redemption time

The subscription `modify/execute` add-coupon path (`executeAddCoupon`) bypassed **every** coupon redemption control:
- `max_redemptions` never checked — a coupon with `max_redemptions=2` could be redeemed unlimited times.
- `redeem_after` / `redeem_before` never checked — coupons outside their validity window redeemed freely.
- `total_redemptions` never incremented — so the counter the *other* (sanctioned) path reads never grew, silently un-enforcing its limit too.

Validation was already fully implemented and correctly wired on the `ApplyCouponsToSubscription` path; `executeAddCoupon` just re-implemented association creation and skipped it.

**Fix:**
- Call `ValidateCoupon(ctx, *c, sub)` before creating the association (covers dates + max + currency/cadence), matching the sanctioned path.
- Call `IncrementRedemptions` inside the association-create transaction. Its DB-level CAS (`WHERE total_redemptions < max_redemptions`) is the real limit guard — it closes the TOCTOU between the validate read and the insert, and keeps the counter in sync.

### Finding 4 (LOW) — no upper bound on max_redemptions

`POST /v1/coupons` accepted `max_redemptions=100000000000`. Added `MaxCouponRedemptionsLimit = 1,000,000`; DTO `Validate()` now rejects values outside `[1, 1000000]`.

## Tests

- `TestCouponRedemptionEnforcement` — max reached rejected, redeem_after future rejected, redeem_before past rejected, successful add increments the counter.
- `TestCreateCouponRequest_MaxRedemptions` — boundary table incl. the exact VAPT value `100000000000`.

All coupon-modification and coupon-DTO suites pass. No interface changes (no mock regen). No new dependencies.

## Notes

- Preview path (`previewAddCoupon`) intentionally left unchanged in this PR — happy to mirror validation there in a follow-up if desired.
- The pre-existing `TestCreditNoteService` failure on `develop` is unrelated to this change (reproduces with these commits stashed).


___

## **CodeAnt-AI Description**
Enforce coupon redemption rules when modifying subscriptions

### What Changed
- Subscription coupon additions now reject coupons that have reached their redemption limit or are outside their valid redemption dates.
- Successful coupon additions update the redemption count, preventing repeated use beyond the configured limit.
- New coupons must set `max_redemptions` between 1 and 1,000,000, while unlimited redemption remains available when omitted.
- Added coverage for redemption limits, validity dates, redemption counting, and maximum values.

### Impact
`✅ Fewer unauthorized coupon redemptions`
`✅ Enforced coupon validity dates`
`✅ Safer redemption limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced coupon redemption limits, preventing invalid or excessive `max_redemptions` values.
  * Prevented coupon use before its start date or after its expiration date.
  * Ensured coupon redemption counts update correctly when a coupon is applied.
  * Added validation for coupon currency and billing cadence before association.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->