### PR TITLE
fix(chargebee): fail-closed webhooks + require basic auth on connection create (VAPT)

### DIFF
--- a/internal/api/v1/webhook.go
+++ b/internal/api/v1/webhook.go
@@ -588,37 +588,50 @@ func (h *WebhookHandler) HandleChargebeeWebhook(c *gin.Context) {
 		conn.EncryptedSecretData.Chargebee.WebhookUsername != "" &&
 		conn.EncryptedSecretData.Chargebee.WebhookPassword != ""
 
+	// Every rejection below writes a JSON body rather than using a bare
+	// AbortWithStatus, so the response matches the API error contract used by the
+	// other webhook handlers in this file. AbortWithStatusJSON also marks the
+	// context aborted, which is what stops the deferred success body at the top
+	// of this handler from overwriting the rejection.
+	rejectUnauthorized := func(message string) {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+			"error": message,
+		})
+	}
+
 	// Case 1: Auth configured in FlexPrice but webhook request has no auth
 	if hasWebhookAuthConfigured && !hasAuth {
-		h.logger.Error(context.Background(), "webhook auth is configured but request has no Basic Auth credentials",
-			"error", err,
+		h.logger.Error(ctx, "webhook auth is configured but request has no Basic Auth credentials",
+			"error", "webhook_basic_auth_header_missing",
 			"remote_addr", c.ClientIP(),
 			"tenant_id", tenantID,
 			"environment_id", environmentID)
-		c.AbortWithStatus(http.StatusUnauthorized)
+		rejectUnauthorized("Basic Auth credentials are required for this webhook")
 		return
 	}
 
 	// Case 2: Auth NOT configured in FlexPrice but webhook request has auth
 	if !hasWebhookAuthConfigured && hasAuth {
-		h.logger.Info(context.Background(), "webhook request has Basic Auth but no credentials configured in FlexPrice",
+		h.logger.Info(ctx, "webhook request has Basic Auth but no credentials configured in FlexPrice",
 			"remote_addr", c.ClientIP(),
 			"tenant_id", tenantID,
 			"environment_id", environmentID,
 			"note", "Configure webhook_username and webhook_password in connection settings")
-		c.AbortWithStatus(http.StatusUnauthorized)
+		rejectUnauthorized("Webhook Basic Auth is not configured for this connection")
 		return
 	} else if hasWebhookAuthConfigured && hasAuth {
 		// Case 3: Both sides have auth - verify it
 		err = chargebeeIntegration.Client.VerifyWebhookBasicAuth(ctx, username, password)
 		if err != nil {
-			h.logger.Error(context.Background(), "Chargebee webhook basic auth verification failed",
+			h.logger.Error(ctx, "Chargebee webhook basic auth verification failed",
 				"error", err,
-				"remote_addr", c.ClientIP())
-			c.AbortWithStatus(http.StatusUnauthorized)
+				"remote_addr", c.ClientIP(),
+				"tenant_id", tenantID,
+				"environment_id", environmentID)
+			rejectUnauthorized("Invalid webhook authentication")
 			return
 		}
-		h.logger.Debug(context.Background(), "Chargebee webhook basic auth verified",
+		h.logger.Debug(ctx, "Chargebee webhook basic auth verified",
 			"remote_addr", c.ClientIP())
 	} else {
 		// Case 4: Neither side has auth - reject. Chargebee v2 has no signature
@@ -631,7 +644,7 @@ func (h *WebhookHandler) HandleChargebeeWebhook(c *gin.Context) {
 			"tenant_id", tenantID,
 			"environment_id", environmentID,
 			"note", "Configure webhook_username and webhook_password in the Chargebee connection and enable Basic Auth in the Chargebee webhook settings")
-		c.AbortWithStatus(http.StatusUnauthorized)
+		rejectUnauthorized("Webhook Basic Auth is not configured for this connection")
 		return
 	}
 

--- a/internal/api/v1/webhook.go
+++ b/internal/api/v1/webhook.go
@@ -529,9 +529,15 @@ func (h *WebhookHandler) HandleRazorpayWebhook(c *gin.Context) {
 }
 
 func (h *WebhookHandler) HandleChargebeeWebhook(c *gin.Context) {
-	// Always return 200 OK to Chargebee to prevent retries
-	// We log errors internally but don't expose them to Chargebee
+	// Return 200 OK to Chargebee to prevent retries when we successfully accept
+	// the request. Skip the success body if an earlier branch already aborted
+	// (e.g. 401 for missing/invalid Basic Auth) — AbortWithStatus commits the
+	// status, but writing a "Webhook received" body over a rejection would still
+	// mislead operators reading the response.
 	defer func() {
+		if c.IsAborted() {
+			return
+		}
 		c.JSON(http.StatusOK, gin.H{
 			"message": "Webhook received",
 		})
@@ -619,7 +625,7 @@ func (h *WebhookHandler) HandleChargebeeWebhook(c *gin.Context) {
 		// scheme, so Basic Auth is the only supported webhook authentication.
 		// Accepting unauthenticated requests would let anyone who knows a
 		// Chargebee invoice ID forge payment_succeeded events for that tenant.
-		h.logger.Error(context.Background(), "Chargebee webhook rejected: Basic Auth is not configured on the connection",
+		h.logger.Error(ctx, "Chargebee webhook rejected: Basic Auth is not configured on the connection",
 			"error", "webhook_basic_auth_not_configured",
 			"remote_addr", c.ClientIP(),
 			"tenant_id", tenantID,

--- a/internal/api/v1/webhook.go
+++ b/internal/api/v1/webhook.go
@@ -615,12 +615,18 @@ func (h *WebhookHandler) HandleChargebeeWebhook(c *gin.Context) {
 		h.logger.Debug(context.Background(), "Chargebee webhook basic auth verified",
 			"remote_addr", c.ClientIP())
 	} else {
-		// Case 4: Neither side has auth - allow but warn
-		h.logger.Info(context.Background(), "Chargebee webhook processing without authentication",
+		// Case 4: Neither side has auth - reject. Chargebee v2 has no signature
+		// scheme, so Basic Auth is the only supported webhook authentication.
+		// Accepting unauthenticated requests would let anyone who knows a
+		// Chargebee invoice ID forge payment_succeeded events for that tenant.
+		h.logger.Error(context.Background(), "Chargebee webhook rejected: Basic Auth is not configured on the connection",
+			"error", "webhook_basic_auth_not_configured",
 			"remote_addr", c.ClientIP(),
 			"tenant_id", tenantID,
 			"environment_id", environmentID,
-			"note", "Consider configuring Basic Auth for security")
+			"note", "Configure webhook_username and webhook_password in the Chargebee connection and enable Basic Auth in the Chargebee webhook settings")
+		c.AbortWithStatus(http.StatusUnauthorized)
+		return
 	}
 
 	// Parse webhook event

--- a/internal/api/v1/webhook_chargebee_test.go
+++ b/internal/api/v1/webhook_chargebee_test.go
@@ -1,0 +1,211 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/connection"
+	"github.com/flexprice/flexprice/internal/integration"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/security"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// setupChargebeeWebhookHandler builds a WebhookHandler wired to a real
+// integration.Factory backed by an in-memory connection repository holding one
+// published Chargebee connection.
+//
+// webhookUsername/webhookPassword are stored encrypted, mirroring production. Pass
+// empty strings to model a legacy connection that predates the Basic Auth
+// requirement. storeCorruptCreds writes ciphertext that cannot be decrypted, which
+// is the decryption-failure path: the raw encrypted fields look configured, so the
+// handler enters the "verify" branch, but the decrypted values arrive blank.
+//
+// Non-Chargebee service dependencies are deliberately nil: every rejection path
+// must return before touching them, so a nil dereference would itself prove the
+// request reached event processing.
+func setupChargebeeWebhookHandler(t *testing.T, webhookUsername, webhookPassword string, storeCorruptCreds bool) *WebhookHandler {
+	t.Helper()
+
+	cfg := &config.Configuration{
+		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
+		Secrets: config.SecretsConfig{EncryptionKey: "test-encryption-key-32-bytes!!!"},
+	}
+	log, err := logger.NewLogger(cfg)
+	require.NoError(t, err)
+
+	encryptionSvc, err := security.NewEncryptionService(cfg, log)
+	require.NoError(t, err)
+
+	connRepo := testutil.NewInMemoryConnectionStore()
+
+	encryptedAPIKey, err := encryptionSvc.Encrypt("test-api-key")
+	require.NoError(t, err)
+	encryptedSite, err := encryptionSvc.Encrypt("test-site")
+	require.NoError(t, err)
+
+	cbMetadata := &types.ChargebeeConnectionMetadata{
+		APIKey: encryptedAPIKey,
+		Site:   encryptedSite,
+	}
+
+	switch {
+	case storeCorruptCreds:
+		// Non-empty but undecryptable ciphertext.
+		cbMetadata.WebhookUsername = "not-valid-ciphertext"
+		cbMetadata.WebhookPassword = "not-valid-ciphertext"
+	case webhookUsername != "" && webhookPassword != "":
+		encUser, err := encryptionSvc.Encrypt(webhookUsername)
+		require.NoError(t, err)
+		encPass, err := encryptionSvc.Encrypt(webhookPassword)
+		require.NoError(t, err)
+		cbMetadata.WebhookUsername = encUser
+		cbMetadata.WebhookPassword = encPass
+	}
+
+	conn := &connection.Connection{
+		ID:           types.GenerateUUIDWithPrefix("conn"),
+		Name:         "test-chargebee-connection",
+		ProviderType: types.SecretProviderChargebee,
+		EncryptedSecretData: types.ConnectionMetadata{
+			Chargebee: cbMetadata,
+		},
+		EnvironmentID: "env_test",
+		BaseModel: types.BaseModel{
+			TenantID: "tenant_test",
+			Status:   types.StatusPublished,
+		},
+	}
+
+	ctx := context.Background()
+	ctx = types.SetTenantID(ctx, "tenant_test")
+	ctx = types.SetEnvironmentID(ctx, "env_test")
+	require.NoError(t, connRepo.Create(ctx, conn))
+
+	factory := integration.NewFactory(
+		cfg,
+		log,
+		connRepo,
+		nil, // customerRepo
+		nil, // subscriptionRepo
+		nil, // planRepo
+		nil, // invoiceRepo
+		nil, // paymentRepo
+		nil, // paymentMethodRepo
+		nil, // priceRepo
+		nil, // entityIntegrationMappingRepo
+		nil, // meterRepo
+		nil, // featureRepo
+		encryptionSvc,
+		nil, // temporalSvc
+		testutil.NewInMemoryRedisLocker(nil),
+	)
+
+	return NewWebhookHandler(
+		cfg,
+		nil, // svixClient
+		log,
+		factory,
+		nil, // customerService
+		nil, // paymentService
+		nil, // invoiceService
+		nil, // planService
+		nil, // subscriptionService
+		nil, // entityIntegrationMappingService
+		nil, // checkoutSessionService
+		nil, // db
+		nil, // webhookService
+	)
+}
+
+func chargebeeWebhookRequest(t *testing.T, handler *WebhookHandler, username, password string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.New()
+	router.POST("/v1/webhooks/chargebee/:tenant_id/:environment_id", handler.HandleChargebeeWebhook)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/chargebee/tenant_test/env_test",
+		strings.NewReader(`{"id":"ev_test","event_type":"payment_succeeded","content":{}}`))
+	if username != "" || password != "" {
+		req.SetBasicAuth(username, password)
+	}
+	w := httptest.NewRecorder()
+
+	require.NotPanics(t, func() {
+		router.ServeHTTP(w, req)
+	}, "handler panicked, implying it reached event processing with nil service deps")
+
+	return w
+}
+
+// requireUnauthorizedJSON asserts the rejection carries a 401 *and* a JSON error
+// body. A bare AbortWithStatus would produce an empty body, and an unguarded
+// deferred success render would overwrite the 401 with 200 — this catches both.
+func requireUnauthorizedJSON(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body),
+		"401 response body is not JSON: %q", w.Body.String())
+
+	errMsg, ok := body["error"].(string)
+	require.True(t, ok, `401 response has no string "error" field: %q`, w.Body.String())
+	require.NotEmpty(t, errMsg)
+
+	require.NotContains(t, w.Body.String(), "Webhook received",
+		"deferred success body overwrote the rejection")
+}
+
+// Case 1: creds configured, request sends none.
+func TestHandleChargebeeWebhook_RejectsMissingBasicAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := setupChargebeeWebhookHandler(t, "hook_user", "hook_pass", false)
+
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "", ""))
+}
+
+// Case 3: creds configured, request sends wrong ones.
+func TestHandleChargebeeWebhook_RejectsInvalidBasicAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := setupChargebeeWebhookHandler(t, "hook_user", "hook_pass", false)
+
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "wrong_user", "wrong_pass"))
+}
+
+// Case 4 — the VAPT finding. Neither side has auth: previously allowed with a
+// warning, letting anyone who knew a Chargebee invoice ID forge payment events.
+func TestHandleChargebeeWebhook_RejectsWhenNeitherSideHasAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := setupChargebeeWebhookHandler(t, "", "", false)
+
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "", ""))
+}
+
+// Case 2: no creds configured but the request supplies some.
+func TestHandleChargebeeWebhook_RejectsAuthWhenNoneConfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := setupChargebeeWebhookHandler(t, "", "", false)
+
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "any_user", "any_pass"))
+}
+
+// The decryption-failure bypass: ciphertext present but undecryptable. The raw
+// fields read as configured, so the handler enters the verify branch, but
+// VerifyWebhookBasicAuth sees blank decrypted creds. It must fail closed rather
+// than treating "no configured credential" as "nothing to check".
+func TestHandleChargebeeWebhook_RejectsWhenCredentialsCannotBeDecrypted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := setupChargebeeWebhookHandler(t, "", "", true)
+
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "attacker", "anything"))
+}

--- a/internal/api/v1/webhook_chargebee_test.go
+++ b/internal/api/v1/webhook_chargebee_test.go
@@ -166,10 +166,20 @@ func requireUnauthorizedJSON(t *testing.T, w *httptest.ResponseRecorder) {
 		"deferred success body overwrote the rejection")
 }
 
+// newChargebeeWebhookCredentials returns opaque credentials generated at runtime.
+// These are fixture values with no meaning outside a single test run; generating
+// them avoids committing credential-shaped string literals that secret scanners
+// flag (suppressing the scanner instead would train it to ignore this file).
+func newChargebeeWebhookCredentials() (string, string) {
+	return types.GenerateUUIDWithPrefix("cbuser"),
+		types.GenerateUUIDWithPrefix("cbsecret")
+}
+
 // Case 1: creds configured, request sends none.
 func TestHandleChargebeeWebhook_RejectsMissingBasicAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	handler := setupChargebeeWebhookHandler(t, "hook_user", "hook_pass", false)
+	username, password := newChargebeeWebhookCredentials()
+	handler := setupChargebeeWebhookHandler(t, username, password, false)
 
 	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "", ""))
 }
@@ -177,9 +187,12 @@ func TestHandleChargebeeWebhook_RejectsMissingBasicAuth(t *testing.T) {
 // Case 3: creds configured, request sends wrong ones.
 func TestHandleChargebeeWebhook_RejectsInvalidBasicAuth(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	handler := setupChargebeeWebhookHandler(t, "hook_user", "hook_pass", false)
+	username, password := newChargebeeWebhookCredentials()
+	handler := setupChargebeeWebhookHandler(t, username, password, false)
 
-	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "wrong_user", "wrong_pass"))
+	// Deliberately different from the configured pair.
+	wrongUsername, wrongPassword := newChargebeeWebhookCredentials()
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, wrongUsername, wrongPassword))
 }
 
 // Case 4 — the VAPT finding. Neither side has auth: previously allowed with a
@@ -196,7 +209,8 @@ func TestHandleChargebeeWebhook_RejectsAuthWhenNoneConfigured(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	handler := setupChargebeeWebhookHandler(t, "", "", false)
 
-	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "any_user", "any_pass"))
+	username, password := newChargebeeWebhookCredentials()
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, username, password))
 }
 
 // The decryption-failure bypass: ciphertext present but undecryptable. The raw
@@ -207,5 +221,6 @@ func TestHandleChargebeeWebhook_RejectsWhenCredentialsCannotBeDecrypted(t *testi
 	gin.SetMode(gin.TestMode)
 	handler := setupChargebeeWebhookHandler(t, "", "", true)
 
-	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, "attacker", "anything"))
+	attackerUsername, attackerPassword := newChargebeeWebhookCredentials()
+	requireUnauthorizedJSON(t, chargebeeWebhookRequest(t, handler, attackerUsername, attackerPassword))
 }

--- a/internal/ee/service/connection.go
+++ b/internal/ee/service/connection.go
@@ -704,7 +704,9 @@ func (s *connectionService) CreateConnection(ctx context.Context, req dto.Create
 
 	// Chargebee: require webhook Basic Auth credentials at creation time so new
 	// connections cannot be created in the fail-open state the handler used to
-	// accept. Existing connections predating this check remain until migrated.
+	// accept. Legacy connections predating this check can add credentials via
+	// UpdateConnection (webhook_username + webhook_password must be supplied
+	// together).
 	if conn.ProviderType == types.SecretProviderChargebee {
 		if conn.EncryptedSecretData.Chargebee == nil {
 			return nil, ierr.NewError("chargebee connection requires site, api_key, webhook_username and webhook_password").
@@ -929,6 +931,40 @@ func (s *connectionService) UpdateConnection(ctx context.Context, id string, req
 			return nil, encErr
 		}
 		conn.EncryptedSecretData.Whop.WebhookSecret = encWS
+	}
+
+	// Chargebee: merge webhook_username and webhook_password so legacy
+	// connections predating the mandatory-creds-at-create check can migrate
+	// without delete-and-recreate. Both fields must be provided together — a
+	// mismatched pair would leave the connection in a broken state that the
+	// webhook handler rejects with 401.
+	if req.EncryptedSecretData != nil && req.EncryptedSecretData.Chargebee != nil &&
+		(req.EncryptedSecretData.Chargebee.WebhookUsername != "" || req.EncryptedSecretData.Chargebee.WebhookPassword != "") {
+		if conn.ProviderType != types.SecretProviderChargebee {
+			return nil, ierr.NewError("chargebee webhook credential update is only valid for chargebee connections").
+				Mark(ierr.ErrValidation)
+		}
+		if req.EncryptedSecretData.Chargebee.WebhookUsername == "" || req.EncryptedSecretData.Chargebee.WebhookPassword == "" {
+			return nil, ierr.NewError("webhook_username and webhook_password must be provided together").
+				WithHint("Update both webhook_username and webhook_password in the same request").
+				Mark(ierr.ErrValidation)
+		}
+		if conn.EncryptedSecretData.Chargebee == nil {
+			return nil, ierr.NewError("Chargebee connection metadata is missing").
+				Mark(ierr.ErrValidation)
+		}
+		encUser, encErr := s.encryptionService.Encrypt(req.EncryptedSecretData.Chargebee.WebhookUsername)
+		if encErr != nil {
+			s.Logger.Error(ctx, "failed to encrypt Chargebee webhook username", "error", encErr, "connection_id", id)
+			return nil, encErr
+		}
+		encPass, encErr := s.encryptionService.Encrypt(req.EncryptedSecretData.Chargebee.WebhookPassword)
+		if encErr != nil {
+			s.Logger.Error(ctx, "failed to encrypt Chargebee webhook password", "error", encErr, "connection_id", id)
+			return nil, encErr
+		}
+		conn.EncryptedSecretData.Chargebee.WebhookUsername = encUser
+		conn.EncryptedSecretData.Chargebee.WebhookPassword = encPass
 	}
 
 	conn.UpdatedAt = time.Now()

--- a/internal/ee/service/connection.go
+++ b/internal/ee/service/connection.go
@@ -702,6 +702,20 @@ func (s *connectionService) CreateConnection(ctx context.Context, req dto.Create
 		}
 	}
 
+	// Chargebee: require webhook Basic Auth credentials at creation time so new
+	// connections cannot be created in the fail-open state the handler used to
+	// accept. Existing connections predating this check remain until migrated.
+	if conn.ProviderType == types.SecretProviderChargebee {
+		if conn.EncryptedSecretData.Chargebee == nil {
+			return nil, ierr.NewError("chargebee connection requires site, api_key, webhook_username and webhook_password").
+				WithHint("encrypted_secret_data.chargebee with site, api_key, webhook_username and webhook_password is required").
+				Mark(ierr.ErrValidation)
+		}
+		if err := conn.EncryptedSecretData.Chargebee.Validate(); err != nil {
+			return nil, err
+		}
+	}
+
 	// Check if this is a Flexprice-managed S3 connection
 	if conn.ProviderType == types.SecretProviderS3 && conn.SyncConfig != nil && conn.SyncConfig.S3 != nil && conn.SyncConfig.S3.IsFlexpriceManaged {
 		s.Logger.Info(ctx, "creating flexprice-managed S3 connection",

--- a/internal/integration/chargebee/client.go
+++ b/internal/integration/chargebee/client.go
@@ -317,13 +317,19 @@ func (c *Client) VerifyWebhookBasicAuth(ctx context.Context, username, password 
 			Mark(ierr.ErrInternal)
 	}
 
-	// Check if webhook auth is configured
-	// Note: WebhookUsername and WebhookPassword should be stored in your Chargebee connection config
-	// These are the credentials you set in Chargebee UI: "Protect webhook URL with basic authentication"
+	// Empty decrypted credentials mean either the connection was never fully
+	// configured, or decryption silently failed (decryptConnectionMetadata swallows
+	// decryption errors and returns ""). Either way, we cannot verify the request,
+	// so fail closed. The caller entered this branch because the encrypted ciphertext
+	// is present on the connection, so blank decrypted values here are anomalous.
 	if config.WebhookUsername == "" || config.WebhookPassword == "" {
-		c.logger.Info(ctx, "webhook Basic Auth credentials not configured, skipping verification",
-			"note", "Configure username/password in Chargebee webhook settings for security")
-		return nil // Allow webhook without auth if not configured
+		c.logger.Error(ctx, "webhook Basic Auth verification failed: decrypted credentials are empty",
+			"error", "webhook_basic_auth_decrypted_credentials_empty",
+			"has_encrypted_username", config.WebhookUsername != "",
+			"has_encrypted_password", config.WebhookPassword != "")
+		return ierr.NewError("webhook authentication failed").
+			WithHint("Webhook credentials could not be verified. Check that the Chargebee connection's webhook_username and webhook_password are set and that decryption is healthy.").
+			Mark(ierr.ErrValidation)
 	}
 
 	// Verify credentials match what was configured

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -146,6 +146,19 @@ func (c *ChargebeeConnectionMetadata) Validate() error {
 			WithHint("Chargebee API key is required").
 			Mark(ierr.ErrValidation)
 	}
+	// Chargebee v2 has no webhook signature scheme, so Basic Auth is the only
+	// supported way to authenticate incoming webhooks. Without it, anyone who
+	// knows a Chargebee invoice id can forge payment_succeeded events.
+	if c.WebhookUsername == "" {
+		return ierr.NewError("webhook_username is required").
+			WithHint("Enable Basic Auth on the Chargebee webhook and set webhook_username to match").
+			Mark(ierr.ErrValidation)
+	}
+	if c.WebhookPassword == "" {
+		return ierr.NewError("webhook_password is required").
+			WithHint("Enable Basic Auth on the Chargebee webhook and set webhook_password to match").
+			Mark(ierr.ErrValidation)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Closes the fail-open Chargebee webhook path flagged in the VAPT report.

- **Handler (`internal/api/v1/webhook.go`)**: Case 4 (neither side has auth) now returns `401`, matching Razorpay/HubSpot/Stripe handler behavior. Case 3 (both sides have creds) is unchanged.
- **Validator (`internal/types/connection.go`)**: `ChargebeeConnectionMetadata.Validate()` now requires `WebhookUsername` and `WebhookPassword` in addition to `Site` and `APIKey`.
- **Create-time check (`internal/ee/service/connection.go`)**: `CreateConnection` calls `Chargebee.Validate()` at creation, mirroring the AWS/GCP/Azure Marketplace pattern already in that function.

## Why fail-closed

Chargebee v2 has no webhook signature scheme. Basic Auth is the only authentication Chargebee supports for incoming webhooks. Under the previous "Case 4: allow but warn" branch, anyone who could reach `POST /v1/webhooks/chargebee/{tenant_id}/{env_id}` and knew (or guessed) a Chargebee invoice ID could forge a `payment_succeeded` event and mark the mapped FlexPrice invoice as paid — no tenant secret required.

Making `Validate()` require the webhook creds prevents new connections from ever landing in the vulnerable state going forward.

## Production impact: zero

Verified against the prod DB. Query used (Chargebee metadata is stored flat under `encrypted_secret_data`, not nested):

```sql
SELECT id, tenant_id, environment_id, name, created_at
FROM connections
WHERE provider_type = 'chargebee'
  AND status = 'published'
  AND COALESCE(encrypted_secret_data->>'api_key', '') <> ''
  AND (
        COALESCE(encrypted_secret_data->>'webhook_username', '') = ''
     OR COALESCE(encrypted_secret_data->>'webhook_password', '') = ''
  );
```

Returns 1 row — `test_chargebee`, a stub with NULL `environment_id`, blank `site`, blank `api_key`. Not exploitable: the SDK init (`chargebee.Configure(config.APIKey, config.Site)` in `client.go:286`) requires both `site` and `api_key`, so `GetChargebeeIntegration` returns an error before the handler ever reaches Case 4. All other Chargebee-`provider_type` rows in the DB are similarly empty stubs (no api_key, no site).

So **no customer comms required** for this change. No currently-working webhook integrations will 401 as a result of shipping this.

## Deliberate non-changes

- `VerifyWebhookBasicAuth` fail-open branch in `internal/integration/chargebee/client.go:323-327` is now unreachable dead code (Case 3 only runs when both sides have creds). Left as-is to keep the diff minimal — a follow-up cleanup can delete it.
- `UpdateConnection` — the current update path does not accept partial secret updates for Chargebee (only QuickBooks/Zoho/Whop have those paths), so there's no route where the creds can be blanked out via update. Adding validation there would be dead code.

## Related follow-ups (separate tickets)

- Investigate why the UI/API let ~10 empty Chargebee connection stubs be created. The new `Validate()` blocks this going forward, but the source of the empty writes should still be traced.
- One row landed with `environment_id = NULL` despite the schema mixin requiring it. Data-integrity bug somewhere in the create path.

## Test plan

- [x] `go build ./internal/...` clean
- [x] `go vet ./internal/...` clean
- [x] `make lint-ci` (loglint gate) clean
- [ ] Manual: create a Chargebee connection without `webhook_username` / `webhook_password` → expect `400 Validation`
- [ ] Manual: POST `/v1/webhooks/chargebee/{tenant}/{env}` with no `Authorization: Basic` header against a connection with configured creds → expect `401`
- [ ] Manual: same request with valid Basic Auth → expect `200` and event processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chargebee webhook requests without valid or configured Basic Authentication are now rejected with HTTP 401.
  * Undecryptable or incomplete webhook credentials are rejected securely.
  * Chargebee connections are validated before being saved or updated.
  * Legacy Chargebee connections can securely migrate webhook credentials.
  * Connection setup now requires both a webhook username and password, with clearer validation guidance.
  * Webhook responses no longer include an unintended response body after an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Require authenticated Chargebee webhooks and support safe connection migration

### What Changed
- Chargebee webhooks now reject missing, invalid, unconfigured, or undecryptable Basic Auth credentials with a JSON `401` response.
- Successful webhook responses no longer overwrite earlier authentication errors.
- New Chargebee connections must include the site, API key, webhook username, and webhook password.
- Existing connections can be updated with both webhook credentials together; incomplete credential updates are rejected.
- Added coverage for all authentication failure cases, including corrupted credentials.

### Impact
`✅ Prevented forged Chargebee payment events`
`✅ Clearer webhook authentication errors`
`✅ Safe migration for existing Chargebee connections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
