### PR TITLE
Grouped invoicing checkout support in create subs

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -321,6 +321,30 @@ type SubscriptionInheritanceConfig struct {
 	GroupedInvoicingChildrenToCreate []GroupedInvoicingChildRequest `json:"grouped_invoicing_children_to_create,omitempty" validate:"omitempty,dive"`
 }
 
+func (c *SubscriptionInheritanceConfig) checkoutUnsupportedFields() bool {
+	if c == nil {
+		return false
+	}
+
+	if len(c.ExternalCustomerIDsToInheritSubscription) > 0 {
+		return true
+	}
+	if c.ParentSubscriptionID != "" {
+		return true
+	}
+	if c.InvoicingCustomerExternalID != nil {
+		return true
+	}
+	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 {
+		return true
+	}
+	if len(c.GroupedInvoicingChildrenToCreate) > 0 {
+		return true
+	}
+
+	return false
+}
+
 func (c *SubscriptionInheritanceConfig) Validate() error {
 	if c == nil {
 		return nil
@@ -849,10 +873,10 @@ func (r *CreateSubscriptionRequest) validateCheckoutCompatibility() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	// TODO: Handle inheritance for checkout-gated creates
-	if r.Inheritance != nil {
-		return ierr.NewError("inheritance is not supported with checkout").
-			WithHint("Remove checkout to create an inherited or grouped-invoicing subscription").
+	if unsupported := r.Inheritance.checkoutUnsupportedFields(); unsupported {
+		return ierr.NewError("inheritance field is not supported with checkout").
+			WithHint("Remove checkout, or remove the listed inheritance fields to gate this subscription behind payment").
+			WithReportableDetails(map[string]any{"fields": unsupported}).
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -338,9 +338,6 @@ func (c *SubscriptionInheritanceConfig) checkoutUnsupportedFields() bool {
 	if len(c.SubscriptionsIDsForGroupedInvoicing) > 0 {
 		return true
 	}
-	if len(c.GroupedInvoicingChildrenToCreate) > 0 {
-		return true
-	}
 
 	return false
 }
@@ -860,6 +857,10 @@ func (r *CreateSubscriptionRequest) validateCheckoutCompatibility() error {
 		return nil
 	}
 
+	if r.SubscriptionType == types.SubscriptionTypeGroupedInvoicing {
+		return nil
+	}
+
 	if r.SubscriptionStatus != "" {
 		return ierr.NewError("subscription_status is not supported with checkout").
 			WithHint("Remove subscription_status; a checkout-gated subscription is created as draft and activated once payment succeeds").
@@ -873,18 +874,26 @@ func (r *CreateSubscriptionRequest) validateCheckoutCompatibility() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	if unsupported := r.Inheritance.checkoutUnsupportedFields(); unsupported {
+	if r.Inheritance.checkoutUnsupportedFields() {
 		return ierr.NewError("inheritance field is not supported with checkout").
-			WithHint("Remove checkout, or remove the listed inheritance fields to gate this subscription behind payment").
-			WithReportableDetails(map[string]any{"fields": unsupported}).
+			WithHint("Only grouped_invoicing_children_to_create is supported with checkout; remove the other inheritance fields, or remove checkout").
 			Mark(ierr.ErrValidation)
+	}
+
+	if r.Inheritance != nil {
+		for i, child := range r.Inheritance.GroupedInvoicingChildrenToCreate {
+			if len(child.Phases) > 0 {
+				return ierr.NewError("phases is not supported with checkout").
+					WithHintf("Remove phases from grouped_invoicing_children_to_create[%d], or remove checkout", i).
+					Mark(ierr.ErrValidation)
+			}
+		}
 	}
 
 	return nil
 }
 
 func (r *CreateSubscriptionRequest) Validate() error {
-
 	err := validator.ValidateRequest(r)
 	if err != nil {
 		return err

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -348,16 +348,15 @@ func TestSubscriptionInheritanceConfig_CheckoutUnsupportedFields(t *testing.T) {
 			want:   true,
 		},
 		{
-			name: "grouped_invoicing_children_to_create",
+			name: "grouped_invoicing_children_to_create is supported",
 			config: &SubscriptionInheritanceConfig{
 				GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
 					{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
 				},
 			},
-			want: true,
 		},
 		{
-			name: "reports every unsupported field present",
+			name: "a supported field alongside an unsupported one still reports",
 			config: &SubscriptionInheritanceConfig{
 				GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
 					{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
@@ -384,11 +383,6 @@ func TestCreateSubscriptionRequestValidate_CheckoutRejectsEachInheritanceField(t
 		"parent_subscription_id":                        {ParentSubscriptionID: "subs_parent"},
 		"invoicing_customer_external_id":                {InvoicingCustomerExternalID: lo.ToPtr("ext_payer")},
 		"subscriptions_ids_for_grouped_invoicing":       {SubscriptionsIDsForGroupedInvoicing: []string{"subs_child"}},
-		"grouped_invoicing_children_to_create": {
-			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
-				{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
-			},
-		},
 	}
 
 	for field, config := range configs {
@@ -411,6 +405,55 @@ func TestCreateSubscriptionRequestValidate_CheckoutRejectsEachInheritanceField(t
 func TestCreateSubscriptionRequestValidate_CheckoutWithoutInheritancePasses(t *testing.T) {
 	req := baseCreateSubscriptionRequest()
 	req.Checkout = checkoutParamsForTest()
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestCreateSubscriptionRequestValidate_CheckoutAllowsGroupedInvoicingChildren(t *testing.T) {
+	req := baseCreateSubscriptionRequest()
+	req.Checkout = checkoutParamsForTest()
+	req.Inheritance = &SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+			{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+		},
+	}
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+// Inline children never reach handleSubscriptionPhases, so a gated create carrying child phases
+// would persist a half-built schedule.
+func TestCreateSubscriptionRequestValidate_CheckoutRejectsChildPhases(t *testing.T) {
+	child := GroupedInvoicingChildRequest{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"}
+	child.Phases = []SubscriptionPhaseCreateRequest{{StartDate: time.Now().UTC()}}
+
+	req := baseCreateSubscriptionRequest()
+	req.Checkout = checkoutParamsForTest()
+	req.Inheritance = &SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{child},
+	}
+
+	err := req.Validate()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "phases is not supported with checkout") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateSubscriptionRequestValidate_ChildPhasesAllowedWithoutCheckout(t *testing.T) {
+	child := GroupedInvoicingChildRequest{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"}
+	child.Phases = []SubscriptionPhaseCreateRequest{{StartDate: time.Now().UTC()}}
+
+	req := baseCreateSubscriptionRequest()
+	req.Inheritance = &SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{child},
+	}
 
 	if err := req.Validate(); err != nil {
 		t.Fatalf("expected no error, got: %v", err)

--- a/internal/api/dto/subscription_test.go
+++ b/internal/api/dto/subscription_test.go
@@ -304,3 +304,115 @@ func TestCreateSubscriptionRequestValidate_GroupedInvoicingChildrenToCreate_Requ
 		}
 	})
 }
+
+func checkoutParamsForTest() *CheckoutParams {
+	return &CheckoutParams{
+		PaymentParams: PaymentParams{
+			PaymentProvider: types.CheckoutPaymentProviderRazorpay,
+		},
+	}
+}
+
+func TestSubscriptionInheritanceConfig_CheckoutUnsupportedFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *SubscriptionInheritanceConfig
+		want   bool
+	}{
+		{
+			name:   "nil config reports nothing",
+			config: nil,
+		},
+		{
+			name:   "empty config reports nothing",
+			config: &SubscriptionInheritanceConfig{},
+		},
+		{
+			name:   "external_customer_ids_to_inherit_subscription",
+			config: &SubscriptionInheritanceConfig{ExternalCustomerIDsToInheritSubscription: []string{"ext_child_1"}},
+			want:   true,
+		},
+		{
+			name:   "parent_subscription_id",
+			config: &SubscriptionInheritanceConfig{ParentSubscriptionID: "subs_parent"},
+			want:   true,
+		},
+		{
+			name:   "invoicing_customer_external_id",
+			config: &SubscriptionInheritanceConfig{InvoicingCustomerExternalID: lo.ToPtr("ext_payer")},
+			want:   true,
+		},
+		{
+			name:   "subscriptions_ids_for_grouped_invoicing",
+			config: &SubscriptionInheritanceConfig{SubscriptionsIDsForGroupedInvoicing: []string{"subs_child"}},
+			want:   true,
+		},
+		{
+			name: "grouped_invoicing_children_to_create",
+			config: &SubscriptionInheritanceConfig{
+				GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+					{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "reports every unsupported field present",
+			config: &SubscriptionInheritanceConfig{
+				GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+					{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+				},
+				InvoicingCustomerExternalID: lo.ToPtr("ext_payer"),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.config.checkoutUnsupportedFields()
+			if got != tt.want {
+				t.Fatalf("expected fields %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCreateSubscriptionRequestValidate_CheckoutRejectsEachInheritanceField(t *testing.T) {
+	configs := map[string]*SubscriptionInheritanceConfig{
+		"external_customer_ids_to_inherit_subscription": {ExternalCustomerIDsToInheritSubscription: []string{"ext_child_1"}},
+		"parent_subscription_id":                        {ParentSubscriptionID: "subs_parent"},
+		"invoicing_customer_external_id":                {InvoicingCustomerExternalID: lo.ToPtr("ext_payer")},
+		"subscriptions_ids_for_grouped_invoicing":       {SubscriptionsIDsForGroupedInvoicing: []string{"subs_child"}},
+		"grouped_invoicing_children_to_create": {
+			GroupedInvoicingChildrenToCreate: []GroupedInvoicingChildRequest{
+				{PlanID: "plan_seat", ExternalCustomerID: "ext_seat_1"},
+			},
+		},
+	}
+
+	for field, config := range configs {
+		t.Run("rejects "+field, func(t *testing.T) {
+			req := baseCreateSubscriptionRequest()
+			req.Checkout = checkoutParamsForTest()
+			req.Inheritance = config
+
+			err := req.Validate()
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), "inheritance field is not supported with checkout") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateSubscriptionRequestValidate_CheckoutWithoutInheritancePasses(t *testing.T) {
+	req := baseCreateSubscriptionRequest()
+	req.Checkout = checkoutParamsForTest()
+
+	if err := req.Validate(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -1556,6 +1556,12 @@ func (s *billingService) PrepareSubscriptionInvoiceRequest(
 			types.SubscriptionStatusActive,
 			types.SubscriptionStatusTrialing,
 		}
+
+		// A draft parent is only ever invoiced by the checkout pricing pass, and its inline
+		// children are draft too, so they belong on the amount the customer is asked to pay.
+		if sub.SubscriptionStatus == types.SubscriptionStatusDraft {
+			filter.SubscriptionStatus = append(filter.SubscriptionStatus, types.SubscriptionStatusDraft)
+		}
 		children, err := s.SubRepo.List(ctx, filter)
 		if err != nil {
 			return nil, err

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -335,7 +335,7 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 	}
 
 	if req.Inheritance != nil && len(req.Inheritance.GroupedInvoicingChildrenToCreate) > 0 {
-		if err := s.createGroupedInvoicingChildren(ctx, sub, req.Inheritance.GroupedInvoicingChildrenToCreate); err != nil {
+		if err := s.createGroupedInvoicingChildren(ctx, sub, req.Inheritance.GroupedInvoicingChildrenToCreate, req.Checkout); err != nil {
 			return nil, err
 		}
 	}
@@ -7968,7 +7968,12 @@ func (s *subscriptionService) prepareSubscriptionInheritanceForCreate(ctx contex
 		if err != nil {
 			return nil, nil, err
 		}
-		if parentSub.SubscriptionStatus != types.SubscriptionStatusActive {
+
+		isCheckoutGatedChild := req.Checkout != nil &&
+			sub.SubscriptionType == types.SubscriptionTypeGroupedInvoicing &&
+			parentSub.SubscriptionStatus == types.SubscriptionStatusDraft
+
+		if parentSub.SubscriptionStatus != types.SubscriptionStatusActive && !isCheckoutGatedChild {
 			return nil, nil, ierr.NewError("parent subscription is not active").
 				WithHint("The parent subscription must be active").
 				WithReportableDetails(map[string]interface{}{"parent_subscription_id": inh.ParentSubscriptionID, "subscription_status": parentSub.SubscriptionStatus}).
@@ -8105,6 +8110,7 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 	ctx context.Context,
 	parent *subscription.Subscription,
 	childRequests []dto.GroupedInvoicingChildRequest,
+	checkout *dto.CheckoutParams,
 ) error {
 	for _, c := range childRequests {
 		startDate := parent.StartDate
@@ -8127,6 +8133,7 @@ func (s *subscriptionService) createGroupedInvoicingChildren(
 			BillingAnchor:              billingAnchor,
 			SubscriptionType:           types.SubscriptionTypeGroupedInvoicing,
 			SubscriptionCreationConfig: c.SubscriptionCreationConfig,
+			Checkout:                   checkout,
 			Inheritance: &dto.SubscriptionInheritanceConfig{
 				ParentSubscriptionID: parent.ID,
 			},

--- a/internal/ee/service/subscription_create.go
+++ b/internal/ee/service/subscription_create.go
@@ -51,10 +51,36 @@ func (s *subscriptionService) startCreateSubscriptionCheckout(
 	return nil
 }
 
+func (s *subscriptionService) draftChildSubscriptions(ctx context.Context, parentID string) ([]*subscription.Subscription, error) {
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+	filter.ParentSubscriptionIDs = []string{parentID}
+	filter.SubscriptionTypes = []types.SubscriptionType{
+		types.SubscriptionTypeInherited,
+		types.SubscriptionTypeGroupedInvoicing,
+	}
+	filter.SubscriptionStatus = []types.SubscriptionStatus{types.SubscriptionStatusDraft}
+
+	return s.SubRepo.List(ctx, filter)
+}
+
 func (s *subscriptionService) activateDraftSubscription(ctx context.Context, sub *subscription.Subscription) error {
 	if sub == nil {
 		return ierr.NewError("subscription is required to activate a draft create").
 			Mark(ierr.ErrValidation)
+	}
+
+	if sub.SubscriptionType == types.SubscriptionTypeParent {
+		children, err := s.draftChildSubscriptions(ctx, sub.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, child := range children {
+			if err := s.activateDraftSubscription(ctx, child); err != nil {
+				return err
+			}
+		}
 	}
 
 	if sub.SubscriptionStatus == types.SubscriptionStatusDraft {
@@ -95,6 +121,24 @@ func (s *subscriptionService) archiveDraftCheckoutSubscription(ctx context.Conte
 			"subscription_status", sub.SubscriptionStatus,
 		)
 		return
+	}
+
+	if children, err := s.draftChildSubscriptions(ctx, subscriptionID); err != nil {
+		s.Logger.Error(ctx, "failed to list draft children for checkout cleanup",
+			"error", err,
+			"subscription_id", subscriptionID,
+		)
+	} else {
+		for _, child := range children {
+			s.archiveDraftSubscriptionDependencies(ctx, child.ID)
+			if err := s.SubRepo.Delete(ctx, child.ID); err != nil {
+				s.Logger.Error(ctx, "failed to archive draft child subscription",
+					"error", err,
+					"subscription_id", subscriptionID,
+					"child_subscription_id", child.ID,
+				)
+			}
+		}
 	}
 
 	s.archiveDraftSubscriptionDependencies(ctx, subscriptionID)

--- a/internal/ee/service/subscription_create.go
+++ b/internal/ee/service/subscription_create.go
@@ -51,7 +51,7 @@ func (s *subscriptionService) startCreateSubscriptionCheckout(
 	return nil
 }
 
-func (s *subscriptionService) draftChildSubscriptions(ctx context.Context, parentID string) ([]*subscription.Subscription, error) {
+func (s *subscriptionService) childSubscriptions(ctx context.Context, parentID string, statuses ...types.SubscriptionStatus) ([]*subscription.Subscription, error) {
 	filter := types.NewNoLimitSubscriptionFilter()
 	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
 	filter.ParentSubscriptionIDs = []string{parentID}
@@ -59,7 +59,7 @@ func (s *subscriptionService) draftChildSubscriptions(ctx context.Context, paren
 		types.SubscriptionTypeInherited,
 		types.SubscriptionTypeGroupedInvoicing,
 	}
-	filter.SubscriptionStatus = []types.SubscriptionStatus{types.SubscriptionStatusDraft}
+	filter.SubscriptionStatus = statuses
 
 	return s.SubRepo.List(ctx, filter)
 }
@@ -71,7 +71,7 @@ func (s *subscriptionService) activateDraftSubscription(ctx context.Context, sub
 	}
 
 	if sub.SubscriptionType == types.SubscriptionTypeParent {
-		children, err := s.draftChildSubscriptions(ctx, sub.ID)
+		children, err := s.childSubscriptions(ctx, sub.ID, types.SubscriptionStatusDraft)
 		if err != nil {
 			return err
 		}
@@ -123,21 +123,26 @@ func (s *subscriptionService) archiveDraftCheckoutSubscription(ctx context.Conte
 		return
 	}
 
-	if children, err := s.draftChildSubscriptions(ctx, subscriptionID); err != nil {
-		s.Logger.Error(ctx, "failed to list draft children for checkout cleanup",
+	// Every status: the parent is still draft, so nothing here was ever paid for, whatever
+	// status its children resolved to.
+	children, err := s.childSubscriptions(ctx, subscriptionID)
+	if err != nil {
+		s.Logger.Error(ctx, "failed to list children for checkout cleanup, leaving the group intact",
 			"error", err,
 			"subscription_id", subscriptionID,
 		)
-	} else {
-		for _, child := range children {
-			s.archiveDraftSubscriptionDependencies(ctx, child.ID)
-			if err := s.SubRepo.Delete(ctx, child.ID); err != nil {
-				s.Logger.Error(ctx, "failed to archive draft child subscription",
-					"error", err,
-					"subscription_id", subscriptionID,
-					"child_subscription_id", child.ID,
-				)
-			}
+		return
+	}
+
+	for _, child := range children {
+		s.archiveDraftSubscriptionDependencies(ctx, child.ID)
+		if err := s.SubRepo.Delete(ctx, child.ID); err != nil {
+			s.Logger.Error(ctx, "failed to archive child subscription, leaving the group intact",
+				"error", err,
+				"subscription_id", subscriptionID,
+				"child_subscription_id", child.ID,
+			)
+			return
 		}
 	}
 

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -745,11 +745,11 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_Collection
 }
 
 // ─────────────────────────────────────────────
-// Draft-child cascade plumbing
+// Child cascade plumbing
 //
-// Inheritance is still rejected with checkout, so no create path produces draft children yet.
-// These seed the state directly through the repo — the exact shape the gated parent create will
-// materialize once a field is unlocked.
+// A gated parent create materializes these through grouped_invoicing_children_to_create; the
+// inherited shapes are still gated off. These seed the state directly through the repo so the
+// cascade can be exercised against every child status independently of how it was produced.
 // ─────────────────────────────────────────────
 
 func (s *SubscriptionServiceSuite) seedChildSubscription(
@@ -799,7 +799,7 @@ func (s *SubscriptionServiceSuite) seedDraftParent(planID string) *subscription.
 	return resp.Subscription
 }
 
-func (s *SubscriptionServiceSuite) TestDraftChildSubscriptions_ListsBothShapesAndOnlyDrafts() {
+func (s *SubscriptionServiceSuite) TestChildSubscriptions_DraftFilterVsEveryStatus() {
 	ctx := s.GetContext()
 	subService := s.service.(*subscriptionService)
 	s.seedFixedPricePlan("plan_draft_children_lister", decimal.NewFromInt(50), 0)
@@ -807,15 +807,20 @@ func (s *SubscriptionServiceSuite) TestDraftChildSubscriptions_ListsBothShapesAn
 	parent := s.seedDraftParent("plan_draft_children_lister")
 	inheritedDraft := s.seedChildSubscription(parent, types.SubscriptionTypeInherited, types.SubscriptionStatusDraft)
 	groupedDraft := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusDraft)
+	trialingChild := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusTrialing)
 	activeChild := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusActive)
 
-	children, err := subService.draftChildSubscriptions(ctx, parent.ID)
+	drafts, err := subService.childSubscriptions(ctx, parent.ID, types.SubscriptionStatusDraft)
 	s.Require().NoError(err)
+	draftIDs := lo.Map(drafts, func(c *subscription.Subscription, _ int) string { return c.ID })
+	s.ElementsMatch([]string{inheritedDraft.ID, groupedDraft.ID}, draftIDs,
+		"the activation cascade takes both inheritance shapes, and only while draft")
 
-	ids := lo.Map(children, func(c *subscription.Subscription, _ int) string { return c.ID })
-	s.ElementsMatch([]string{inheritedDraft.ID, groupedDraft.ID}, ids,
-		"both inheritance shapes must be listed, and only while draft")
-	s.NotContains(ids, activeChild.ID, "an already-active child is not the cascade's business")
+	all, err := subService.childSubscriptions(ctx, parent.ID)
+	s.Require().NoError(err)
+	allIDs := lo.Map(all, func(c *subscription.Subscription, _ int) string { return c.ID })
+	s.ElementsMatch([]string{inheritedDraft.ID, groupedDraft.ID, trialingChild.ID, activeChild.ID}, allIDs,
+		"cleanup takes every child, whatever status it resolved to")
 }
 
 func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_CascadesToDraftChildren() {
@@ -1050,12 +1055,50 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_SessionFai
 	s.Require().NoError(err)
 	s.Equal(types.StatusArchived, archivedParent.Status)
 
-	for _, child := range s.groupedChildrenOf(parent.ID) {
+	children := s.groupedChildrenOf(parent.ID)
+	s.Require().Len(children, 1, "the seat must exist for its archival to mean anything")
+	for _, child := range children {
 		archivedChild, err := s.GetStores().SubscriptionRepo.Get(ctx, child.ID)
 		s.Require().NoError(err)
 		s.Equal(types.StatusArchived, archivedChild.Status,
 			"an abandoned checkout must not leave a seat behind")
 	}
+}
+
+// A seat whose plan carries a trial falls through the gate as trialing rather than draft, so a
+// draft-only cleanup would leave it live — entitlements running for a bundle nobody paid for.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_SessionFailureArchivesTrialingSeat() {
+	ctx := s.GetContext()
+	s.seedFixedPricePlan("plan_trial_archive_parent", decimal.NewFromInt(50), 0)
+	s.seedFixedPricePlan("plan_trial_archive_seat", decimal.NewFromInt(30), 14)
+	s.seedChildCustomer("ext_seat_trial_archive")
+
+	idempKey := "create-subscription-trial-archive-idemp-key"
+	s.seedCollidingCheckoutSession(idempKey)
+
+	req := s.checkoutCreateRequest("plan_trial_archive_parent")
+	req.Checkout.IdempotencyKey = &idempKey
+	req.Inheritance = &dto.SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+			{PlanID: "plan_trial_archive_seat", ExternalCustomerID: "ext_seat_trial_archive"},
+		},
+	}
+
+	_, err := s.service.CreateSubscription(ctx, req)
+	s.Require().Error(err)
+
+	parent := s.subscriptionForPlan("plan_trial_archive_parent")
+	s.Require().NotNil(parent)
+
+	children := s.groupedChildrenOf(parent.ID)
+	s.Require().Len(children, 1)
+	s.Require().Equal(types.SubscriptionStatusTrialing, children[0].SubscriptionStatus,
+		"fixture guard — this test is only meaningful while the seat falls through as trialing")
+
+	archivedChild, err := s.GetStores().SubscriptionRepo.Get(ctx, children[0].ID)
+	s.Require().NoError(err)
+	s.Equal(types.StatusArchived, archivedChild.Status,
+		"a trialing seat must not outlive the abandoned bundle it belongs to")
 }
 
 // seedDraftGroupedChild builds a draft grouped_invoicing child that carries real line items, which

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -742,3 +742,146 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_Collection
 		})
 	}
 }
+
+// ─────────────────────────────────────────────
+// Draft-child cascade plumbing
+//
+// Inheritance is still rejected with checkout, so no create path produces draft children yet.
+// These seed the state directly through the repo — the exact shape the gated parent create will
+// materialize once a field is unlocked.
+// ─────────────────────────────────────────────
+
+func (s *SubscriptionServiceSuite) seedChildSubscription(
+	parent *subscription.Subscription,
+	subType types.SubscriptionType,
+	status types.SubscriptionStatus,
+) *subscription.Subscription {
+	ctx := s.GetContext()
+
+	child := &subscription.Subscription{
+		ID:                   types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		CustomerID:           parent.CustomerID,
+		PlanID:               parent.PlanID,
+		Currency:             parent.Currency,
+		SubscriptionStatus:   status,
+		SubscriptionType:     subType,
+		ParentSubscriptionID: lo.ToPtr(parent.ID),
+		BillingAnchor:        parent.BillingAnchor,
+		BillingCycle:         parent.BillingCycle,
+		StartDate:            parent.StartDate,
+		CurrentPeriodStart:   parent.CurrentPeriodStart,
+		CurrentPeriodEnd:     parent.CurrentPeriodEnd,
+		BillingCadence:       parent.BillingCadence,
+		BillingPeriod:        parent.BillingPeriod,
+		BillingPeriodCount:   parent.BillingPeriodCount,
+		Version:              1,
+		EnvironmentID:        parent.EnvironmentID,
+		BaseModel:            types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Create(ctx, child))
+	return child
+}
+
+// seedDraftParent creates a draft parent-typed subscription without going through the gated path.
+func (s *SubscriptionServiceSuite) seedDraftParent(planID string) *subscription.Subscription {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+
+	req := s.checkoutCreateRequest(planID)
+	req.Checkout = nil
+	req.SubscriptionStatus = types.SubscriptionStatusDraft
+	resp, err := subService.CreateSubscription(ctx, req)
+	s.Require().NoError(err)
+
+	resp.Subscription.SubscriptionType = types.SubscriptionTypeParent
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, resp.Subscription))
+	return resp.Subscription
+}
+
+func (s *SubscriptionServiceSuite) TestDraftChildSubscriptions_ListsBothShapesAndOnlyDrafts() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_draft_children_lister", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_draft_children_lister")
+	inheritedDraft := s.seedChildSubscription(parent, types.SubscriptionTypeInherited, types.SubscriptionStatusDraft)
+	groupedDraft := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusDraft)
+	activeChild := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusActive)
+
+	children, err := subService.draftChildSubscriptions(ctx, parent.ID)
+	s.Require().NoError(err)
+
+	ids := lo.Map(children, func(c *subscription.Subscription, _ int) string { return c.ID })
+	s.ElementsMatch([]string{inheritedDraft.ID, groupedDraft.ID}, ids,
+		"both inheritance shapes must be listed, and only while draft")
+	s.NotContains(ids, activeChild.ID, "an already-active child is not the cascade's business")
+}
+
+func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_CascadesToDraftChildren() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_activate_cascade", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_activate_cascade")
+	inheritedChild := s.seedChildSubscription(parent, types.SubscriptionTypeInherited, types.SubscriptionStatusDraft)
+	groupedChild := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusDraft)
+
+	s.Require().NoError(subService.activateDraftSubscription(ctx, parent))
+
+	for _, id := range []string{parent.ID, inheritedChild.ID, groupedChild.ID} {
+		activated, err := s.GetStores().SubscriptionRepo.Get(ctx, id)
+		s.Require().NoError(err)
+		s.Equal(types.SubscriptionStatusActive, activated.SubscriptionStatus,
+			"payment activates the whole group, not just the parent (%s)", id)
+	}
+}
+
+// A second webhook delivery must not error, and must not un-activate anything.
+func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_CascadeIsIdempotent() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_activate_cascade_replay", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_activate_cascade_replay")
+	child := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusDraft)
+
+	s.Require().NoError(subService.activateDraftSubscription(ctx, parent))
+	s.Require().NoError(subService.activateDraftSubscription(ctx, parent))
+
+	activated, err := s.GetStores().SubscriptionRepo.Get(ctx, child.ID)
+	s.Require().NoError(err)
+	s.Equal(types.SubscriptionStatusActive, activated.SubscriptionStatus)
+}
+
+func (s *SubscriptionServiceSuite) TestArchiveDraftCheckoutSubscription_CascadesToDraftChildren() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_archive_cascade", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_archive_cascade")
+	inheritedChild := s.seedChildSubscription(parent, types.SubscriptionTypeInherited, types.SubscriptionStatusDraft)
+	groupedChild := s.seedChildSubscription(parent, types.SubscriptionTypeGroupedInvoicing, types.SubscriptionStatusDraft)
+
+	subService.archiveDraftCheckoutSubscription(ctx, parent.ID)
+
+	for _, id := range []string{parent.ID, inheritedChild.ID, groupedChild.ID} {
+		archived, err := s.GetStores().SubscriptionRepo.Get(ctx, id)
+		s.Require().NoError(err)
+		s.Equal(types.StatusArchived, archived.Status,
+			"an abandoned checkout must not leave the group behind (%s)", id)
+	}
+}
+
+// The cascade must stay inert for the standalone subscriptions every existing gated create produces.
+func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_StandaloneIsUnchanged() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_activate_standalone", decimal.NewFromInt(50), 0)
+
+	_, draftSub, _ := s.seedPayFirstSubscriptionCheckout("plan_activate_standalone")
+	s.Require().NoError(subService.activateDraftSubscription(ctx, draftSub))
+
+	activated, err := s.GetStores().SubscriptionRepo.Get(ctx, draftSub.ID)
+	s.Require().NoError(err)
+	s.Equal(types.SubscriptionStatusActive, activated.SubscriptionStatus)
+}

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
+	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
@@ -884,4 +885,274 @@ func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_StandaloneIsUnc
 	activated, err := s.GetStores().SubscriptionRepo.Get(ctx, draftSub.ID)
 	s.Require().NoError(err)
 	s.Equal(types.SubscriptionStatusActive, activated.SubscriptionStatus)
+}
+
+// ─────────────────────────────────────────────
+// Inline grouped-invoicing children behind the gate
+// ─────────────────────────────────────────────
+
+func (s *SubscriptionServiceSuite) seedChildCustomer(externalID string) *customer.Customer {
+	ctx := s.GetContext()
+	c := &customer.Customer{
+		ID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CUSTOMER),
+		ExternalID: externalID,
+		Name:       externalID,
+		Email:      externalID + "@example.com",
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().CustomerRepo.Create(ctx, c))
+	return c
+}
+
+func (s *SubscriptionServiceSuite) groupedChildrenOf(parentID string) []*subscription.Subscription {
+	filter := types.NewNoLimitSubscriptionFilter()
+	filter.ParentSubscriptionIDs = []string{parentID}
+	filter.SubscriptionTypes = []types.SubscriptionType{types.SubscriptionTypeGroupedInvoicing}
+	children, err := s.GetStores().SubscriptionRepo.List(s.GetContext(), filter)
+	s.Require().NoError(err)
+	return children
+}
+
+// The point of the whole phase: one payment link whose amount covers the parent AND every inline
+// seat. Without the draft-aware merge filter the children are invisible and this reads 50.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_GroupedChildrenArePricedIntoTheDraft() {
+	ctx := s.GetContext()
+	s.seedFixedPricePlan("plan_grouped_parent", decimal.NewFromInt(50), 0)
+	s.seedFixedPricePlan("plan_grouped_seat", decimal.NewFromInt(30), 0)
+	s.seedChildCustomer("ext_seat_priced_1")
+	s.seedChildCustomer("ext_seat_priced_2")
+
+	idempKey := "create-subscription-grouped-priced-idemp-key"
+	s.seedCollidingCheckoutSession(idempKey)
+
+	req := s.checkoutCreateRequest("plan_grouped_parent")
+	req.Checkout.IdempotencyKey = &idempKey
+	req.Inheritance = &dto.SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+			{PlanID: "plan_grouped_seat", ExternalCustomerID: "ext_seat_priced_1"},
+			{PlanID: "plan_grouped_seat", ExternalCustomerID: "ext_seat_priced_2"},
+		},
+	}
+
+	_, err := s.service.CreateSubscription(ctx, req)
+	s.Require().Error(err, "expected the seeded idempotency collision to fail session create")
+
+	inv := s.draftInvoiceForPlan("plan_grouped_parent")
+	s.Require().NotNil(inv, "the gated create must have priced a draft invoice before opening a session")
+	s.True(inv.AmountDue.Equal(decimal.NewFromInt(110)),
+		"the locked amount must cover parent (50) + two seats (30 each), got %s", inv.AmountDue)
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_GroupedChildrenAreCreatedDraft() {
+	ctx := s.GetContext()
+	s.seedFixedPricePlan("plan_grouped_draft_parent", decimal.NewFromInt(50), 0)
+	s.seedFixedPricePlan("plan_grouped_draft_seat", decimal.NewFromInt(30), 0)
+	s.seedChildCustomer("ext_seat_draft_1")
+
+	idempKey := "create-subscription-grouped-draft-idemp-key"
+	s.seedCollidingCheckoutSession(idempKey)
+
+	req := s.checkoutCreateRequest("plan_grouped_draft_parent")
+	req.Checkout.IdempotencyKey = &idempKey
+	req.Inheritance = &dto.SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+			{PlanID: "plan_grouped_draft_seat", ExternalCustomerID: "ext_seat_draft_1"},
+		},
+	}
+
+	_, err := s.service.CreateSubscription(ctx, req)
+	s.Require().Error(err)
+
+	parent := s.subscriptionForPlan("plan_grouped_draft_parent")
+	s.Require().NotNil(parent)
+	s.Equal(types.SubscriptionTypeParent, parent.SubscriptionType)
+
+	children := s.groupedChildrenOf(parent.ID)
+	s.Require().Len(children, 1)
+	s.Equal(types.SubscriptionStatusDraft, children[0].SubscriptionStatus,
+		"a seat must not go live before the bundle is paid for")
+	s.Empty(s.invoicesForSubscription(children[0].ID),
+		"the seat's charges belong on the parent's invoice, not its own")
+}
+
+// The status relaxation is keyed on the internal grouped_invoicing marker, so the wire-reachable
+// inherited shape must still be refused a draft parent.
+func (s *SubscriptionServiceSuite) TestPrepareInheritance_InheritedChildUnderDraftParentStillRejected() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_inherited_draft_parent", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_inherited_draft_parent")
+
+	req := &dto.CreateSubscriptionRequest{
+		Inheritance: &dto.SubscriptionInheritanceConfig{ParentSubscriptionID: parent.ID},
+	}
+	sub := &subscription.Subscription{CustomerID: s.testData.customer.ID}
+
+	_, _, err := subService.prepareSubscriptionInheritanceForCreate(ctx, req, sub)
+	s.Require().Error(err, "an inherited child must not attach to an unpaid draft parent")
+	s.Contains(err.Error(), "parent subscription is not active")
+}
+
+// A seat whose plan carries a trial resolves to trialing and must not be flattened into a draft
+// that would later activate as ACTIVE, destroying the trial.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_GroupedChildTrialFallsThrough() {
+	ctx := s.GetContext()
+	s.seedFixedPricePlan("plan_grouped_trial_parent", decimal.NewFromInt(50), 0)
+	s.seedFixedPricePlan("plan_grouped_trial_seat", decimal.NewFromInt(30), 14)
+	s.seedChildCustomer("ext_seat_trial_1")
+
+	idempKey := "create-subscription-grouped-trial-idemp-key"
+	s.seedCollidingCheckoutSession(idempKey)
+
+	req := s.checkoutCreateRequest("plan_grouped_trial_parent")
+	req.Checkout.IdempotencyKey = &idempKey
+	req.Inheritance = &dto.SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+			{PlanID: "plan_grouped_trial_seat", ExternalCustomerID: "ext_seat_trial_1"},
+		},
+	}
+
+	_, err := s.service.CreateSubscription(ctx, req)
+	s.Require().Error(err)
+
+	parent := s.subscriptionForPlan("plan_grouped_trial_parent")
+	s.Require().NotNil(parent)
+	children := s.groupedChildrenOf(parent.ID)
+	s.Require().Len(children, 1)
+	s.Equal(types.SubscriptionStatusTrialing, children[0].SubscriptionStatus,
+		"a plan-inherited trial on a seat must survive the gate")
+}
+
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_SessionFailureArchivesGroupedChildren() {
+	ctx := s.GetContext()
+	s.seedFixedPricePlan("plan_grouped_archive_parent", decimal.NewFromInt(50), 0)
+	s.seedFixedPricePlan("plan_grouped_archive_seat", decimal.NewFromInt(30), 0)
+	s.seedChildCustomer("ext_seat_archive_1")
+
+	idempKey := "create-subscription-grouped-archive-idemp-key"
+	s.seedCollidingCheckoutSession(idempKey)
+
+	req := s.checkoutCreateRequest("plan_grouped_archive_parent")
+	req.Checkout.IdempotencyKey = &idempKey
+	req.Inheritance = &dto.SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+			{PlanID: "plan_grouped_archive_seat", ExternalCustomerID: "ext_seat_archive_1"},
+		},
+	}
+
+	_, err := s.service.CreateSubscription(ctx, req)
+	s.Require().Error(err)
+
+	parent := s.subscriptionForPlan("plan_grouped_archive_parent")
+	s.Require().NotNil(parent)
+	archivedParent, err := s.GetStores().SubscriptionRepo.Get(ctx, parent.ID)
+	s.Require().NoError(err)
+	s.Equal(types.StatusArchived, archivedParent.Status)
+
+	for _, child := range s.groupedChildrenOf(parent.ID) {
+		archivedChild, err := s.GetStores().SubscriptionRepo.Get(ctx, child.ID)
+		s.Require().NoError(err)
+		s.Equal(types.StatusArchived, archivedChild.Status,
+			"an abandoned checkout must not leave a seat behind")
+	}
+}
+
+// seedDraftGroupedChild builds a draft grouped_invoicing child that carries real line items, which
+// a bare repo insert cannot do — the merge only ever sees a child through its line items.
+func (s *SubscriptionServiceSuite) seedDraftGroupedChild(
+	parent *subscription.Subscription,
+	planID string,
+) *subscription.Subscription {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan(planID, decimal.NewFromInt(30), 0)
+
+	req := s.checkoutCreateRequest(planID)
+	req.Checkout = nil
+	req.SubscriptionStatus = types.SubscriptionStatusDraft
+	req.StartDate = lo.ToPtr(parent.StartDate)
+	resp, err := subService.CreateSubscription(ctx, req)
+	s.Require().NoError(err)
+
+	resp.Subscription.SubscriptionType = types.SubscriptionTypeGroupedInvoicing
+	resp.Subscription.ParentSubscriptionID = lo.ToPtr(parent.ID)
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, resp.Subscription))
+	return resp.Subscription
+}
+
+// The merge relaxation is scoped to a draft parent. A live parent's cycle invoice must never pick
+// up a draft child left behind by a partial activation — that child was never paid for.
+func (s *SubscriptionServiceSuite) TestPrepareSubscriptionInvoiceRequest_ActiveParentIgnoresDraftChildren() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_active_parent_merge", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_active_parent_merge")
+	draftChild := s.seedDraftGroupedChild(parent, "plan_active_parent_merge_seat")
+
+	billingSvc := NewBillingService(subService.ServiceParams)
+	params := &dto.PrepareSubscriptionInvoiceRequestParams{
+		Subscription:   parent,
+		PeriodStart:    parent.CurrentPeriodStart,
+		PeriodEnd:      parent.CurrentPeriodEnd,
+		ReferencePoint: types.ReferencePointPeriodStart,
+	}
+
+	gated, err := billingSvc.PrepareSubscriptionInvoiceRequest(ctx, params)
+	s.Require().NoError(err)
+	s.True(lo.SomeBy(gated.LineItems, func(li dto.CreateInvoiceLineItemRequest) bool {
+		return lo.FromPtr(li.SubscriptionID) == draftChild.ID
+	}), "a draft parent must price its draft children into the checkout amount")
+
+	parent.SubscriptionStatus = types.SubscriptionStatusActive
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, parent))
+
+	live, err := billingSvc.PrepareSubscriptionInvoiceRequest(ctx, params)
+	s.Require().NoError(err)
+	s.False(lo.SomeBy(live.LineItems, func(li dto.CreateInvoiceLineItemRequest) bool {
+		return lo.FromPtr(li.SubscriptionID) == draftChild.ID
+	}), "an active parent must not bill an unpaid draft child on its cycle invoice")
+}
+
+// A seat's first period was already covered by the parent's checkout invoice, so activating it
+// must not raise one of its own.
+func (s *SubscriptionServiceSuite) TestActivateDraftSubscription_GroupedChildGetsNoOwnInvoice() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_seat_no_own_invoice_parent", decimal.NewFromInt(50), 0)
+
+	parent := s.seedDraftParent("plan_seat_no_own_invoice_parent")
+	child := s.seedDraftGroupedChild(parent, "plan_seat_no_own_invoice_seat")
+
+	s.Require().NoError(subService.activateDraftSubscription(ctx, parent))
+
+	activated, err := s.GetStores().SubscriptionRepo.Get(ctx, child.ID)
+	s.Require().NoError(err)
+	s.Equal(types.SubscriptionStatusActive, activated.SubscriptionStatus)
+	s.Empty(s.invoicesForSubscription(child.ID),
+		"the seat's charges settled on the parent's invoice; a second one would double-charge")
+}
+
+// An explicitly-draft parent is not a gated one: nothing would ever activate its seats, and once
+// the parent goes live the merge excludes draft children, so the seats would never be billed.
+// Only a checkout-gated create may link a child to a draft parent.
+func (s *SubscriptionServiceSuite) TestCreateSubscription_ExplicitDraftParentRejectsGroupedChildren() {
+	ctx := s.GetContext()
+	s.seedFixedPricePlan("plan_explicit_draft_parent", decimal.NewFromInt(50), 0)
+	s.seedFixedPricePlan("plan_explicit_draft_seat", decimal.NewFromInt(30), 0)
+	s.seedChildCustomer("ext_seat_explicit_draft")
+
+	req := s.checkoutCreateRequest("plan_explicit_draft_parent")
+	req.Checkout = nil
+	req.SubscriptionStatus = types.SubscriptionStatusDraft
+	req.Inheritance = &dto.SubscriptionInheritanceConfig{
+		GroupedInvoicingChildrenToCreate: []dto.GroupedInvoicingChildRequest{
+			{PlanID: "plan_explicit_draft_seat", ExternalCustomerID: "ext_seat_explicit_draft"},
+		},
+	}
+
+	_, err := s.service.CreateSubscription(ctx, req)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "parent subscription is not active")
 }


### PR DESCRIPTION
## **User description**
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating grouped-invoicing child subscriptions during checkout, including pricing and trial handling.
  * Draft parent subscriptions now activate and archive related child subscriptions together.
  * Draft grouped-invoicing children are included in applicable invoice processing.

* **Bug Fixes**
  * Improved checkout validation for inherited subscription settings.
  * Prevented duplicate invoices and ensured failed checkouts clean up related subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Support grouped-invoicing children in checkout as one paid subscription bundle

### What Changed
- Checkout can create grouped-invoicing child subscriptions with a parent and include their first-period charges in the parent’s payment amount
- Children remain unpaid until checkout succeeds, and activation enables the parent and draft children together without creating duplicate child invoices
- Failed or abandoned checkout archives the entire parent-and-child group, including children that entered trialing status
- Checkout rejects unsupported inheritance options and child phases while allowing grouped-invoicing children to be created

### Impact
`✅ One payment covers the parent and grouped-invoicing children`
`✅ No duplicate first-period child invoices`
`✅ Fewer abandoned checkout subscriptions left behind`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
