### PR TITLE
feat(users): add support for rbac

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/environment"
 	"github.com/flexprice/flexprice/internal/domain/incomingwebhookevent"
 	"github.com/flexprice/flexprice/internal/domain/proration"
+	"github.com/flexprice/flexprice/internal/domain/user"
 	syncExport "github.com/flexprice/flexprice/internal/ee/service/sync/export"
 	"github.com/flexprice/flexprice/internal/integration"
 	"github.com/flexprice/flexprice/internal/interfaces"
@@ -436,6 +437,7 @@ func provideRouter(
 	tenantService service.TenantService,
 	webhookRequestRepo incomingwebhookevent.Repository,
 	environmentRepo environment.Repository,
+	userRepo user.Repository,
 ) *gin.Engine {
 	return api.NewRouter(
 		handlers,
@@ -447,6 +449,7 @@ func provideRouter(
 		tenantService,
 		webhookRequestRepo,
 		environmentRepo,
+		userRepo,
 	)
 }
 

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -46,7 +46,7 @@ func (User) Fields() []ent.Field {
 			Default("user"),
 		field.Strings("roles").
 			Optional().
-			Default([]string{"super_admin"}),
+			Default([]string{}),
 	}
 }
 

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -46,7 +46,7 @@ func (User) Fields() []ent.Field {
 			Default("user"),
 		field.Strings("roles").
 			Optional().
-			Default([]string{}),
+			Default([]string{"super_admin"}),
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -6,6 +6,7 @@ import (
 	"github.com/flexprice/flexprice/internal/config"
 	domainEnvironment "github.com/flexprice/flexprice/internal/domain/environment"
 	domainIncomingWebhookEvent "github.com/flexprice/flexprice/internal/domain/incomingwebhookevent"
+	domainUser "github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/rbac"
@@ -78,6 +79,7 @@ func NewRouter(
 	tenantService service.TenantService,
 	webhookRequestRepo domainIncomingWebhookEvent.Repository,
 	environmentRepo domainEnvironment.Repository,
+	userRepo domainUser.Repository,
 ) *gin.Engine {
 	// gin.SetMode(gin.ReleaseMode)
 
@@ -140,7 +142,7 @@ func NewRouter(
 		v1Public.POST("/auth/login", handlers.Auth.Login)
 	}
 
-	private := router.Group("/", middleware.AuthenticateMiddleware(cfg, secretService, environmentRepo, logger))
+	private := router.Group("/", middleware.AuthenticateMiddleware(cfg, secretService, environmentRepo, userRepo, logger))
 	private.Use(middleware.TenantStatusMiddleware(tenantService, logger))
 	private.Use(middleware.EnvAccessMiddleware(envAccessService, logger))
 	private.Use(middleware.TenantContextMiddleware)

--- a/internal/config/rbac/roles.json
+++ b/internal/config/rbac/roles.json
@@ -17,9 +17,9 @@
 
   "writer": {
     "name": "Writer",
-    "description": "Limited to writing resources for users.",
+    "description": "Can read and write resources for users.",
     "permissions": {
-      "*": ["write"]
+      "*": ["read", "write"]
     }
   },
   

--- a/internal/config/rbac/roles.json
+++ b/internal/config/rbac/roles.json
@@ -6,6 +6,22 @@
       "*": ["*"]
     }
   },
+
+  "reader": {
+    "name": "Reader",
+    "description": "Limited to reading resources for users.",
+    "permissions": {
+      "*": ["read"]
+    }
+  },
+
+  "writer": {
+    "name": "Writer",
+    "description": "Limited to writing resources for users.",
+    "permissions": {
+      "*": ["write"]
+    }
+  },
   
   "event_ingestor": {
     "name": "Event Ingestor",

--- a/internal/ee/service/auth_test.go
+++ b/internal/ee/service/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -140,6 +141,14 @@ func (s *AuthServiceSuite) TestSignUp() {
 				s.NotNil(resp)
 				// We used a real provider, so check that token exists (not necessarily 'auth-token' as before)
 				s.NotEmpty(resp.Token)
+
+				// The user who creates a tenant owns it, so onboarding must grant
+				// super_admin outright — no roles would leave them unable to
+				// administer the tenant they just signed up for.
+				owner, err := s.userRepo.GetByEmail(s.GetContext(), tc.req.Email)
+				s.NoError(err)
+				s.Equal([]string{types.RoleSuperAdmin.String()}, owner.Roles)
+				s.Equal(types.UserTypeUser, owner.Type)
 
 				if tc.req.Metadata != nil {
 					createdUser, err := s.userRepo.GetByEmail(s.GetContext(), tc.req.Email)

--- a/internal/ee/service/onboarding.go
+++ b/internal/ee/service/onboarding.go
@@ -437,6 +437,8 @@ func (s *onboardingService) OnboardNewUserWithTenant(ctx context.Context, req dt
 	newUser := &user.User{
 		ID:       req.UserID,
 		Email:    req.Email,
+		Type:     types.UserTypeUser,
+		Roles:    []string{types.RoleSuperAdmin.String()},
 		Metadata: req.Metadata,
 		BaseModel: types.BaseModel{
 			TenantID:  tenantID,

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -133,18 +133,8 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 				WithHint("Service accounts require RBAC for role validation; provide a non-nil RBAC service.").
 				Mark(ierr.ErrValidation)
 		}
-		for _, role := range req.Roles {
-			if !s.rbacService.ValidateRole(role) {
-				return nil, ierr.NewError("invalid role").
-					WithHint("Role '" + role + "' does not exist").
-					WithReportableDetails(map[string]interface{}{"role": role}).
-					Mark(ierr.ErrValidation)
-			}
-		}
-		if lo.Contains(req.Roles, "super_admin") && len(req.Roles) > 1 {
-			return nil, ierr.NewError("super admin role need not be combined with other roles").
-				WithHint("When super_admin is selected, no other roles need to be assigned").
-				Mark(ierr.ErrValidation)
+		if err := s.rbacService.ValidateRoles(req.Type, req.Roles); err != nil {
+			return nil, err
 		}
 		newUser = &user.User{
 			ID:    types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USER),
@@ -387,11 +377,26 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 		}
 	}
 
+	// Invited users default to read-only access.
+	roles := req.Roles
+	if len(roles) == 0 {
+		roles = []string{types.RoleReader.String()}
+	} else {
+		if s.rbacService == nil {
+			return nil, nil, ierr.NewError("RBAC not configured").
+				WithHint("Role assignment requires RBAC for role validation; provide a non-nil RBAC service.").
+				Mark(ierr.ErrValidation)
+		}
+		if err := s.rbacService.ValidateRoles(types.UserTypeUser, roles); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	newUser := &user.User{
 		ID:    userID,
 		Email: req.Email,
 		Type:  types.UserTypeUser,
-		Roles: []string{},
+		Roles: roles,
 	}
 	newUser.BaseModel = types.GetDefaultBaseModel(ctx)
 	newUser.BaseModel.CreatedBy = currentUserID

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -312,6 +312,28 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 
 	var userID string
 
+	// Resolve and check the roles up front. Everything below provisions state —
+	// a provider identity, an auth record — that this function does not roll
+	// back, so a rejected role must fail before any of it is created rather than
+	// leaving an orphaned account behind holding the invitee's email.
+	// Invited users default to read-only access.
+	roles := req.Roles
+	if len(roles) == 0 {
+		roles = []string{types.RoleReader.String()}
+	} else {
+		if s.rbacService == nil {
+			return nil, nil, ierr.NewError("RBAC not configured").
+				WithHint("Role assignment requires RBAC for role validation; provide a non-nil RBAC service.").
+				Mark(ierr.ErrValidation)
+		}
+		if err := s.rbacService.ValidateRoles(types.UserTypeUser, roles); err != nil {
+			return nil, nil, err
+		}
+		if err := s.rbacService.CanGrantRoles(types.GetRoles(ctx), roles); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// Check if user by email already exists
 	existingUser, err := s.userRepo.GetByEmail(ctx, req.Email)
 	if err != nil && !ierr.IsNotFound(err) {
@@ -376,24 +398,6 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 				Mark(ierr.ErrValidation)
 		}
 		if err := s.authRepo.CreateAuth(ctx, inviteResp.AuthRecord); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	// Invited users default to read-only access.
-	roles := req.Roles
-	if len(roles) == 0 {
-		roles = []string{types.RoleReader.String()}
-	} else {
-		if s.rbacService == nil {
-			return nil, nil, ierr.NewError("RBAC not configured").
-				WithHint("Role assignment requires RBAC for role validation; provide a non-nil RBAC service.").
-				Mark(ierr.ErrValidation)
-		}
-		if err := s.rbacService.ValidateRoles(types.UserTypeUser, roles); err != nil {
-			return nil, nil, err
-		}
-		if err := s.rbacService.CanGrantRoles(types.GetRoles(ctx), roles); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -312,6 +312,14 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 
 	var userID string
 
+	// Admitting someone to the tenant is an administrative act, so it is
+	// restricted to super_admins regardless of which role the invitee is given.
+	if !lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String()) {
+		return nil, nil, ierr.NewError("only super_admin can invite users").
+			WithHint("Ask a tenant super_admin to invite this user").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
 	// Resolve and check the roles up front. Everything below provisions state —
 	// a provider identity, an auth record — that this function does not roll
 	// back, so a rejected role must fail before any of it is created rather than

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -136,6 +136,9 @@ func (s *userService) CreateUser(ctx context.Context, req *dto.CreateUserRequest
 		if err := s.rbacService.ValidateRoles(req.Type, req.Roles); err != nil {
 			return nil, err
 		}
+		if err := s.rbacService.CanGrantRoles(types.GetRoles(ctx), req.Roles); err != nil {
+			return nil, err
+		}
 		newUser = &user.User{
 			ID:    types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USER),
 			Name:  req.Name,
@@ -388,6 +391,9 @@ func (s *userService) InviteUser(ctx context.Context, req *dto.CreateUserRequest
 				Mark(ierr.ErrValidation)
 		}
 		if err := s.rbacService.ValidateRoles(types.UserTypeUser, roles); err != nil {
+			return nil, nil, err
+		}
+		if err := s.rbacService.CanGrantRoles(types.GetRoles(ctx), roles); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -114,14 +114,10 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 	ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
 	ctx = context.WithValue(ctx, types.CtxUserID, "test-actor")
 
-	rbacSvc, _ := rbac.NewRBACService(&config.Configuration{
-		RBAC: config.RBACConfig{RolesConfigPath: "internal/config/rbac/roles.json"},
+	rbacSvc, err := rbac.NewRBACService(&config.Configuration{
+		RBAC: config.RBACConfig{RolesConfigPath: "../../config/rbac/roles.json"},
 	})
-	if rbacSvc == nil {
-		rbacSvc, _ = rbac.NewRBACService(&config.Configuration{
-			RBAC: config.RBACConfig{RolesConfigPath: "../internal/config/rbac/roles.json"},
-		})
-	}
+	s.Require().NoError(err)
 
 	tests := []struct {
 		name        string
@@ -177,7 +173,7 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 		},
 	}
 
-	if rbacSvc != nil {
+	{
 		tests = append(tests, struct {
 			name        string
 			req         dto.CreateUserRequest
@@ -198,6 +194,29 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 			},
 			wantErr:     false,
 			errContains: "",
+		})
+
+		// reader is a person's access level, so a service account must not hold it.
+		tests = append(tests, struct {
+			name        string
+			req         dto.CreateUserRequest
+			setup       func() *userService
+			wantErr     bool
+			errContains string
+		}{
+			name: "type_service_account_with_user_role_rejected",
+			req:  dto.CreateUserRequest{Type: types.UserTypeServiceAccount, Roles: []string{types.RoleReader.String()}},
+			setup: func() *userService {
+				return &userService{
+					userRepo:        s.userRepo,
+					tenantRepo:      s.tenantRepo,
+					rbacService:     rbacSvc,
+					supabaseAuth:    nil,
+					settingsService: nil,
+				}
+			},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
 		})
 	}
 
@@ -222,6 +241,110 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 				s.NotNil(resp.UserResponse)
 				s.Equal(tt.req.Type, resp.UserResponse.Type)
 			}
+		})
+	}
+}
+
+// An invited user must land on a role rather than on no roles at all: with the
+// empty-role-set fallback gone, a user created without roles would be refused
+// every request.
+func (s *UserServiceSuite) TestInviteUser_RoleAssignment() {
+	rbacSvc, err := rbac.NewRBACService(&config.Configuration{
+		RBAC: config.RBACConfig{RolesConfigPath: "../../config/rbac/roles.json"},
+	})
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name        string
+		reqRoles    []string
+		wantRoles   []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "no roles requested defaults to reader",
+			reqRoles:  nil,
+			wantRoles: []string{types.RoleReader.String()},
+		},
+		{
+			name:      "empty roles requested defaults to reader",
+			reqRoles:  []string{},
+			wantRoles: []string{types.RoleReader.String()},
+		},
+		{
+			name:      "requested roles are honoured",
+			reqRoles:  []string{types.RoleWriter.String()},
+			wantRoles: []string{types.RoleWriter.String()},
+		},
+		{
+			name:        "undefined role is rejected",
+			reqRoles:    []string{"nonexistent"},
+			wantErr:     true,
+			errContains: "invalid role",
+		},
+		{
+			name:        "super_admin cannot be combined with another role",
+			reqRoles:    []string{types.RoleSuperAdmin.String(), types.RoleReader.String()},
+			wantErr:     true,
+			errContains: "super admin role need not be combined",
+		},
+		{
+			name:        "a service account scope cannot be given to a person",
+			reqRoles:    []string{types.RoleEventIngestor.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			ctx := testutil.SetupContext()
+			ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
+			ctx = context.WithValue(ctx, types.CtxUserID, "actor-1")
+
+			userRepo := testutil.NewInMemoryUserStore()
+			tenantRepo := testutil.NewInMemoryTenantStore()
+			_ = tenantRepo.Create(ctx, &tenant.Tenant{ID: types.DefaultTenantID, Name: "Test Tenant"})
+
+			svc := &userService{
+				userRepo:    userRepo,
+				tenantRepo:  tenantRepo,
+				authRepo:    testutil.NewInMemoryAuthRepository(),
+				rbacService: rbacSvc,
+				cfg: &config.Configuration{
+					Auth: config.AuthConfig{
+						Provider: types.AuthProviderFlexprice,
+						Secret:   "test-secret-key-32-bytes-minimum!",
+					},
+				},
+				settingsService: &settingsService{
+					ServiceParams: ServiceParams{SettingsRepo: testutil.NewInMemorySettingsStore()},
+				},
+			}
+
+			created, password, err := svc.InviteUser(ctx, &dto.CreateUserRequest{
+				Type:  types.UserTypeUser,
+				Email: "invitee@example.com",
+				Roles: tc.reqRoles,
+			}, "actor-1")
+
+			if tc.wantErr {
+				s.Error(err)
+				s.Nil(created)
+				s.Contains(err.Error(), tc.errContains)
+				return
+			}
+
+			s.NoError(err)
+			s.Require().NotNil(created)
+			s.Equal(tc.wantRoles, created.Roles)
+			s.Equal(types.UserTypeUser, created.Type)
+			s.NotNil(password)
+
+			// The role must be on the persisted record, not just the returned struct.
+			stored, err := userRepo.GetByID(ctx, created.ID)
+			s.NoError(err)
+			s.Equal(tc.wantRoles, stored.Roles)
 		})
 	}
 }
@@ -535,10 +658,13 @@ func (s *RBACPermissionSuite) TestUnknownRole_DeniedEverything() {
 	s.False(s.rbacSvc.HasPermission(roles, "customer", "write"))
 }
 
-func (s *RBACPermissionSuite) TestNoRoles_FullAccess() {
-	// Empty roles = backward-compatible full access (see HasPermission implementation)
-	s.True(s.rbacSvc.HasPermission([]string{}, "event", "read"))
-	s.True(s.rbacSvc.HasPermission([]string{}, "customer", "write"))
+// A caller carrying no roles holds no grant, so every check must deny. This
+// closes the former fail-open path, where an empty role set was read as full
+// access and any principal whose roles were never populated passed every check.
+func (s *RBACPermissionSuite) TestNoRoles_DeniedEverything() {
+	s.False(s.rbacSvc.HasPermission([]string{}, "event", "read"))
+	s.False(s.rbacSvc.HasPermission([]string{}, "customer", "write"))
+	s.False(s.rbacSvc.HasPermission(nil, "customer", "read"))
 }
 
 func (s *RBACPermissionSuite) TestSuperAdmin_CombinedWithOtherRoles_StillFullAccess() {
@@ -547,10 +673,109 @@ func (s *RBACPermissionSuite) TestSuperAdmin_CombinedWithOtherRoles_StillFullAcc
 		"super_admin in role set grants full access regardless of other roles")
 }
 
-func (s *RBACPermissionSuite) TestValidateRole() {
-	s.True(s.rbacSvc.ValidateRole("super_admin"))
-	s.True(s.rbacSvc.ValidateRole("event_ingestor"))
-	s.True(s.rbacSvc.ValidateRole("event_reader"))
-	s.False(s.rbacSvc.ValidateRole("nonexistent"))
-	s.False(s.rbacSvc.ValidateRole(""))
+func (s *RBACPermissionSuite) TestValidateRoles() {
+	testCases := []struct {
+		name        string
+		userType    types.UserType
+		roles       []string
+		wantErr     bool
+		errContains string
+	}{
+		{name: "empty_role_set_is_allowed", userType: types.UserTypeUser, roles: []string{}},
+
+		// A person holds an access level over the tenant.
+		{name: "user_may_hold_super_admin", userType: types.UserTypeUser, roles: []string{types.RoleSuperAdmin.String()}},
+		{name: "user_may_hold_reader", userType: types.UserTypeUser, roles: []string{types.RoleReader.String()}},
+		{name: "user_may_hold_writer", userType: types.UserTypeUser, roles: []string{types.RoleWriter.String()}},
+		{name: "user_may_hold_reader_and_writer", userType: types.UserTypeUser, roles: []string{types.RoleReader.String(), types.RoleWriter.String()}},
+
+		// A service account holds full access or a narrow machine scope.
+		{name: "service_account_may_hold_super_admin", userType: types.UserTypeServiceAccount, roles: []string{types.RoleSuperAdmin.String()}},
+		{name: "service_account_may_hold_event_scopes", userType: types.UserTypeServiceAccount, roles: []string{types.RoleEventIngestor.String(), types.RoleEventReader.String()}},
+
+		// The two sets are disjoint apart from super_admin.
+		{
+			name:        "user_may_not_hold_event_ingestor",
+			userType:    types.UserTypeUser,
+			roles:       []string{types.RoleEventIngestor.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+		{
+			name:        "user_may_not_hold_event_reader",
+			userType:    types.UserTypeUser,
+			roles:       []string{types.RoleEventReader.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+		{
+			name:        "service_account_may_not_hold_reader",
+			userType:    types.UserTypeServiceAccount,
+			roles:       []string{types.RoleReader.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+		{
+			name:        "service_account_may_not_hold_writer",
+			userType:    types.UserTypeServiceAccount,
+			roles:       []string{types.RoleWriter.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+		{
+			name:        "one_disallowed_role_rejects_the_whole_set",
+			userType:    types.UserTypeServiceAccount,
+			roles:       []string{types.RoleEventReader.String(), types.RoleWriter.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+		{
+			name:        "unknown_user_type_may_hold_nothing",
+			userType:    types.UserType("robot"),
+			roles:       []string{types.RoleReader.String()},
+			wantErr:     true,
+			errContains: "not assignable to this user type",
+		},
+
+		{
+			name:        "undefined_role_rejected",
+			userType:    types.UserTypeUser,
+			roles:       []string{"nonexistent"},
+			wantErr:     true,
+			errContains: "invalid role",
+		},
+		{
+			name:        "empty_role_name_rejected",
+			userType:    types.UserTypeUser,
+			roles:       []string{""},
+			wantErr:     true,
+			errContains: "invalid role",
+		},
+		{
+			name:        "one_undefined_role_rejects_the_whole_set",
+			userType:    types.UserTypeUser,
+			roles:       []string{types.RoleReader.String(), "nonexistent"},
+			wantErr:     true,
+			errContains: "invalid role",
+		},
+		{
+			name:        "super_admin_cannot_be_combined",
+			userType:    types.UserTypeUser,
+			roles:       []string{types.RoleSuperAdmin.String(), types.RoleReader.String()},
+			wantErr:     true,
+			errContains: "super admin role need not be combined",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := s.rbacSvc.ValidateRoles(tc.userType, tc.roles)
+			if tc.wantErr {
+				s.Error(err)
+				s.Contains(err.Error(), tc.errContains)
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
 }

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -381,10 +381,11 @@ func (s *UserServiceSuite) TestInviteUser_RoleAssignment() {
 			tenantRepo := testutil.NewInMemoryTenantStore()
 			_ = tenantRepo.Create(ctx, &tenant.Tenant{ID: types.DefaultTenantID, Name: "Test Tenant"})
 
+			authRepo := testutil.NewInMemoryAuthRepository()
 			svc := &userService{
 				userRepo:    userRepo,
 				tenantRepo:  tenantRepo,
-				authRepo:    testutil.NewInMemoryAuthRepository(),
+				authRepo:    authRepo,
 				rbacService: rbacSvc,
 				cfg: &config.Configuration{
 					Auth: config.AuthConfig{
@@ -407,6 +408,11 @@ func (s *UserServiceSuite) TestInviteUser_RoleAssignment() {
 				s.Error(err)
 				s.Nil(created)
 				s.Contains(err.Error(), tc.errContains)
+
+				// A rejected role must fail before anything is provisioned,
+				// otherwise an auth record is left behind holding the invitee's
+				// identity with no user attached to it.
+				s.Zero(authRepo.Count(), "a rejected role must not leave auth material behind")
 				return
 			}
 

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -725,6 +725,25 @@ func (s *RBACPermissionSuite) TestEventReader_CanOnlyReadEvents() {
 	}
 }
 
+// A writer that could not read would be unable to fetch the very records it is
+// allowed to modify, so write implies read.
+func (s *RBACPermissionSuite) TestWriter_CanReadAndWrite() {
+	roles := []string{types.RoleWriter.String()}
+	for _, entity := range []string{"customer", "invoice", "event"} {
+		s.True(s.rbacSvc.HasPermission(roles, entity, "read"), "writer should read %s", entity)
+		s.True(s.rbacSvc.HasPermission(roles, entity, "write"), "writer should write %s", entity)
+	}
+}
+
+// Reader stays read-only; widening writer must not have widened reader with it.
+func (s *RBACPermissionSuite) TestReader_CanOnlyRead() {
+	roles := []string{types.RoleReader.String()}
+	for _, entity := range []string{"customer", "invoice", "event"} {
+		s.True(s.rbacSvc.HasPermission(roles, entity, "read"), "reader should read %s", entity)
+		s.False(s.rbacSvc.HasPermission(roles, entity, "write"), "reader should NOT write %s", entity)
+	}
+}
+
 func (s *RBACPermissionSuite) TestMultipleRoles_UnionOfPermissions() {
 	roles := []string{"event_ingestor", "event_reader"}
 
@@ -797,10 +816,9 @@ func (s *RBACPermissionSuite) TestCanGrantRoles() {
 			wantErr:     true,
 		},
 		{
-			name:        "writer cannot grant a read scope it does not hold",
+			name:        "writer can grant a read scope, since writer includes read",
 			callerRoles: []string{types.RoleWriter.String()},
 			requested:   []string{types.RoleEventReader.String()},
-			wantErr:     true,
 		},
 		{
 			name:        "writer cannot grant super_admin",

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -113,6 +113,8 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 	ctx := testutil.SetupContext()
 	ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
 	ctx = context.WithValue(ctx, types.CtxUserID, "test-actor")
+	// The caller can only grant access it holds, so these cases act as a super_admin.
+	ctx = context.WithValue(ctx, types.CtxRoles, []string{types.RoleSuperAdmin.String()})
 
 	rbacSvc, err := rbac.NewRBACService(&config.Configuration{
 		RBAC: config.RBACConfig{RolesConfigPath: "../../config/rbac/roles.json"},
@@ -245,6 +247,77 @@ func (s *UserServiceSuite) TestCreateUser_TableDriven() {
 	}
 }
 
+// Creating a principal is a way to hand out access, so it must not become a
+// route around the caller's own limits: a reader minting a write-scoped service
+// account would be a straightforward privilege escalation.
+func (s *UserServiceSuite) TestCreateUser_CannotGrantBeyondCallerAccess() {
+	rbacSvc, err := rbac.NewRBACService(&config.Configuration{
+		RBAC: config.RBACConfig{RolesConfigPath: "../../config/rbac/roles.json"},
+	})
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name        string
+		callerRoles []string
+		saRoles     []string
+		wantErr     bool
+	}{
+		{
+			name:        "super_admin can create a write-scoped service account",
+			callerRoles: []string{types.RoleSuperAdmin.String()},
+			saRoles:     []string{types.RoleEventIngestor.String()},
+		},
+		{
+			name:        "writer can create a write-scoped service account",
+			callerRoles: []string{types.RoleWriter.String()},
+			saRoles:     []string{types.RoleEventIngestor.String()},
+		},
+		{
+			name:        "reader cannot create a write-scoped service account",
+			callerRoles: []string{types.RoleReader.String()},
+			saRoles:     []string{types.RoleEventIngestor.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "writer cannot create a super_admin service account",
+			callerRoles: []string{types.RoleWriter.String()},
+			saRoles:     []string{types.RoleSuperAdmin.String()},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			ctx := testutil.SetupContext()
+			ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
+			ctx = context.WithValue(ctx, types.CtxUserID, "actor-1")
+			ctx = context.WithValue(ctx, types.CtxRoles, tc.callerRoles)
+
+			userRepo := testutil.NewInMemoryUserStore()
+			tenantRepo := testutil.NewInMemoryTenantStore()
+			_ = tenantRepo.Create(ctx, &tenant.Tenant{ID: types.DefaultTenantID, Name: "Test Tenant"})
+
+			svc := &userService{userRepo: userRepo, tenantRepo: tenantRepo, rbacService: rbacSvc}
+
+			resp, err := svc.CreateUser(ctx, &dto.CreateUserRequest{
+				Type:  types.UserTypeServiceAccount,
+				Name:  "sa",
+				Roles: tc.saRoles,
+			})
+
+			if tc.wantErr {
+				s.Error(err)
+				s.Nil(resp)
+				s.Contains(err.Error(), "exceeds your own access")
+			} else {
+				s.NoError(err)
+				s.Require().NotNil(resp)
+				s.Equal(tc.saRoles, resp.Roles)
+			}
+		})
+	}
+}
+
 // An invited user must land on a role rather than on no roles at all: with the
 // empty-role-set fallback gone, a user created without roles would be refused
 // every request.
@@ -301,6 +374,8 @@ func (s *UserServiceSuite) TestInviteUser_RoleAssignment() {
 			ctx := testutil.SetupContext()
 			ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
 			ctx = context.WithValue(ctx, types.CtxUserID, "actor-1")
+			// The caller can only grant access it holds, so the inviter is a super_admin.
+			ctx = context.WithValue(ctx, types.CtxRoles, []string{types.RoleSuperAdmin.String()})
 
 			userRepo := testutil.NewInMemoryUserStore()
 			tenantRepo := testutil.NewInMemoryTenantStore()
@@ -671,6 +746,93 @@ func (s *RBACPermissionSuite) TestSuperAdmin_CombinedWithOtherRoles_StillFullAcc
 	roles := []string{"event_reader", "super_admin"}
 	s.True(s.rbacSvc.HasPermission(roles, "customer", "write"),
 		"super_admin in role set grants full access regardless of other roles")
+}
+
+// A caller must not be able to hand out access it does not itself hold,
+// otherwise any writer could mint a super_admin service account and escalate.
+func (s *RBACPermissionSuite) TestCanGrantRoles() {
+	testCases := []struct {
+		name        string
+		callerRoles []string
+		requested   []string
+		wantErr     bool
+	}{
+		{
+			name:        "super_admin can grant anything",
+			callerRoles: []string{types.RoleSuperAdmin.String()},
+			requested:   []string{types.RoleSuperAdmin.String()},
+		},
+		{
+			name:        "super_admin can grant a narrow scope",
+			callerRoles: []string{types.RoleSuperAdmin.String()},
+			requested:   []string{types.RoleEventIngestor.String()},
+		},
+		{
+			name:        "writer can grant a write scope it fully covers",
+			callerRoles: []string{types.RoleWriter.String()},
+			requested:   []string{types.RoleEventIngestor.String()},
+		},
+		{
+			name:        "reader can grant a read scope it fully covers",
+			callerRoles: []string{types.RoleReader.String()},
+			requested:   []string{types.RoleEventReader.String()},
+		},
+
+		{
+			name:        "reader cannot grant a write scope",
+			callerRoles: []string{types.RoleReader.String()},
+			requested:   []string{types.RoleEventIngestor.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "reader cannot grant writer",
+			callerRoles: []string{types.RoleReader.String()},
+			requested:   []string{types.RoleWriter.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "writer cannot grant a read scope it does not hold",
+			callerRoles: []string{types.RoleWriter.String()},
+			requested:   []string{types.RoleEventReader.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "writer cannot grant super_admin",
+			callerRoles: []string{types.RoleWriter.String()},
+			requested:   []string{types.RoleSuperAdmin.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "reader cannot grant super_admin",
+			callerRoles: []string{types.RoleReader.String()},
+			requested:   []string{types.RoleSuperAdmin.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "caller with no roles can grant nothing",
+			callerRoles: []string{},
+			requested:   []string{types.RoleEventReader.String()},
+			wantErr:     true,
+		},
+		{
+			name:        "one ungrantable role rejects the whole set",
+			callerRoles: []string{types.RoleReader.String()},
+			requested:   []string{types.RoleEventReader.String(), types.RoleEventIngestor.String()},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			err := s.rbacSvc.CanGrantRoles(tc.callerRoles, tc.requested)
+			if tc.wantErr {
+				s.Error(err)
+				s.Contains(err.Error(), "exceeds your own access")
+			} else {
+				s.NoError(err)
+			}
+		})
+	}
 }
 
 func (s *RBACPermissionSuite) TestValidateRoles() {

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -369,6 +369,43 @@ func (s *UserServiceSuite) TestInviteUser_RoleAssignment() {
 		},
 	}
 
+	// Admitting someone to the tenant is restricted to super_admins, so a
+	// writer is refused even when the invitee would only be a reader.
+	s.Run("only a super_admin can invite", func() {
+		for _, callerRoles := range [][]string{
+			{types.RoleWriter.String()},
+			{types.RoleReader.String()},
+			{},
+		} {
+			ctx := testutil.SetupContext()
+			ctx = context.WithValue(ctx, types.CtxTenantID, types.DefaultTenantID)
+			ctx = context.WithValue(ctx, types.CtxUserID, "actor-1")
+			ctx = context.WithValue(ctx, types.CtxRoles, callerRoles)
+
+			tenantRepo := testutil.NewInMemoryTenantStore()
+			_ = tenantRepo.Create(ctx, &tenant.Tenant{ID: types.DefaultTenantID, Name: "Test Tenant"})
+			authRepo := testutil.NewInMemoryAuthRepository()
+
+			svc := &userService{
+				userRepo:    testutil.NewInMemoryUserStore(),
+				tenantRepo:  tenantRepo,
+				authRepo:    authRepo,
+				rbacService: rbacSvc,
+			}
+
+			created, _, err := svc.InviteUser(ctx, &dto.CreateUserRequest{
+				Type:  types.UserTypeUser,
+				Email: "invitee@example.com",
+				Roles: []string{types.RoleReader.String()},
+			}, "actor-1")
+
+			s.Error(err, "caller %v must not be able to invite", callerRoles)
+			s.Nil(created)
+			s.Contains(err.Error(), "only super_admin can invite users")
+			s.Zero(authRepo.Count(), "a refused invite must not leave auth material behind")
+		}
+	})
+
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			ctx := testutil.SetupContext()

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -129,6 +129,40 @@ func (s *RBACService) ValidateRoles(userType types.UserType, roles []string) err
 	return nil
 }
 
+// CanGrantRoles reports whether a caller holding callerRoles may hand out
+// requestedRoles. A caller may only grant access it already holds, so a reader
+// cannot mint a service account that writes, and only a super_admin can create
+// another super_admin. Containment is checked permission by permission rather
+// than by comparing role names, so a writer can still grant a narrower
+// write-scoped role it fully covers.
+func (s *RBACService) CanGrantRoles(callerRoles []string, requestedRoles []string) error {
+	for _, role := range requestedRoles {
+		permissions := s.permissions[role]
+		if permissions == nil {
+			// Unknown roles are rejected by ValidateRoles; nothing to compare here.
+			continue
+		}
+
+		for entity, actions := range permissions {
+			for action := range actions {
+				if !s.HasPermission(callerRoles, entity, action) {
+					return ierr.NewError("cannot grant a role that exceeds your own access").
+						WithHintf("Role '%s' grants '%s' on '%s', which you do not have", role, action, entity).
+						WithReportableDetails(map[string]interface{}{
+							"role":         role,
+							"entity":       entity,
+							"action":       action,
+							"caller_roles": callerRoles,
+						}).
+						Mark(ierr.ErrPermissionDenied)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // GetAllRoles returns all roles with metadata (for API endpoint)
 // This is called rarely (only when fetching available roles for UI)
 func (s *RBACService) ListRoles() []*Role {

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -6,6 +6,9 @@ import (
 	"os"
 
 	"github.com/flexprice/flexprice/internal/config"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
 
 // Service handles permission checks with set-based lookups
@@ -72,11 +75,6 @@ func NewRBACService(cfg *config.Configuration) (*RBACService, error) {
 // Complexity: O(roles) with O(1) lookups = ~3 operations for typical use
 // NOTE: Never touches role.Name or role.Description - zero overhead
 func (s *RBACService) HasPermission(roles []string, entity string, action string) bool {
-	// Empty roles = full access (backward compatibility)
-	if len(roles) == 0 {
-		return true
-	}
-
 	// Check each role - if ANY role grants permission, allow
 	for _, role := range roles {
 		permissions := s.permissions[role]
@@ -96,10 +94,39 @@ func (s *RBACService) HasPermission(roles []string, entity string, action string
 	return false
 }
 
-// ValidateRole checks if role exists in definitions
-func (s *RBACService) ValidateRole(roleName string) bool {
-	_, exists := s.permissions[roleName]
-	return exists
+// ValidateRoles checks that every role exists, that it is assignable to the
+// given user type, and that super_admin, which already grants everything, is
+// not combined with other roles.
+func (s *RBACService) ValidateRoles(userType types.UserType, roles []string) error {
+	allowed := userType.AllowedRoles()
+
+	for _, role := range roles {
+		if _, exists := s.permissions[role]; !exists {
+			return ierr.NewError("invalid role").
+				WithHintf("Role '%s' does not exist", role).
+				WithReportableDetails(map[string]interface{}{"role": role}).
+				Mark(ierr.ErrValidation)
+		}
+
+		if !lo.Contains(allowed, types.Role(role)) {
+			return ierr.NewError("role is not assignable to this user type").
+				WithHintf("Role '%s' cannot be assigned to a '%s' account", role, userType).
+				WithReportableDetails(map[string]interface{}{
+					"role":          role,
+					"user_type":     userType,
+					"allowed_roles": lo.Map(allowed, func(r types.Role, _ int) string { return r.String() }),
+				}).
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	if lo.Contains(roles, types.RoleSuperAdmin.String()) && len(roles) > 1 {
+		return ierr.NewError("super admin role need not be combined with other roles").
+			WithHint("When super_admin is selected, no other roles need to be assigned").
+			Mark(ierr.ErrValidation)
+	}
+
+	return nil
 }
 
 // GetAllRoles returns all roles with metadata (for API endpoint)

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/auth"
 	"github.com/flexprice/flexprice/internal/config"
 	domainEnvironment "github.com/flexprice/flexprice/internal/domain/environment"
+	domainUser "github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -25,7 +26,9 @@ func validateAPIKey(ctx context.Context, cfg *config.Configuration, secretServic
 	// First check in config
 	tenantID, userID, valid = auth.ValidateAPIKey(cfg, apiKey)
 	if valid {
-		return tenantID, userID, "", "", []string{}, true // Empty roles = full access for config keys
+		// Config keys are operator-provisioned and carry no database record to
+		// hold roles, so they are granted full access explicitly.
+		return tenantID, userID, "", "", []string{types.RoleSuperAdmin.String()}, true
 	}
 
 	// If not found in config, check in database
@@ -228,7 +231,7 @@ func APIKeyAuthMiddleware(cfg *config.Configuration, secretService service.Secre
 // AuthenticateMiddleware is a middleware that authenticates requests based on either:
 // 1. JWT token in the Authorization header as a Bearer token
 // 2. API key in the x-api-key header (or configured header name)
-func AuthenticateMiddleware(cfg *config.Configuration, secretService service.SecretService, environmentRepo domainEnvironment.Repository, logger *logger.Logger) gin.HandlerFunc {
+func AuthenticateMiddleware(cfg *config.Configuration, secretService service.SecretService, environmentRepo domainEnvironment.Repository, userRepo domainUser.Repository, logger *logger.Logger) gin.HandlerFunc {
 	authProvider := auth.NewProvider(cfg)
 
 	return func(c *gin.Context) {
@@ -274,8 +277,41 @@ func AuthenticateMiddleware(cfg *config.Configuration, secretService service.Sec
 			return
 		}
 
-		// JWT users have empty roles = full access
-		if err := setContextValues(c, environmentRepo, claims.TenantID, claims.UserID, claims.EnvironmentID, "", []string{}); err != nil {
+		// A JWT carries no roles claim, so the user record is the only source
+		// of the session's permissions.
+		user, err := userRepo.GetByID(types.SetTenantID(c.Request.Context(), claims.TenantID), claims.UserID)
+		if err != nil {
+			if ierr.IsNotFound(err) {
+				logger.Info(c.Request.Context(), "rejecting token for a user that no longer exists",
+					"user_id", claims.UserID,
+					"tenant_id", claims.TenantID,
+				)
+				c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+				c.Abort()
+				return
+			}
+			logger.Error(c.Request.Context(), "failed to load user roles", "error", err, "user_id", claims.UserID)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			c.Abort()
+			return
+		}
+
+		// A token outlives the account it was issued for, so an archived user
+		// must be refused here rather than on the strength of the token alone.
+		// The response does not distinguish this from a missing user: telling an
+		// unauthenticated caller which accounts exist is an enumeration oracle.
+		if user.Status != types.StatusPublished {
+			logger.Info(c.Request.Context(), "rejecting token for an inactive user",
+				"user_id", claims.UserID,
+				"tenant_id", claims.TenantID,
+				"status", user.Status,
+			)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			c.Abort()
+			return
+		}
+
+		if err := setContextValues(c, environmentRepo, claims.TenantID, claims.UserID, claims.EnvironmentID, "", user.Roles); err != nil {
 			abortEnvironmentResolution(c, logger, err, claims.TenantID, claims.UserID)
 			return
 		}

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -278,8 +278,10 @@ func AuthenticateMiddleware(cfg *config.Configuration, secretService service.Sec
 		}
 
 		// A JWT carries no roles claim, so the user record is the only source
-		// of the session's permissions.
-		user, err := userRepo.GetByID(types.SetTenantID(c.Request.Context(), claims.TenantID), claims.UserID)
+		// of the session's permissions. The lookup is scoped to the tenant the
+		// token names, since the repository takes it from the context.
+		tenantCtx := types.SetTenantID(c.Request.Context(), claims.TenantID)
+		user, err := userRepo.GetByID(tenantCtx, claims.UserID)
 		if err != nil {
 			if ierr.IsNotFound(err) {
 				logger.Info(c.Request.Context(), "rejecting token for a user that no longer exists",

--- a/internal/rest/middleware/auth_test.go
+++ b/internal/rest/middleware/auth_test.go
@@ -7,9 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/auth"
 	"github.com/flexprice/flexprice/internal/config"
 	domainEnvironment "github.com/flexprice/flexprice/internal/domain/environment"
+	"github.com/flexprice/flexprice/internal/domain/user"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
@@ -109,6 +112,38 @@ func newTestEnvironmentRepo() *fakeEnvironmentRepo {
 	}
 }
 
+// newTestUserRepo seeds the active "usr_dev" user that makeJWT mints tokens for,
+// in each tenant these tests issue tokens for, so the middleware's role lookup
+// resolves and the request reaches the behaviour under test. Tests concerned
+// with the lookup itself seed their own store instead.
+func newTestUserRepo() *testutil.InMemoryUserStore {
+	devUser := func(tenantID, email string) *user.User {
+		return &user.User{
+			ID:    "usr_dev",
+			Email: email,
+			Type:  types.UserTypeUser,
+			Roles: []string{types.RoleSuperAdmin.String()},
+			BaseModel: types.BaseModel{
+				TenantID: tenantID,
+				Status:   types.StatusPublished,
+			},
+		}
+	}
+	return newUserRepoWith(
+		devUser("t_tenant1", "usr_dev@example.com"),
+		devUser("t_tenant_without_envs", "usr_dev+no_envs@example.com"),
+	)
+}
+
+func newUserRepoWith(users ...*user.User) *testutil.InMemoryUserStore {
+	store := testutil.NewInMemoryUserStore()
+	for _, u := range users {
+		ctx := context.WithValue(context.Background(), types.CtxTenantID, u.TenantID)
+		_ = store.Create(ctx, u)
+	}
+	return store
+}
+
 func makeJWT(t *testing.T, tenantID, userID, environmentID string, expiryHours int) string {
 	t.Helper()
 	claims := jwt.MapClaims{
@@ -140,7 +175,7 @@ func newAuthTestRouter(t *testing.T) *gin.Engine {
 	log := newTestLogger(t)
 
 	r := gin.New()
-	r.Use(AuthenticateMiddleware(cfg, nil, newTestEnvironmentRepo(), log))
+	r.Use(AuthenticateMiddleware(cfg, nil, newTestEnvironmentRepo(), newTestUserRepo(), log))
 	r.GET("/test", func(c *gin.Context) {
 		ctx := c.Request.Context()
 		c.JSON(http.StatusOK, gin.H{
@@ -258,7 +293,7 @@ func TestAuthenticateMiddleware_EnvironmentIDFromJWT(t *testing.T) {
 				Secret:   testSecret,
 				APIKey:   config.APIKeyConfig{Header: "x-api-key"},
 			},
-		}, nil, newTestEnvironmentRepo(), newTestLogger(t)))
+		}, nil, newTestEnvironmentRepo(), newTestUserRepo(), newTestLogger(t)))
 		r.GET("/capture", func(c *gin.Context) {
 			capturedCtx = c.Request.Context()
 			c.Status(http.StatusOK)
@@ -405,7 +440,7 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 
 	newRouter := func() *gin.Engine {
 		r := gin.New()
-		r.Use(AuthenticateMiddleware(cfg, nil, newTestEnvironmentRepo(), newTestLogger(t)))
+		r.Use(AuthenticateMiddleware(cfg, nil, newTestEnvironmentRepo(), newTestUserRepo(), newTestLogger(t)))
 		handler := func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{
 				"environment_id": types.GetEnvironmentID(c.Request.Context()),
@@ -493,7 +528,7 @@ func TestAuthenticateMiddleware_EnvironmentLookupFailureIsNotForbidden(t *testin
 	r := gin.New()
 	r.Use(AuthenticateMiddleware(cfg, nil, &fakeEnvironmentRepo{
 		getErr: ierr.NewError("connection refused").Mark(ierr.ErrDatabase),
-	}, newTestLogger(t)))
+	}, newTestUserRepo(), newTestLogger(t)))
 	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	w := httptest.NewRecorder()
@@ -503,4 +538,150 @@ func TestAuthenticateMiddleware_EnvironmentLookupFailureIsNotForbidden(t *testin
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// A JWT carries no roles claim, so the user record is the only thing that can
+// establish what a dashboard session may do — and the only thing that can
+// withdraw it, since a token stays valid after the account behind it is closed.
+func TestAuthenticateMiddleware_JWTRolesComeFromUserRecord(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Configuration{
+		Auth: config.AuthConfig{
+			Provider: types.AuthProviderFlexprice,
+			Secret:   testSecret,
+			APIKey:   config.APIKeyConfig{Header: "x-api-key"},
+		},
+	}
+
+	activeUser := func(roles []string) *user.User {
+		return &user.User{
+			ID:    "usr_dev",
+			Email: "usr_dev@example.com",
+			Type:  types.UserTypeUser,
+			Roles: roles,
+			BaseModel: types.BaseModel{
+				TenantID: "t_tenant1",
+				Status:   types.StatusPublished,
+			},
+		}
+	}
+
+	withStatus := func(status types.Status) *user.User {
+		u := activeUser([]string{types.RoleSuperAdmin.String()})
+		u.Status = status
+		return u
+	}
+
+	testCases := []struct {
+		name      string
+		userRepo  *testutil.InMemoryUserStore
+		wantCode  int
+		wantRoles []string
+	}{
+		{
+			name:      "roles on the record are placed in the request context",
+			userRepo:  newUserRepoWith(activeUser([]string{types.RoleReader.String()})),
+			wantCode:  http.StatusOK,
+			wantRoles: []string{types.RoleReader.String()},
+		},
+		{
+			name:      "multiple roles are carried through intact",
+			userRepo:  newUserRepoWith(activeUser([]string{types.RoleReader.String(), types.RoleWriter.String()})),
+			wantCode:  http.StatusOK,
+			wantRoles: []string{types.RoleReader.String(), types.RoleWriter.String()},
+		},
+		// An empty role set is no longer read as full access, so it must reach
+		// RequirePermission as-is rather than being substituted for anything.
+		{
+			name:      "an empty role set is carried through, not widened",
+			userRepo:  newUserRepoWith(activeUser([]string{})),
+			wantCode:  http.StatusOK,
+			wantRoles: []string{},
+		},
+		{
+			name:     "a valid token for a user that no longer exists is refused",
+			userRepo: testutil.NewInMemoryUserStore(),
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "an archived user is refused",
+			userRepo: newUserRepoWith(withStatus(types.StatusArchived)),
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "a deleted user is refused",
+			userRepo: newUserRepoWith(withStatus(types.StatusDeleted)),
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedRoles []string
+
+			r := gin.New()
+			r.Use(AuthenticateMiddleware(cfg, nil, newTestEnvironmentRepo(), tc.userRepo, newTestLogger(t)))
+			r.GET("/test", func(c *gin.Context) {
+				capturedRoles = types.GetRoles(c.Request.Context())
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+			req.Header.Set("Authorization", "Bearer "+makeJWT(t, "t_tenant1", "usr_dev", "env_dev", 1))
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, tc.wantCode, w.Code)
+			if tc.wantCode == http.StatusOK {
+				assert.Equal(t, tc.wantRoles, capturedRoles)
+			} else {
+				// The refusal must not disclose whether the account exists.
+				assert.JSONEq(t, `{"error":"Unauthorized"}`, w.Body.String())
+			}
+		})
+	}
+}
+
+// Config-map API keys have no database record to carry roles, so the middleware
+// grants them super_admin explicitly. Without it they would hold no roles at
+// all and be refused every check.
+func TestAuthenticateMiddleware_ConfigAPIKeyIsSuperAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const apiKey = "test-config-key"
+	cfg := &config.Configuration{
+		Auth: config.AuthConfig{
+			Provider: types.AuthProviderFlexprice,
+			Secret:   testSecret,
+			APIKey: config.APIKeyConfig{
+				Header: "x-api-key",
+				Keys: map[string]config.APIKeyDetails{
+					auth.HashAPIKey(apiKey): {
+						TenantID: "t_tenant1",
+						UserID:   "usr_dev",
+						Name:     "config key",
+						IsActive: true,
+					},
+				},
+			},
+		},
+	}
+
+	var capturedRoles []string
+	r := gin.New()
+	r.Use(AuthenticateMiddleware(cfg, nil, newTestEnvironmentRepo(), newTestUserRepo(), newTestLogger(t)))
+	r.GET("/test", func(c *gin.Context) {
+		capturedRoles = types.GetRoles(c.Request.Context())
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set(types.HeaderEnvironment, "env_dev")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []string{types.RoleSuperAdmin.String()}, capturedRoles)
 }

--- a/internal/rest/middleware/errhandler.go
+++ b/internal/rest/middleware/errhandler.go
@@ -41,9 +41,7 @@ func getDisplayMessage(err error) string {
 			}
 		}
 	}
-
-	// fallback to the error message
-	return "An unexpected error occurred"
+	return err.Error()
 }
 
 func getSafeDetails(err error) map[string]any {

--- a/internal/rest/middleware/errhandler.go
+++ b/internal/rest/middleware/errhandler.go
@@ -41,7 +41,8 @@ func getDisplayMessage(err error) string {
 			}
 		}
 	}
-	return err.Error()
+	// fallback to the error message
+	return "An unexpected error occurred"
 }
 
 func getSafeDetails(err error) map[string]any {

--- a/internal/rest/middleware/permission.go
+++ b/internal/rest/middleware/permission.go
@@ -38,24 +38,21 @@ func (pm *PermissionMiddleware) RequirePermission(entity types.Entity, action ty
 			return
 		}
 
-		// Service accounts are subject to RBAC; JWT users and config keys are not.
-		if types.IsServiceAccount(ctx) {
-			roles := types.GetRoles(ctx)
-			if !pm.rbacService.HasPermission(roles, string(entity), string(action)) {
-				pm.logger.Info(ctx, "service account access denied due to insufficient RBAC roles",
-					"user_id", types.GetUserID(ctx),
-					"tenant_id", types.GetTenantID(ctx),
-					"environment_id", types.GetEnvironmentID(ctx),
-					"roles", roles,
-					"entity", entity,
-					"action", action,
-					"path", c.Request.URL.Path,
-				)
-				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-					"message": "insufficient permissions",
-				})
-				return
-			}
+		roles := types.GetRoles(ctx)
+		if !pm.rbacService.HasPermission(roles, string(entity), string(action)) {
+			pm.logger.Info(ctx, "access denied due to insufficient RBAC roles",
+				"user_id", types.GetUserID(ctx),
+				"tenant_id", types.GetTenantID(ctx),
+				"environment_id", types.GetEnvironmentID(ctx),
+				"roles", roles,
+				"entity", entity,
+				"action", action,
+				"path", c.Request.URL.Path,
+			)
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"message": "insufficient permissions",
+			})
+			return
 		}
 
 		c.Next()

--- a/internal/rest/middleware/permission.go
+++ b/internal/rest/middleware/permission.go
@@ -40,6 +40,18 @@ func (pm *PermissionMiddleware) RequirePermission(entity types.Entity, action ty
 
 		roles := types.GetRoles(ctx)
 		if !pm.rbacService.HasPermission(roles, string(entity), string(action)) {
+			// A caller carrying no roles at all is refused every check, which
+			// looks identical to holding the wrong role. Call it out separately:
+			// it usually means the principal's roles column is null or empty
+			// rather than that the role set is misconfigured.
+			if len(roles) == 0 {
+				pm.logger.Info(ctx, "access denied: caller has no roles assigned",
+					"user_id", types.GetUserID(ctx),
+					"tenant_id", types.GetTenantID(ctx),
+					"path", c.Request.URL.Path,
+				)
+			}
+
 			pm.logger.Info(ctx, "access denied due to insufficient RBAC roles",
 				"user_id", types.GetUserID(ctx),
 				"tenant_id", types.GetTenantID(ctx),

--- a/internal/rest/middleware/tenant_access_test.go
+++ b/internal/rest/middleware/tenant_access_test.go
@@ -12,9 +12,9 @@ import (
 	dto "github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/config"
 	domainTenant "github.com/flexprice/flexprice/internal/domain/tenant"
+	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/rbac"
-	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -79,12 +79,15 @@ func newTestRouter(t *testing.T, tenantID string, svc *mockTenantService) *gin.E
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 
-	// Simulate AuthenticateMiddleware seeding tenantID
+	// Simulate AuthenticateMiddleware seeding tenantID and the caller's roles.
+	// The roles grant everything so that a refusal here can only come from the
+	// tenant's suspended status, which is what these tests are about.
 	r.Use(func(c *gin.Context) {
+		ctx := context.WithValue(c.Request.Context(), types.CtxRoles, []string{types.RoleSuperAdmin.String()})
 		if tenantID != "" {
-			ctx := context.WithValue(c.Request.Context(), types.CtxTenantID, tenantID)
-			c.Request = c.Request.WithContext(ctx)
+			ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 		}
+		c.Request = c.Request.WithContext(ctx)
 		c.Next()
 	})
 
@@ -105,12 +108,17 @@ func newTestRouter(t *testing.T, tenantID string, svc *mockTenantService) *gin.E
 	return r
 }
 
-// newPermissiveRBACService returns a real *rbac.RBACService with no roles defined.
-// Empty roles always grant full access (HasPermission returns true), so tests
+// newPermissiveRBACService returns a real *rbac.RBACService whose only role
+// grants every entity and action, so tests pairing it with a super_admin caller
 // focus purely on tenant suspension rather than RBAC rules.
 func newPermissiveRBACService(t *testing.T) *rbac.RBACService {
 	t.Helper()
-	return newRBACServiceWithRoles(t, "{}")
+	return newRBACServiceWithRoles(t, `{
+		"super_admin": {
+			"name": "Super Admin",
+			"permissions": { "*": ["*"] }
+		}
+	}`)
 }
 
 // newRBACServiceWithRoles creates a real *rbac.RBACService from a raw JSON roles definition.
@@ -261,15 +269,29 @@ func TestTenantStatusMiddleware(t *testing.T) {
 	}
 }
 
-// rolesJSON with event_ingestor role that allows event writes.
+// rolesJSON with a wildcard super_admin role, an event_ingestor role that
+// allows event writes, and a read-only reader role. reader is defined so that a
+// denial for a reader is caused by the role lacking the grant rather than by the
+// role being unknown.
 const testRolesJSON = `{
+	"super_admin": {
+		"name": "Super Admin",
+		"permissions": { "*": ["*"] }
+	},
 	"event_ingestor": {
 		"name": "Event Ingestor",
 		"permissions": { "event": ["write"] }
+	},
+	"reader": {
+		"name": "Reader",
+		"permissions": { "*": ["read"] }
 	}
 }`
 
-func TestRequirePermission_ServiceAccountRBAC(t *testing.T) {
+// RBAC applies to every caller type, not just service accounts, so the cases
+// below are organised by the roles a caller holds rather than by how it
+// authenticated.
+func TestRequirePermission_RBAC(t *testing.T) {
 	testCases := []struct {
 		name         string
 		userType     string
@@ -293,24 +315,44 @@ func TestRequirePermission_ServiceAccountRBAC(t *testing.T) {
 			wantCode:     http.StatusForbidden,
 			wantErrMsg:   "insufficient permissions",
 		},
+		// Every caller type is now subject to RBAC. A caller carrying no roles
+		// holds no grant and is refused, where it previously fell through to
+		// full access.
 		{
-			name:         "JWT user (empty userType) bypasses RBAC",
+			name:         "caller with no roles at all is denied",
 			userType:     "",
 			roles:        nil,
 			tenantStatus: types.TenantInternalStatusActive,
-			wantCode:     http.StatusOK,
+			wantCode:     http.StatusForbidden,
+			wantErrMsg:   "insufficient permissions",
 		},
 		{
-			name:         "user-type DB API key bypasses RBAC",
+			name:         "caller with an empty role set is denied",
+			userType:     "",
+			roles:        []string{},
+			tenantStatus: types.TenantInternalStatusActive,
+			wantCode:     http.StatusForbidden,
+			wantErrMsg:   "insufficient permissions",
+		},
+		{
+			name:         "user with the required role is allowed",
 			userType:     string(types.UserTypeUser),
 			roles:        []string{"event_ingestor"},
 			tenantStatus: types.TenantInternalStatusActive,
 			wantCode:     http.StatusOK,
 		},
 		{
-			name:         "config API key (empty userType) bypasses RBAC",
+			name:         "user without the required role is denied",
+			userType:     string(types.UserTypeUser),
+			roles:        []string{types.RoleReader.String()},
+			tenantStatus: types.TenantInternalStatusActive,
+			wantCode:     http.StatusForbidden,
+			wantErrMsg:   "insufficient permissions",
+		},
+		{
+			name:         "config API key carries super_admin and is allowed",
 			userType:     "",
-			roles:        []string{},
+			roles:        []string{types.RoleSuperAdmin.String()},
 			tenantStatus: types.TenantInternalStatusActive,
 			wantCode:     http.StatusOK,
 		},

--- a/internal/testutil/inmemory_auth_store.go
+++ b/internal/testutil/inmemory_auth_store.go
@@ -75,6 +75,15 @@ func (r *InMemoryAuthRepository) DeleteAuth(ctx context.Context, userID string) 
 	return nil
 }
 
+// Count returns how many auth records the store holds, letting tests assert
+// that a failed flow left no auth material behind.
+func (r *InMemoryAuthRepository) Count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.auths)
+}
+
 // Clear clears all auth records from the in-memory store
 func (r *InMemoryAuthRepository) Clear() {
 	r.mu.Lock()

--- a/internal/testutil/inmemory_user_store.go
+++ b/internal/testutil/inmemory_user_store.go
@@ -72,8 +72,11 @@ func (r *InMemoryUserStore) GetByID(ctx context.Context, userID string) (*user.U
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Scoped to the tenant in context, matching the real repository: an ID
+	// belonging to another tenant must resolve to not-found, not to the record.
+	tenantID, _ := ctx.Value(types.CtxTenantID).(string)
 	for _, u := range r.users {
-		if u.ID == userID {
+		if u.ID == userID && (tenantID == "" || u.TenantID == tenantID) {
 			return u, nil
 		}
 	}

--- a/internal/testutil/inmemory_user_store.go
+++ b/internal/testutil/inmemory_user_store.go
@@ -72,11 +72,19 @@ func (r *InMemoryUserStore) GetByID(ctx context.Context, userID string) (*user.U
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Scoped to the tenant in context, matching the real repository: an ID
-	// belonging to another tenant must resolve to not-found, not to the record.
-	tenantID, _ := ctx.Value(types.CtxTenantID).(string)
+	// Scoped to the tenant in context, matching the real repository: a missing
+	// tenant is an error rather than a wildcard, so a test that forgets to
+	// propagate tenant context fails here instead of silently reading across
+	// tenants.
+	tenantID, ok := ctx.Value(types.CtxTenantID).(string)
+	if !ok || tenantID == "" {
+		return nil, ierr.NewError("tenant ID not found in context").
+			WithHint("Tenant ID is required in the context").
+			Mark(ierr.ErrValidation)
+	}
+
 	for _, u := range r.users {
-		if u.ID == userID && (tenantID == "" || u.TenantID == tenantID) {
+		if u.ID == userID && u.TenantID == tenantID {
 			return u, nil
 		}
 	}

--- a/internal/types/context.go
+++ b/internal/types/context.go
@@ -70,12 +70,14 @@ func GetEnvironmentID(ctx context.Context) string {
 	return ""
 }
 
-// GetRoles returns the RBAC roles array from the context
+// GetRoles returns the RBAC roles array from the context. A caller with no
+// roles holds no grant and is refused every permission check, so an absent or
+// unexpected value fails closed rather than widening access.
 func GetRoles(ctx context.Context) []string {
 	if roles, ok := ctx.Value(CtxRoles).([]string); ok {
 		return roles
 	}
-	return []string{} // Empty roles = full access
+	return []string{}
 }
 
 // GetCustomerID returns the customer ID from the context
@@ -120,7 +122,8 @@ func SetCustomerID(ctx context.Context, customerID string) context.Context {
 }
 
 // IsServiceAccount reports whether the request was made by a service account API key.
-// Returns false for JWT users and config API keys, which bypass RBAC enforcement.
+// Returns false for JWT users and config API keys. RBAC applies to every caller
+// type regardless, so this reports the caller's kind and never grants a bypass.
 func IsServiceAccount(ctx context.Context) bool {
 	t, _ := ctx.Value(CtxUserType).(string)
 	return t == string(UserTypeServiceAccount)

--- a/internal/types/rbac.go
+++ b/internal/types/rbac.go
@@ -1,5 +1,32 @@
 package types
 
+type Role string
+
+func (r Role) String() string { return string(r) }
+
+const (
+	RoleSuperAdmin    Role = "super_admin"
+	RoleReader        Role = "reader"
+	RoleWriter        Role = "writer"
+	RoleEventIngestor Role = "event_ingestor"
+	RoleEventReader   Role = "event_reader"
+)
+
+// AllowedRoles returns the roles assignable to this user type. People hold a
+// broad access level over the whole tenant, while service accounts hold either
+// full access or a single narrow machine scope, so the two sets are disjoint
+// apart from super_admin.
+func (ut UserType) AllowedRoles() []Role {
+	switch ut {
+	case UserTypeUser:
+		return []Role{RoleSuperAdmin, RoleReader, RoleWriter}
+	case UserTypeServiceAccount:
+		return []Role{RoleSuperAdmin, RoleEventIngestor, RoleEventReader}
+	default:
+		return nil
+	}
+}
+
 type Action string
 
 func (a Action) String() string { return string(a) }


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reader and writer roles with clear read/write access.
  - Added role assignment controls for invitations and service accounts.
  - New users receive appropriate default roles.
- **Bug Fixes**
  - Strengthened tenant-aware authentication and rejected inactive or unknown users.
  - Enforced permissions across all account types, including workflow and environment access.
  - Customer portal access now respects tenant suspension status.
  - Improved error handling with safer generic messages.
  - Configured API keys now receive appropriate administrative access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Enforce role-based access for every caller and safely assign user roles

### What Changed
- All authenticated callers, including dashboard users and API keys, are checked against their assigned permissions; callers without roles are denied.
- JWT sessions now load roles from the current user record and reject missing or inactive users, so revoked accounts can no longer use existing tokens.
- Invited users default to read-only access, while requested roles are validated before account setup and invalid assignments leave no orphaned authentication records.
- Users and service accounts can only receive roles allowed for their account type, and callers cannot grant access beyond their own permissions.
- Writer access includes reading, while reader access remains read-only; initial tenant owners receive super-admin access.

### Impact
`✅ Fewer unauthorized requests from unassigned or inactive accounts`
`✅ Blocked privilege escalation through user and service-account creation`
`✅ Safer default access for invited users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
