### PR TITLE
fix(webhook): re-embed customer in subscription webhook payload

### DIFF
--- a/internal/webhook/dto/subscription.go
+++ b/internal/webhook/dto/subscription.go
@@ -40,6 +40,7 @@ type Subscription struct {
 	SubscriptionType     types.SubscriptionType   `json:"subscription_type"`
 	ParentSubscriptionID *string                  `json:"parent_subscription_id,omitempty"`
 	Metadata             types.Metadata           `json:"metadata,omitempty"`
+	Customer             *Customer                `json:"customer,omitempty"`
 }
 
 func NewSubscription(resp *dto.SubscriptionResponse) *Subscription {
@@ -69,6 +70,7 @@ func NewSubscription(resp *dto.SubscriptionResponse) *Subscription {
 		SubscriptionType:     resp.SubscriptionType,
 		ParentSubscriptionID: resp.ParentSubscriptionID,
 		Metadata:             resp.Metadata,
+		Customer:             NewCustomer(resp.Customer),
 	}
 }
 
@@ -99,6 +101,7 @@ func NewSubscriptionFromV2(resp *dto.SubscriptionResponseV2) *Subscription {
 		SubscriptionType:     resp.SubscriptionType,
 		ParentSubscriptionID: resp.ParentSubscriptionID,
 		Metadata:             resp.Metadata,
+		Customer:             NewCustomer(resp.Customer),
 	}
 }
 


### PR DESCRIPTION
## **User description**
## Summary
- The webhook payload trimming refactor (#2432 / follow-up hand-picked-struct refactor) dropped `Customer` from the `subscription.*` webhook payload entirely.
- Re-adds it to `webhookDto.Subscription` using the existing trimmed `Customer` struct (already used by `customer.*` webhooks), so a consumer that depends on the embedded customer keeps working without reintroducing the payload-size regression the original refactor fixed.

## Test plan
- [x] `go build ./internal/webhook/...`
- [x] `go test ./internal/webhook/...`


___

## **CodeAnt-AI Description**
Restore customer details in subscription webhook payloads

### What Changed
- Subscription webhook events include the embedded customer details again
- Customer data is populated for both supported subscription response formats
- The payload uses the existing trimmed customer representation

### Impact
`✅ Subscription webhook consumers can access customer details`
`✅ Restored compatibility for integrations using embedded customers`
`✅ Avoids unnecessary webhook payload growth`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription webhook data now includes optional customer details when available.
  * Customer information is populated consistently across supported subscription versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->