### PR TITLE
docs: fix broken relative links to api/tests and internal packages

### DIFF
--- a/api/custom/go/README.md
+++ b/api/custom/go/README.md
@@ -25,7 +25,7 @@ import "github.com/flexprice/go-sdk/v2"
 | `FLEXPRICE_API_KEY` | Yes | API key |
 | `FLEXPRICE_API_HOST` | Optional | Full base URL including `https://` and `/v1` (default: `https://us.api.flexprice.io/v1`). No trailing slash. |
 
-**Integration tests** in [api/tests/go/test_sdk.go](../tests/go/test_sdk.go) use a different env shape (host without scheme); see [api/tests/README.md](../tests/README.md).
+**Integration tests** in [api/tests/go/test_sdk.go](../../tests/go/test_sdk.go) use a different env shape (host without scheme); see [api/tests/README.md](../../tests/README.md).
 
 ## Quick start
 
@@ -445,4 +445,4 @@ func handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 - [FlexPrice API documentation](https://docs.flexprice.io)
 - [Go SDK examples](examples/) in this repo
-- [SDK integration tests](../tests/README.md) — full API coverage (different `FLEXPRICE_API_HOST` shape; see that README)
+- [SDK integration tests](../../tests/README.md) — full API coverage (different `FLEXPRICE_API_HOST` shape; see that README)

--- a/api/custom/go/examples/README.md
+++ b/api/custom/go/examples/README.md
@@ -6,4 +6,4 @@
 
 This sample creates a customer, ingests one event (sync), then enqueues via the **custom async client** (`NewAsyncClientWithConfig`). Custom SDK files live in `api/custom/go/`.
 
-**Integration tests:** Full API flows use a different env shape (host without scheme); see [api/tests/go/test_sdk.go](../../tests/go/test_sdk.go) and [api/tests/README.md](../../tests/README.md).
+**Integration tests:** Full API flows use a different env shape (host without scheme); see [api/tests/go/test_sdk.go](../../../tests/go/test_sdk.go) and [api/tests/README.md](../../../tests/README.md).

--- a/api/custom/python/README.md
+++ b/api/custom/python/README.md
@@ -29,7 +29,7 @@ Runnable samples are in the `examples/` directory.
 | `FLEXPRICE_API_KEY` | Yes | API key |
 | `FLEXPRICE_API_HOST` | Optional | Full base URL including `https://` and `/v1` (default: `https://us.api.flexprice.io/v1`). No trailing slash. |
 
-**Integration tests** in [api/tests/python/test_sdk.py](../tests/python/test_sdk.py) use a different env shape; see [api/tests/README.md](../tests/README.md).
+**Integration tests** in [api/tests/python/test_sdk.py](../../tests/python/test_sdk.py) use a different env shape; see [api/tests/README.md](../../tests/README.md).
 
 ## Quick start
 
@@ -194,4 +194,4 @@ def handle_webhook(raw_body: str) -> None:
 
 - [FlexPrice API documentation](https://docs.flexprice.io)
 - [Python SDK examples](examples/) in this repo
-- [SDK integration tests](../tests/README.md) — different `FLEXPRICE_API_HOST` shape for automated tests
+- [SDK integration tests](../../tests/README.md) — different `FLEXPRICE_API_HOST` shape for automated tests

--- a/api/custom/python/examples/README.md
+++ b/api/custom/python/examples/README.md
@@ -11,4 +11,4 @@
    Run the async example: `python async_event_example.py`  
    (From the package root: `python examples/example.py` or `python examples/async_event_example.py`.)
 
-**Integration tests:** Full API flows are in [api/tests/python/test_sdk.py](../../tests/python/test_sdk.py). Install with `pip install -r requirements.txt` in `api/tests/python`; see [api/tests/README.md](../../tests/README.md).
+**Integration tests:** Full API flows are in [api/tests/python/test_sdk.py](../../../tests/python/test_sdk.py). Install with `pip install -r requirements.txt` in `api/tests/python`; see [api/tests/README.md](../../../tests/README.md).

--- a/api/custom/typescript/README.md
+++ b/api/custom/typescript/README.md
@@ -51,7 +51,7 @@ Runnable samples are in the `examples/` directory.
 | `FLEXPRICE_API_KEY` | Yes | API key |
 | `FLEXPRICE_API_HOST` | Optional | Full base URL including `https://` and `/v1` (default: `https://us.api.flexprice.io/v1`). No trailing slash. |
 
-**Integration tests** in [api/tests/ts/test_sdk.ts](../tests/ts/test_sdk.ts) use a different env shape; see [api/tests/README.md](../tests/README.md).
+**Integration tests** in [api/tests/ts/test_sdk.ts](../../tests/ts/test_sdk.ts) use a different env shape; see [api/tests/README.md](../../tests/README.md).
 
 ## Quick start
 
@@ -228,4 +228,4 @@ function handleWebhook(rawBody: string): void {
 
 - [FlexPrice API documentation](https://docs.flexprice.io)
 - [TypeScript SDK examples](examples/) in this repo
-- [SDK integration tests](../tests/README.md) — different `FLEXPRICE_API_HOST` shape for automated tests
+- [SDK integration tests](../../tests/README.md) — different `FLEXPRICE_API_HOST` shape for automated tests

--- a/api/custom/typescript/examples/README.md
+++ b/api/custom/typescript/examples/README.md
@@ -4,4 +4,4 @@
 2. Copy `.env.sample` to `.env` and set **`FLEXPRICE_API_KEY`**. Optionally set **`FLEXPRICE_API_HOST`** to a full URL (default: `https://us.api.flexprice.io/v1`).
 3. Run: from the package root, `npx tsx examples/quick-start.ts`; or from `examples/`, `npx tsx quick-start.ts`.
 
-**Integration tests:** Full API flows are in [api/tests/ts/test_sdk.ts](../../tests/ts/test_sdk.ts). Run `npm test` from `api/tests/ts`; see [api/tests/README.md](../../tests/README.md).
+**Integration tests:** Full API flows are in [api/tests/ts/test_sdk.ts](../../../tests/ts/test_sdk.ts). Run `npm test` from `api/tests/ts`; see [api/tests/README.md](../../../tests/README.md).

--- a/docs/FLOWS/api-request-lifecycle.md
+++ b/docs/FLOWS/api-request-lifecycle.md
@@ -6,7 +6,7 @@
 
 ## Execution path
 
-1. **Router construction** [`internal/api/NewRouter`](internal/api/router.go)
+1. **Router construction** [`internal/api/NewRouter`](../../internal/api/router.go)
    - `gin.New()` + custom middleware ordering (recovery → request id → structured logging → CORS → Sentry → Pyroscope).
    - Dynamic swagger host shim.
 2. Route groups:

--- a/docs/FLOWS/authentication.md
+++ b/docs/FLOWS/authentication.md
@@ -3,14 +3,14 @@
 ## Trigger
 
 - Any request to **`/v1/**` routes** gated by **`AuthenticateMiddleware`** (private group) vs public auth endpoints under `GuestAuthenticateMiddleware`.
-- Middleware chain established in [`internal/api/router.go`](internal/api/router.go).
+- Middleware chain established in [`internal/api/router.go`](../../internal/api/router.go).
 
 ## Execution path
 
 1. **Guest public auth** (`/v1/auth/signup`, `/v1/auth/login`) — bypass full auth stack (see router grouping).
 2. **Protected routes:**
    - Read configured API key header (default **`x-api-key`** family per `cfg.Auth.APIKey.Header`).
-   - **`validateAPIKey`** in [`internal/rest/middleware/auth.go`](internal/rest/middleware/auth.go):
+   - **`validateAPIKey`** in [`internal/rest/middleware/auth.go`](../../internal/rest/middleware/auth.go):
      - First: static/config keys (`internal/auth.ValidateAPIKey`).
      - Else: **`SecretService.VerifyAPIKey`** (DB-backed secrets with RBAC roles + environment affinity).
    - Else: parse **`Authorization: Bearer <jwt>`**.

--- a/docs/FLOWS/event-processing.md
+++ b/docs/FLOWS/event-processing.md
@@ -3,13 +3,13 @@
 ## Trigger
 
 1. Authenticated ingestion via **`POST /v1/events`** (+ bulk/query variants gated by RBAC `'event':'write'` in router grouping).
-2. Internal republish/transform jobs (staging-oriented topics referenced in [`internal/config/config.yaml`](internal/config/config.yaml)).
+2. Internal republish/transform jobs (staging-oriented topics referenced in [`internal/config/config.yaml`](../../internal/config/config.yaml)).
 
 ## Execution path — produce
 
 1. `EventsHandler` (see `internal/api/v1/events*.go`) calls **`EventService`**.
 2. Service validates metering payload and persists or stages according to architectural branch.
-3. **`publisher.EventPublisher.Publish`** (see [`internal/publisher/event_publisher.go`](internal/publisher/event_publisher.go)):
+3. **`publisher.EventPublisher.Publish`** (see [`internal/publisher/event_publisher.go`](../../internal/publisher/event_publisher.go)):
    - `PublishToKafka` path → `kafka.EventPublisher`.
    - Optional Dynamo publication when configured (`PublishToDynamoDB` / ALL mode—both must succeed-ish policy encoded in publisher).
 

--- a/docs/FLOWS/retry-handling.md
+++ b/docs/FLOWS/retry-handling.md
@@ -4,7 +4,7 @@ FlexPrice centralizes **consumer-side** retry semantics in the Watermill-based m
 
 ## Primary mechanism
 
-Configured in [`internal/pubsub/router/router.go`](internal/pubsub/router/router.go):
+Configured in [`internal/pubsub/router/router.go`](../../internal/pubsub/router/router.go):
 
 1. **PoisonQueue middleware** (first)
    - Publishes irrecoverably failed handling attempts to **`cfg.Kafka.TopicDLQ`** when configured (real Kafka DLQ publisher).

--- a/docs/FLOWS/webhook-processing.md
+++ b/docs/FLOWS/webhook-processing.md
@@ -39,7 +39,7 @@ Internal domain milestones enqueue messages onto **system-events Kafka topics** 
 ### Execution path
 
 1. **WebhookService.RegisterHandler** hooks into **`pubsub.Router`** when processing mode allows (`includeProcessingHandlers` true in deployment modes exercising consumers).
-2. **Payload factories** hydrate JSON from many read-services (see [`internal/webhook/module.go`](internal/webhook/module.go) injecting invoice/plan/feature/subscription/etc. services).
+2. **Payload factories** hydrate JSON from many read-services (see [`internal/webhook/module.go`](../../internal/webhook/module.go) injecting invoice/plan/feature/subscription/etc. services).
 3. **WebhookPublisher** (backed by shared Kafka producer) emits final envelope (potential persistence of `systemevent` aggregates — follow `publisher` package interplay with `repository/ent/SystemEvent`).
 4. **Svix integration** optionally delivers routed events (see Svix handlers in webhook API endpoints for dashboard onboarding).
 


### PR DESCRIPTION
Several README and `docs/FLOWS` links were one directory too shallow, so they pointed to files that do not exist. This fixes those paths across the Go, Python, and TypeScript SDK docs and the flow docs.

I left three broken references alone because their targets appear to have been removed and I could not identify a reliable replacement: `RUNTIMES.md`, the ERD document, and the Postman collection.

The documentation checks on my fork passed.
