### PR TITLE
chore(e2e): Update coverage

### DIFF
--- a/internal/api/v1/entitlement.go
+++ b/internal/api/v1/entitlement.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
 )

--- a/internal/api/v1/tax.go
+++ b/internal/api/v1/tax.go
@@ -83,7 +83,7 @@ func (h *TaxHandler) GetTaxRate(c *gin.Context) {
 // @Produce json
 // @Security ApiKeyAuth
 // @Param filter query types.TaxRateFilter true "Filter"
-// @Success 200 {object} []dto.TaxRateResponse
+// @Success 200 {object} dto.ListTaxRatesResponse
 // @Failure 400 {object} ierr.ErrorResponse "Invalid request"
 // @Failure 500 {object} ierr.ErrorResponse "Server error"
 // @Router /taxes/rates [get]

--- a/internal/e2eprobe/checks/janitor.go
+++ b/internal/e2eprobe/checks/janitor.go
@@ -233,10 +233,18 @@ func (j *Janitor) sweepOrphans(ctx context.Context, cutoff time.Time) error {
 // tax rate and deletes any whose EntityID (subscription) 404s on lookup.
 // The seed tax association on persistent cust #0 is preserved because its
 // subscription is persistent and never 404s.
+//
+// Soft-skips when SharedTaxRateID is empty. That can happen when the seed's
+// CreateTaxRate call returned "already exists" AND no CreateTaxAssociation
+// has yet backfilled the ID (see ensureTaxRates + ensurePersistentTaxAssociation
+// in seed_ensure.go, added as workarounds for the SDK v2.0.24 GetTaxRates
+// schema mismatch). Missing a cleanup cycle in that edge state is acceptable
+// — orphan accumulation is slow and a fresh probe iteration typically
+// backfills the ID within one cycle.
 func (j *Janitor) sweepOrphanTaxAssociations(ctx context.Context) error {
 	taxRateID := j.reg.Seeds().SharedTaxRateID
 	if taxRateID == "" {
-		return nil // seed hasn't run — nothing to sweep
+		return nil // seed hasn't run yet, or ID wasn't recoverable — nothing to sweep
 	}
 	resp, err := j.client.TaxAssociations().List(ctx, nil, nil, nil, &taxRateID)
 	if err != nil {

--- a/internal/e2eprobe/checks/persistent_billing_invariants_probe.go
+++ b/internal/e2eprobe/checks/persistent_billing_invariants_probe.go
@@ -38,16 +38,18 @@ func (p *PersistentBillingInvariantsProbe) Run(ctx context.Context) error {
 		return nil
 	}
 
-	// Persistent cust #0 → tax invariant.
-	if seeds.SharedTaxRateID != "" {
+	// Persistent cust #0 → tax invariant. Match by ID when available, else
+	// by nested TaxRate.Code (SharedTaxRateID may be empty when the SDK's
+	// broken GetTaxRates list forced create-only idempotency in the seed).
+	if seeds.SharedTaxRateID != "" || seeds.SharedTaxRateCode != "" {
 		cust0 := seeds.PersistentCustomerIDs[0]
 		inv, err := p.latestInvoice(ctx, cust0)
 		if err != nil {
 			return e2eprobe.Errorf(map[string]string{"step": "query_invoice_cust0", "external_customer_id": cust0}, "query invoice: %w", err)
 		}
 		if inv != nil {
-			if !invoiceHasTaxRate(inv, seeds.SharedTaxRateID) {
-				return e2eprobe.Errorf(map[string]string{"step": "assert_tax_present_cust0", "external_customer_id": cust0, "tax_rate_id": seeds.SharedTaxRateID}, "latest invoice for cust #0 does not include tax rate %s", seeds.SharedTaxRateID)
+			if !invoiceHasTaxRate(inv, seeds.SharedTaxRateID, seeds.SharedTaxRateCode) {
+				return e2eprobe.Errorf(map[string]string{"step": "assert_tax_present_cust0", "external_customer_id": cust0, "tax_rate_id": seeds.SharedTaxRateID, "tax_rate_code": seeds.SharedTaxRateCode}, "latest invoice for cust #0 does not include our tax rate (checked id %q AND code %q)", seeds.SharedTaxRateID, seeds.SharedTaxRateCode)
 			}
 		}
 	}
@@ -84,9 +86,12 @@ func (p *PersistentBillingInvariantsProbe) latestInvoice(ctx context.Context, ex
 	return &inv, nil
 }
 
-func invoiceHasTaxRate(inv *types.InvoiceResponse, taxRateID string) bool {
+func invoiceHasTaxRate(inv *types.InvoiceResponse, taxRateID, taxRateCode string) bool {
 	for _, tx := range inv.Taxes {
-		if tx.TaxRateID != nil && *tx.TaxRateID == taxRateID {
+		if taxRateID != "" && tx.TaxRateID != nil && *tx.TaxRateID == taxRateID {
+			return true
+		}
+		if taxRateCode != "" && tx.TaxRate != nil && tx.TaxRate.Code != nil && *tx.TaxRate.Code == taxRateCode {
 			return true
 		}
 	}

--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/e2eprobe"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/go-sdk/v2/models/dtos"
 	sdkerrors "github.com/flexprice/go-sdk/v2/models/errors"
 	"github.com/flexprice/go-sdk/v2/models/types"
 )
@@ -338,22 +338,20 @@ func (s *SeedEnsure) ensureCoupons(ctx context.Context, out *e2eprobe.Seeds) err
 
 // ensureTaxRates idempotently provisions the shared E2EPROBE_TAX_10PCT tax
 // rate (10% percentage, EXTERNAL scope) reused by tax-application-probe and
-// by the persistent tax association on customer #0. Lookup uses the SDK's
-// server-side TaxrateCodes filter.
+// by the persistent tax association on customer #0.
+//
+// SDK v2.0.24's TaxRates.List (GET /taxes/rates) is broken: the server
+// returns {items, pagination} but the SDK expects a bare array (schema-
+// annotation mismatch in the server's Swagger doc). Rather than call the
+// broken List method, this step attempts Create and treats an already-
+// exists response (HTTP 409 or Code=="already_exists") as success. On a
+// duplicate we cannot recover the existing ID (there is no exposed
+// GET-by-code endpoint), so out.SharedTaxRateID stays empty on that path
+// and downstream callers must tolerate that.
 func (s *SeedEnsure) ensureTaxRates(ctx context.Context, out *e2eprobe.Seeds) error {
-	listResp, err := s.client.TaxRates().List(ctx, dtos.GetTaxRatesRequest{
-		TaxrateCodes: []string{SharedTaxRateCode},
-	})
-	if err != nil {
-		return e2eprobe.Errorf(map[string]string{"step": "list_tax_rates"}, "list tax rates: %w", err)
-	}
-	for _, tr := range listResp.TaxRateResponses {
-		if tr.Code != nil && *tr.Code == SharedTaxRateCode && tr.ID != nil {
-			out.SharedTaxRateID = *tr.ID
-			out.SharedTaxRateCode = SharedTaxRateCode
-			return nil
-		}
-	}
+	// Populate the code first so downstream soft-skips (that only need code)
+	// still get it even if Create returns an unexpected error below.
+	out.SharedTaxRateCode = SharedTaxRateCode
 
 	percentage := "10"
 	scope := types.TaxRateScopeExternal
@@ -369,14 +367,52 @@ func (s *SeedEnsure) ensureTaxRates(ctx context.Context, out *e2eprobe.Seeds) er
 			"e2eprobe_role": "seed",
 		},
 	})
-	if err != nil {
-		return e2eprobe.Errorf(map[string]string{"tax_rate_code": SharedTaxRateCode}, "create tax rate: %w", err)
+	if err == nil {
+		if createResp.TaxRateResponse != nil && createResp.TaxRateResponse.ID != nil {
+			out.SharedTaxRateID = *createResp.TaxRateResponse.ID
+		}
+		return nil
 	}
-	if createResp.TaxRateResponse != nil && createResp.TaxRateResponse.ID != nil {
-		out.SharedTaxRateID = *createResp.TaxRateResponse.ID
+	if isAlreadyExists(err) {
+		if s.logger != nil {
+			s.logger.Info(ctx, "ensureTaxRates: tax rate already exists (no ID lookup available in SDK v2.0.24, downstream will fall back to code match)",
+				"tax_rate_code", SharedTaxRateCode,
+			)
+		}
+		return nil
 	}
-	out.SharedTaxRateCode = SharedTaxRateCode
-	return nil
+	return e2eprobe.Errorf(map[string]string{"tax_rate_code": SharedTaxRateCode}, "create tax rate: %w", err)
+}
+
+// isAlreadyExists returns true when the given SDK error represents a
+// "resource already exists" (HTTP 409, or an ErrorResponse with Code
+// "already_exists"). Used by seed steps for create-then-swallow-duplicate
+// idempotency where a list-then-create round-trip is unavailable.
+func isAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errResp *sdkerrors.ErrorResponse
+	if errors.As(err, &errResp) {
+		if errResp.HTTPStatusCode != nil && *errResp.HTTPStatusCode == http.StatusConflict {
+			return true
+		}
+		if errResp.Code != nil && *errResp.Code == types.ErrorCodeAlreadyExists {
+			return true
+		}
+	}
+	var apiErr *sdkerrors.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode == http.StatusConflict {
+			return true
+		}
+		// The generic 4xx SDK path returns *APIError with the raw JSON body;
+		// fall back to substring match on the error code within the body.
+		if strings.Contains(apiErr.Body, `"code":"already_exists"`) {
+			return true
+		}
+	}
+	return false
 }
 
 // bucketedFeatureLookupKeys is the set of lookup keys whose features are
@@ -761,12 +797,17 @@ func (s *SeedEnsure) ensureSubscriptions(ctx context.Context, seeds *e2eprobe.Se
 }
 
 // ensurePersistentTaxAssociation attaches the shared E2EPROBE_TAX_10PCT
-// tax rate to persistent cust #0's subscription. Idempotent: lists
-// existing associations filtered by tax_rate_id + entity_id and creates
-// only if absent. Unlike coupons, tax associations are a separate call
-// (not a sub-create field), so this covers both new and existing subs.
+// tax rate to persistent cust #0's subscription. Idempotency lists all
+// tax associations for the subscription (filtered by entity_type + entity_id
+// only — NOT by tax_rate_id, since SharedTaxRateID may be empty when the
+// tax rate pre-existed) and treats "any association present" as done. Safe
+// because the seed only ever attaches one tax rate to this sub.
+//
+// Unlike coupons (attached at sub-create via SubscriptionCoupons), tax
+// associations are a separate API call, so this covers both freshly-
+// created and pre-existing seed subs.
 func (s *SeedEnsure) ensurePersistentTaxAssociation(ctx context.Context, out *e2eprobe.Seeds) error {
-	if out.SharedTaxRateCode == "" || out.SharedTaxRateID == "" {
+	if out.SharedTaxRateCode == "" {
 		return nil // tax rate seed didn't run — soft skip
 	}
 	if len(out.PersistentCustomerIDs) == 0 || len(out.PersistentSubIDs) == 0 {
@@ -779,16 +820,35 @@ func (s *SeedEnsure) ensurePersistentTaxAssociation(ctx context.Context, out *e2
 		return nil
 	}
 	subID := out.PersistentSubIDs[0]
-	taxRateID := out.SharedTaxRateID
 
 	entityType := "SUBSCRIPTION"
-	listResp, err := s.client.TaxAssociations().List(ctx, &entityType, &subID, nil, &taxRateID)
+	listResp, err := s.client.TaxAssociations().List(ctx, &entityType, &subID, nil, nil)
 	if err != nil {
-		return e2eprobe.Errorf(map[string]string{"subscription_id": subID, "tax_rate_id": taxRateID}, "list tax associations: %w", err)
+		return e2eprobe.Errorf(map[string]string{"subscription_id": subID, "tax_rate_code": out.SharedTaxRateCode}, "list tax associations: %w", err)
 	}
+	// The seed only ever attaches ONE tax rate to persistent cust #0's sub,
+	// so any existing association is by definition OUR association. On the
+	// happy path we match by SharedTaxRateID; when the ID is unknown (SDK
+	// v2.0.24 TaxRates.List is broken and CreateTaxRate returned
+	// "already exists"), we opportunistically backfill SharedTaxRateID from
+	// the existing association's TaxRateID so downstream janitor / probe
+	// assertions can use the strong ID match.
 	if listResp.ListTaxAssociationsResponse != nil {
 		for _, ta := range listResp.ListTaxAssociationsResponse.Items {
-			if ta.TaxRateID != nil && *ta.TaxRateID == taxRateID {
+			if out.SharedTaxRateID != "" && ta.TaxRateID != nil && *ta.TaxRateID == out.SharedTaxRateID {
+				return nil
+			}
+			if ta.TaxRate != nil && ta.TaxRate.Code != nil && *ta.TaxRate.Code == out.SharedTaxRateCode {
+				if out.SharedTaxRateID == "" && ta.TaxRateID != nil {
+					out.SharedTaxRateID = *ta.TaxRateID
+				}
+				return nil
+			}
+			// Unknown-code, unknown-ID fallback: seed invariant guarantees only
+			// our shared rate is ever attached to cust #0's sub, so any
+			// association wins. Backfill the ID from it.
+			if out.SharedTaxRateID == "" && ta.TaxRateID != nil {
+				out.SharedTaxRateID = *ta.TaxRateID
 				return nil
 			}
 		}
@@ -796,7 +856,7 @@ func (s *SeedEnsure) ensurePersistentTaxAssociation(ctx context.Context, out *e2
 
 	autoApply := true
 	tType := types.TaxRateEntityTypeSubscription
-	_, err = s.client.TaxAssociations().Create(ctx, types.CreateTaxAssociationRequest{
+	createResp, err := s.client.TaxAssociations().Create(ctx, types.CreateTaxAssociationRequest{
 		TaxRateCode: out.SharedTaxRateCode,
 		EntityID:    &subID,
 		EntityType:  &tType,
@@ -807,7 +867,15 @@ func (s *SeedEnsure) ensurePersistentTaxAssociation(ctx context.Context, out *e2
 		},
 	})
 	if err != nil {
+		if isAlreadyExists(err) {
+			return nil // benign — a prior seed already attached it
+		}
 		return e2eprobe.Errorf(map[string]string{"subscription_id": subID, "tax_rate_code": out.SharedTaxRateCode}, "create tax association: %w", err)
+	}
+	// Opportunistically backfill SharedTaxRateID from the association response
+	// so downstream janitor / probe assertions can use the stronger ID match.
+	if out.SharedTaxRateID == "" && createResp.TaxAssociationResponse != nil && createResp.TaxAssociationResponse.TaxRateID != nil {
+		out.SharedTaxRateID = *createResp.TaxAssociationResponse.TaxRateID
 	}
 	return nil
 }

--- a/internal/e2eprobe/checks/seed_ensure_test.go
+++ b/internal/e2eprobe/checks/seed_ensure_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/config"
@@ -9,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 	itypes "github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/go-sdk/v2/models/dtos"
+	sdkerrors "github.com/flexprice/go-sdk/v2/models/errors"
 	"github.com/flexprice/go-sdk/v2/models/types"
 )
 
@@ -256,7 +258,7 @@ func TestSeedEnsure_TaxRateProvisioning(t *testing.T) {
 	}
 	seeds := reg.Seeds()
 	if seeds.SharedTaxRateID == "" {
-		t.Fatalf("SharedTaxRateID empty after seed run")
+		t.Fatalf("SharedTaxRateID empty after seed run (Create succeeded — should carry the id)")
 	}
 	if seeds.SharedTaxRateCode != "E2EPROBE_TAX_10PCT" {
 		t.Errorf("SharedTaxRateCode = %q, want E2EPROBE_TAX_10PCT", seeds.SharedTaxRateCode)
@@ -274,19 +276,37 @@ func TestSeedEnsure_TaxRateProvisioning(t *testing.T) {
 	if got.Scope == nil || *got.Scope != types.TaxRateScopeExternal {
 		t.Errorf("tax rate Scope = %v, want EXTERNAL", got.Scope)
 	}
+}
 
-	// Simulate the second run finding the existing rate via List.
-	codeCopy := "E2EPROBE_TAX_10PCT"
-	idCopy := seeds.SharedTaxRateID
-	fc.taxRates.listResp = &dtos.GetTaxRatesResponse{
-		TaxRateResponses: []types.TaxRateResponse{{ID: &idCopy, Code: &codeCopy}},
+// TestSeedEnsure_TaxRateAlreadyExistsSwallowed simulates the second-run
+// scenario where CreateTaxRate returns "already exists" — the seed treats
+// this as success, populates only the Code, and leaves the ID empty (the
+// SDK v2.0.24 workaround for the broken TaxRates.List response shape).
+func TestSeedEnsure_TaxRateAlreadyExistsSwallowed(t *testing.T) {
+	fc := newFakeClient()
+	reg := e2eprobe.NewRegistry()
+	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
+	s := NewSeedEnsure(fc, reg, "test-run", lg)
+
+	code := types.ErrorCodeAlreadyExists
+	status := int64(http.StatusConflict)
+	msg := "A taxrate with this code E2EPROBE_TAX_10PCT already exists"
+	fc.taxRates.createErr = &sdkerrors.ErrorResponse{
+		Code:           &code,
+		HTTPStatusCode: &status,
+		Message:        &msg,
 	}
+
 	if err := s.Run(context.Background()); err != nil {
-		t.Fatalf("second Run() unexpected error: %v", err)
+		t.Fatalf("Run() must swallow ErrAlreadyExists on tax rate; got %v", err)
 	}
-	if len(fc.taxRates.created) != 1 {
-		t.Errorf("tax rate created %d times across 2 runs; want 1 (idempotency broken)", len(fc.taxRates.created))
+	seeds := reg.Seeds()
+	if seeds.SharedTaxRateCode != "E2EPROBE_TAX_10PCT" {
+		t.Errorf("SharedTaxRateCode = %q, want E2EPROBE_TAX_10PCT (must be set even on duplicate path)", seeds.SharedTaxRateCode)
 	}
+	// SharedTaxRateID may end up populated by ensurePersistentTaxAssociation's
+	// backfill from the fake CreateTaxAssociation response — that's fine.
+	// The key invariant is that Run() did not fail.
 }
 
 func TestSeedEnsure_PlanEntitlementsProvisioned(t *testing.T) {
@@ -401,15 +421,18 @@ func TestSeedEnsure_PersistentTaxAssociation(t *testing.T) {
 		t.Errorf("EntityType = %v, want SUBSCRIPTION", req.EntityType)
 	}
 
-	// Idempotency: the fake doesn't dedupe on repeat Runs (it creates fresh IDs
-	// each time), so pre-populate both TaxRates.List (so ensureTaxRates returns
-	// the same rate ID) AND TaxAssociations.List (so ensurePersistentTaxAssociation
-	// sees the existing association). On real APIs both lookups deduplicate
-	// server-side.
+	// Idempotency on second Run:
+	//   1. ensureTaxRates: fake CreateTaxRate returns "already exists" (the
+	//      real server behaviour when the tax rate was created by Run #1).
+	//   2. ensurePersistentTaxAssociation: fake TaxAssociations.List returns
+	//      the existing association we created in Run #1, so create is
+	//      skipped.
 	trID := reg.Seeds().SharedTaxRateID
-	trCode := "E2EPROBE_TAX_10PCT"
-	fc.taxRates.listResp = &dtos.GetTaxRatesResponse{
-		TaxRateResponses: []types.TaxRateResponse{{ID: &trID, Code: &trCode}},
+	dupCode := types.ErrorCodeAlreadyExists
+	dupStatus := int64(http.StatusConflict)
+	fc.taxRates.createErr = &sdkerrors.ErrorResponse{
+		Code:           &dupCode,
+		HTTPStatusCode: &dupStatus,
 	}
 	fc.taxAssociations.listResp = &dtos.ListTaxAssociationsResponse{
 		ListTaxAssociationsResponse: &types.ListTaxAssociationsResponse{

--- a/internal/e2eprobe/checks/tax_application_probe.go
+++ b/internal/e2eprobe/checks/tax_application_probe.go
@@ -153,7 +153,14 @@ func (p *TaxApplicationProbe) Run(ctx context.Context) error {
 	epsilon := decimal.NewFromFloat(0.01)
 	found := false
 	for _, tx := range inv.Taxes {
+		// Prefer strong match by tax_rate_id when available; fall back to
+		// nested TaxRate.Code == SharedTaxRateCode. Seeds.SharedTaxRateID is
+		// empty when the SDK's broken GetTaxRates list + our create-only
+		// idempotency workaround couldn't recover the ID.
 		if tx.TaxRateID != nil && seeds.SharedTaxRateID != "" && *tx.TaxRateID == seeds.SharedTaxRateID {
+			found = true
+		}
+		if !found && tx.TaxRate != nil && tx.TaxRate.Code != nil && *tx.TaxRate.Code == seeds.SharedTaxRateCode {
 			found = true
 		}
 		if tx.TaxableAmount != nil && tx.TaxAmount != nil {
@@ -170,10 +177,11 @@ func (p *TaxApplicationProbe) Run(ctx context.Context) error {
 			}
 		}
 	}
-	if !found && seeds.SharedTaxRateID != "" {
+	if !found {
 		return e2eprobe.Errorf(map[string]string{
-			"step": "assert_tax_rate_match", "subscription_id": subID, "tax_rate_id": seeds.SharedTaxRateID,
-		}, "preview.Taxes did not include tax_rate_id %s", seeds.SharedTaxRateID)
+			"step": "assert_tax_rate_match", "subscription_id": subID,
+			"tax_rate_id": seeds.SharedTaxRateID, "tax_rate_code": seeds.SharedTaxRateCode,
+		}, "preview.Taxes did not include our tax rate (checked id %q AND code %q)", seeds.SharedTaxRateID, seeds.SharedTaxRateCode)
 	}
 	return nil
 }


### PR DESCRIPTION
## **CodeAnt-AI Description**
Keep tax-rate E2E checks working when an existing rate cannot be listed

### What Changed
- Tax-rate seeding now creates the shared rate directly and treats duplicate responses as success, avoiding the broken list response handling.
- Persistent tax associations can be reused when the tax-rate ID is unavailable, matching by tax-rate code and recovering the ID when possible.
- Tax application and billing checks now accept either the tax-rate ID or its code.
- Orphan tax cleanup safely waits until a tax-rate ID is available instead of failing.
- API documentation now describes the tax-rate list response correctly, and tests cover duplicate tax-rate provisioning.

### Impact
`✅ Fewer E2E seed startup failures`
`✅ Reliable reuse of existing tax rates`
`✅ Tax checks continue to pass when IDs are unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tax-rate setup to handle duplicate creations and recover existing tax-rate details.
  * Tax associations are now validated using either a tax-rate ID or code, improving compatibility when one identifier is unavailable.
  * Enhanced billing checks to recognize valid tax configurations more reliably.
  * Improved handling of temporary or incomplete tax-rate data during verification.
* **Documentation**
  * Clarified tax-rate cleanup behavior for deferred verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->