### PR TITLE
fix(authz): remove X-Environment-ID fallback + guard environment list routes

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -112,6 +112,7 @@ func NewRouter(
 	// Initialize permission middleware
 	permissionMW := middleware.NewPermissionMiddleware(rbacService, logger)
 	write := permissionMW.RequirePermission // shorthand used on every write route
+	read := permissionMW.RequirePermission  // shorthand used on read-guarded routes
 
 	// Add middleware to set swagger host dynamically
 	router.Use(func(c *gin.Context) {
@@ -158,8 +159,8 @@ func NewRouter(
 		environment := v1Private.Group("/environments")
 		{
 			environment.POST("", write(types.EntityEnvironment, types.ActionWrite), handlers.Environment.CreateEnvironment)
-			environment.GET("", handlers.Environment.GetEnvironments)
-			environment.GET("/:id", handlers.Environment.GetEnvironment)
+			environment.GET("", read(types.EntityEnvironment, types.ActionRead), handlers.Environment.GetEnvironments)
+			environment.GET("/:id", read(types.EntityEnvironment, types.ActionRead), handlers.Environment.GetEnvironment)
 			environment.PUT("/:id", write(types.EntityEnvironment, types.ActionWrite), handlers.Environment.UpdateEnvironment)
 			environment.POST("/:id/clone", write(types.EntityEnvironment, types.ActionWrite), handlers.Environment.CloneEnvironment)
 		}

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -52,11 +52,6 @@ func setContextValues(c *gin.Context, tenantID, userID, environmentID, userType 
 		ctx = context.WithValue(ctx, types.CtxUserType, userType)
 	}
 
-	// Set additional headers for downstream handlers
-	if environmentID == "" {
-		environmentID = c.GetHeader(types.HeaderEnvironment)
-	}
-
 	if environmentID != "" {
 		ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 	}

--- a/internal/rest/middleware/auth_test.go
+++ b/internal/rest/middleware/auth_test.go
@@ -75,7 +75,7 @@ func TestAuthenticateMiddleware_EnvironmentIDFromJWT(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "env_prod")
 	})
 
-	t.Run("falls back to X-Environment-ID header when claim absent", func(t *testing.T) {
+	t.Run("X-Environment-ID header has no effect when claim absent", func(t *testing.T) {
 		token := makeJWT(t, "t_tenant1", "usr_dev", "", 1)
 
 		w := httptest.NewRecorder()
@@ -85,7 +85,8 @@ func TestAuthenticateMiddleware_EnvironmentIDFromJWT(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), "env_from_header")
+		assert.Contains(t, w.Body.String(), `"environment_id":""`)
+		assert.NotContains(t, w.Body.String(), "env_from_header")
 	})
 
 	t.Run("JWT claim takes priority over header", func(t *testing.T) {

--- a/internal/rest/middleware/permission_test.go
+++ b/internal/rest/middleware/permission_test.go
@@ -89,3 +89,38 @@ func TestRequirePermission_AllowsServiceAccountWithRole(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "service account with the right role must be allowed through")
 }
+
+// TestRequirePermission_DeniesServiceAccountEnvironmentRead reproduces the
+// live-verified staging PoC: a service-account key scoped to
+// event_ingestor/event_reader (neither of which grants environment:read)
+// successfully called GET /v1/environments and got all 50 tenant environment
+// UUIDs. That must now be 403.
+func TestRequirePermission_DeniesServiceAccountEnvironmentRead(t *testing.T) {
+	rbacSvc := realRBACService(t)
+	router := newPermissionTestRouter(t, rbacSvc, string(types.UserTypeServiceAccount),
+		[]string{"event_ingestor", "event_reader"}, types.EntityEnvironment, types.ActionRead)
+
+	req := httptest.NewRequest(http.MethodPost, "/customers", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "service account without environment:read role must be denied")
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "insufficient permissions", body["message"])
+}
+
+// TestRequirePermission_AllowsSuperAdminEnvironmentRead confirms super_admin's
+// wildcard role is unaffected by the new environment:read guard.
+func TestRequirePermission_AllowsSuperAdminEnvironmentRead(t *testing.T) {
+	rbacSvc := realRBACService(t)
+	router := newPermissionTestRouter(t, rbacSvc, string(types.UserTypeServiceAccount),
+		[]string{"super_admin"}, types.EntityEnvironment, types.ActionRead)
+
+	req := httptest.NewRequest(http.MethodPost, "/customers", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "super_admin must retain access to environment reads")
+}


### PR DESCRIPTION
## Summary
Fixes two authorization findings identified during internal security testing:

- **Environment ID header not validated**: `internal/rest/middleware/auth.go` accepted a caller-supplied `X-Environment-ID` header verbatim whenever a credential (JWT user, config-map API key) had no bound environment ID. Confirmed no legitimate SDK/frontend caller relies on this header — removed outright.
- **Missing permission check on environment listing**: `GET /v1/environments` and `GET /v1/environments/:id` had no RBAC permission check, unlike every write route on the same resource. Now gated behind `environment:read`, same pattern as the existing `write` checks.

**Scope note**: the second fix closes the exploit path for DB-backed service-account keys. JWT users and config-map API keys bypass RBAC entirely by design in this codebase (`permission.go:41-42`) — that is a separate, already-tracked issue and is not addressed by this PR.

Related ClickHouse SQL injection findings were fixed separately in #2253 (already merged to `develop`; this branch is rebased on top of it).

## Out of scope (follow-ups to file)
- Full audit of every unguarded GET route in `router.go` (broader than these two findings).
- `UserEnvMapping` fail-open default (dead config today, not itself exploitable once the header fallback above is gone).
- JWT/config-key RBAC bypass (empty roles) — separate known issue, still open.
- A handful of dev-only docs still instruct engineers to pass `X-Environment-ID` alongside a JWT/config key — now silently inert, should be corrected.
- The router-level wiring itself (the two `read(...)` guard placements) has no end-to-end regression test — the new tests exercise `RequirePermission` in isolation via the existing test helper, consistent with prior convention in this file.

## Test plan
- [x] `internal/rest/middleware/auth_test.go` — subtest confirms `X-Environment-ID` header has no effect when the JWT claim is absent.
- [x] `internal/rest/middleware/permission_test.go` — new tests confirm a minimal service-account role is denied and `super_admin` is allowed on `environment:read`.
- [x] `go test ./internal/... -race` green (56 packages, 0 failures).
- [x] `go build`, `go vet`, `gofmt`, `make lint-ci` all clean.