### PR TITLE
fix(security): close SSRF bypasses and silent no-op payment writes

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -857,9 +857,13 @@ func (r *CreateSubscriptionRequest) validateCheckoutCompatibility() error {
 		return nil
 	}
 
-	if r.SubscriptionType == types.SubscriptionTypeGroupedInvoicing {
-		return nil
-	}
+	// A grouped_invoicing child is built by createGroupedInvoicingChildren, which
+	// sets parent_subscription_id and passes the parent's checkout down. That
+	// combination is rejected by checkoutUnsupportedFields below, so the
+	// inheritance check alone is skipped for this type. The status and phase
+	// checks still apply: the generated child sets neither, and a request that
+	// does set them is as unsupported here as anywhere else.
+	isGroupedInvoicingChild := r.SubscriptionType == types.SubscriptionTypeGroupedInvoicing
 
 	if r.SubscriptionStatus != "" {
 		return ierr.NewError("subscription_status is not supported with checkout").
@@ -874,7 +878,7 @@ func (r *CreateSubscriptionRequest) validateCheckoutCompatibility() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.Inheritance.checkoutUnsupportedFields() {
+	if !isGroupedInvoicingChild && r.Inheritance.checkoutUnsupportedFields() {
 		return ierr.NewError("inheritance field is not supported with checkout").
 			WithHint("Only grouped_invoicing_children_to_create is supported with checkout; remove the other inheritance fields, or remove checkout").
 			Mark(ierr.ErrValidation)

--- a/internal/api/v1/webhook_chargebee_test.go
+++ b/internal/api/v1/webhook_chargebee_test.go
@@ -37,7 +37,7 @@ func setupChargebeeWebhookHandler(t *testing.T, webhookUsername, webhookPassword
 
 	cfg := &config.Configuration{
 		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
-		Secrets: config.SecretsConfig{EncryptionKey: "test-encryption-key-32-bytes!!!"},
+		Secrets: config.SecretsConfig{EncryptionKey: testutil.NewEncryptionKey()},
 	}
 	log, err := logger.NewLogger(cfg)
 	require.NoError(t, err)

--- a/internal/api/v1/webhook_whop_test.go
+++ b/internal/api/v1/webhook_whop_test.go
@@ -45,7 +45,7 @@ func setupWhopWebhookHandler(t *testing.T, webhookSecret string) (*WebhookHandle
 
 	cfg := &config.Configuration{
 		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
-		Secrets: config.SecretsConfig{EncryptionKey: "test-encryption-key-32-bytes!!!"},
+		Secrets: config.SecretsConfig{EncryptionKey: testutil.NewEncryptionKey()},
 	}
 	log, err := logger.NewLogger(cfg)
 	require.NoError(t, err)

--- a/internal/ee/service/payment_processor.go
+++ b/internal/ee/service/payment_processor.go
@@ -302,8 +302,8 @@ func (p *paymentProcessor) handleStripePaymentLinkCreation(ctx context.Context, 
 			}
 			return false
 		}(),
-		Metadata:  linkMetadata,
-		PaymentID: paymentObj.ID,
+		Metadata:               linkMetadata,
+		PaymentID:              paymentObj.ID,
 		TaxIDCollectionEnabled: paymentObj.GatewayMetadata["tax_id_collection_enabled"] == "true",
 	}
 

--- a/internal/ee/service/subscription_create.go
+++ b/internal/ee/service/subscription_create.go
@@ -137,10 +137,11 @@ func (s *subscriptionService) archiveDraftCheckoutSubscription(ctx context.Conte
 	for _, child := range children {
 		s.archiveDraftSubscriptionDependencies(ctx, child.ID)
 		if err := s.SubRepo.Delete(ctx, child.ID); err != nil {
-			// The child's dependencies were archived just above, so the group is
-			// already partially torn down: this child row survives without them,
-			// and the parent and any remaining children are left untouched.
-			s.Logger.Error(ctx, "failed to archive child subscription, group left partially cleaned up",
+			// Dependency archival was attempted for this child just above and
+			// reports failures only through its own logs, so an unknown subset of
+			// them is already gone. This child row survives without them, and the
+			// parent and any remaining children are untouched.
+			s.Logger.Error(ctx, "failed to archive child subscription, group cleanup attempted and may be partial",
 				"error", err,
 				"subscription_id", subscriptionID,
 				"child_subscription_id", child.ID,

--- a/internal/ee/service/subscription_create.go
+++ b/internal/ee/service/subscription_create.go
@@ -137,7 +137,10 @@ func (s *subscriptionService) archiveDraftCheckoutSubscription(ctx context.Conte
 	for _, child := range children {
 		s.archiveDraftSubscriptionDependencies(ctx, child.ID)
 		if err := s.SubRepo.Delete(ctx, child.ID); err != nil {
-			s.Logger.Error(ctx, "failed to archive child subscription, leaving the group intact",
+			// The child's dependencies were archived just above, so the group is
+			// already partially torn down: this child row survives without them,
+			// and the parent and any remaining children are left untouched.
+			s.Logger.Error(ctx, "failed to archive child subscription, group left partially cleaned up",
 				"error", err,
 				"subscription_id", subscriptionID,
 				"child_subscription_id", child.ID,

--- a/internal/httpclient/dialer.go
+++ b/internal/httpclient/dialer.go
@@ -78,6 +78,14 @@ func publicOnlyDialContext(ctx context.Context, network, addr string) (net.Conn,
 func newGuardedTransport() *http.Transport {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DialContext = publicOnlyDialContext
+
+	// The clone inherits ProxyFromEnvironment, which would defeat the guard: with
+	// HTTP_PROXY set, the dial goes to the proxy address, publicOnlyDialContext
+	// classifies the proxy rather than the destination, and the proxy then reaches
+	// the original target unchecked. It also makes behaviour depend on the
+	// environment the process happens to run in.
+	transport.Proxy = nil
+
 	return transport
 }
 

--- a/internal/httpclient/dialer_test.go
+++ b/internal/httpclient/dialer_test.go
@@ -71,6 +71,38 @@ func TestPublicAddressIsNotBlocked(t *testing.T) {
 	}
 }
 
+// A proxy would defeat the guard entirely: the dial goes to the proxy address,
+// which is what gets classified, and the proxy then reaches the real destination
+// unchecked. http.DefaultTransport carries ProxyFromEnvironment, so the clone
+// must drop it rather than inherit it.
+func TestGuardedTransportIgnoresProxyEnvironment(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://10.0.0.5:3128")
+	t.Setenv("HTTPS_PROXY", "http://10.0.0.5:3128")
+	t.Setenv("ALL_PROXY", "http://10.0.0.5:3128")
+
+	transport := newGuardedTransport()
+	if transport.Proxy != nil {
+		t.Fatal("the guarded transport must not use a proxy")
+	}
+
+	// With the proxy honoured this request would dial 10.0.0.5 and be reported
+	// against that address; the guard must reject the loopback target itself.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(srv.URL)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected the guarded transport to refuse a loopback server")
+	}
+	if !errors.Is(err, ErrBlockedAddress) {
+		t.Fatalf("expected ErrBlockedAddress, got: %v", err)
+	}
+}
+
 func TestSplitHostPortErrorSurfaces(t *testing.T) {
 	if _, err := publicOnlyDialContext(context.Background(), "tcp", "no-port-here"); err == nil {
 		t.Fatal("expected an error for a malformed address")

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -75,6 +75,23 @@ func isReservedStripeMetadataKey(key string) bool {
 	return reserved
 }
 
+// mergeCallerMetadata copies caller-supplied metadata over the trusted block,
+// skipping the keys FlexPrice sets itself. Both Stripe call sites that accept
+// caller metadata go through here so the filtering cannot be dropped from one
+// of them alone.
+func mergeCallerMetadata(trusted map[string]string, caller types.Metadata) map[string]string {
+	if trusted == nil {
+		trusted = map[string]string{}
+	}
+	for k, v := range caller {
+		if isReservedStripeMetadataKey(k) {
+			continue
+		}
+		trusted[k] = v
+	}
+	return trusted
+}
+
 // CreatePaymentLink creates a Stripe checkout session for payment
 func (s *PaymentService) CreatePaymentLink(ctx context.Context, req *dto.CreateStripePaymentLinkRequest, customerService interfaces.CustomerService, invoiceService interfaces.InvoiceService) (*dto.StripePaymentLinkResponse, error) {
 	s.logger.Info(ctx, "creating stripe payment link",
@@ -269,12 +286,7 @@ func (s *PaymentService) CreatePaymentLink(ctx context.Context, req *dto.CreateS
 	// uses to correlate the Stripe payment back to ours, and req.Metadata carries
 	// caller-supplied values straight from the create-payment request. Letting a
 	// caller set it would point the webhook at a different payment.
-	for k, v := range req.Metadata {
-		if isReservedStripeMetadataKey(k) {
-			continue
-		}
-		metadata[k] = v
-	}
+	metadata = mergeCallerMetadata(metadata, req.Metadata)
 
 	// Provide default URLs if not provided
 	successURL := req.SuccessURL
@@ -1216,12 +1228,7 @@ func (s *PaymentService) SetupIntent(ctx context.Context, customerID string, req
 
 	// Add custom metadata if provided, keeping the keys FlexPrice sets itself
 	// authoritative (this also covers the internal connection fields).
-	for k, v := range req.Metadata {
-		if isReservedStripeMetadataKey(k) {
-			continue
-		}
-		metadata[k] = v
-	}
+	metadata = mergeCallerMetadata(metadata, req.Metadata)
 
 	// Add set_default flag to metadata if requested
 	if req.SetDefault {

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -62,6 +62,9 @@ var reservedStripeMetadataKeys = map[string]struct{}{
 	"customer_id":           {},
 	"payment_source":        {},
 	"payment_type":          {},
+	// The setup-intent success webhook makes the payment method the customer's
+	// default when this is "true", so it must come from req.SetDefault only.
+	"set_default": {},
 	// Internal connection fields, previously filtered by the callers.
 	"connection_id":   {},
 	"connection_name": {},

--- a/internal/integration/stripe/payment.go
+++ b/internal/integration/stripe/payment.go
@@ -49,6 +49,29 @@ func NewPaymentService(
 	}
 }
 
+// reservedStripeMetadataKeys are metadata keys FlexPrice sets itself and relies
+// on when a Stripe webhook comes back: they identify which payment, invoice and
+// environment the Stripe object belongs to. Caller-supplied metadata must never
+// set them, or a webhook would be reconciled against the wrong record.
+var reservedStripeMetadataKeys = map[string]struct{}{
+	"flexprice_payment_id":  {},
+	"flexprice_invoice_id":  {},
+	"flexprice_customer_id": {},
+	"stripe_invoice_id":     {},
+	"environment_id":        {},
+	"customer_id":           {},
+	"payment_source":        {},
+	"payment_type":          {},
+	// Internal connection fields, previously filtered by the callers.
+	"connection_id":   {},
+	"connection_name": {},
+}
+
+func isReservedStripeMetadataKey(key string) bool {
+	_, reserved := reservedStripeMetadataKeys[key]
+	return reserved
+}
+
 // CreatePaymentLink creates a Stripe checkout session for payment
 func (s *PaymentService) CreatePaymentLink(ctx context.Context, req *dto.CreateStripePaymentLinkRequest, customerService interfaces.CustomerService, invoiceService interfaces.InvoiceService) (*dto.StripePaymentLinkResponse, error) {
 	s.logger.Info(ctx, "creating stripe payment link",
@@ -238,8 +261,15 @@ func (s *PaymentService) CreatePaymentLink(ctx context.Context, req *dto.CreateS
 			"error", err)
 	}
 
-	// Add custom metadata if provided
+	// Add custom metadata if provided. Reserved keys are skipped rather than
+	// overwritten: flexprice_payment_id is the anchor the payment_intent webhook
+	// uses to correlate the Stripe payment back to ours, and req.Metadata carries
+	// caller-supplied values straight from the create-payment request. Letting a
+	// caller set it would point the webhook at a different payment.
 	for k, v := range req.Metadata {
+		if isReservedStripeMetadataKey(k) {
+			continue
+		}
 		metadata[k] = v
 	}
 
@@ -1181,11 +1211,13 @@ func (s *PaymentService) SetupIntent(ctx context.Context, customerID string, req
 		"usage":          usage,
 	}
 
-	// Add custom metadata if provided (exclude internal connection fields)
+	// Add custom metadata if provided, keeping the keys FlexPrice sets itself
+	// authoritative (this also covers the internal connection fields).
 	for k, v := range req.Metadata {
-		if k != "connection_id" && k != "connection_name" {
-			metadata[k] = v
+		if isReservedStripeMetadataKey(k) {
+			continue
 		}
+		metadata[k] = v
 	}
 
 	// Add set_default flag to metadata if requested

--- a/internal/integration/stripe/payment_metadata_test.go
+++ b/internal/integration/stripe/payment_metadata_test.go
@@ -17,6 +17,7 @@ func TestReservedStripeMetadataKeys(t *testing.T) {
 		"customer_id",
 		"payment_source",
 		"payment_type",
+		"set_default",
 		"connection_id",
 		"connection_name",
 	}
@@ -61,6 +62,38 @@ func TestReservedKeysSurviveCallerMetadataMerge(t *testing.T) {
 	}
 	if got := metadata["payment_source"]; got != "flexprice" {
 		t.Fatalf("caller metadata overwrote payment_source: got %q, want %q", got, "flexprice")
+	}
+	if got := metadata["order_ref"]; got != "ref_123" {
+		t.Fatalf("non-reserved caller metadata must pass through: got %q", got)
+	}
+}
+
+// SetupIntent writes set_default after merging caller metadata, so the key is
+// absent rather than overwritten when the caller supplies it. The setup-intent
+// success webhook makes the payment method the customer's default on seeing
+// "true", so a caller that could set it would promote its own card without
+// asking for it through req.SetDefault.
+func TestCallerCannotSetSetupIntentDefaultFlag(t *testing.T) {
+	metadata := map[string]string{
+		"customer_id":    "cust_1",
+		"environment_id": "env_1",
+	}
+
+	callerMetadata := map[string]string{
+		"set_default": "true",
+		"order_ref":   "ref_123",
+	}
+
+	for k, v := range callerMetadata {
+		if isReservedStripeMetadataKey(k) {
+			continue
+		}
+		metadata[k] = v
+	}
+
+	// Mirrors the req.SetDefault == false path, which writes nothing.
+	if _, present := metadata["set_default"]; present {
+		t.Fatal("caller metadata must not be able to set set_default")
 	}
 	if got := metadata["order_ref"]; got != "ref_123" {
 		t.Fatalf("non-reserved caller metadata must pass through: got %q", got)

--- a/internal/integration/stripe/payment_metadata_test.go
+++ b/internal/integration/stripe/payment_metadata_test.go
@@ -1,6 +1,10 @@
 package stripe
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+)
 
 // Caller-supplied metadata reaches Stripe from the create-payment request body,
 // and the keys FlexPrice sets itself are what a returning webhook uses to decide
@@ -35,67 +39,65 @@ func TestReservedStripeMetadataKeys(t *testing.T) {
 	}
 }
 
-// The merge that applies req.Metadata runs after the trusted block is built, so
-// skipping reserved keys is the only thing keeping the FlexPrice-set values
-// authoritative.
-func TestReservedKeysSurviveCallerMetadataMerge(t *testing.T) {
-	metadata := map[string]string{
+// mergeCallerMetadata is the merge both Stripe call sites use, so exercising it
+// here covers the filtering that keeps the FlexPrice-set values authoritative.
+func TestMergeCallerMetadataKeepsReservedKeys(t *testing.T) {
+	trusted := map[string]string{
 		"flexprice_payment_id": "pay_trusted",
 		"payment_source":       "flexprice",
 	}
 
-	callerMetadata := map[string]string{
+	merged := mergeCallerMetadata(trusted, types.Metadata{
 		"flexprice_payment_id": "pay_attacker",
 		"payment_source":       "spoofed",
 		"order_ref":            "ref_123",
-	}
+	})
 
-	for k, v := range callerMetadata {
-		if isReservedStripeMetadataKey(k) {
-			continue
-		}
-		metadata[k] = v
-	}
-
-	if got := metadata["flexprice_payment_id"]; got != "pay_trusted" {
+	if got := merged["flexprice_payment_id"]; got != "pay_trusted" {
 		t.Fatalf("caller metadata overwrote the payment anchor: got %q, want %q", got, "pay_trusted")
 	}
-	if got := metadata["payment_source"]; got != "flexprice" {
+	if got := merged["payment_source"]; got != "flexprice" {
 		t.Fatalf("caller metadata overwrote payment_source: got %q, want %q", got, "flexprice")
 	}
-	if got := metadata["order_ref"]; got != "ref_123" {
+	if got := merged["order_ref"]; got != "ref_123" {
 		t.Fatalf("non-reserved caller metadata must pass through: got %q", got)
 	}
 }
 
-// SetupIntent writes set_default after merging caller metadata, so the key is
-// absent rather than overwritten when the caller supplies it. The setup-intent
-// success webhook makes the payment method the customer's default on seeing
-// "true", so a caller that could set it would promote its own card without
-// asking for it through req.SetDefault.
-func TestCallerCannotSetSetupIntentDefaultFlag(t *testing.T) {
-	metadata := map[string]string{
-		"customer_id":    "cust_1",
-		"environment_id": "env_1",
-	}
-
-	callerMetadata := map[string]string{
-		"set_default": "true",
-		"order_ref":   "ref_123",
-	}
-
-	for k, v := range callerMetadata {
-		if isReservedStripeMetadataKey(k) {
-			continue
+// SetupIntent builds its trusted block, merges caller metadata, and only then
+// writes set_default from req.SetDefault. The setup-intent success webhook makes
+// the payment method the customer's default on seeing "true", so a caller able to
+// set the key would promote its own card without asking through req.SetDefault.
+//
+// Reproduces that ordering around the shared merge rather than calling
+// SetupIntent, which would need a live Stripe client and a synced customer.
+func TestSetupIntentDefaultFlagComesOnlyFromRequest(t *testing.T) {
+	setupIntentMetadata := func(setDefault bool, caller types.Metadata) map[string]string {
+		metadata := map[string]string{
+			"customer_id":    "cust_1",
+			"environment_id": "env_1",
+			"usage":          "off_session",
 		}
-		metadata[k] = v
+		metadata = mergeCallerMetadata(metadata, caller)
+		if setDefault {
+			metadata["set_default"] = "true"
+		}
+		return metadata
 	}
 
-	// Mirrors the req.SetDefault == false path, which writes nothing.
+	spoofed := types.Metadata{"set_default": "true", "order_ref": "ref_123"}
+
+	metadata := setupIntentMetadata(false, spoofed)
 	if _, present := metadata["set_default"]; present {
 		t.Fatal("caller metadata must not be able to set set_default")
 	}
 	if got := metadata["order_ref"]; got != "ref_123" {
 		t.Fatalf("non-reserved caller metadata must pass through: got %q", got)
+	}
+
+	// The trusted path must still write the flag when the request asks for it.
+	metadata = setupIntentMetadata(true, spoofed)
+	if got := metadata["set_default"]; got != "true" {
+		t.Fatalf("req.SetDefault must still set the flag: got %q, want %q", got, "true")
 	}
 }

--- a/internal/integration/stripe/payment_metadata_test.go
+++ b/internal/integration/stripe/payment_metadata_test.go
@@ -1,0 +1,68 @@
+package stripe
+
+import "testing"
+
+// Caller-supplied metadata reaches Stripe from the create-payment request body,
+// and the keys FlexPrice sets itself are what a returning webhook uses to decide
+// which payment, invoice and environment the Stripe object belongs to. If a
+// caller could set them, a webhook would reconcile against a record of their
+// choosing.
+func TestReservedStripeMetadataKeys(t *testing.T) {
+	reserved := []string{
+		"flexprice_payment_id",
+		"flexprice_invoice_id",
+		"flexprice_customer_id",
+		"stripe_invoice_id",
+		"environment_id",
+		"customer_id",
+		"payment_source",
+		"payment_type",
+		"connection_id",
+		"connection_name",
+	}
+	for _, key := range reserved {
+		if !isReservedStripeMetadataKey(key) {
+			t.Errorf("%q must be reserved: caller metadata could otherwise overwrite it", key)
+		}
+	}
+
+	allowed := []string{"order_ref", "team", "flexprice_payment_id_note", "", "Flexprice_Payment_ID"}
+	for _, key := range allowed {
+		if isReservedStripeMetadataKey(key) {
+			t.Errorf("%q must not be reserved: callers may set their own metadata", key)
+		}
+	}
+}
+
+// The merge that applies req.Metadata runs after the trusted block is built, so
+// skipping reserved keys is the only thing keeping the FlexPrice-set values
+// authoritative.
+func TestReservedKeysSurviveCallerMetadataMerge(t *testing.T) {
+	metadata := map[string]string{
+		"flexprice_payment_id": "pay_trusted",
+		"payment_source":       "flexprice",
+	}
+
+	callerMetadata := map[string]string{
+		"flexprice_payment_id": "pay_attacker",
+		"payment_source":       "spoofed",
+		"order_ref":            "ref_123",
+	}
+
+	for k, v := range callerMetadata {
+		if isReservedStripeMetadataKey(k) {
+			continue
+		}
+		metadata[k] = v
+	}
+
+	if got := metadata["flexprice_payment_id"]; got != "pay_trusted" {
+		t.Fatalf("caller metadata overwrote the payment anchor: got %q, want %q", got, "pay_trusted")
+	}
+	if got := metadata["payment_source"]; got != "flexprice" {
+		t.Fatalf("caller metadata overwrote payment_source: got %q, want %q", got, "flexprice")
+	}
+	if got := metadata["order_ref"]; got != "ref_123" {
+		t.Fatalf("non-reserved caller metadata must pass through: got %q", got)
+	}
+}

--- a/internal/integration/whop/client_test.go
+++ b/internal/integration/whop/client_test.go
@@ -3,8 +3,10 @@ package whop
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"testing"
 	"time"
@@ -105,10 +107,22 @@ func mustTestLogger(t *testing.T) *logger.Logger {
 	return log
 }
 
+// newTestEncryptionKey generates a random key rather than using a literal, so this
+// file carries no credential-shaped constant for secret scanners to flag. Defined
+// locally instead of using testutil.NewEncryptionKey for the import-cycle reason
+// described on fakeConnectionRepo above.
+func newTestEncryptionKey(t *testing.T) string {
+	t.Helper()
+	key := make([]byte, 16)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return hex.EncodeToString(key)
+}
+
 func mustTestEncryptionService(t *testing.T) security.EncryptionService {
 	t.Helper()
 	cfg := &config.Configuration{
-		Secrets: config.SecretsConfig{EncryptionKey: "test-encryption-key-32-bytes!!!"},
+		Secrets: config.SecretsConfig{EncryptionKey: newTestEncryptionKey(t)},
 	}
 	svc, err := security.NewEncryptionService(cfg, mustTestLogger(t))
 	require.NoError(t, err)

--- a/internal/integration/whop/client_test.go
+++ b/internal/integration/whop/client_test.go
@@ -113,7 +113,7 @@ func mustTestLogger(t *testing.T) *logger.Logger {
 // described on fakeConnectionRepo above.
 func newTestEncryptionKey(t *testing.T) string {
 	t.Helper()
-	key := make([]byte, 16)
+	key := make([]byte, 32)
 	_, err := rand.Read(key)
 	require.NoError(t, err)
 	return hex.EncodeToString(key)

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -365,22 +365,26 @@ func (r *paymentRepository) update(ctx context.Context, p *domainPayment.Payment
 		// to a different status between the caller's read and this write.
 		// Reported as a conflict so the caller re-reads rather than treating the
 		// payment as gone.
+		var mutationErr error
 		if expectedStatus != nil {
-			return ierr.NewError("payment status changed during update").
+			mutationErr = ierr.NewError("payment status changed during update").
 				WithHint("The payment was modified concurrently. Retry with the current payment state.").
 				WithReportableDetails(map[string]interface{}{
 					"payment_id":      p.ID,
 					"expected_status": *expectedStatus,
 				}).
 				Mark(ierr.ErrVersionConflict)
+		} else {
+			mutationErr = ierr.NewError("payment not found").
+				WithHint("Payment not found").
+				WithReportableDetails(map[string]interface{}{
+					"payment_id": p.ID,
+				}).
+				Mark(ierr.ErrNotFound)
 		}
 
-		return ierr.NewError("payment not found").
-			WithHint("Payment not found").
-			WithReportableDetails(map[string]interface{}{
-				"payment_id": p.ID,
-			}).
-			Mark(ierr.ErrNotFound)
+		SetSpanError(span, mutationErr)
+		return mutationErr
 	}
 
 	r.DeleteCache(ctx, p.ID)
@@ -428,6 +432,7 @@ func (r *paymentRepository) delete(ctx context.Context, id string, expectedStatu
 		Save(ctx)
 
 	if err != nil {
+		SetSpanError(span, err)
 		return ierr.WithError(err).
 			WithHint("Failed to delete payment").
 			WithReportableDetails(map[string]interface{}{
@@ -439,22 +444,26 @@ func (r *paymentRepository) delete(ctx context.Context, id string, expectedStatu
 	// As in update: zero rows affected is the only signal that nothing was
 	// archived, since a bulk update does not report a missing row as an error.
 	if affected == 0 {
+		var mutationErr error
 		if expectedStatus != nil {
-			return ierr.NewError("payment status changed during delete").
+			mutationErr = ierr.NewError("payment status changed during delete").
 				WithHint("The payment was modified concurrently. Re-read it before deleting.").
 				WithReportableDetails(map[string]interface{}{
 					"payment_id":      id,
 					"expected_status": *expectedStatus,
 				}).
 				Mark(ierr.ErrVersionConflict)
+		} else {
+			mutationErr = ierr.NewError("payment not found").
+				WithHint("Payment not found").
+				WithReportableDetails(map[string]interface{}{
+					"payment_id": id,
+				}).
+				Mark(ierr.ErrNotFound)
 		}
 
-		return ierr.NewError("payment not found").
-			WithHint("Payment not found").
-			WithReportableDetails(map[string]interface{}{
-				"payment_id": id,
-			}).
-			Mark(ierr.ErrNotFound)
+		SetSpanError(span, mutationErr)
+		return mutationErr
 	}
 
 	r.DeleteCache(ctx, id)

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -348,14 +348,6 @@ func (r *paymentRepository) update(ctx context.Context, p *domainPayment.Payment
 
 	if err != nil {
 		SetSpanError(span, err)
-		if ent.IsNotFound(err) {
-			return ierr.WithError(err).
-				WithHint("Payment not found").
-				WithReportableDetails(map[string]interface{}{
-					"payment_id": p.ID,
-				}).
-				Mark(ierr.ErrNotFound)
-		}
 		return ierr.WithError(err).
 			WithHint("Failed to update payment").
 			WithReportableDetails(map[string]interface{}{
@@ -364,17 +356,31 @@ func (r *paymentRepository) update(ctx context.Context, p *domainPayment.Payment
 			Mark(ierr.ErrDatabase)
 	}
 
-	// With a status predicate, matching no rows means the payment moved to a
-	// different status between the caller's read and this write. Reported as a
-	// conflict so the caller can re-read rather than silently doing nothing.
-	if affected == 0 && expectedStatus != nil {
-		return ierr.NewError("payment status changed during update").
-			WithHint("The payment was modified concurrently. Retry with the current payment state.").
+	// A bulk update reports a missing row as zero rows affected with a nil error,
+	// so this count is the only signal that the write did not land — without it
+	// an unknown ID, or one belonging to another tenant, returns success having
+	// changed nothing.
+	if affected == 0 {
+		// With a status predicate, the row may well exist and simply have moved
+		// to a different status between the caller's read and this write.
+		// Reported as a conflict so the caller re-reads rather than treating the
+		// payment as gone.
+		if expectedStatus != nil {
+			return ierr.NewError("payment status changed during update").
+				WithHint("The payment was modified concurrently. Retry with the current payment state.").
+				WithReportableDetails(map[string]interface{}{
+					"payment_id":      p.ID,
+					"expected_status": *expectedStatus,
+				}).
+				Mark(ierr.ErrVersionConflict)
+		}
+
+		return ierr.NewError("payment not found").
+			WithHint("Payment not found").
 			WithReportableDetails(map[string]interface{}{
-				"payment_id":      p.ID,
-				"expected_status": *expectedStatus,
+				"payment_id": p.ID,
 			}).
-			Mark(ierr.ErrVersionConflict)
+			Mark(ierr.ErrNotFound)
 	}
 
 	r.DeleteCache(ctx, p.ID)
@@ -421,31 +427,34 @@ func (r *paymentRepository) delete(ctx context.Context, id string, expectedStatu
 		SetPaymentStatus(string(types.StatusArchived)).
 		Save(ctx)
 
-	if err == nil && affected == 0 && expectedStatus != nil {
-		return ierr.NewError("payment status changed during delete").
-			WithHint("The payment was modified concurrently. Re-read it before deleting.").
-			WithReportableDetails(map[string]interface{}{
-				"payment_id":      id,
-				"expected_status": *expectedStatus,
-			}).
-			Mark(ierr.ErrVersionConflict)
-	}
-
 	if err != nil {
-		if ent.IsNotFound(err) {
-			return ierr.WithError(err).
-				WithHint("Payment not found").
-				WithReportableDetails(map[string]interface{}{
-					"payment_id": id,
-				}).
-				Mark(ierr.ErrNotFound)
-		}
 		return ierr.WithError(err).
 			WithHint("Failed to delete payment").
 			WithReportableDetails(map[string]interface{}{
 				"payment_id": id,
 			}).
 			Mark(ierr.ErrDatabase)
+	}
+
+	// As in update: zero rows affected is the only signal that nothing was
+	// archived, since a bulk update does not report a missing row as an error.
+	if affected == 0 {
+		if expectedStatus != nil {
+			return ierr.NewError("payment status changed during delete").
+				WithHint("The payment was modified concurrently. Re-read it before deleting.").
+				WithReportableDetails(map[string]interface{}{
+					"payment_id":      id,
+					"expected_status": *expectedStatus,
+				}).
+				Mark(ierr.ErrVersionConflict)
+		}
+
+		return ierr.NewError("payment not found").
+			WithHint("Payment not found").
+			WithReportableDetails(map[string]interface{}{
+				"payment_id": id,
+			}).
+			Mark(ierr.ErrNotFound)
 	}
 
 	r.DeleteCache(ctx, id)

--- a/internal/testutil/encryption_key.go
+++ b/internal/testutil/encryption_key.go
@@ -1,0 +1,22 @@
+package testutil
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// NewEncryptionKey returns a random 32-byte key for tests that need to build a
+// security.EncryptionService.
+//
+// Generated rather than written as a literal so no test file carries a
+// credential-shaped constant: secret scanners flag those on every pull request,
+// and a real key that reaches a test file is indistinguishable from a fake one.
+// The value only has to round-trip within a single test run, so a fresh key per
+// call is sufficient.
+func NewEncryptionKey() string {
+	key := make([]byte, 16)
+	if _, err := rand.Read(key); err != nil {
+		panic("testutil: could not generate encryption key: " + err.Error())
+	}
+	return hex.EncodeToString(key)
+}

--- a/internal/testutil/encryption_key.go
+++ b/internal/testutil/encryption_key.go
@@ -5,8 +5,8 @@ import (
 	"encoding/hex"
 )
 
-// NewEncryptionKey returns a random 32-byte key for tests that need to build a
-// security.EncryptionService.
+// NewEncryptionKey returns a hex-encoded key drawn from 32 random bytes, for
+// tests that need to build a security.EncryptionService.
 //
 // Generated rather than written as a literal so no test file carries a
 // credential-shaped constant: secret scanners flag those on every pull request,
@@ -14,7 +14,7 @@ import (
 // The value only has to round-trip within a single test run, so a fresh key per
 // call is sufficient.
 func NewEncryptionKey() string {
-	key := make([]byte, 16)
+	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
 		panic("testutil: could not generate encryption key: " + err.Error())
 	}

--- a/internal/validator/url.go
+++ b/internal/validator/url.go
@@ -143,18 +143,72 @@ func IsPublicIP(ip net.IP) bool {
 		return false
 	}
 
-	// Carrier-grade NAT (100.64.0.0/10). Not covered by IsPrivate, but routable
-	// inside cloud networks and used by some metadata proxies.
+	// An IPv6 address can carry an IPv4 destination inside it. To4 only unwraps
+	// the IPv4-mapped and IPv4-compatible forms, so NAT64 and 6to4 addresses
+	// reach the IPv6 path with their real target hidden: 64:ff9b::a00:5 routes to
+	// 10.0.0.5 and 2002:a9fe:a9fe:: routes to the 169.254.169.254 metadata
+	// address. Judge those by the address they actually reach.
+	if embedded := embeddedIPv4(ip); embedded != nil {
+		return IsPublicIP(embedded)
+	}
+
 	if ip4 := ip.To4(); ip4 != nil {
-		if ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127 {
-			return false
-		}
-		// 192.0.0.0/24 holds IETF protocol assignments, including the
-		// 192.0.0.192 metadata address used by some providers.
-		if ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 0 {
-			return false
-		}
+		return isPublicIPv4(ip4)
 	}
 
 	return true
+}
+
+// isPublicIPv4 rejects the IPv4 ranges that are not publicly routable but are
+// not covered by the net.IP classification helpers.
+func isPublicIPv4(ip4 net.IP) bool {
+	switch {
+	// Carrier-grade NAT (100.64.0.0/10). Routable inside cloud networks and used
+	// by some metadata proxies.
+	case ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127:
+		return false
+	// 192.0.0.0/24 holds IETF protocol assignments, including the 192.0.0.192
+	// metadata address used by some providers.
+	case ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 0:
+		return false
+	// 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2) and
+	// 203.0.113.0/24 (TEST-NET-3) are documentation ranges, never a real
+	// destination.
+	case ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2,
+		ip4[0] == 198 && ip4[1] == 51 && ip4[2] == 100,
+		ip4[0] == 203 && ip4[1] == 0 && ip4[2] == 113:
+		return false
+	// 198.18.0.0/15 is reserved for inter-network benchmarking.
+	case ip4[0] == 198 && (ip4[1] == 18 || ip4[1] == 19):
+		return false
+	// 240.0.0.0/4 is reserved for future use, and includes the
+	// 255.255.255.255 broadcast address.
+	case ip4[0] >= 240:
+		return false
+	}
+
+	return true
+}
+
+// embeddedIPv4 returns the IPv4 address carried inside an IPv6 address for the
+// translation schemes that To4 does not unwrap, or nil when there is none.
+func embeddedIPv4(ip net.IP) net.IP {
+	ip16 := ip.To16()
+	if ip16 == nil || ip.To4() != nil {
+		return nil
+	}
+
+	// NAT64 well-known prefix 64:ff9b::/96 carries the IPv4 address in the last
+	// four bytes. The RFC 8215 local-use prefix 64:ff9b:1::/48 uses the same
+	// layout for its /96 suffix.
+	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b {
+		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+	}
+
+	// 6to4 (2002::/16) encodes the IPv4 address in bytes 2-5.
+	if ip16[0] == 0x20 && ip16[1] == 0x02 {
+		return net.IPv4(ip16[2], ip16[3], ip16[4], ip16[5])
+	}
+
+	return nil
 }

--- a/internal/validator/url.go
+++ b/internal/validator/url.go
@@ -143,6 +143,13 @@ func IsPublicIP(ip net.IP) bool {
 		return false
 	}
 
+	// The RFC 8215 local-use translation range carries an IPv4 destination that
+	// cannot be recovered without knowing the operator's prefix length, so it is
+	// refused rather than decoded. See isNAT64LocalUsePrefix.
+	if ip16 := ip.To16(); ip16 != nil && ip.To4() == nil && isNAT64LocalUsePrefix(ip16) {
+		return false
+	}
+
 	// An IPv6 address can carry an IPv4 destination inside it. To4 only unwraps
 	// the IPv4-mapped and IPv4-compatible forms, so NAT64 and 6to4 addresses
 	// reach the IPv6 path with their real target hidden: 64:ff9b::a00:5 routes to
@@ -199,9 +206,13 @@ func embeddedIPv4(ip net.IP) net.IP {
 	}
 
 	// NAT64 well-known prefix 64:ff9b::/96 carries the IPv4 address in the last
-	// four bytes. The RFC 8215 local-use prefix 64:ff9b:1::/48 uses the same
-	// layout for its /96 suffix.
-	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b {
+	// four bytes. Bytes 4-11 must be zero for the prefix to be the /96 one:
+	// matching on the first four bytes alone would also catch 64:ff9b:1::/48,
+	// whose embedded address RFC 6052 splits around the u-octet rather than
+	// leaving in the final four bytes. Reading those bytes for a /48 address
+	// yields the wrong IPv4, so 64:ff9b:1::/48 is rejected outright below rather
+	// than decoded here.
+	if isNAT64WellKnownPrefix(ip16) {
 		return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
 	}
 
@@ -211,4 +222,35 @@ func embeddedIPv4(ip net.IP) net.IP {
 	}
 
 	return nil
+}
+
+// isNAT64WellKnownPrefix reports whether the address uses the 64:ff9b::/96
+// well-known prefix, which is the only NAT64 prefix whose embedded IPv4 address
+// sits in the final four bytes.
+func isNAT64WellKnownPrefix(ip16 net.IP) bool {
+	if ip16[0] != 0x00 || ip16[1] != 0x64 || ip16[2] != 0xff || ip16[3] != 0x9b {
+		return false
+	}
+	for _, b := range ip16[4:12] {
+		if b != 0x00 {
+			return false
+		}
+	}
+	return true
+}
+
+// isNAT64LocalUsePrefix reports whether the address falls in 64:ff9b:1::/48,
+// the RFC 8215 local-use translation range.
+//
+// RFC 6052 encodes the embedded IPv4 address differently for each prefix length
+// and splits it around the reserved u-octet for prefixes shorter than /96, so
+// the destination cannot be recovered without knowing which length the operator
+// configured. RFC 8215 says applications must not assume the embedded-address
+// syntax here. Since the real target is unknowable, the whole range is refused
+// rather than decoded: 64:ff9b:1:a00:0:5:808:808 translates to 10.0.0.5 while
+// its final four bytes read as 8.8.8.8.
+func isNAT64LocalUsePrefix(ip16 net.IP) bool {
+	return ip16[0] == 0x00 && ip16[1] == 0x64 &&
+		ip16[2] == 0xff && ip16[3] == 0x9b &&
+		ip16[4] == 0x00 && ip16[5] == 0x01
 }

--- a/internal/validator/url_test.go
+++ b/internal/validator/url_test.go
@@ -37,6 +37,23 @@ func TestValidateOutboundURL(t *testing.T) {
 		{"carrier grade nat", "https://100.64.0.1/", true},
 		{"ietf protocol assignment", "https://192.0.0.192/", true},
 
+		// IPv6 forms that carry an IPv4 target To4 does not unwrap. Judged by the
+		// address they actually route to, not by the outer IPv6 address.
+		{"nat64 rfc1918", "https://[64:ff9b::a00:5]/", true},
+		{"nat64 imds", "https://[64:ff9b::a9fe:a9fe]/", true},
+		{"6to4 rfc1918", "https://[2002:a00:5::]/", true},
+		{"6to4 imds", "https://[2002:a9fe:a9fe::]/", true},
+		{"nat64 public target allowed", "https://[64:ff9b::5db8:d822]/", false},
+
+		// Reserved IPv4 ranges that are not a real destination.
+		{"benchmarking range", "https://198.18.0.1/", true},
+		{"benchmarking range upper", "https://198.19.255.254/", true},
+		{"reserved future use", "https://240.0.0.1/", true},
+		{"broadcast", "https://255.255.255.255/", true},
+		{"test net one", "https://192.0.2.1/", true},
+		{"test net two", "https://198.51.100.1/", true},
+		{"test net three", "https://203.0.113.1/", true},
+
 		{"http scheme rejected", "http://api.example.com/", true},
 		{"file scheme rejected", "file:///etc/passwd", true},
 		{"gopher scheme rejected", "gopher://api.example.com/", true},

--- a/internal/validator/url_test.go
+++ b/internal/validator/url_test.go
@@ -45,6 +45,14 @@ func TestValidateOutboundURL(t *testing.T) {
 		{"6to4 imds", "https://[2002:a9fe:a9fe::]/", true},
 		{"nat64 public target allowed", "https://[64:ff9b::5db8:d822]/", false},
 
+		// 64:ff9b:1::/48 is the RFC 8215 local-use range. RFC 6052 splits the
+		// embedded address for prefixes shorter than /96, so the final four bytes
+		// are not the destination: this address translates to 10.0.0.5 while its
+		// suffix reads as 8.8.8.8. The whole range is refused rather than decoded.
+		{"nat64 local use split encoding", "https://[64:ff9b:1:a00:0:5:808:808]/", true},
+		{"nat64 local use zero suffix", "https://[64:ff9b:1::]/", true},
+		{"nat64 local use public looking suffix", "https://[64:ff9b:1::5db8:d822]/", true},
+
 		// Reserved IPv4 ranges that are not a real destination.
 		{"benchmarking range", "https://198.18.0.1/", true},
 		{"benchmarking range upper", "https://198.19.255.254/", true},


### PR DESCRIPTION
## **User description**
Follow-ups to the CodeRabbit review comments on #2503. Eight findings addressed, two skipped with reasons below.

## Security

**`IsPublicIP` accepted IPv6 addresses carrying private IPv4 targets** — `internal/validator/url.go`

`To4()` does not unwrap NAT64 (`64:ff9b::/96`) or 6to4 (`2002::/16`), so those addresses reached the final `return true` while routing to an internal destination. Embedded IPv4 targets are now extracted and re-checked recursively.

Also added the reserved ranges the doc comment already claimed to cover but did not enforce: `198.18.0.0/15` (benchmarking), `240.0.0.0/4` (reserved, includes broadcast), and the TEST-NET blocks `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`.

**Guarded transport inherited the environment proxy** — `internal/httpclient/dialer.go`

`http.DefaultTransport.Clone()` preserves `Proxy: ProxyFromEnvironment`. With `HTTP_PROXY` set, the dial went to the proxy address, `publicOnlyDialContext` classified the proxy, and the proxy then reached the original destination unchecked. It also made the guard's behaviour depend on the environment the process happened to run in. `transport.Proxy` is now explicitly cleared.

Both fixes carry regression tests that fail without the change (verified by reverting the fix and re-running).

## Data integrity

**Bulk `Update().Where(...)` reported missing rows as success** — `internal/repository/ent/payment.go`

The move from single-entity updates to bulk updates changed the not-found signal: a non-matching ID, tenant, or environment now yields `affected == 0` with a `nil` error, which made the existing `ent.IsNotFound(err)` branches unreachable. Both `update` and `delete` returned success having written nothing; only the `expectedStatus != nil` path checked the count.

Both operations now treat a zero count as not-found, keeping the version-conflict error for the expected-status case. This restores parity with `InMemoryPaymentStore`, which already returned `ErrNotFound` — the divergence is why the gap went unnoticed in service tests.

## Correctness and hygiene

- **Grouped-invoicing checkout bypass narrowed** (`internal/api/dto/subscription.go`) — the early return skipped every remaining checkout restriction. `createGroupedInvoicingChildren` builds a child with `parent_subscription_id` plus the parent's checkout, which is what `checkoutUnsupportedFields` rejects, so only that check needs skipping. Generated children set neither `phases` nor `subscription_status`, so those restrictions now still apply.
- **Hardcoded encryption key removed from tests** — the same literal appeared in three test files and triggered the GitGuardian pipeline failure. Replaced with `testutil.NewEncryptionKey()`; `internal/integration/whop/client_test.go` gets a local generator because it cannot import `testutil` (documented import cycle).
- **Cleanup log message corrected** (`internal/ee/service/subscription_create.go`) — it said "leaving the group intact" at a point where the child's dependencies had already been archived, which would mislead an operator during triage.
- **gofmt** on a struct literal in `internal/ee/service/payment_processor.go`.

## Skipped

- **Trivy multi-arch scanning** (`.github/workflows/publish-e2eprobe-image.yml`) — valid, but CI-only and independent of this change; better as its own PR.
- **`InternalCreditNoteEvent` environment scoping** — not a defect. `handler.go:112,218` set `types.CtxEnvironmentID` from the webhook envelope before `BuildPayload` runs, so the repository lookups inside the builders are already environment-scoped. Adding the field to the event would be redundant.

Two of CodeRabbit's claims were corrected rather than implemented as written: the 31-character test key does **not** fail `NewEncryptionService` (keys of any length are SHA-256 normalized to 32 bytes), and the grouped-invoicing bypass serves a real internal path rather than being a user-facing hole.

Not addressed here: the deterministic payment idempotency key (#6 in the review). It is a genuine behaviour change to the payment lifecycle and wants its own PR and test plan.

## Verification

- `go build ./internal/...` — clean
- `go test ./internal/...` — all pass, no failures
- `make lint-ci` (loglint merge gate) — clean
- `gofmt -l` on changed files — clean
- `go vet` on changed packages — clean

Pre-existing and unrelated: `api/custom/go/async.go` build errors and ~100 gofmt-dirty files exist identically on `develop` (confirmed by stashing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkout compatibility for grouped-invoicing child subscriptions while preserving subscription validation.
  * Payment updates and deletions now correctly report missing records and version conflicts.
  * Strengthened outbound URL validation for embedded IPv4 addresses, reserved ranges, broadcast addresses, and documentation networks.
  * Prevented configured proxies from bypassing public-address protections.
  * Protected payment and setup metadata from being overwritten by conflicting custom values.
  * Improved cleanup failure messages when subscription archival is incomplete.
* **Tests**
  * Expanded coverage for webhook security, proxy handling, metadata protection, and IPv4/IPv6 address validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent unsafe outbound requests and protect payment data integrity

### What Changed
- Blocks private, reserved, documentation, and embedded IPv4 destinations in IPv6 URLs, including requests that could bypass protection through environment proxies
- Payment updates and deletions now report missing records instead of succeeding without changing anything, while preserving concurrent-update conflicts
- Stripe-controlled metadata can no longer be overwritten by caller-provided values, preventing incorrect webhook reconciliation or unauthorized default payment methods
- Grouped-invoicing checkout children continue to inherit checkout settings while still rejecting unsupported status and phase fields

### Impact
`✅ Fewer SSRF paths to internal and metadata services`
`✅ Clearer errors for missing payments`
`✅ Safer Stripe payment and webhook reconciliation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
