### PR TITLE
fix(pubsub): gate watermill debug logging on configured log level

### DIFF
--- a/internal/pubsub/memory/pubsub.go
+++ b/internal/pubsub/memory/pubsub.go
@@ -34,7 +34,7 @@ func NewPubSub(
 			// Buffer size for output channel
 			OutputChannelBuffer: 100,
 		},
-		watermill.NewStdLogger(true, false),
+		watermill.NewStdLogger(cfg.Logging.Level == types.LogLevelDebug, false),
 	)
 
 	return &PubSub{

--- a/internal/pubsub/router/router.go
+++ b/internal/pubsub/router/router.go
@@ -22,13 +22,18 @@ type Router struct {
 	tracing      *tracing.Service
 	config       *config.Webhook
 	dlqPublisher message.Publisher
+	debugLogs    bool
 }
 
 // NewRouter creates a new message router
 func NewRouter(cfg *config.Configuration, logger *logger.Logger, tracingSvc *tracing.Service) (*Router, error) {
+	// enableDebugLogs allows watermill DEBUG messages in debug mode.
+	// TRACE is never enabled — it logs every individual message sent/received, which is too noisy.
+	enableDebugLogs := cfg.Logging.Level == types.LogLevelDebug
+
 	router, err := message.NewRouter(
 		message.RouterConfig{},
-		watermill.NewStdLogger(true, false),
+		watermill.NewStdLogger(enableDebugLogs, false),
 	)
 	if err != nil {
 		return nil, err
@@ -59,6 +64,7 @@ func NewRouter(cfg *config.Configuration, logger *logger.Logger, tracingSvc *tra
 		tracing:      tracingSvc,
 		config:       &cfg.Webhook,
 		dlqPublisher: dlqPublisher,
+		debugLogs:    enableDebugLogs,
 	}, nil
 }
 
@@ -195,7 +201,7 @@ func (r *Router) AddNoPublishHandler(
 		Multiplier:          2.0,
 		MaxElapsedTime:      2 * time.Minute,
 		RandomizationFactor: 0.5,
-		Logger:              watermill.NewStdLogger(true, false),
+		Logger:              watermill.NewStdLogger(r.debugLogs, false),
 		OnRetryHook: func(retryNum int, delay time.Duration) {
 			r.logger.Info(context.Background(), "retrying message",
 				"handler", handlerName,


### PR DESCRIPTION
## **User description**
## Problem

`internal/pubsub/router/router.go` built the watermill router with `watermill.NewStdLogger(true, false)` — the first argument is `debug`, hardcoded on regardless of `FLEXPRICE_LOGGING_LEVEL`. The same hardcoding existed in the per-handler `middleware.Retry` logger and in the in-memory gochannel pubsub.

Consequences:
- One log line per routed message.
- Written to unstructured stdout, bypassing the JSON format configured via `FLEXPRICE_LOGGING_FORMAT`.
- Unnecessary CPU and log-volume overhead at scale, and noise that makes real errors harder to spot.

The intended pattern already exists nearby: `internal/kafka/consumer.go` enables watermill debug only when `cfg.Logging.Level == types.LogLevelDebug`, and `createDLQPublisher` uses `NewStdLogger(false, false)`.

## Change

Derive the debug flag from the configured log level in all three places:

- `internal/pubsub/router/router.go` — router construction; flag stored on `Router.debugLogs` and reused for the `Retry` middleware logger.
- `internal/pubsub/memory/pubsub.go` — gochannel construction.

TRACE (second argument) stays `false` everywhere; it logs every individual message sent/received.

## Behaviour

- `FLEXPRICE_LOGGING_LEVEL=info` (default): no watermill per-message debug output.
- `FLEXPRICE_LOGGING_LEVEL=debug`: unchanged from today.

## Verification

- `go build ./internal/...` — passes
- `go vet ./internal/pubsub/...` — clean


___

## **CodeAnt-AI Description**
Respect the configured log level for pub/sub debug logging

### What Changed
- Watermill no longer emits per-message debug logs when the application uses the default or info log level
- Debug-level pub/sub and retry logs remain available when `FLEXPRICE_LOGGING_LEVEL=debug`
- TRACE logging remains disabled to avoid logging every message sent and received

### Impact
`✅ Lower log volume at info level`
`✅ Lower CPU overhead for message processing`
`✅ Less noisy application output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned messaging and router log output with the configured logging level.
  * Prevented debug logs from appearing when debug logging is not enabled.
  * Preserved disabled trace logging while ensuring retry-related logs follow the configured level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->