### PR TITLE
fix(helm): repair topology spread selector and kafka broker list

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -772,14 +772,26 @@ could land in one AZ with nothing in the manifest to show for it.
 
 A constraint that DOES define labelSelector is passed through untouched, so an
 operator can still spread against an arbitrary set of pods.
+
+Presence is tested with `hasKey`, not truthiness: an explicit `labelSelector: {}`
+is a VALID selector meaning "match every pod in the namespace", but it is falsey
+in Go templates. Testing truthiness would take the injection branch and emit
+`labelSelector` twice in the same constraint — YAML resolves the duplicate to the
+last occurrence, so the operator's explicit selector would be silently discarded
+rather than rejected.
 */}}
 {{- define "flexprice.topologySpreadConstraints" -}}
 {{- $ctx := .ctx -}}
 {{- $component := .component -}}
 {{- $cfg := index $ctx.Values $component | default dict -}}
 {{- $tsc := default $ctx.Values.topologySpreadConstraints (get $cfg "topologySpreadConstraints") -}}
+{{- /* `--set topologySpreadConstraints=[]` yields the STRING "[]", not an empty
+       list, and `range` over a string is a render error. Anything that is not a
+       real list is treated as "no constraints" so the caller's `with` emits
+       nothing, matching `topologySpreadConstraints: []` set via a values file. */ -}}
+{{- if not (kindIs "slice" $tsc) }}{{- $tsc = list }}{{- end -}}
 {{- range $tsc }}
-{{- if .labelSelector }}
+{{- if hasKey . "labelSelector" }}
 - {{ toYaml . | nindent 2 | trim }}
 {{- else }}
 - {{ toYaml . | nindent 2 | trim }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -751,3 +751,42 @@ All service addresses are resolved via named templates above so this block stays
 {{ toYaml . | trim }}
 {{- end }}
 {{- end }}
+
+{{/*
+Topology spread constraints for a component, with a defaulted labelSelector.
+Usage: include "flexprice.topologySpreadConstraints" (dict "ctx" . "component" "api")
+
+Resolves `.Values.<component>.topologySpreadConstraints` first, falling back to
+the global `.Values.topologySpreadConstraints`.
+
+Any constraint that carries NO labelSelector of its own gets one injected:
+the chart's selector labels (which honour nameOverride/fullnameOverride) plus
+the component key, so each workload spreads against its own replicas rather
+than against every pod in the release.
+
+This defaulting exists because the previous values.yaml hardcoded
+`app.kubernetes.io/name: flexprice`. That matched zero pods the moment an
+operator set nameOverride, and since the default whenUnsatisfiable is
+ScheduleAnyway the scheduler silently ignored the constraint — all replicas
+could land in one AZ with nothing in the manifest to show for it.
+
+A constraint that DOES define labelSelector is passed through untouched, so an
+operator can still spread against an arbitrary set of pods.
+*/}}
+{{- define "flexprice.topologySpreadConstraints" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $cfg := index $ctx.Values $component | default dict -}}
+{{- $tsc := default $ctx.Values.topologySpreadConstraints (get $cfg "topologySpreadConstraints") -}}
+{{- range $tsc }}
+{{- if .labelSelector }}
+- {{ toYaml . | nindent 2 | trim }}
+{{- else }}
+- {{ toYaml . | nindent 2 | trim }}
+  labelSelector:
+    matchLabels:
+      {{- include "flexprice.selectorLabels" $ctx | nindent 6 }}
+      app.kubernetes.io/component: {{ $component }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -53,8 +53,17 @@ data:
       timeout: {{ .Values.redisConfig.timeout | default "5s" | quote }}
 
     kafka:
+      {{- /* One YAML entry per broker. flexprice.kafkaBrokers returns the
+             comma-joined form the FLEXPRICE_KAFKA_BROKERS env var needs, which is
+             correct there but NOT here: emitted as a single list item it produces
+             one malformed address ("b1:9093,b2:9093"), and sarama treats the whole
+             string as one host. It only ever worked because the env var takes
+             precedence over this file at Unmarshal time — remove that env var and
+             the cluster becomes unreachable. Split it back out. */}}
       brokers:
-        - {{ include "flexprice.kafkaBrokers" . | quote }}
+        {{- range (splitList "," (include "flexprice.kafkaBrokers" .)) }}
+        - {{ . | trim | quote }}
+        {{- end }}
       consumer_group: {{ .Values.kafkaConfig.consumerGroup | quote }}
       topic: {{ .Values.kafkaConfig.topic | quote }}
       topic_lazy: {{ .Values.kafkaConfig.topicLazy | quote }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
@@ -106,10 +106,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tsc := default .Values.topologySpreadConstraints .Values.api.topologySpreadConstraints }}
-      {{- if $tsc }}
+      {{- with (include "flexprice.topologySpreadConstraints" (dict "ctx" . "component" "api") | trim) }}
       topologySpreadConstraints:
-        {{- toYaml $tsc | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
 {{- end }}
 

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
@@ -113,10 +113,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tsc := default .Values.topologySpreadConstraints .Values.consumer.topologySpreadConstraints }}
-      {{- if $tsc }}
+      {{- with (include "flexprice.topologySpreadConstraints" (dict "ctx" . "component" "consumer") | trim) }}
       topologySpreadConstraints:
-        {{- toYaml $tsc | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
 {{- end }}
 

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-frontend.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-frontend.yaml
@@ -74,10 +74,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tsc := default .Values.topologySpreadConstraints .Values.frontend.topologySpreadConstraints }}
-      {{- if $tsc }}
+      {{- with (include "flexprice.topologySpreadConstraints" (dict "ctx" . "component" "frontend") | trim) }}
       topologySpreadConstraints:
-        {{- toYaml $tsc | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
 {{- end }}
 ---

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
@@ -104,10 +104,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- $tsc := default .Values.topologySpreadConstraints .Values.worker.topologySpreadConstraints }}
-      {{- if $tsc }}
+      {{- with (include "flexprice.topologySpreadConstraints" (dict "ctx" . "component" "worker") | trim) }}
       topologySpreadConstraints:
-        {{- toYaml $tsc | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
 {{- end }}
 

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -1160,13 +1160,19 @@ affinity: {}
 # HA on real EKS/GKE/AKS deployments. Override per-component via
 # `<component>.topologySpreadConstraints`. Use `whenUnsatisfiable: DoNotSchedule`
 # for strict HA where you'd rather pods stay Pending than land in one AZ.
+#
+# labelSelector is left EMPTY on purpose: the deployment templates inject
+# `app.kubernetes.io/name` (honouring nameOverride) plus the per-component key
+# when a constraint carries no selector of its own. Hardcoding
+# `app.kubernetes.io/name: flexprice` here matched nothing as soon as an
+# operator set nameOverride, and because whenUnsatisfiable is ScheduleAnyway
+# that failed SILENTLY — every replica could land in one AZ with no signal.
+# Set labelSelector explicitly only if you want to spread against a different
+# set of pods than the component being rendered.
 topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
-    labelSelector:
-      matchLabels:
-        app.kubernetes.io/name: flexprice
 
 # Liveness probe
 livenessProbe:


### PR DESCRIPTION
Two defects in the Helm chart's rendered config. Both were invisible in practice because something else was compensating — which is what makes them worth fixing now rather than when the compensation goes away.

## 1. Topology spread constraints matched zero pods

`values.yaml` hardcoded the selector:

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        app.kubernetes.io/name: flexprice   # <-- hardcoded
```

Pods are labelled via `flexprice.name`, which honours `nameOverride`. Any deployment setting `nameOverride` therefore got a selector matching **no pods at all**.

Because the default is `whenUnsatisfiable: ScheduleAnyway`, the scheduler silently ignores an unsatisfiable constraint — no Pending pods, no events, nothing in the manifest to indicate spreading was lost. Every replica could land in a single AZ. It "worked" only for deployments that left `nameOverride` unset, where the chart name happens to equal the label.

**Fix:** drop the selector from `values.yaml`; inject it per component via a new `flexprice.topologySpreadConstraints` helper — selector labels (honouring `nameOverride`) plus the component key, so api/consumer/worker/frontend each spread against their own replicas instead of being balanced as one pool.

Preserved behaviour:
- a constraint defining its own `labelSelector` passes through untouched
- `<component>.topologySpreadConstraints` still overrides the global list
- an empty list renders no block

## 2. `kafka.brokers` rendered as one malformed address

```yaml
brokers:
  - {{ include "flexprice.kafkaBrokers" . | quote }}
```

`flexprice.kafkaBrokers` returns the comma-joined form that `FLEXPRICE_KAFKA_BROKERS` needs — correct for the env var, wrong for the config file. As a single list item it yields one entry, `"b1:9093,b2:9093,b3:9093"`, which sarama treats as a single hostname.

This never surfaced because the env var outranks the config file at `Unmarshal` time and viper's default `StringToSliceHookFunc(",")` splits it correctly. I confirmed the precedence directly against viper: from the config file alone the value stays a single malformed broker; with the env var set it splits into three. So the env var is the only reason multi-broker clusters work today — remove or rename it and the cluster silently becomes unreachable.

**Fix:** emit one YAML entry per broker.

## Verification

`helm lint` clean. `helm template` checks:

- selector tracks `nameOverride` — the previously broken case
- each component gets its own `app.kubernetes.io/component` in the selector
- operator-supplied `labelSelector` passes through unmodified
- per-component override wins; other components keep the global default
- `topologySpreadConstraints: []` renders no block
- rendered `config.yaml` parses and yields three distinct brokers

No values-schema change: `topologySpreadConstraints` keeps its shape, only the redundant hardcoded selector is gone. Existing values files that set their own `labelSelector` are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka broker configuration rendering so multiple brokers are correctly represented as separate YAML entries.
  * Improved Kubernetes pod distribution settings across API, consumer, frontend, and worker deployments.
  * Deployment labels and selectors are now applied consistently, including when custom naming is configured.
  * Explicit topology selector settings are preserved, while invalid configuration formats are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->