### PR TITLE
fix(helm): re-run migration Job on image change; port ArgoCD hook fixes to develop

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -21,8 +21,22 @@ metadata:
     flexprice.env is the actual config surface (74 vars in a production region),
     so hashing it gives a suffix that is stable when config is unchanged and
     changes whenever it is — which is what the checksum was always meant to do.
+
+    The resolved image reference is hashed ALONGSIDE the environment, because
+    the environment alone is not enough. New migrations ship inside the app
+    image, not in the config: a deploy that only bumps image.tag (the normal
+    case — image-updater writes the tag back and nothing else changes) leaves
+    flexprice.env byte-identical, so the Job name is unchanged, so ArgoCD sees
+    a hook already completed for that name and skips it. The new image's
+    migrations never run and the pods roll out against a database one schema
+    version behind.
+
+    Including the image means every image change produces a new Job name and
+    therefore a run. Migrations are idempotent (Ent/Atlas no-op when the schema
+    already matches, the ClickHouse and seed steps are IF NOT EXISTS /
+    ON CONFLICT DO NOTHING), so an extra run on an unchanged schema is cheap.
   */}}
-  name: {{ include "flexprice.fullname" . }}-migration-{{ include "flexprice.env" . | sha256sum | trunc 8 }}
+  name: {{ include "flexprice.fullname" . }}-migration-{{ printf "%s|%s:%s" (include "flexprice.env" .) .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) | sha256sum | trunc 8 }}
   labels:
     {{- include "flexprice.labels" . | nindent 4 }}
     app.kubernetes.io/component: migration
@@ -32,7 +46,8 @@ metadata:
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-weight": "-5"
     {{- /*
-      hook-succeeded ONLY — deliberately NOT before-hook-creation.
+      hook-succeeded and hook-failed only — deliberately NOT
+      before-hook-creation.
 
       ArgoCD implements before-hook-creation by deleting the existing hook
       resource and then immediately reconciling against it, which races itself:
@@ -43,14 +58,16 @@ metadata:
       still roll out, leaving pods running against an unmigrated database.
 
       Nothing is lost by dropping it: the Job name already embeds a checksum of
-      the rendered ConfigMap (see metadata.name above), so a changed config
-      produces a differently-named Job and there is no same-named predecessor
-      to clear. hook-succeeded still removes the Job once it completes.
+      the rendered environment and the resolved image reference (see
+      metadata.name above), so a changed config or image produces a
+      differently-named Job and there is no same-named predecessor to clear.
+      hook-succeeded still removes the Job once it completes.
     */}}
     {{- /*
       hook-failed is paired with hook-succeeded so the Job is removed whichever
       way it ends. Without it a FAILED Job lingers under a name derived from the
-      config checksum, and retrying with unchanged config collides with it:
+      environment and image checksum, and retrying with an unchanged config and
+      image collides with it:
       ArgoCD reports the hook as already-completed and never re-runs it, or the
       apply fails on an immutable Job spec. That is precisely what stalled the
       northamerica-northeast2 bring-up — the migration had failed once, and


### PR DESCRIPTION
## **User description**
## What

Make the migration Job re-run on every image change, and bring `develop`'s copy of `templates/jobs/migration.yaml` up to `main`'s — it was missing the ArgoCD hook fixes entirely.

## Why: migrations skipped on an image-only bump

The Job's name suffix hashed only the rendered environment. A deploy that bumps `image.tag` and nothing else — the normal case, since image-updater writes the tag back — leaves `flexprice.env` byte-identical, so the Job name is unchanged. ArgoCD sees a hook already completed under that name and skips it.

The new image's migrations never run. Pods roll out Running against a database one schema version behind, and `/health` doesn't touch Postgres, so nothing surfaces it.

The suffix now hashes the resolved image reference alongside the environment:

```
name: ...-migration-{{ printf "%s|%s:%s" (include "flexprice.env" .) .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) | sha256sum | trunc 8 }}
```

Every image change yields a new name and therefore a run. Migrations are idempotent — Ent/Atlas no-op on a matching schema, ClickHouse/database/extension steps are `IF NOT EXISTS`, seed is `ON CONFLICT DO NOTHING` — so a run against an unchanged schema is a cheap no-op.

## Why the diff is larger than one line

The ArgoCD hook fixes landed on `main` via #2541 and were never back-merged. `develop` still carried:

- **Constant name suffix** — hashed `templates/app/configmap.yaml`, which renders empty (app config moved out of a ConfigMap), producing an identical suffix for every release in every region. Fatal under ArgoCD: the hook is recorded complete for the revision and never recreated, and a hand-made Job with that name is pruned as a duplicate.
- **`hook-delete-policy: before-hook-creation`** — ArgoCD implements this as delete-then-immediately-reconcile, which races itself: `Resource batch/Job/<name> is missing, it might have been deleted`. PreSync never advances past the ServiceAccount.
- **No `hook-failed`** — a failed Job lingered under its checksum name, so retrying with unchanged config collided with it and every later sync silently declined to re-run. This is what stalled the northamerica-northeast2 bring-up.

Both now match `main`: `hook-delete-policy: hook-succeeded,hook-failed`.

Without this, the next `develop` → `main` merge would regress `main` and reintroduce that failure.

## Cleanup

No Job accumulation despite more names being generated. `hook-succeeded,hook-failed` removes the Job whichever way it ends; `ttlSecondsAfterFinished` (default 3600) is a backstop for anything created out-of-band. Trade-off, unchanged from `main`: logs from a *failed* migration are lost with the Job, in exchange for retry being immediate rather than blocked for an hour.

## Verification

Render-level only — `helm lint` clean, plus:

```
v1.0.0 -> fp-flexprice-migration-c8e82cee
v2.0.0 -> fp-flexprice-migration-15645997
v1.0.0 -> fp-flexprice-migration-c8e82cee   (deterministic, no churn on resync)
```

and the emitted Job carries `"helm.sh/hook-delete-policy": hook-succeeded,hook-failed`.

**Not exercised against a live cluster** — no ArgoCD sync was run to confirm the hook actually fires on an image bump in practice. Worth a scratch/staging sync before this rides to a production region.

## Note for reviewers

This makes migrations run on *every* image bump, including tags with no migration content: roughly a 30s Job in the PreSync path of each deploy, and a migration failure now blocks a rollout it previously would have sailed past. That is the intended trade — surfacing schema skew beats silent drift — but it does make deploys slower and more brittle by design.


___

## **CodeAnt-AI Description**
Ensure database migrations run reliably for new images and fresh environments

### What Changed
- Migration jobs now run again when the application image or configuration changes, instead of being skipped by ArgoCD
- Failed migration jobs are removed so later deployments can retry immediately without name conflicts
- Fresh PostgreSQL and ClickHouse environments are initialized automatically before migrations run
- ClickHouse migrations now use the application’s migration runner and support ClickHouse instances in another namespace

### Impact
`✅ Fewer deployments with an outdated database schema`
`✅ Automatic recovery after failed migrations`
`✅ Successful setup of new PostgreSQL and ClickHouse environments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database setup now automatically creates the target PostgreSQL database when it is missing.
  * Improved ClickHouse connectivity in namespaced deployments.
  * Migration jobs now rerun when relevant configuration or migration images change.
  * Successful and failed migration jobs are cleaned up automatically to support reliable retries.

* **Improvements**
  * Streamlined ClickHouse migration execution for more consistent deployment upgrades.
  * Removed obsolete migration resources and simplified upgrade processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->