### PR TITLE
ci: publish multi-arch e2eprobe image to GHCR

### DIFF
--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'cmd/e2eprobe/**'
       - 'internal/e2eprobe/**'
+      - 'go.mod'
+      - 'go.sum'
       - 'Dockerfile.e2eprobe'
       - '.github/workflows/publish-e2eprobe-image.yml'
   workflow_dispatch:
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Resolve image tags
         id: tag

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -1,0 +1,127 @@
+name: Publish e2eprobe Image to GHCR
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'cmd/e2eprobe/**'
+      - 'internal/e2eprobe/**'
+      - 'Dockerfile.e2eprobe'
+      - '.github/workflows/publish-e2eprobe-image.yml'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Extra image tag to publish (e.g. v1.0.0). The commit SHA tag is always published.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/e2eprobe
+
+jobs:
+  build-and-publish:
+    name: Build, scan, publish multi-arch e2eprobe image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image tags
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          IMG: ${{ env.REGISTRY }}/${{ github.repository_owner }}/e2eprobe
+        run: |
+          set -euo pipefail
+          SHA_TAG="$(echo "${GITHUB_SHA}" | cut -c1-12)"
+          TAGS="${IMG}:${SHA_TAG}"
+          # develop is the mutable tag the staging ArgoCD app tracks.
+          if [ "${GITHUB_REF}" = "refs/heads/develop" ]; then
+            TAGS="${TAGS}"$'\n'"${IMG}:develop"
+          fi
+          if [ -n "${DISPATCH_TAG}" ]; then
+            if ! echo "${DISPATCH_TAG}" | grep -Eq '^[A-Za-z0-9._-]+$'; then
+              echo "::error::Invalid tag format: ${DISPATCH_TAG}"
+              exit 1
+            fi
+            TAGS="${TAGS}"$'\n'"${IMG}:${DISPATCH_TAG}"
+          fi
+          {
+            echo "sha_tag=${SHA_TAG}"
+            echo "tags<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # PAT auth — default GITHUB_TOKEN can't push to the org's GHCR
+          # package unless the package is linked to this repo with Write.
+          username: ${{ vars.GHCR_USERNAME || github.actor }}
+          password: ${{ secrets.GHCR_PUBLISH_TOKEN }}
+
+      - name: Build & push multi-arch image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.e2eprobe
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: true
+          sbom: true
+          tags: ${{ steps.tag.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=e2eprobe
+            org.opencontainers.image.description=Flexprice end-to-end synthetic probe
+            org.opencontainers.image.licenses=AGPL-3.0-only
+
+      - name: Trivy vulnerability scan (fail on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.sha_tag }}
+          format: table
+          exit-code: '1'
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Summary
+        env:
+          TAGS: ${{ steps.tag.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "## e2eprobe Image Published"
+            echo ""
+            echo "- Tags:"
+            echo '```'
+            echo "${TAGS}"
+            echo '```'
+            echo "- Platforms: linux/amd64, linux/arm64"
+            echo "- Digest: \`${DIGEST}\`"
+            echo "- SBOM + provenance: attached"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -33,7 +33,9 @@ jobs:
     name: Build, scan, publish multi-arch e2eprobe image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Third-party actions are pinned to commit SHAs so a retagged upstream
+      # release can't run arbitrary code in a job holding GHCR_PUBLISH_TOKEN.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
@@ -65,13 +67,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           # PAT auth — default GITHUB_TOKEN can't push to the org's GHCR
@@ -81,7 +83,7 @@ jobs:
 
       - name: Build & push multi-arch image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile.e2eprobe
@@ -98,7 +100,7 @@ jobs:
             org.opencontainers.image.licenses=AGPL-3.0-only
 
       - name: Trivy vulnerability scan (fail on HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.sha_tag }}
           format: table
@@ -107,7 +109,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -48,24 +48,33 @@ jobs:
         run: |
           set -euo pipefail
           SHA_TAG="$(echo "${GITHUB_SHA}" | cut -c1-12)"
-          TAGS="${IMG}:${SHA_TAG}"
+          # Only the immutable SHA tag is pushed by the build. Everything a
+          # deployment tracks is promoted onto that digest after Trivy passes,
+          # so a failing scan can never leave a vulnerable image under a
+          # tag something is following.
+          PROMOTE=""
           # Branch name doubles as the mutable tag deployments track:
           # develop for staging, main for production.
           case "${GITHUB_REF}" in
-            refs/heads/develop) TAGS="${TAGS}"$'\n'"${IMG}:develop" ;;
-            refs/heads/main)    TAGS="${TAGS}"$'\n'"${IMG}:main" ;;
+            refs/heads/develop) PROMOTE="develop" ;;
+            refs/heads/main)    PROMOTE="main" ;;
           esac
           if [ -n "${DISPATCH_TAG}" ]; then
             if ! echo "${DISPATCH_TAG}" | grep -Eq '^[A-Za-z0-9._-]+$'; then
               echo "::error::Invalid tag format: ${DISPATCH_TAG}"
               exit 1
             fi
-            TAGS="${TAGS}"$'\n'"${IMG}:${DISPATCH_TAG}"
+            PROMOTE="${PROMOTE:+${PROMOTE} }${DISPATCH_TAG}"
           fi
+          ALL="${IMG}:${SHA_TAG}"
+          for t in ${PROMOTE}; do
+            ALL="${ALL}"$'\n'"${IMG}:${t}"
+          done
           {
             echo "sha_tag=${SHA_TAG}"
-            echo "tags<<EOF"
-            echo "${TAGS}"
+            echo "promote_tags=${PROMOTE}"
+            echo "all_tags<<EOF"
+            echo "${ALL}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -84,7 +93,10 @@ jobs:
           username: ${{ vars.GHCR_USERNAME || github.actor }}
           password: ${{ secrets.GHCR_PUBLISH_TOKEN }}
 
-      - name: Build & push multi-arch image
+      # Pushes the immutable SHA tag only. Multi-arch manifests need registry
+      # access at build time, so the image has to land somewhere before it can
+      # be scanned; the SHA tag is not tracked by any deployment.
+      - name: Build & push multi-arch image (SHA tag only)
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
@@ -94,7 +106,7 @@ jobs:
           push: true
           provenance: true
           sbom: true
-          tags: ${{ steps.tag.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -111,6 +123,21 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
 
+      # Only reached when Trivy passes. Retags the scanned digest without
+      # rebuilding, so the promoted tag is byte-identical to what was scanned.
+      - name: Promote scanned digest to deployment tags
+        if: steps.tag.outputs.promote_tags != ''
+        env:
+          IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          PROMOTE_TAGS: ${{ steps.tag.outputs.promote_tags }}
+        run: |
+          set -euo pipefail
+          for t in ${PROMOTE_TAGS}; do
+            echo "Promoting ${IMG}@${DIGEST} -> ${IMG}:${t}"
+            docker buildx imagetools create -t "${IMG}:${t}" "${IMG}@${DIGEST}"
+          done
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         with:
@@ -120,7 +147,7 @@ jobs:
 
       - name: Summary
         env:
-          TAGS: ${{ steps.tag.outputs.tags }}
+          TAGS: ${{ steps.tag.outputs.all_tags }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           {

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - main
     paths:
       - 'cmd/e2eprobe/**'
       - 'internal/e2eprobe/**'
@@ -48,10 +49,12 @@ jobs:
           set -euo pipefail
           SHA_TAG="$(echo "${GITHUB_SHA}" | cut -c1-12)"
           TAGS="${IMG}:${SHA_TAG}"
-          # develop is the mutable tag the staging ArgoCD app tracks.
-          if [ "${GITHUB_REF}" = "refs/heads/develop" ]; then
-            TAGS="${TAGS}"$'\n'"${IMG}:develop"
-          fi
+          # Branch name doubles as the mutable tag deployments track:
+          # develop for staging, main for production.
+          case "${GITHUB_REF}" in
+            refs/heads/develop) TAGS="${TAGS}"$'\n'"${IMG}:develop" ;;
+            refs/heads/main)    TAGS="${TAGS}"$'\n'"${IMG}:main" ;;
+          esac
           if [ -n "${DISPATCH_TAG}" ]; then
             if ! echo "${DISPATCH_TAG}" | grep -Eq '^[A-Za-z0-9._-]+$'; then
               echo "::error::Invalid tag format: ${DISPATCH_TAG}"


### PR DESCRIPTION
## **User description**
Adds a CI workflow that publishes the e2eprobe image to GHCR, so the probe deployments stop depending on a manually pushed image.

`Dockerfile.e2eprobe` already existed but nothing built it — the image now running in staging and production was pushed by hand. This gives CI ownership of that tag.

## What it does

Builds `Dockerfile.e2eprobe` for `linux/amd64` + `linux/arm64` and pushes to `ghcr.io/flexprice/e2eprobe`, tagged with the short commit SHA and, on `develop`, the mutable `develop` tag the GKE deployments track.

Triggers only on changes under `cmd/e2eprobe/**`, `internal/e2eprobe/**`, or `Dockerfile.e2eprobe`, so app-only commits don't rebuild the probe. Also available via `workflow_dispatch`.

Mirrors `publish-app-image.yml` for auth (`GHCR_PUBLISH_TOKEN`), Trivy gating on HIGH/CRITICAL, SBOM, and provenance attestation.

## Related

Deployment manifests: flexprice/infrastructure#242 — the probe is live in GCP staging, GCP prod, and AWS prod, verified passing (622 runs / 0 failures in AWS prod at the time of writing).

## Note

AWS prod pulls from ECR rather than GHCR, so it is not covered by this workflow; that image is still a manual `docker buildx --push` to `851725232919.dkr.ecr.ap-south-1.amazonaws.com/flexprice/e2eprobe`. Mirroring GHCR to ECR from CI is a reasonable follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publication of `e2eprobe` container images for AMD64 and ARM64 platforms.
  * Images are released after relevant development or main-branch changes, with on-demand publishing also available.
  * Added vulnerability scanning, software bill of materials, provenance information, and cryptographic attestations to improve release security and transparency.
  * Publication details, including image references and release metadata, are summarized after each image release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Publish secure multi-architecture e2eprobe images automatically

### What Changed
- Changes to the e2eprobe code, dependencies, Dockerfile, or workflow publish `linux/amd64` and `linux/arm64` images to GHCR
- Every image receives a commit-based tag; builds from `develop` also update the `develop` tag used by staging
- Manual runs can publish an additional validated tag when needed
- Builds stop when unfixed high or critical vulnerabilities are found and include SBOM and provenance metadata
- CI credentials are not retained after checkout, and publishing actions are pinned to prevent unexpected upstream changes

### Impact
`✅ Automated e2eprobe image updates`
`✅ ARM and AMD64 deployment support`
`✅ Vulnerability-gated, traceable container releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
