### PR TITLE
fix(coupon): enforce redemption limits at redemption time on modify path (VAPT 6.3)

### DIFF
--- a/internal/ee/service/subscription_modification_coupon.go
+++ b/internal/ee/service/subscription_modification_coupon.go
@@ -56,6 +56,24 @@ func (s *subscriptionModificationService) executeAddCoupon(
 	}
 	couponID := c.ID
 
+	// Enforce coupon redemption rules (max_redemptions, redeem_after,
+	// redeem_before, currency/cadence) before creating the association. Without
+	// this, the modify/execute path bypasses every restriction the create path
+	// enforces (VAPT: coupon limits/validity not enforced at redemption time).
+	validationService := NewCouponValidationService(sp)
+	if err := validationService.ValidateCoupon(ctx, *c, sub); err != nil {
+		// ValidateCoupon returns a raw *CouponValidationError; mark it as
+		// ErrValidation (mirroring ApplyCouponsToSubscription) so the REST layer
+		// maps it to 400, not 500.
+		return nil, ierr.WithError(err).
+			WithHint("Coupon validation failed").
+			WithReportableDetails(map[string]interface{}{
+				"coupon_id":       couponID,
+				"subscription_id": subscriptionID,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
 	// Resolve target: line-item level or subscription level.
 	var lineItemID *string
 	if params.SubscriptionLineItemID != nil {
@@ -122,7 +140,19 @@ func (s *subscriptionModificationService) executeAddCoupon(
 		BaseModel:              types.GetDefaultBaseModel(ctx),
 	}
 	if err := sp.DB.WithTx(ctx, func(txCtx context.Context) error {
-		return sp.CouponAssociationRepo.Create(txCtx, assoc)
+		if err := sp.CouponAssociationRepo.Create(txCtx, assoc); err != nil {
+			return err
+		}
+		// Atomically increment total_redemptions within the same transaction.
+		// The DB-level CAS in IncrementRedemptions (WHERE total_redemptions <
+		// max_redemptions) is the real limit guard — it closes the TOCTOU between
+		// the ValidateCoupon read above and this insert, and keeps the counter in
+		// sync so the create path's limit stays enforced too. c.MaxRedemptions is
+		// immutable coupon config, safe to reuse from the earlier read.
+		if err := sp.CouponRepo.IncrementRedemptions(txCtx, couponID, c.MaxRedemptions); err != nil {
+			return err
+		}
+		return nil
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/ee/service/subscription_modification_coupon_test.go
+++ b/internal/ee/service/subscription_modification_coupon_test.go
@@ -557,3 +557,121 @@ func (s *SubscriptionModificationServiceSuite) TestCouponModification() {
 		})
 	}
 }
+
+// createCouponWithLimits creates a published percentage-off coupon with the
+// given redemption controls, for the VAPT redemption-enforcement tests.
+func (s *SubscriptionModificationServiceSuite) createCouponWithLimits(
+	maxRedemptions *int,
+	totalRedemptions int,
+	redeemAfter, redeemBefore *time.Time,
+) *coupon_domain.Coupon {
+	ctx := s.GetContext()
+	pct := decimal.NewFromInt(10)
+	id := types.GenerateUUIDWithPrefix(types.UUID_PREFIX_COUPON)
+	c := &coupon_domain.Coupon{
+		ID:               id,
+		Name:             "Limited Coupon",
+		Type:             types.CouponTypePercentage,
+		Cadence:          types.CouponCadenceForever,
+		PercentageOff:    &pct,
+		CouponCode:       lo.ToPtr(id),
+		MaxRedemptions:   maxRedemptions,
+		TotalRedemptions: totalRedemptions,
+		RedeemAfter:      redeemAfter,
+		RedeemBefore:     redeemBefore,
+		EnvironmentID:    types.GetEnvironmentID(ctx),
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	c.Status = types.StatusPublished
+	s.Require().NoError(s.GetStores().CouponRepo.Create(ctx, c))
+	return c
+}
+
+// TestCouponRedemptionEnforcement covers the VAPT finding that the
+// subscription modify/execute add-coupon path did not enforce max_redemptions,
+// redeem_after, or redeem_before, and never incremented total_redemptions.
+func (s *SubscriptionModificationServiceSuite) TestCouponRedemptionEnforcement() {
+	s.Run("max_redemptions already reached — add is rejected", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-max-reached")
+		sub := s.createActiveSub(cust.ID)
+		// max=2, already at 2 → limit reached.
+		c := s.createCouponWithLimits(lo.ToPtr(2), 2, nil, nil)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().Error(err, "coupon at max_redemptions must not be redeemable")
+
+		// No association should have been created.
+		assocs, listErr := s.GetStores().CouponAssociationRepo.List(ctx, &types.CouponAssociationFilter{
+			QueryFilter:     types.NewNoLimitQueryFilter(),
+			SubscriptionIDs: []string{sub.ID},
+			CouponIDs:       []string{c.ID},
+		})
+		s.Require().NoError(listErr)
+		s.Len(assocs, 0)
+	})
+
+	s.Run("redeem_after in the future — add is rejected", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-not-yet-valid")
+		sub := s.createActiveSub(cust.ID)
+		future := s.GetNow().Add(72 * time.Hour)
+		c := s.createCouponWithLimits(nil, 0, &future, nil)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().Error(err, "coupon before its redeem_after must not be redeemable")
+	})
+
+	s.Run("redeem_before in the past — add is rejected", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-expired")
+		sub := s.createActiveSub(cust.ID)
+		past := s.GetNow().Add(-72 * time.Hour)
+		c := s.createCouponWithLimits(nil, 0, nil, &past)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().Error(err, "coupon past its redeem_before must not be redeemable")
+	})
+
+	s.Run("successful add increments total_redemptions", func() {
+		ctx := s.GetContext()
+		cust := s.createCustomer("coup-increments")
+		sub := s.createActiveSub(cust.ID)
+		c := s.createCouponWithLimits(lo.ToPtr(5), 0, nil, nil)
+
+		req := dto.ExecuteSubscriptionModifyRequest{
+			Type: dto.SubscriptionModifyTypeCoupon,
+			CouponParams: &dto.SubModifyCouponParams{
+				Action:     dto.SubModifyCouponActionAdd,
+				CouponCode: c.CouponCode,
+			},
+		}
+		_, err := s.service.Execute(ctx, sub.ID, req)
+		s.Require().NoError(err)
+
+		updated, getErr := s.GetStores().CouponRepo.Get(ctx, c.ID)
+		s.Require().NoError(getErr)
+		s.Equal(1, updated.TotalRedemptions, "total_redemptions must be incremented on redemption")
+	})
+}


### PR DESCRIPTION
## **User description**
## What

Closes **VAPT 6.3 (MEDIUM)** — coupon `max_redemptions` / `redeem_before` / `redeem_after` **not enforced at redemption time** on the subscription `modify/execute` add-coupon path.

This is a re-scope of #2469: that PR bundled this fix with a separate `max_redemptions` creation-time cap, which was closed as debatable input-hygiene. **This PR drops the cap and keeps only the redemption-time enforcement bug** — a distinct, exploitable finding with a working VAPT PoC.

## The bug

`executeAddCoupon` (the `POST /v1/subscriptions/{id}/modify/execute` → `coupon_params.action=add` path) bypassed **every** redemption control:

- `max_redemptions` never checked — VAPT PoC: coupon with `max_redemptions=2` redeemed on 3 subscriptions, all 200.
- `redeem_after` / `redeem_before` never checked — coupon with a future `redeem_after` and one with a past `redeem_before` both redeemed, 200.
- `total_redemptions` never incremented — so even the *sanctioned* path's limit silently stopped being enforced, because the counter it reads never grew.

The validation was already fully implemented (`CouponValidationService.ValidateCoupon`) and correctly wired on the `ApplyCouponsToSubscription` path (subscription-create). `executeAddCoupon` just re-implemented association creation inline and skipped both the validation and the counter increment.

## Fix

- Call `ValidateCoupon(ctx, *c, sub)` before creating the association — covers `redeem_after`, `redeem_before`, `max_redemptions`, currency, cadence. Same service the create path uses.
- Call `IncrementRedemptions` inside the association-create transaction. Its DB-level CAS (`WHERE total_redemptions < max_redemptions`) is the real guard: it closes the TOCTOU between the validate read and the insert, and keeps `total_redemptions` in sync.

## Tests

`TestCouponRedemptionEnforcement`:
- max_redemptions already reached → add rejected, no association created
- redeem_after in the future → add rejected
- redeem_before in the past → add rejected
- successful add → `total_redemptions` incremented

Existing coupon-modification suite still green. No interface changes (no mock regen), no new dependencies.

## Verification plan
Re-test against staging (`api-dev`) once deployed: replay the VAPT PoC (redeem past-limit + out-of-window) and confirm 4xx + counter increments.


___

## **CodeAnt-AI Description**
Enforce coupon redemption limits when adding coupons through subscription modifications

### What Changed
- Subscription modification coupon additions now reject coupons that have reached their redemption limit.
- Coupons cannot be added before their start date or after their expiration date.
- Successful coupon additions update the redemption count, keeping future limit checks accurate.
- Added coverage for limit, date-window, and redemption-count behavior.

### Impact
`✅ Fewer unauthorized coupon redemptions`
`✅ Enforced coupon validity windows`
`✅ Accurate redemption limits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Coupon applications now respect maximum redemption limits.
  * Coupons are rejected when used outside their valid redemption period.
  * Coupon currency and billing cadence are validated before application.
  * Successful coupon applications update redemption counts atomically, preventing over-redemption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->