### PR TITLE
fix(security): remediate Shannon r4v1 VAPT findings — DRAFT-sub payment, OAuth SSRF, login enumeration

### DIFF
--- a/internal/ee/service/auth.go
+++ b/internal/ee/service/auth.go
@@ -121,14 +121,18 @@ func (s *authService) SignUp(ctx context.Context, req *dto.SignUpRequest) (*dto.
 func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.AuthResponse, error) {
 	user, err := s.UserRepo.GetByEmail(ctx, req.Email)
 	if err != nil {
-		// Do not leak whether the email exists: an unknown email must return the
+		// Only normalize the not-found case: an unknown email must return the
 		// same "invalid credentials" response as a valid email with a wrong
 		// password (both ErrPermissionDenied / 401), otherwise the distinct
 		// not-found status enables account enumeration on this unauthenticated,
-		// unthrottled endpoint.
-		return nil, ierr.WithError(err).
-			WithHint("Invalid email or password").
-			Mark(ierr.ErrPermissionDenied)
+		// unthrottled endpoint. Other errors (e.g. a database failure) must
+		// propagate as-is so they surface as server errors, not bad credentials.
+		if ierr.IsNotFound(err) {
+			return nil, ierr.WithError(err).
+				WithHint("Invalid email or password").
+				Mark(ierr.ErrPermissionDenied)
+		}
+		return nil, err
 	}
 
 	var auth *auth.Auth

--- a/internal/ee/service/auth.go
+++ b/internal/ee/service/auth.go
@@ -121,7 +121,14 @@ func (s *authService) SignUp(ctx context.Context, req *dto.SignUpRequest) (*dto.
 func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.AuthResponse, error) {
 	user, err := s.UserRepo.GetByEmail(ctx, req.Email)
 	if err != nil {
-		return nil, err
+		// Do not leak whether the email exists: an unknown email must return the
+		// same "invalid credentials" response as a valid email with a wrong
+		// password (both ErrPermissionDenied / 401), otherwise the distinct
+		// not-found status enables account enumeration on this unauthenticated,
+		// unthrottled endpoint.
+		return nil, ierr.WithError(err).
+			WithHint("Invalid email or password").
+			Mark(ierr.ErrPermissionDenied)
 	}
 
 	var auth *auth.Auth
@@ -140,17 +147,16 @@ func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.Au
 	}, auth)
 
 	if err != nil {
+		// Same generic response as the unknown-email and identity-mismatch cases
+		// so none of the three is distinguishable to an enumerating caller.
 		return nil, ierr.WithError(err).
-			WithHint("Failed to authenticate").
+			WithHint("Invalid email or password").
 			Mark(ierr.ErrPermissionDenied)
 	}
 
 	if authResponse.ID != user.ID {
-		return nil, ierr.NewError("user not found").
-			WithHint("User not found").
-			WithReportableDetails(map[string]interface{}{
-				"user_id": user.ID,
-			}).
+		return nil, ierr.NewError("invalid credentials").
+			WithHint("Invalid email or password").
 			Mark(ierr.ErrPermissionDenied)
 	}
 

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -2461,6 +2461,23 @@ func (s *invoiceService) AttemptPayment(ctx context.Context, id string) error {
 		return nil // No-op for zero-dollar skipped invoices
 	}
 
+	// A payment must only be attempted against a finalized invoice: finalization
+	// is what applies credits, tax, and discounts. The subscription payment path
+	// below does not re-check this, so a DRAFT subscription invoice would
+	// otherwise be charged pre-finalization (the non-subscription path already
+	// enforces the same rule). Internal subscription-creation/renewal flows that
+	// legitimately process a DRAFT invoice call attemptPaymentForSubscriptionInvoice
+	// directly and do not go through this entry point.
+	if inv.InvoiceStatus != types.InvoiceStatusFinalized {
+		return ierr.NewError("invoice must be finalized").
+			WithHint("Invoice must be finalized before attempting payment").
+			WithReportableDetails(map[string]any{
+				"invoice_id":     inv.ID,
+				"invoice_status": inv.InvoiceStatus,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
 	// Use the new payment function with nil parameters to use subscription defaults
 	return s.attemptPaymentForSubscriptionInvoice(ctx, inv, nil, nil, types.InvoiceFlowManual)
 }

--- a/internal/ee/service/invoice_test.go
+++ b/internal/ee/service/invoice_test.go
@@ -1749,6 +1749,36 @@ func (s *InvoiceServiceSuite) TestAttemptPayment() {
 			expectedErrorMessage: "invoice must be finalized",
 		},
 		{
+			// Regression (AUTHZ-VULN-05): a DRAFT *subscription* invoice must also be
+			// rejected. The subscription payment path does not re-check finalization,
+			// so before the guard in AttemptPayment this returned success and charged
+			// pre-finalization, bypassing credit/tax/discount application.
+			name: "Subscription invoice not in finalized state",
+			setupInvoice: func() *invoice.Invoice {
+				inv := &invoice.Invoice{
+					ID:              "inv_test_sub_not_finalized",
+					CustomerID:      s.testData.customer.ID,
+					SubscriptionID:  &s.testData.subscription.ID,
+					InvoiceType:     types.InvoiceTypeSubscription,
+					InvoiceStatus:   types.InvoiceStatusDraft, // Not finalized
+					PaymentStatus:   types.PaymentStatusPending,
+					Currency:        "usd",
+					AmountDue:       decimal.NewFromInt(100),
+					AmountPaid:      decimal.Zero,
+					AmountRemaining: decimal.NewFromInt(100),
+					Description:     "Test Subscription Invoice - Not Finalized",
+					BaseModel:       types.GetDefaultBaseModel(s.GetContext()),
+				}
+				s.NoError(s.invoiceRepo.Create(s.GetContext(), inv))
+				return inv
+			},
+			setupWallets: func() {
+				s.setupWallets()
+			},
+			expectedError:        true,
+			expectedErrorMessage: "invoice must be finalized",
+		},
+		{
 			name: "Invoice already paid",
 			setupInvoice: func() *invoice.Invoice {
 				inv := &invoice.Invoice{

--- a/internal/ee/service/oauth.go
+++ b/internal/ee/service/oauth.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/security"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/flexprice/flexprice/internal/validator"
 )
 
 const (
@@ -599,6 +600,14 @@ func (s *oauthService) BuildOAuthURL(provider types.OAuthProvider, clientID, red
 		if accountsServer == "" {
 			accountsServer = "https://accounts.zoho.com"
 		}
+		// Validate the client-supplied accounts_server before building a URL the
+		// user's browser is redirected to, so it cannot be turned into an
+		// open-redirect / internal-endpoint target.
+		if err := validator.ValidateOutboundURL(accountsServer); err != nil {
+			return "", ierr.WithError(err).
+				WithHint("Invalid accounts_server: must be a public https endpoint").
+				Mark(ierr.ErrValidation)
+		}
 		return fmt.Sprintf("%s/oauth/v2/auth?%s", strings.TrimRight(accountsServer, "/"), params.Encode()), nil
 
 	// Add more providers here:
@@ -808,6 +817,17 @@ func (s *oauthService) ExchangeCodeForConnection(
 			accountsServer = "https://accounts.zoho.com"
 		}
 
+		// accounts_server is client-supplied (via POST /v1/oauth/complete) and is
+		// used verbatim to build the outbound token-exchange URL below, which
+		// carries client_id/client_secret. Validate it as a public https endpoint
+		// so it cannot be pointed at cloud metadata (169.254.169.254), localhost,
+		// or any internal address to exfiltrate those credentials.
+		if err := validator.ValidateOutboundURL(accountsServer); err != nil {
+			return "", ierr.WithError(err).
+				WithHint("Invalid accounts_server: must be a public https endpoint").
+				Mark(ierr.ErrValidation)
+		}
+
 		form := url.Values{}
 		form.Set("code", code)
 		form.Set("client_id", clientID)
@@ -830,9 +850,14 @@ func (s *oauthService) ExchangeCodeForConnection(
 
 		bodyBytes, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			// Do not reflect the raw response body to the caller: the outbound host
+			// is client-influenced, so echoing the body back would leak the content
+			// of whatever endpoint was reached. Log it server-side instead.
+			s.logger.Error(ctx, "Zoho token exchange failed",
+				"error", "non_2xx_from_token_endpoint",
+				"status_code", resp.StatusCode)
 			return "", ierr.NewError("Zoho token exchange failed").
 				WithHintf("Zoho token endpoint returned status %d", resp.StatusCode).
-				WithReportableDetails(map[string]interface{}{"response_body": string(bodyBytes)}).
 				Mark(ierr.ErrHTTPClient)
 		}
 

--- a/internal/ee/service/oauth.go
+++ b/internal/ee/service/oauth.go
@@ -600,9 +600,12 @@ func (s *oauthService) BuildOAuthURL(provider types.OAuthProvider, clientID, red
 		if accountsServer == "" {
 			accountsServer = "https://accounts.zoho.com"
 		}
-		// Validate the client-supplied accounts_server before building a URL the
-		// user's browser is redirected to, so it cannot be turned into an
-		// open-redirect / internal-endpoint target.
+		// Restrict the client-supplied accounts_server to a Zoho domain before
+		// building a URL the user's browser is redirected to, so it cannot be
+		// turned into an open-redirect or internal-endpoint target.
+		if err := types.ValidateZohoEndpoint(accountsServer, "accounts_server"); err != nil {
+			return "", err
+		}
 		if err := validator.ValidateOutboundURL(accountsServer); err != nil {
 			return "", ierr.WithError(err).
 				WithHint("Invalid accounts_server: must be a public https endpoint").
@@ -819,9 +822,13 @@ func (s *oauthService) ExchangeCodeForConnection(
 
 		// accounts_server is client-supplied (via POST /v1/oauth/complete) and is
 		// used verbatim to build the outbound token-exchange URL below, which
-		// carries client_id/client_secret. Validate it as a public https endpoint
-		// so it cannot be pointed at cloud metadata (169.254.169.254), localhost,
-		// or any internal address to exfiltrate those credentials.
+		// carries client_id/client_secret. Restrict it to a Zoho domain so those
+		// credentials cannot be exfiltrated to an attacker-chosen host, and also
+		// run the outbound-URL guard for defense-in-depth against DNS/private-IP
+		// tricks (metadata 169.254.169.254, localhost, internal ranges).
+		if err := types.ValidateZohoEndpoint(accountsServer, "accounts_server"); err != nil {
+			return "", err
+		}
 		if err := validator.ValidateOutboundURL(accountsServer); err != nil {
 			return "", ierr.WithError(err).
 				WithHint("Invalid accounts_server: must be a public https endpoint").

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -376,15 +376,35 @@ var zohoEndpointSuffixes = []string{
 // ValidateZohoEndpoint restricts a client-supplied Zoho URL to an https Zoho
 // domain. Callers performing the OAuth token exchange must apply this to the
 // accounts_server before sending client_id/client_secret to it, so those
-// credentials cannot be exfiltrated to an attacker-chosen host. Unlike an
-// empty-allowed field validation, this rejects an empty value.
+// credentials cannot be exfiltrated to an attacker-chosen host.
+//
+// Unlike the internal check, this enforces a bare-origin invariant: the value is
+// concatenated with a fixed OAuth path (e.g. accounts_server + "/oauth/v2/token"),
+// so any path, query, fragment, or userinfo component would change which URL is
+// actually reached — a query would swallow the OAuth path, a fragment would strip
+// the OAuth query, and userinfo would send credentials to a different authority.
+// It also rejects an empty value.
 func ValidateZohoEndpoint(raw, field string) error {
-	if strings.TrimSpace(raw) == "" {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
 		return ierr.NewError(field + " is required").
 			WithHintf("Zoho Books %s must be provided", field).
 			Mark(ierr.ErrValidation)
 	}
-	return validateZohoEndpoint(raw, field)
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return ierr.NewError(field + " must be a valid https URL").
+			WithHintf("Zoho Books %s must be an https URL", field).
+			Mark(ierr.ErrValidation)
+	}
+	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return ierr.NewError(field + " must be a bare origin").
+			WithHintf("Zoho Books %s must be a scheme and host only, with no path, query, fragment, or credentials", field).
+			Mark(ierr.ErrValidation)
+	}
+
+	return validateZohoEndpoint(trimmed, field)
 }
 
 // validateZohoEndpoint checks a Zoho-supplied URL is https and served from a

--- a/internal/types/connection.go
+++ b/internal/types/connection.go
@@ -373,6 +373,20 @@ var zohoEndpointSuffixes = []string{
 	".zohoapiscloud.ca",
 }
 
+// ValidateZohoEndpoint restricts a client-supplied Zoho URL to an https Zoho
+// domain. Callers performing the OAuth token exchange must apply this to the
+// accounts_server before sending client_id/client_secret to it, so those
+// credentials cannot be exfiltrated to an attacker-chosen host. Unlike an
+// empty-allowed field validation, this rejects an empty value.
+func ValidateZohoEndpoint(raw, field string) error {
+	if strings.TrimSpace(raw) == "" {
+		return ierr.NewError(field + " is required").
+			WithHintf("Zoho Books %s must be provided", field).
+			Mark(ierr.ErrValidation)
+	}
+	return validateZohoEndpoint(raw, field)
+}
+
 // validateZohoEndpoint checks a Zoho-supplied URL is https and served from a
 // Zoho domain. An empty value is allowed: these fields are populated by the
 // token exchange and are absent before OAuth completes.

--- a/internal/types/connection_endpoint_test.go
+++ b/internal/types/connection_endpoint_test.go
@@ -38,6 +38,42 @@ func TestValidateZohoEndpoint(t *testing.T) {
 	}
 }
 
+// ValidateZohoEndpoint is the stricter exported variant used for the
+// accounts_server that gets a fixed OAuth path concatenated onto it. It must
+// reject an empty value and any URL component beyond scheme+host, since a path,
+// query, fragment, or userinfo would change which URL the token exchange reaches.
+func TestValidateZohoEndpoint_BareOrigin(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"bare zoho origin allowed", "https://accounts.zoho.com", false},
+		{"zoho eu origin allowed", "https://accounts.zoho.eu", false},
+
+		{"empty rejected", "", true},
+		{"trailing slash path rejected", "https://accounts.zoho.com/", true},
+		{"oauth path rejected", "https://accounts.zoho.com/oauth/v2/token", true},
+		{"query rejected", "https://accounts.zoho.com?x=1", true},
+		{"fragment rejected", "https://accounts.zoho.com#frag", true},
+		{"userinfo rejected", "https://user:pass@accounts.zoho.com", true},
+		{"non-zoho rejected", "https://evil.example.com", true},
+		{"http rejected", "http://accounts.zoho.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateZohoEndpoint(tt.url, "accounts_server")
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected %q to be rejected, got nil error", tt.url)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected %q to be allowed, got: %v", tt.url, err)
+			}
+		})
+	}
+}
+
 func TestValidateGoogleEndpoint(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## User description

Remediates three application findings from the Shannon (Keygraph) r4v1 backend pentest. All were live-proven on staging and re-audited against `develop`; the RBAC cluster (AUTH-04/05, AUTHZ-01/02) is already fixed by #2510 and the SSRF helper by #2509, so this PR covers what remained.

**The Whop webhook fail-open fix (AUTHZ-07) has moved to #2521** so it can be reviewed separately. This branch no longer touches `internal/api/v1/webhook.go`.

## Findings fixed

**AUTHZ-05 — payment on DRAFT subscription invoice** (`internal/ee/service/invoice.go`)
`AttemptPayment` charged DRAFT subscription invoices: the subscription payment path never re-checked finalization (only the non-subscription path did), bypassing credit/tax/discount application. `AttemptPayment` now rejects any non-finalized invoice at the entry point. Internal creation/renewal flows call `attemptPaymentForSubscriptionInvoice` directly and are unaffected. Regression test added.

**SSRF-01/03 — OAuth `accounts_server`** (`internal/ee/service/oauth.go`)
The client-supplied `accounts_server` from `POST /v1/oauth/complete` was used verbatim to build the Zoho token-exchange URL (carrying `client_id`/`client_secret`/`code`) and the browser authorize-redirect, with no validation. Both sites now run `validator.ValidateOutboundURL` (the guard added in #2509), plus a bare-origin invariant in `internal/types/connection.go`; the raw upstream body is no longer reflected.

**AUTH-01/02 — login account enumeration** (`internal/ee/service/auth.go`)
Login returned distinct status codes for unknown email vs wrong password, enabling enumeration on an unthrottled endpoint. All three login-failure paths now return an identical generic 401. Signup 409 and auth rate-limiting are noted as follow-ups.

## Verification
- `go build ./internal/...` — clean
- `go test ./internal/ee/service/ ./internal/types/ ./internal/api/v1/` — pass
- loglint clean on changed files