### PR TITLE
fix(payment): deterministic idempotency key + idempotent create (VAPT)

### DIFF
--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1442,7 +1442,7 @@ var (
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "environment_id", Type: field.TypeString, Nullable: true, Default: "", SchemaType: map[string]string{"postgres": "varchar(50)"}},
-		{Name: "idempotency_key", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "varchar(50)"}},
+		{Name: "idempotency_key", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "destination_type", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "destination_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
 		{Name: "payment_method_type", Type: field.TypeString, SchemaType: map[string]string{"postgres": "varchar(50)"}},
@@ -1486,6 +1486,11 @@ var (
 				Annotation: &entsql.IndexAnnotation{
 					Where: "((payment_gateway IS NOT NULL) AND (gateway_payment_id IS NOT NULL))",
 				},
+			},
+			{
+				Name:    "idx_tenant_environment_payment_idempotency_key_unique",
+				Unique:  true,
+				Columns: []*schema.Column{PaymentsColumns[1], PaymentsColumns[7], PaymentsColumns[8]},
 			},
 		},
 	}
@@ -1699,6 +1704,14 @@ var (
 				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[35], PricesColumns[34], PricesColumns[40]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "((status)::text = 'published'::text)",
+				},
+			},
+			{
+				Name:    "price_tenant_id_environment_id_entity_id_parent_price_id",
+				Unique:  false,
+				Columns: []*schema.Column{PricesColumns[1], PricesColumns[7], PricesColumns[35], PricesColumns[36]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "(((status)::text = 'published'::text) AND ((entity_type)::text = 'SUBSCRIPTION'::text))",
 				},
 			},
 		},
@@ -1995,9 +2008,9 @@ var (
 				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[17], SubscriptionsColumns[11], SubscriptionsColumns[2]},
 			},
 			{
-				Name:    "subscription_tenant_id_environment_id_plan_id_synced_price_sequence",
+				Name:    "subscription_tenant_id_environment_id_plan_id_synced_price_sequence_id",
 				Unique:  false,
-				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[10], SubscriptionsColumns[44]},
+				Columns: []*schema.Column{SubscriptionsColumns[1], SubscriptionsColumns[7], SubscriptionsColumns[10], SubscriptionsColumns[44], SubscriptionsColumns[0]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "(((status)::text = 'published'::text) AND ((subscription_type)::text = ANY (ARRAY[('standalone'::character varying)::text, ('delegated_invoicing'::character varying)::text, ('parent'::character varying)::text, ('grouped_invoicing'::character varying)::text])))",
 				},
@@ -2093,6 +2106,14 @@ var (
 				Name:    "subscriptionlineitem_subscription_id_status",
 				Unique:  false,
 				Columns: []*schema.Column{SubscriptionLineItemsColumns[37], SubscriptionLineItemsColumns[2]},
+			},
+			{
+				Name:    "subscriptionlineitem_tenant_id_environment_id_subscription_id_price_id_entity_type",
+				Unique:  false,
+				Columns: []*schema.Column{SubscriptionLineItemsColumns[1], SubscriptionLineItemsColumns[7], SubscriptionLineItemsColumns[37], SubscriptionLineItemsColumns[12], SubscriptionLineItemsColumns[10]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "((status)::text = 'published'::text)",
+				},
 			},
 		},
 	}

--- a/ent/schema/payment.go
+++ b/ent/schema/payment.go
@@ -36,7 +36,6 @@ func (Payment) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				"postgres": "varchar(50)",
 			}).
-			Unique().
 			Immutable(),
 		field.String("destination_type").
 			SchemaType(map[string]string{
@@ -135,6 +134,12 @@ func (Payment) Edges() []ent.Edge {
 	}
 }
 
+// Idx_tenant_environment_payment_idempotency_key_unique is exported so the
+// repository can identify unique-constraint violations on this specific
+// index and return them as ErrAlreadyExists (used to resolve concurrent
+// idempotent-create races).
+var Idx_tenant_environment_payment_idempotency_key_unique = "idx_tenant_environment_payment_idempotency_key_unique"
+
 // Indexes of the Payment.
 func (Payment) Indexes() []ent.Index {
 	return []ent.Index{
@@ -145,5 +150,10 @@ func (Payment) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "payment_gateway", "gateway_payment_id").
 			StorageKey("idx_tenant_gateway_payment").
 			Annotations(entsql.IndexWhere("((payment_gateway IS NOT NULL) AND (gateway_payment_id IS NOT NULL))")),
+		// Idempotency is scoped per tenant+environment: the same caller-supplied
+		// key (e.g. "retry-1") can legitimately be used by different tenants.
+		index.Fields("tenant_id", "environment_id", "idempotency_key").
+			Unique().
+			StorageKey(Idx_tenant_environment_payment_idempotency_key_unique),
 	}
 }

--- a/ent/schema/payment.go
+++ b/ent/schema/payment.go
@@ -135,9 +135,7 @@ func (Payment) Edges() []ent.Edge {
 }
 
 // Idx_tenant_environment_payment_idempotency_key_unique is exported so the
-// repository can identify unique-constraint violations on this specific
-// index and return them as ErrAlreadyExists (used to resolve concurrent
-// idempotent-create races).
+// repository can pattern-match this constraint name when translating errors.
 var Idx_tenant_environment_payment_idempotency_key_unique = "idx_tenant_environment_payment_idempotency_key_unique"
 
 // Indexes of the Payment.
@@ -150,8 +148,8 @@ func (Payment) Indexes() []ent.Index {
 		index.Fields("tenant_id", "environment_id", "payment_gateway", "gateway_payment_id").
 			StorageKey("idx_tenant_gateway_payment").
 			Annotations(entsql.IndexWhere("((payment_gateway IS NOT NULL) AND (gateway_payment_id IS NOT NULL))")),
-		// Idempotency is scoped per tenant+environment: the same caller-supplied
-		// key (e.g. "retry-1") can legitimately be used by different tenants.
+		// Scoped per (tenant, environment) so different tenants can reuse the
+		// same caller-supplied key without colliding.
 		index.Fields("tenant_id", "environment_id", "idempotency_key").
 			Unique().
 			StorageKey(Idx_tenant_environment_payment_idempotency_key_unique),

--- a/internal/domain/payment/repository.go
+++ b/internal/domain/payment/repository.go
@@ -2,9 +2,28 @@ package payment
 
 import (
 	"context"
+	"errors"
 
 	"github.com/flexprice/flexprice/internal/types"
 )
+
+// ErrIdempotencyKeyConflict marks the specific case of a Create losing the race
+// on the (tenant_id, environment_id, idempotency_key) unique index — i.e. a
+// concurrent request already inserted this exact payment intent.
+//
+// It exists to distinguish that case from every other constraint violation. The
+// repository marks all constraint errors ErrAlreadyExists, so without this a
+// duplicate payment ID would also look like an idempotency conflict, and the
+// caller's re-fetch by idempotency key would miss and surface a misleading
+// ErrNotFound. Errors carrying this are still marked ierr.ErrAlreadyExists, so
+// the HTTP status stays 409.
+var ErrIdempotencyKeyConflict = errors.New("payment idempotency key conflict")
+
+// IsIdempotencyKeyConflict reports whether err came from losing the race on the
+// idempotency-key unique index.
+func IsIdempotencyKeyConflict(err error) bool {
+	return errors.Is(err, ErrIdempotencyKeyConflict)
+}
 
 // ScopedPayment identifies a payment along with its tenant/environment so a
 // cron running outside any tenant scope can re-establish context per payment.

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -156,20 +156,45 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 		}
 	}
 
-	// Generate idempotency key
+	// Generate idempotency key when the caller didn't supply one.
+	//
+	// The previous implementation embedded time.Now() (RFC3339, second precision)
+	// which produced a fresh key on every call — defeating idempotency and letting
+	// naive client retries (network timeout → retry) create duplicate payment rows
+	// AND, when ProcessPayment=true, double-charge the customer's card via the
+	// gateway. The unique DB constraint on idempotency_key never caught it because
+	// the key was unique per call by design.
+	//
+	// Deterministic key on {invoice_id, amount, currency} means:
+	//   - Retries of the same charge intent hit the pre-Create lookup below and
+	//     return the existing payment (true idempotent behavior, matching the
+	//     razorpay/invoice.go and tax.go patterns).
+	//   - Callers who legitimately need multiple payments for the same
+	//     invoice+amount+currency (installments, partial re-attempts) can still
+	//     do so by supplying their own IdempotencyKey in the request — the
+	//     `if p.IdempotencyKey == ""` guard already respects that.
 	if p.IdempotencyKey == "" {
 		p.IdempotencyKey = s.idempGen.GenerateKey(idempotency.ScopePayment, map[string]interface{}{
 			"invoice_id": p.DestinationID,
 			"amount":     p.Amount,
 			"currency":   p.Currency,
-			// TODO: think of a better way to generate this key rather than using the current timestamp
-			"timestamp": time.Now().UTC().Format(time.RFC3339),
 		})
 	}
 
 	// validate the payment object before creating it
 	if err := p.Validate(); err != nil {
 		return nil, err
+	}
+
+	// Idempotent create: if a payment with the same idempotency key already exists,
+	// return it as the response instead of racing the unique constraint on Create.
+	// GetByIdempotencyKey is tenant/env-scoped via ctx.
+	existing, err := s.PaymentRepo.GetByIdempotencyKey(ctx, p.IdempotencyKey)
+	if err != nil && !ierr.IsNotFound(err) {
+		return nil, err
+	}
+	if existing != nil {
+		return dto.NewPaymentResponse(existing), nil
 	}
 
 	if err := s.PaymentRepo.Create(ctx, p); err != nil {

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -156,23 +156,10 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 		}
 	}
 
-	// Generate idempotency key when the caller didn't supply one.
-	//
-	// The previous implementation embedded time.Now() (RFC3339, second precision)
-	// which produced a fresh key on every call — defeating idempotency and letting
-	// naive client retries (network timeout → retry) create duplicate payment rows
-	// AND, when ProcessPayment=true, double-charge the customer's card via the
-	// gateway. The unique DB constraint on idempotency_key never caught it because
-	// the key was unique per call by design.
-	//
-	// Key composition — {invoice_id, amount, currency, payment_method_type,
-	// payment_gateway} — dedups genuine retries of the same charge intent but
-	// keeps distinct intents distinct: switching payment method (card → link)
-	// or gateway after a failed attempt must not collapse into the earlier
-	// payment record. Callers who legitimately need multiple payments for the
-	// same intent (installments, partial re-attempts) can still opt out by
-	// supplying their own IdempotencyKey — the `if p.IdempotencyKey == ""`
-	// guard already respects that.
+	// Auto-generated key includes payment_method_type and payment_gateway so
+	// switching method (card → link) or gateway after a failed attempt creates
+	// a new payment intent instead of colliding with the earlier row. Callers
+	// can pass their own IdempotencyKey to opt out (installments, etc).
 	if p.IdempotencyKey == "" {
 		p.IdempotencyKey = s.idempGen.GenerateKey(idempotency.ScopePayment, map[string]interface{}{
 			"invoice_id":          p.DestinationID,
@@ -183,29 +170,12 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 		})
 	}
 
-	// validate the payment object before creating it
 	if err := p.Validate(); err != nil {
 		return nil, err
 	}
 
-	// Idempotent create.
-	// Fast path: check for an existing payment first and return it. Avoids
-	// generating a wasted payment ID + burning a Create attempt for typical
-	// serial retries.
-	// Race path: two concurrent requests can both observe not-found and both
-	// call Create; the unique index on (tenant_id, environment_id,
-	// idempotency_key) fails one with ErrAlreadyExists — we then re-fetch and
-	// return the winner's payment.
-	// GetByIdempotencyKey is tenant/env-scoped via ctx.
-	existing, err := s.PaymentRepo.GetByIdempotencyKey(ctx, p.IdempotencyKey)
-	if err != nil && !ierr.IsNotFound(err) {
-		return nil, err
-	}
-	if existing != nil {
-		return dto.NewPaymentResponse(existing), nil
-	}
-
 	if err := s.PaymentRepo.Create(ctx, p); err != nil {
+		// Concurrent request already inserted with this key — return theirs.
 		if ierr.IsAlreadyExists(err) {
 			existing, fetchErr := s.PaymentRepo.GetByIdempotencyKey(ctx, p.IdempotencyKey)
 			if fetchErr != nil {

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -165,19 +165,21 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 	// gateway. The unique DB constraint on idempotency_key never caught it because
 	// the key was unique per call by design.
 	//
-	// Deterministic key on {invoice_id, amount, currency} means:
-	//   - Retries of the same charge intent hit the pre-Create lookup below and
-	//     return the existing payment (true idempotent behavior, matching the
-	//     razorpay/invoice.go and tax.go patterns).
-	//   - Callers who legitimately need multiple payments for the same
-	//     invoice+amount+currency (installments, partial re-attempts) can still
-	//     do so by supplying their own IdempotencyKey in the request — the
-	//     `if p.IdempotencyKey == ""` guard already respects that.
+	// Key composition — {invoice_id, amount, currency, payment_method_type,
+	// payment_gateway} — dedups genuine retries of the same charge intent but
+	// keeps distinct intents distinct: switching payment method (card → link)
+	// or gateway after a failed attempt must not collapse into the earlier
+	// payment record. Callers who legitimately need multiple payments for the
+	// same intent (installments, partial re-attempts) can still opt out by
+	// supplying their own IdempotencyKey — the `if p.IdempotencyKey == ""`
+	// guard already respects that.
 	if p.IdempotencyKey == "" {
 		p.IdempotencyKey = s.idempGen.GenerateKey(idempotency.ScopePayment, map[string]interface{}{
-			"invoice_id": p.DestinationID,
-			"amount":     p.Amount,
-			"currency":   p.Currency,
+			"invoice_id":          p.DestinationID,
+			"amount":              p.Amount,
+			"currency":            p.Currency,
+			"payment_method_type": p.PaymentMethodType,
+			"payment_gateway":     lo.FromPtr(p.PaymentGateway),
 		})
 	}
 
@@ -186,8 +188,14 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 		return nil, err
 	}
 
-	// Idempotent create: if a payment with the same idempotency key already exists,
-	// return it as the response instead of racing the unique constraint on Create.
+	// Idempotent create.
+	// Fast path: check for an existing payment first and return it. Avoids
+	// generating a wasted payment ID + burning a Create attempt for typical
+	// serial retries.
+	// Race path: two concurrent requests can both observe not-found and both
+	// call Create; the unique index on (tenant_id, environment_id,
+	// idempotency_key) fails one with ErrAlreadyExists — we then re-fetch and
+	// return the winner's payment.
 	// GetByIdempotencyKey is tenant/env-scoped via ctx.
 	existing, err := s.PaymentRepo.GetByIdempotencyKey(ctx, p.IdempotencyKey)
 	if err != nil && !ierr.IsNotFound(err) {
@@ -198,6 +206,13 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 	}
 
 	if err := s.PaymentRepo.Create(ctx, p); err != nil {
+		if ierr.IsAlreadyExists(err) {
+			existing, fetchErr := s.PaymentRepo.GetByIdempotencyKey(ctx, p.IdempotencyKey)
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
+			return dto.NewPaymentResponse(existing), nil
+		}
 		return nil, err
 	}
 

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -181,10 +181,15 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 
 	if err := s.PaymentRepo.Create(ctx, p); err != nil {
 		// Concurrent request already inserted with this key — return theirs.
-		if ierr.IsAlreadyExists(err) {
+		// Gated on the idempotency-key conflict specifically: any other
+		// constraint violation is also ErrAlreadyExists, and re-fetching by a
+		// key that was never inserted would turn it into a misleading 404.
+		if payment.IsIdempotencyKeyConflict(err) {
 			existing, fetchErr := s.PaymentRepo.GetByIdempotencyKey(ctx, p.IdempotencyKey)
 			if fetchErr != nil {
-				return nil, fetchErr
+				// The row is gone or unreadable — report the original conflict
+				// rather than the lookup miss, which would misdescribe the cause.
+				return nil, err
 			}
 			return dto.NewPaymentResponse(existing), nil
 		}

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -156,16 +156,21 @@ func (s *paymentService) CreatePayment(ctx context.Context, req *dto.CreatePayme
 		}
 	}
 
-	// Auto-generated key includes payment_method_type and payment_gateway so
-	// switching method (card → link) or gateway after a failed attempt creates
-	// a new payment intent instead of colliding with the earlier row. Callers
-	// can pass their own IdempotencyKey to opt out (installments, etc).
+	// Auto-generated key includes payment_method_type, payment_method_id, and
+	// payment_gateway so distinct intents don't collapse into one row: switching
+	// method (card → link), swapping the underlying card (pm_1 → pm_2), or
+	// changing gateway all produce distinct keys. payment_method_id also
+	// captures gateway implicitly, since each method belongs to a single gateway
+	// — this matters for subscription card charges where the caller doesn't set
+	// payment_gateway (gets resolved later in ProcessPayment). Callers can pass
+	// their own IdempotencyKey to opt out (installments, etc).
 	if p.IdempotencyKey == "" {
 		p.IdempotencyKey = s.idempGen.GenerateKey(idempotency.ScopePayment, map[string]interface{}{
 			"invoice_id":          p.DestinationID,
 			"amount":              p.Amount,
 			"currency":            p.Currency,
 			"payment_method_type": p.PaymentMethodType,
+			"payment_method_id":   p.PaymentMethodID,
 			"payment_gateway":     lo.FromPtr(p.PaymentGateway),
 		})
 	}

--- a/internal/ee/service/payment_test.go
+++ b/internal/ee/service/payment_test.go
@@ -384,3 +384,41 @@ func (s *PaymentServiceSuite) TestCreatePayment_ConcurrentRetriesReturnSamePayme
 	unique := lo.Uniq(ids)
 	s.Len(unique, 1, "concurrent identical requests produced %d distinct payments (duplicate charges)", len(unique))
 }
+
+// A constraint violation that is NOT the idempotency-key index (a duplicate
+// payment ID, say) is also marked ErrAlreadyExists by the repository. Treating
+// every ErrAlreadyExists as an idempotency conflict made CreatePayment re-fetch
+// by a key that was never inserted, turning a 409 into a misleading 404.
+func (s *PaymentServiceSuite) TestCreatePayment_NonIdempotencyConstraintErrorIsNotMasked() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "test-env-id")
+
+	err := s.GetStores().PaymentRepo.Create(ctx, &payment.Payment{
+		ID:                "pay_duplicate_id_probe",
+		IdempotencyKey:    "key-already-taken",
+		DestinationType:   types.PaymentDestinationTypeInvoice,
+		DestinationID:     s.testData.invoice.ID,
+		PaymentMethodType: types.PaymentMethodTypeOffline,
+		Amount:            decimal.NewFromInt(100),
+		Currency:          "usd",
+		PaymentStatus:     types.PaymentStatusPending,
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	})
+	s.Require().NoError(err)
+
+	// Same ID, different idempotency key: a non-idempotency constraint failure.
+	err = s.GetStores().PaymentRepo.Create(ctx, &payment.Payment{
+		ID:                "pay_duplicate_id_probe",
+		IdempotencyKey:    "a-different-key",
+		DestinationType:   types.PaymentDestinationTypeInvoice,
+		DestinationID:     s.testData.invoice.ID,
+		PaymentMethodType: types.PaymentMethodTypeOffline,
+		Amount:            decimal.NewFromInt(100),
+		Currency:          "usd",
+		PaymentStatus:     types.PaymentStatusPending,
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	})
+	s.Require().Error(err)
+	s.False(payment.IsIdempotencyKeyConflict(err),
+		"a duplicate-ID violation must not be tagged as an idempotency conflict")
+	s.False(ierr.IsNotFound(err), "must not surface as ErrNotFound")
+}

--- a/internal/ee/service/payment_test.go
+++ b/internal/ee/service/payment_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -282,4 +283,104 @@ func (s *PaymentServiceSuite) TestCreatePayment_CustomerDestination_ValidatesCus
 		s.Equal(types.PaymentDestinationTypeCustomer, resp.DestinationType)
 		s.Equal(s.testData.customer.ID, resp.DestinationID)
 	})
+}
+
+// The VAPT finding: CreatePayment previously auto-generated its idempotency key
+// from time.Now() at second precision, so a client timeout + retry produced a
+// different key, bypassed the unique constraint, and inserted a second payment
+// row. With process_payment=true that meant a second real gateway charge against
+// the customer's card.
+//
+// The key is now deterministic on the payment intent, and Create surfaces the
+// unique-constraint violation as ErrAlreadyExists which CreatePayment catches and
+// resolves by returning the existing payment.
+func (s *PaymentServiceSuite) TestCreatePayment_RetryIsIdempotent() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "test-env-id")
+
+	newReq := func() *dto.CreatePaymentRequest {
+		return &dto.CreatePaymentRequest{
+			DestinationType:   types.PaymentDestinationTypeInvoice,
+			DestinationID:     s.testData.invoice.ID,
+			PaymentMethodType: types.PaymentMethodTypeOffline,
+			Amount:            decimal.NewFromInt(100),
+			Currency:          "usd",
+			ProcessPayment:    false,
+		}
+	}
+
+	first, err := s.service.CreatePayment(ctx, newReq())
+	s.Require().NoError(err)
+	s.Require().NotEmpty(first.IdempotencyKey, "auto-generated key must be set")
+
+	// The retry: identical intent, no caller-supplied key.
+	second, err := s.service.CreatePayment(ctx, newReq())
+	s.Require().NoError(err, "retry must not error — it must return the existing payment")
+	s.Equal(first.ID, second.ID, "retry created a duplicate payment row (the duplicate-charge bug)")
+	s.Equal(first.IdempotencyKey, second.IdempotencyKey, "auto-generated key must be deterministic")
+}
+
+// Callers that genuinely want a second payment for the same intent (installments,
+// partial re-attempts) opt out by supplying their own key. This is the escape
+// hatch that makes the deterministic default safe to ship.
+func (s *PaymentServiceSuite) TestCreatePayment_DistinctIdempotencyKeysCreateDistinctPayments() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "test-env-id")
+
+	newReq := func(key string) *dto.CreatePaymentRequest {
+		return &dto.CreatePaymentRequest{
+			DestinationType:   types.PaymentDestinationTypeInvoice,
+			DestinationID:     s.testData.invoice.ID,
+			PaymentMethodType: types.PaymentMethodTypeOffline,
+			Amount:            decimal.NewFromInt(100),
+			Currency:          "usd",
+			ProcessPayment:    false,
+			IdempotencyKey:    key,
+		}
+	}
+
+	first, err := s.service.CreatePayment(ctx, newReq("installment-1"))
+	s.Require().NoError(err)
+
+	second, err := s.service.CreatePayment(ctx, newReq("installment-2"))
+	s.Require().NoError(err)
+
+	s.NotEqual(first.ID, second.ID, "distinct caller-supplied keys must create distinct payments")
+}
+
+// The concurrency case CodeRabbit and CodeAnt both flagged. Lookup-then-insert is
+// not atomic, so two in-flight requests can both miss and both attempt Create.
+// The loser must receive the winner's payment rather than a raw constraint error.
+func (s *PaymentServiceSuite) TestCreatePayment_ConcurrentRetriesReturnSamePayment() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "test-env-id")
+
+	const concurrent = 8
+	var wg sync.WaitGroup
+	ids := make([]string, concurrent)
+	errs := make([]error, concurrent)
+
+	wg.Add(concurrent)
+	for i := 0; i < concurrent; i++ {
+		go func(i int) {
+			defer wg.Done()
+			resp, err := s.service.CreatePayment(ctx, &dto.CreatePaymentRequest{
+				DestinationType:   types.PaymentDestinationTypeInvoice,
+				DestinationID:     s.testData.invoice.ID,
+				PaymentMethodType: types.PaymentMethodTypeOffline,
+				Amount:            decimal.NewFromInt(100),
+				Currency:          "usd",
+				ProcessPayment:    false,
+			})
+			errs[i] = err
+			if err == nil {
+				ids[i] = resp.ID
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		s.Require().NoError(err, "concurrent request %d failed instead of returning the existing payment", i)
+	}
+
+	unique := lo.Uniq(ids)
+	s.Len(unique, 1, "concurrent identical requests produced %d distinct payments (duplicate charges)", len(unique))
 }

--- a/internal/ee/service/payment_test.go
+++ b/internal/ee/service/payment_test.go
@@ -422,3 +422,40 @@ func (s *PaymentServiceSuite) TestCreatePayment_NonIdempotencyConstraintErrorIsN
 		"a duplicate-ID violation must not be tagged as an idempotency conflict")
 	s.False(ierr.IsNotFound(err), "must not surface as ErrNotFound")
 }
+
+// Payments created without an explicit TenantID take it from context. The store
+// must persist that resolved tenant, otherwise the row is kept with an empty
+// TenantID, a later retry compares "" against the context tenant, the duplicate
+// goes undetected, and the idempotency guarantee silently disappears.
+func (s *PaymentServiceSuite) TestCreatePayment_RetryIsIdempotentWhenTenantComesFromContext() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "test-env-id")
+
+	newPayment := func() *payment.Payment {
+		return &payment.Payment{
+			ID:                types.GenerateUUIDWithPrefix("pay"),
+			IdempotencyKey:    "tenant-from-context-key",
+			DestinationType:   types.PaymentDestinationTypeInvoice,
+			DestinationID:     s.testData.invoice.ID,
+			PaymentMethodType: types.PaymentMethodTypeOffline,
+			Amount:            decimal.NewFromInt(100),
+			Currency:          "usd",
+			PaymentStatus:     types.PaymentStatusPending,
+			EnvironmentID:     "test-env-id",
+			// TenantID deliberately left empty — resolved from ctx.
+		}
+	}
+
+	s.Require().NoError(s.GetStores().PaymentRepo.Create(ctx, newPayment()))
+
+	// The retry carries the tenant explicitly — as a caller that populated
+	// BaseModel would. If the first insert was stored with an empty TenantID,
+	// this comparison misses and the duplicate slips through.
+	retry := newPayment()
+	retry.TenantID = types.GetTenantID(ctx)
+	s.Require().NotEmpty(retry.TenantID, "test context must carry a tenant for this to be meaningful")
+
+	err := s.GetStores().PaymentRepo.Create(ctx, retry)
+	s.Require().Error(err, "second insert with the same key must be rejected")
+	s.True(payment.IsIdempotencyKeyConflict(err),
+		"context-resolved tenant must still be matched by the uniqueness check")
+}

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -91,10 +91,6 @@ func (r *paymentRepository) Create(ctx context.Context, p *domainPayment.Payment
 
 	if err != nil {
 		SetSpanError(span, err)
-		// Idempotent create: surface unique-index conflicts on the
-		// (tenant_id, environment_id, idempotency_key) index as ErrAlreadyExists
-		// so the service layer can re-fetch and return the existing payment
-		// instead of the caller seeing a generic DB error under concurrent retries.
 		if ent.IsConstraintError(err) {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) && pqErr.Constraint == entSchema.Idx_tenant_environment_payment_idempotency_key_unique {

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -94,7 +94,11 @@ func (r *paymentRepository) Create(ctx context.Context, p *domainPayment.Payment
 		if ent.IsConstraintError(err) {
 			var pqErr *pq.Error
 			if errors.As(err, &pqErr) && pqErr.Constraint == entSchema.Idx_tenant_environment_payment_idempotency_key_unique {
-				return ierr.WithError(err).
+				// Tag this specific constraint so callers can tell an idempotency
+				// race apart from any other constraint violation (a duplicate
+				// payment ID, say). Both stay ErrAlreadyExists → HTTP 409; only
+				// this one means "re-fetching by idempotency key will find it".
+				return ierr.WithError(errors.Join(err, domainPayment.ErrIdempotencyKeyConflict)).
 					WithHint("A payment with this idempotency key already exists").
 					WithReportableDetails(map[string]interface{}{
 						"idempotency_key": p.IdempotencyKey,

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -2,17 +2,20 @@ package ent
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/flexprice/flexprice/ent"
 	"github.com/flexprice/flexprice/ent/payment"
 	"github.com/flexprice/flexprice/ent/paymentattempt"
+	entSchema "github.com/flexprice/flexprice/ent/schema"
 	"github.com/flexprice/flexprice/internal/cache"
 	domainPayment "github.com/flexprice/flexprice/internal/domain/payment"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/postgres"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/lib/pq"
 )
 
 type paymentRepository struct {
@@ -88,6 +91,24 @@ func (r *paymentRepository) Create(ctx context.Context, p *domainPayment.Payment
 
 	if err != nil {
 		SetSpanError(span, err)
+		// Idempotent create: surface unique-index conflicts on the
+		// (tenant_id, environment_id, idempotency_key) index as ErrAlreadyExists
+		// so the service layer can re-fetch and return the existing payment
+		// instead of the caller seeing a generic DB error under concurrent retries.
+		if ent.IsConstraintError(err) {
+			var pqErr *pq.Error
+			if errors.As(err, &pqErr) && pqErr.Constraint == entSchema.Idx_tenant_environment_payment_idempotency_key_unique {
+				return ierr.WithError(err).
+					WithHint("A payment with this idempotency key already exists").
+					WithReportableDetails(map[string]interface{}{
+						"idempotency_key": p.IdempotencyKey,
+					}).
+					Mark(ierr.ErrAlreadyExists)
+			}
+			return ierr.WithError(err).
+				WithHint("Payment creation failed due to constraint violation").
+				Mark(ierr.ErrAlreadyExists)
+		}
 		return ierr.WithError(err).
 			WithHint("Failed to create payment").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/testutil/inmemory_payment_store.go
+++ b/internal/testutil/inmemory_payment_store.go
@@ -58,6 +58,14 @@ func (m *InMemoryPaymentStore) Create(ctx context.Context, p *payment.Payment) e
 		p.EnvironmentID = types.GetEnvironmentID(ctx)
 	}
 
+	// Same for tenant. This must be persisted onto p, not just resolved into a
+	// local: the duplicate check below compares against stored payments, so a row
+	// kept with an empty TenantID would never match a later retry carrying the
+	// context tenant, silently defeating the uniqueness check.
+	if p.TenantID == "" {
+		p.TenantID = types.GetTenantID(ctx)
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -66,13 +74,9 @@ func (m *InMemoryPaymentStore) Create(ctx context.Context, p *payment.Payment) e
 	// test of the idempotent-create path would pass vacuously — the duplicate
 	// insert would silently succeed instead of surfacing ErrAlreadyExists.
 	if p.IdempotencyKey != "" {
-		tenantID := p.TenantID
-		if tenantID == "" {
-			tenantID = types.GetTenantID(ctx)
-		}
 		for _, existing := range m.createdInOrder {
 			if existing.IdempotencyKey == p.IdempotencyKey &&
-				existing.TenantID == tenantID &&
+				existing.TenantID == p.TenantID &&
 				existing.EnvironmentID == p.EnvironmentID {
 				return ierr.WithError(payment.ErrIdempotencyKeyConflict).
 					WithHint("A payment with this idempotency key already exists").

--- a/internal/testutil/inmemory_payment_store.go
+++ b/internal/testutil/inmemory_payment_store.go
@@ -74,7 +74,7 @@ func (m *InMemoryPaymentStore) Create(ctx context.Context, p *payment.Payment) e
 			if existing.IdempotencyKey == p.IdempotencyKey &&
 				existing.TenantID == tenantID &&
 				existing.EnvironmentID == p.EnvironmentID {
-				return ierr.NewError("payment with this idempotency key already exists").
+				return ierr.WithError(payment.ErrIdempotencyKeyConflict).
 					WithHint("A payment with this idempotency key already exists").
 					WithReportableDetails(map[string]interface{}{
 						"idempotency_key": p.IdempotencyKey,

--- a/internal/testutil/inmemory_payment_store.go
+++ b/internal/testutil/inmemory_payment_store.go
@@ -61,6 +61,29 @@ func (m *InMemoryPaymentStore) Create(ctx context.Context, p *payment.Payment) e
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Mirror the (tenant_id, environment_id, idempotency_key) unique index from
+	// ent/schema/payment.go. Without this, the store keys only on p.ID and any
+	// test of the idempotent-create path would pass vacuously — the duplicate
+	// insert would silently succeed instead of surfacing ErrAlreadyExists.
+	if p.IdempotencyKey != "" {
+		tenantID := p.TenantID
+		if tenantID == "" {
+			tenantID = types.GetTenantID(ctx)
+		}
+		for _, existing := range m.createdInOrder {
+			if existing.IdempotencyKey == p.IdempotencyKey &&
+				existing.TenantID == tenantID &&
+				existing.EnvironmentID == p.EnvironmentID {
+				return ierr.NewError("payment with this idempotency key already exists").
+					WithHint("A payment with this idempotency key already exists").
+					WithReportableDetails(map[string]interface{}{
+						"idempotency_key": p.IdempotencyKey,
+					}).
+					Mark(ierr.ErrAlreadyExists)
+			}
+		}
+	}
+
 	err := m.InMemoryStore.Create(ctx, p.ID, p)
 	if err != nil {
 		return err


### PR DESCRIPTION
## **User description**
## Summary

Closes the payment idempotency finding from the VAPT report. Originally flagged as "reliability debt with no practical exploit" — that framing understated the impact.

**One file, +28/-3:** `internal/ee/service/payment.go`

## The bug

`CreatePayment` auto-generated its idempotency key using `time.Now().UTC().Format(time.RFC3339)` (second precision) when the caller didn't supply one:

```go
p.IdempotencyKey = s.idempGen.GenerateKey(idempotency.ScopePayment, map[string]interface{}{
    "invoice_id": p.DestinationID,
    "amount":     p.Amount,
    "currency":   p.Currency,
    // TODO: think of a better way to generate this key rather than using the current timestamp
    "timestamp": time.Now().UTC().Format(time.RFC3339),
})
```

The code itself carried a `TODO`. Every call produced a fresh key, so the `UNIQUE` constraint on `payment.idempotency_key` (`ent/schema/payment.go:35-40`) never fired for auto-generated keys, and there was no `GetByIdempotencyKey` pre-check before `Create`.

## Real impact (worse than "self-inflicted")

`CreatePayment` accepts `process_payment: true` (`payment.go:181-192`). When set, the payment row is created *and* charged against the gateway in the same call.

Scenario — no attacker required, plain network flakiness:
1. Tenant's client does `POST /v1/payments {invoice_id, amount, process_payment: true}`.
2. Server takes 800ms to respond, client times out at 700ms and retries.
3. Two payment rows get created (different auto-keys because ≥1s apart). Both trigger real gateway charges.
4. **The customer's card is debited twice.** Not the tenant's card — the tenant's customer's card. Chargeback territory + trust hit.

## Fix

1. **Remove the timestamp** from the auto-generated key. It's now deterministic on `{invoice_id, amount, currency}`, matching the pattern already used by `CreatePaymentForCheckout` at line 766 and `razorpay/invoice.go:131`.
2. **Add a `GetByIdempotencyKey` lookup before `Create`.** If a payment with the same key exists, return it as the response — true idempotent behavior, matching `razorpay/invoice.go:133` and `tax.go:1108`.

## Caller contract preserved

The `if p.IdempotencyKey == ""` guard is unchanged. Clients that want distinct payments for the same `{invoice_id, amount, currency}` (installments, partial re-attempts) can still do so by supplying their own `IdempotencyKey` in the request.

## Behavior change to be aware of

Any legacy caller that today issues two `CreatePayment` calls for the same `{invoice_id, amount, currency}` more than 1 second apart *expecting* both to succeed will now get the first payment back on the second call. This is a bug fix, not a regression — the previous behavior (silent duplicate charge) was the vulnerability.

## Test plan

- [x] `go build ./internal/...` clean
- [x] `go vet ./internal/...` clean
- [x] `make lint-ci` clean
- [x] Existing `TestPaymentService` suite passes unchanged
- [ ] Manual: `POST /v1/payments {invoice_id, amount, process_payment: false}` twice in a row without `IdempotencyKey` → expect same payment ID returned on second call, no duplicate row
- [ ] Manual: same two calls with distinct `IdempotencyKey` values → expect two distinct payment IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment creation reliability by preventing duplicate payments when requests are retried.
  * Repeated payment requests now consistently reuse the original payment when matching payment details.
  * Concurrent duplicate requests return the existing payment instead of creating another.
  * Payment idempotency is correctly scoped to the applicable account and environment.
  * Payment conflicts and lookup failures now provide clearer error handling and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent duplicate payment creation and charges when payment requests are retried

### What Changed
- Identical payment requests now reuse the existing payment instead of creating another payment or triggering a duplicate charge
- Automatic idempotency keys now distinguish payment method, payment method ID, and gateway, while remaining stable across retries
- Idempotency is isolated by tenant and environment, so separate tenants can reuse the same caller-supplied key
- Callers can still create separate payments by providing distinct idempotency keys
- Concurrent duplicate requests return the same payment, with coverage for retries, custom keys, and concurrent requests

### Impact
`✅ Fewer duplicate customer charges`
`✅ Safe retries after payment timeouts`
`✅ Isolated payment intents across tenants`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
