### PR TITLE
fix(ci): gate ECS deploys on a successful image build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -259,7 +259,16 @@ jobs:
   deploy-preprod:
     name: Deploy Preprod (${{ strategy.job-index }})
     needs: [build, resolve-config]
-    if: ${{ always() && needs.resolve-config.result == 'success' && needs.resolve-config.outputs.preprod_targets != '[]' }}
+    # `always()` is required so a skipped approval-gate does not block staging, but it
+    # also cancels the implicit "skip on failed needs" rule — so every dependency this
+    # job actually relies on must be asserted explicitly. `needs.build.result` is the
+    # one that matters: without it a failed image build still reaches the deploy step,
+    # which registers a task definition referencing an image that was never pushed.
+    if: >-
+      ${{ always() &&
+          needs.build.result == 'success' &&
+          needs.resolve-config.result == 'success' &&
+          needs.resolve-config.outputs.preprod_targets != '[]' }}
     runs-on: self-hosted
     strategy:
       matrix:
@@ -379,6 +388,7 @@ jobs:
     # dry-run: bypasses the gate; composite action prints plan only
     if: >-
       ${{ always() &&
+          needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
           (needs.resolve-config.outputs.environment != 'production' ||
            needs.resolve-config.outputs.dry_run == 'true' ||
@@ -415,6 +425,7 @@ jobs:
     # dry-run: bypasses the gate; composite action prints plan only
     if: >-
       ${{ always() &&
+          needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
           (needs.resolve-config.outputs.environment != 'production' ||
            needs.resolve-config.outputs.dry_run == 'true' ||
@@ -451,6 +462,7 @@ jobs:
     # dry-run: bypasses the gate; composite action prints plan only
     if: >-
       ${{ always() &&
+          needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
           (needs.resolve-config.outputs.environment != 'production' ||
            needs.resolve-config.outputs.dry_run == 'true' ||


### PR DESCRIPTION
## **User description**
## Problem

The deploy jobs use `always()` so a skipped approval-gate does not block staging rollouts. That also cancels GitHub's implicit "skip when a `needs` job failed" rule — and the conditions only asserted `resolve-config` and `approval-gate`, never `build`.

So when the image build fails, the deploy jobs still run and report success. They call `describe-task-definition`, swap in the image tag for the current SHA, and register a new revision — producing **task definitions that reference an image which was never pushed to ECR**.

## This actually happened

Run [`31410108104`](https://github.com/flexprice/flexprice/actions/runs/31410108104) (push to `main`, sha `33f8144`) on 2026-08-10:

```
✗ Build & Push Docker Image    ← step "Build & push image to ECR" FAILED
✓ Deploy Consumer (0)
✓ Deploy API (0)
✓ Deploy Worker (0)
```

It registered `web_api:692`, `web_consumer:642` and `temporal_worker:460` against image tag `33f81444…`, which does not exist in ECR (`ImageNotFoundException`).

Nothing deployed them at the time, but they became the **newest revision on each family**. Anything resolving "latest" — a manual `update-service`, a console rollback, a script — picks up a phantom image. Deploying one fails with `CannotPullImageManifestError`, and because these services run `minimumHealthyPercent: 0`, ECS drains to zero *before* discovering it. That was confirmed the hard way: `flexprice-consumer-v1` sat at 0 running tasks for ~4 minutes before the circuit breaker rolled it back.

## Fix

Add `needs.build.result == 'success'` to `deploy-preprod`, `deploy-api`, `deploy-consumer` and `deploy-worker`.

`promote-main-ghcr` **already had this check**, which is why it correctly skipped during that run. This brings the four outliers in line with the pattern already in the file.

`always()` is retained — it is needed so a skipped approval-gate does not block staging. The bug was `always()` without asserting the dependency that actually matters.

## Testing

A `workflow_dispatch` run with `dry_run: true` skips the `build` job entirely, so the deploy jobs' behaviour when `build` does not succeed can be confirmed without breaking anything.

## Not covered here

`web_api:692`, `web_consumer:642` and `temporal_worker:460` are still ACTIVE and still newest on their families. This change prevents new ones; it does not retire the existing three. They should be deregistered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent ECS deployments from running when the image build fails

### What Changed
- Preprod, API, consumer, and worker deployments now run only after the container image is built successfully
- Failed image builds no longer create task definitions that reference unavailable images
- Existing staging, production approval, and dry-run deployment behavior remains unchanged

### Impact
`✅ Fewer deployments with missing container images`
`✅ Prevents ECS services from draining on invalid revisions`
`✅ Keeps failed builds from being reported as successful deployments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented preproduction and production deployments from running when the image build fails.
  * Existing approval and deployment conditions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->