### PR TITLE
fix(security): cross-tenant line-item IDOR (SHN-9b) + QuickBooks query injection (SHN-10)

### DIFF
--- a/internal/integration/quickbooks/client.go
+++ b/internal/integration/quickbooks/client.go
@@ -19,6 +19,33 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 )
 
+// maxQueryLiteralLen bounds a value interpolated into a QuickBooks query. The
+// QuickBooks fields these match (email, DisplayName, item Name) are documented
+// at 100 characters; bounding here also limits the size of any injection payload.
+const maxQueryLiteralLen = 100
+
+// escapeQueryLiteral makes a caller-supplied value safe to interpolate inside a
+// single-quoted QuickBooks Query Language string literal. Customer email/name and
+// item name reach these queries from tenant-controlled entity fields, so without
+// escaping a single quote breaks out of the literal (SOQL-like injection).
+//
+// QuickBooks escapes a single quote by doubling it (''), not with a backslash
+// (backslash is not special). Control characters have no place in these fields
+// and could smuggle clauses or corrupt the request URL, so they are removed. The
+// result is length-bounded to the field maximum.
+func escapeQueryLiteral(s string) string {
+	if len(s) > maxQueryLiteralLen {
+		s = s[:maxQueryLiteralLen]
+	}
+	s = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+	return strings.ReplaceAll(s, "'", "''")
+}
+
 // QuickBooksClient defines the interface for QuickBooks API operations
 type QuickBooksClient interface {
 	// Configuration and initialization
@@ -514,15 +541,13 @@ func (c *Client) CreateCustomer(ctx context.Context, req *CustomerCreateRequest)
 }
 
 // QueryCustomerByEmail queries a customer by email
-// Note: QuickBooks Query API requires backslash escaping for single quotes (e.g., \' )
 func (c *Client) QueryCustomerByEmail(ctx context.Context, email string) (*CustomerResponse, error) {
 	// Ensure valid access token before making API call
 	if err := c.EnsureValidAccessToken(ctx); err != nil {
 		return nil, err
 	}
 
-	// Escape single quotes with backslash as required by QuickBooks Query API
-	query := fmt.Sprintf("SELECT * FROM Customer WHERE PrimaryEmailAddr = '%s'", email)
+	query := fmt.Sprintf("SELECT * FROM Customer WHERE PrimaryEmailAddr = '%s'", escapeQueryLiteral(email))
 
 	body, err := c.queryEntitiesWithRetry(ctx, "Customer", query, 0)
 	if err != nil {
@@ -542,14 +567,13 @@ func (c *Client) QueryCustomerByEmail(ctx context.Context, email string) (*Custo
 }
 
 // QueryCustomerByName queries a customer by display name
-// Note: QuickBooks Query API requires backslash escaping for single quotes (e.g., \' )
 func (c *Client) QueryCustomerByName(ctx context.Context, name string) (*CustomerResponse, error) {
 	// Ensure valid access token before making API call
 	if err := c.EnsureValidAccessToken(ctx); err != nil {
 		return nil, err
 	}
 
-	query := fmt.Sprintf("SELECT * FROM Customer WHERE DisplayName = '%s'", name)
+	query := fmt.Sprintf("SELECT * FROM Customer WHERE DisplayName = '%s'", escapeQueryLiteral(name))
 
 	body, err := c.queryEntitiesWithRetry(ctx, "Customer", query, 0)
 	if err != nil {
@@ -674,14 +698,13 @@ func (c *Client) GetItem(ctx context.Context, itemID string) (*ItemResponse, err
 }
 
 // QueryItemByName queries an item by name
-// Note: QuickBooks Query API requires backslash escaping for single quotes (e.g., \' )
 func (c *Client) QueryItemByName(ctx context.Context, name string) (*ItemResponse, error) {
 	// Ensure valid access token before making API call
 	if err := c.EnsureValidAccessToken(ctx); err != nil {
 		return nil, err
 	}
 
-	query := fmt.Sprintf("SELECT * FROM Item WHERE Name = '%s' AND Type = 'Service' AND Active = true", name)
+	query := fmt.Sprintf("SELECT * FROM Item WHERE Name = '%s' AND Type = 'Service' AND Active = true", escapeQueryLiteral(name))
 
 	body, err := c.queryEntitiesWithRetry(ctx, "Item", query, 0)
 	if err != nil {

--- a/internal/integration/quickbooks/client.go
+++ b/internal/integration/quickbooks/client.go
@@ -34,15 +34,17 @@ const maxQueryLiteralLen = 100
 // and could smuggle clauses or corrupt the request URL, so they are removed. The
 // result is length-bounded to the field maximum.
 func escapeQueryLiteral(s string) string {
-	if len(s) > maxQueryLiteralLen {
-		s = s[:maxQueryLiteralLen]
-	}
+	// Strip control characters first, then bound by runes (not bytes) so a
+	// multi-byte character is never cut in half, and finally double single quotes.
 	s = strings.Map(func(r rune) rune {
 		if r < 0x20 || r == 0x7f {
 			return -1
 		}
 		return r
 	}, s)
+	if runes := []rune(s); len(runes) > maxQueryLiteralLen {
+		s = string(runes[:maxQueryLiteralLen])
+	}
 	return strings.ReplaceAll(s, "'", "''")
 }
 

--- a/internal/integration/quickbooks/escape_test.go
+++ b/internal/integration/quickbooks/escape_test.go
@@ -3,6 +3,7 @@ package quickbooks
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestEscapeQueryLiteral(t *testing.T) {
@@ -35,8 +36,27 @@ func TestEscapeQueryLiteral(t *testing.T) {
 func TestEscapeQueryLiteral_LengthBound(t *testing.T) {
 	long := strings.Repeat("a", maxQueryLiteralLen+50)
 	got := escapeQueryLiteral(long)
-	if len(got) != maxQueryLiteralLen {
-		t.Fatalf("length = %d, want %d", len(got), maxQueryLiteralLen)
+	if len([]rune(got)) != maxQueryLiteralLen {
+		t.Fatalf("rune length = %d, want %d", len([]rune(got)), maxQueryLiteralLen)
+	}
+}
+
+func TestEscapeQueryLiteral_RuneBoundary(t *testing.T) {
+	// Multi-byte runes: bounding must be by rune, never cutting a rune in half.
+	// "€" is 3 bytes; a string of these that exceeds the rune cap must truncate
+	// to exactly maxQueryLiteralLen runes and remain valid UTF-8.
+	in := strings.Repeat("€", maxQueryLiteralLen+20)
+	got := escapeQueryLiteral(in)
+	if len([]rune(got)) != maxQueryLiteralLen {
+		t.Fatalf("rune length = %d, want %d", len([]rune(got)), maxQueryLiteralLen)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8: %q", got)
+	}
+	// Under the cap: a multi-byte value must pass through unchanged.
+	small := "café O'Brien"
+	if got := escapeQueryLiteral(small); got != "café O''Brien" {
+		t.Fatalf("escapeQueryLiteral(%q) = %q, want %q", small, got, "café O''Brien")
 	}
 }
 

--- a/internal/integration/quickbooks/escape_test.go
+++ b/internal/integration/quickbooks/escape_test.go
@@ -1,0 +1,55 @@
+package quickbooks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEscapeQueryLiteral(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "acme@example.com", "acme@example.com"},
+		{"single quote doubled", "O'Brien", "O''Brien"},
+		{
+			// SHN-10: the injection payload must not break out of the literal.
+			name: "soql injection payload neutralized",
+			in:   "x' OR '1'='1",
+			want: "x'' OR ''1''=''1",
+		},
+		{"control chars stripped", "ab\ncd\tef\x00gh", "abcdefgh"},
+		{"del stripped", "a\x7fb", "ab"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeQueryLiteral(tt.in); got != tt.want {
+				t.Fatalf("escapeQueryLiteral(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEscapeQueryLiteral_LengthBound(t *testing.T) {
+	long := strings.Repeat("a", maxQueryLiteralLen+50)
+	got := escapeQueryLiteral(long)
+	if len(got) != maxQueryLiteralLen {
+		t.Fatalf("length = %d, want %d", len(got), maxQueryLiteralLen)
+	}
+}
+
+func TestEscapeQueryLiteral_NoUnescapedQuoteRemains(t *testing.T) {
+	// Every apostrophe in the output must be part of a doubled pair, so no lone
+	// quote can terminate the surrounding string literal.
+	out := escapeQueryLiteral("a'b'c")
+	for i := 0; i < len(out); i++ {
+		if out[i] == '\'' {
+			if i+1 >= len(out) || out[i+1] != '\'' {
+				t.Fatalf("lone single quote at %d in %q", i, out)
+			}
+			i++ // skip the pair
+		}
+	}
+}

--- a/internal/repository/ent/creditnote.go
+++ b/internal/repository/ent/creditnote.go
@@ -257,7 +257,12 @@ func (r *creditnoteRepository) AddLineItems(ctx context.Context, creditNoteID st
 
 	return r.client.WithTx(ctx, func(ctx context.Context) error {
 		// Verify credit note exists
-		exists, err := r.client.Writer(ctx).CreditNote.Query().Where(creditnote.ID(creditNoteID)).Exist(ctx)
+		exists, err := r.client.Writer(ctx).CreditNote.Query().
+			Where(
+				creditnote.ID(creditNoteID),
+				creditnote.TenantID(types.GetTenantID(ctx)),
+				creditnote.EnvironmentID(types.GetEnvironmentID(ctx)),
+			).Exist(ctx)
 		if err != nil {
 			return ierr.WithError(err).WithHint("credit note existence check failed").Mark(ierr.ErrDatabase)
 		}
@@ -306,7 +311,12 @@ func (r *creditnoteRepository) RemoveLineItems(ctx context.Context, creditNoteID
 
 	return r.client.WithTx(ctx, func(ctx context.Context) error {
 		// Verify credit note exists
-		exists, err := r.client.Writer(ctx).CreditNote.Query().Where(creditnote.ID(creditNoteID)).Exist(ctx)
+		exists, err := r.client.Writer(ctx).CreditNote.Query().
+			Where(
+				creditnote.ID(creditNoteID),
+				creditnote.TenantID(types.GetTenantID(ctx)),
+				creditnote.EnvironmentID(types.GetEnvironmentID(ctx)),
+			).Exist(ctx)
 		if err != nil {
 			return ierr.WithError(err).WithHint("credit note existence check failed").Mark(ierr.ErrDatabase)
 		}

--- a/internal/repository/ent/creditnote.go
+++ b/internal/repository/ent/creditnote.go
@@ -327,6 +327,7 @@ func (r *creditnoteRepository) RemoveLineItems(ctx context.Context, creditNoteID
 		_, err = r.client.Writer(ctx).CreditNoteLineItem.Update().
 			Where(
 				creditnotelineitem.TenantID(types.GetTenantID(ctx)),
+				creditnotelineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 				creditnotelineitem.CreditNoteID(creditNoteID),
 				creditnotelineitem.IDIn(itemIDs...),
 			).

--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -403,6 +403,7 @@ func (r *invoiceRepository) RemoveLineItems(ctx context.Context, invoiceID strin
 		_, err = r.client.Writer(ctx).InvoiceLineItem.Update().
 			Where(
 				invoicelineitem.TenantID(types.GetTenantID(ctx)),
+				invoicelineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 				invoicelineitem.InvoiceID(invoiceID),
 				invoicelineitem.IDIn(itemIDs...),
 			).
@@ -626,6 +627,7 @@ func (r *invoiceRepository) Delete(ctx context.Context, id string) error {
 			Where(
 				invoicelineitem.InvoiceID(id),
 				invoicelineitem.TenantID(types.GetTenantID(ctx)),
+				invoicelineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 			).
 			SetStatus(string(types.StatusDeleted)).
 			SetUpdatedBy(types.GetUserID(ctx)).

--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -309,8 +309,15 @@ func (r *invoiceRepository) AddLineItems(ctx context.Context, invoiceID string, 
 	r.logger.Debug(ctx, "adding line items", "invoice_id", invoiceID, "count", len(items))
 
 	return r.client.WithTx(ctx, func(ctx context.Context) error {
-		// Verify invoice exists
-		exists, err := r.client.Writer(ctx).Invoice.Query().Where(invoice.ID(invoiceID)).Exist(ctx)
+		// Verify invoice exists within the caller's tenant + environment. Without
+		// this predicate the existence gate would accept a foreign-tenant invoice
+		// ID, allowing a cross-tenant line-item write (SHN-9b / A01 invariant).
+		exists, err := r.client.Writer(ctx).Invoice.Query().
+			Where(
+				invoice.ID(invoiceID),
+				invoice.TenantID(types.GetTenantID(ctx)),
+				invoice.EnvironmentID(types.GetEnvironmentID(ctx)),
+			).Exist(ctx)
 		if err != nil {
 			return ierr.WithError(err).WithHint("invoice existence check failed").Mark(ierr.ErrDatabase)
 		}
@@ -377,8 +384,15 @@ func (r *invoiceRepository) RemoveLineItems(ctx context.Context, invoiceID strin
 	r.logger.Debug(ctx, "removing line items", "invoice_id", invoiceID, "count", len(itemIDs))
 
 	return r.client.WithTx(ctx, func(ctx context.Context) error {
-		// Verify invoice exists
-		exists, err := r.client.Writer(ctx).Invoice.Query().Where(invoice.ID(invoiceID)).Exist(ctx)
+		// Verify invoice exists within the caller's tenant + environment. Without
+		// this predicate the existence gate would accept a foreign-tenant invoice
+		// ID, allowing a cross-tenant line-item write (SHN-9b / A01 invariant).
+		exists, err := r.client.Writer(ctx).Invoice.Query().
+			Where(
+				invoice.ID(invoiceID),
+				invoice.TenantID(types.GetTenantID(ctx)),
+				invoice.EnvironmentID(types.GetEnvironmentID(ctx)),
+			).Exist(ctx)
 		if err != nil {
 			return ierr.WithError(err).WithHint("invoice existence check failed").Mark(ierr.ErrDatabase)
 		}


### PR DESCRIPTION
## **User description**
Two application findings from the Shannon staging pentest.

## SHN-9b (S11) — cross-tenant IDOR on line-item existence gates
The invoice and credit-note line-item add/remove paths gated on a bare existence check — `Query().Where(<entity>.ID(id)).Exist(ctx)` — with **no tenant_id/environment_id predicate**. The gate would accept a foreign tenant's ID and allow a cross-tenant line-item (and invoice-total) rewrite, violating the A01 invariant.

All four gates now filter `tenant_id + environment_id`, matching the A01 `/v1/costs` fix (#2451):
- `invoiceRepository.AddLineItems` / `RemoveLineItems`
- `creditnoteRepository.AddLineItems` / `RemoveLineItems`

An audit of every `Get`/`GetByID` on the affected entities (invoice, credit note, wallet, checkout session, API keys, service accounts, customers) confirmed those were **already tenant-scoped**; these four bare `Exist` gates were the only unscoped single-id lookups remaining. The `recalculate-v2` path pre-loads the invoice tenant-scoped before the write, so it was not directly exploitable, but the gates violated the invariant and were a defense-in-depth hole for any other caller.

## SHN-10 (S12) — QuickBooks SOQL-like injection
Customer email, customer DisplayName, and item Name were interpolated into `SELECT ... WHERE x = '%s'` via raw `fmt.Sprintf` in `quickbooks/client.go`. All three are tenant-controlled entity fields, so a single quote broke out of the string literal. `url.QueryEscape` on the whole query is **not** a defense — the QuickBooks server url-decodes before parsing, restoring the `'`.

Added `escapeQueryLiteral`, applied at all three sinks:
- doubles single quotes (`''` — the QuickBooks escaping scheme; backslash is not special)
- strips control characters (`< 0x20`, `0x7f`)
- bounds length to the field maximum (100)

Removed three doc-comments that claimed a backslash-escaping scheme that never existed in code and is the wrong scheme for QuickBooks. Unit tests cover the injection payload, control-char stripping, and the length bound.

## Verification
- `go build ./internal/...` — clean
- `go test ./internal/integration/quickbooks/ ./internal/repository/ent/` — pass (new escape tests included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent unauthorized line-item updates and unsafe QuickBooks lookups

### What Changed
- Invoice and credit-note line-item changes now only accept records from the active tenant and environment
- QuickBooks customer and item searches safely handle quotes, control characters, and oversized values
- Added tests covering injection payloads, quote handling, control-character removal, and length limits

### Impact
`✅ Blocks cross-tenant invoice and credit-note changes`
`✅ Prevents QuickBooks query injection`
`✅ Safer customer and item searches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for customer and item searches by safely handling special characters and potentially malicious input.
  * Prevented invoice and credit note line-item changes from affecting records in another tenant or environment.
  * Added safeguards for control characters and excessively long search values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->