### PR TITLE
fix(security): cap event ingestion request body size (VAPT SFX-0203-F11)

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -172,8 +172,14 @@ func NewRouter(
 		// Events routes
 		events := v1Private.Group("/events")
 		{
-			events.POST("", write(types.EntityEvent, types.ActionWrite), handlers.Events.IngestEvent)
-			events.POST("/bulk", write(types.EntityEvent, types.ActionWrite), handlers.Events.BulkIngestEvent)
+			// Ingestion is the only caller-supplied-payload surface here, so the
+			// body cap goes on those three routes rather than the whole group —
+			// the query/analytics routes take small filter bodies and reprocess
+			// takes none.
+			ingestBodyLimit := middleware.BodyLimitMiddleware(middleware.MaxEventIngestionBodyBytes)
+
+			events.POST("", ingestBodyLimit, write(types.EntityEvent, types.ActionWrite), handlers.Events.IngestEvent)
+			events.POST("/bulk", ingestBodyLimit, write(types.EntityEvent, types.ActionWrite), handlers.Events.BulkIngestEvent)
 			events.GET("", handlers.Events.GetEvents)
 			events.GET("/lookup", handlers.Events.GetEventByID)
 			events.GET("/:id", handlers.Events.GetEventByID) // legacy alias, remove once no caller uses /events/:id
@@ -183,7 +189,7 @@ func NewRouter(
 			events.POST("/analytics", handlers.Events.GetUsageAnalytics)
 			events.POST("/huggingface-billing", handlers.Events.GetHuggingFaceBillingData)
 			events.GET("/monitoring", handlers.Events.GetMonitoringData)
-			events.POST("/raw/bulk", write(types.EntityEvent, types.ActionWrite), handlers.Events.BulkIngestRawEvent)
+			events.POST("/raw/bulk", ingestBodyLimit, write(types.EntityEvent, types.ActionWrite), handlers.Events.BulkIngestRawEvent)
 			events.POST("/raw/reprocess/all", write(types.EntityEvent, types.ActionWrite), handlers.Events.ReprocessRawEvents)
 			events.POST("/raw/reprocess/pending", write(types.EntityEvent, types.ActionWrite), handlers.Events.ReprocessUnprocessedRawEvents)
 		}

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/rest/middleware"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
@@ -53,7 +54,7 @@ func NewEventsHandler(eventService service.EventService, rawEventsReprocessingSe
 func (h *EventsHandler) IngestEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.IngestEventRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	if err := middleware.BindJSONWithLimit(c, &req); err != nil {
 		if isRequestBodyTooLarge(err) {
 			c.Error(errRequestBodyTooLarge())
 			return
@@ -95,7 +96,7 @@ func (h *EventsHandler) IngestEvent(c *gin.Context) {
 func (h *EventsHandler) BulkIngestEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.BulkIngestEventRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	if err := middleware.BindJSONWithLimit(c, &req); err != nil {
 		if isRequestBodyTooLarge(err) {
 			c.Error(errRequestBodyTooLarge())
 			return
@@ -144,7 +145,7 @@ func errRequestBodyTooLarge() error {
 func (h *EventsHandler) BulkIngestRawEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.BulkIngestRawEventRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	if err := middleware.BindJSONWithLimit(c, &req); err != nil {
 		if isRequestBodyTooLarge(err) {
 			c.Error(errRequestBodyTooLarge())
 			return

--- a/internal/api/v1/events.go
+++ b/internal/api/v1/events.go
@@ -54,6 +54,10 @@ func (h *EventsHandler) IngestEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.IngestEventRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			c.Error(errRequestBodyTooLarge())
+			return
+		}
 		h.log.Error(c.Request.Context(), "Failed to bind JSON", "error", err)
 		c.Error(ierr.NewError("invalid request payload").
 			WithHint("Invalid request payload").
@@ -92,6 +96,10 @@ func (h *EventsHandler) BulkIngestEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.BulkIngestEventRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			c.Error(errRequestBodyTooLarge())
+			return
+		}
 		h.log.Error(c.Request.Context(), "Failed to bind JSON", "error", err)
 		c.Error(ierr.WithError(err).
 			WithHint("Invalid request payload").
@@ -114,6 +122,22 @@ func (h *EventsHandler) BulkIngestEvent(c *gin.Context) {
 	c.JSON(http.StatusAccepted, gin.H{"message": "Events accepted for processing"})
 }
 
+// isRequestBodyTooLarge reports whether a bind error was caused by the ingestion
+// body cap (middleware.MaxEventIngestionBodyBytes) rather than malformed JSON.
+// MaxBytesReader truncates the stream, so the decoder surfaces this wrapped
+// behind an unmarshal error — without the check an oversized batch would be
+// reported to the caller as invalid JSON.
+func isRequestBodyTooLarge(err error) bool {
+	var maxErr *http.MaxBytesError
+	return errors.As(err, &maxErr)
+}
+
+func errRequestBodyTooLarge() error {
+	return ierr.NewError("request body too large").
+		WithHint("Request body exceeds the maximum size; split the batch into smaller requests").
+		Mark(ierr.ErrValidation)
+}
+
 // BulkIngestRawEvent publishes a batch of raw Bento-format event payloads directly to the
 // raw_events Kafka topic (POST /v1/events/raw/bulk). Intentionally excluded from Swagger/SDK
 // — this is an internal endpoint for testing and backfills, not part of the public API.
@@ -121,6 +145,10 @@ func (h *EventsHandler) BulkIngestRawEvent(c *gin.Context) {
 	ctx := c.Request.Context()
 	var req dto.BulkIngestRawEventRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		if isRequestBodyTooLarge(err) {
+			c.Error(errRequestBodyTooLarge())
+			return
+		}
 		h.log.Error(c.Request.Context(), "Failed to bind JSON", "error", err)
 		c.Error(ierr.WithError(err).
 			WithHint("Invalid request payload").

--- a/internal/rest/middleware/body_limit.go
+++ b/internal/rest/middleware/body_limit.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// MaxEventIngestionBodyBytes caps a single event-ingestion request body.
+//
+// Set deliberately high: bulk ingestion is a supported pattern and customers
+// post large batches in normal operation, so this is a backstop against a
+// single request consuming unbounded memory, not a throughput control.
+// Sustained volume is bounded separately by the per-pipeline consumer
+// throttles (see EventProcessing.RateLimit and friends).
+const MaxEventIngestionBodyBytes = 32 << 20 // 32 MiB
+
+// BodyLimitMiddleware caps the request body at limitBytes.
+//
+// MaxBytesReader enforces the limit while the body is read rather than
+// buffering it first, so an oversized request is cut off mid-stream instead of
+// being fully materialised. The handler's existing bind-error path surfaces the
+// resulting *http.MaxBytesError as a validation error (HTTP 400).
+func BodyLimitMiddleware(limitBytes int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Body != nil {
+			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, limitBytes)
+		}
+		c.Next()
+	}
+}

--- a/internal/rest/middleware/body_limit.go
+++ b/internal/rest/middleware/body_limit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -21,6 +22,14 @@ const MaxEventIngestionBodyBytes = 32 << 20 // 32 MiB
 // buffering it first, so an oversized request is cut off mid-stream instead of
 // being fully materialised. The handler's existing bind-error path surfaces the
 // resulting *http.MaxBytesError as a validation error (HTTP 400).
+//
+// The wrapper alone is not sufficient. ShouldBindJSON decodes a single JSON
+// value and stops at its closing brace — it does not read to EOF — so a small
+// valid object followed by megabytes of trailing whitespace or garbage decodes
+// successfully without the reader ever reaching its limit. drainBody therefore
+// consumes whatever follows the decoded value, which is what actually trips
+// MaxBytesReader on an oversized body. Anything left after the first value is
+// junk the handler would have ignored regardless.
 func BodyLimitMiddleware(limitBytes int64) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Body != nil {
@@ -28,4 +37,28 @@ func BodyLimitMiddleware(limitBytes int64) gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+// BindJSONWithLimit binds the request body and enforces the cap set by
+// BodyLimitMiddleware.
+//
+// The middleware alone does not enforce it. encoding/json stops at the closing
+// brace of the first complete value and does not read to EOF — measured, a small
+// object is decoded in a single 512-byte read — so a valid object followed by
+// megabytes of trailing bytes binds successfully without MaxBytesReader ever
+// reaching its limit. Draining after the bind is what actually trips the reader:
+// if the remainder pushes the request past the cap, the drain fails and the
+// request is rejected.
+//
+// Trailing content after the first JSON value is malformed input regardless, so
+// nothing legitimate is lost by consuming it.
+func BindJSONWithLimit(c *gin.Context, obj any) error {
+	if err := c.ShouldBindJSON(obj); err != nil {
+		return err
+	}
+	if c.Request.Body == nil {
+		return nil
+	}
+	_, err := io.Copy(io.Discard, c.Request.Body)
+	return err
 }

--- a/internal/rest/middleware/body_limit_test.go
+++ b/internal/rest/middleware/body_limit_test.go
@@ -88,3 +88,63 @@ func TestBodyLimitMiddleware_NilBody(t *testing.T) {
 	assert.NotPanics(t, func() { router.ServeHTTP(w, req) })
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+// Regression for the bypass CodeAnt flagged on PR #2527: encoding/json stops at
+// the first complete value, so a small valid object followed by a large tail was
+// accepted despite exceeding the cap. BindJSONWithLimit drains after binding,
+// which is what makes the limit hold.
+func TestBindJSONWithLimit_RejectsOversizedTail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const limit = 1024
+
+	tests := []struct {
+		name string
+		tail string
+	}{
+		{name: "trailing whitespace", tail: strings.Repeat(" ", limit*10)},
+		{name: "trailing garbage", tail: strings.Repeat("A", limit*10)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bindErr error
+			router := gin.New()
+			router.POST("/", BodyLimitMiddleware(limit), func(c *gin.Context) {
+				var v map[string]any
+				bindErr = BindJSONWithLimit(c, &v)
+				c.Status(http.StatusOK)
+			})
+
+			body := `{"a":1}` + tt.tail
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			assert.Error(t, bindErr, "%d-byte body must be rejected under a %d-byte cap", len(body), limit)
+			var maxErr *http.MaxBytesError
+			assert.True(t, errors.As(bindErr, &maxErr), "want *http.MaxBytesError, got %v", bindErr)
+		})
+	}
+}
+
+// A well-formed body under the cap must still bind cleanly.
+func TestBindJSONWithLimit_AllowsValidBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var bindErr error
+	var got map[string]any
+
+	router := gin.New()
+	router.POST("/", BodyLimitMiddleware(1024), func(c *gin.Context) {
+		bindErr = BindJSONWithLimit(c, &got)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"a":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.NoError(t, bindErr)
+	assert.Equal(t, float64(1), got["a"])
+}

--- a/internal/rest/middleware/body_limit_test.go
+++ b/internal/rest/middleware/body_limit_test.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBodyLimitMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const limit = 64
+
+	tests := []struct {
+		name          string
+		body          string
+		wantTooLarge  bool
+		wantBytesRead int
+	}{
+		{
+			name:          "body under the limit is read in full",
+			body:          strings.Repeat("a", limit-1),
+			wantTooLarge:  false,
+			wantBytesRead: limit - 1,
+		},
+		{
+			name:          "body exactly at the limit is allowed",
+			body:          strings.Repeat("a", limit),
+			wantTooLarge:  false,
+			wantBytesRead: limit,
+		},
+		{
+			name:         "body over the limit is rejected",
+			body:         strings.Repeat("a", limit+1),
+			wantTooLarge: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var readErr error
+			var n int
+
+			router := gin.New()
+			router.POST("/", BodyLimitMiddleware(limit), func(c *gin.Context) {
+				b, err := io.ReadAll(c.Request.Body)
+				readErr = err
+				n = len(b)
+				c.Status(http.StatusOK)
+			})
+
+			req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(tt.body))
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			if tt.wantTooLarge {
+				var maxErr *http.MaxBytesError
+				assert.True(t, errors.As(readErr, &maxErr),
+					"expected *http.MaxBytesError, got %v", readErr)
+				return
+			}
+
+			assert.NoError(t, readErr)
+			assert.Equal(t, tt.wantBytesRead, n)
+		})
+	}
+}
+
+// A nil body must not panic — GET-style requests reach the middleware too.
+func TestBodyLimitMiddleware_NilBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/", BodyLimitMiddleware(64), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Body = nil
+	w := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() { router.ServeHTTP(w, req) })
+	assert.Equal(t, http.StatusOK, w.Code)
+}


### PR DESCRIPTION
## **User description**
Closes the body-size half of Secfox finding **SFX-2026-0203-F11** (MEDIUM), raised in the 2026-08-11 backend retest.

## Context

The finding states event ingestion has *no body-size limit or rate limiting*. Only half of that holds:

- **Rate limiting — already present.** Every consumption path is throttled: `EventProcessing`, `EventProcessingLazy`, `BulkEventConsumption`, replay and costsheet tracking each build a `middleware.NewThrottle(cfg.…RateLimit, time.Second)` (`internal/service/event_consumption.go:120/220/249/284`). No change needed.
- **Body size — genuinely missing.** `http.MaxBytesReader` appeared only in `internal/api/v1/ai_pricing.go`. Nothing bounded an ingestion request, so a single call could be materialised without limit.

## Change

`BodyLimitMiddleware` applied to the three ingestion routes — `POST /events`, `/events/bulk`, `/events/raw/bulk`. Query and analytics routes take small filter bodies and are deliberately untouched.

**Limit: 32 MiB.** Chosen to sit far above any legitimate batch. This is a backstop on a single request's memory cost, not a throughput control — sustained volume stays governed by the consumer throttles above. No customer batch we serve today comes close, so this should reject nothing in practice.

`MaxBytesReader` enforces during the read rather than buffering first, so an oversized request is cut off mid-stream instead of being fully allocated.

## Error surfacing

The JSON decoder wraps `*http.MaxBytesError` behind an unmarshal error, so without unwrapping it an oversized batch would be reported to the caller as invalid JSON. The three bind paths now detect it and return an explicit `request body too large` validation error (HTTP 400) with a hint to split the batch.

## Testing

`go test -race ./internal/rest/middleware/` — table-driven over under-limit, exactly-at-limit and over-limit, plus a nil-body case. All pass. Unwrapping of a wrapped `MaxBytesError` verified separately.

`make lint-ci` clean. `go build ./internal/...` clean. (Two pre-existing `api/custom/go/async.go` build errors are unrelated and present on `develop`.)

## Reviewer note

If 32 MiB reads as too generous, it is a one-constant change in `internal/rest/middleware/body_limit.go`. Erring high deliberately: rejecting a real customer batch is worse than permitting a large one, given the throttles behind it.


___

## **CodeAnt-AI Description**
Limit event ingestion requests and clearly reject oversized batches

### What Changed
- Event ingestion endpoints now enforce a 32 MiB request-body limit while reading the request
- Oversized event batches receive a clear validation error explaining that the batch must be split
- Query, analytics, and reprocessing endpoints remain unchanged
- Added coverage for requests below, at, and above the limit, including requests without a body

### Impact
`✅ Bounded memory use for event ingestion`
`✅ Clearer errors for oversized batches`
`✅ Fewer risks from unbounded ingestion requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against oversized event-ingestion requests.
  * Requests exceeding the 32 MiB limit now receive a clear validation error.
  * Standard, bulk, and raw event-ingestion endpoints now handle oversized payloads consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->