### PR TITLE
Revert "fix(authz): remove X-Environment-ID fallback + guard environment list routes"

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -112,7 +112,6 @@ func NewRouter(
 	// Initialize permission middleware
 	permissionMW := middleware.NewPermissionMiddleware(rbacService, logger)
 	write := permissionMW.RequirePermission // shorthand used on every write route
-	read := permissionMW.RequirePermission  // shorthand used on read-guarded routes
 
 	// Add middleware to set swagger host dynamically
 	router.Use(func(c *gin.Context) {
@@ -159,8 +158,8 @@ func NewRouter(
 		environment := v1Private.Group("/environments")
 		{
 			environment.POST("", write(types.EntityEnvironment, types.ActionWrite), handlers.Environment.CreateEnvironment)
-			environment.GET("", read(types.EntityEnvironment, types.ActionRead), handlers.Environment.GetEnvironments)
-			environment.GET("/:id", read(types.EntityEnvironment, types.ActionRead), handlers.Environment.GetEnvironment)
+			environment.GET("", handlers.Environment.GetEnvironments)
+			environment.GET("/:id", handlers.Environment.GetEnvironment)
 			environment.PUT("/:id", write(types.EntityEnvironment, types.ActionWrite), handlers.Environment.UpdateEnvironment)
 			environment.POST("/:id/clone", write(types.EntityEnvironment, types.ActionWrite), handlers.Environment.CloneEnvironment)
 		}

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -52,6 +52,11 @@ func setContextValues(c *gin.Context, tenantID, userID, environmentID, userType 
 		ctx = context.WithValue(ctx, types.CtxUserType, userType)
 	}
 
+	// Set additional headers for downstream handlers
+	if environmentID == "" {
+		environmentID = c.GetHeader(types.HeaderEnvironment)
+	}
+
 	if environmentID != "" {
 		ctx = context.WithValue(ctx, types.CtxEnvironmentID, environmentID)
 	}

--- a/internal/rest/middleware/auth_test.go
+++ b/internal/rest/middleware/auth_test.go
@@ -75,7 +75,7 @@ func TestAuthenticateMiddleware_EnvironmentIDFromJWT(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "env_prod")
 	})
 
-	t.Run("X-Environment-ID header has no effect when claim absent", func(t *testing.T) {
+	t.Run("falls back to X-Environment-ID header when claim absent", func(t *testing.T) {
 		token := makeJWT(t, "t_tenant1", "usr_dev", "", 1)
 
 		w := httptest.NewRecorder()
@@ -85,8 +85,7 @@ func TestAuthenticateMiddleware_EnvironmentIDFromJWT(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), `"environment_id":""`)
-		assert.NotContains(t, w.Body.String(), "env_from_header")
+		assert.Contains(t, w.Body.String(), "env_from_header")
 	})
 
 	t.Run("JWT claim takes priority over header", func(t *testing.T) {

--- a/internal/rest/middleware/permission_test.go
+++ b/internal/rest/middleware/permission_test.go
@@ -89,38 +89,3 @@ func TestRequirePermission_AllowsServiceAccountWithRole(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "service account with the right role must be allowed through")
 }
-
-// TestRequirePermission_DeniesServiceAccountEnvironmentRead reproduces the
-// live-verified staging PoC: a service-account key scoped to
-// event_ingestor/event_reader (neither of which grants environment:read)
-// successfully called GET /v1/environments and got all 50 tenant environment
-// UUIDs. That must now be 403.
-func TestRequirePermission_DeniesServiceAccountEnvironmentRead(t *testing.T) {
-	rbacSvc := realRBACService(t)
-	router := newPermissionTestRouter(t, rbacSvc, string(types.UserTypeServiceAccount),
-		[]string{"event_ingestor", "event_reader"}, types.EntityEnvironment, types.ActionRead)
-
-	req := httptest.NewRequest(http.MethodPost, "/customers", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusForbidden, w.Code, "service account without environment:read role must be denied")
-
-	var body map[string]string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	assert.Equal(t, "insufficient permissions", body["message"])
-}
-
-// TestRequirePermission_AllowsSuperAdminEnvironmentRead confirms super_admin's
-// wildcard role is unaffected by the new environment:read guard.
-func TestRequirePermission_AllowsSuperAdminEnvironmentRead(t *testing.T) {
-	rbacSvc := realRBACService(t)
-	router := newPermissionTestRouter(t, rbacSvc, string(types.UserTypeServiceAccount),
-		[]string{"super_admin"}, types.EntityEnvironment, types.ActionRead)
-
-	req := httptest.NewRequest(http.MethodPost, "/customers", nil)
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code, "super_admin must retain access to environment reads")
-}


### PR DESCRIPTION
Reverts flexprice/flexprice#2494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment-specific requests now correctly use the `X-Environment-ID` header when the authentication token does not include an environment identifier.
  * Environment GET requests continue to require authentication and tenant validation while no longer applying a separate read-permission check.
  * Improved consistency for accessing environment information across supported authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->