### PR TITLE
fix(wallet): Lock wallet before processing transactions

### DIFF
--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -832,16 +832,21 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 	var walletTransactionID string
 	var invoiceID string
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
-		// Serialize with processWalletOperation and completePurchasedCreditTransaction
-		// so the wallet snapshot we base the tx record's balance-before/after and the
-		// (auto-complete) balance write on is not raced. Released on tx commit/rollback.
-		if err := s.DB.LockWithWait(ctx, postgres.LockRequest{Key: walletID}); err != nil {
-			return ierr.WithError(err).
-				WithHint("Failed to acquire wallet lock").
-				Mark(ierr.ErrInternal)
+		// Only take the wallet advisory lock when this tx actually mutates the wallet balance (auto-complete branch).
+		// In the pending path we only record a tx snapshot; the balance write is deferred to completePurchasedCreditTransaction
+		// which takes its own lock and overwrites CreditBalanceBefore/After at that
+		// point, so this record's initial snapshot need not be lock-consistent.
+		// Keeping the lock out of the pending path avoids holding it across tax
+		// lookup, invoice creation, and any inline external sync.
+		if autoCompleteEnabled {
+			if err := s.DB.LockWithWait(ctx, postgres.LockRequest{Key: walletID}); err != nil {
+				return ierr.WithError(err).
+					WithHint("Failed to acquire wallet lock").
+					Mark(ierr.ErrInternal)
+			}
 		}
 
-		// Retrieve wallet inside the lock — authoritative snapshot.
+		// Retrieve wallet inside the tx (under the lock when auto-complete).
 		w, err := s.WalletRepo.GetWalletByID(ctx, walletID)
 		if err != nil {
 			return err

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -808,12 +808,6 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 		ServiceParams: s.ServiceParams,
 	}
 
-	// Retrieve wallet and customer details
-	w, err := s.WalletRepo.GetWalletByID(ctx, walletID)
-	if err != nil {
-		return "", "", err
-	}
-
 	// Get invoice config setting to check auto_complete flag
 	invoiceConfig, err := GetSetting[types.InvoiceConfig](
 		settingsService,
@@ -838,6 +832,21 @@ func (s *walletService) handlePurchasedCreditInvoicedTransaction(ctx context.Con
 	var walletTransactionID string
 	var invoiceID string
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
+		// Serialize with processWalletOperation and completePurchasedCreditTransaction
+		// so the wallet snapshot we base the tx record's balance-before/after and the
+		// (auto-complete) balance write on is not raced. Released on tx commit/rollback.
+		if err := s.DB.LockWithWait(ctx, postgres.LockRequest{Key: walletID}); err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to acquire wallet lock").
+				Mark(ierr.ErrInternal)
+		}
+
+		// Retrieve wallet inside the lock — authoritative snapshot.
+		w, err := s.WalletRepo.GetWalletByID(ctx, walletID)
+		if err != nil {
+			return err
+		}
+
 		// Step 1: Create wallet transaction (pending or completed based on setting)
 		txStatus := types.TransactionStatusPending
 		balanceAfter := w.CreditBalance
@@ -1152,7 +1161,8 @@ func (s *walletService) CompletePurchasedCreditTransactionWithRetry(ctx context.
 
 // completePurchasedCreditTransaction performs the actual completion logic
 func (s *walletService) completePurchasedCreditTransaction(ctx context.Context, walletTransactionID string) error {
-	// Get the pending transaction
+	// Fast-path pre-check to skip the lock for terminal / wrong-type txns; the
+	// authoritative status check runs again under the lock below.
 	tx, err := s.WalletRepo.GetTransactionByID(ctx, walletTransactionID)
 	if err != nil {
 		return ierr.WithError(err).
@@ -1160,19 +1170,17 @@ func (s *walletService) completePurchasedCreditTransaction(ctx context.Context, 
 			Mark(ierr.ErrNotFound)
 	}
 
-	// Validate transaction state
+	if tx.TxStatus == types.TransactionStatusCompleted {
+		s.Logger.Debug(ctx, "wallet transaction already completed",
+			"wallet_transaction_id", walletTransactionID,
+		)
+		return nil
+	}
 	if tx.TxStatus != types.TransactionStatusPending {
 		s.Logger.Debug(ctx, "wallet transaction is not pending",
 			"wallet_transaction_id", walletTransactionID,
 			"current_status", tx.TxStatus,
 		)
-		// If already completed (e.g., via auto-complete setting), this is idempotent - return success
-		if tx.TxStatus == types.TransactionStatusCompleted {
-			s.Logger.Debug(ctx, "wallet transaction already completed",
-				"wallet_transaction_id", walletTransactionID,
-			)
-			return nil
-		}
 		return ierr.NewError("wallet transaction is not in pending state").
 			WithHint("Only pending transactions can be completed").
 			WithReportableDetails(map[string]interface{}{
@@ -1192,16 +1200,54 @@ func (s *walletService) completePurchasedCreditTransaction(ctx context.Context, 
 			Mark(ierr.ErrInvalidOperation)
 	}
 
-	// Get wallet to check current balance
-	w, err := s.WalletRepo.GetWalletByID(ctx, tx.WalletID)
-	if err != nil {
-		return ierr.WithError(err).
-			WithHint("Failed to get wallet").
-			Mark(ierr.ErrNotFound)
-	}
+	var w *wallet.Wallet
+	// alreadyCompleted flips true if a concurrent completer finished this tx while
+	// we were waiting for the advisory lock — suppresses the post-commit webhook
+	// publish and alert side effects to avoid double firing.
+	alreadyCompleted := false
 
 	// Execute completion in a transaction
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
+		// Serialize with processWalletOperation and other completion paths so a
+		// concurrent debit/credit cannot overwrite the absolute-value balance write
+		// below with a stale-snapshot value. Released on tx commit/rollback.
+		if err := s.DB.LockWithWait(ctx, postgres.LockRequest{Key: tx.WalletID}); err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to acquire wallet lock").
+				Mark(ierr.ErrInternal)
+		}
+
+		// Re-read tx under the lock so a concurrent completer that raced us to the
+		// lock is observed as terminal instead of double-applying its credit.
+		var err error
+		tx, err = s.WalletRepo.GetTransactionByID(ctx, walletTransactionID)
+		if err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to get wallet transaction").
+				Mark(ierr.ErrNotFound)
+		}
+		if tx.TxStatus == types.TransactionStatusCompleted {
+			alreadyCompleted = true
+			return nil
+		}
+		if tx.TxStatus != types.TransactionStatusPending {
+			return ierr.NewError("wallet transaction is not in pending state").
+				WithHint("Only pending transactions can be completed").
+				WithReportableDetails(map[string]interface{}{
+					"wallet_transaction_id": walletTransactionID,
+					"current_status":        tx.TxStatus,
+				}).
+				Mark(ierr.ErrInvalidOperation)
+		}
+
+		// Re-read wallet under the lock — authoritative balance.
+		w, err = s.WalletRepo.GetWalletByID(ctx, tx.WalletID)
+		if err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to get wallet").
+				Mark(ierr.ErrNotFound)
+		}
+
 		// Calculate new balances
 		finalBalance := w.Balance.Add(tx.Amount)
 		newCreditBalance := w.CreditBalance.Add(tx.CreditAmount)
@@ -1284,6 +1330,12 @@ func (s *walletService) completePurchasedCreditTransaction(ctx context.Context, 
 
 	if err != nil {
 		return err
+	}
+
+	// A concurrent completer finished this tx first — the winner already published
+	// the webhook and alert events, so we return without repeating them.
+	if alreadyCompleted {
+		return nil
 	}
 
 	// Publish webhook event after transaction commits


### PR DESCRIPTION
## **CodeAnt-AI Description**
Prevent concurrent wallet transactions from overwriting balances or duplicating completion effects

### What Changed
- Wallet credits and other wallet operations now use the latest balance snapshot when transactions run at the same time
- Completing the same pending credit transaction concurrently applies the credit only once
- Duplicate webhook events and credit-balance alerts are suppressed when another completion finishes first
- Wallet transaction records now consistently show the balance before and after the operation

### Impact
`✅ Accurate balances during concurrent wallet activity`
`✅ No duplicate wallet credits`
`✅ No duplicate transaction notifications`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of wallet purchases during simultaneous or repeated processing.
  * Prevented duplicate credit transactions, webhook notifications, and alerts when a purchase completion is received more than once.
  * Ensured wallet balances remain accurate when multiple purchase updates occur concurrently.
  * Improved handling of repeated or delayed purchase completion updates, reducing the risk of inconsistent wallet crediting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->