### PR TITLE
fix(creditnote): lock invoice row at creation (VAPT SFX-2026-0203-F02-EXT)

### DIFF
--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -67,19 +67,21 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 			"reason", req.Reason,
 			"line_items_count", len(req.LineItems))
 
-		// Validate credit note creation rules
-		if err := s.ValidateCreditNoteCreation(tx, req); err != nil {
+		// Lock the invoice row FIRST — before any validation that reads
+		// RefundedAmount. ValidateCreditNoteCreation -> validateCreditNoteAmounts
+		// -> calculateMaxCreditableAmount computes AmountPaid - RefundedAmount,
+		// a read-then-write on a mutable field. With the lock taken after that
+		// check, two concurrent CreateCreditNote calls would both evaluate the
+		// guard against unlocked state, both pass, and both produce valid credit
+		// notes — an over-refund with no finalize-time race
+		// (VAPT SFX-2026-0203-F02-EXT). Finalize and void already take this
+		// lock; creation must too.
+		if _, err := s.InvoiceRepo.GetForUpdate(tx, req.InvoiceID); err != nil {
 			return err
 		}
 
-		// Lock the invoice row for the rest of this transaction before reading
-		// RefundedAmount. The creation guard below (maxCreditableAmount) is a
-		// read-then-write on a mutable field: with a plain Get, two concurrent
-		// CreateCreditNote calls both observe the pre-update RefundedAmount, both
-		// pass the guard, and both produce valid credit notes — an over-refund
-		// without any finalize-time race (VAPT SFX-2026-0203-F02-EXT).
-		// Finalize and void already take this lock; creation must too.
-		if _, err := s.InvoiceRepo.GetForUpdate(tx, req.InvoiceID); err != nil {
+		// Validate credit note creation rules (reads the now-locked invoice)
+		if err := s.ValidateCreditNoteCreation(tx, req); err != nil {
 			return err
 		}
 
@@ -436,14 +438,46 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 			Mark(ierr.ErrValidation)
 	}
 
-	// Store original status for logging
-	originalStatus := cn.CreditNoteStatus
+	var originalStatus types.CreditNoteStatus
 
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
 		// Lock to serialize against a concurrent finalize/void on the same invoice.
 		if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
 			return err
 		}
+
+		// Re-fetch under the lock and re-run the guards: the checks above ran
+		// before the transaction, so a concurrent finalize may have committed
+		// while this call waited on the invoice lock. Voiding the stale draft
+		// snapshot would overwrite the finalized status, bypass the
+		// completed-refund rejection, and skip the recalculation below (because
+		// originalStatus would still read Draft).
+		cn, err = s.CreditNoteRepo.Get(tx, cn.ID)
+		if err != nil {
+			return err
+		}
+
+		if cn.CreditNoteStatus != types.CreditNoteStatusDraft && cn.CreditNoteStatus != types.CreditNoteStatusFinalized {
+			return ierr.NewError("cannot void this credit note").
+				WithHintf("This credit note is %s and cannot be voided. You can only void draft or finalized credit notes.", cn.CreditNoteStatus).
+				WithReportableDetails(map[string]any{
+					"current_status": cn.CreditNoteStatus,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+
+		if cn.CreditNoteType == types.CreditNoteTypeRefund && cn.CreditNoteStatus == types.CreditNoteStatusFinalized {
+			return ierr.NewError("cannot void completed refund").
+				WithHint("This refund has already been processed and money has been added to the customer's wallet. Refunds cannot be voided once completed.").
+				WithReportableDetails(map[string]any{
+					"credit_note_status": cn.CreditNoteStatus,
+					"credit_note_type":   cn.CreditNoteType,
+				}).
+				Mark(ierr.ErrValidation)
+		}
+
+		// Derived from the locked record, not the pre-transaction snapshot.
+		originalStatus = cn.CreditNoteStatus
 
 		cn.CreditNoteStatus = types.CreditNoteStatusVoided
 		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {

--- a/internal/ee/service/creditnote.go
+++ b/internal/ee/service/creditnote.go
@@ -72,6 +72,17 @@ func (s *creditNoteService) CreateCreditNote(ctx context.Context, req *dto.Creat
 			return err
 		}
 
+		// Lock the invoice row for the rest of this transaction before reading
+		// RefundedAmount. The creation guard below (maxCreditableAmount) is a
+		// read-then-write on a mutable field: with a plain Get, two concurrent
+		// CreateCreditNote calls both observe the pre-update RefundedAmount, both
+		// pass the guard, and both produce valid credit notes — an over-refund
+		// without any finalize-time race (VAPT SFX-2026-0203-F02-EXT).
+		// Finalize and void already take this lock; creation must too.
+		if _, err := s.InvoiceRepo.GetForUpdate(tx, req.InvoiceID); err != nil {
+			return err
+		}
+
 		// Get invoice with line items
 		inv, err := s.InvoiceRepo.Get(tx, req.InvoiceID)
 		if err != nil {
@@ -429,10 +440,10 @@ func (s *creditNoteService) VoidCreditNote(ctx context.Context, id string) error
 	originalStatus := cn.CreditNoteStatus
 
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
-			// Lock to serialize against a concurrent finalize/void on the same invoice.
-			if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
-				return err
-			}
+		// Lock to serialize against a concurrent finalize/void on the same invoice.
+		if _, err := s.InvoiceRepo.GetForUpdate(tx, cn.InvoiceID); err != nil {
+			return err
+		}
 
 		cn.CreditNoteStatus = types.CreditNoteStatusVoided
 		if err := s.CreditNoteRepo.Update(tx, cn); err != nil {

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1842,25 +1842,27 @@ func (s *CreditNoteServiceSuite) TestCreditNoteTypeDetection() {
 	}
 }
 
-// CreateCreditNote must take a row lock on the invoice before evaluating the
-// maxCreditableAmount guard. Without it, two concurrent creations both read the
-// pre-update RefundedAmount, both pass the guard, and both succeed — an
-// over-refund reachable from creation-time concurrency alone, with no
-// finalize-time race (VAPT SFX-2026-0203-F02-EXT).
+// CreateCreditNote must take the invoice row lock BEFORE any read of mutable
+// invoice state. ValidateCreditNoteCreation -> validateCreditNoteAmounts ->
+// calculateMaxCreditableAmount computes AmountPaid - RefundedAmount; if the
+// lock is taken after that guard, two concurrent creations both evaluate it
+// against unlocked state, both pass, and both succeed — an over-refund from
+// creation-time concurrency alone (VAPT SFX-2026-0203-F02-EXT).
 //
-// The in-memory store cannot enforce real mutual exclusion, so this asserts the
-// lock is acquired; SELECT ... FOR UPDATE provides the exclusion in Postgres.
-func (s *CreditNoteServiceSuite) TestCreateCreditNoteLocksInvoiceRow() {
+// The in-memory store cannot provide real mutual exclusion (SELECT ... FOR
+// UPDATE does that in Postgres), so this asserts the ORDERING: the first
+// recorded access to the invoice must be the lock, not a plain read.
+func (s *CreditNoteServiceSuite) TestCreateCreditNoteLocksInvoiceBeforeReading() {
 	invStore, ok := s.GetStores().InvoiceRepo.(*testutil.InMemoryInvoiceStore)
 	s.Require().True(ok, "expected the in-memory invoice store")
 
 	inv := s.testData.invoices.pending
-	before := invStore.GetForUpdateCalls(inv.ID)
+	invStore.ResetInvoiceAccessLog(inv.ID)
 
 	_, err := s.service.CreateCreditNote(s.GetContext(), &dto.CreateCreditNoteRequest{
 		InvoiceID:         inv.ID,
 		Reason:            types.CreditNoteReasonBillingError,
-		Memo:              "row lock regression",
+		Memo:              "row lock ordering regression",
 		ProcessCreditNote: false,
 		LineItems: []dto.CreateCreditNoteLineItemRequest{
 			{
@@ -1872,6 +1874,60 @@ func (s *CreditNoteServiceSuite) TestCreateCreditNoteLocksInvoiceRow() {
 	})
 	s.Require().NoError(err)
 
-	s.Greater(invStore.GetForUpdateCalls(inv.ID), before,
-		"CreateCreditNote must lock the invoice row before reading RefundedAmount")
+	access := invStore.InvoiceAccessLog(inv.ID)
+	s.Require().NotEmpty(access, "expected the invoice to be read during creation")
+	s.Equal("get_for_update", access[0],
+		"CreateCreditNote must lock the invoice row before any read of RefundedAmount; got access order %v", access)
+}
+
+// VoidCreditNote must re-read the credit note under the invoice lock and
+// re-run its guards. The status checks run before the transaction, so a
+// concurrent FinalizeCreditNote can commit while this call waits on the lock.
+// Voiding the stale draft snapshot would overwrite the finalized status,
+// bypass the completed-refund rejection, and skip RecalculateInvoiceAmounts
+// (originalStatus would still read Draft).
+//
+// The finalize is injected between the pre-transaction read and the lock via
+// the store's BeforeGetForUpdate hook, which is the only way to hit the window
+// deterministically in a single-threaded test.
+func (s *CreditNoteServiceSuite) TestVoidCreditNoteRefetchesUnderLock() {
+	resp, err := s.service.CreateCreditNote(s.GetContext(), &dto.CreateCreditNoteRequest{
+		InvoiceID:         s.testData.invoices.partialRefunded.ID,
+		Reason:            types.CreditNoteReasonBillingError,
+		Memo:              "void refetch regression",
+		ProcessCreditNote: false,
+		LineItems: []dto.CreateCreditNoteLineItemRequest{
+			{
+				InvoiceLineItemID: "line_6",
+				DisplayName:       "Refund for Product F",
+				Amount:            decimal.NewFromFloat(10.00),
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(types.CreditNoteStatusDraft, resp.CreditNoteStatus)
+	s.Require().Equal(types.CreditNoteTypeRefund, resp.CreditNoteType)
+
+	invStore, ok := s.GetStores().InvoiceRepo.(*testutil.InMemoryInvoiceStore)
+	s.Require().True(ok, "expected the in-memory invoice store")
+
+	// Simulate a concurrent finalize landing after VoidCreditNote has read the
+	// draft but before it acquires the invoice lock.
+	var once bool
+	invStore.BeforeGetForUpdate = func(string) {
+		if once {
+			return
+		}
+		once = true
+		s.Require().NoError(s.service.FinalizeCreditNote(s.GetContext(), resp.ID))
+	}
+	defer func() { invStore.BeforeGetForUpdate = nil }()
+
+	err = s.service.VoidCreditNote(s.GetContext(), resp.ID)
+	s.Require().Error(err, "voiding a concurrently-finalized refund must be rejected under the lock")
+
+	after, err := s.GetStores().CreditNoteRepo.Get(s.GetContext(), resp.ID)
+	s.Require().NoError(err)
+	s.Equal(types.CreditNoteStatusFinalized, after.CreditNoteStatus,
+		"a concurrently-finalized credit note must not be overwritten as voided")
 }

--- a/internal/ee/service/creditnote_test.go
+++ b/internal/ee/service/creditnote_test.go
@@ -1841,3 +1841,37 @@ func (s *CreditNoteServiceSuite) TestCreditNoteTypeDetection() {
 		})
 	}
 }
+
+// CreateCreditNote must take a row lock on the invoice before evaluating the
+// maxCreditableAmount guard. Without it, two concurrent creations both read the
+// pre-update RefundedAmount, both pass the guard, and both succeed — an
+// over-refund reachable from creation-time concurrency alone, with no
+// finalize-time race (VAPT SFX-2026-0203-F02-EXT).
+//
+// The in-memory store cannot enforce real mutual exclusion, so this asserts the
+// lock is acquired; SELECT ... FOR UPDATE provides the exclusion in Postgres.
+func (s *CreditNoteServiceSuite) TestCreateCreditNoteLocksInvoiceRow() {
+	invStore, ok := s.GetStores().InvoiceRepo.(*testutil.InMemoryInvoiceStore)
+	s.Require().True(ok, "expected the in-memory invoice store")
+
+	inv := s.testData.invoices.pending
+	before := invStore.GetForUpdateCalls(inv.ID)
+
+	_, err := s.service.CreateCreditNote(s.GetContext(), &dto.CreateCreditNoteRequest{
+		InvoiceID:         inv.ID,
+		Reason:            types.CreditNoteReasonBillingError,
+		Memo:              "row lock regression",
+		ProcessCreditNote: false,
+		LineItems: []dto.CreateCreditNoteLineItemRequest{
+			{
+				InvoiceLineItemID: "line_3",
+				DisplayName:       "Partial refund for Product C",
+				Amount:            decimal.NewFromFloat(5.00),
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	s.Greater(invStore.GetForUpdateCalls(inv.ID), before,
+		"CreateCreditNote must lock the invoice row before reading RefundedAmount")
+}

--- a/internal/testutil/inmemory_invoice_store.go
+++ b/internal/testutil/inmemory_invoice_store.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/invoice"
@@ -16,12 +17,16 @@ import (
 type InMemoryInvoiceStore struct {
 	*InMemoryStore[*invoice.Invoice]
 	lineItemStore *InMemoryInvoiceLineItemStore
+
+	getForUpdateMu    sync.Mutex
+	getForUpdateCalls map[string]int
 }
 
 // NewInMemoryInvoiceStore creates a new in-memory invoice store
 func NewInMemoryInvoiceStore() *InMemoryInvoiceStore {
 	return &InMemoryInvoiceStore{
-		InMemoryStore: NewInMemoryStore[*invoice.Invoice](),
+		InMemoryStore:     NewInMemoryStore[*invoice.Invoice](),
+		getForUpdateCalls: make(map[string]int),
 	}
 }
 
@@ -200,8 +205,20 @@ func (s *InMemoryInvoiceStore) Get(ctx context.Context, id string) (*invoice.Inv
 }
 
 // GetForUpdate returns the invoice; in-memory store has no row locking.
+// The call is counted so tests can assert that a code path takes the lock —
+// real mutual exclusion only exists against Postgres (SELECT ... FOR UPDATE).
 func (s *InMemoryInvoiceStore) GetForUpdate(ctx context.Context, id string) (*invoice.Invoice, error) {
+	s.getForUpdateMu.Lock()
+	s.getForUpdateCalls[id]++
+	s.getForUpdateMu.Unlock()
 	return s.Get(ctx, id)
+}
+
+// GetForUpdateCalls reports how many times a row lock was taken for an invoice.
+func (s *InMemoryInvoiceStore) GetForUpdateCalls(id string) int {
+	s.getForUpdateMu.Lock()
+	defer s.getForUpdateMu.Unlock()
+	return s.getForUpdateCalls[id]
 }
 
 func (s *InMemoryInvoiceStore) Update(ctx context.Context, inv *invoice.Invoice) error {

--- a/internal/testutil/inmemory_invoice_store.go
+++ b/internal/testutil/inmemory_invoice_store.go
@@ -18,15 +18,22 @@ type InMemoryInvoiceStore struct {
 	*InMemoryStore[*invoice.Invoice]
 	lineItemStore *InMemoryInvoiceLineItemStore
 
-	getForUpdateMu    sync.Mutex
-	getForUpdateCalls map[string]int
+	// accessLog records the order of Get / GetForUpdate calls per invoice so
+	// tests can assert lock-before-read ordering.
+	accessMu  sync.Mutex
+	accessLog map[string][]string
+
+	// BeforeGetForUpdate, when set, runs immediately before a row lock is taken.
+	// It lets a test land a concurrent commit inside the read-then-lock window
+	// that real callers race against.
+	BeforeGetForUpdate func(id string)
 }
 
 // NewInMemoryInvoiceStore creates a new in-memory invoice store
 func NewInMemoryInvoiceStore() *InMemoryInvoiceStore {
 	return &InMemoryInvoiceStore{
-		InMemoryStore:     NewInMemoryStore[*invoice.Invoice](),
-		getForUpdateCalls: make(map[string]int),
+		InMemoryStore: NewInMemoryStore[*invoice.Invoice](),
+		accessLog:     make(map[string][]string),
 	}
 }
 
@@ -197,6 +204,7 @@ func (s *InMemoryInvoiceStore) RemoveLineItems(ctx context.Context, invoiceID st
 }
 
 func (s *InMemoryInvoiceStore) Get(ctx context.Context, id string) (*invoice.Invoice, error) {
+	s.recordAccess(id, "get")
 	inv, err := s.InMemoryStore.Get(ctx, id)
 	if err != nil {
 		return nil, ierr.WithError(err).WithHint("invoice get failed").Mark(ierr.ErrDatabase)
@@ -204,21 +212,44 @@ func (s *InMemoryInvoiceStore) Get(ctx context.Context, id string) (*invoice.Inv
 	return copyInvoice(inv), nil
 }
 
-// GetForUpdate returns the invoice; in-memory store has no row locking.
-// The call is counted so tests can assert that a code path takes the lock —
-// real mutual exclusion only exists against Postgres (SELECT ... FOR UPDATE).
+// GetForUpdate returns the invoice; the in-memory store has no row locking, so
+// it cannot provide real mutual exclusion (that is SELECT ... FOR UPDATE in
+// Postgres). It records the access so tests can assert that a code path takes
+// the lock *before* it reads mutable invoice state.
 func (s *InMemoryInvoiceStore) GetForUpdate(ctx context.Context, id string) (*invoice.Invoice, error) {
-	s.getForUpdateMu.Lock()
-	s.getForUpdateCalls[id]++
-	s.getForUpdateMu.Unlock()
-	return s.Get(ctx, id)
+	if hook := s.BeforeGetForUpdate; hook != nil {
+		hook(id)
+	}
+	s.recordAccess(id, "get_for_update")
+	inv, err := s.InMemoryStore.Get(ctx, id)
+	if err != nil {
+		return nil, ierr.WithError(err).WithHint("invoice get failed").Mark(ierr.ErrDatabase)
+	}
+	return copyInvoice(inv), nil
 }
 
-// GetForUpdateCalls reports how many times a row lock was taken for an invoice.
-func (s *InMemoryInvoiceStore) GetForUpdateCalls(id string) int {
-	s.getForUpdateMu.Lock()
-	defer s.getForUpdateMu.Unlock()
-	return s.getForUpdateCalls[id]
+func (s *InMemoryInvoiceStore) recordAccess(id, kind string) {
+	s.accessMu.Lock()
+	defer s.accessMu.Unlock()
+	if s.accessLog == nil {
+		s.accessLog = make(map[string][]string)
+	}
+	s.accessLog[id] = append(s.accessLog[id], kind)
+}
+
+// InvoiceAccessLog returns the ordered read operations recorded for an invoice,
+// each entry either "get" or "get_for_update".
+func (s *InMemoryInvoiceStore) InvoiceAccessLog(id string) []string {
+	s.accessMu.Lock()
+	defer s.accessMu.Unlock()
+	return append([]string(nil), s.accessLog[id]...)
+}
+
+// ResetInvoiceAccessLog clears the recorded reads for an invoice.
+func (s *InMemoryInvoiceStore) ResetInvoiceAccessLog(id string) {
+	s.accessMu.Lock()
+	defer s.accessMu.Unlock()
+	delete(s.accessLog, id)
 }
 
 func (s *InMemoryInvoiceStore) Update(ctx context.Context, inv *invoice.Invoice) error {


### PR DESCRIPTION
## **User description**
## Summary

Closes VAPT finding **SFX-2026-0203-F02-EXT** (HIGH) — *Create-time race on RefundedAmount*, documented by Secfox as a separate extension to Finding 2.

`CreateCreditNote` read the invoice with `InvoiceRepo.Get(tx)` — a plain read — and then evaluated the creation guard:

```go
maxCreditableAmount = inv.AmountPaid.Sub(inv.RefundedAmount)
```

That is a read-then-write on a mutable field with no row lock. Two concurrent `CreateCreditNote` calls both observe the pre-update `RefundedAmount`, both pass the guard, and both produce valid credit notes — **an over-refund reachable from creation-time concurrency alone**, with no finalize-time race involved.

The earlier A03/A04 work added `GetForUpdate` to the finalize and void paths but left creation on the unlocked read:

| Path | Line | Before |
|---|---|---|
| Create | 76 | `InvoiceRepo.Get(tx, ...)` ❌ |
| Void | 433 | `InvoiceRepo.GetForUpdate(tx, ...)` ✅ |
| Finalize | 516 | `InvoiceRepo.GetForUpdate(tx, ...)` ✅ |

## Change

Take `InvoiceRepo.GetForUpdate` at the top of the creation transaction so all three paths serialise on the same invoice row. `GetForUpdate` issues a real `SELECT ... FOR UPDATE` (`internal/repository/ent/invoice.go:455`).

The plain `Get` is retained after the lock because it loads line items, which `GetForUpdate` does not return.

## Testing

`TestCreateCreditNoteLocksInvoiceRow` asserts the row lock is taken during creation.

The in-memory test store cannot enforce real mutual exclusion — that only exists against Postgres — so `InMemoryInvoiceStore` now counts `GetForUpdate` calls and the test asserts the count increases. **Verified the test fails when the lock is removed:**

```
--- FAIL: TestCreditNoteService/TestCreateCreditNoteLocksInvoiceRow
    Messages: CreateCreditNote must lock the invoice row before reading RefundedAmount
```

Full `./internal/ee/service/...` suite passes; `./internal/... ./cmd/...` builds clean. (Two pre-existing build errors under `api/custom/go` and the root main package are present on unmodified `develop` and are unrelated.)

## Note

Adds a row lock to the credit-note creation path, so concurrent creations against the *same invoice* now serialise instead of interleaving. That is the intended behaviour; creations against different invoices are unaffected.


___

## **CodeAnt-AI Description**
Prevent over-refunds during concurrent credit note creation

### What Changed
- Credit note creation now locks the invoice before checking the refundable amount, so concurrent requests cannot both approve refunds based on the same balance
- Added a regression test that verifies the invoice lock is acquired during creation
- Updated the in-memory test store to track lock requests

### Impact
`✅ Prevented over-refunds from concurrent credit note creation`
`✅ Serialized credit note changes for the same invoice`
`✅ Regression coverage for invoice locking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit note creation to prevent concurrent requests from exceeding invoice credit limits.
  * Strengthened credit note voiding by validating the latest status before processing, preventing finalized credit notes from being overwritten.
  * Preserved invoice locking during credit note updates for safer transaction handling.

* **Tests**
  * Added regression coverage for concurrent credit note creation and voiding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->