### PR TITLE
security: reject HTTP redirects in httpclient (VAPT SFX-2026-0203-F16)

### DIFF
--- a/internal/ee/service/file_processor.go
+++ b/internal/ee/service/file_processor.go
@@ -50,6 +50,9 @@ func NewFileProcessor(client httpclient.Client, logger *logger.Logger) *FileProc
 	retryClient.Logger = logger.GetRetryableHTTPLogger()
 	// Instrument outbound file downloads for SigNoz External API Monitoring.
 	retryClient.HTTPClient.Transport = httpclient.OtelTransport(retryClient.HTTPClient.Transport)
+	// Refuse redirects: file_url is caller-supplied and only the initial URL is
+	// validated, so a redirect would reach an unvalidated host (VAPT F16).
+	retryClient.HTTPClient.CheckRedirect = httpclient.RejectRedirects
 
 	return &FileProcessor{
 		StreamingProcessor: NewStreamingProcessor(client, logger),

--- a/internal/ee/service/file_processor.go
+++ b/internal/ee/service/file_processor.go
@@ -168,11 +168,10 @@ func (fp *FileProcessor) DownloadFileStream(ctx context.Context, t *task.Task) (
 			Mark(ierr.ErrHTTPClient)
 	}
 
-	// Make the request with extended timeout for large file downloads
-	httpClient := &http.Client{
-		Timeout:   10 * time.Minute, // Extended timeout for large file downloads
-		Transport: httpclient.OtelTransport(nil),
-	}
+	// Make the request with extended timeout for large file downloads.
+	// NewOtelHTTPClient refuses redirects — file_url is caller-supplied and only
+	// the initial URL is validated, so a redirect would reach an unvalidated host.
+	httpClient := httpclient.NewOtelHTTPClient(10 * time.Minute)
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		fp.Logger.Error(ctx, "failed to download file stream", "error", err, "url", downloadURL, "provider", provider.GetProviderName())
@@ -235,10 +234,9 @@ func (fp *FileProcessor) GetFileSize(ctx context.Context, t *task.Task) (int64, 
 			Mark(ierr.ErrHTTPClient)
 	}
 
-	httpClient := &http.Client{
-		Timeout:   30 * time.Second, // Shorter timeout for HEAD requests
-		Transport: httpclient.OtelTransport(nil),
-	}
+	// Shorter timeout for HEAD requests; redirects refused (same reasoning as
+	// the download path above).
+	httpClient := httpclient.NewOtelHTTPClient(30 * time.Second)
 	resp, err := httpClient.Do(httpReq)
 	if err != nil {
 		fp.Logger.Error(ctx, "failed to get file size", "error", err, "url", downloadURL, "provider", provider.GetProviderName())

--- a/internal/ee/service/streaming_processor.go
+++ b/internal/ee/service/streaming_processor.go
@@ -42,6 +42,9 @@ func NewStreamingProcessor(client httpclient.Client, logger *logger.Logger) *Str
 	retryClient.Logger = logger.GetRetryableHTTPLogger()
 	// Instrument outbound file downloads for SigNoz External API Monitoring.
 	retryClient.HTTPClient.Transport = httpclient.OtelTransport(retryClient.HTTPClient.Transport)
+	// Refuse redirects: this client streams the caller-supplied file_url and only
+	// the initial URL is validated (VAPT F16).
+	retryClient.HTTPClient.CheckRedirect = httpclient.RejectRedirects
 
 	return &StreamingProcessor{
 		Client:           client,

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -35,6 +35,18 @@ type ClientConfig struct {
 	Timeout time.Duration
 }
 
+// rejectRedirects refuses to follow any HTTP redirect.
+//
+// Go's default http.Client silently follows up to 10 redirects. Callers that
+// validate a user-supplied URL (for example the file-import providers) only
+// ever check the *initial* URL, so a redirect to an internal address —
+// 169.254.169.254, localhost, or any RFC1918 host — would be followed without
+// a second validation and would not be visible in the stored task metadata.
+// Refusing redirects keeps the validated URL the only URL we ever fetch.
+func rejectRedirects(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
 // NewClientWithConfig creates a new DefaultClient with custom configuration
 func NewClientWithConfig(config ClientConfig) Client {
 	timeout := config.Timeout
@@ -44,8 +56,9 @@ func NewClientWithConfig(config ClientConfig) Client {
 
 	return &DefaultClient{
 		client: &http.Client{
-			Timeout:   timeout,
-			Transport: OtelTransport(nil),
+			Timeout:       timeout,
+			Transport:     OtelTransport(nil),
+			CheckRedirect: rejectRedirects,
 		},
 	}
 }
@@ -59,8 +72,9 @@ type DefaultClient struct {
 func NewDefaultClient() Client {
 	return &DefaultClient{
 		client: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: OtelTransport(nil),
+			Timeout:       30 * time.Second,
+			Transport:     OtelTransport(nil),
+			CheckRedirect: rejectRedirects,
 		},
 	}
 }
@@ -98,6 +112,15 @@ func (c *DefaultClient) Send(ctx context.Context, req *Request) (*Response, erro
 			Mark(ierr.ErrHTTPClient)
 	}
 	defer resp.Body.Close()
+
+	// CheckRedirect returns ErrUseLastResponse, so a redirect arrives here as a
+	// 3xx rather than being followed. Reject it explicitly: the redirect target
+	// has not been through whatever validation the caller applied to req.URL.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return nil, ierr.NewError("redirects are not allowed").
+			WithHint("The requested URL responded with a redirect, which is not followed").
+			Mark(ierr.ErrHTTPClient)
+	}
 
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -35,7 +35,8 @@ type ClientConfig struct {
 	Timeout time.Duration
 }
 
-// rejectRedirects refuses to follow any HTTP redirect.
+// RejectRedirects refuses to follow any HTTP redirect. Assign it to an
+// http.Client's CheckRedirect field.
 //
 // Go's default http.Client silently follows up to 10 redirects. Callers that
 // validate a user-supplied URL (for example the file-import providers) only
@@ -43,7 +44,10 @@ type ClientConfig struct {
 // 169.254.169.254, localhost, or any RFC1918 host — would be followed without
 // a second validation and would not be visible in the stored task metadata.
 // Refusing redirects keeps the validated URL the only URL we ever fetch.
-func rejectRedirects(_ *http.Request, _ []*http.Request) error {
+//
+// Exported so callers that build their own client (retryablehttp, third-party
+// SDKs) can apply the same policy.
+func RejectRedirects(_ *http.Request, _ []*http.Request) error {
 	return http.ErrUseLastResponse
 }
 
@@ -58,7 +62,7 @@ func NewClientWithConfig(config ClientConfig) Client {
 		client: &http.Client{
 			Timeout:       timeout,
 			Transport:     OtelTransport(nil),
-			CheckRedirect: rejectRedirects,
+			CheckRedirect: RejectRedirects,
 		},
 	}
 }
@@ -74,7 +78,7 @@ func NewDefaultClient() Client {
 		client: &http.Client{
 			Timeout:       30 * time.Second,
 			Transport:     OtelTransport(nil),
-			CheckRedirect: rejectRedirects,
+			CheckRedirect: RejectRedirects,
 		},
 	}
 }
@@ -113,21 +117,21 @@ func (c *DefaultClient) Send(ctx context.Context, req *Request) (*Response, erro
 	}
 	defer resp.Body.Close()
 
-	// CheckRedirect returns ErrUseLastResponse, so a redirect arrives here as a
-	// 3xx rather than being followed. Reject it explicitly: the redirect target
-	// has not been through whatever validation the caller applied to req.URL.
-	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-		return nil, ierr.NewError("redirects are not allowed").
-			WithHint("The requested URL responded with a redirect, which is not followed").
-			Mark(ierr.ErrHTTPClient)
-	}
-
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, ierr.WithError(err).
 			WithHint("Please check the request payload").
 			Mark(ierr.ErrHTTPClient)
+	}
+
+	// CheckRedirect returns ErrUseLastResponse, so a redirect arrives here as a
+	// 3xx rather than being followed. Reject it explicitly: the redirect target
+	// has not been through whatever validation the caller applied to req.URL.
+	// Returned as the package's typed *Error so IsHTTPError and status-based
+	// retry/mapping keep working for this case like any other HTTP failure.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return nil, NewError(resp.StatusCode, respBody)
 	}
 
 	// Copy response headers

--- a/internal/httpclient/client_redirect_test.go
+++ b/internal/httpclient/client_redirect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -11,9 +12,9 @@ import (
 // A redirect must never be followed: the redirect target has not been through
 // the caller's URL validation (VAPT SFX-2026-0203-F16).
 func TestSendDoesNotFollowRedirects(t *testing.T) {
-	var internalHit bool
+	var internalHit atomic.Bool
 	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		internalHit = true
+		internalHit.Store(true)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("secret-metadata"))
 	}))
@@ -33,7 +34,7 @@ func TestSendDoesNotFollowRedirects(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected an error for a redirect response, got resp=%+v", resp)
 	}
-	if internalHit {
+	if internalHit.Load() {
 		t.Fatal("redirect was followed: the internal target received a request")
 	}
 }
@@ -41,9 +42,9 @@ func TestSendDoesNotFollowRedirects(t *testing.T) {
 // NewDefaultClient shares the redirect policy — a regression there would
 // otherwise go unnoticed.
 func TestNewDefaultClientDoesNotFollowRedirects(t *testing.T) {
-	var internalHit bool
+	var internalHit atomic.Bool
 	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		internalHit = true
+		internalHit.Store(true)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer internal.Close()
@@ -60,7 +61,7 @@ func TestNewDefaultClientDoesNotFollowRedirects(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for a redirect response")
 	}
-	if internalHit {
+	if internalHit.Load() {
 		t.Fatal("redirect was followed: the internal target received a request")
 	}
 }
@@ -68,9 +69,9 @@ func TestNewDefaultClientDoesNotFollowRedirects(t *testing.T) {
 // NewOtelHTTPClient is used directly (not via Send) by the file-import download
 // and HEAD paths, so its redirect policy must hold on the bare *http.Client.
 func TestNewOtelHTTPClientDoesNotFollowRedirects(t *testing.T) {
-	var internalHit bool
+	var internalHit atomic.Bool
 	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		internalHit = true
+		internalHit.Store(true)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer internal.Close()
@@ -91,7 +92,7 @@ func TestNewOtelHTTPClientDoesNotFollowRedirects(t *testing.T) {
 	if resp.StatusCode != http.StatusFound {
 		t.Fatalf("expected the 302 to be returned unfollowed, got %d", resp.StatusCode)
 	}
-	if internalHit {
+	if internalHit.Load() {
 		t.Fatal("redirect was followed: the internal target received a request")
 	}
 }

--- a/internal/httpclient/client_redirect_test.go
+++ b/internal/httpclient/client_redirect_test.go
@@ -1,0 +1,59 @@
+package httpclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// A redirect must never be followed: the redirect target has not been through
+// the caller's URL validation (VAPT SFX-2026-0203-F16).
+func TestSendDoesNotFollowRedirects(t *testing.T) {
+	var internalHit bool
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("secret-metadata"))
+	}))
+	defer internal.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	client := NewClientWithConfig(ClientConfig{})
+	resp, err := client.Send(context.Background(), &Request{
+		Method: http.MethodGet,
+		URL:    redirector.URL,
+	})
+
+	if err == nil {
+		t.Fatalf("expected an error for a redirect response, got resp=%+v", resp)
+	}
+	if internalHit {
+		t.Fatal("redirect was followed: the internal target received a request")
+	}
+}
+
+// Non-redirect responses must still work normally.
+func TestSendFollowsNoRedirectHappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	client := NewClientWithConfig(ClientConfig{})
+	resp, err := client.Send(context.Background(), &Request{
+		Method: http.MethodGet,
+		URL:    srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK || string(resp.Body) != "ok" {
+		t.Fatalf("unexpected response: %d %q", resp.StatusCode, resp.Body)
+	}
+}

--- a/internal/httpclient/client_redirect_test.go
+++ b/internal/httpclient/client_redirect_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // A redirect must never be followed: the redirect target has not been through
@@ -31,6 +32,64 @@ func TestSendDoesNotFollowRedirects(t *testing.T) {
 
 	if err == nil {
 		t.Fatalf("expected an error for a redirect response, got resp=%+v", resp)
+	}
+	if internalHit {
+		t.Fatal("redirect was followed: the internal target received a request")
+	}
+}
+
+// NewDefaultClient shares the redirect policy — a regression there would
+// otherwise go unnoticed.
+func TestNewDefaultClientDoesNotFollowRedirects(t *testing.T) {
+	var internalHit bool
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internal.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	_, err := NewDefaultClient().Send(context.Background(), &Request{
+		Method: http.MethodGet,
+		URL:    redirector.URL,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a redirect response")
+	}
+	if internalHit {
+		t.Fatal("redirect was followed: the internal target received a request")
+	}
+}
+
+// NewOtelHTTPClient is used directly (not via Send) by the file-import download
+// and HEAD paths, so its redirect policy must hold on the bare *http.Client.
+func TestNewOtelHTTPClientDoesNotFollowRedirects(t *testing.T) {
+	var internalHit bool
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer internal.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := NewOtelHTTPClient(5 * time.Second).Get(redirector.URL)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// CheckRedirect returns ErrUseLastResponse, so the 302 is surfaced as-is
+	// rather than followed.
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected the 302 to be returned unfollowed, got %d", resp.StatusCode)
 	}
 	if internalHit {
 		t.Fatal("redirect was followed: the internal target received a request")

--- a/internal/httpclient/otel.go
+++ b/internal/httpclient/otel.go
@@ -37,9 +37,15 @@ func OtelTransport(base http.RoundTripper) http.RoundTripper {
 
 // NewOtelHTTPClient returns an *http.Client whose Transport is wrapped with
 // OpenTelemetry client-side instrumentation. The provided timeout is preserved.
+//
+// Redirects are refused (see rejectRedirects): callers that validate a
+// user-supplied URL only check the initial location, so following a redirect
+// would reach an unvalidated target. Callers that legitimately need redirects
+// must opt in by overriding CheckRedirect on the returned client.
 func NewOtelHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: OtelTransport(nil),
+		Timeout:       timeout,
+		Transport:     OtelTransport(nil),
+		CheckRedirect: rejectRedirects,
 	}
 }

--- a/internal/httpclient/otel.go
+++ b/internal/httpclient/otel.go
@@ -46,6 +46,6 @@ func NewOtelHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout:       timeout,
 		Transport:     OtelTransport(nil),
-		CheckRedirect: rejectRedirects,
+		CheckRedirect: RejectRedirects,
 	}
 }


### PR DESCRIPTION
## **User description**
## Summary

Closes VAPT finding **SFX-2026-0203-F16** — *HTTP client allows unvalidated redirects, amplifying SSRF* (MEDIUM, escalates Finding 5 / A07).

Go's default `http.Client` follows up to 10 redirects automatically with no revalidation. Callers that validate a user-supplied URL — notably the file-import providers in `internal/ee/service/file_provider.go` — only check the **initial** URL. A redirect to `169.254.169.254`, `localhost`, or any RFC1918 address was followed silently, and only the initial URL appeared in the stored task metadata, hiding the real target from anyone reviewing task records.

## Changes

- Added `rejectRedirects` returning `http.ErrUseLastResponse`
- Wired `CheckRedirect` into **both** constructors (`NewClientWithConfig`, `NewDefaultClient`)
- `Send` now rejects any 3xx explicitly — `ErrUseLastResponse` returns the redirect response rather than erroring, so without this the caller would get a 302 body and treat it as a successful fetch

## Testing

`client_redirect_test.go` — two-server test: a redirector pointing at an "internal" target. Asserts the request errors **and** that the internal server receives zero requests. Plus a happy-path test confirming non-redirect responses are unaffected.

```
--- PASS: TestSendDoesNotFollowRedirects
--- PASS: TestSendFollowsNoRedirectHappyPath
--- PASS: TestSend_RecordsClientSpan   (pre-existing, no regression)
ok  github.com/flexprice/flexprice/internal/httpclient
```

`go build ./internal/...` passes.

## Blast radius

All 7 non-test callers are API clients hitting fixed known endpoints (Gemini, Azure Marketplace, HubSpot, Whop, Nomod, onboarding, `cmd/server`). None rely on redirect following. No existing `CheckRedirect` usage to conflict with.

## Note

The repo has pre-existing vendoring drift (`inconsistent vendoring in go.mod vs vendor/modules.txt`) unrelated to this change — I used `-mod=mod` to build and test. CI may need `go mod vendor`.


___

## **CodeAnt-AI Description**
Block unsafe HTTP redirects in the HTTP client

### What Changed
- HTTP requests no longer follow redirect responses automatically
- Redirect responses now fail with a clear error instead of being treated as successful fetches
- Normal non-redirect responses continue to work as before

### Impact
`✅ Prevented requests from reaching unvalidated internal targets`
`✅ Reduced SSRF risk from user-supplied URLs`
`✅ Clearer errors for rejected redirects`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP requests no longer automatically follow redirects.
  * Redirect responses now return a clear client error while preserving the original response.
  * Requests that receive redirects do not contact the redirect destination.
  * File downloads and streaming requests consistently reject redirects.
  * Standard successful responses continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->