### PR TITLE
fix(ci): pin Go builder to 1.25.12 to match go.mod directive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.25.0'
+          go-version: '1.25.12'
           cache: true
 
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.25.0'
+          go-version: '1.25.12'
           cache: true
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@
 # Pin the builder to the runner's native arch ($BUILDPLATFORM) and
 # cross-compile to the requested $TARGETARCH. Avoids QEMU emulation of
 # the Go toolchain, which is 10-20x slower on multi-arch builds.
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS builder
+#
+# Pinned to an exact patch: the image sets GOTOOLCHAIN=local, so the builder
+# Go version must be >= the `go` directive in go.mod or `go mod download`
+# hard-fails. Bump this whenever that directive moves.
+FROM --platform=$BUILDPLATFORM golang:1.25.12-alpine AS builder
 WORKDIR /app
 
 RUN apk add --no-cache git

--- a/Dockerfile.e2eprobe
+++ b/Dockerfile.e2eprobe
@@ -3,7 +3,11 @@
 # Pin the builder to the runner's native arch ($BUILDPLATFORM) and
 # cross-compile to the requested $TARGETARCH. Avoids QEMU emulation of
 # the Go toolchain, which is 10-20x slower on multi-arch builds.
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 AS builder
+#
+# Pinned to an exact patch: the image sets GOTOOLCHAIN=local, so the builder
+# Go version must be >= the `go` directive in go.mod or `go mod download`
+# hard-fails. Bump this whenever that directive moves.
+FROM --platform=$BUILDPLATFORM golang:1.25.12-alpine AS builder
 WORKDIR /app
 
 RUN apk add --no-cache git


### PR DESCRIPTION
## **User description**
## Problem

The **Build & Push Docker Image** job has been failing on `develop` since db03a0a3e raised the `go` directive in `go.mod` to `1.25.12`:

```
#23 0.051 go: go.mod requires go >= 1.25.12 (running go 1.25.11; GOTOOLCHAIN=local)
#23 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

Both Dockerfiles pinned `golang:1.25-alpine3.22`. That tag stopped receiving patch builds once the upstream image moved its floating `1.25-alpine` to newer Alpine releases — it is frozen at Go 1.25.11, and no `1.25.12-alpine3.22` was ever published. The official golang images set `GOTOOLCHAIN=local`, so Go refuses to auto-download the required toolchain and hard-fails instead of recovering.

`develop` is currently red for image builds; this unblocks it.

## Change

- `Dockerfile` and `Dockerfile.e2eprobe` → `golang:1.25.12-alpine`. `Dockerfile.e2eprobe` carried the identical stale pin and would have hit the same failure on its next rebuild.
- `test.yml` → `go-version: '1.25.12'` (was `1.25.0`).

## Why an exact patch pin rather than restoring a floating tag

Release images are built multi-arch against a shared registry buildcache. A compiler version that can shift between runs makes builds non-reproducible and invalidates that cache unpredictably. The alternative of setting `GOTOOLCHAIN=auto` was rejected: it would make the production image build depend on a live toolchain download from `proxy.golang.org` on every uncached build, adding a network dependency and supply-chain surface to the path that produces the ECS image.

The tradeoff is that this pin must be bumped whenever the `go.mod` directive moves. A loud build failure beats silent version drift, and an inline comment at each `FROM` records that requirement.

## Note on `test.yml`

`setup-go` leaves `GOTOOLCHAIN=auto`, so the previous `1.25.0` pin silently downloaded 1.25.12 on every run. Tests were passing, but on a toolchain version nobody had declared. Now aligned with `go.mod`.

`generate-sdks.yml` and `generate-wl-sdks.yml` still pin `1.24.0`. Left alone here — they are further behind and worth confirming whether they compile the main module, which is separate from unblocking this build.

## Verification

Built the `builder` stage of both Dockerfiles for `linux/arm64` (the arch that failed in CI). `go mod download` succeeds and the `server` and `migrate` binaries compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Align Go builds and tests with the required Go 1.25.12 toolchain

### What Changed
- Docker image builds now use Go 1.25.12, allowing dependency downloads and compilation to complete successfully
- Test and lint workflows now run with Go 1.25.12 instead of relying on an older version to download the required toolchain
- Exact Go patch-version pins keep image builds and CI results reproducible

### Impact
`✅ Successful Docker image builds`
`✅ Reliable test and lint runs`
`✅ Reproducible Go build environments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized automated testing and linting environments on Go 1.25.12.
  - Updated container build environments to use a consistent, fixed Go patch version.
  - Added maintenance notes documenting the Go version requirement and update process.
  - Improved build reproducibility and consistency across local container builds and automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->