### PR TITLE
fix: update environment discovery routes

### DIFF
--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -96,12 +96,11 @@ func resolveEnvironmentID(ctx context.Context, c *gin.Context, environmentRepo d
 // isEnvironmentDiscoveryRoute reports whether a route can be served without an
 // environment selected.
 //
-// Listing and reading environments is scoped by tenant and user, never by
-// environment, so these handlers do not consult the resolved value. They are
-// also the only way an unbound caller — a dashboard JWT, which carries no
-// environment claim — can discover an ID to send in X-Environment-ID on every
-// later request. Refusing them for lack of a header would leave such a caller
-// unable to ever obtain one.
+// Only the bootstrap GETs are exempt: identity, environment discovery, and
+// tenant shell. Writes under the same groups still require a resolved
+// environment so a JWT without X-Environment-ID cannot create users, clone
+// environments, or mutate tenant billing. Signup already creates a default
+// environment, so CreateEnvironment is not part of this set.
 func isEnvironmentDiscoveryRoute(c *gin.Context) bool {
 	if c.Request.Method != http.MethodGet {
 		return false
@@ -109,7 +108,7 @@ func isEnvironmentDiscoveryRoute(c *gin.Context) bool {
 	// FullPath is the matched route template, so this cannot be spoofed by a
 	// crafted URL the router did not match to these handlers.
 	switch c.FullPath() {
-	case "/v1/environments", "/v1/environments/:id":
+	case "/v1/users/me", "/v1/environments", "/v1/environments/:id", "/v1/tenants/:id":
 		return true
 	default:
 		return false

--- a/internal/rest/middleware/auth_test.go
+++ b/internal/rest/middleware/auth_test.go
@@ -382,11 +382,10 @@ func TestResolveEnvironmentIDPropagatesRepositoryFailures(t *testing.T) {
 
 }
 
-// The dashboard learns which environments exist by calling GET /v1/environments,
-// and only then can it send X-Environment-ID on subsequent requests. Its login
-// JWT carries no environment claim, so requiring a header to reach that route
-// would be circular: the caller could never obtain an ID to send. These routes
-// are tenant- and user-scoped and do not read the resolved environment.
+// The dashboard bootstraps via a small set of GETs before it can send
+// X-Environment-ID. Its login JWT carries no environment claim, so requiring a
+// header to reach those routes would be circular. Writes under the same groups
+// still require a selection.
 func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -406,36 +405,55 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 				"environment_id": types.GetEnvironmentID(c.Request.Context()),
 			})
 		}
+		r.GET("/v1/users/me", handler)
+		r.PUT("/v1/users/me", handler)
+		r.POST("/v1/users", handler)
 		r.GET("/v1/environments", handler)
 		r.GET("/v1/environments/:id", handler)
+		r.POST("/v1/environments", handler)
+		r.POST("/v1/environments/:id/clone", handler)
+		r.GET("/v1/tenants/:id", handler)
+		r.GET("/v1/tenants/billing", handler)
+		r.PUT("/v1/tenants/update", handler)
 		r.GET("/v1/customers", handler)
 		return r
 	}
 
-	get := func(path string) *httptest.ResponseRecorder {
+	do := func(method, path string) *httptest.ResponseRecorder {
 		w := httptest.NewRecorder()
-		req, _ := http.NewRequest(http.MethodGet, path, nil)
+		req, _ := http.NewRequest(method, path, nil)
 		req.Header.Set("Authorization", "Bearer "+makeJWT(t, "t_tenant1", "usr_dev", "", 1))
 		newRouter().ServeHTTP(w, req)
 		return w
 	}
 
-	t.Run("listing environments succeeds without a header", func(t *testing.T) {
-		w := get("/v1/environments")
-
-		require.Equal(t, http.StatusOK, w.Code)
-		// No environment is selected, so none is placed in the context.
-		assert.Contains(t, w.Body.String(), `"environment_id":""`)
+	t.Run("bootstrap GETs succeed without a header", func(t *testing.T) {
+		for _, path := range []string{
+			"/v1/users/me",
+			"/v1/environments",
+			"/v1/environments/env_dev",
+			"/v1/tenants/t_tenant1",
+		} {
+			w := do(http.MethodGet, path)
+			require.Equal(t, http.StatusOK, w.Code, path)
+			assert.Contains(t, w.Body.String(), `"environment_id":""`, path)
+		}
 	})
 
-	t.Run("reading a single environment succeeds without a header", func(t *testing.T) {
-		assert.Equal(t, http.StatusOK, get("/v1/environments/env_dev").Code)
-	})
-
-	// The exemption is limited to discovery: every other route still requires a
-	// selection, so this cannot be used to reach tenant data without one.
-	t.Run("an ordinary route without a header is still refused", func(t *testing.T) {
-		assert.Equal(t, http.StatusForbidden, get("/v1/customers").Code)
+	t.Run("writes and non-bootstrap reads under the same groups still require a header", func(t *testing.T) {
+		for _, tc := range []struct {
+			method, path string
+		}{
+			{http.MethodPut, "/v1/users/me"},
+			{http.MethodPost, "/v1/users"},
+			{http.MethodPost, "/v1/environments"},
+			{http.MethodPost, "/v1/environments/env_dev/clone"},
+			{http.MethodGet, "/v1/tenants/billing"},
+			{http.MethodPut, "/v1/tenants/update"},
+			{http.MethodGet, "/v1/customers"},
+		} {
+			assert.Equal(t, http.StatusForbidden, do(tc.method, tc.path).Code, tc.method+" "+tc.path)
+		}
 	})
 }
 


### PR DESCRIPTION
## **CodeAnt-AI Description**
Allow dashboard bootstrap requests without an environment selection

### What Changed
- Unauthenticated-by-environment GET requests for the current user, environment discovery, and tenant details now work without `X-Environment-ID`
- Writes and environment-dependent reads in those areas still require an environment selection
- Expanded coverage verifies allowed bootstrap requests and blocked non-bootstrap requests

### Impact
`✅ Dashboard setup can discover environments`
`✅ Prevented environment-less data access`
`✅ Clear separation between bootstrap reads and protected operations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard initialization requests can now load user, environment, and tenant details without an environment header.
  * Write operations and other routes continue to require environment context, improving authorization consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->