### PR TITLE
fix(tabs): update invoice sync logic to use billing schedule start date instead of issue date

### DIFF
--- a/docs/design/2026-07-08-FLE-965-Tabs-Invoice-Sync.md
+++ b/docs/design/2026-07-08-FLE-965-Tabs-Invoice-Sync.md
@@ -12,7 +12,7 @@
 
 ## 1. Executive Summary
 
-- **What ships (Phase 1):** One-way (outbound) sync of finalized FlexPrice invoices into [Tabs](https://tabsplatform.com) as contract **obligations**, triggered automatically when an invoice is finalized. Tabs is added as the 10th integration provider alongside Stripe, Chargebee, QuickBooks, Zoho Books, Paddle, Whop, HubSpot, Razorpay, Nomod, Moyasar.
+- **What ships (Phase 1):** One-way (outbound) sync of finalized Flexprice invoices into [Tabs](https://tabsplatform.com) as contract **obligations**, triggered automatically when an invoice is finalized. Tabs is added as the 10th integration provider alongside Stripe, Chargebee, QuickBooks, Zoho Books, Paddle, Whop, HubSpot, Razorpay, Nomod, Moyasar.
 - **Data:** No new tables. Reuses `entity_integration_mapping` with one new `EntityType` (`invoice_line_item`) and a new `ProviderType` value (`tabs`).
 - **Reused:** integration-events dispatch fan-out, connection/secret storage + encryption, `entity_integration_mapping` idempotency ledger, Temporal per-provider workflow/activity pattern, integration `Factory` provider-construction pattern.
 - **New infra:** None — one new outbound HTTP client (`internal/integration/tabs`), one new Temporal workflow/activity pair, all on existing task queues.
@@ -23,11 +23,11 @@
 
 ### 2.1 What we're building
 
-When a FlexPrice invoice is finalized, its line items are pushed to Tabs as billing **obligations** on a Tabs **contract**, so that Tabs — the customer's contract and revenue-recognition system — has an accurate, up-to-date mirror of what FlexPrice billed. Concretely, for an invoice with two line items (a $500 platform fee and a $120 usage overage) on the same price/product, FlexPrice: ensures the customer and subscription exist in Tabs, creates one obligation of $620 against the mapped Tabs product, and records the resulting Tabs invoice ID back onto the FlexPrice invoice via a mapping row.
+When a Flexprice invoice is finalized, its line items are pushed to Tabs as billing **obligations** on a Tabs **contract**, so that Tabs — the customer's contract and revenue-recognition system — has an accurate, up-to-date mirror of what Flexprice billed. Concretely, for an invoice with two line items (a $500 platform fee and a $120 usage overage) on the same price/product, Flexprice: ensures the customer and subscription exist in Tabs, creates one obligation of $620 against the mapped Tabs product, and records the resulting Tabs invoice ID back onto the Flexprice invoice via a mapping row.
 
 ### 2.2 Why we need it
 
-A specific customer/partner contract requires that invoices raised in FlexPrice also be reflected as obligations in Tabs, since Tabs is the system of record the partner uses for contract billing and revenue recognition on that deal. Without this sync, the partner would have to re-key FlexPrice invoice data into Tabs by hand.
+A specific customer/partner contract requires that invoices raised in Flexprice also be reflected as obligations in Tabs, since Tabs is the system of record the partner uses for contract billing and revenue recognition on that deal. Without this sync, the partner would have to re-key Flexprice invoice data into Tabs by hand.
 
 ## 3. Goals & Non-Goals
 
@@ -40,22 +40,22 @@ A specific customer/partner contract requires that invoices raised in FlexPrice 
 
 ### 3.2 Non-Goals
 
-- **No inbound/webhook sync.** Tabs does not push events (invoice paid, obligation updated, etc.) back into FlexPrice in this phase. Compare Whop, which has a `MarkWhopInvoicePaid` workflow for exactly this — Tabs has no equivalent.
+- **No inbound/webhook sync.** Tabs does not push events (invoice paid, obligation updated, etc.) back into Flexprice in this phase. Compare Whop, which has a `MarkWhopInvoicePaid` workflow for exactly this — Tabs has no equivalent.
 - **No pull/resync support.** Tabs is registered in `Factory.GetIntegrationByProvider`, `GetSupportedProviders`, and `GetAvailableProviders` (`factory.go:735`, `:760`, `:1240`) so it is visible to the generic integration paths and provider-listing, consistent with every other provider. But `TabsIntegration.PullAndUpdateInvoice` returns "not supported" (`factory.go:1049`) — identical to Stripe/HubSpot/Chargebee/Nomod/Zoho/Whop — so `IntegrationSyncService.pullInvoice` is effectively a no-op for Tabs. Only the push path (`syncInvoice` → Kafka → `DispatchInvoiceVendorSync` → `triggerTabsIfEnabled`) actually syncs.
 - **No customer creation outside of invoice sync.** There is no standalone "sync customer to Tabs" trigger (unlike Stripe/Paddle/etc., which have `triggerXCustomerSyncIfEnabled`); a Tabs customer is only created lazily, the first time that customer's invoice is synced.
 - **No multi-currency / multi-line-item-cadence obligations beyond simple aggregation.** Line items are grouped only by their mapped Tabs product; cadence comes from the first item's price in the group. Mixed-cadence line items on the same product in one invoice are not specially handled.
-- **No tiered/usage-based Tabs pricing.** Every obligation is built as `PricingType: SIMPLE`, `BillingType: FLAT`, a single `TOTAL_INVOICE` tier — FlexPrice always sends Tabs a pre-computed total, never raw usage.
+- **No tiered/usage-based Tabs pricing.** Every obligation is built as `PricingType: SIMPLE`, `BillingType: FLAT`, a single `TOTAL_INVOICE` tier — Flexprice always sends Tabs a pre-computed total, never raw usage.
 
 ## 4. Terminology
 
 | Term | Meaning |
 |---|---|
-| Tabs **Customer** | Tabs-side counterpart of a FlexPrice `customer.Customer`. Created async via a Tabs job. |
-| Tabs **Contract** | Tabs-side counterpart of a FlexPrice `subscription.Subscription`. One contract per subscription, named after the plan. |
-| Tabs **Product** | Tabs-side counterpart of a FlexPrice `price.Price`. One product per distinct price referenced by an invoice's line items. |
-| Tabs **Obligation** | A charge on a contract — the counterpart of one or more FlexPrice `invoice.InvoiceLineItem`s grouped by product. |
+| Tabs **Customer** | Tabs-side counterpart of a Flexprice `customer.Customer`. Created async via a Tabs job. |
+| Tabs **Contract** | Tabs-side counterpart of a Flexprice `subscription.Subscription`. One contract per subscription, named after the plan. |
+| Tabs **Product** | Tabs-side counterpart of a Flexprice `price.Price`. One product per distinct price referenced by an invoice's line items. |
+| Tabs **Obligation** | A charge on a contract — the counterpart of one or more Flexprice `invoice.InvoiceLineItem`s grouped by product. |
 | Tabs **Job** | Tabs' async-operation envelope (used only for customer creation); polled via `GET /v3/jobs/{id}` until `SUCCESS`/`FAILED`. |
-| `entity_integration_mapping` | Existing table (`internal/domain/entityintegrationmapping/model.go:11`) that stores FlexPrice-entity → provider-entity ID pairs; used here for all four mapping kinds (customer, subscription→contract, price→product, line-item→obligation, invoice→contract). |
+| `entity_integration_mapping` | Existing table (`internal/domain/entityintegrationmapping/model.go:11`) that stores Flexprice-entity → provider-entity ID pairs; used here for all four mapping kinds (customer, subscription→contract, price→product, line-item→obligation, invoice→contract). |
 
 ## 5. High-Level View
 
@@ -114,7 +114,7 @@ Before this change, `internal/integration/events/dispatch.go` already fanned a f
 |---|---|---|
 | Fan-out trigger on invoice finalize, config/connection/idempotency gating | `internal/integration/events/dispatch.go:100` (`DispatchInvoiceVendorSync`), pattern e.g. `triggerZohoBooksIfEnabled` at `dispatch.go:620` | No new Kafka topic, no new race-condition handling — the existing 5s-sleep-then-fetch pattern (`dispatch.go:79-81` comment) already solves the "event arrives before DB commit" problem |
 | Encrypted per-tenant provider credentials | `internal/ee/service/connection.go` `encryptMetadata` switch (e.g. Whop case just above the new Tabs case), `security.EncryptionService` | Tabs API key is encrypted/decrypted using the same service every other provider uses — no new crypto code |
-| Idempotent FlexPrice-entity ↔ provider-entity mapping | `internal/domain/entityintegrationmapping/model.go:11` + `types.NewNoLimitEntityIntegrationMappingFilter` | The customer/contract/product/obligation mapping chain in `tabs.go` is just repeated `List`+`Create` calls against the existing table — no new persistence layer, and retries are safe by construction (§8.y) |
+| Idempotent Flexprice-entity ↔ provider-entity mapping | `internal/domain/entityintegrationmapping/model.go:11` + `types.NewNoLimitEntityIntegrationMappingFilter` | The customer/contract/product/obligation mapping chain in `tabs.go` is just repeated `List`+`Create` calls against the existing table — no new persistence layer, and retries are safe by construction (§8.y) |
 | Temporal per-provider workflow/activity registration | `internal/temporal/registration.go:246` (`tabsActivities.NewInvoiceSyncActivities`), pattern from `zohoInvoiceSyncActivities` just above it | Workflow tracking, retry policy (3 attempts, 5m timeout), and task-queue placement (`TemporalTaskQueueTask`) come for free — `internal/temporal/workflows/tabs_invoice_sync_workflow.go` is a near-identical copy of the Zoho Books workflow |
 | Deterministic workflow ID (dedupe concurrent syncs for the same invoice) | `internal/temporal/service/service.go:464` (`extractWorkflowContextID` case `TemporalTabsInvoiceSyncWorkflow`) | Two Kafka redeliveries of the same finalize event can't start two concurrent Tabs syncs for the same invoice |
 | Provider construction / DI wiring | `internal/integration/factory.go:683` (`GetTabsIntegration`), mirrors `GetZohoBooksIntegration` immediately above it (connection-must-be-published guard, then wire client + service) | Consistent error shape (`ErrNotFound` with a hint) when a tenant hasn't configured Tabs yet |
@@ -138,13 +138,13 @@ No new tables. Two additive, backward-compatible changes to existing enums:
 
 | `entity_type` | `entity_id` | `provider_entity_id` | Written by |
 |---|---|---|---|
-| `customer` | FlexPrice customer ID | Tabs customer ID | `ensureCustomer` (`tabs.go:177`) |
-| `subscription` | FlexPrice subscription ID | Tabs contract ID | `ensureContract` (`tabs.go:236`) |
-| `price` | FlexPrice price ID | Tabs product ID | `createProduct` (`tabs.go:489`) |
-| `invoice_line_item` | FlexPrice line item ID | Tabs obligation ID | `mapLineItemsToObligation` (`tabs.go:403`) |
-| `invoice` | FlexPrice invoice ID | Tabs **invoice** ID | `mapInvoice` (`tabs.go:155`), with `contract_id`, `tabs_customer_id`, `tabs_invoice_id`, `synced_at` in `metadata` |
+| `customer` | Flexprice customer ID | Tabs customer ID | `ensureCustomer` (`tabs.go:177`) |
+| `subscription` | Flexprice subscription ID | Tabs contract ID | `ensureContract` (`tabs.go:236`) |
+| `price` | Flexprice price ID | Tabs product ID | `createProduct` (`tabs.go:489`) |
+| `invoice_line_item` | Flexprice line item ID | Tabs obligation ID | `mapLineItemsToObligation` (`tabs.go:403`) |
+| `invoice` | Flexprice invoice ID | Tabs **invoice** ID | `mapInvoice` (`tabs.go:155`), with `contract_id`, `tabs_customer_id`, `tabs_invoice_id`, `synced_at` in `metadata` |
 
-The `invoice` mapping stores the Tabs **invoice** ID as `provider_entity_id` (`tabs.go:161`), consistent with how every other provider maps a FlexPrice invoice to its provider-side invoice. The Tabs contract ID is preserved in `metadata.contract_id`.
+The `invoice` mapping stores the Tabs **invoice** ID as `provider_entity_id` (`tabs.go:161`), consistent with how every other provider maps a Flexprice invoice to its provider-side invoice. The Tabs contract ID is preserved in `metadata.contract_id`.
 
 ## 8. Approach
 
@@ -153,8 +153,8 @@ The `invoice` mapping stores the Tabs **invoice** ID as `provider_entity_id` (`t
 1. **Idempotency check** — if the invoice already has a published `invoice`-type Tabs mapping, return it unchanged (no API calls). (`tabs.go:68`)
 2. **`ensureCustomer`** — look up or create the Tabs customer. Creation is async (Tabs returns a `jobId`); `WaitForJob` polls `GET /v3/jobs/{id}` up to 3× every 2s (bounded further by the activity's 5-minute `StartToCloseTimeout`). (`tabs.go:177`, `client.go:217`)
 3. **`ensureContract`** — requires the invoice to be subscription-linked (validation error otherwise, since "Tabs obligations are created on a contract, which maps to a subscription" — `tabs.go:90`). Contract creation is synchronous; it's immediately transitioned `NEW → PROCESSED` via a contract action before the mapping is persisted, so a persisted mapping always means "fully usable contract". (`tabs.go:236`)
-4. **`syncObligations`** — bulk-loads the invoice line items' prices, resolves/creates a Tabs product per distinct price, groups line items by product, and creates one obligation per group (amount = sum of the group, service period = union of the group's periods, billing-schedule start = invoice issue date, invoice-date strategy derived from the price's `InvoiceCadence`: `ADVANCE → FIRST_OF_PERIOD`, `ARREAR → ARREARS`). (`tabs.go:308`)
-5. **`fetchTabsInvoiceID`** — Tabs generates its own invoice from the obligations; FlexPrice looks it up by `contractId` + `issueDate` and records it for observability. (`tabs.go:521`)
+4. **`syncObligations`** — bulk-loads the invoice line items' prices, resolves/creates a Tabs product per distinct price, groups line items by product, and creates one obligation per group (amount = sum of the group, service period = union of the group's periods, billing-schedule start = invoice period start, invoice-date strategy derived from the price's `InvoiceCadence`: `ADVANCE → FIRST_OF_PERIOD`, `ARREAR → ARREARS`). (`tabs.go:308`)
+5. **`fetchTabsInvoiceID`** — Tabs generates its own invoice from the obligations; Flexprice looks it up by `contractId` + the same period-start date (via Tabs' `issueDate` filter) and records it for observability. (`tabs.go:521`)
 6. **`mapInvoice`** — persists the final invoice → Tabs-invoice mapping (Tabs invoice ID as `provider_entity_id`; contract ID, Tabs customer ID and `synced_at` in metadata), making step 1 a no-op on any retry. If Tabs hasn't generated an invoice yet (`tabsInvoiceID == ""`), the sync errors out (`tabs.go:114`) rather than persisting an incomplete mapping. (`tabs.go:155`)
 
 ### 8.y Failure modes
@@ -177,14 +177,14 @@ The `invoice` mapping stores the Tabs **invoice** ID as `provider_entity_id` (`t
 
 1. **`ListInvoicesResponse` / `TabsInvoice` DTOs are marked "best guess pending a confirmed sample response"** (`dto.go:50-57`) — they were written against Tabs' documented shape, not a captured real response. Since `mapInvoice` now stores the Tabs invoice ID as the mapping's `provider_entity_id` (not just metadata), an incorrect DTO shape means `fetchTabsInvoiceID` returns `""` and the whole sync fails at `tabs.go:114` — so this must be verified against a live Tabs sandbox call before it's trusted for a real customer.
 2. **`jobPollAttempts`/`jobPollInterval` (3 attempts × 2s ≈ 6s)** is quite short for an async customer-creation job with no documented Tabs SLA. If Tabs' job actually takes longer under load, every first sync for a new customer will fail and rely on the workflow's 3× activity retry to eventually succeed — worth confirming Tabs' real p99 job latency.
-3. **Tabs products no longer carry the FlexPrice price ID** (`integrationItemId` was dropped from `CreateProductRequest`). The price↔product association now lives only in FlexPrice's `entity_integration_mapping`, not on the Tabs side — confirm Tabs doesn't need a back-reference for its own reconciliation/reporting.
+3. **Tabs products no longer carry the Flexprice price ID** (`integrationItemId` was dropped from `CreateProductRequest`). The price↔product association now lives only in Flexprice's `entity_integration_mapping`, not on the Tabs side — confirm Tabs doesn't need a back-reference for its own reconciliation/reporting.
 
 ## 11. Alternatives Considered
 
 | Alternative | Rejected because |
 |---|---|
 | Route Tabs sync through `interfaces.EntityIntegrationMappingService` (the adapter Paddle uses, `factory.go:108`) instead of calling `mappingRepo` directly | Every other push-only provider (Stripe, Zoho, Chargebee, etc.) also calls `entityIntegrationMappingRepo` directly; the adapter exists specifically to decouple Paddle's more complex bidirectional sync loop. Using it here would be inconsistent with the simpler providers this one most resembles, for no benefit. |
-| One obligation per line item (no product grouping) | Tabs contracts likely expect one obligation per priced product, and grouping avoids creating N nearly-identical obligations for, e.g., a plan with a flat fee plus several usage line items on the same price. Chosen grouping key is the Tabs product (i.e., the FlexPrice price), matching how Tabs models recurring charges. |
+| One obligation per line item (no product grouping) | Tabs contracts likely expect one obligation per priced product, and grouping avoids creating N nearly-identical obligations for, e.g., a plan with a flat fee plus several usage line items on the same price. Chosen grouping key is the Tabs product (i.e., the Flexprice price), matching how Tabs models recurring charges. |
 | Real-time (synchronous) Tabs sync during invoice finalization, instead of async via Kafka + Temporal | Every other provider already uses the async dispatch pattern specifically to keep invoice finalization fast and to get Temporal's retry/idempotency guarantees for free; deviating here would both slow down finalization and require bespoke error handling. |
 
 ## 12. Decisions Log
@@ -193,10 +193,10 @@ The `invoice` mapping stores the Tabs **invoice** ID as `provider_entity_id` (`t
 |---|---|
 | Add Tabs as provider #10 using the exact same client/service/activity/workflow/factory shape as the other providers | Minimizes reviewer cognitive load and reuses every cross-cutting concern (idempotency, retries, encryption, dispatch gating) instead of re-deriving it |
 | Group line items by Tabs product before creating obligations, rather than 1:1 | Matches Tabs' contract/obligation data model (one obligation = one charge type) and keeps the number of Tabs API calls proportional to distinct products, not line items |
-| Use `entity_integration_mapping` with a new `invoice_line_item` entity type instead of a new join table | The existing mapping table already generalizes to "any FlexPrice entity ↔ any provider entity"; adding a table for one new granularity would duplicate its schema for no new capability |
+| Use `entity_integration_mapping` with a new `invoice_line_item` entity type instead of a new join table | The existing mapping table already generalizes to "any Flexprice entity ↔ any provider entity"; adding a table for one new granularity would duplicate its schema for no new capability |
 | Mark Tabs contracts `PROCESSED` immediately after creation, before persisting the mapping | Ensures a persisted subscription→contract mapping always represents a contract that's actually usable for obligations, so a retry never has to special-case "contract exists but isn't processed yet" |
 | No dedicated Tabs customer-sync trigger (unlike Stripe/Paddle) | Tabs customers are cheap to create lazily on first invoice sync and there's no other trigger (e.g. no `customer.created` webhook consumer) that currently needs a Tabs customer to exist ahead of an invoice |
 | Store the Tabs **invoice** ID (not contract ID) as the `invoice` mapping's `provider_entity_id` | Consistency with every other provider's `invoice` mapping; the contract ID is preserved in `metadata.contract_id`. Removes the asymmetry that was previously flagged as an open question |
-| Dropped `integrationItemId` from `CreateProductRequest` | The price↔product link is fully owned by FlexPrice's `entity_integration_mapping`; sending a redundant back-reference to Tabs added coupling with no consumer (tracked as Open Question #3) |
+| Dropped `integrationItemId` from `CreateProductRequest` | The price↔product link is fully owned by Flexprice's `entity_integration_mapping`; sending a redundant back-reference to Tabs added coupling with no consumer (tracked as Open Question #3) |
 | Registered Tabs in `GetIntegrationByProvider`/`GetSupportedProviders`/`GetAvailableProviders` | Tabs is now visible to the generic integration and provider-listing paths for consistency with every other provider; `PullAndUpdateInvoice` stays "not supported" so no pull behavior is added |
 | Removed unused `TemporalIntegrationInvoiceSyncWorkflow` constant | Added to `types/temporal.go` during development but never wired to a workflow function or dispatch trigger; dead code, removed rather than documented as a gap |

--- a/internal/integration/tabs/tabs.go
+++ b/internal/integration/tabs/tabs.go
@@ -134,9 +134,9 @@ func (s *InvoiceService) SyncInvoiceToTabs(ctx context.Context, req TabsInvoiceS
 		return nil, err
 	}
 
-	// Find the Tabs invoice generated from the obligations (by contract + issue date).
-	issueDate := lo.FromPtr(inv.IssueDate)
-	tabsInvoiceID, err := s.fetchTabsInvoiceID(ctx, tabsContractID, issueDate.Format(time.DateOnly))
+	// Find the Tabs invoice generated from the obligations (by contract + billing-schedule start date).
+	billingStartDate := invoiceBillingStartDate(inv)
+	tabsInvoiceID, err := s.fetchTabsInvoiceID(ctx, tabsContractID, billingStartDate.Format(time.DateOnly))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +456,7 @@ func (s *InvoiceService) syncObligations(ctx context.Context, inv *invoice.Invoi
 	}
 	obligationIDs := distinctObligationIDs(existingMappings)
 
-	billingStartDate := lo.FromPtr(inv.IssueDate)
+	billingStartDate := invoiceBillingStartDate(inv)
 	itemsByCategory := groupLineItemsByCategory(inv.LineItems)
 
 	// Aggregate only the categories present on the invoice (it may carry just one type of charge).
@@ -690,6 +690,15 @@ func (s *InvoiceService) mapLineItemsToObligation(ctx context.Context, items []*
 	return nil
 }
 
+// invoiceBillingStartDate is the invoice's billing period start, falling back to its issue date for
+// invoice types (e.g. one-off, credit) that don't carry a period.
+func invoiceBillingStartDate(inv *invoice.Invoice) time.Time {
+	if inv.PeriodStart != nil {
+		return *inv.PeriodStart
+	}
+	return lo.FromPtr(inv.IssueDate)
+}
+
 // aggregateLineItems sums the line items' amounts and returns the group total and its service period.
 // Must be called with a non-empty group.
 func aggregateLineItems(items []*invoice.InvoiceLineItem) (total decimal.Decimal, serviceStart, serviceEnd time.Time) {
@@ -702,9 +711,9 @@ func aggregateLineItems(items []*invoice.InvoiceLineItem) (total decimal.Decimal
 	return total, serviceStart, serviceEnd
 }
 
-// fetchTabsInvoiceID returns the first Tabs invoice for the contract + issue date (empty if none yet).
-func (s *InvoiceService) fetchTabsInvoiceID(ctx context.Context, contractID string, issueDate string) (string, error) {
-	resp, err := s.client.ListInvoicesByContract(ctx, contractID, issueDate)
+// fetchTabsInvoiceID returns the first Tabs invoice for the contract + billing-schedule start date (empty if none yet).
+func (s *InvoiceService) fetchTabsInvoiceID(ctx context.Context, contractID string, billingStartDate string) (string, error) {
+	resp, err := s.client.ListInvoicesByContract(ctx, contractID, billingStartDate)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## **CodeAnt-AI Description**
Use the invoice billing period start when matching invoices in Tabs

### What Changed
- Tabs obligations and generated-invoice lookups now use the invoice’s billing period start date instead of its issue date.
- Invoices without a billing period, such as one-off or credit invoices, continue using the issue date as a fallback.
- Updated the Tabs sync documentation to describe the period-start behavior.

### Impact
`✅ Correct Tabs invoice matching for recurring billing periods`
`✅ Fewer failed invoice synchronizations`
`✅ Reliable handling of one-off and credit invoices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice synchronization now uses the invoice billing-period start date for lookups and obligation billing schedules.
  * If no billing-period start date is available, the invoice issue date is used instead.
* **Documentation**
  * Clarified invoice-sync behavior, provider registration, billing dates, product mappings, invoice ID storage, and grouped obligations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->