### PR TITLE
feat(e2e): Fixes

### DIFF
--- a/internal/e2eprobe/checks/commitment_true_up_probe.go
+++ b/internal/e2eprobe/checks/commitment_true_up_probe.go
@@ -16,14 +16,17 @@ import (
 // CommitmentTrueUpProbe creates a fresh ephemeral customer + sub with a
 // $5/mo commitment (1.5× overage), ingests a deterministic amount of usage
 // on e2eprobe_sum ($0.01/unit), then calls GetInvoicePreview and asserts
-// the resulting math.
+// the resulting math. The plan carries a $19.99 monthly fixed base fee
+// (`e2eprobe_base_price` in seed_ensure.go); expected preview totals below
+// bake that in.
 //
 // Alternates legs per run:
 //   - Odd runs (cursor%2 == 1): under-commitment (100 events × $0.01 = $1.00).
-//     Preview total must be at least the commitment ($5.00) — true-up bumps up.
+//     Preview total must be at least commitment + base ($5 + $19.99 = $24.99).
+//     True-up bumps usage up to the commitment.
 //   - Even runs (cursor%2 == 0): over-commitment (700 events × $0.01 = $7.00).
-//     Preview total must equal commitment + (usage - commitment) × 1.5
-//     = $5 + $2 × 1.5 = $8.00 (epsilon $0.01).
+//     Preview total must equal commitment + (usage - commitment) × 1.5 + base
+//     = $5 + $2 × 1.5 + $19.99 = $27.99 (epsilon $0.01).
 type CommitmentTrueUpProbe struct {
 	client e2eprobe.Client
 	reg    e2eprobe.Registry
@@ -98,8 +101,10 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 
 	// Ingest e2eprobe_sum events (priced at $0.01/unit); amount=1 per event.
 	n := 100
+	expectedUsage := 1.00
 	if overLeg {
 		n = 700
+		expectedUsage = 7.00
 	}
 	for i := 0; i < n; i++ {
 		if _, err := p.client.Events().Ingest(ctx, types.IngestEventRequest{
@@ -115,8 +120,9 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 		}
 	}
 
-	// Poll GetUsage until aggregation catches up. Success signal: no error.
-	if err := p.pollSubUsage(ctx, subID, ext); err != nil {
+	// Poll GetUsage until aggregation reflects the ingested amount. A successful
+	// response can still report zero usage while the pipeline catches up.
+	if err := p.pollSubUsage(ctx, subID, ext, expectedUsage); err != nil {
 		return err
 	}
 
@@ -130,15 +136,33 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 	return p.assertPreview(previewResp.InvoiceResponse, overLeg, ext, subID)
 }
 
-func (p *CommitmentTrueUpProbe) pollSubUsage(ctx context.Context, subID, ext string) error {
+func (p *CommitmentTrueUpProbe) pollSubUsage(ctx context.Context, subID, ext string, expectedAmount float64) error {
 	deadline := time.Now().Add(90 * time.Second)
+	usageEpsilon := 0.005
+	var lastErr error
+	var lastAmount float64
 	for {
-		_, err := p.client.Subscriptions().GetUsage(ctx, types.GetUsageBySubscriptionRequest{SubscriptionID: subID})
-		if err == nil {
-			return nil
+		resp, err := p.client.Subscriptions().GetUsage(ctx, types.GetUsageBySubscriptionRequest{SubscriptionID: subID})
+		if err == nil && resp != nil && resp.GetUsageBySubscriptionResponse != nil && resp.GetUsageBySubscriptionResponse.Amount != nil {
+			lastAmount = *resp.GetUsageBySubscriptionResponse.Amount
+			if lastAmount+usageEpsilon >= expectedAmount {
+				return nil
+			}
+		} else if err != nil {
+			lastErr = err
 		}
 		if time.Now().After(deadline) {
-			return e2eprobe.Errorf(map[string]string{"step": "poll_sub_usage", "external_customer_id": ext, "subscription_id": subID}, "sub usage poll: %w", err)
+			fields := map[string]string{
+				"step":                 "poll_sub_usage",
+				"external_customer_id": ext,
+				"subscription_id":      subID,
+				"expected_amount":      fmt.Sprintf("%.2f", expectedAmount),
+				"last_amount":          fmt.Sprintf("%.2f", lastAmount),
+			}
+			if lastErr != nil {
+				return e2eprobe.Errorf(fields, "sub usage did not reach expected amount %.2f (last=%.2f): %w", expectedAmount, lastAmount, lastErr)
+			}
+			return e2eprobe.Errorf(fields, "sub usage did not reach expected amount %.2f (last=%.2f)", expectedAmount, lastAmount)
 		}
 		select {
 		case <-ctx.Done():
@@ -150,17 +174,21 @@ func (p *CommitmentTrueUpProbe) pollSubUsage(ctx context.Context, subID, ext str
 
 func (p *CommitmentTrueUpProbe) assertPreview(inv *types.InvoiceResponse, overLeg bool, ext, subID string) error {
 	commitment := decimal.NewFromFloat(5.00)
+	// e2eprobe_base_price ($19.99 monthly fixed) is on seeds.PlanIDs[0] and
+	// always appears on the preview, so bake it into the expected totals.
+	baseFee := decimal.NewFromFloat(19.99)
 	epsilon := decimal.NewFromFloat(0.01)
 
 	total := invoiceTotal(inv)
 
 	if !overLeg {
-		// Under leg: total must be at least the commitment (true-up bumps up).
-		if total.LessThan(commitment.Sub(epsilon)) {
+		// Under leg: total must be at least commitment + base fee (true-up bumps up).
+		expectedMin := commitment.Add(baseFee)
+		if total.LessThan(expectedMin.Sub(epsilon)) {
 			return e2eprobe.Errorf(map[string]string{
 				"step": "assert_commitment_under", "external_customer_id": ext, "subscription_id": subID,
-				"preview_total": total.String(),
-			}, "under-leg preview total %s < commitment %s; expected true-up to bring total to at least %s", total, commitment, commitment)
+				"preview_total": total.String(), "expected_min": expectedMin.String(),
+			}, "under-leg preview total %s < commitment+base %s; expected true-up to bring total to at least %s", total, expectedMin, expectedMin)
 		}
 		if !hasCommitmentTrueUpLine(inv) {
 			return e2eprobe.Errorf(map[string]string{
@@ -171,12 +199,13 @@ func (p *CommitmentTrueUpProbe) assertPreview(inv *types.InvoiceResponse, overLe
 		return nil
 	}
 
-	// Over leg: total ≈ commitment + (usage_past_commitment × 1.5) = $5 + $2×1.5 = $8.
-	expected := decimal.NewFromFloat(8.00)
+	// Over leg: total ≈ commitment + (usage_past_commitment × 1.5) + base
+	//         = $5 + $2×1.5 + $19.99 = $27.99.
+	expected := decimal.NewFromFloat(8.00).Add(baseFee)
 	if total.Sub(expected).Abs().GreaterThan(epsilon) {
 		return e2eprobe.Errorf(map[string]string{
 			"step": "assert_commitment_over", "external_customer_id": ext, "subscription_id": subID,
-			"preview_total": total.String(),
+			"preview_total": total.String(), "expected": expected.String(),
 		}, "over-leg preview total %s differs from expected %s by more than %s", total, expected, epsilon)
 	}
 	return nil

--- a/internal/e2eprobe/checks/commitment_true_up_probe_test.go
+++ b/internal/e2eprobe/checks/commitment_true_up_probe_test.go
@@ -18,7 +18,8 @@ func TestCommitmentTrueUpProbe_UnderLeg(t *testing.T) {
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 	reg.LoadSeeds(e2eprobe.Seeds{PlanIDs: []string{"plan_1"}})
 
-	total := "5.00"
+	// commitment ($5) + base fee ($19.99) = $24.99 minimum.
+	total := "24.99"
 	displayName := "Commitment True-Up"
 	fc.invoices.previewResp = &sdkdtos.GetInvoicePreviewResponse{
 		InvoiceResponse: &sdktypes.InvoiceResponse{
@@ -46,7 +47,8 @@ func TestCommitmentTrueUpProbe_OverLeg(t *testing.T) {
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 	reg.LoadSeeds(e2eprobe.Seeds{PlanIDs: []string{"plan_1"}})
 
-	total := "8.00"
+	// commitment ($5) + overage ($2 × 1.5) + base fee ($19.99) = $27.99.
+	total := "27.99"
 	fc.invoices.previewResp = &sdkdtos.GetInvoicePreviewResponse{
 		InvoiceResponse: &sdktypes.InvoiceResponse{Total: &total},
 	}
@@ -67,8 +69,9 @@ func TestCommitmentTrueUpProbe_UnderLegMissingTrueUpLineFails(t *testing.T) {
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 	reg.LoadSeeds(e2eprobe.Seeds{PlanIDs: []string{"plan_1"}})
 
-	// Preview has correct total but no true-up marker on any line item.
-	total := "5.00"
+	// Preview has correct total ($24.99 = commitment + base) but no true-up
+	// marker on any line item.
+	total := "24.99"
 	unrelated := "Base Fee"
 	fc.invoices.previewResp = &sdkdtos.GetInvoicePreviewResponse{
 		InvoiceResponse: &sdktypes.InvoiceResponse{

--- a/internal/e2eprobe/checks/coupon_application_probe.go
+++ b/internal/e2eprobe/checks/coupon_application_probe.go
@@ -38,7 +38,10 @@ func (p *CouponApplicationProbe) Kind() e2eprobe.Kind { return e2eprobe.KindScen
 
 func (p *CouponApplicationProbe) Run(ctx context.Context) error {
 	seeds := p.reg.Seeds()
-	if len(seeds.PlanIDs) == 0 || seeds.SharedCouponCode == "" {
+	// SharedCouponID is required — the assertion at the end matches coupon
+	// applications by ID, so a missing ID is an unmet prerequisite (not a
+	// failure worth paging on-call for).
+	if len(seeds.PlanIDs) == 0 || seeds.SharedCouponCode == "" || seeds.SharedCouponID == "" {
 		return nil
 	}
 	planID := seeds.PlanIDs[0]

--- a/internal/e2eprobe/checks/entitlement_enforcement_probe.go
+++ b/internal/e2eprobe/checks/entitlement_enforcement_probe.go
@@ -61,8 +61,11 @@ func (p *EntitlementEnforcementProbe) Run(ctx context.Context) error {
 	if err != nil {
 		return e2eprobe.Errorf(map[string]string{"step": "query_entitlement", "plan_id": planID, "feature_id": featID}, "query entitlement: %w", err)
 	}
+	// Soft-skip when the plan-level entitlement hasn't been seeded yet — the
+	// seed step lands asynchronously and running before it does would page
+	// on-call for a still-pending prerequisite.
 	if entResp.ListEntitlementsResponse == nil || len(entResp.ListEntitlementsResponse.Items) == 0 {
-		return e2eprobe.Errorf(map[string]string{"step": "assert_entitlement_exists", "plan_id": planID, "feature_id": featID}, "no entitlement for feature %s on plan %s", featID, planID)
+		return nil
 	}
 	ent := entResp.ListEntitlementsResponse.Items[0]
 	if ent.UsageLimit == nil || *ent.UsageLimit != 100 {

--- a/internal/e2eprobe/checks/entitlement_enforcement_probe_test.go
+++ b/internal/e2eprobe/checks/entitlement_enforcement_probe_test.go
@@ -71,16 +71,20 @@ func TestEntitlementEnforcementProbe_HappyPath(t *testing.T) {
 	}
 }
 
-func TestEntitlementEnforcementProbe_MissingEntitlementFails(t *testing.T) {
+func TestEntitlementEnforcementProbe_MissingEntitlementSoftSkip(t *testing.T) {
 	fc, regPtr := entTestFake(t)
 	reg := *regPtr
-	// Drop the entitlement response — probe must fail with assert_entitlement_exists.
+	// Drop the entitlement response — an absent entitlement means the seed
+	// step hasn't landed yet; the probe must soft-skip, not page on-call.
 	fc.entitlements.queryResp = nil
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 
 	p := NewEntitlementEnforcementProbe(fc, reg, "test-run", lg)
-	if err := p.Run(context.Background()); err == nil {
-		t.Fatalf("expected error when entitlement absent, got nil")
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("absent entitlement must soft-skip; got %v", err)
+	}
+	if len(fc.customers.created) != 0 {
+		t.Errorf("no customer should be created when entitlement prerequisite unmet")
 	}
 }
 

--- a/internal/e2eprobe/checks/entitlement_grant_additive_probe.go
+++ b/internal/e2eprobe/checks/entitlement_grant_additive_probe.go
@@ -151,11 +151,16 @@ func (p *EntitlementGrantAdditiveProbe) pollSubEntitlementPresent(ctx context.Co
 
 func (p *EntitlementGrantAdditiveProbe) pollRawEvents(ctx context.Context, ext, subID, featID string) error {
 	eventName := "e2eprobe_sum_multiplier"
+	// POST /events/query defaults PageSize=50, but the probe ingests 200
+	// events and asserts len(...) >= 200 — request 200 in a single page so
+	// the assertion can succeed without paginating.
+	pageSize := int64(200)
 	deadline := time.Now().Add(30 * time.Second)
 	for {
 		resp, err := p.client.Events().ListRaw(ctx, types.GetEventsRequest{
 			ExternalCustomerID: &ext,
 			EventName:          &eventName,
+			PageSize:           &pageSize,
 		})
 		if err == nil && resp.GetEventsResponse != nil && len(resp.GetEventsResponse.Events) >= 200 {
 			return nil

--- a/internal/e2eprobe/checks/fakeclient_test.go
+++ b/internal/e2eprobe/checks/fakeclient_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/flexprice/flexprice/internal/e2eprobe"
@@ -324,7 +325,12 @@ func (f *fakeSubscriptions) GetEntitlements(_ context.Context, _ string, _ []str
 	return &dtos.GetSubscriptionEntitlementsResponse{}, nil
 }
 func (f *fakeSubscriptions) GetUsage(_ context.Context, _ types.GetUsageBySubscriptionRequest) (*dtos.GetSubscriptionUsageResponse, error) {
-	return &dtos.GetSubscriptionUsageResponse{}, nil
+	// Return a large enough Amount that probe usage-threshold gates always
+	// pass in unit tests — the polling loop is exercised in staging.
+	amt := 1e12
+	return &dtos.GetSubscriptionUsageResponse{
+		GetUsageBySubscriptionResponse: &types.GetUsageBySubscriptionResponse{Amount: &amt},
+	}, nil
 }
 func (f *fakeSubscriptions) CreateLineItem(_ context.Context, _ string, _ types.CreateSubscriptionLineItemRequest) (*dtos.CreateSubscriptionLineItemResponse, error) {
 	return &dtos.CreateSubscriptionLineItemResponse{}, nil
@@ -685,6 +691,11 @@ type fakeCoupons struct {
 	byCode    map[string]string // code -> id
 }
 
+// normalizeCouponCode mirrors internal/repository/ent/coupon.go: the real
+// repo lowercases/trims coupon codes on INSERT and stores the normalized
+// form, so the fake must do the same for the CouponCodes filter to hit.
+func normalizeCouponCode(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+
 func (f *fakeCoupons) Create(_ context.Context, req types.CreateCouponRequest) (*dtos.CreateCouponResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -697,7 +708,7 @@ func (f *fakeCoupons) Create(_ context.Context, req types.CreateCouponRequest) (
 		if f.byCode == nil {
 			f.byCode = map[string]string{}
 		}
-		f.byCode[*req.CouponCode] = id
+		f.byCode[normalizeCouponCode(*req.CouponCode)] = id
 	}
 	return &dtos.CreateCouponResponse{
 		CouponResponse: &types.CouponResponse{ID: &id, CouponCode: req.CouponCode, Name: &req.Name},
@@ -708,8 +719,9 @@ func (f *fakeCoupons) Query(_ context.Context, filter types.CouponFilter) (*dtos
 	defer f.mu.Unlock()
 	var items []types.CouponResponse
 	for _, code := range filter.CouponCodes {
-		if id, ok := f.byCode[code]; ok {
-			c := code
+		norm := normalizeCouponCode(code)
+		if id, ok := f.byCode[norm]; ok {
+			c := norm
 			i := id
 			items = append(items, types.CouponResponse{ID: &i, CouponCode: &c})
 		}

--- a/internal/e2eprobe/checks/persistent_billing_invariants_probe.go
+++ b/internal/e2eprobe/checks/persistent_billing_invariants_probe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/flexprice/go-sdk/v2/models/types"
 )
 
-// PersistentBillingInvariantsProbe queries the latest cycle invoice for
+// persistentBillingInvariantsProbe queries the latest cycle invoice for
 // persistent cust #0 (tax-attached) and cust #1 (coupon-attached), asserting
 // that each invoice contains the seeded tax rate / coupon association.
 //
@@ -18,21 +18,21 @@ import (
 //
 // Soft-skips when the seed hasn't run, when persistent customers haven't
 // been provisioned, or when no invoice exists yet for the customer.
-type PersistentBillingInvariantsProbe struct {
+type persistentBillingInvariantsProbe struct {
 	client e2eprobe.Client
 	reg    e2eprobe.Registry
 	runID  string
 	lg     *logger.Logger
 }
 
-func NewPersistentBillingInvariantsProbe(c e2eprobe.Client, r e2eprobe.Registry, runID string, lg *logger.Logger) *PersistentBillingInvariantsProbe {
-	return &PersistentBillingInvariantsProbe{client: c, reg: r, runID: runID, lg: lg}
+func NewPersistentBillingInvariantsProbe(c e2eprobe.Client, r e2eprobe.Registry, runID string, lg *logger.Logger) e2eprobe.Check {
+	return &persistentBillingInvariantsProbe{client: c, reg: r, runID: runID, lg: lg}
 }
 
-func (p *PersistentBillingInvariantsProbe) Name() string        { return "persistent-billing-invariants-probe" }
-func (p *PersistentBillingInvariantsProbe) Kind() e2eprobe.Kind { return e2eprobe.KindProbe }
+func (p *persistentBillingInvariantsProbe) Name() string        { return "persistent-billing-invariants-probe" }
+func (p *persistentBillingInvariantsProbe) Kind() e2eprobe.Kind { return e2eprobe.KindProbe }
 
-func (p *PersistentBillingInvariantsProbe) Run(ctx context.Context) error {
+func (p *persistentBillingInvariantsProbe) Run(ctx context.Context) error {
 	seeds := p.reg.Seeds()
 	if len(seeds.PersistentCustomerIDs) < 2 {
 		return nil
@@ -70,7 +70,7 @@ func (p *PersistentBillingInvariantsProbe) Run(ctx context.Context) error {
 	return nil
 }
 
-func (p *PersistentBillingInvariantsProbe) latestInvoice(ctx context.Context, extID string) (*types.InvoiceResponse, error) {
+func (p *persistentBillingInvariantsProbe) latestInvoice(ctx context.Context, extID string) (*types.InvoiceResponse, error) {
 	limit := int64(1)
 	resp, err := p.client.Invoices().Query(ctx, types.InvoiceFilter{
 		ExternalCustomerID: &extID,

--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -332,8 +332,14 @@ func (s *SeedEnsure) ensureFeatures(ctx context.Context, out *e2eprobe.Seeds) er
 // persistent cust #1. Lookup is by CouponCode (the SDK's canonical id for
 // coupons — CreateCouponRequest has no lookup_key field).
 func (s *SeedEnsure) ensureCoupons(ctx context.Context, out *e2eprobe.Seeds) error {
+	// The coupon repo lowercases coupon_code on INSERT (see
+	// internal/repository/ent/coupon.go:80), so the stored code differs from
+	// SharedCouponCode's on-the-wire casing. Query with the same
+	// normalization so idempotency works — otherwise the existence check
+	// misses and CREATE returns 409 on the next run.
+	normalizedCode := strings.ToLower(strings.TrimSpace(SharedCouponCode))
 	existResp, err := s.client.Coupons().Query(ctx, types.CouponFilter{
-		CouponCodes: []string{SharedCouponCode},
+		CouponCodes: []string{normalizedCode},
 	})
 	if err != nil {
 		return e2eprobe.Errorf(map[string]string{"step": "query_coupons"}, "query coupons: %w", err)
@@ -361,6 +367,22 @@ func (s *SeedEnsure) ensureCoupons(ctx context.Context, out *e2eprobe.Seeds) err
 		},
 	})
 	if err != nil {
+		// A concurrent seed run (or a manual create) can win the race between
+		// the query above and this create; re-query to recover the ID so the
+		// caller still has SharedCouponID populated.
+		if isAlreadyExists(err) {
+			retryResp, retryErr := s.client.Coupons().Query(ctx, types.CouponFilter{
+				CouponCodes: []string{normalizedCode},
+			})
+			if retryErr == nil && retryResp.ListCouponsResponse != nil && len(retryResp.ListCouponsResponse.Items) > 0 {
+				c := retryResp.ListCouponsResponse.Items[0]
+				if c.ID != nil {
+					out.SharedCouponID = *c.ID
+				}
+				out.SharedCouponCode = SharedCouponCode
+				return nil
+			}
+		}
 		return e2eprobe.Errorf(map[string]string{"coupon_code": SharedCouponCode}, "create coupon: %w", err)
 	}
 	if createResp.CouponResponse != nil && createResp.CouponResponse.ID != nil {
@@ -451,13 +473,19 @@ func isAlreadyExists(err error) bool {
 
 // bucketedFeatureLookupKeys is the set of lookup keys whose features are
 // bucketed meters — plan-level entitlements are NOT provisioned for these
-// to keep entitlement enforcement scoped to the 8 non-bucketed metered
-// features. entitlement-enforcement-probe asserts against e2eprobe_count.
-var bucketedFeatureLookupKeys = map[string]bool{
-	"e2eprobe_max_15min_feature": true,
-	"e2eprobe_sum_hour_feature":  true,
-	"e2eprobe_max_day_feature":   true,
-}
+// because the server rejects entitlements on bucketed max meters
+// ("Bucketed max meters process each bucket independently and cannot
+// have entitlements"). Derived from seedFeatureSpecs (bucketSize != nil)
+// so a new bucketed spec is auto-skipped without touching this file.
+var bucketedFeatureLookupKeys = func() map[string]bool {
+	m := map[string]bool{}
+	for _, spec := range seedFeatureSpecs {
+		if spec.bucketSize != nil {
+			m[spec.lookupKey] = true
+		}
+	}
+	return m
+}()
 
 // grantOnlyFeatures is the set of feature lookup keys reserved for
 // grant entitlements. ensurePlanEntitlements skips these; the grant
@@ -808,9 +836,17 @@ func (s *SeedEnsure) ensureEntitlementGrants(ctx context.Context, out *e2eprobe.
 			// grant entitlement, its absence a legacy soft-limit one.
 			raw, rawErr := s.client.Entitlements().GetRaw(ctx, *e.ID)
 			if rawErr != nil {
-				// Best-effort: treat unreadable as legacy for cleanup safety.
-				legacySoftLimitID = *e.ID
-				continue
+				// Never classify on a failed read: a transient 5xx / timeout
+				// would otherwise mark a healthy grant entitlement as legacy
+				// and delete it below. Bubble the error up — the caller
+				// (ensureEntitlementGrants) is non-fatal, so on-call gets one
+				// log line and the next tick retries without destroying state.
+				return e2eprobe.Errorf(map[string]string{
+					"step":           "classify_existing_entitlement",
+					"plan_id":        planID,
+					"feature_id":     featID,
+					"entitlement_id": *e.ID,
+				}, "read existing entitlement for classification: %w", rawErr)
 			}
 			if raw.GrantMeasure != "" {
 				existingGrantID = *e.ID

--- a/internal/e2eprobe/checks/seed_ensure_test.go
+++ b/internal/e2eprobe/checks/seed_ensure_test.go
@@ -319,14 +319,15 @@ func TestSeedEnsure_PlanEntitlementsProvisioned(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 	seeds := reg.Seeds()
-	// 8 non-bucketed metered features get plan-level entitlements.
-	if len(seeds.PlanEntitlementIDs) != 7 {
-		t.Errorf("PlanEntitlementIDs = %d, want 7 (one per non-bucketed feature MINUS the reserved additive-grant feature); got %v", len(seeds.PlanEntitlementIDs), seeds.PlanEntitlementIDs)
+	// 11 total specs − 4 bucketed (e2eprobe_max/max_15min/sum_hour/max_day)
+	// − 1 grant-only (e2eprobe_sum_multiplier) = 6 soft-limit entitlements.
+	if len(seeds.PlanEntitlementIDs) != 6 {
+		t.Errorf("PlanEntitlementIDs = %d, want 6 (non-bucketed features MINUS the reserved additive-grant feature); got %v", len(seeds.PlanEntitlementIDs), seeds.PlanEntitlementIDs)
 	}
 	// Every created entitlement carries usage_limit=100, is_soft_limit=true,
 	// reset_period=MONTHLY, is_enabled=true.
-	if len(fc.entitlements.created) != 7 {
-		t.Errorf("entitlements Create called %d times, want 7 (grant-only feature excluded from soft-limit seeding)", len(fc.entitlements.created))
+	if len(fc.entitlements.created) != 6 {
+		t.Errorf("entitlements Create called %d times, want 6 (grant-only feature excluded from soft-limit seeding)", len(fc.entitlements.created))
 	}
 	for i, req := range fc.entitlements.created {
 		if req.UsageLimit == nil || *req.UsageLimit != 100 {
@@ -462,14 +463,14 @@ func TestSeedEnsure_PlanEntitlements_SkipsGrantFeature(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 	// The additive-grant feature must NOT get a soft-limit entitlement.
-	// Before this change, all 8 non-bucketed features were entitled;
-	// now it's 7. The SDK typed Create is invoked once per soft-limit
+	// 11 total specs − 4 bucketed features − 1 grant-only = 6 soft-limit
+	// entitlements. The SDK typed Create is invoked once per soft-limit
 	// entitlement, so a strict count check is sufficient — the seed
 	// queries features by lookup key and skips the grant feature at
 	// that lookup step, so no create call for the grant feature ever
 	// reaches the fake.
-	if len(fc.entitlements.created) != 7 {
-		t.Errorf("plan-level soft-limit entitlements created = %d, want 7 (8 non-bucketed features minus the reserved grant feature)", len(fc.entitlements.created))
+	if len(fc.entitlements.created) != 6 {
+		t.Errorf("plan-level soft-limit entitlements created = %d, want 6 (non-bucketed features minus the reserved grant feature)", len(fc.entitlements.created))
 	}
 }
 

--- a/internal/e2eprobe/checks/tax_application_probe.go
+++ b/internal/e2eprobe/checks/tax_application_probe.go
@@ -157,12 +157,16 @@ func (p *TaxApplicationProbe) Run(ctx context.Context) error {
 		// nested TaxRate.Code == SharedTaxRateCode. Seeds.SharedTaxRateID is
 		// empty when the SDK's broken GetTaxRates list + our create-only
 		// idempotency workaround couldn't recover the ID.
-		if tx.TaxRateID != nil && seeds.SharedTaxRateID != "" && *tx.TaxRateID == seeds.SharedTaxRateID {
-			found = true
+		matches := tx.TaxRateID != nil && seeds.SharedTaxRateID != "" && *tx.TaxRateID == seeds.SharedTaxRateID
+		if !matches && tx.TaxRate != nil && tx.TaxRate.Code != nil && *tx.TaxRate.Code == seeds.SharedTaxRateCode {
+			matches = true
 		}
-		if !found && tx.TaxRate != nil && tx.TaxRate.Code != nil && *tx.TaxRate.Code == seeds.SharedTaxRateCode {
-			found = true
+		if !matches {
+			// A different tax entry — e.g. a rate applied through a customer-level
+			// association. Not ours to assert 10% math on.
+			continue
 		}
+		found = true
 		if tx.TaxableAmount != nil && tx.TaxAmount != nil {
 			taxable, err1 := decimal.NewFromString(*tx.TaxableAmount)
 			amt, err2 := decimal.NewFromString(*tx.TaxAmount)


### PR DESCRIPTION
## **CodeAnt-AI Description**
Make end-to-end probes reliable with asynchronous seeding and current billing totals

### What Changed
- Probes now wait for usage aggregation to reach the expected amount and request enough events to verify all ingested records
- Missing seed prerequisites are treated as skips instead of failures, avoiding unnecessary alerts and test data creation
- Commitment true-up checks now include the plan’s fixed base fee and validate the actual aggregated usage
- Coupon lookups normalize casing and whitespace, recover from concurrent creation, and keep repeated seeding idempotent
- Seed setup skips unsupported bucketed meters and avoids deleting existing entitlements when classification reads fail
- Tax checks validate only the intended tax rate, while fake clients now match production coupon and usage behavior

### Impact
`✅ Fewer false end-to-end alerts`
`✅ Reliable coupon seeding across repeated runs`
`✅ Accurate commitment and tax invoice checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated commitment billing validations to include the subscription’s base fee and accurately account for overage charges.
  * Improved usage aggregation checks with clearer timeout diagnostics and resilience to temporary errors.
  * Corrected tax validation to select the applicable tax entry and ignore unrelated entries.
  * Standardized coupon code handling and improved recovery when duplicate coupons already exist.
  * Prevented unsafe entitlement removal when entitlement details cannot be read.

* **Reliability**
  * Probes now safely skip when required plans, coupons, or entitlements are not yet available.
  * Event validation now retrieves the full expected batch before checking results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->