### PR TITLE
fix(stripe): reconcile checkout-time discounts against actual captured amount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ graphify-out/server
 # Security assessment working directory. This repository is public; scan
 # configuration and findings must not be published here.
 shannon-setup/
+
+# Local git worktrees for isolated feature work (superpowers:using-git-worktrees)
+.worktrees/

--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -1415,3 +1415,16 @@ type GetUnpaidInvoicesToBePaidResponse struct {
 	// total paid invoice amount
 	TotalPaidInvoiceAmount decimal.Decimal `json:"total_paid_invoice_amount" swaggertype:"string"`
 }
+
+type ApplyExternalInvoiceDiscountRequest struct {
+	DiscountAmount decimal.Decimal `json:"discount_amount"`
+	MetadataKey    string          `json:"metadata_key,omitempty"`
+	MetadataJSON   string          `json:"metadata_json,omitempty"`
+}
+
+func (r *ApplyExternalInvoiceDiscountRequest) Validate() error {
+	if err := validator.ValidateRequest(r); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/api/dto/payment.go
+++ b/internal/api/dto/payment.go
@@ -74,16 +74,17 @@ func (o *StripePaymentGatewayOptions) Validate(paymentMethodType types.PaymentMe
 
 // UpdatePaymentRequest represents a request to update a payment
 type UpdatePaymentRequest struct {
-	PaymentStatus    *string         `json:"payment_status,omitempty"`
-	PaymentGateway   *string         `json:"payment_gateway,omitempty"`
-	GatewayPaymentID *string         `json:"gateway_payment_id,omitempty"`
-	PaymentMethodID  *string         `json:"payment_method_id,omitempty"`
-	Metadata         *types.Metadata `json:"metadata,omitempty"`
-	SucceededAt      *time.Time      `json:"succeeded_at,omitempty"`
-	FailedAt         *time.Time      `json:"failed_at,omitempty"`
-	VoidedAt         *time.Time      `json:"voided_at,omitempty"`
-	RefundedAt       *time.Time      `json:"refunded_at,omitempty"`
-	ErrorMessage     *string         `json:"error_message,omitempty"`
+	PaymentStatus    *string          `json:"payment_status,omitempty"`
+	PaymentGateway   *string          `json:"payment_gateway,omitempty"`
+	GatewayPaymentID *string          `json:"gateway_payment_id,omitempty"`
+	PaymentMethodID  *string          `json:"payment_method_id,omitempty"`
+	Amount           *decimal.Decimal `json:"amount,omitempty" swaggertype:"string"`
+	Metadata         *types.Metadata  `json:"metadata,omitempty"`
+	SucceededAt      *time.Time       `json:"succeeded_at,omitempty"`
+	FailedAt         *time.Time       `json:"failed_at,omitempty"`
+	VoidedAt         *time.Time       `json:"voided_at,omitempty"`
+	RefundedAt       *time.Time       `json:"refunded_at,omitempty"`
+	ErrorMessage     *string          `json:"error_message,omitempty"`
 }
 
 // PaymentResponse represents a payment response

--- a/internal/api/dto/payment.go
+++ b/internal/api/dto/payment.go
@@ -74,20 +74,17 @@ func (o *StripePaymentGatewayOptions) Validate(paymentMethodType types.PaymentMe
 
 // UpdatePaymentRequest represents a request to update a payment
 type UpdatePaymentRequest struct {
-	PaymentStatus    *string `json:"payment_status,omitempty"`
-	PaymentGateway   *string `json:"payment_gateway,omitempty"`
-	GatewayPaymentID *string `json:"gateway_payment_id,omitempty"`
-	PaymentMethodID  *string `json:"payment_method_id,omitempty"`
-	// Amount is for internal/webhook-triggered corrections only (e.g. reconciling against
-	// what a payment gateway actually captured). The public PUT /payments/{id} handler
-	// strips this field before calling the service — never client-settable.
-	Amount       *decimal.Decimal `json:"amount,omitempty" swaggertype:"string"`
-	Metadata     *types.Metadata  `json:"metadata,omitempty"`
-	SucceededAt  *time.Time       `json:"succeeded_at,omitempty"`
-	FailedAt     *time.Time       `json:"failed_at,omitempty"`
-	VoidedAt     *time.Time       `json:"voided_at,omitempty"`
-	RefundedAt   *time.Time       `json:"refunded_at,omitempty"`
-	ErrorMessage *string          `json:"error_message,omitempty"`
+	PaymentStatus    *string          `json:"payment_status,omitempty"`
+	PaymentGateway   *string          `json:"payment_gateway,omitempty"`
+	GatewayPaymentID *string          `json:"gateway_payment_id,omitempty"`
+	PaymentMethodID  *string          `json:"payment_method_id,omitempty"`
+	Amount           *decimal.Decimal `json:"-"`
+	Metadata         *types.Metadata  `json:"metadata,omitempty"`
+	SucceededAt      *time.Time       `json:"succeeded_at,omitempty"`
+	FailedAt         *time.Time       `json:"failed_at,omitempty"`
+	VoidedAt         *time.Time       `json:"voided_at,omitempty"`
+	RefundedAt       *time.Time       `json:"refunded_at,omitempty"`
+	ErrorMessage     *string          `json:"error_message,omitempty"`
 }
 
 // PaymentResponse represents a payment response

--- a/internal/api/dto/payment.go
+++ b/internal/api/dto/payment.go
@@ -74,17 +74,20 @@ func (o *StripePaymentGatewayOptions) Validate(paymentMethodType types.PaymentMe
 
 // UpdatePaymentRequest represents a request to update a payment
 type UpdatePaymentRequest struct {
-	PaymentStatus    *string          `json:"payment_status,omitempty"`
-	PaymentGateway   *string          `json:"payment_gateway,omitempty"`
-	GatewayPaymentID *string          `json:"gateway_payment_id,omitempty"`
-	PaymentMethodID  *string          `json:"payment_method_id,omitempty"`
-	Amount           *decimal.Decimal `json:"amount,omitempty" swaggertype:"string"`
-	Metadata         *types.Metadata  `json:"metadata,omitempty"`
-	SucceededAt      *time.Time       `json:"succeeded_at,omitempty"`
-	FailedAt         *time.Time       `json:"failed_at,omitempty"`
-	VoidedAt         *time.Time       `json:"voided_at,omitempty"`
-	RefundedAt       *time.Time       `json:"refunded_at,omitempty"`
-	ErrorMessage     *string          `json:"error_message,omitempty"`
+	PaymentStatus    *string `json:"payment_status,omitempty"`
+	PaymentGateway   *string `json:"payment_gateway,omitempty"`
+	GatewayPaymentID *string `json:"gateway_payment_id,omitempty"`
+	PaymentMethodID  *string `json:"payment_method_id,omitempty"`
+	// Amount is for internal/webhook-triggered corrections only (e.g. reconciling against
+	// what a payment gateway actually captured). The public PUT /payments/{id} handler
+	// strips this field before calling the service — never client-settable.
+	Amount       *decimal.Decimal `json:"amount,omitempty" swaggertype:"string"`
+	Metadata     *types.Metadata  `json:"metadata,omitempty"`
+	SucceededAt  *time.Time       `json:"succeeded_at,omitempty"`
+	FailedAt     *time.Time       `json:"failed_at,omitempty"`
+	VoidedAt     *time.Time       `json:"voided_at,omitempty"`
+	RefundedAt   *time.Time       `json:"refunded_at,omitempty"`
+	ErrorMessage *string          `json:"error_message,omitempty"`
 }
 
 // PaymentResponse represents a payment response

--- a/internal/api/v1/payment.go
+++ b/internal/api/v1/payment.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
@@ -116,6 +116,9 @@ func (h *PaymentHandler) UpdatePayment(c *gin.Context) {
 			Mark(ierr.ErrValidation))
 		return
 	}
+	// Amount correction is only for internal/webhook-triggered callers (e.g. reconciling
+	// against what Stripe actually captured) — never client-settable via the public API.
+	req.Amount = nil
 
 	resp, err := h.service.UpdatePayment(c.Request.Context(), id, req)
 	if err != nil {

--- a/internal/api/v1/payment.go
+++ b/internal/api/v1/payment.go
@@ -116,10 +116,6 @@ func (h *PaymentHandler) UpdatePayment(c *gin.Context) {
 			Mark(ierr.ErrValidation))
 		return
 	}
-	// Amount correction is only for internal/webhook-triggered callers (e.g. reconciling
-	// against what Stripe actually captured) — never client-settable via the public API.
-	req.Amount = nil
-
 	resp, err := h.service.UpdatePayment(c.Request.Context(), id, req)
 	if err != nil {
 		h.log.Error(c.Request.Context(), "Failed to update payment", "error", err)

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -4579,12 +4579,11 @@ func (s *invoiceService) DistributeInvoiceLevelDiscount(ctx context.Context, lin
 	return nil
 }
 
-// ApplyExternalInvoiceDiscount records a discount applied on an external provider (e.g. a
-// Stripe promotion code at checkout) against an existing invoice: distributes it across line
-// items via DistributeInvoiceLevelDiscount, keeps AmountDue/AmountRemaining/TotalDiscount
-// consistent with Invoice.Validate()'s invariant, and appends discount detail to metadata.
-func (s *invoiceService) ApplyExternalInvoiceDiscount(ctx context.Context, invoiceID string, discountAmount decimal.Decimal, metadataJSON string) error {
-	if discountAmount.IsZero() {
+func (s *invoiceService) ApplyExternalInvoiceDiscount(ctx context.Context, invoiceID string, req dto.ApplyExternalInvoiceDiscountRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+	if req.DiscountAmount.IsZero() {
 		return nil
 	}
 
@@ -4599,7 +4598,7 @@ func (s *invoiceService) ApplyExternalInvoiceDiscount(ctx context.Context, invoi
 			existingInvoiceLevelDiscount = existingInvoiceLevelDiscount.Add(li.InvoiceLevelDiscount)
 		}
 
-		if err := s.DistributeInvoiceLevelDiscount(txCtx, inv.LineItems, existingInvoiceLevelDiscount.Add(discountAmount)); err != nil {
+		if err := s.DistributeInvoiceLevelDiscount(txCtx, inv.LineItems, existingInvoiceLevelDiscount.Add(req.DiscountAmount)); err != nil {
 			return err
 		}
 
@@ -4609,20 +4608,20 @@ func (s *invoiceService) ApplyExternalInvoiceDiscount(ctx context.Context, invoi
 			}
 		}
 
-		inv.TotalDiscount = inv.TotalDiscount.Add(discountAmount)
-		inv.Total = inv.Total.Sub(discountAmount)
-		inv.AmountDue = inv.AmountDue.Sub(discountAmount)
-		inv.AmountRemaining = inv.AmountRemaining.Sub(discountAmount)
+		inv.TotalDiscount = inv.TotalDiscount.Add(req.DiscountAmount)
+		inv.Total = inv.Total.Sub(req.DiscountAmount)
+		inv.AmountDue = inv.AmountDue.Sub(req.DiscountAmount)
+		inv.AmountRemaining = inv.AmountRemaining.Sub(req.DiscountAmount)
 
-		if metadataJSON != "" {
+		if req.MetadataJSON != "" && req.MetadataKey != "" {
 			if inv.Metadata == nil {
 				inv.Metadata = types.Metadata{}
 			}
-			merged, err := mergeJSONArrayMetadata(inv.Metadata["stripe_checkout_discounts"], metadataJSON)
+			merged, err := mergeJSONArrayMetadata(inv.Metadata[req.MetadataKey], req.MetadataJSON)
 			if err != nil {
 				return err
 			}
-			inv.Metadata["stripe_checkout_discounts"] = merged
+			inv.Metadata[req.MetadataKey] = merged
 		}
 
 		if err := inv.Validate(); err != nil {

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -4578,3 +4578,79 @@ func (s *invoiceService) DistributeInvoiceLevelDiscount(ctx context.Context, lin
 
 	return nil
 }
+
+// ApplyExternalInvoiceDiscount records a discount applied on an external provider (e.g. a
+// Stripe promotion code at checkout) against an existing invoice: distributes it across line
+// items via DistributeInvoiceLevelDiscount, keeps AmountDue/AmountRemaining/TotalDiscount
+// consistent with Invoice.Validate()'s invariant, and appends discount detail to metadata.
+func (s *invoiceService) ApplyExternalInvoiceDiscount(ctx context.Context, invoiceID string, discountAmount decimal.Decimal, metadataJSON string) error {
+	if discountAmount.IsZero() {
+		return nil
+	}
+
+	return s.DB.WithTx(ctx, func(txCtx context.Context) error {
+		inv, err := s.InvoiceRepo.GetForUpdate(txCtx, invoiceID)
+		if err != nil {
+			return err
+		}
+
+		existingInvoiceLevelDiscount := decimal.Zero
+		for _, li := range inv.LineItems {
+			existingInvoiceLevelDiscount = existingInvoiceLevelDiscount.Add(li.InvoiceLevelDiscount)
+		}
+
+		if err := s.DistributeInvoiceLevelDiscount(txCtx, inv.LineItems, existingInvoiceLevelDiscount.Add(discountAmount)); err != nil {
+			return err
+		}
+
+		for _, li := range inv.LineItems {
+			if err := s.InvoiceLineItemRepo.Update(txCtx, li); err != nil {
+				return err
+			}
+		}
+
+		inv.TotalDiscount = inv.TotalDiscount.Add(discountAmount)
+		inv.AmountDue = inv.AmountDue.Sub(discountAmount)
+		inv.AmountRemaining = inv.AmountRemaining.Sub(discountAmount)
+
+		if metadataJSON != "" {
+			if inv.Metadata == nil {
+				inv.Metadata = types.Metadata{}
+			}
+			merged, err := mergeJSONArrayMetadata(inv.Metadata["stripe_checkout_discounts"], metadataJSON)
+			if err != nil {
+				return err
+			}
+			inv.Metadata["stripe_checkout_discounts"] = merged
+		}
+
+		if err := inv.Validate(); err != nil {
+			return err
+		}
+
+		return s.InvoiceRepo.Update(txCtx, inv)
+	})
+}
+
+// mergeJSONArrayMetadata appends the entries in newEntriesJSON (a JSON array) onto existing
+// (a JSON array string, or "" if absent), returning the re-marshaled combined array.
+func mergeJSONArrayMetadata(existing string, newEntriesJSON string) (string, error) {
+	var combined []json.RawMessage
+	if existing != "" {
+		if err := json.Unmarshal([]byte(existing), &combined); err != nil {
+			return "", ierr.WithError(err).WithHint("Failed to parse existing discount metadata").Mark(ierr.ErrValidation)
+		}
+	}
+
+	var newEntries []json.RawMessage
+	if err := json.Unmarshal([]byte(newEntriesJSON), &newEntries); err != nil {
+		return "", ierr.WithError(err).WithHint("Failed to parse new discount metadata").Mark(ierr.ErrValidation)
+	}
+	combined = append(combined, newEntries...)
+
+	merged, err := json.Marshal(combined)
+	if err != nil {
+		return "", ierr.WithError(err).WithHint("Failed to marshal merged discount metadata").Mark(ierr.ErrValidation)
+	}
+	return string(merged), nil
+}

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -4610,6 +4610,7 @@ func (s *invoiceService) ApplyExternalInvoiceDiscount(ctx context.Context, invoi
 		}
 
 		inv.TotalDiscount = inv.TotalDiscount.Add(discountAmount)
+		inv.Total = inv.Total.Sub(discountAmount)
 		inv.AmountDue = inv.AmountDue.Sub(discountAmount)
 		inv.AmountRemaining = inv.AmountRemaining.Sub(discountAmount)
 

--- a/internal/ee/service/invoice_apply_external_discount_test.go
+++ b/internal/ee/service/invoice_apply_external_discount_test.go
@@ -1,0 +1,194 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+type ApplyExternalInvoiceDiscountSuite struct {
+	testutil.BaseServiceTestSuite
+	service  InvoiceService
+	testData struct {
+		customer *customer.Customer
+	}
+}
+
+func TestApplyExternalInvoiceDiscount(t *testing.T) {
+	suite.Run(t, new(ApplyExternalInvoiceDiscountSuite))
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.setupService()
+	s.setupTestData()
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) GetContext() context.Context {
+	return types.SetEnvironmentID(s.BaseServiceTestSuite.GetContext(), "env_test")
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) setupService() {
+	s.service = NewInvoiceService(ServiceParams{
+		Logger:                     s.GetLogger(),
+		Config:                     s.GetConfig(),
+		DB:                         s.GetDB(),
+		SubRepo:                    s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo:   s.GetStores().SubscriptionLineItemRepo,
+		PlanRepo:                   s.GetStores().PlanRepo,
+		PriceRepo:                  s.GetStores().PriceRepo,
+		EventRepo:                  s.GetStores().EventRepo,
+		MeterRepo:                  s.GetStores().MeterRepo,
+		CustomerRepo:               s.GetStores().CustomerRepo,
+		InvoiceRepo:                s.GetStores().InvoiceRepo,
+		InvoiceLineItemRepo:        s.GetStores().InvoiceLineItemRepo,
+		EntitlementRepo:            s.GetStores().EntitlementRepo,
+		EnvironmentRepo:            s.GetStores().EnvironmentRepo,
+		FeatureRepo:                s.GetStores().FeatureRepo,
+		AddonAssociationRepo:       s.GetStores().AddonAssociationRepo,
+		TenantRepo:                 s.GetStores().TenantRepo,
+		UserRepo:                   s.GetStores().UserRepo,
+		AuthRepo:                   s.GetStores().AuthRepo,
+		WalletRepo:                 s.GetStores().WalletRepo,
+		PaymentRepo:                s.GetStores().PaymentRepo,
+		CreditNoteRepo:             s.GetStores().CreditNoteRepo,
+		CouponRepo:                 s.GetStores().CouponRepo,
+		CouponAssociationRepo:      s.GetStores().CouponAssociationRepo,
+		CouponApplicationRepo:      s.GetStores().CouponApplicationRepo,
+		EventPublisher:             s.GetPublisher(),
+		WebhookPublisher:           s.GetWebhookPublisher(),
+		CreditGrantRepo:            s.GetStores().CreditGrantRepo,
+		CreditGrantApplicationRepo: s.GetStores().CreditGrantApplicationRepo,
+		CreditNoteLineItemRepo:     s.GetStores().CreditNoteLineItemRepo,
+		TaxRateRepo:                s.GetStores().TaxRateRepo,
+		TaxAppliedRepo:             s.GetStores().TaxAppliedRepo,
+		TaxAssociationRepo:         s.GetStores().TaxAssociationRepo,
+		SettingsRepo:               s.GetStores().SettingsRepo,
+		AlertLogsRepo:              s.GetStores().AlertLogsRepo,
+		WalletBalanceAlertPubSub:   types.WalletBalanceAlertPubSub{PubSub: testutil.NewInMemoryPubSub()},
+	})
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) setupTestData() {
+	s.BaseServiceTestSuite.ClearStores()
+	s.testData.customer = &customer.Customer{
+		ID:         "cust_ext_discount_test",
+		ExternalID: "ext_cust_ext_discount_test",
+		Name:       "External Discount Test Customer",
+		BaseModel:  types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().CustomerRepo.Create(s.GetContext(), s.testData.customer))
+}
+
+// createDraftInvoice creates a one-off draft invoice with a single line item, amountDue == amount,
+// amountRemaining == amount (so it satisfies Invoice.Validate()'s AmountPaid+AmountRemaining==AmountDue).
+func (s *ApplyExternalInvoiceDiscountSuite) createDraftInvoice(id string, amount decimal.Decimal, existingInvoiceLevelDiscount decimal.Decimal) *invoice.Invoice {
+	li := &invoice.InvoiceLineItem{
+		ID:                   s.GetUUID(),
+		InvoiceID:            id,
+		CustomerID:           s.testData.customer.ID,
+		Amount:               amount,
+		Quantity:             decimal.NewFromInt(1),
+		Currency:             "usd",
+		LineItemDiscount:     decimal.Zero,
+		InvoiceLevelDiscount: existingInvoiceLevelDiscount,
+		BaseModel:            types.GetDefaultBaseModel(s.GetContext()),
+	}
+	inv := &invoice.Invoice{
+		ID:              id,
+		CustomerID:      s.testData.customer.ID,
+		Currency:        "usd",
+		Subtotal:        amount,
+		Total:           amount.Sub(existingInvoiceLevelDiscount),
+		TotalDiscount:   existingInvoiceLevelDiscount,
+		AmountDue:       amount.Sub(existingInvoiceLevelDiscount),
+		AmountRemaining: amount.Sub(existingInvoiceLevelDiscount),
+		InvoiceType:     types.InvoiceTypeOneOff,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusPending,
+		BaseModel:       types.GetDefaultBaseModel(s.GetContext()),
+		LineItems:       []*invoice.InvoiceLineItem{li},
+	}
+	s.NoError(s.GetStores().InvoiceRepo.CreateWithLineItems(s.GetContext(), inv))
+	return inv
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) TestFreshInvoice_NoExistingDiscount() {
+	inv := s.createDraftInvoice("inv_fresh", decimal.NewFromInt(100), decimal.Zero)
+
+	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(20), `[{"stripe_coupon_id":"cp_1"}]`)
+	s.NoError(err)
+
+	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(20).Equal(updated.TotalDiscount))
+	s.True(decimal.NewFromInt(80).Equal(updated.AmountDue))
+	s.True(decimal.NewFromInt(80).Equal(updated.AmountRemaining))
+	s.NoError(updated.Validate())
+
+	items, err := s.GetStores().InvoiceLineItemRepo.ListByInvoiceID(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.Require().Len(items, 1)
+	s.True(decimal.NewFromInt(20).Equal(items[0].InvoiceLevelDiscount))
+
+	s.Equal(`[{"stripe_coupon_id":"cp_1"}]`, updated.Metadata["stripe_checkout_discounts"])
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) TestDoesNotClobberExistingInvoiceLevelDiscount() {
+	// Invoice already has a $10 invoice-level discount from FlexPrice's own coupon engine.
+	inv := s.createDraftInvoice("inv_existing_discount", decimal.NewFromInt(100), decimal.NewFromInt(10))
+
+	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(20), `[{"stripe_coupon_id":"cp_2"}]`)
+	s.NoError(err)
+
+	items, err := s.GetStores().InvoiceLineItemRepo.ListByInvoiceID(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.Require().Len(items, 1)
+	// Must be the CUMULATIVE total (10 existing + 20 new = 30), not just the new 20 —
+	// this is the regression test for the DistributeInvoiceLevelDiscount reset bug.
+	s.True(decimal.NewFromInt(30).Equal(items[0].InvoiceLevelDiscount))
+
+	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(30).Equal(updated.TotalDiscount))
+	s.True(decimal.NewFromInt(70).Equal(updated.AmountDue))
+	s.NoError(updated.Validate())
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) TestAppendsMetadataRatherThanOverwriting() {
+	inv := s.createDraftInvoice("inv_second_payment", decimal.NewFromInt(200), decimal.Zero)
+
+	s.NoError(s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(10), `[{"stripe_coupon_id":"cp_first"}]`))
+	s.NoError(s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(5), `[{"stripe_coupon_id":"cp_second"}]`))
+
+	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+
+	var entries []map[string]interface{}
+	s.NoError(json.Unmarshal([]byte(updated.Metadata["stripe_checkout_discounts"]), &entries))
+	s.Require().Len(entries, 2)
+	s.Equal("cp_first", entries[0]["stripe_coupon_id"])
+	s.Equal("cp_second", entries[1]["stripe_coupon_id"])
+
+	s.True(decimal.NewFromInt(15).Equal(updated.TotalDiscount))
+	s.True(decimal.NewFromInt(185).Equal(updated.AmountDue))
+}
+
+func (s *ApplyExternalInvoiceDiscountSuite) TestZeroDiscountIsANoOp() {
+	inv := s.createDraftInvoice("inv_zero", decimal.NewFromInt(50), decimal.Zero)
+
+	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.Zero, "")
+	s.NoError(err)
+
+	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.True(decimal.NewFromInt(50).Equal(updated.AmountDue))
+	s.True(decimal.Zero.Equal(updated.TotalDiscount))
+}

--- a/internal/ee/service/invoice_apply_external_discount_test.go
+++ b/internal/ee/service/invoice_apply_external_discount_test.go
@@ -129,6 +129,7 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestFreshInvoice_NoExistingDiscount(
 	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
 	s.NoError(err)
 	s.True(decimal.NewFromInt(20).Equal(updated.TotalDiscount))
+	s.True(decimal.NewFromInt(80).Equal(updated.Total))
 	s.True(decimal.NewFromInt(80).Equal(updated.AmountDue))
 	s.True(decimal.NewFromInt(80).Equal(updated.AmountRemaining))
 	s.NoError(updated.Validate())
@@ -158,6 +159,7 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestDoesNotClobberExistingInvoiceLev
 	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
 	s.NoError(err)
 	s.True(decimal.NewFromInt(30).Equal(updated.TotalDiscount))
+	s.True(decimal.NewFromInt(70).Equal(updated.Total))
 	s.True(decimal.NewFromInt(70).Equal(updated.AmountDue))
 	s.NoError(updated.Validate())
 }
@@ -178,6 +180,7 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestAppendsMetadataRatherThanOverwri
 	s.Equal("cp_second", entries[1]["stripe_coupon_id"])
 
 	s.True(decimal.NewFromInt(15).Equal(updated.TotalDiscount))
+	s.True(decimal.NewFromInt(185).Equal(updated.Total))
 	s.True(decimal.NewFromInt(185).Equal(updated.AmountDue))
 }
 
@@ -190,5 +193,6 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestZeroDiscountIsANoOp() {
 	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
 	s.NoError(err)
 	s.True(decimal.NewFromInt(50).Equal(updated.AmountDue))
+	s.True(decimal.NewFromInt(50).Equal(updated.Total))
 	s.True(decimal.Zero.Equal(updated.TotalDiscount))
 }

--- a/internal/ee/service/invoice_apply_external_discount_test.go
+++ b/internal/ee/service/invoice_apply_external_discount_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/testutil"
@@ -123,7 +124,11 @@ func (s *ApplyExternalInvoiceDiscountSuite) createDraftInvoice(id string, amount
 func (s *ApplyExternalInvoiceDiscountSuite) TestFreshInvoice_NoExistingDiscount() {
 	inv := s.createDraftInvoice("inv_fresh", decimal.NewFromInt(100), decimal.Zero)
 
-	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(20), `[{"stripe_coupon_id":"cp_1"}]`)
+	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, dto.ApplyExternalInvoiceDiscountRequest{
+		DiscountAmount: decimal.NewFromInt(20),
+		MetadataKey:    "stripe_checkout_discounts",
+		MetadataJSON:   `[{"stripe_coupon_id":"cp_1"}]`,
+	})
 	s.NoError(err)
 
 	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
@@ -146,7 +151,11 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestDoesNotClobberExistingInvoiceLev
 	// Invoice already has a $10 invoice-level discount from FlexPrice's own coupon engine.
 	inv := s.createDraftInvoice("inv_existing_discount", decimal.NewFromInt(100), decimal.NewFromInt(10))
 
-	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(20), `[{"stripe_coupon_id":"cp_2"}]`)
+	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, dto.ApplyExternalInvoiceDiscountRequest{
+		DiscountAmount: decimal.NewFromInt(20),
+		MetadataKey:    "stripe_checkout_discounts",
+		MetadataJSON:   `[{"stripe_coupon_id":"cp_2"}]`,
+	})
 	s.NoError(err)
 
 	items, err := s.GetStores().InvoiceLineItemRepo.ListByInvoiceID(s.GetContext(), inv.ID)
@@ -167,8 +176,16 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestDoesNotClobberExistingInvoiceLev
 func (s *ApplyExternalInvoiceDiscountSuite) TestAppendsMetadataRatherThanOverwriting() {
 	inv := s.createDraftInvoice("inv_second_payment", decimal.NewFromInt(200), decimal.Zero)
 
-	s.NoError(s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(10), `[{"stripe_coupon_id":"cp_first"}]`))
-	s.NoError(s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.NewFromInt(5), `[{"stripe_coupon_id":"cp_second"}]`))
+	s.NoError(s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, dto.ApplyExternalInvoiceDiscountRequest{
+		DiscountAmount: decimal.NewFromInt(10),
+		MetadataKey:    "stripe_checkout_discounts",
+		MetadataJSON:   `[{"stripe_coupon_id":"cp_first"}]`,
+	}))
+	s.NoError(s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, dto.ApplyExternalInvoiceDiscountRequest{
+		DiscountAmount: decimal.NewFromInt(5),
+		MetadataKey:    "stripe_checkout_discounts",
+		MetadataJSON:   `[{"stripe_coupon_id":"cp_second"}]`,
+	}))
 
 	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)
 	s.NoError(err)
@@ -187,7 +204,10 @@ func (s *ApplyExternalInvoiceDiscountSuite) TestAppendsMetadataRatherThanOverwri
 func (s *ApplyExternalInvoiceDiscountSuite) TestZeroDiscountIsANoOp() {
 	inv := s.createDraftInvoice("inv_zero", decimal.NewFromInt(50), decimal.Zero)
 
-	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, decimal.Zero, "")
+	err := s.service.ApplyExternalInvoiceDiscount(s.GetContext(), inv.ID, dto.ApplyExternalInvoiceDiscountRequest{
+		DiscountAmount: decimal.Zero,
+		MetadataKey:    "stripe_checkout_discounts",
+	})
 	s.NoError(err)
 
 	updated, err := s.GetStores().InvoiceRepo.Get(s.GetContext(), inv.ID)

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -426,6 +426,17 @@ func (s *paymentService) UpdatePayment(ctx context.Context, id string, req dto.U
 		p.PaymentMethodID = *req.PaymentMethodID
 	}
 	if req.Amount != nil {
+		// Once settled, an amount correction must go through a refund/credit note, not this.
+		if observedStatus != types.PaymentStatusInitiated && observedStatus != types.PaymentStatusPending &&
+			observedStatus != types.PaymentStatusProcessing {
+			return nil, ierr.NewError("cannot correct amount on a payment that has already settled").
+				WithHint("Amount corrections are only allowed while a payment is initiated, pending, or processing").
+				WithReportableDetails(map[string]interface{}{
+					"payment_id":     id,
+					"current_status": observedStatus,
+				}).
+				Mark(ierr.ErrValidation)
+		}
 		p.Amount = *req.Amount
 	}
 	if req.SucceededAt != nil {

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -425,6 +425,9 @@ func (s *paymentService) UpdatePayment(ctx context.Context, id string, req dto.U
 	if req.PaymentMethodID != nil {
 		p.PaymentMethodID = *req.PaymentMethodID
 	}
+	if req.Amount != nil {
+		p.Amount = *req.Amount
+	}
 	if req.SucceededAt != nil {
 		p.SucceededAt = req.SucceededAt
 	}

--- a/internal/ee/service/payment_test.go
+++ b/internal/ee/service/payment_test.go
@@ -579,6 +579,33 @@ func (s *PaymentServiceSuite) TestUpdatePaymentAppliesWhenStatusUnchanged() {
 	s.Equal(types.PaymentStatusSucceeded, stored.PaymentStatus)
 }
 
+func (s *PaymentServiceSuite) TestUpdatePaymentCorrectsAmount() {
+	ctx := s.GetContext()
+	repo := s.GetStores().PaymentRepo
+
+	p := &payment.Payment{
+		ID:                "pay_amount_correction",
+		DestinationType:   types.PaymentDestinationTypeInvoice,
+		DestinationID:     s.testData.invoice.ID,
+		PaymentMethodType: types.PaymentMethodTypePaymentLink,
+		PaymentStatus:     types.PaymentStatusPending,
+		Amount:            decimal.NewFromFloat(100),
+		Currency:          "usd",
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(repo.Create(ctx, p))
+
+	correctedAmount := decimal.NewFromFloat(80)
+	_, err := s.service.UpdatePayment(ctx, p.ID, dto.UpdatePaymentRequest{
+		Amount: &correctedAmount,
+	})
+	s.NoError(err)
+
+	stored, getErr := repo.Get(ctx, p.ID)
+	s.NoError(getErr)
+	s.True(correctedAmount.Equal(stored.Amount))
+}
+
 // The repository reports a conflict rather than silently writing nothing.
 func (s *PaymentServiceSuite) TestUpdateWithExpectedStatusReportsConflict() {
 	ctx := s.GetContext()

--- a/internal/ee/service/payment_test.go
+++ b/internal/ee/service/payment_test.go
@@ -606,6 +606,33 @@ func (s *PaymentServiceSuite) TestUpdatePaymentCorrectsAmount() {
 	s.True(correctedAmount.Equal(stored.Amount))
 }
 
+func (s *PaymentServiceSuite) TestUpdatePaymentRejectsAmountCorrectionOnSettledPayment() {
+	ctx := s.GetContext()
+	repo := s.GetStores().PaymentRepo
+
+	p := &payment.Payment{
+		ID:                "pay_amount_correction_settled",
+		DestinationType:   types.PaymentDestinationTypeInvoice,
+		DestinationID:     s.testData.invoice.ID,
+		PaymentMethodType: types.PaymentMethodTypePaymentLink,
+		PaymentStatus:     types.PaymentStatusSucceeded,
+		Amount:            decimal.NewFromFloat(100),
+		Currency:          "usd",
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(repo.Create(ctx, p))
+
+	correctedAmount := decimal.NewFromFloat(80)
+	_, err := s.service.UpdatePayment(ctx, p.ID, dto.UpdatePaymentRequest{
+		Amount: &correctedAmount,
+	})
+	s.Error(err)
+
+	stored, getErr := repo.Get(ctx, p.ID)
+	s.NoError(getErr)
+	s.True(p.Amount.Equal(stored.Amount), "amount must be unchanged once the payment has settled")
+}
+
 // The repository reports a conflict rather than silently writing nothing.
 func (s *PaymentServiceSuite) TestUpdateWithExpectedStatusReportsConflict() {
 	ctx := s.GetContext()

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -79,8 +79,10 @@ func (s *PaymentService) buildSyncedLineItems(ctx context.Context, invoiceResp *
 	return lineItems, nil
 }
 
+const checkoutDiscountMetadataKey = "stripe_checkout_discounts"
+
 // stripeCheckoutDiscountEntry is one entry in the JSON array stored under
-// Invoice.Metadata["stripe_checkout_discounts"].
+// Invoice.Metadata[checkoutDiscountMetadataKey].
 type stripeCheckoutDiscountEntry struct {
 	StripeCouponID string    `json:"stripe_coupon_id"`
 	Name           string    `json:"name"`
@@ -90,24 +92,17 @@ type stripeCheckoutDiscountEntry struct {
 	AppliedAt      time.Time `json:"applied_at"`
 }
 
-// computeCheckoutDiscount is pure (no Stripe calls) so it's unit-testable directly. Compares
-// what was requested against what Stripe actually captured. hasDiscount is false when they
-// match, or when actual > requested (the caller logs that case; never treated as a negative
-// discount).
-func computeCheckoutDiscount(session *stripe.CheckoutSession, requestedAmount decimal.Decimal) (
-	actualAmount decimal.Decimal, discountAmount decimal.Decimal, metadataJSON string, hasDiscount bool, err error,
-) {
-	actualAmount = types.FromSmallestUnit(session.AmountTotal, string(session.Currency))
+// computeCheckoutDiscount is pure (no Stripe calls) so it's unit-testable directly.
+func computeCheckoutDiscount(session *stripe.CheckoutSession, requestedAmount decimal.Decimal) (discountAmount decimal.Decimal, metadataJSON string, err error) {
+	actualAmount := types.FromSmallestUnit(session.AmountTotal, string(session.Currency))
 	if !actualAmount.LessThan(requestedAmount) {
-		return actualAmount, decimal.Zero, "", false, nil
+		return decimal.Zero, "", nil
 	}
 
 	discountAmount = requestedAmount.Sub(actualAmount)
 
 	entries := make([]stripeCheckoutDiscountEntry, 0, len(session.Discounts))
 	for _, d := range session.Discounts {
-		// lo.TernaryF (lazy) not lo.Ternary (eager) — d.Coupon.ID would nil-pointer-panic
-		// eagerly evaluating both branches when d.Coupon is nil.
 		entries = append(entries, stripeCheckoutDiscountEntry{
 			StripeCouponID: lo.TernaryF(d.Coupon != nil, func() string { return d.Coupon.ID }, func() string { return "" }),
 			Name:           lo.TernaryF(d.Coupon != nil, func() string { return d.Coupon.Name }, func() string { return "" }),
@@ -120,9 +115,9 @@ func computeCheckoutDiscount(session *stripe.CheckoutSession, requestedAmount de
 
 	metadataBytes, err := json.Marshal(entries)
 	if err != nil {
-		return actualAmount, discountAmount, "", true, err
+		return discountAmount, "", err
 	}
-	return actualAmount, discountAmount, string(metadataBytes), true, nil
+	return discountAmount, string(metadataBytes), nil
 }
 
 // NewPaymentService creates a new Stripe payment service
@@ -1911,18 +1906,20 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		PaymentStatus: &paymentStatus,
 	}
 
-	actualAmount, discountAmount, discountMetadataJSON, hasDiscount, err := computeCheckoutDiscount(session, payment.Amount)
-	if err != nil {
-		s.logger.Error(ctx, "failed to compute checkout discount", "error", err, "payment_id", payment.ID)
-		actualAmount = payment.Amount
-	} else if actualAmount.GreaterThan(payment.Amount) {
+	actualAmount := types.FromSmallestUnit(session.AmountTotal, string(session.Currency))
+	if actualAmount.GreaterThan(payment.Amount) {
 		s.logger.Info(ctx, "checkout session captured more than requested, not treating as a discount",
 			"payment_id", payment.ID, "requested", payment.Amount.String(), "captured", actualAmount.String())
 	}
-
 	if !actualAmount.Equal(payment.Amount) {
 		updateReq.Amount = &actualAmount
 	}
+
+	discountAmount, discountMetadataJSON, err := computeCheckoutDiscount(session, payment.Amount)
+	if err != nil {
+		s.logger.Error(ctx, "failed to compute checkout discount", "error", err, "payment_id", payment.ID)
+	}
+	hasDiscount := err == nil && discountAmount.IsPositive()
 
 	// If payment intent exists, extract payment method and gateway payment ID
 	if paymentIntent != nil {
@@ -1978,10 +1975,6 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		}
 	}
 
-	// Claim the payment before applying any discount. UpdatePayment is CAS-protected
-	// against the status it reads internally (UpdateWithExpectedStatus) — a concurrent
-	// duplicate delivery loses this race and returns ErrVersionConflict, so it never
-	// reaches ApplyExternalInvoiceDiscount below and can't double-discount the invoice.
 	_, err = paymentService.UpdatePayment(ctx, payment.ID, updateReq)
 	if err != nil {
 		s.logger.Error(ctx, "failed to update payment record",
@@ -1998,7 +1991,12 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		"new_status", paymentStatus)
 
 	if hasDiscount {
-		if err := invoiceService.ApplyExternalInvoiceDiscount(ctx, payment.DestinationID, discountAmount, discountMetadataJSON); err != nil {
+		applyDiscountReq := dto.ApplyExternalInvoiceDiscountRequest{
+			DiscountAmount: discountAmount,
+			MetadataKey:    checkoutDiscountMetadataKey,
+			MetadataJSON:   discountMetadataJSON,
+		}
+		if err := invoiceService.ApplyExternalInvoiceDiscount(ctx, payment.DestinationID, applyDiscountReq); err != nil {
 			s.logger.Error(ctx, "failed to apply external invoice discount", "error", err, "payment_id", payment.ID)
 			return err
 		}

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -97,7 +97,7 @@ type stripeCheckoutDiscountEntry struct {
 func computeCheckoutDiscount(session *stripe.CheckoutSession, requestedAmount decimal.Decimal) (
 	actualAmount decimal.Decimal, discountAmount decimal.Decimal, metadataJSON string, hasDiscount bool, err error,
 ) {
-	actualAmount = decimal.NewFromInt(session.AmountTotal).Div(decimal.NewFromInt(100))
+	actualAmount = types.FromSmallestUnit(session.AmountTotal, string(session.Currency))
 	if !actualAmount.LessThan(requestedAmount) {
 		return actualAmount, decimal.Zero, "", false, nil
 	}
@@ -1920,13 +1920,6 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 			"payment_id", payment.ID, "requested", payment.Amount.String(), "captured", actualAmount.String())
 	}
 
-	if hasDiscount {
-		if err := invoiceService.ApplyExternalInvoiceDiscount(ctx, payment.DestinationID, discountAmount, discountMetadataJSON); err != nil {
-			s.logger.Error(ctx, "failed to apply external invoice discount", "error", err, "payment_id", payment.ID)
-			return err
-		}
-	}
-
 	if !actualAmount.Equal(payment.Amount) {
 		updateReq.Amount = &actualAmount
 	}
@@ -1985,6 +1978,10 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		}
 	}
 
+	// Claim the payment before applying any discount. UpdatePayment is CAS-protected
+	// against the status it reads internally (UpdateWithExpectedStatus) — a concurrent
+	// duplicate delivery loses this race and returns ErrVersionConflict, so it never
+	// reaches ApplyExternalInvoiceDiscount below and can't double-discount the invoice.
 	_, err = paymentService.UpdatePayment(ctx, payment.ID, updateReq)
 	if err != nil {
 		s.logger.Error(ctx, "failed to update payment record",
@@ -1999,6 +1996,13 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 	s.logger.Info(ctx, "successfully updated payment record",
 		"payment_id", payment.ID,
 		"new_status", paymentStatus)
+
+	if hasDiscount {
+		if err := invoiceService.ApplyExternalInvoiceDiscount(ctx, payment.DestinationID, discountAmount, discountMetadataJSON); err != nil {
+			s.logger.Error(ctx, "failed to apply external invoice discount", "error", err, "payment_id", payment.ID)
+			return err
+		}
+	}
 
 	err = s.ReconcilePaymentWithInvoice(ctx, payment.ID, actualAmount, paymentService, invoiceService)
 	if err != nil {

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -1892,6 +1892,7 @@ func paymentIntentCustomerID(paymentIntent *stripe.PaymentIntent) string {
 // paymentIntent is optional and can be nil
 func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 	ctx context.Context,
+	session *stripe.CheckoutSession,
 	paymentIntent *stripe.PaymentIntent,
 	payment *dto.PaymentResponse,
 	customerService interfaces.CustomerService,
@@ -1908,6 +1909,26 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 	// Update payment record
 	updateReq := dto.UpdatePaymentRequest{
 		PaymentStatus: &paymentStatus,
+	}
+
+	actualAmount, discountAmount, discountMetadataJSON, hasDiscount, err := computeCheckoutDiscount(session, payment.Amount)
+	if err != nil {
+		s.logger.Error(ctx, "failed to compute checkout discount", "error", err, "payment_id", payment.ID)
+		actualAmount = payment.Amount
+	} else if actualAmount.GreaterThan(payment.Amount) {
+		s.logger.Warn(ctx, "checkout session captured more than requested, not treating as a discount",
+			"payment_id", payment.ID, "requested", payment.Amount.String(), "captured", actualAmount.String())
+	}
+
+	if hasDiscount {
+		if err := invoiceService.ApplyExternalInvoiceDiscount(ctx, payment.DestinationID, discountAmount, discountMetadataJSON); err != nil {
+			s.logger.Error(ctx, "failed to apply external invoice discount", "error", err, "payment_id", payment.ID)
+			return err
+		}
+	}
+
+	if !actualAmount.Equal(payment.Amount) {
+		updateReq.Amount = &actualAmount
 	}
 
 	// If payment intent exists, extract payment method and gateway payment ID
@@ -1964,7 +1985,7 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		}
 	}
 
-	_, err := paymentService.UpdatePayment(ctx, payment.ID, updateReq)
+	_, err = paymentService.UpdatePayment(ctx, payment.ID, updateReq)
 	if err != nil {
 		s.logger.Error(ctx, "failed to update payment record",
 			"error", err,
@@ -1979,19 +2000,17 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		"payment_id", payment.ID,
 		"new_status", paymentStatus)
 
-	// get the amount from the payment
-	amount := payment.Amount
-	err = s.ReconcilePaymentWithInvoice(ctx, payment.ID, amount, paymentService, invoiceService)
+	err = s.ReconcilePaymentWithInvoice(ctx, payment.ID, actualAmount, paymentService, invoiceService)
 	if err != nil {
 		s.logger.Error(ctx, "failed to reconcile payment with invoice",
 			"error", err,
 			"payment_id", payment.ID,
-			"amount", amount.String())
+			"amount", actualAmount.String())
 		// Don't fail the entire webhook processing
 	} else {
 		s.logger.Info(ctx, "successfully reconciled payment with invoice",
 			"payment_id", payment.ID,
-			"amount", amount.String())
+			"amount", actualAmount.String())
 	}
 
 	// Only attach to Stripe invoice and reconcile if we have a payment intent

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -79,6 +79,52 @@ func (s *PaymentService) buildSyncedLineItems(ctx context.Context, invoiceResp *
 	return lineItems, nil
 }
 
+// stripeCheckoutDiscountEntry is one entry in the JSON array stored under
+// Invoice.Metadata["stripe_checkout_discounts"].
+type stripeCheckoutDiscountEntry struct {
+	StripeCouponID string    `json:"stripe_coupon_id"`
+	Name           string    `json:"name"`
+	AmountOff      int64     `json:"amount_off,omitempty"`
+	PercentOff     float64   `json:"percent_off,omitempty"`
+	PromotionCode  string    `json:"promotion_code,omitempty"`
+	AppliedAt      time.Time `json:"applied_at"`
+}
+
+// computeCheckoutDiscount is pure (no Stripe calls) so it's unit-testable directly. Compares
+// what was requested against what Stripe actually captured. hasDiscount is false when they
+// match, or when actual > requested (the caller logs that case; never treated as a negative
+// discount).
+func computeCheckoutDiscount(session *stripe.CheckoutSession, requestedAmount decimal.Decimal) (
+	actualAmount decimal.Decimal, discountAmount decimal.Decimal, metadataJSON string, hasDiscount bool, err error,
+) {
+	actualAmount = decimal.NewFromInt(session.AmountTotal).Div(decimal.NewFromInt(100))
+	if !actualAmount.LessThan(requestedAmount) {
+		return actualAmount, decimal.Zero, "", false, nil
+	}
+
+	discountAmount = requestedAmount.Sub(actualAmount)
+
+	entries := make([]stripeCheckoutDiscountEntry, 0, len(session.Discounts))
+	for _, d := range session.Discounts {
+		// lo.TernaryF (lazy) not lo.Ternary (eager) — d.Coupon.ID would nil-pointer-panic
+		// eagerly evaluating both branches when d.Coupon is nil.
+		entries = append(entries, stripeCheckoutDiscountEntry{
+			StripeCouponID: lo.TernaryF(d.Coupon != nil, func() string { return d.Coupon.ID }, func() string { return "" }),
+			Name:           lo.TernaryF(d.Coupon != nil, func() string { return d.Coupon.Name }, func() string { return "" }),
+			AmountOff:      lo.TernaryF(d.Coupon != nil, func() int64 { return d.Coupon.AmountOff }, func() int64 { return 0 }),
+			PercentOff:     lo.TernaryF(d.Coupon != nil, func() float64 { return d.Coupon.PercentOff }, func() float64 { return 0 }),
+			PromotionCode:  lo.TernaryF(d.PromotionCode != nil, func() string { return d.PromotionCode.Code }, func() string { return "" }),
+			AppliedAt:      time.Now().UTC(),
+		})
+	}
+
+	metadataBytes, err := json.Marshal(entries)
+	if err != nil {
+		return actualAmount, discountAmount, "", true, err
+	}
+	return actualAmount, discountAmount, string(metadataBytes), true, nil
+}
+
 // NewPaymentService creates a new Stripe payment service
 func NewPaymentService(
 	client *Client,

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -1916,7 +1916,7 @@ func (s *PaymentService) HandleFlexPriceCheckoutPayment(
 		s.logger.Error(ctx, "failed to compute checkout discount", "error", err, "payment_id", payment.ID)
 		actualAmount = payment.Amount
 	} else if actualAmount.GreaterThan(payment.Amount) {
-		s.logger.Warn(ctx, "checkout session captured more than requested, not treating as a discount",
+		s.logger.Info(ctx, "checkout session captured more than requested, not treating as a discount",
 			"payment_id", payment.ID, "requested", payment.Amount.String(), "captured", actualAmount.String())
 	}
 

--- a/internal/integration/stripe/payment_test.go
+++ b/internal/integration/stripe/payment_test.go
@@ -158,11 +158,9 @@ func TestBuildSyncedLineItems_ZeroAmountLineItemsSkipped(t *testing.T) {
 func TestComputeCheckoutDiscount_NoDiscountWhenEqual(t *testing.T) {
 	session := &stripe.CheckoutSession{AmountTotal: 10000}
 
-	actual, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+	discount, metadataJSON, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
 
 	require.NoError(t, err)
-	require.False(t, hasDiscount)
-	require.True(t, decimal.NewFromInt(100).Equal(actual))
 	require.True(t, decimal.Zero.Equal(discount))
 	require.Empty(t, metadataJSON)
 }
@@ -173,33 +171,27 @@ func TestComputeCheckoutDiscount_ZeroDecimalCurrencyNoFalseDiscount(t *testing.T
 	// captured amount of 100 and report a false 9,900 discount.
 	session := &stripe.CheckoutSession{AmountTotal: 10000, Currency: stripe.CurrencyJPY}
 
-	actual, discount, _, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(10000))
+	discount, _, err := computeCheckoutDiscount(session, decimal.NewFromInt(10000))
 
 	require.NoError(t, err)
-	require.False(t, hasDiscount)
-	require.True(t, decimal.NewFromInt(10000).Equal(actual))
 	require.True(t, decimal.Zero.Equal(discount))
 }
 
 func TestComputeCheckoutDiscount_ZeroDecimalCurrencyRealDiscount(t *testing.T) {
 	session := &stripe.CheckoutSession{AmountTotal: 8000, Currency: stripe.CurrencyJPY}
 
-	actual, discount, _, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(10000))
+	discount, _, err := computeCheckoutDiscount(session, decimal.NewFromInt(10000))
 
 	require.NoError(t, err)
-	require.True(t, hasDiscount)
-	require.True(t, decimal.NewFromInt(8000).Equal(actual))
 	require.True(t, decimal.NewFromInt(2000).Equal(discount))
 }
 
 func TestComputeCheckoutDiscount_NoDiscountWhenCapturedMore(t *testing.T) {
 	session := &stripe.CheckoutSession{AmountTotal: 10500}
 
-	actual, discount, _, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+	discount, _, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
 
 	require.NoError(t, err)
-	require.False(t, hasDiscount)
-	require.True(t, decimal.NewFromInt(105).Equal(actual))
 	require.True(t, decimal.Zero.Equal(discount))
 }
 
@@ -214,11 +206,9 @@ func TestComputeCheckoutDiscount_DiscountWithCouponAndPromoCode(t *testing.T) {
 		},
 	}
 
-	actual, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+	discount, metadataJSON, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
 
 	require.NoError(t, err)
-	require.True(t, hasDiscount)
-	require.True(t, decimal.NewFromInt(80).Equal(actual))
 	require.True(t, decimal.NewFromInt(20).Equal(discount))
 
 	var entries []stripeCheckoutDiscountEntry
@@ -238,10 +228,9 @@ func TestComputeCheckoutDiscount_MultipleStackedDiscounts(t *testing.T) {
 		},
 	}
 
-	_, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+	discount, metadataJSON, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
 
 	require.NoError(t, err)
-	require.True(t, hasDiscount)
 	require.True(t, decimal.NewFromInt(30).Equal(discount))
 
 	var entries []stripeCheckoutDiscountEntry
@@ -253,10 +242,9 @@ func TestComputeCheckoutDiscount_DiscountWithNoCouponsListedYet(t *testing.T) {
 	// AmountTotal reduced with no session.Discounts populated (e.g. a manual amount edit).
 	session := &stripe.CheckoutSession{AmountTotal: 9000}
 
-	_, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+	discount, metadataJSON, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
 
 	require.NoError(t, err)
-	require.True(t, hasDiscount)
 	require.True(t, decimal.NewFromInt(10).Equal(discount))
 
 	var entries []stripeCheckoutDiscountEntry
@@ -272,10 +260,9 @@ func TestComputeCheckoutDiscount_NilCouponOrPromotionCode(t *testing.T) {
 		},
 	}
 
-	_, _, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+	_, metadataJSON, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
 
 	require.NoError(t, err)
-	require.True(t, hasDiscount)
 	var entries []stripeCheckoutDiscountEntry
 	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &entries))
 	require.Len(t, entries, 1)
@@ -309,7 +296,7 @@ type checkoutTestInvoiceService struct {
 	applyDiscountCalls int
 }
 
-func (f *checkoutTestInvoiceService) ApplyExternalInvoiceDiscount(_ context.Context, _ string, _ decimal.Decimal, _ string) error {
+func (f *checkoutTestInvoiceService) ApplyExternalInvoiceDiscount(_ context.Context, _ string, _ dto.ApplyExternalInvoiceDiscountRequest) error {
 	f.applyDiscountCalls++
 	return nil
 }

--- a/internal/integration/stripe/payment_test.go
+++ b/internal/integration/stripe/payment_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -8,7 +9,9 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
@@ -164,6 +167,31 @@ func TestComputeCheckoutDiscount_NoDiscountWhenEqual(t *testing.T) {
 	require.Empty(t, metadataJSON)
 }
 
+func TestComputeCheckoutDiscount_ZeroDecimalCurrencyNoFalseDiscount(t *testing.T) {
+	// JPY has zero decimal places: AmountTotal is already the yen amount, not cents.
+	// Dividing by 100 (the USD-shaped conversion) would wrongly read 10,000 JPY as a
+	// captured amount of 100 and report a false 9,900 discount.
+	session := &stripe.CheckoutSession{AmountTotal: 10000, Currency: stripe.CurrencyJPY}
+
+	actual, discount, _, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(10000))
+
+	require.NoError(t, err)
+	require.False(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(10000).Equal(actual))
+	require.True(t, decimal.Zero.Equal(discount))
+}
+
+func TestComputeCheckoutDiscount_ZeroDecimalCurrencyRealDiscount(t *testing.T) {
+	session := &stripe.CheckoutSession{AmountTotal: 8000, Currency: stripe.CurrencyJPY}
+
+	actual, discount, _, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(10000))
+
+	require.NoError(t, err)
+	require.True(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(8000).Equal(actual))
+	require.True(t, decimal.NewFromInt(2000).Equal(discount))
+}
+
 func TestComputeCheckoutDiscount_NoDiscountWhenCapturedMore(t *testing.T) {
 	session := &stripe.CheckoutSession{AmountTotal: 10500}
 
@@ -253,4 +281,82 @@ func TestComputeCheckoutDiscount_NilCouponOrPromotionCode(t *testing.T) {
 	require.Len(t, entries, 1)
 	require.Equal(t, "", entries[0].StripeCouponID)
 	require.Equal(t, "NOCOUPON", entries[0].PromotionCode)
+}
+
+// ── fakes for HandleFlexPriceCheckoutPayment ordering tests ─────────────────────────────
+
+type checkoutTestPaymentService struct {
+	interfaces.PaymentService
+	payment          *dto.PaymentResponse
+	updatePaymentErr error
+	updatePaymentReq dto.UpdatePaymentRequest
+}
+
+func (f *checkoutTestPaymentService) UpdatePayment(_ context.Context, _ string, req dto.UpdatePaymentRequest) (*dto.PaymentResponse, error) {
+	f.updatePaymentReq = req
+	if f.updatePaymentErr != nil {
+		return nil, f.updatePaymentErr
+	}
+	return &dto.PaymentResponse{}, nil
+}
+
+func (f *checkoutTestPaymentService) GetPayment(_ context.Context, _ string) (*dto.PaymentResponse, error) {
+	return f.payment, nil
+}
+
+type checkoutTestInvoiceService struct {
+	interfaces.InvoiceService
+	applyDiscountCalls int
+}
+
+func (f *checkoutTestInvoiceService) ApplyExternalInvoiceDiscount(_ context.Context, _ string, _ decimal.Decimal, _ string) error {
+	f.applyDiscountCalls++
+	return nil
+}
+
+func (f *checkoutTestInvoiceService) GetInvoice(_ context.Context, id string) (*dto.InvoiceResponse, error) {
+	return &dto.InvoiceResponse{Invoice: invoice.Invoice{
+		ID:              id,
+		AmountDue:       decimal.NewFromInt(80),
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.NewFromInt(80),
+	}}, nil
+}
+
+func (f *checkoutTestInvoiceService) ReconcilePaymentStatus(_ context.Context, _ string, _ types.PaymentStatus, _ *decimal.Decimal) error {
+	return nil
+}
+
+func TestHandleFlexPriceCheckoutPayment_DiscountNotAppliedWhenPaymentClaimFails(t *testing.T) {
+	s := &PaymentService{logger: logger.NewNoopLogger()}
+	session := &stripe.CheckoutSession{
+		AmountTotal: 8000,
+		Discounts:   []*stripe.CheckoutSessionDiscount{{Coupon: &stripe.Coupon{ID: "cp_1"}}},
+	}
+	payment := &dto.PaymentResponse{ID: "pay_1", Amount: decimal.NewFromInt(100), DestinationID: "inv_1"}
+	invoiceSvc := &checkoutTestInvoiceService{}
+	paymentSvc := &checkoutTestPaymentService{payment: payment, updatePaymentErr: errors.New("payment status changed during update")}
+
+	err := s.HandleFlexPriceCheckoutPayment(context.Background(), session, nil, payment, nil, invoiceSvc, paymentSvc)
+
+	require.Error(t, err)
+	require.Equal(t, 0, invoiceSvc.applyDiscountCalls, "a failed/conflicting payment claim must never apply the discount")
+}
+
+func TestHandleFlexPriceCheckoutPayment_DiscountAppliedAfterSuccessfulClaim(t *testing.T) {
+	s := &PaymentService{logger: logger.NewNoopLogger()}
+	session := &stripe.CheckoutSession{
+		AmountTotal: 8000,
+		Discounts:   []*stripe.CheckoutSessionDiscount{{Coupon: &stripe.Coupon{ID: "cp_1"}}},
+	}
+	payment := &dto.PaymentResponse{ID: "pay_1", Amount: decimal.NewFromInt(100), DestinationID: "inv_1"}
+	invoiceSvc := &checkoutTestInvoiceService{}
+	paymentSvc := &checkoutTestPaymentService{payment: payment}
+
+	err := s.HandleFlexPriceCheckoutPayment(context.Background(), session, nil, payment, nil, invoiceSvc, paymentSvc)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, invoiceSvc.applyDiscountCalls)
+	require.NotNil(t, paymentSvc.updatePaymentReq.Amount)
+	require.True(t, decimal.NewFromInt(80).Equal(*paymentSvc.updatePaymentReq.Amount))
 }

--- a/internal/integration/stripe/payment_test.go
+++ b/internal/integration/stripe/payment_test.go
@@ -1,6 +1,7 @@
 package stripe
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v82"
 )
 
 func TestBuildSyncedLineItems_HappyPath(t *testing.T) {
@@ -148,4 +150,107 @@ func TestBuildSyncedLineItems_ZeroAmountLineItemsSkipped(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, lineItems, 1)
+}
+
+func TestComputeCheckoutDiscount_NoDiscountWhenEqual(t *testing.T) {
+	session := &stripe.CheckoutSession{AmountTotal: 10000}
+
+	actual, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+
+	require.NoError(t, err)
+	require.False(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(100).Equal(actual))
+	require.True(t, decimal.Zero.Equal(discount))
+	require.Empty(t, metadataJSON)
+}
+
+func TestComputeCheckoutDiscount_NoDiscountWhenCapturedMore(t *testing.T) {
+	session := &stripe.CheckoutSession{AmountTotal: 10500}
+
+	actual, discount, _, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+
+	require.NoError(t, err)
+	require.False(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(105).Equal(actual))
+	require.True(t, decimal.Zero.Equal(discount))
+}
+
+func TestComputeCheckoutDiscount_DiscountWithCouponAndPromoCode(t *testing.T) {
+	session := &stripe.CheckoutSession{
+		AmountTotal: 8000,
+		Discounts: []*stripe.CheckoutSessionDiscount{
+			{
+				Coupon:        &stripe.Coupon{ID: "cp_1", Name: "20 off", AmountOff: 2000},
+				PromotionCode: &stripe.PromotionCode{Code: "SAVE20"},
+			},
+		},
+	}
+
+	actual, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+
+	require.NoError(t, err)
+	require.True(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(80).Equal(actual))
+	require.True(t, decimal.NewFromInt(20).Equal(discount))
+
+	var entries []stripeCheckoutDiscountEntry
+	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &entries))
+	require.Len(t, entries, 1)
+	require.Equal(t, "cp_1", entries[0].StripeCouponID)
+	require.Equal(t, "SAVE20", entries[0].PromotionCode)
+	require.EqualValues(t, 2000, entries[0].AmountOff)
+}
+
+func TestComputeCheckoutDiscount_MultipleStackedDiscounts(t *testing.T) {
+	session := &stripe.CheckoutSession{
+		AmountTotal: 7000,
+		Discounts: []*stripe.CheckoutSessionDiscount{
+			{Coupon: &stripe.Coupon{ID: "cp_1", Name: "First"}},
+			{Coupon: &stripe.Coupon{ID: "cp_2", Name: "Second"}},
+		},
+	}
+
+	_, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+
+	require.NoError(t, err)
+	require.True(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(30).Equal(discount))
+
+	var entries []stripeCheckoutDiscountEntry
+	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &entries))
+	require.Len(t, entries, 2)
+}
+
+func TestComputeCheckoutDiscount_DiscountWithNoCouponsListedYet(t *testing.T) {
+	// AmountTotal reduced with no session.Discounts populated (e.g. a manual amount edit).
+	session := &stripe.CheckoutSession{AmountTotal: 9000}
+
+	_, discount, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+
+	require.NoError(t, err)
+	require.True(t, hasDiscount)
+	require.True(t, decimal.NewFromInt(10).Equal(discount))
+
+	var entries []stripeCheckoutDiscountEntry
+	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &entries))
+	require.Empty(t, entries)
+}
+
+func TestComputeCheckoutDiscount_NilCouponOrPromotionCode(t *testing.T) {
+	session := &stripe.CheckoutSession{
+		AmountTotal: 9000,
+		Discounts: []*stripe.CheckoutSessionDiscount{
+			{Coupon: nil, PromotionCode: &stripe.PromotionCode{Code: "NOCOUPON"}},
+		},
+	}
+
+	_, _, metadataJSON, hasDiscount, err := computeCheckoutDiscount(session, decimal.NewFromInt(100))
+
+	require.NoError(t, err)
+	require.True(t, hasDiscount)
+	var entries []stripeCheckoutDiscountEntry
+	require.NoError(t, json.Unmarshal([]byte(metadataJSON), &entries))
+	require.Len(t, entries, 1)
+	require.Equal(t, "", entries[0].StripeCouponID)
+	require.Equal(t, "NOCOUPON", entries[0].PromotionCode)
 }

--- a/internal/integration/stripe/webhook/handler.go
+++ b/internal/integration/stripe/webhook/handler.go
@@ -836,7 +836,7 @@ func (h *Handler) handleCheckoutSessionCompleted(ctx context.Context, event *str
 	}
 
 	// Call HandleFlexPriceCheckoutPayment with optional payment intent
-	err = h.paymentSvc.HandleFlexPriceCheckoutPayment(ctx, paymentIntent, payment, services.CustomerService, services.InvoiceService, services.PaymentService)
+	err = h.paymentSvc.HandleFlexPriceCheckoutPayment(ctx, &checkoutSession, paymentIntent, payment, services.CustomerService, services.InvoiceService, services.PaymentService)
 	if err != nil {
 		h.logger.Error(ctx, "failed to handle FlexPrice checkout payment, skipping event",
 			"error", err,

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -51,10 +51,8 @@ type InvoiceService interface {
 	UpdateInvoice(ctx context.Context, id string, req dto.UpdateInvoiceRequest) (*dto.InvoiceResponse, error)
 	DeleteInvoice(ctx context.Context, id string) error
 	ReconcilePaymentStatus(ctx context.Context, invoiceID string, paymentStatus types.PaymentStatus, paymentAmount *decimal.Decimal) error
-	// ApplyExternalInvoiceDiscount records a discount that was applied on an external
-	// provider (not FlexPrice's own coupon engine) against an already-existing invoice —
-	// e.g. a Stripe promotion code applied at checkout after the invoice was created.
-	ApplyExternalInvoiceDiscount(ctx context.Context, invoiceID string, discountAmount decimal.Decimal, metadataJSON string) error
+
+	ApplyExternalInvoiceDiscount(ctx context.Context, invoiceID string, req dto.ApplyExternalInvoiceDiscountRequest) error
 	VoidInvoice(ctx context.Context, id string, req dto.InvoiceVoidRequest) error
 }
 

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -51,6 +51,10 @@ type InvoiceService interface {
 	UpdateInvoice(ctx context.Context, id string, req dto.UpdateInvoiceRequest) (*dto.InvoiceResponse, error)
 	DeleteInvoice(ctx context.Context, id string) error
 	ReconcilePaymentStatus(ctx context.Context, invoiceID string, paymentStatus types.PaymentStatus, paymentAmount *decimal.Decimal) error
+	// ApplyExternalInvoiceDiscount records a discount that was applied on an external
+	// provider (not FlexPrice's own coupon engine) against an already-existing invoice —
+	// e.g. a Stripe promotion code applied at checkout after the invoice was created.
+	ApplyExternalInvoiceDiscount(ctx context.Context, invoiceID string, discountAmount decimal.Decimal, metadataJSON string) error
 	VoidInvoice(ctx context.Context, id string, req dto.InvoiceVoidRequest) error
 }
 

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -331,6 +331,7 @@ func (r *paymentRepository) update(ctx context.Context, p *domainPayment.Payment
 		Where(predicates...).
 		SetPaymentStatus(string(p.PaymentStatus)).
 		SetPaymentMethodID(p.PaymentMethodID).
+		SetAmount(p.Amount).
 		SetNillablePaymentGateway(p.PaymentGateway).
 		SetNillableGatewayPaymentID(p.GatewayPaymentID).
 		SetNillableGatewayTrackingID(p.GatewayTrackingID).

--- a/internal/types/currency.go
+++ b/internal/types/currency.go
@@ -111,6 +111,15 @@ func ToSmallestUnit(amount decimal.Decimal, currency string) int64 {
 	return result
 }
 
+// FromSmallestUnit converts an integer amount in the currency's smallest unit (e.g. cents for
+// USD, fils for KWD, yen for JPY — JPY's smallest unit is 1 yen since it has zero decimal
+// places) back to a decimal amount. Inverse of ToSmallestUnit.
+func FromSmallestUnit(smallestUnitAmount int64, currency string) decimal.Decimal {
+	precision := GetCurrencyPrecision(currency)
+	divisor := decimal.New(1, precision) // 10^precision
+	return decimal.NewFromInt(smallestUnitAmount).Div(divisor)
+}
+
 // RoundToCurrencyPrecision rounds a decimal amount to the appropriate currency precision.
 //
 // This function ensures monetary amounts are displayed and processed with the correct


### PR DESCRIPTION
## **User description**
## Summary
- Fixes a revenue-recognition bug: when a customer applies a Stripe promotion code at a FlexPrice-generated checkout payment link (`CreatePaymentLink`, `AllowPromotionCodes: true`), Stripe collects less than the originally requested amount, but the invoice was previously reconciled using the stale requested amount — silently over-crediting the invoice.
- `HandleFlexPriceCheckoutPayment` now compares the Checkout Session's actual captured total (`computeCheckoutDiscount`, a pure helper) against what was requested, corrects `Payment.Amount` to match reality, and — when there's a discount — calls a new `InvoiceService.ApplyExternalInvoiceDiscount` before reconciling, so `AmountDue`/`AmountRemaining`/`TotalDiscount` land on figures consistent with what Stripe actually collected.
- `ApplyExternalInvoiceDiscount` correctly handles two edge cases verified against real code: it sums any *pre-existing* invoice-level discount (from FlexPrice's own coupon engine) before redistributing, since `DistributeInvoiceLevelDiscount` unconditionally zeroes and rebuilds — passing only the new increment would silently erase an existing discount. It also appends (not overwrites) the `stripe_checkout_discounts` metadata entry, so multiple partial payments on the same invoice don't clobber each other's discount record.
- No `CouponApplication`/shadow `Coupon` records — externally-sourced discounts are represented via existing invoice/line-item discount fields + metadata, since `CouponApplication` requires non-nullable FKs to `Coupon`/`CouponAssociation` that a Stripe-side promo code has no backing for.
- Uses `InvoiceRepo.GetForUpdate` (row-level lock) inside the transaction to close the concurrent-payment race on the invoice's amount fields.

## Test plan
- [x] `go test ./internal/...` — full suite passes (57 packages)
- [x] `go vet ./internal/... ./cmd/...` — clean
- [x] `go vet -vettool=./tools/bin/loglint ./internal/...` — clean
- [x] Unit tests: `computeCheckoutDiscount` (6 cases: no discount, overcharge, coupon+promo code, stacked discounts, no-coupon-listed, nil coupon/promo code fields), `ApplyExternalInvoiceDiscount` (4 cases incl. the pre-existing-discount clobber regression test and the metadata-append test), `UpdatePayment` amount correction
- [ ] Manual staging verification against a real Stripe test-mode checkout session with a promotion code applied (can't be unit tested — no injectable Stripe SDK interface, and full webhook signature verification needs a live flow)

Design doc: `docs/superpowers/specs/2026-08-10-stripe-checkout-coupon-reconciliation-design.md` (not checked in — gitignored local spec).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Stripe Checkout tax ID collection options.
  - Added support for applying external discounts to finalized invoices.
  - Added gateway-specific payment configuration and currency amount handling.
  - Improved checkout discount and invoice reconciliation using captured totals.
  - Preserved combined discount details and checkout metadata.

- **Bug Fixes**
  - Corrected discount calculations for zero-decimal currencies and stacked promotions.
  - Enabled payment amount corrections to persist reliably.
  - Prevented conflicting payment updates and deletions from overwriting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Reconcile Stripe checkout payments with the amount actually captured

### What Changed
- Stripe checkout payments now use the amount Stripe actually captured, including discounts and promotion codes, when updating payments and invoices
- External checkout discounts are reflected in invoice totals, amounts due, remaining balances, line items, and discount metadata without removing existing discounts
- Duplicate webhook deliveries cannot apply the same discount twice, and payment amount corrections are saved reliably
- Currency-aware conversion prevents incorrect discount calculations for zero-decimal currencies such as JPY

### Impact
`✅ Accurate invoice balances after Stripe discounts`
`✅ No duplicate discounts from repeated checkout webhooks`
`✅ Correct payment amounts for JPY and other currency formats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
