### PR TITLE
feat(subscription): publish subscription.line_item.{created,deleted} events

### DIFF
--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -127,7 +127,7 @@ func (s *SeedEnsure) Run(ctx context.Context) error {
 	// tenant. See the "no ephemeral customers on staging" report.
 	if err := s.ensureEntitlementGrants(ctx, &seeds); err != nil {
 		if s.logger != nil {
-			s.logger.Warn(ctx, "seed-ensure: grant provisioning failed; continuing without grant coverage",
+			s.logger.Info(ctx, "seed-ensure: grant provisioning failed; continuing without grant coverage",
 				"error", err.Error(),
 			)
 		}

--- a/internal/ee/service/checkout_session_actions.go
+++ b/internal/ee/service/checkout_session_actions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	domainCheckout "github.com/flexprice/flexprice/internal/domain/checkout"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/types"
@@ -242,12 +243,25 @@ func (s *checkoutSessionService) completeModifySubscriptionCheckout(
 	if err != nil {
 		return err
 	}
-	if _, err := modSvc.applyQuantityChange(ctx, quantityChangeReq); err != nil {
+	_, lineItemDeltas, err := modSvc.applyQuantityChange(ctx, quantityChangeReq)
+	if err != nil {
 		return err
 	}
 
 	if err := s.finalizeCheckoutInvoiceAndPayment(ctx, invoiceID, paymentID, providerResult); err != nil {
 		return err
+	}
+
+	// subscriptionModificationService only holds serviceParams (unexported field), not a
+	// *subscriptionService, so publishLineItemEvents is reached via a throwaway concrete
+	// instance sharing the same ServiceParams, matching this file's own existing pattern
+	// (see completeAddAddonCheckout's subSvc construction just below in this same file).
+	lineItemPublisher := &subscriptionService{ServiceParams: s.ServiceParams}
+	for _, delta := range lineItemDeltas {
+		lineItemPublisher.publishLineItemEvents(ctx, params.SubscriptionID,
+			[]*subscription.SubscriptionLineItem{delta.ended}, types.WebhookEventSubscriptionLineItemDeleted)
+		lineItemPublisher.publishLineItemEvents(ctx, params.SubscriptionID,
+			[]*subscription.SubscriptionLineItem{delta.new}, types.WebhookEventSubscriptionLineItemCreated)
 	}
 
 	modSvc.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, params.SubscriptionID)

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2083,6 +2083,10 @@ func (s *subscriptionService) CancelSubscription(
 
 	logger.Info(ctx, "processing enhanced subscription cancellation")
 
+	// Declared before the "subscription" identifier below shadows the domain package name
+	// for the rest of this function's scope.
+	var terminatedLineItemsForCancellation []*subscription.SubscriptionLineItem
+
 	// Step 1: Validate request
 	if err := req.Validate(); err != nil {
 		return nil, err
@@ -2251,13 +2255,15 @@ func (s *subscriptionService) CancelSubscription(
 		// period-rollover loop) so that reverting a pending schedule never leaves these resources
 		// terminated while the subscription itself is active again.
 		if req.CancellationType == types.CancellationTypeImmediate {
-			if err := s.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
+			terminated, err := s.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
 				SubscriptionID:     subscription.ID,
 				EffectiveDate:      effectiveDate,
 				CancellationReason: req.Reason,
-			}); err != nil {
+			})
+			if err != nil {
 				return err
 			}
+			terminatedLineItemsForCancellation = terminated
 		}
 
 		// Step 7c: Handle scheduling for future cancellations (end_of_period and scheduled_date)
@@ -2296,7 +2302,7 @@ func (s *subscriptionService) CancelSubscription(
 
 	if !req.SuppressWebhook {
 		// Step 10: Publish events
-		s.publishCancellationEvents(ctx, subscription, req.CancellationType)
+		s.publishCancellationEvents(ctx, subscription, req.CancellationType, terminatedLineItemsForCancellation)
 	}
 
 	// Gate on the resulting status, not the request's cancellation type: only an immediate
@@ -3540,6 +3546,7 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 	}
 
 	isSubscriptionCancelled := false
+	var terminatedLineItemsForPeriodCancellation []*subscription.SubscriptionLineItem
 	// Use db's WithTx for atomic operations
 	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
 		// Process all periods except the last one (which becomes the new current period)
@@ -3647,13 +3654,15 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 		// deferred in the first place and must be left alone.
 		if sub.SubscriptionStatus == types.SubscriptionStatusCancelled &&
 			sub.CancelAtPeriodEnd && sub.CancelAt != nil {
-			if err := s.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
+			terminated, err := s.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
 				SubscriptionID:     sub.ID,
 				EffectiveDate:      *sub.CancelAt,
 				CancellationReason: sub.Metadata["cancellation_reason"],
-			}); err != nil {
+			})
+			if err != nil {
 				return err
 			}
+			terminatedLineItemsForPeriodCancellation = terminated
 		}
 
 		// Update the subscription
@@ -3710,7 +3719,7 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 	}
 
 	if isSubscriptionCancelled {
-		s.PublishCancellationEvents(ctx, sub)
+		s.PublishCancellationEvents(ctx, sub, terminatedLineItemsForPeriodCancellation)
 	}
 
 	return nil
@@ -4711,7 +4720,8 @@ func (s *subscriptionService) publishSystemEvent(ctx context.Context, eventName 
 	}
 }
 
-func (s *subscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription) {
+func (s *subscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription, terminatedLineItems []*subscription.SubscriptionLineItem) {
+	s.publishLineItemEvents(ctx, sub.ID, terminatedLineItems, types.WebhookEventSubscriptionLineItemDeleted)
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCancelled, sub.ID)
 }
@@ -5338,17 +5348,19 @@ func (s *subscriptionService) pendingAddonFeatureResetPeriods(
 func (s *subscriptionService) TerminateSubscriptionResources(
 	ctx context.Context,
 	req dto.TerminateSubscriptionResourcesRequest,
-) error {
+) ([]*subscription.SubscriptionLineItem, error) {
 	if err := req.Validate(); err != nil {
-		return err
+		return nil, err
 	}
 
-	if err := s.cancelAddonsForSubscription(ctx, req.SubscriptionID, req.EffectiveDate, req.CancellationReason); err != nil {
-		return err
+	addonTerminated, err := s.cancelAddonsForSubscription(ctx, req.SubscriptionID, req.EffectiveDate, req.CancellationReason)
+	if err != nil {
+		return nil, err
 	}
 
-	if err := s.cancelAllLineItemsForSubscription(ctx, req.SubscriptionID, req.EffectiveDate); err != nil {
-		return err
+	planTerminated, err := s.cancelAllLineItemsForSubscription(ctx, req.SubscriptionID, req.EffectiveDate)
+	if err != nil {
+		return nil, err
 	}
 
 	creditGrantService := NewCreditGrantService(s.ServiceParams)
@@ -5356,10 +5368,10 @@ func (s *subscriptionService) TerminateSubscriptionResources(
 		SubscriptionID: req.SubscriptionID,
 		EffectiveDate:  &req.EffectiveDate,
 	}); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return append(addonTerminated, planTerminated...), nil
 }
 
 // listPendingAddonAssociations returns the subscription's addon associations that are still
@@ -5378,7 +5390,7 @@ func (s *subscriptionService) listPendingAddonAssociations(
 
 // Called during subscription cancellation (immediate or end_of_period) with the effective cancellation date.
 // Uses the same GetActiveAddonAssociation path as the API so we reliably find all active addons on the subscription.
-func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, subscriptionID string, effectiveDate time.Time, reason string) error {
+func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, subscriptionID string, effectiveDate time.Time, reason string) ([]*subscription.SubscriptionLineItem, error) {
 	logger := s.Logger.With(
 		"subscription_id", subscriptionID,
 		"effective_date", effectiveDate,
@@ -5390,7 +5402,7 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 		EntityType: types.AddonAssociationEntityTypeSubscription,
 	})
 	if err != nil {
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to get active addon associations for subscription").
 			Mark(ierr.ErrDatabase)
 	}
@@ -5399,7 +5411,7 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 	// active read above, but they must be cancelled here too or they outlive the subscription.
 	pendingAddons, err := s.listPendingAddonAssociations(ctx, subscriptionID)
 	if err != nil {
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to get pending addon associations for subscription").
 			Mark(ierr.ErrDatabase)
 	}
@@ -5417,7 +5429,7 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 
 	if len(associations) == 0 {
 		logger.Debug(ctx, "no addon associations to cancel")
-		return nil
+		return nil, nil
 	}
 
 	logger.Info(ctx, "cancelling addon associations for subscription",
@@ -5456,7 +5468,7 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 			logger.Error(ctx, "failed to update addon association",
 				"addon_association_id", association.ID,
 				"error", err)
-			return ierr.WithError(err).
+			return nil, ierr.WithError(err).
 				WithHintf("Failed to cancel addon association %s", association.ID).
 				Mark(ierr.ErrDatabase)
 		}
@@ -5467,7 +5479,7 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 	}
 
 	if len(addonIDsToCancel) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	addonIDList := lo.Keys(addonIDsToCancel)
@@ -5481,7 +5493,7 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 		logger.Error(ctx, "failed to list subscription line items for addon termination",
 			"subscription_id", subscriptionID,
 			"error", err)
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to list subscription line items for addon termination").
 			Mark(ierr.ErrDatabase)
 	}
@@ -5492,30 +5504,31 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 		"line_items_found", len(allLineItems))
 
 	deleteReq := dto.DeleteSubscriptionLineItemRequest{EffectiveFrom: &effectiveDate}
-	terminated := 0
+	terminatedLineItems := make([]*subscription.SubscriptionLineItem, 0, len(allLineItems))
 	for _, lineItem := range allLineItems {
 		if !lineItem.EndDate.IsZero() {
 			continue
 		}
 
-		if _, err := s.deleteSubscriptionLineItem(ctx, lineItem.ID, deleteReq); err != nil {
+		deletedResp, err := s.deleteSubscriptionLineItem(ctx, lineItem.ID, deleteReq)
+		if err != nil {
 			logger.Error(ctx, "failed to terminate addon line item",
 				"line_item_id", lineItem.ID,
 				"entity_id", lineItem.EntityID,
 				"error", err)
-			return ierr.WithError(err).
+			return nil, ierr.WithError(err).
 				WithHintf("Failed to terminate line item %s (entity_type=addon, entity_id=%s)", lineItem.ID, lineItem.EntityID).
 				Mark(ierr.ErrDatabase)
 		}
-		terminated++
+		terminatedLineItems = append(terminatedLineItems, deletedResp.SubscriptionLineItem)
 	}
 
 	logger.Info(ctx, "terminated addon line items for subscription",
 		"subscription_id", subscriptionID,
 		"addon_ids_count", len(addonIDsToCancel),
-		"line_items_terminated", terminated)
+		"line_items_terminated", len(terminatedLineItems))
 
-	return nil
+	return terminatedLineItems, nil
 }
 
 // RemoveAddonFromSubscription removes an addon from a subscription by addon association ID
@@ -6549,7 +6562,10 @@ func (s *subscriptionService) publishCancellationEvents(
 	ctx context.Context,
 	sub *subscription.Subscription,
 	cancellationType types.CancellationType,
+	terminatedLineItems []*subscription.SubscriptionLineItem,
 ) {
+	s.publishLineItemEvents(ctx, sub.ID, terminatedLineItems, types.WebhookEventSubscriptionLineItemDeleted)
+
 	// Publish standard subscription events
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
 	if cancellationType == types.CancellationTypeImmediate {
@@ -7799,22 +7815,52 @@ func (s *subscriptionService) cancelAllLineItemsForSubscription(
 	ctx context.Context,
 	subscriptionID string,
 	effectiveDate time.Time,
-) error {
+) ([]*subscription.SubscriptionLineItem, error) {
 	logger := s.Logger.With(
 		"subscription_id", subscriptionID,
 		"effective_date", effectiveDate,
 	)
 
+	// Fetch BEFORE BulkTerminate: fetching after would read every affected row's
+	// EndDate as already equal to effectiveDate, matching neither half of the
+	// predicate below, silently producing an empty result. filter is deliberately
+	// unfiltered by date/status (no ActiveFilter/CurrentPeriodStart/Status) — this
+	// must be a superset so the in-Go predicate below is the sole source of truth,
+	// kept identical to BulkTerminate's own WHERE clause (EndDateIsNil() OR
+	// EndDateGT(effectiveDate), no status filter) rather than trusting two
+	// separately-constructed queries to stay in sync.
+	filter := types.NewNoLimitSubscriptionLineItemFilter()
+	filter.SubscriptionIDs = []string{subscriptionID}
+	allLineItems, err := s.SubscriptionLineItemRepo.List(ctx, filter)
+	if err != nil {
+		logger.Error(ctx, "failed to list line items before termination", "error", err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to list line items before termination").
+			Mark(ierr.ErrDatabase)
+	}
+
+	terminatedLineItems := make([]*subscription.SubscriptionLineItem, 0, len(allLineItems))
+	for _, li := range allLineItems {
+		if li == nil || li.EntityType == types.SubscriptionLineItemEntityTypeAddon {
+			continue
+		}
+		if li.EndDate.IsZero() || li.EndDate.After(effectiveDate) {
+			terminatedLineItems = append(terminatedLineItems, li)
+		}
+	}
+
 	terminated, err := s.SubscriptionLineItemRepo.BulkTerminate(ctx, subscriptionID, effectiveDate)
 	if err != nil {
 		logger.Error(ctx, "failed to terminate line items for subscription", "error", err)
-		return ierr.WithError(err).
+		return nil, ierr.WithError(err).
 			WithHint("Failed to terminate line items for subscription").
 			Mark(ierr.ErrDatabase)
 	}
 
-	logger.Info(ctx, "terminated line items for subscription", "line_items_terminated", terminated)
-	return nil
+	logger.Info(ctx, "terminated line items for subscription",
+		"line_items_terminated", terminated,
+		"line_items_terminated_for_publish", len(terminatedLineItems))
+	return terminatedLineItems, nil
 }
 
 // resolveExternalCustomersForInheritance resolves published customers by external ID and validates

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -570,6 +570,17 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionCreated, result.Sub.ID)
 	}
 
+	// Re-fetch rather than trust result.Sub.LineItems: addon-derived and extra
+	// req.LineItems-derived line items are appended to a different in-memory
+	// subscription object by their own internal fetch-and-append calls, and never
+	// make it back onto this one.
+	if _, allLineItems, err := s.SubRepo.GetWithLineItems(ctx, result.Sub.ID); err == nil {
+		s.publishLineItemEvents(ctx, result.Sub.ID, allLineItems, types.WebhookEventSubscriptionLineItemCreated)
+	} else {
+		s.Logger.Error(ctx, "failed to fetch line items for post-create publish",
+			"error", err, "subscription_id", result.Sub.ID)
+	}
+
 	if req.Checkout != nil && result.Sub.SubscriptionStatus == types.SubscriptionStatusDraft {
 		invResp, skipped, err := buildCheckoutDraftInvoice(ctx, s.ServiceParams, response)
 		if err != nil {

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -2,15 +2,65 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	webhookDto "github.com/flexprice/flexprice/internal/webhook/dto"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
+
+// publishLineItemEvents publishes a subscription.line_item.created/deleted webhook
+// event for each FIXED-price line item in lineItems; non-FIXED line items are
+// skipped since only fixed charges are synced to HubSpot deal line items.
+func (s *subscriptionService) publishLineItemEvents(
+	ctx context.Context,
+	subscriptionID string,
+	lineItems []*subscription.SubscriptionLineItem,
+	eventName types.WebhookEventName,
+) {
+	for _, li := range lineItems {
+		if li == nil || li.PriceType != types.PRICE_TYPE_FIXED {
+			continue
+		}
+
+		eventPayload := webhookDto.InternalSubscriptionLineItemEvent{
+			SubscriptionID: subscriptionID,
+			LineItemID:     li.ID,
+			CustomerID:     li.CustomerID,
+			PriceType:      li.PriceType,
+			TenantID:       types.GetTenantID(ctx),
+			EnvironmentID:  types.GetEnvironmentID(ctx),
+		}
+
+		webhookPayload, err := json.Marshal(eventPayload)
+		if err != nil {
+			s.Logger.Error(ctx, "failed to marshal line item webhook payload",
+				"error", err, "line_item_id", li.ID)
+			continue
+		}
+
+		webhookEvent := &types.WebhookEvent{
+			ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SYSTEM_EVENT),
+			EventName:     eventName,
+			TenantID:      types.GetTenantID(ctx),
+			EnvironmentID: types.GetEnvironmentID(ctx),
+			UserID:        types.GetUserID(ctx),
+			Timestamp:     time.Now().UTC(),
+			Payload:       json.RawMessage(webhookPayload),
+			EntityType:    types.SystemEntityTypeSubscription,
+			EntityID:      subscriptionID,
+		}
+		if err := s.WebhookPublisher.PublishWebhook(ctx, webhookEvent); err != nil {
+			s.Logger.Error(ctx, "failed to publish line item webhook event",
+				"error", err, "event_name", eventName, "line_item_id", li.ID)
+		}
+	}
+}
 
 // AddSubscriptionLineItem adds a new line item to an existing subscription
 func (s *subscriptionService) AddSubscriptionLineItem(ctx context.Context, subscriptionID string, req dto.CreateSubscriptionLineItemRequest) (*dto.SubscriptionLineItemResponse, error) {
@@ -20,6 +70,9 @@ func (s *subscriptionService) AddSubscriptionLineItem(ctx context.Context, subsc
 	}
 
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, subscriptionID)
+	s.publishLineItemEvents(ctx, subscriptionID,
+		[]*subscription.SubscriptionLineItem{resp.SubscriptionLineItem},
+		types.WebhookEventSubscriptionLineItemCreated)
 	return resp, nil
 }
 
@@ -319,6 +372,9 @@ func (s *subscriptionService) DeleteSubscriptionLineItem(ctx context.Context, li
 		return nil, err
 	}
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, resp.SubscriptionID)
+	s.publishLineItemEvents(ctx, resp.SubscriptionID,
+		[]*subscription.SubscriptionLineItem{resp.SubscriptionLineItem},
+		types.WebhookEventSubscriptionLineItemDeleted)
 	return resp, nil
 }
 

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -580,6 +580,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 
 		// Execute the complex update within a transaction
 		var newLineItem *subscription.SubscriptionLineItem
+		var terminatedLineItem *subscription.SubscriptionLineItem
 		err = s.DB.WithTx(ctx, func(ctx context.Context) error {
 			// Process the price override using existing method
 			lineItems := []*subscription.SubscriptionLineItem{existingLineItem}
@@ -595,10 +596,11 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			deleteReq := dto.DeleteSubscriptionLineItemRequest{
 				EffectiveFrom: &endDate,
 			}
-			_, err := s.deleteSubscriptionLineItem(ctx, lineItemID, deleteReq)
+			deletedResp, err := s.deleteSubscriptionLineItem(ctx, lineItemID, deleteReq)
 			if err != nil {
 				return err
 			}
+			terminatedLineItem = deletedResp.SubscriptionLineItem
 
 			// Create new line item using the DTO method
 			newLineItem = req.ToSubscriptionLineItem(ctx, existingLineItem, newPriceID)
@@ -657,6 +659,12 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 		)
 
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, sub.ID)
+		s.publishLineItemEvents(ctx, sub.ID,
+			[]*subscription.SubscriptionLineItem{terminatedLineItem},
+			types.WebhookEventSubscriptionLineItemDeleted)
+		s.publishLineItemEvents(ctx, sub.ID,
+			[]*subscription.SubscriptionLineItem{newLineItem},
+			types.WebhookEventSubscriptionLineItemCreated)
 		return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: newLineItem}, nil
 	} else {
 		// Update metadata and commitment fields if provided

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -2165,3 +2165,34 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_UsagePric
 	s.Equal(0, s.countLineItemCreated(),
 		"a USAGE-price line item must not publish subscription.line_item.created")
 }
+
+func (s *SubscriptionLineItemServiceSuite) TestUpdateSubscriptionLineItem_PriceOverride_PublishesDeleteThenCreate() {
+	ctx := s.GetContext()
+
+	req := dto.UpdateSubscriptionLineItemRequest{
+		Amount: lo.ToPtr(decimal.NewFromInt(500)), // triggers ShouldCreateNewLineItem()
+	}
+
+	s.resetWebhooks()
+	resp, err := s.service.UpdateSubscriptionLineItem(ctx, s.testData.lineItem.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotEqual(s.testData.lineItem.ID, resp.SubscriptionLineItem.ID, "expected a new line item, not an in-place update")
+
+	events := s.GetPublishedWebhooks()
+	var sawDeleted, sawCreated bool
+	var deletedIdx, createdIdx int
+	for i, e := range events {
+		if e.EventName == types.WebhookEventSubscriptionLineItemDeleted {
+			sawDeleted = true
+			deletedIdx = i
+		}
+		if e.EventName == types.WebhookEventSubscriptionLineItemCreated {
+			sawCreated = true
+			createdIdx = i
+		}
+	}
+	s.Require().True(sawDeleted, "expected subscription.line_item.deleted for the old line item")
+	s.Require().True(sawCreated, "expected subscription.line_item.created for the new line item")
+	s.Require().Less(deletedIdx, createdIdx, "deleted must publish before created, matching delete-old-then-create-new order")
+}

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -2078,3 +2078,90 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItemInternal_D
 	s.Require().NoError(err)
 	s.Equal(0, s.countSubscriptionUpdated())
 }
+
+func (s *SubscriptionLineItemServiceSuite) countLineItemCreated() int {
+	n := 0
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName == types.WebhookEventSubscriptionLineItemCreated {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *SubscriptionLineItemServiceSuite) countLineItemDeleted() int {
+	n := 0
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName == types.WebhookEventSubscriptionLineItemDeleted {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_PublishesLineItemCreated() {
+	ctx := s.GetContext()
+	price2 := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(25),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, price2))
+
+	s.resetWebhooks()
+	resp, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, dto.CreateSubscriptionLineItemRequest{
+		PriceID:              price2.ID,
+		Quantity:             decimal.NewFromInt(1),
+		SkipEntitlementCheck: true,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(1, s.countLineItemCreated())
+}
+
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_PublishesLineItemDeleted() {
+	ctx := s.GetContext()
+	s.resetWebhooks()
+	resp, err := s.service.DeleteSubscriptionLineItem(ctx, s.testData.lineItem.ID, dto.DeleteSubscriptionLineItemRequest{})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Equal(1, s.countLineItemDeleted())
+}
+
+// TestAddSubscriptionLineItem_UsagePriceDoesNotPublishLineItemEvent verifies that a
+// USAGE-price line item must NOT publish subscription.line_item.created — only
+// FIXED-price line items sync to HubSpot deal line items.
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_UsagePriceDoesNotPublishLineItemEvent() {
+	ctx := s.GetContext()
+	usagePrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.Zero,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, usagePrice))
+
+	s.resetWebhooks()
+	_, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, dto.CreateSubscriptionLineItemRequest{
+		PriceID:              usagePrice.ID,
+		SkipEntitlementCheck: true,
+	})
+	s.Require().NoError(err)
+	s.Equal(0, s.countLineItemCreated(),
+		"a USAGE-price line item must not publish subscription.line_item.created")
+}

--- a/internal/ee/service/subscription_modification.go
+++ b/internal/ee/service/subscription_modification.go
@@ -338,12 +338,24 @@ func (s *subscriptionModificationService) executeQuantityChange(
 		// checkout + net credit/zero → immediate path (ignore checkout)
 	}
 
-	changedLineItems, changedInvoices, err := s.settlePayLater(ctx, quantityChangeReq, prorationResult)
+	changedLineItems, changedInvoices, lineItemDeltas, err := s.settlePayLater(ctx, quantityChangeReq, prorationResult)
 	if err != nil {
 		return nil, err
 	}
 
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, subscriptionID)
+
+	// subscriptionModificationService only holds ServiceParams (unexported field), not a
+	// *subscriptionService, so publishLineItemEvents is reached via a throwaway concrete
+	// instance sharing the same ServiceParams — this is the idiomatic pattern already used
+	// elsewhere in this package (see checkout_session_actions.go).
+	lineItemPublisher := &subscriptionService{ServiceParams: s.serviceParams}
+	for _, delta := range lineItemDeltas {
+		lineItemPublisher.publishLineItemEvents(ctx, subscriptionID,
+			[]*subscription.SubscriptionLineItem{delta.ended}, types.WebhookEventSubscriptionLineItemDeleted)
+		lineItemPublisher.publishLineItemEvents(ctx, subscriptionID,
+			[]*subscription.SubscriptionLineItem{delta.new}, types.WebhookEventSubscriptionLineItemCreated)
+	}
 
 	subSvc := NewSubscriptionService(sp)
 	subResp, err := subSvc.GetSubscription(ctx, subscriptionID)

--- a/internal/ee/service/subscription_modification_quantity.go
+++ b/internal/ee/service/subscription_modification_quantity.go
@@ -564,25 +564,36 @@ func (s *subscriptionModificationService) calculateProration(
 // apply time. No invoices, payments, or wallets.
 // Idempotent: if a line item is already ended at effective_date, that mod is skipped
 // (safe for duplicate checkout-complete webhooks).
+// quantityChangeLineItemDelta pairs the ended line item with its replacement for
+// one quantity-change modification, so callers can publish
+// subscription.line_item.{deleted,created} for both halves of the delete-old/
+// create-new pair after the transaction commits.
+type quantityChangeLineItemDelta struct {
+	ended *subscription.SubscriptionLineItem
+	new   *subscription.SubscriptionLineItem
+}
+
 func (s *subscriptionModificationService) applyQuantityChange(
 	ctx context.Context,
 	request *quantityChangeRequest,
-) ([]dto.ChangedLineItem, error) {
+) ([]dto.ChangedLineItem, []quantityChangeLineItemDelta, error) {
 	if request == nil {
-		return nil, ierr.NewError("quantity change request is required").
+		return nil, nil, ierr.NewError("quantity change request is required").
 			Mark(ierr.ErrValidation)
 	}
 
 	sp := s.serviceParams
 	mods := request.GetModifications()
 	if len(mods) == 0 {
-		return []dto.ChangedLineItem{}, nil
+		return []dto.ChangedLineItem{}, nil, nil
 	}
 
 	changedLineItems := make([]dto.ChangedLineItem, 0, len(mods)*2)
+	var lineItemDeltas []quantityChangeLineItemDelta
 
 	err := sp.DB.WithTx(ctx, func(txCtx context.Context) error {
 		changedLineItems = nil
+		lineItemDeltas = nil
 
 		for _, mod := range mods {
 			if mod == nil {
@@ -663,15 +674,20 @@ func (s *subscriptionModificationService) applyQuantityChange(
 					ChangeAction: dto.ChangedLineItemActionCreated,
 				},
 			)
+
+			lineItemDeltas = append(lineItemDeltas, quantityChangeLineItemDelta{
+				ended: endedItem,
+				new:   newItem,
+			})
 		}
 
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return changedLineItems, nil
+	return changedLineItems, lineItemDeltas, nil
 }
 
 // ─────────────────────────────────────────────
@@ -685,14 +701,15 @@ func (s *subscriptionModificationService) settlePayLater(
 	ctx context.Context,
 	request *quantityChangeRequest,
 	prorationResult *quantityChangeProration,
-) ([]dto.ChangedLineItem, []dto.ChangedInvoice, error) {
+) ([]dto.ChangedLineItem, []dto.ChangedInvoice, []quantityChangeLineItemDelta, error) {
 	sp := s.serviceParams
 	var changedLineItems []dto.ChangedLineItem
+	var lineItemDeltas []quantityChangeLineItemDelta
 	changedInvoices := make([]dto.ChangedInvoice, 0)
 
 	err := sp.DB.WithTx(ctx, func(txCtx context.Context) error {
 		var err error
-		changedLineItems, err = s.applyQuantityChange(txCtx, request)
+		changedLineItems, lineItemDeltas, err = s.applyQuantityChange(txCtx, request)
 		if err != nil {
 			return err
 		}
@@ -723,7 +740,7 @@ func (s *subscriptionModificationService) settlePayLater(
 		return nil
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Best-effort collection after LI + invoice rows are committed together.
@@ -745,7 +762,7 @@ func (s *subscriptionModificationService) settlePayLater(
 		}
 	}
 
-	return changedLineItems, changedInvoices, nil
+	return changedLineItems, changedInvoices, lineItemDeltas, nil
 }
 
 // ─────────────────────────────────────────────
@@ -985,7 +1002,7 @@ func (s *subscriptionModificationService) createProrationChargeInvoice(
 				).
 				Mark(ierr.ErrValidation)
 		}
-		
+
 		return &dto.ChangedInvoice{
 			ID:      latest.ID,
 			Action:  dto.ChangedInvoiceActionCreated,

--- a/internal/ee/service/subscription_modification_test.go
+++ b/internal/ee/service/subscription_modification_test.go
@@ -1110,6 +1110,43 @@ func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_Version
 	s.True(newQty.Equal(newLI.Quantity), "new line item should have updated quantity")
 }
 
+// TestExecuteQuantityChange_PublishesLineItemDeleteAndCreate verifies that executing a
+// quantity change on a FIXED-price line item publishes subscription.line_item.deleted for
+// the ended line item and subscription.line_item.created for its replacement.
+func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_PublishesLineItemDeleteAndCreate() {
+	ctx := s.GetContext()
+
+	cust := s.createCustomer("ext-qty-lineitem-events")
+	sub := s.createActiveSub(cust.ID)
+	li := s.createFixedLineItem(sub.ID, cust.ID, decimal.NewFromInt(5), types.InvoiceCadenceArrear)
+
+	req := dto.ExecuteSubscriptionModifyRequest{
+		Type: dto.SubscriptionModifyTypeQuantityChange,
+		QuantityChangeParams: &dto.SubModifyQuantityChangeRequest{
+			LineItems: []dto.LineItemQuantityChange{
+				{ID: li.ID, Quantity: decimal.NewFromInt(10)},
+			},
+		},
+	}
+
+	s.GetWebhookPublisher().(*testutil.InMemoryWebhookPublisher).Reset()
+	resp, err := s.service.Execute(ctx, sub.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	var sawDeleted, sawCreated bool
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName == types.WebhookEventSubscriptionLineItemDeleted {
+			sawDeleted = true
+		}
+		if e.EventName == types.WebhookEventSubscriptionLineItemCreated {
+			sawCreated = true
+		}
+	}
+	s.Require().True(sawDeleted, "expected subscription.line_item.deleted")
+	s.Require().True(sawCreated, "expected subscription.line_item.created")
+}
+
 // TestExecuteQuantityChange_PreservesFiniteEndDate verifies that a replacement line item
 // keeps the source item's finite EndDate (not cleared to open-ended).
 func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_PreservesFiniteEndDate() {
@@ -2407,7 +2444,7 @@ func (s *SubscriptionModificationServiceSuite) TestCompleteModifySubscriptionChe
 	// Re-apply the same request — must not create another open LI.
 	rebuilt, err := modSvc.requestFromModifySubscriptionParams(ctx, request.toModifySubscriptionParams())
 	s.Require().NoError(err)
-	_, err = modSvc.applyQuantityChange(ctx, rebuilt)
+	_, _, err = modSvc.applyQuantityChange(ctx, rebuilt)
 	s.Require().NoError(err)
 
 	_, afterSecond, err := s.GetStores().SubscriptionRepo.GetWithLineItems(ctx, sub.ID)

--- a/internal/ee/service/subscription_modification_test.go
+++ b/internal/ee/service/subscription_modification_test.go
@@ -2127,6 +2127,79 @@ func (s *SubscriptionModificationServiceSuite) TestCompleteModifySubscriptionChe
 // Pay-first quantity change tests
 // ─────────────────────────────────────────────
 
+// TestCompleteModifySubscriptionCheckout_PublishesLineItemDeleteAndCreate verifies that
+// completing a checkout-driven quantity change publishes subscription.line_item.deleted
+// for the ended line item and subscription.line_item.created for its replacement.
+func (s *SubscriptionModificationServiceSuite) TestCompleteModifySubscriptionCheckout_PublishesLineItemDeleteAndCreate() {
+	ctx := s.GetContext()
+	periodStart := s.GetNow()
+	effectiveDate := periodStart.AddDate(0, 0, 15)
+
+	cust := s.createCustomer("payfirst-lineitem-events")
+	sub := s.createActiveSub(cust.ID)
+	priceAmount := decimal.NewFromInt(50)
+	p := s.createFixedPrice(priceAmount, types.InvoiceCadenceAdvance)
+	li := s.createFixedLineItemWithPrice(sub.ID, cust.ID, decimal.NewFromInt(1), types.InvoiceCadenceAdvance, p.ID)
+
+	modSvc := s.service.(*subscriptionModificationService)
+	request, err := modSvc.buildQuantityChangeRequest(ctx, sub.ID, &dto.SubModifyQuantityChangeRequest{
+		LineItems: []dto.LineItemQuantityChange{
+			{ID: li.ID, Quantity: decimal.NewFromInt(3), EffectiveDate: &effectiveDate},
+		},
+	})
+	s.Require().NoError(err)
+
+	proration, err := modSvc.calculateProration(ctx, request)
+	s.Require().NoError(err)
+	s.Require().True(proration.GetNetAmount().GreaterThan(decimal.Zero))
+
+	draftInv, err := modSvc.createAggregatedProrationDraftInvoice(ctx, request.GetSubscription(), proration)
+	s.Require().NoError(err)
+	s.Require().NotNil(draftInv)
+
+	params := s.buildServiceParams()
+	checkoutSvc := &checkoutSessionService{ServiceParams: params}
+	payResp, err := checkoutSvc.createCheckoutPayment(ctx, &draftInv.Invoice, types.CheckoutPaymentProviderRazorpay)
+	s.Require().NoError(err)
+
+	invID := draftInv.ID
+	payID := payResp.ID
+	session := &domainCheckout.CheckoutSession{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CHECKOUT_SESSION),
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		CustomerID:      cust.ID,
+		Action:          types.CheckoutActionModifySubscription,
+		CheckoutStatus:  types.CheckoutStatusPending,
+		PaymentProvider: types.CheckoutPaymentProviderRazorpay,
+		Configuration: domainCheckout.ToJSONBCheckoutConfiguration(types.CheckoutConfiguration{
+			ModifySubscriptionParams: request.toModifySubscriptionParams(),
+		}),
+		CheckoutInvoiceID: &invID,
+		CheckoutPaymentID: &payID,
+		ExpiresAt:         time.Now().UTC().Add(time.Hour),
+		BaseModel:         types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().CheckoutSessionRepo.Create(ctx, session))
+
+	s.GetWebhookPublisher().(*testutil.InMemoryWebhookPublisher).Reset()
+	err = checkoutSvc.CompleteCheckoutSession(ctx, session.ID, &types.CheckoutProviderResult{
+		ProviderPaymentIntentID: "pay_test_lineitem_events_001",
+	})
+	s.Require().NoError(err)
+
+	var sawDeleted, sawCreated bool
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName == types.WebhookEventSubscriptionLineItemDeleted {
+			sawDeleted = true
+		}
+		if e.EventName == types.WebhookEventSubscriptionLineItemCreated {
+			sawCreated = true
+		}
+	}
+	s.Require().True(sawDeleted, "expected subscription.line_item.deleted")
+	s.Require().True(sawCreated, "expected subscription.line_item.created")
+}
+
 func (s *SubscriptionModificationServiceSuite) TestExecuteQuantityChange_CheckoutIgnoredOnCredit() {
 	ctx := s.GetContext()
 	effectiveDate := s.GetNow().AddDate(0, 0, 15)

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
+	webhookDto "github.com/flexprice/flexprice/internal/webhook/dto"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/suite"
@@ -5244,6 +5246,110 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 	})
 }
 
+// TestCancelSubscription_Immediate_PublishesLineItemDeleted verifies that an immediate
+// cancellation publishes subscription.line_item.deleted for the subscription's FIXED-price
+// line item.
+func (s *SubscriptionServiceSuite) TestCancelSubscription_Immediate_PublishesLineItemDeleted() {
+	ctx := s.GetContext()
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_cancel_lineitem_deleted",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+		CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems: []*subscription.SubscriptionLineItem{
+			{
+				ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+				SubscriptionID:  "sub_cancel_lineitem_deleted",
+				CustomerID:      s.testData.customer.ID,
+				EntityID:        s.testData.plan.ID,
+				EntityType:      types.SubscriptionLineItemEntityTypePlan,
+				PlanDisplayName: s.testData.plan.Name,
+				PriceID:         s.testData.prices.fixedMonthly.ID,
+				PriceType:       s.testData.prices.fixedMonthly.Type,
+				DisplayName:     "Fixed line item",
+				Quantity:        decimal.NewFromInt(1),
+				Currency:        "usd",
+				BillingPeriod:   types.BILLING_PERIOD_MONTHLY,
+				InvoiceCadence:  types.InvoiceCadenceAdvance,
+				StartDate:       s.testData.now.Add(-30 * 24 * time.Hour),
+				BaseModel:       types.GetDefaultBaseModel(ctx),
+			},
+		},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	s.GetWebhookPublisher().(*testutil.InMemoryWebhookPublisher).Reset()
+	_, err := s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeImmediate,
+		ProrationBehavior: types.ProrationBehaviorNone,
+	})
+	s.Require().NoError(err)
+
+	found := false
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName == types.WebhookEventSubscriptionLineItemDeleted {
+			found = true
+		}
+	}
+	s.Require().True(found, "expected line_item.deleted on immediate cancellation")
+}
+
+// TestCancelSubscription_AddonLineItemDeletedEventFiresExactlyOnce verifies that an addon's
+// FIXED-price line item — terminated by cancelAddonsForSubscription — does not also get
+// double-counted by cancelAllLineItemsForSubscription's separate termination pass, which
+// would otherwise publish subscription.line_item.deleted for it twice.
+func (s *SubscriptionServiceSuite) TestCancelSubscription_AddonLineItemDeletedEventFiresExactlyOnce() {
+	ctx := s.GetContext()
+	sub := s.testData.subscription
+
+	addonID := "addon_cancel_lineitem_once"
+	s.seedFixedPriceAddon(addonID, decimal.NewFromInt(20), types.InvoiceCadenceAdvance)
+
+	addAddonNow := sub.CurrentPeriodStart
+	_, err := s.service.AddAddonToSubscription(ctx, &dto.AddAddonRequest{
+		SubscriptionID: sub.ID,
+		AddAddonToSubscriptionRequest: dto.AddAddonToSubscriptionRequest{
+			AddonID:           addonID,
+			Cadence:           types.AddonCadenceRecurring,
+			StartDate:         &addAddonNow,
+			ProrationBehavior: types.ProrationBehaviorNone,
+		},
+	})
+	s.Require().NoError(err)
+
+	addonLineItems := s.addonLineItemsFor(sub.ID, addonID)
+	s.Require().Len(addonLineItems, 1)
+	addonLineItemID := addonLineItems[0].ID
+
+	s.GetWebhookPublisher().(*testutil.InMemoryWebhookPublisher).Reset()
+	_, err = s.service.CancelSubscription(ctx, sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeImmediate,
+		ProrationBehavior: types.ProrationBehaviorNone,
+	})
+	s.Require().NoError(err)
+
+	count := 0
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName != types.WebhookEventSubscriptionLineItemDeleted {
+			continue
+		}
+		var payload webhookDto.InternalSubscriptionLineItemEvent
+		s.Require().NoError(json.Unmarshal(e.Payload, &payload))
+		if payload.LineItemID == addonLineItemID {
+			count++
+		}
+	}
+	s.Require().Equal(1, count, "addon line item must publish line_item.deleted exactly once, not double-counted between the addon-scoped and plan/subscription-scoped termination paths")
+}
+
 func (s *SubscriptionServiceSuite) TestCancelSubscription_ScheduledDoesNotEagerlyTerminateResources() {
 	ctx := s.GetContext()
 	subService := s.service.(*subscriptionService)
@@ -5412,18 +5518,20 @@ func (s *SubscriptionServiceSuite) TestTerminateSubscriptionResources_Idempotent
 
 	effectiveDate := s.testData.now.Add(3 * 24 * time.Hour)
 
-	s.NoError(subService.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
+	_, err = subService.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
 		SubscriptionID:     sub.ID,
 		EffectiveDate:      effectiveDate,
 		CancellationReason: "idempotency_test",
-	}))
+	})
+	s.NoError(err)
 	// Calling it again with the same effectiveDate must not error, even though every
 	// resource is already terminated (repo-level guards make this a no-op the second time).
-	s.NoError(subService.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
+	_, err = subService.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
 		SubscriptionID:     sub.ID,
 		EffectiveDate:      effectiveDate,
 		CancellationReason: "idempotency_test",
-	}))
+	})
+	s.NoError(err)
 
 	liFilter := types.NewNoLimitSubscriptionLineItemFilter()
 	liFilter.SubscriptionIDs = []string{sub.ID}

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -2764,6 +2764,79 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems() {
 	}
 }
 
+// TestCreateSubscription_PublishesLineItemCreatedForPlanAndExtraLineItems verifies that
+// CreateSubscription publishes subscription.line_item.created for both the plan-derived
+// line item and any extra FIXED-price line item supplied via req.LineItems — using a
+// self-contained plan with exactly one FIXED price so the plan-derived count is exact
+// (avoids depending on the shared testData.plan's many prices).
+func (s *SubscriptionServiceSuite) TestCreateSubscription_PublishesLineItemCreatedForPlanAndExtraLineItems() {
+	ctx := s.GetContext()
+
+	onePricePlan := &plan.Plan{
+		ID:          types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PLAN),
+		Name:        "Single Fixed Price Plan",
+		Description: "Plan with exactly one FIXED usd/monthly price",
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PlanRepo.Create(ctx, onePricePlan))
+
+	planPrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(50),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           onePricePlan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, planPrice))
+
+	inlinePriceReq := &dto.SubscriptionPriceCreateRequest{
+		Type:               types.PRICE_TYPE_FIXED,
+		PriceUnitType:      types.PRICE_UNIT_TYPE_FIAT,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		Amount:             lo.ToPtr(decimal.NewFromInt(5)),
+		LookupKey:          "extra_fixed_line_item",
+	}
+
+	req := dto.CreateSubscriptionRequest{
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             onePricePlan.ID,
+		StartDate:          lo.ToPtr(s.testData.now),
+		EndDate:            lo.ToPtr(s.testData.now.Add(90 * 24 * time.Hour)),
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingCycle:       types.BillingCycleAnniversary,
+		SubscriptionCreationConfig: dto.SubscriptionCreationConfig{
+			LineItems: []dto.CreateSubscriptionLineItemRequest{
+				{Price: inlinePriceReq},
+			},
+		},
+	}
+
+	s.GetWebhookPublisher().(*testutil.InMemoryWebhookPublisher).Reset()
+	resp, err := s.service.CreateSubscription(ctx, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	createdCount := 0
+	for _, e := range s.GetPublishedWebhooks() {
+		if e.EventName == types.WebhookEventSubscriptionLineItemCreated {
+			createdCount++
+		}
+	}
+	s.Require().Equal(2, createdCount,
+		"expected line_item.created for both the plan-derived line item and the extra req.LineItems entry")
+}
+
 // TestCreateSubscriptionWithLineItems_ValidationErrors asserts that CreateSubscription fails when LineItems
 // have invalid or out-of-bound values (e.g. start_date before subscription start, end_date after subscription end).
 func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithLineItems_ValidationErrors() {

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -1019,10 +1019,10 @@ func (m *mockSubscriptionService) CascadeCancelToInheritedSubscriptions(ctx cont
 func (m *mockSubscriptionService) ExternalCustomerIDsForSubscription(ctx context.Context, sub *subscription.Subscription) ([]string, error) {
 	return nil, nil
 }
-func (m *mockSubscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription) {
+func (m *mockSubscriptionService) PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription, terminatedLineItems []*subscription.SubscriptionLineItem) {
 }
-func (m *mockSubscriptionService) TerminateSubscriptionResources(ctx context.Context, req apidto.TerminateSubscriptionResourcesRequest) error {
-	return nil
+func (m *mockSubscriptionService) TerminateSubscriptionResources(ctx context.Context, req apidto.TerminateSubscriptionResourcesRequest) ([]*subscription.SubscriptionLineItem, error) {
+	return nil, nil
 }
 
 // --- ProcessSubscriptionActivatedWebhook tests ---

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -191,11 +191,15 @@ type SubscriptionService interface {
 	// immediate cancellations, and by both processSubscriptionPeriod's period-rollover loop and
 	// the Temporal CheckCancellationActivity when a previously scheduled cancellation fires, so
 	// resources are terminated exactly once, at the point cancellation actually takes effect.
-	TerminateSubscriptionResources(ctx context.Context, req dto.TerminateSubscriptionResourcesRequest) error
+	// Returns the FIXED-price line items it terminated, which callers thread into
+	// PublishCancellationEvents so a line_item.deleted event fires for each one post-commit.
+	TerminateSubscriptionResources(ctx context.Context, req dto.TerminateSubscriptionResourcesRequest) ([]*subscription.SubscriptionLineItem, error)
 
-	// PublishCancellationEvents publishes a update and cancel webhook event for a subscription and its inherited subs.
-	// Used by Temporal activities and other callers that need to fire subscription lifecycle events.
-	PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription)
+	// PublishCancellationEvents publishes an update and cancel webhook event for a subscription
+	// and its inherited subs, plus a line_item.deleted event for each terminated FIXED-price
+	// line item. Used by Temporal activities and other callers that need to fire subscription
+	// lifecycle events.
+	PublishCancellationEvents(ctx context.Context, sub *subscription.Subscription, terminatedLineItems []*subscription.SubscriptionLineItem)
 
 	// ExternalCustomerIDsForSubscription returns distinct non-empty external customer IDs
 	// for the subscription owner plus all active/trialing/draft inherited children.

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -305,6 +305,7 @@ func (s *BillingActivities) CheckCancellationActivity(
 		sub.SubscriptionStatus = types.SubscriptionStatusCancelled
 		sub.CancelledAt = cancelledAt
 		subscriptionService := service.NewSubscriptionService(s.serviceParams)
+		var terminatedLineItemsForCancellation []*subscription.SubscriptionLineItem
 
 		err := s.serviceParams.DB.WithTx(ctx, func(ctx context.Context) error {
 			// Update subscription
@@ -319,13 +320,15 @@ func (s *BillingActivities) CheckCancellationActivity(
 			// internal/ee/service/subscription.go — never fires for a bare EndDate set through
 			// some other path that never had termination deferred in the first place.
 			if sub.CancelAtPeriodEnd && sub.CancelAt != nil {
-				if err := subscriptionService.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
+				terminated, err := subscriptionService.TerminateSubscriptionResources(ctx, dto.TerminateSubscriptionResourcesRequest{
 					SubscriptionID:     sub.ID,
 					EffectiveDate:      *sub.CancelAt,
 					CancellationReason: sub.Metadata["cancellation_reason"],
-				}); err != nil {
+				})
+				if err != nil {
 					return err
 				}
+				terminatedLineItemsForCancellation = terminated
 			}
 
 			// Update the cancellation schedule status to executed
@@ -350,7 +353,7 @@ func (s *BillingActivities) CheckCancellationActivity(
 			return nil, err
 		}
 
-		subscriptionService.PublishCancellationEvents(ctx, sub)
+		subscriptionService.PublishCancellationEvents(ctx, sub, terminatedLineItemsForCancellation)
 
 		s.logger.Info(ctx, "subscription cancelled successfully",
 			"subscription_id", sub.ID,

--- a/internal/types/webhook.go
+++ b/internal/types/webhook.go
@@ -10,6 +10,23 @@ import (
 // @name WebhookEventName
 type WebhookEventName = string
 
+// IsInternalOnlyWebhookEvent reports whether this event is never meant to reach a
+// customer's webhook endpoint (no PayloadBuilder is registered for it) — used by
+// internal/webhook/handler to skip delivery attempts for these outright, rather
+// than letting them fail with "no builder registered" on every mutation.
+//
+// This is a free function rather than a method on WebhookEventName because
+// WebhookEventName is a type alias for string (`= string`, not `string`), and Go
+// does not allow defining methods on an alias for a builtin type.
+func IsInternalOnlyWebhookEvent(e WebhookEventName) bool {
+	switch e {
+	case WebhookEventSubscriptionLineItemCreated, WebhookEventSubscriptionLineItemDeleted:
+		return true
+	default:
+		return false
+	}
+}
+
 // WebhookEvent represents a webhook event to be delivered
 type WebhookEvent struct {
 	ID            string           `json:"id"`
@@ -183,6 +200,13 @@ const (
 
 	// cron driven webhook event names
 	WebhookEventSubscriptionRenewalDue WebhookEventName = "subscription.renewal.due"
+
+	// subscription line-item lifecycle events — internal only, never delivered to
+	// customer webhook endpoints (see IsInternalOnlyWebhookEvent below). Published
+	// whenever a FIXED-price subscription line item is created or ends; consumed by
+	// the HubSpot deal line-item sync dispatcher.
+	WebhookEventSubscriptionLineItemCreated WebhookEventName = "subscription.line_item.created"
+	WebhookEventSubscriptionLineItemDeleted WebhookEventName = "subscription.line_item.deleted"
 )
 
 // communication event names

--- a/internal/webhook/dto/subscription_line_item_event.go
+++ b/internal/webhook/dto/subscription_line_item_event.go
@@ -1,0 +1,18 @@
+package webhookDto
+
+import "github.com/flexprice/flexprice/internal/types"
+
+// InternalSubscriptionLineItemEvent is the payload for the internal-only
+// subscription.line_item.created / subscription.line_item.deleted events. These
+// events are never delivered to customers — types.IsInternalOnlyWebhookEvent
+// makes internal/webhook/handler skip delivery outright — they exist solely to
+// decouple line-item mutation points from integration-specific side effects (see
+// internal/integration/events/dispatch.go in a later PR).
+type InternalSubscriptionLineItemEvent struct {
+	SubscriptionID string          `json:"subscription_id"`
+	LineItemID     string          `json:"line_item_id"`
+	CustomerID     string          `json:"customer_id"`
+	PriceType      types.PriceType `json:"price_type"`
+	TenantID       string          `json:"tenant_id"`
+	EnvironmentID  string          `json:"environment_id"`
+}

--- a/internal/webhook/dto/subscription_line_item_event_test.go
+++ b/internal/webhook/dto/subscription_line_item_event_test.go
@@ -1,0 +1,32 @@
+package webhookDto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalSubscriptionLineItemEvent_JSON(t *testing.T) {
+	ev := InternalSubscriptionLineItemEvent{
+		SubscriptionID: "sub_123",
+		LineItemID:     "li_456",
+		CustomerID:     "cust_789",
+		PriceType:      types.PRICE_TYPE_FIXED,
+		TenantID:       "tenant_test",
+		EnvironmentID:  "env_test",
+	}
+
+	raw, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.Equal(t, "sub_123", got["subscription_id"])
+	require.Equal(t, "li_456", got["line_item_id"])
+	require.Equal(t, "cust_789", got["customer_id"])
+	require.Equal(t, string(types.PRICE_TYPE_FIXED), got["price_type"])
+	require.Equal(t, "tenant_test", got["tenant_id"])
+	require.Equal(t, "env_test", got["environment_id"])
+}

--- a/internal/webhook/handler/delivery_test.go
+++ b/internal/webhook/handler/delivery_test.go
@@ -134,6 +134,31 @@ func TestAbsorbDeliveryError_MissingEntityUsesSkipLogSemantics(t *testing.T) {
 	})
 }
 
+func TestDeliverWebhook_InternalOnlyEventSkipsDelivery(t *testing.T) {
+	t.Parallel()
+
+	h := &handler{
+		// Svix disabled and no native tenant config at all — if the internal-only
+		// skip did not short-circuit before deliverSvix/deliverNative, this would
+		// fail with ErrNotFound (no tenant config) rather than returning nil.
+		config: &config.Webhook{
+			Enabled: true,
+			Svix:    config.Svix{Enabled: false},
+			Tenants: map[string]config.TenantWebhookConfig{},
+		},
+		logger: testLogger(t),
+		// systemEventRepo intentionally nil — guards must handle this safely
+	}
+
+	err := h.DeliverWebhook(context.Background(), &types.WebhookEvent{
+		ID:            "sev_1",
+		TenantID:      "ten_1",
+		EnvironmentID: "env_1",
+		EventName:     types.WebhookEventSubscriptionLineItemCreated,
+	})
+	require.NoError(t, err)
+}
+
 func TestAbsorbDeliveryError_RealErrorNoPanicWithoutRepo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/webhook/handler/handler.go
+++ b/internal/webhook/handler/handler.go
@@ -108,6 +108,24 @@ func (h *handler) DeliverWebhook(ctx context.Context, event *types.WebhookEvent)
 			Mark(ierr.ErrValidation)
 	}
 
+	if types.IsInternalOnlyWebhookEvent(event.EventName) {
+		h.logger.Debug(ctx, "skipping delivery for internal-only event",
+			"event_id", event.ID,
+			"event_name", event.EventName,
+		)
+		if h.systemEventRepo != nil && event.ID != "" {
+			if err := h.systemEventRepo.OnDelivered(ctx, event.ID, nil); err != nil {
+				h.logger.Info(ctx, "system_events OnDelivered failed for internal-only event",
+					"error", err,
+					"event_id", event.ID,
+					"event_name", event.EventName,
+				)
+				return err
+			}
+		}
+		return nil
+	}
+
 	ctx = context.WithValue(ctx, types.CtxTenantID, event.TenantID)
 	ctx = context.WithValue(ctx, types.CtxEnvironmentID, event.EnvironmentID)
 	ctx = context.WithValue(ctx, types.CtxUserID, event.UserID)
@@ -212,6 +230,22 @@ func (h *handler) processMessage(ctx context.Context, msg *message.Message) erro
 			}
 		}
 		return nil // Don't retry on unmarshal errors
+	}
+
+	if types.IsInternalOnlyWebhookEvent(event.EventName) {
+		if h.systemEventRepo != nil && msg.UUID != "" {
+			if err := h.systemEventRepo.OnDelivered(ctx, msg.UUID, nil); err != nil {
+				// Swallow, don't propagate: an error here would let Watermill nack and
+				// redeliver the Kafka message, reintroducing the exact retry churn this
+				// skip exists to close. Matches the unmarshal-error branch above.
+				h.logger.Info(ctx, "system_events OnDelivered failed for internal-only event",
+					"error", err,
+					"message_uuid", msg.UUID,
+					"event_name", event.EventName,
+				)
+			}
+		}
+		return nil
 	}
 
 	ctx = context.WithValue(ctx, types.CtxTenantID, event.TenantID)


### PR DESCRIPTION
## **User description**
## Summary
- Publishes new internal-only webhook events, `subscription.line_item.created` and `subscription.line_item.deleted`, from every point a FIXED-price subscription line item is created or ends: `AddSubscriptionLineItem`, `DeleteSubscriptionLineItem`, `UpdateSubscriptionLineItem`'s price-override replace path (delete-old + create-new), `CreateSubscription`, the quantity-change execute/checkout paths, and all three cancellation call paths (immediate, period-rollover, Temporal-deferred) — all published strictly after their enclosing transaction commits.
- `TerminateSubscriptionResources`/`PublishCancellationEvents` now return/accept the terminated line items so cancellation can publish per-line-item events alongside the existing subscription-level ones.
- Adds a global skip in `internal/webhook/handler/handler.go` so these two internal-only events don't produce delivery-failure noise on the native-webhook path (no `PayloadBuilder` is registered for them).

This is PR 2 of 3 in a stack that adds ongoing HubSpot deal line-item sync, split out for independent review. Independent of PR 1 (the HubSpot client PR) — no shared files.

**No consumer yet.** These events currently have zero consumers — a follow-up "orchestration" PR adds the dispatcher that syncs them to HubSpot. The existing one-shot HubSpot bulk-sync trigger (`triggerHubSpotDealSyncWorkflow`) is deliberately left completely untouched in this PR; it's removed in the orchestration PR once the new event-driven path replaces it. Until then, this PR cannot regress current HubSpot behavior.

## Test plan
- Added/extended tests across `subscription_line_item_test.go`, `subscription_modification_test.go`, `checkout_session_actions_test.go`, `subscription_test.go` covering: each hook point publishes the right event(s); all three cancellation paths publish strictly post-commit; an addon line item terminated during a full cancellation publishes exactly once (not double-counted between the addon-scoped and plan/subscription-scoped termination paths).
- `go build ./...`, `go test ./...`, `gofmt`, and loglint all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internal subscription line-item creation and deletion events for fixed-price items.
  * Line-item events are emitted when subscriptions are created, modified, canceled, or quantities change.
  * Internal-only events are recorded without delivery to customer webhook endpoints.

* **Bug Fixes**
  * Improved event accuracy for replaced and terminated line items.
  * Prevented duplicate deletion events during cancellation workflows.
  * Preserved transaction rollback behavior when cancellation processing fails.
  * Usage-priced items do not generate fixed-price line-item events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Publish internal subscription line-item lifecycle events

### What Changed
- Publishes internal `subscription.line_item.created` events whenever a FIXED-price line item is created, including subscription creation, direct additions, and quantity or price changes.
- Publishes internal `subscription.line_item.deleted` events when a FIXED-price line item ends, including direct deletion, replacements, and immediate or scheduled cancellations.
- Usage-based line items are excluded from these events.
- Internal-only events are marked delivered without attempting customer webhook delivery, preventing delivery errors and retry noise.
- Cancellation and replacement flows publish each affected line item once, after the related database changes complete.

### Impact
`✅ Reliable HubSpot line-item synchronization triggers`
`✅ No customer webhook failures for internal events`
`✅ No duplicate deletion events during cancellation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
