### PR TITLE
fix(coupon): cap max_redemptions at creation (VAPT 6.4)

### DIFF
--- a/internal/api/dto/coupon.go
+++ b/internal/api/dto/coupon.go
@@ -10,6 +10,11 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// MaxCouponRedemptionsLimit caps the max_redemptions a coupon may be created
+// with. Prevents impractically large limits that undermine business controls
+// (VAPT 6.4: no upper bound on max_redemptions).
+const MaxCouponRedemptionsLimit = 1_000_000
+
 // CreateCouponRequest represents the request to create a new coupon
 type CreateCouponRequest struct {
 	Name              string                  `json:"name" validate:"required"`
@@ -81,9 +86,13 @@ func (r *CreateCouponRequest) Validate() error {
 		}
 	}
 
-	if r.MaxRedemptions != nil && *r.MaxRedemptions <= 0 {
-		return ierr.NewError("max_redemptions must be greater than zero").
+	if r.MaxRedemptions != nil && (*r.MaxRedemptions <= 0 || *r.MaxRedemptions > MaxCouponRedemptionsLimit) {
+		return ierr.NewError("max_redemptions must be between 1 and 1000000").
 			WithHint("Please provide a valid maximum redemption count").
+			WithReportableDetails(map[string]interface{}{
+				"max_redemptions": *r.MaxRedemptions,
+				"limit":           MaxCouponRedemptionsLimit,
+			}).
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/api/dto/coupon_test.go
+++ b/internal/api/dto/coupon_test.go
@@ -1,0 +1,57 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseValidCouponRequest returns a minimal CreateCouponRequest that passes
+// Validate(), so tests can vary a single field in isolation.
+func baseValidCouponRequest() CreateCouponRequest {
+	pct := decimal.NewFromInt(10)
+	return CreateCouponRequest{
+		Name:          "Test Coupon",
+		Type:          types.CouponTypePercentage,
+		Cadence:       types.CouponCadenceOnce,
+		PercentageOff: &pct,
+	}
+}
+
+// TestCreateCouponRequest_MaxRedemptions covers VAPT 6.4: max_redemptions had
+// no upper bound, so impractically large values were accepted at creation.
+func TestCreateCouponRequest_MaxRedemptions(t *testing.T) {
+	cases := []struct {
+		name    string
+		max     *int
+		wantErr bool
+	}{
+		{name: "nil is allowed (unlimited)", max: nil, wantErr: false},
+		{name: "one is allowed", max: lo.ToPtr(1), wantErr: false},
+		{name: "at the limit is allowed", max: lo.ToPtr(MaxCouponRedemptionsLimit), wantErr: false},
+		{name: "zero is rejected", max: lo.ToPtr(0), wantErr: true},
+		{name: "negative is rejected", max: lo.ToPtr(-5), wantErr: true},
+		{name: "just over the limit is rejected", max: lo.ToPtr(MaxCouponRedemptionsLimit + 1), wantErr: true},
+		{name: "the VAPT value 100000000000 is rejected", max: lo.ToPtr(100_000_000_000), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := baseValidCouponRequest()
+			req.MaxRedemptions = tc.max
+
+			err := req.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err, "expected max_redemptions=%v to be rejected", tc.max)
+				assert.Contains(t, err.Error(), "max_redemptions")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## **User description**
## Summary

Closes VAPT finding **6.4** (Atom, LOW) — *No limit on maximum coupon redemptions*.

`CreateCouponRequest.Validate` rejected `max_redemptions <= 0` but had **no upper bound**, so a coupon could be created with an impractically large limit (Atom's report used `100000000000`). That undermines the business control the field exists to provide.

Caps at **1,000,000**. `nil` remains valid and still means unlimited, so existing uncapped coupons are unaffected — this constrains new creations only.

## Why this is a re-raise

This revives the validation half of **#2469**, which was closed on 6 Aug. That PR carried two things:

| Change | Status |
|---|---|
| Redemption-time enforcement on the subscription-modify path (**A10 / VAPT 6.3**) | Shipped separately in **#2470**, already on `develop` ✅ |
| The `max_redemptions` cap (**A18 / VAPT 6.4**) | Lost when 2469 closed — **this PR** |

I verified against `upstream/develop` before branching: `ValidateCoupon` + `IncrementRedemptions` are present in `subscription_modification_coupon.go`, but `MaxCouponRedemptionsLimit` is not in `coupon.go` and `coupon_test.go` does not exist. So there is no overlap with #2470.

## Testing

`TestCreateCouponRequest_MaxRedemptions` — table-driven, 7 cases:

```
--- PASS: nil_is_allowed_(unlimited)
--- PASS: one_is_allowed
--- PASS: at_the_limit_is_allowed
--- PASS: zero_is_rejected
--- PASS: negative_is_rejected
--- PASS: just_over_the_limit_is_rejected
--- PASS: the_VAPT_value_100000000000_is_rejected
ok  github.com/flexprice/flexprice/internal/api/dto
```

`go build ./internal/...` passes.

## Tracker impact

A18 was recorded as **ACCEPTED** (*"input hygiene, negligible impact. PR #2469 closed"*) — an exception granted on the basis that the fix had been dropped. Merging this converts it from a closed-by-decision exception into a genuine fix, which is a cleaner position on vendor retest.


___

## **CodeAnt-AI Description**
Cap coupon redemption limits during creation

### What Changed
- New coupons must specify a redemption limit between 1 and 1,000,000 when a limit is provided
- Unlimited coupons remain supported when the limit is omitted
- Invalid zero, negative, and excessively large limits now return a clear validation error
- Added coverage for valid, invalid, boundary, and reported excessive values

### Impact
`✅ Prevents impractically large coupon redemption limits`
`✅ Clearer coupon validation errors`
`✅ Preserves unlimited coupons when no limit is set`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for coupon redemption limits.
  * Coupon creation now rejects redemption limits below 1 or above 1,000,000.
  * Validation errors include the submitted value and the permitted maximum for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->