### PR TITLE
feat(integration): allow configuring custom Stripe API base URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -498,6 +498,7 @@ Environment variables override config.yaml. Example:
 
 - `FLEXPRICE_POSTGRES_HOST` overrides `postgres.host`
 - `FLEXPRICE_KAFKA_BROKERS` overrides `kafka.brokers`
+- `FLEXPRICE_STRIPE_ALLOWED_BASE_URLS`: Optional comma-separated operator allowlist of exact origins (`scheme://hostname[:port]`, e.g. `http://stripe-mock:12111,https://stripe-proxy.internal:8443`) for custom Stripe base URLs. Required only when connections configure a custom `base_url` (private/internal origins are supported when explicitly listed). Standard Stripe integration (`https://api.stripe.com`) requires no allowlist configuration.
 
 **ClickHouse per-query memory limit:** Every ClickHouse query is bounded by a hardcoded limit of 90 GB (`max_memory_usage`).
 

--- a/internal/api/dto/connection.go
+++ b/internal/api/dto/connection.go
@@ -70,6 +70,9 @@ func ConvertFlatMetadataToStructured(flatMetadata map[string]interface{}, provid
 		if aid, ok := flatMetadata["account_id"].(string); ok {
 			stripeMetadata.AccountID = aid
 		}
+		if bu, ok := flatMetadata["base_url"].(string); ok {
+			stripeMetadata.BaseURL = bu
+		}
 
 		return types.ConnectionMetadata{
 			Stripe: stripeMetadata,

--- a/internal/domain/connection/model.go
+++ b/internal/domain/connection/model.go
@@ -24,6 +24,7 @@ type StripeConnection struct {
 	SecretKey      string `json:"secret_key"`
 	WebhookSecret  string `json:"webhook_secret"`
 	AccountID      string `json:"account_id,omitempty"`
+	BaseURL        string `json:"base_url,omitempty"`
 }
 
 // GetStripeConfig extracts Stripe configuration from connection metadata
@@ -45,6 +46,7 @@ func (c *Connection) GetStripeConfig() (*StripeConnection, error) {
 		SecretKey:      c.EncryptedSecretData.Stripe.SecretKey,
 		WebhookSecret:  c.EncryptedSecretData.Stripe.WebhookSecret,
 		AccountID:      c.EncryptedSecretData.Stripe.AccountID,
+		BaseURL:        c.EncryptedSecretData.Stripe.BaseURL,
 	}
 
 	return config, nil
@@ -80,6 +82,9 @@ func convertMapToConnectionMetadata(metadata map[string]interface{}, providerTyp
 		}
 		if aid, ok := metadata["account_id"].(string); ok {
 			stripeMetadata.AccountID = aid
+		}
+		if bu, ok := metadata["base_url"].(string); ok {
+			stripeMetadata.BaseURL = bu
 		}
 		return types.ConnectionMetadata{
 			Stripe: stripeMetadata,

--- a/internal/integration/stripe/client.go
+++ b/internal/integration/stripe/client.go
@@ -193,8 +193,7 @@ func (c *Client) GetDecryptedStripeConfig(conn *connection.Connection) (*StripeC
 	if webhookSecret, exists := decryptedMetadata["webhook_secret"]; exists {
 		stripeConfig.WebhookSecret = webhookSecret
 		c.logger.Info(context.Background(), "webhook secret found in decrypted metadata",
-			"has_webhook_secret", webhookSecret != "",
-			"webhook_secret_length", len(webhookSecret))
+			"has_webhook_secret", webhookSecret != "")
 	} else {
 		c.logger.Info(context.Background(), "webhook_secret not found in decrypted metadata",
 			"available_keys", lo.Keys(decryptedMetadata))

--- a/internal/integration/stripe/client.go
+++ b/internal/integration/stripe/client.go
@@ -70,8 +70,8 @@ func normalizeStripeOrigin(raw string) (string, error) {
 		return "", fmt.Errorf("userinfo/credentials are forbidden in origin")
 	}
 
-	if parsedURL.Host == "" {
-		return "", fmt.Errorf("host is required")
+	if parsedURL.Hostname() == "" {
+		return "", fmt.Errorf("hostname is required")
 	}
 
 	if parsedURL.RawQuery != "" {

--- a/internal/integration/stripe/client.go
+++ b/internal/integration/stripe/client.go
@@ -47,6 +47,50 @@ type StripeConfig struct {
 	BaseURL        string
 }
 
+// normalizeStripeOrigin parses, validates, and normalizes a raw URL string into an origin (scheme://hostname[:port]).
+// It enforces that the URL is an absolute origin: scheme must be http or https, host must be non-empty,
+// and userinfo/credentials, query parameters, fragments, and non-root paths (other than optional trailing slash) are rejected.
+func normalizeStripeOrigin(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("URL is empty")
+	}
+
+	parsedURL, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL syntax: %w", err)
+	}
+
+	scheme := strings.ToLower(parsedURL.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("scheme must be http or https")
+	}
+
+	if parsedURL.User != nil {
+		return "", fmt.Errorf("userinfo/credentials are forbidden in origin")
+	}
+
+	if parsedURL.Host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+
+	if parsedURL.RawQuery != "" {
+		return "", fmt.Errorf("query string is forbidden in origin")
+	}
+
+	if parsedURL.Fragment != "" {
+		return "", fmt.Errorf("fragment is forbidden in origin")
+	}
+
+	// Reject paths other than empty or "/"
+	if parsedURL.Path != "" && parsedURL.Path != "/" {
+		return "", fmt.Errorf("non-root path is forbidden in origin")
+	}
+
+	host := strings.ToLower(parsedURL.Host)
+	return scheme + "://" + host, nil
+}
+
 // GetStripeClient returns a configured Stripe client for the current environment
 func (c *Client) GetStripeClient(ctx context.Context) (*stripe.Client, *StripeConfig, error) {
 	// Get Stripe connection for this environment
@@ -70,15 +114,12 @@ func (c *Client) GetStripeClient(ctx context.Context) (*stripe.Client, *StripeCo
 	httpClient := httpclient.NewOtelHTTPClient(80 * time.Second)
 
 	if stripeConfig.BaseURL != "" {
-		parsedURL, err := url.Parse(stripeConfig.BaseURL)
-		if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" {
-			return nil, nil, ierr.NewError("invalid Stripe base URL").
-				WithHint("connection base_url must be a valid http or https URL with a host").
+		targetOrigin, err := normalizeStripeOrigin(stripeConfig.BaseURL)
+		if err != nil {
+			return nil, nil, ierr.NewError(fmt.Sprintf("invalid Stripe base URL origin: %v", err)).
+				WithHint("connection base_url must be a valid origin (scheme://hostname[:port])").
 				Mark(ierr.ErrValidation)
 		}
-
-		// Normalize origin (scheme://host[:port])
-		targetOrigin := strings.ToLower(parsedURL.Scheme + "://" + parsedURL.Host)
 
 		allowedOriginsEnv := os.Getenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS")
 		if allowedOriginsEnv == "" {
@@ -90,15 +131,10 @@ func (c *Client) GetStripeClient(ctx context.Context) (*stripe.Client, *StripeCo
 		allowedList := strings.Split(allowedOriginsEnv, ",")
 		isAllowed := false
 		for _, raw := range allowedList {
-			raw = strings.TrimSpace(raw)
-			if raw == "" {
+			allowedOrigin, err := normalizeStripeOrigin(raw)
+			if err != nil {
 				continue
 			}
-			allowedParsed, err := url.Parse(raw)
-			if err != nil || allowedParsed.Scheme == "" || allowedParsed.Host == "" {
-				continue
-			}
-			allowedOrigin := strings.ToLower(allowedParsed.Scheme + "://" + allowedParsed.Host)
 			if targetOrigin == allowedOrigin {
 				isAllowed = true
 				break

--- a/internal/integration/stripe/client.go
+++ b/internal/integration/stripe/client.go
@@ -3,6 +3,10 @@ package stripe
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/connection"
@@ -40,6 +44,7 @@ type StripeConfig struct {
 	SecretKey      string
 	PublishableKey string
 	WebhookSecret  string
+	BaseURL        string
 }
 
 // GetStripeClient returns a configured Stripe client for the current environment
@@ -62,7 +67,69 @@ func (c *Client) GetStripeClient(ctx context.Context) (*stripe.Client, *StripeCo
 	// Initialize Stripe client with an OTel-instrumented HTTP backend so that
 	// outbound Stripe API calls surface in SigNoz External API Monitoring.
 	// 80s mirrors the Stripe SDK's default HTTP timeout.
-	backends := stripe.NewBackends(httpclient.NewOtelHTTPClient(80 * time.Second))
+	httpClient := httpclient.NewOtelHTTPClient(80 * time.Second)
+
+	if stripeConfig.BaseURL != "" {
+		parsedURL, err := url.Parse(stripeConfig.BaseURL)
+		if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" {
+			return nil, nil, ierr.NewError("invalid Stripe base URL").
+				WithHint("connection base_url must be a valid http or https URL with a host").
+				Mark(ierr.ErrValidation)
+		}
+
+		// Normalize origin (scheme://host[:port])
+		targetOrigin := strings.ToLower(parsedURL.Scheme + "://" + parsedURL.Host)
+
+		allowedOriginsEnv := os.Getenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS")
+		if allowedOriginsEnv == "" {
+			return nil, nil, ierr.NewError("custom Stripe base URL is not enabled").
+				WithHint("operator must set FLEXPRICE_STRIPE_ALLOWED_BASE_URLS env var to allow custom Stripe endpoints").
+				Mark(ierr.ErrValidation)
+		}
+
+		allowedList := strings.Split(allowedOriginsEnv, ",")
+		isAllowed := false
+		for _, raw := range allowedList {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			allowedParsed, err := url.Parse(raw)
+			if err != nil || allowedParsed.Scheme == "" || allowedParsed.Host == "" {
+				continue
+			}
+			allowedOrigin := strings.ToLower(allowedParsed.Scheme + "://" + allowedParsed.Host)
+			if targetOrigin == allowedOrigin {
+				isAllowed = true
+				break
+			}
+		}
+
+		if !isAllowed {
+			return nil, nil, ierr.NewError("custom Stripe base URL origin is not in the operator allowlist").
+				WithHint("connection base_url origin must be explicitly listed in FLEXPRICE_STRIPE_ALLOWED_BASE_URLS").
+				Mark(ierr.ErrValidation)
+		}
+
+		// Prevent redirects on custom backends to block open-redirect SSRF
+		httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		backends := stripe.NewBackends(httpClient)
+		backends.API = stripe.GetBackendWithConfig(
+			stripe.APIBackend,
+			&stripe.BackendConfig{
+				URL:        stripe.String(stripeConfig.BaseURL),
+				HTTPClient: httpClient,
+			},
+		)
+		c.logger.Info(ctx, "configured custom Stripe API base URL", "has_custom_base_url", true)
+		stripeClient := stripe.NewClient(stripeConfig.SecretKey, stripe.WithBackends(backends))
+		return stripeClient, stripeConfig, nil
+	}
+
+	backends := stripe.NewBackends(httpClient)
 	stripeClient := stripe.NewClient(stripeConfig.SecretKey, stripe.WithBackends(backends))
 
 	return stripeClient, stripeConfig, nil
@@ -97,10 +164,15 @@ func (c *Client) GetDecryptedStripeConfig(conn *connection.Connection) (*StripeC
 			"available_keys", lo.Keys(decryptedMetadata))
 	}
 
+	if baseURL, exists := decryptedMetadata["base_url"]; exists {
+		stripeConfig.BaseURL = baseURL
+	}
+
 	c.logger.Info(context.Background(), "final stripe config",
 		"has_secret_key", stripeConfig.SecretKey != "",
 		"has_publishable_key", stripeConfig.PublishableKey != "",
-		"has_webhook_secret", stripeConfig.WebhookSecret != "")
+		"has_webhook_secret", stripeConfig.WebhookSecret != "",
+		"has_custom_base_url", stripeConfig.BaseURL != "")
 
 	return stripeConfig, nil
 }
@@ -149,6 +221,7 @@ func (c *Client) decryptConnectionMetadata(conn *connection.Connection) (types.M
 			"publishable_key": publishableKey,
 			"webhook_secret":  webhookSecret,
 			"account_id":      conn.EncryptedSecretData.Stripe.AccountID,
+			"base_url":        conn.EncryptedSecretData.Stripe.BaseURL,
 		}
 
 		c.logger.Info(context.Background(), "successfully decrypted connection metadata",

--- a/internal/integration/stripe/client_test.go
+++ b/internal/integration/stripe/client_test.go
@@ -209,7 +209,9 @@ func TestGetStripeClient_RedirectToAnotherOriginRejected(t *testing.T) {
 	}))
 	defer secondServer.Close()
 
+	firstServerCalled := false
 	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		firstServerCalled = true
 		http.Redirect(w, r, secondServer.URL+"/v1/customers/cus_123", http.StatusFound)
 	}))
 	defer firstServer.Close()
@@ -223,8 +225,9 @@ func TestGetStripeClient_RedirectToAnotherOriginRejected(t *testing.T) {
 	stripeSDKClient, _, err := client.GetStripeClient(context.Background())
 	require.NoError(t, err)
 
-	// Retrieve will succeed with 302 response body from firstServer without following redirect to secondServer
-	cust, _ := stripeSDKClient.V1Customers.Retrieve(context.Background(), "cus_123", nil)
+	cust, err := stripeSDKClient.V1Customers.Retrieve(context.Background(), "cus_123", nil)
+	require.Error(t, err, "Stripe SDK must return an error for 302 response without following redirect")
+	assert.True(t, firstServerCalled, "request must reach the configured first server backend")
 	assert.False(t, secondServerCalled, "request must not reach redirected target origin")
 	if cust != nil {
 		assert.NotEqual(t, "cus_123", cust.ID)
@@ -350,4 +353,18 @@ func TestConvertFlatMetadataToStructured_StripeBaseURL(t *testing.T) {
 	require.NotNil(t, res.Stripe)
 	assert.Equal(t, "http://localhost:12111", res.Stripe.BaseURL)
 	assert.Equal(t, "sk_test_123", res.Stripe.SecretKey)
+
+	// Verify StripeConnectionMetadata.Validate() validates BaseURL
+	err := res.Stripe.Validate()
+	require.NoError(t, err)
+
+	invalidMetadata := &types.StripeConnectionMetadata{
+		PublishableKey: "pk_test_123",
+		SecretKey:      "sk_test_123",
+		WebhookSecret:  "whsec_123",
+		BaseURL:        "https://user:pass@payments.example.com",
+	}
+	err = invalidMetadata.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid base_url")
 }

--- a/internal/integration/stripe/client_test.go
+++ b/internal/integration/stripe/client_test.go
@@ -282,7 +282,59 @@ func TestGetStripeClient_NonHTTPScheme(t *testing.T) {
 	_, _, err := client.GetStripeClient(context.Background())
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid Stripe base URL")
+	assert.Contains(t, err.Error(), "invalid Stripe base URL origin")
+}
+
+func TestGetStripeClient_CredentialsUserinfoRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://payments.example.com")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://user:pass@payments.example.com"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials are forbidden")
+}
+
+func TestGetStripeClient_QueryStringRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://payments.example.com")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://payments.example.com?token=x"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query string is forbidden")
+}
+
+func TestGetStripeClient_FragmentRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://payments.example.com")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://payments.example.com#fragment"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fragment is forbidden")
+}
+
+func TestGetStripeClient_NonRootPathRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://payments.example.com")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://payments.example.com/foo"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-root path is forbidden")
 }
 
 func TestConvertFlatMetadataToStructured_StripeBaseURL(t *testing.T) {

--- a/internal/integration/stripe/client_test.go
+++ b/internal/integration/stripe/client_test.go
@@ -1,0 +1,301 @@
+package stripe_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/connection"
+	"github.com/flexprice/flexprice/internal/integration/stripe"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockConnectionRepo struct {
+	mock.Mock
+}
+
+func (m *mockConnectionRepo) Create(ctx context.Context, c *connection.Connection) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *mockConnectionRepo) Get(ctx context.Context, id string) (*connection.Connection, error) {
+	args := m.Called(ctx, id)
+	if conn, ok := args.Get(0).(*connection.Connection); ok {
+		return conn, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockConnectionRepo) GetByProvider(ctx context.Context, provider types.SecretProvider) (*connection.Connection, error) {
+	args := m.Called(ctx, provider)
+	if conn, ok := args.Get(0).(*connection.Connection); ok {
+		return conn, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockConnectionRepo) ListPublishedByProvider(ctx context.Context, provider types.SecretProvider) ([]*connection.Connection, error) {
+	args := m.Called(ctx, provider)
+	if conns, ok := args.Get(0).([]*connection.Connection); ok {
+		return conns, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockConnectionRepo) List(ctx context.Context, filter *types.ConnectionFilter) ([]*connection.Connection, error) {
+	args := m.Called(ctx, filter)
+	if conns, ok := args.Get(0).([]*connection.Connection); ok {
+		return conns, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockConnectionRepo) Count(ctx context.Context, filter *types.ConnectionFilter) (int, error) {
+	args := m.Called(ctx, filter)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *mockConnectionRepo) Update(ctx context.Context, c *connection.Connection) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+func (m *mockConnectionRepo) Delete(ctx context.Context, c *connection.Connection) error {
+	args := m.Called(ctx, c)
+	return args.Error(0)
+}
+
+type mockEncryptionService struct{}
+
+func (m *mockEncryptionService) Encrypt(text string) (string, error) { return text, nil }
+func (m *mockEncryptionService) Decrypt(text string) (string, error) { return text, nil }
+func (m *mockEncryptionService) Hash(value string) string            { return value }
+
+func setupTestStripeClient(repo connection.Repository) *stripe.Client {
+	log := logger.NewNoopLogger()
+	return stripe.NewClient(repo, &mockEncryptionService{}, log)
+}
+
+func createDummyConnection(baseURL string) *connection.Connection {
+	return &connection.Connection{
+		ID:           "conn_123",
+		ProviderType: types.SecretProviderStripe,
+		EncryptedSecretData: types.ConnectionMetadata{
+			Stripe: &types.StripeConnectionMetadata{
+				SecretKey:      "sk_test_123",
+				PublishableKey: "pk_test_123",
+				WebhookSecret:  "whsec_123",
+				BaseURL:        baseURL,
+			},
+		},
+		EnvironmentID: "env_test",
+		BaseModel: types.BaseModel{
+			TenantID:  "tenant_test",
+			Status:    types.StatusPublished,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+}
+
+func TestGetStripeClient_DefaultURL(t *testing.T) {
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection(""), nil)
+
+	client := setupTestStripeClient(repo)
+	stripeSDKClient, config, err := client.GetStripeClient(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, stripeSDKClient)
+	assert.Equal(t, "sk_test_123", config.SecretKey)
+	assert.Empty(t, config.BaseURL)
+}
+
+func TestGetStripeClient_CustomURLNoAllowlistConfigured(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://stripe-proxy.internal"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "custom Stripe base URL is not enabled")
+}
+
+func TestGetStripeClient_AllowedHTTPSSEndpoint(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://stripe-proxy.internal:8443")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://stripe-proxy.internal:8443"), nil)
+
+	client := setupTestStripeClient(repo)
+	stripeSDKClient, config, err := client.GetStripeClient(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, stripeSDKClient)
+	assert.Equal(t, "https://stripe-proxy.internal:8443", config.BaseURL)
+}
+
+func TestGetStripeClient_AllowedLocalhostPrivateHTTPEndpoint(t *testing.T) {
+	var requestedPath string
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"cus_123","object":"customer"}`))
+	}))
+	defer mockServer.Close()
+
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", mockServer.URL)
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection(mockServer.URL), nil)
+
+	client := setupTestStripeClient(repo)
+	stripeSDKClient, config, err := client.GetStripeClient(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, stripeSDKClient)
+	assert.Equal(t, mockServer.URL, config.BaseURL)
+
+	cust, err := stripeSDKClient.V1Customers.Retrieve(context.Background(), "cus_123", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cus_123", cust.ID)
+	assert.Equal(t, "/v1/customers/cus_123", requestedPath)
+}
+
+func TestGetStripeClient_NonAllowlistedEndpointRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://stripe-proxy.internal")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://unauthorized-proxy.com"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in the operator allowlist")
+}
+
+func TestGetStripeClient_LookalikeHostnameRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "https://stripe-proxy.internal")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("https://stripe-proxy.internal.evil.com"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in the operator allowlist")
+}
+
+func TestGetStripeClient_RedirectToAnotherOriginRejected(t *testing.T) {
+	secondServerCalled := false
+	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondServerCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"cus_123","object":"customer"}`))
+	}))
+	defer secondServer.Close()
+
+	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, secondServer.URL+"/v1/customers/cus_123", http.StatusFound)
+	}))
+	defer firstServer.Close()
+
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", firstServer.URL)
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection(firstServer.URL), nil)
+
+	client := setupTestStripeClient(repo)
+	stripeSDKClient, _, err := client.GetStripeClient(context.Background())
+	require.NoError(t, err)
+
+	// Retrieve will succeed with 302 response body from firstServer without following redirect to secondServer
+	cust, _ := stripeSDKClient.V1Customers.Retrieve(context.Background(), "cus_123", nil)
+	assert.False(t, secondServerCalled, "request must not reach redirected target origin")
+	if cust != nil {
+		assert.NotEqual(t, "cus_123", cust.ID)
+	}
+}
+
+func TestGetStripeClient_CustomURLWithTrailingSlash(t *testing.T) {
+	var requestedPath string
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"cus_456","object":"customer"}`))
+	}))
+	defer mockServer.Close()
+
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", mockServer.URL)
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection(mockServer.URL+"/"), nil)
+
+	client := setupTestStripeClient(repo)
+	stripeSDKClient, config, err := client.GetStripeClient(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, stripeSDKClient)
+	assert.Equal(t, mockServer.URL+"/", config.BaseURL)
+
+	cust, err := stripeSDKClient.V1Customers.Retrieve(context.Background(), "cus_456", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cus_456", cust.ID)
+	assert.Equal(t, "/v1/customers/cus_456", requestedPath)
+}
+
+func TestGetStripeClient_InvalidURL(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "http://localhost")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("not-a-valid-url"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Stripe base URL")
+}
+
+func TestGetStripeClient_NonHTTPScheme(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "ftp://localhost:8080")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("ftp://localhost:8080"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Stripe base URL")
+}
+
+func TestConvertFlatMetadataToStructured_StripeBaseURL(t *testing.T) {
+	flatData := map[string]interface{}{
+		"publishable_key": "pk_test_123",
+		"secret_key":      "sk_test_123",
+		"webhook_secret":  "whsec_123",
+		"account_id":      "acct_123",
+		"base_url":        "http://localhost:12111",
+	}
+
+	res := dto.ConvertFlatMetadataToStructured(flatData, types.SecretProviderStripe)
+	require.NotNil(t, res.Stripe)
+	assert.Equal(t, "http://localhost:12111", res.Stripe.BaseURL)
+	assert.Equal(t, "sk_test_123", res.Stripe.SecretKey)
+}

--- a/internal/integration/stripe/client_test.go
+++ b/internal/integration/stripe/client_test.go
@@ -340,6 +340,59 @@ func TestGetStripeClient_NonRootPathRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-root path is forbidden")
 }
 
+func TestGetStripeClient_PortOnlyHostRejected(t *testing.T) {
+	t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", "http://:8080")
+
+	repo := new(mockConnectionRepo)
+	repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection("http://:8080"), nil)
+
+	client := setupTestStripeClient(repo)
+	_, _, err := client.GetStripeClient(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hostname is required")
+}
+
+func TestGetStripeClient_ValidHostnamesIPv4IPv6Accepted(t *testing.T) {
+	testCases := []struct {
+		name      string
+		url       string
+		allowlist string
+	}{
+		{
+			name:      "domain with port",
+			url:       "http://example.com:8080",
+			allowlist: "http://example.com:8080",
+		},
+		{
+			name:      "ipv4 with port",
+			url:       "http://127.0.0.1:8080",
+			allowlist: "http://127.0.0.1:8080",
+		},
+		{
+			name:      "ipv6 literal with port",
+			url:       "http://[::1]:8080",
+			allowlist: "http://[::1]:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("FLEXPRICE_STRIPE_ALLOWED_BASE_URLS", tc.allowlist)
+
+			repo := new(mockConnectionRepo)
+			repo.On("GetByProvider", mock.Anything, types.SecretProviderStripe).Return(createDummyConnection(tc.url), nil)
+
+			client := setupTestStripeClient(repo)
+			stripeSDKClient, config, err := client.GetStripeClient(context.Background())
+
+			require.NoError(t, err)
+			assert.NotNil(t, stripeSDKClient)
+			assert.Equal(t, tc.url, config.BaseURL)
+		})
+	}
+}
+
 func TestConvertFlatMetadataToStructured_StripeBaseURL(t *testing.T) {
 	flatData := map[string]interface{}{
 		"publishable_key": "pk_test_123",

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -2,10 +2,53 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/samber/lo"
 )
+
+// validateStripeBaseURL validates that a raw URL is a valid origin (scheme://hostname[:port]).
+func validateStripeBaseURL(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("URL is empty")
+	}
+
+	parsedURL, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL syntax: %w", err)
+	}
+
+	scheme := strings.ToLower(parsedURL.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+
+	if parsedURL.User != nil {
+		return fmt.Errorf("userinfo/credentials are forbidden in origin")
+	}
+
+	if parsedURL.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+
+	if parsedURL.RawQuery != "" {
+		return fmt.Errorf("query string is forbidden in origin")
+	}
+
+	if parsedURL.Fragment != "" {
+		return fmt.Errorf("fragment is forbidden in origin")
+	}
+
+	if parsedURL.Path != "" && parsedURL.Path != "/" {
+		return fmt.Errorf("non-root path is forbidden in origin")
+	}
+
+	return nil
+}
 
 // ConnectionMetadataType represents the type of connection metadata
 type ConnectionMetadataType string
@@ -326,6 +369,13 @@ func (s *StripeConnectionMetadata) Validate() error {
 		return ierr.NewError("webhook_secret is required").
 			WithHint("Stripe webhook secret is required").
 			Mark(ierr.ErrValidation)
+	}
+	if s.BaseURL != "" {
+		if err := validateStripeBaseURL(s.BaseURL); err != nil {
+			return ierr.NewError("invalid base_url: " + err.Error()).
+				WithHint("connection base_url must be a valid origin (scheme://hostname[:port])").
+				Mark(ierr.ErrValidation)
+		}
 	}
 	return nil
 }

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -56,6 +56,7 @@ type StripeConnectionMetadata struct {
 	SecretKey      string `json:"secret_key"`
 	WebhookSecret  string `json:"webhook_secret"`
 	AccountID      string `json:"account_id,omitempty"`
+	BaseURL        string `json:"base_url,omitempty"`
 }
 
 // S3ConnectionMetadata represents S3-specific connection metadata (encrypted secrets only)

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -31,8 +31,8 @@ func validateStripeBaseURL(raw string) error {
 		return fmt.Errorf("userinfo/credentials are forbidden in origin")
 	}
 
-	if parsedURL.Host == "" {
-		return fmt.Errorf("host is required")
+	if parsedURL.Hostname() == "" {
+		return fmt.Errorf("hostname is required")
 	}
 
 	if parsedURL.RawQuery != "" {


### PR DESCRIPTION
### Summary

Adds optional support for configuring a custom Stripe API base URL per Stripe connection.

This allows Flexprice's existing Stripe integration to communicate with approved Stripe-compatible endpoints, development proxies, and mock servers while preserving the existing Stripe behavior by default.

### Changes

* Adds an optional `base_url` to Stripe connection configuration.
* Preserves `base_url` through connection DTO conversion, encryption/persistence, and decryption.
* Requires deployment-operator approval through `FLEXPRICE_STRIPE_ALLOWED_BASE_URLS` before a custom Stripe endpoint can be used.
* Treats custom endpoints as HTTP(S) origins and validates them consistently.
* Rejects custom origins containing:

  * unsupported schemes
  * missing hostnames
  * credentials/userinfo
  * query strings
  * fragments
  * non-root paths
* Uses exact normalized origin matching against the operator allowlist to prevent hostname-prefix/lookalike matches.
* Supports explicitly allowlisted localhost, private-network, and internal endpoints for self-hosted Docker/Kubernetes deployments.
* Disables automatic HTTP redirects for custom Stripe backends so an approved endpoint cannot redirect Stripe-authenticated requests to another origin.
* Preserves the existing OpenTelemetry HTTP client and timeout behavior.
* Keeps the standard Stripe API endpoint unchanged when `base_url` is not configured.
* Removes Stripe webhook-secret length information from logs.

### Security Model

Custom Stripe endpoints use a fail-closed, two-party configuration model:

1. A Stripe connection selects a custom `base_url`.
2. The deployment operator must independently allow that exact origin through `FLEXPRICE_STRIPE_ALLOWED_BASE_URLS`.
3. Flexprice sends Stripe-authenticated requests to the custom endpoint only when both conditions are satisfied.

If a custom `base_url` is configured but the operator allowlist is not configured, the connection is rejected.

Private and localhost endpoints are intentionally supported for self-hosted deployments, but they must be explicitly allowlisted by the deployment operator.

### Example Configuration

```env
FLEXPRICE_STRIPE_ALLOWED_BASE_URLS=https://stripe-proxy.example.com,http://stripe-mock:12111
```

Example Stripe connection metadata:

```json
{
  "publishable_key": "pk_test_...",
  "secret_key": "sk_test_...",
  "webhook_secret": "whsec_...",
  "base_url": "https://stripe-proxy.example.com"
}
```

Connections without `base_url` continue using Stripe's default API endpoint and do not require `FLEXPRICE_STRIPE_ALLOWED_BASE_URLS`.

### Testing

```bash
go test -v ./internal/integration/stripe/...
```

Test coverage includes:

* default Stripe backend behavior
* custom endpoint fail-closed behavior when no allowlist is configured
* allowlisted HTTPS endpoints
* explicitly allowlisted localhost/private endpoints
* rejection of non-allowlisted origins
* rejection of lookalike hostnames
* rejection of malformed origins
* credentials/userinfo rejection
* query-string and fragment rejection
* non-root path rejection
* port-only hostname rejection
* domain, IPv4, and IPv6 origins
* trailing-slash handling
* cross-origin redirect prevention
* Stripe metadata conversion and validation
* `base_url` persistence through connection metadata handling

All Stripe integration tests pass.
