### PR TITLE
feat(saml): SAML 2.0 single sign-on

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/dynamodb"
+	"github.com/flexprice/flexprice/internal/ee/auth/saml"
 	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/httpclient"
 	integrationevents "github.com/flexprice/flexprice/internal/integration/events"
@@ -314,6 +315,7 @@ func main() {
 func provideHandlers(
 	cfg *config.Configuration,
 	logger *logger.Logger,
+	serviceParams service.ServiceParams,
 	redisCache cache.RedisCache,
 	locker cache.Locker,
 	meterService service.MeterService,
@@ -423,6 +425,7 @@ func provideHandlers(
 		Dashboard:                v1.NewDashboardHandler(dashboardService, logger),
 		Workflow:                 v1.NewWorkflowHandler(workflowService, logger),
 		MeterUsage:               v1.NewMeterUsageHandler(meterUsageService, logger),
+		SAML:                     saml.NewHandler(cfg, serviceParams, logger),
 		CheckoutSession:          v1.NewCheckoutSessionHandler(checkoutSessionService, logger),
 	}
 }

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -1917,9 +1917,12 @@ var (
 		PrimaryKey: []*schema.Column{SettingsColumns[0]},
 		Indexes: []*schema.Index{
 			{
-				Name:    "settings_tenant_id_environment_id_status_key",
+				Name:    "settings_tenant_id_environment_id_key",
 				Unique:  true,
-				Columns: []*schema.Column{SettingsColumns[1], SettingsColumns[7], SettingsColumns[2], SettingsColumns[8]},
+				Columns: []*schema.Column{SettingsColumns[1], SettingsColumns[7], SettingsColumns[8]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "((status)::text = 'published'::text)",
+				},
 			},
 		},
 	}

--- a/ent/schema/settings.go
+++ b/ent/schema/settings.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	"github.com/flexprice/flexprice/ent/schema/mixin"
@@ -49,6 +50,14 @@ func (Settings) Edges() []ent.Edge {
 // Indexes of the Settings.
 func (Settings) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("tenant_id", "environment_id", "status", "key").Unique(),
+		// Uniqueness applies to the live row only. With status inside the index
+		// instead, exactly one archived row could exist per setting, so deleting
+		// a key twice — delete, recreate, delete again — collided with the
+		// previous tombstone and failed. Restricting the constraint to published
+		// rows lets deletion history accumulate and keeps the guarantee that
+		// matters: one live configuration per tenant, environment and key.
+		index.Fields("tenant_id", "environment_id", "key").
+			Unique().
+			Annotations(entsql.IndexWhere("((status)::text = 'published'::text)")),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,9 @@ require (
 )
 
 require (
+	github.com/beevik/etree v1.5.0 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
+	github.com/crewjam/saml v0.5.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
@@ -89,8 +91,11 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
+	github.com/russellhaering/goxmldsig v1.4.0 // indirect
 	github.com/sv-tools/openapi v0.4.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.6.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chargebee/chargebee-go/v3 v3.39.0
 	github.com/cockroachdb/errors v1.11.3
+	github.com/crewjam/saml v0.5.1
 	github.com/flexprice/go-sdk/v2 v2.0.24
 	github.com/getsentry/sentry-go v0.43.0
 	github.com/gin-gonic/gin v1.12.0
@@ -78,9 +79,8 @@ require (
 )
 
 require (
-	github.com/beevik/etree v1.5.0 // indirect
+	github.com/beevik/etree v1.7.0 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
-	github.com/crewjam/saml v0.5.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
@@ -91,11 +91,11 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/mattermost/xml-roundtrip-validator v0.1.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
-	github.com/russellhaering/goxmldsig v1.4.0 // indirect
+	github.com/russellhaering/goxmldsig v1.6.1 // indirect
 	github.com/sv-tools/openapi v0.4.0 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.6.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,9 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.3 h1:Xgv/hyNgvLda/M9l9qxXc4UFSgpp
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.3/go.mod h1:5Gn+d+VaaRgsjewpMvGazt0WfcFO+Md4wLOuBfGR9Bc=
 github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
 github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
+github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
+github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
@@ -117,6 +120,8 @@ github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/crewjam/saml v0.5.1 h1:g+mfp0CrLuLRZCK793PgJcZeg5dS/0CDwoeAX2zcwNI=
+github.com/crewjam/saml v0.5.1/go.mod h1:r0fDkmFe5URDgPrmtH0IYokva6fac3AUdstiPhyEolQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -315,6 +320,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -351,6 +358,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=
+github.com/mattermost/xml-roundtrip-validator v0.1.0/go.mod h1:qccnGMcpgwcNaBnxqpJpWWUiPNr5H3O8eDgGV9gT5To=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
@@ -414,9 +423,12 @@ github.com/resend/resend-go/v2 v2.26.0/go.mod h1:3YCb8c8+pLiqhtRFXTyFwlLvfjQtlux
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYzkPUJ7Qhys=
+github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -383,6 +385,8 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/go.sum
+++ b/go.sum
@@ -82,9 +82,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.3 h1:Xgv/hyNgvLda/M9l9qxXc4UFSgpp
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.3/go.mod h1:5Gn+d+VaaRgsjewpMvGazt0WfcFO+Md4wLOuBfGR9Bc=
 github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
 github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
-github.com/beevik/etree v1.5.0 h1:iaQZFSDS+3kYZiGoc9uKeOkUY3nYMXOKLl6KIJxiJWs=
-github.com/beevik/etree v1.5.0/go.mod h1:gPNJNaBGVZ9AwsidazFZyygnd+0pAU38N4D+WemwKNs=
+github.com/beevik/etree v1.7.0 h1:xjBk9O4p4x7D1YajePjfLzdaFC4/uYUENA7P0pv6gXA=
+github.com/beevik/etree v1.7.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
@@ -320,8 +319,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
-github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
-github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -423,12 +422,11 @@ github.com/resend/resend-go/v2 v2.26.0/go.mod h1:3YCb8c8+pLiqhtRFXTyFwlLvfjQtlux
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/russellhaering/goxmldsig v1.4.0 h1:8UcDh/xGyQiyrW+Fq5t8f+l2DLB1+zlhYzkPUJ7Qhys=
-github.com/russellhaering/goxmldsig v1.4.0/go.mod h1:gM4MDENBQf7M+V824SGfyIUVFWydB7n0KkEubVJl+Tw=
+github.com/russellhaering/goxmldsig v1.6.1 h1:SB7R5ttvrGIDB2juJAK/i7DQ2Ivr7agG+ohfNJjwyYU=
+github.com/russellhaering/goxmldsig v1.6.1/go.mod h1:haZkRcLs9W/Xp989fIjP3BrTdbFQveRF0QNZSYoH09w=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
@@ -758,5 +756,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -705,12 +705,19 @@ func NewRouter(
 		webhooks.POST("/whop/:tenant_id/:environment_id", handlers.Webhook.HandleWhopWebhook)
 	}
 
-	// Settings routes
+	// Settings routes.
+	//
+	// Super admin throughout, reads included. The route is shared by every
+	// settings key, and some of them decide how people authenticate — a SAML
+	// configuration names the identity provider the tenant trusts, so an
+	// all_writer who could change it can have themselves provisioned in, and
+	// anyone who could read it learns which provider to attack and whether it
+	// has been approved.
 	settings := v1Private.Group("/settings")
 	{
-		settings.GET("/:key", handlers.Settings.GetSettingByKey)
-		settings.PUT("/:key", write(types.EntitySetting, types.ActionWrite), handlers.Settings.UpdateSettingByKey)
-		settings.DELETE("/:key", write(types.EntitySetting, types.ActionWrite), handlers.Settings.DeleteSettingByKey)
+		settings.GET("/:key", read(types.EntitySetting, types.ActionRead, superAdminOnly), handlers.Settings.GetSettingByKey)
+		settings.PUT("/:key", write(types.EntitySetting, types.ActionWrite, superAdminOnly), handlers.Settings.UpdateSettingByKey)
+		settings.DELETE("/:key", write(types.EntitySetting, types.ActionWrite, superAdminOnly), handlers.Settings.DeleteSettingByKey)
 	}
 
 	// Alert routes

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -7,6 +7,7 @@ import (
 	domainEnvironment "github.com/flexprice/flexprice/internal/domain/environment"
 	domainIncomingWebhookEvent "github.com/flexprice/flexprice/internal/domain/incomingwebhookevent"
 	domainUser "github.com/flexprice/flexprice/internal/domain/user"
+	"github.com/flexprice/flexprice/internal/ee/auth/saml"
 	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/rbac"
@@ -62,6 +63,9 @@ type Handlers struct {
 	Workflow                 *v1.WorkflowHandler
 	MeterUsage               *v1.MeterUsageHandler
 	CheckoutSession          *v1.CheckoutSessionHandler
+
+	// Enterprise handlers
+	SAML *saml.Handler
 
 	// Portal handlers
 	Onboarding     *v1.OnboardingHandler
@@ -141,6 +145,13 @@ func NewRouter(
 		// Auth routes
 		v1Public.POST("/auth/signup", handlers.Auth.SignUp)
 		v1Public.POST("/auth/login", handlers.Auth.Login)
+
+		// SAML single sign-on. Public because these run before a session
+		// exists: the login redirect starts the flow, and the ACS callback is
+		// posted by the identity provider, which carries no credentials.
+		if handlers.SAML != nil {
+			handlers.SAML.RegisterRoutes(v1Public)
+		}
 	}
 
 	private := router.Group("/", middleware.AuthenticateMiddleware(cfg, secretService, environmentRepo, userRepo, logger))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -146,11 +146,19 @@ func NewRouter(
 		v1Public.POST("/auth/signup", handlers.Auth.SignUp)
 		v1Public.POST("/auth/login", handlers.Auth.Login)
 
-		// SAML single sign-on. Public because these run before a session
-		// exists: the login redirect starts the flow, and the ACS callback is
-		// posted by the identity provider, which carries no credentials.
-		if handlers.SAML != nil {
-			handlers.SAML.RegisterRoutes(v1Public)
+		// SAML single sign-on. Public because these run before a session exists:
+		// the login redirect starts the flow, and the ACS callback is posted by
+		// the identity provider, which carries no credentials.
+		//
+		// Mounted only when the deployment offers SAML, so the endpoints 404 as
+		// though the feature did not exist rather than announcing a disabled one.
+		if handlers.SAML != nil && cfg.Auth.SAML.Enabled {
+			saml := v1Public.Group("/auth/saml/:tenant")
+			{
+				saml.GET("/metadata", handlers.SAML.Metadata)
+				saml.GET("/login", handlers.SAML.Login)
+				saml.POST("/acs", handlers.SAML.ACS)
+			}
 		}
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -707,15 +707,19 @@ func NewRouter(
 
 	// Settings routes.
 	//
-	// Super admin throughout, reads included. The route is shared by every
-	// settings key, and some of them decide how people authenticate — a SAML
-	// configuration names the identity provider the tenant trusts, so an
-	// all_writer who could change it can have themselves provisioned in, and
-	// anyone who could read it learns which provider to attack and whether it
-	// has been approved.
+	// Writes require a super admin: the route is shared by every settings key,
+	// and one of them decides how people authenticate — a SAML configuration
+	// names the identity provider the tenant trusts, so anyone who can change it
+	// can have themselves provisioned into the tenant.
+	//
+	// Reads keep the ordinary setting:read permission. Most settings are
+	// configuration the dashboard shows to any member, and requiring an
+	// administrator to read an invoice prefix helps nobody. saml_config is the
+	// exception and is refused to non-administrators in the service, where the
+	// key is known.
 	settings := v1Private.Group("/settings")
 	{
-		settings.GET("/:key", read(types.EntitySetting, types.ActionRead, superAdminOnly), handlers.Settings.GetSettingByKey)
+		settings.GET("/:key", read(types.EntitySetting, types.ActionRead), handlers.Settings.GetSettingByKey)
 		settings.PUT("/:key", write(types.EntitySetting, types.ActionWrite, superAdminOnly), handlers.Settings.UpdateSettingByKey)
 		settings.DELETE("/:key", write(types.EntitySetting, types.ActionWrite, superAdminOnly), handlers.Settings.DeleteSettingByKey)
 	}

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -77,6 +77,13 @@ func NewProvider(cfg *config.Configuration) Provider {
 	switch cfg.Auth.Provider {
 	case types.AuthProviderSupabase:
 		return NewSupabaseAuth(cfg)
+	case types.AuthProviderSAML:
+		// Nil when the enterprise SAML package is not linked in; an
+		// unconfigured deployment then behaves as it did before.
+		if samlProviderFactory != nil {
+			return samlProviderFactory(cfg)
+		}
+		return NewFlexpriceAuth(cfg)
 	default:
 		return NewFlexpriceAuth(cfg)
 	}

--- a/internal/auth/saml_provider.go
+++ b/internal/auth/saml_provider.go
@@ -1,0 +1,19 @@
+package auth
+
+import "github.com/flexprice/flexprice/internal/config"
+
+// samlProviderFactory builds the SAML provider.
+//
+// The implementation lives in internal/ee/auth/saml, which imports this package
+// for the Provider interface — so this package cannot import it back. The
+// enterprise package registers itself from an init() instead, which breaks the
+// cycle without a registry.
+//
+// Nil until that package is linked in, in which case auth.provider=saml falls
+// through to the default provider.
+var samlProviderFactory func(cfg *config.Configuration) Provider
+
+// RegisterSAMLProvider is called from internal/ee/auth/saml at init time.
+func RegisterSAMLProvider(factory func(cfg *config.Configuration) Provider) {
+	samlProviderFactory = factory
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,6 +188,13 @@ type AuthConfig struct {
 // SAMLConfig holds deployment-level SAML settings. Per-tenant identity provider
 // details live in the tenant's saml_config setting, not here.
 type SAMLConfig struct {
+	// Enabled is the deployment-wide switch for the whole SAML feature. When it
+	// is off the SAML routes are not mounted at all and no tenant may store a
+	// configuration, so a deployment that does not offer SSO exposes none of it
+	// and cannot accumulate configurations that silently do nothing.
+	//
+	// Defaults to off: SSO is opt-in per deployment.
+	Enabled bool `mapstructure:"enabled"`
 	// BaseURL is the externally reachable origin of this deployment. It builds
 	// the SP entity ID and ACS URL published in our metadata, so it must match
 	// what the identity provider is configured to call back.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,8 +180,26 @@ type ServerConfig struct {
 type AuthConfig struct {
 	Provider types.AuthProvider `mapstructure:"provider" validate:"required"`
 	Secret   string             `mapstructure:"secret" validate:"required"`
+	SAML     SAMLConfig         `mapstructure:"saml"`
 	Supabase SupabaseConfig     `mapstructure:"supabase"`
 	APIKey   APIKeyConfig       `mapstructure:"api_key"`
+}
+
+// SAMLConfig holds deployment-level SAML settings. Per-tenant identity provider
+// details live in the tenant's saml_config setting, not here.
+type SAMLConfig struct {
+	// BaseURL is the externally reachable origin of this deployment. It builds
+	// the SP entity ID and ACS URL published in our metadata, so it must match
+	// what the identity provider is configured to call back.
+	BaseURL string `mapstructure:"base_url"`
+	// DashboardURL receives the browser redirect after a successful assertion,
+	// carrying the minted token.
+	DashboardURL string `mapstructure:"dashboard_url"`
+	// EnforceSSO rejects password login deployment-wide.
+	EnforceSSO bool `mapstructure:"enforce_sso"`
+	// DefaultTenantID lets a single-tenant deployment use "default" in place of
+	// a tenant UUID in the SAML URLs. Empty disables the alias.
+	DefaultTenantID string `mapstructure:"default_tenant_id"`
 }
 
 type SupabaseConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,18 +195,24 @@ type SAMLConfig struct {
 	//
 	// Defaults to off: SSO is opt-in per deployment.
 	Enabled bool `mapstructure:"enabled"`
-	// BaseURL is the externally reachable origin of this deployment. It builds
-	// the SP entity ID and ACS URL published in our metadata, so it must match
-	// what the identity provider is configured to call back.
+
+	// BaseURL is the externally reachable origin of this deployment — scheme and
+	// host only; the SAML paths are built onto it. It is deployment-level rather
+	// than per-tenant because a deployment has exactly one API origin, and
+	// because it must not come from the inbound request: it is signed into the
+	// AuthnRequest as the ACS URL and checked again when the assertion arrives,
+	// so a request-derived origin would let a caller controlling the Host header
+	// have assertions delivered to a host of their choosing.
+	//
+	// Nothing tenant-specific lives here. The tenant appears in the path, which
+	// the SP builds, so one origin serves every tenant.
 	BaseURL string `mapstructure:"base_url"`
+
 	// DashboardURL receives the browser redirect after a successful assertion,
-	// carrying the minted token.
+	// carrying the minted token. Deployment-level for the same reason: it names
+	// this deployment's own frontend, and taking it from the request would make
+	// the callback an open redirect.
 	DashboardURL string `mapstructure:"dashboard_url"`
-	// EnforceSSO rejects password login deployment-wide.
-	EnforceSSO bool `mapstructure:"enforce_sso"`
-	// DefaultTenantID lets a single-tenant deployment use "default" in place of
-	// a tenant UUID in the SAML URLs. Empty disables the alias.
-	DefaultTenantID string `mapstructure:"default_tenant_id"`
 }
 
 type SupabaseConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"reflect"
 	"slices"
@@ -213,6 +214,74 @@ type SAMLConfig struct {
 	// this deployment's own frontend, and taking it from the request would make
 	// the callback an open redirect.
 	DashboardURL string `mapstructure:"dashboard_url"`
+}
+
+// validate refuses a SAML deployment that cannot serve a working login.
+//
+// Only enforced when the feature is on, so a deployment that does not offer SSO
+// is unaffected by any of it.
+//
+// Both URLs must be absolute: BaseURL builds the entity ID and ACS URL published
+// in our metadata, and a relative value produces endpoints an identity provider
+// cannot call back. Both must be https away from loopback: the assertion and the
+// minted token both travel through the browser, so plaintext exposes them in
+// transit. Loopback is exempt because it never leaves the machine and is how
+// this is developed against a local identity provider.
+func (c SAMLConfig) validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	for _, field := range []struct{ name, raw string }{
+		{"auth.saml.base_url", c.BaseURL},
+		{"auth.saml.dashboard_url", c.DashboardURL},
+	} {
+		value := strings.TrimSpace(field.raw)
+		if value == "" {
+			return fmt.Errorf("%s is required when auth.saml.enabled is true", field.name)
+		}
+
+		u, err := url.Parse(value)
+		if err != nil || u.Host == "" {
+			return fmt.Errorf("%s must be an absolute URL (got %q)", field.name, field.raw)
+		}
+		if u.Scheme != "https" && !isLoopbackHost(u.Hostname()) {
+			return fmt.Errorf("%s must use https (plain http is allowed only for localhost) (got %q)", field.name, field.raw)
+		}
+	}
+	return nil
+}
+
+// validateSAMLDependencies refuses to start a SAML deployment without Redis.
+//
+// The AuthnRequest IDs that make an assertion single-use are held in Redis. The
+// redirect that starts a login and the callback that finishes it are separate
+// requests, and a load balancer may route them to different replicas, so
+// process-local state fails roughly (N-1)/N of logins on an N-replica
+// deployment — at random, and looking like an identity provider fault rather
+// than a Flexprice one.
+//
+// Failing at boot is much kinder than that: a deployment either has the state
+// store SAML needs, or it does not offer SAML.
+func (c Configuration) validateSAMLDependencies() error {
+	if !c.Auth.SAML.Enabled {
+		return nil
+	}
+	if !c.Cache.Enabled || !c.Cache.Redis.Enabled {
+		return fmt.Errorf("auth.saml.enabled requires cache.enabled and cache.redis.enabled: " +
+			"SAML keeps outstanding login requests in Redis so a login started on one replica " +
+			"can be completed on another")
+	}
+	return nil
+}
+
+// isLoopbackHost reports whether a host never leaves this machine.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
 }
 
 type SupabaseConfig struct {
@@ -1035,6 +1104,22 @@ func NewValidatedConfig() (*Configuration, error) {
 	// clean via a staging deploy.
 	if err := cfg.validateSecrets(); err != nil {
 		log.Printf("[config] WARNING: %v", err)
+	}
+
+	// Scoped hard fail, unlike the warn-only check above. It applies only when
+	// auth.saml.enabled is on, so a deployment that does not offer SSO cannot be
+	// taken down by it — the risk that made the rest of this function warn-only.
+	//
+	// Failing at boot is the right trade here because the alternative is worse
+	// than a crash: with an empty or relative base URL the SP metadata a
+	// customer uploads to their identity provider contains unusable endpoints,
+	// and the failure surfaces much later as an audience mismatch on every
+	// assertion, pointing at signatures rather than at configuration.
+	if err := cfg.Auth.SAML.validate(); err != nil {
+		return nil, err
+	}
+	if err := cfg.validateSAMLDependencies(); err != nil {
+		return nil, err
 	}
 	return cfg, nil
 }

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -12,19 +12,19 @@ auth:
   saml:
     # Deployment-wide switch for the whole feature. Off means the SAML routes
     # are not mounted and no tenant may store a configuration.
+    #
+    # This is the only SAML policy that is set here. Everything about how a
+    # tenant authenticates — its identity provider, whether SSO is on, whether
+    # password login is refused — lives in that tenant's saml_config setting.
     enabled: false
-    # Externally reachable origin. Builds the SP entity ID and ACS URL in our
-    # metadata, so it must match what the identity provider calls back.
+    # This deployment's own origin (scheme and host); the SAML paths are built
+    # onto it. Not per-tenant: one deployment has one API origin, and the tenant
+    # appears in the path rather than the origin. It must not be taken from the
+    # request, because it is signed into the AuthnRequest as the ACS URL.
     base_url: "http://localhost:8080"
-    # Where the browser lands after a successful assertion, carrying the token.
+    # This deployment's frontend, where the browser lands after a successful
+    # assertion, carrying the token.
     dashboard_url: "http://localhost:3000/auth/callback"
-    # Refuse password login deployment-wide, regardless of tenant. Per-tenant
-    # enforcement lives in the tenant's saml_config (enforce_sso), which exempts
-    # super admins; this one does not and is intended for single-tenant on-prem.
-    enforce_sso: false
-    # Single-tenant deployments can use /v1/auth/saml/default/... instead of the
-    # tenant UUID. Leave empty for multi-tenant.
-    default_tenant_id: "00000000-0000-0000-0000-000000000000"
   supabase:
     base_url: "http://localhost:54321"
     service_key: "<supabase service key>"

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -10,12 +10,17 @@ auth:
   # SAML single sign-on. Per-tenant identity provider details live in the
   # tenant's saml_config setting, not here.
   saml:
+    # Deployment-wide switch for the whole feature. Off means the SAML routes
+    # are not mounted and no tenant may store a configuration.
+    enabled: false
     # Externally reachable origin. Builds the SP entity ID and ACS URL in our
     # metadata, so it must match what the identity provider calls back.
     base_url: "http://localhost:8080"
     # Where the browser lands after a successful assertion, carrying the token.
     dashboard_url: "http://localhost:3000/auth/callback"
-    # Refuse password login deployment-wide.
+    # Refuse password login deployment-wide, regardless of tenant. Per-tenant
+    # enforcement lives in the tenant's saml_config (enforce_sso), which exempts
+    # super admins; this one does not and is intended for single-tenant on-prem.
     enforce_sso: false
     # Single-tenant deployments can use /v1/auth/saml/default/... instead of the
     # tenant UUID. Leave empty for multi-tenant.

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -7,6 +7,19 @@ server:
 auth:
   provider: "flexprice" # "flexprice" or "supabase"
   secret: "super_secret"
+  # SAML single sign-on. Per-tenant identity provider details live in the
+  # tenant's saml_config setting, not here.
+  saml:
+    # Externally reachable origin. Builds the SP entity ID and ACS URL in our
+    # metadata, so it must match what the identity provider calls back.
+    base_url: "http://localhost:8080"
+    # Where the browser lands after a successful assertion, carrying the token.
+    dashboard_url: "http://localhost:3000/auth/callback"
+    # Refuse password login deployment-wide.
+    enforce_sso: false
+    # Single-tenant deployments can use /v1/auth/saml/default/... instead of the
+    # tenant UUID. Leave empty for multi-tenant.
+    default_tenant_id: "00000000-0000-0000-0000-000000000000"
   supabase:
     base_url: "http://localhost:54321"
     service_key: "<supabase service key>"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSAMLConfigValidate covers the boot-time gate. The alternative to failing
+// here is worse than a crash: an empty or relative base URL produces SP metadata
+// whose endpoints an identity provider cannot call, and the failure then
+// surfaces much later as an audience mismatch on every assertion.
+func TestSAMLConfigValidate(t *testing.T) {
+	valid := SAMLConfig{
+		Enabled:      true,
+		BaseURL:      "https://billing.example.com",
+		DashboardURL: "https://app.example.com/auth/callback",
+	}
+
+	if err := valid.validate(); err != nil {
+		t.Fatalf("a complete https configuration must pass: %v", err)
+	}
+
+	// Nothing is enforced while the feature is off, so a deployment that does
+	// not offer SSO cannot be taken down by any of this.
+	if err := (SAMLConfig{}).validate(); err != nil {
+		t.Errorf("a disabled configuration must not be validated: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*SAMLConfig)
+		want   string
+	}{
+		{"base url empty", func(c *SAMLConfig) { c.BaseURL = "" }, "base_url is required"},
+		{"base url relative", func(c *SAMLConfig) { c.BaseURL = "/v1" }, "absolute URL"},
+		{"base url plaintext", func(c *SAMLConfig) { c.BaseURL = "http://billing.example.com" }, "https"},
+		{"dashboard url empty", func(c *SAMLConfig) { c.DashboardURL = "" }, "dashboard_url is required"},
+		{"dashboard url relative", func(c *SAMLConfig) { c.DashboardURL = "/auth/callback" }, "absolute URL"},
+		{"dashboard url plaintext", func(c *SAMLConfig) { c.DashboardURL = "http://app.example.com" }, "https"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := valid
+			tc.mutate(&cfg)
+			err := cfg.validate()
+			if err == nil {
+				t.Fatalf("expected rejection mentioning %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+
+	// Loopback keeps plain http: it never leaves the machine, and it is how this
+	// is developed against a local identity provider.
+	for _, host := range []string{"http://localhost:8080", "http://127.0.0.1:8080"} {
+		cfg := valid
+		cfg.BaseURL = host
+		cfg.DashboardURL = host + "/auth/callback"
+		if err := cfg.validate(); err != nil {
+			t.Errorf("loopback %s must be allowed for local development: %v", host, err)
+		}
+	}
+}
+
+// TestValidateSAMLDependencies pins the Redis requirement. SAML keeps its
+// outstanding login requests there so a login begun on one replica can be
+// completed on another; without it a multi-replica deployment fails most logins
+// at random, which looks like an identity provider fault.
+func TestValidateSAMLDependencies(t *testing.T) {
+	withRedis := Configuration{}
+	withRedis.Auth.SAML.Enabled = true
+	withRedis.Cache.Enabled = true
+	withRedis.Cache.Redis.Enabled = true
+
+	if err := withRedis.validateSAMLDependencies(); err != nil {
+		t.Fatalf("SAML with Redis available must start: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name         string
+		cache, redis bool
+	}{
+		{"cache disabled entirely", false, true},
+		{"redis cache disabled", true, false},
+		{"neither", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := withRedis
+			cfg.Cache.Enabled = tc.cache
+			cfg.Cache.Redis.Enabled = tc.redis
+			if err := cfg.validateSAMLDependencies(); err == nil {
+				t.Error("SAML must not start without Redis")
+			}
+		})
+	}
+
+	// A deployment that does not offer SAML is unaffected.
+	off := Configuration{}
+	if err := off.validateSAMLDependencies(); err != nil {
+		t.Errorf("a non-SAML deployment must not require Redis: %v", err)
+	}
+}

--- a/internal/ee/auth/saml/acs.go
+++ b/internal/ee/auth/saml/acs.go
@@ -93,6 +93,16 @@ func extractEmail(assertion *saml.Assertion, cfg Config) (string, error) {
 				}
 				for _, v := range a.Values {
 					if value := strings.TrimSpace(v.Value); value != "" {
+						// Checked here as well as on the NameID path. An
+						// identity provider can map the configured attribute to
+						// a username or an employee number, and users.email is
+						// globally unique — provisioning one of those writes a
+						// permanent row that blocks the real address later.
+						if !strings.Contains(value, "@") {
+							return "", ierr.NewErrorf("assertion %s attribute is not an email address", attr).
+								WithHint("The identity provider sent something other than an email address in the configured attribute").
+								Mark(ierr.ErrValidation)
+						}
 						return normaliseEmail(value), nil
 					}
 				}

--- a/internal/ee/auth/saml/acs.go
+++ b/internal/ee/auth/saml/acs.go
@@ -122,7 +122,12 @@ func normaliseEmail(email string) string {
 // tenant B, and the failure has to be explicit rather than a silent login into
 // the wrong tenant.
 func (p *samlProvider) resolveUser(ctx context.Context, params service.ServiceParams, tenantID, email string, cfg Config) (string, error) {
-	existing, err := params.UserRepo.GetByEmail(ctx, email)
+	// Look the user up without a tenant in context. GetByEmail filters by tenant
+	// when one is set, which would hide a user belonging to another
+	// organisation — the caller would then fall through to provisioning and hit
+	// the global unique index on users.email as an opaque database error rather
+	// than the explicit refusal below.
+	existing, err := params.UserRepo.GetByEmail(types.SetTenantID(ctx, ""), email)
 	if err == nil && existing != nil {
 		if existing.TenantID != tenantID {
 			return "", ierr.NewError("user belongs to a different organisation").

--- a/internal/ee/auth/saml/acs.go
+++ b/internal/ee/auth/saml/acs.go
@@ -1,0 +1,163 @@
+package saml
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/crewjam/saml"
+
+	"github.com/flexprice/flexprice/internal/domain/user"
+	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// assertionResult is what a validated assertion yields.
+type assertionResult struct {
+	Email string
+}
+
+// validateAssertion parses and verifies a SAMLResponse.
+//
+// crewjam/saml's ParseResponse performs the checks that matter, and each is here
+// for a specific published attack:
+//
+//   - signature verified against the configured certificate only, never one
+//     carried inside the response
+//   - XML signature wrapping detection, so the signature must cover the
+//     assertion actually consumed
+//   - audience restriction, so an assertion minted for a different service
+//     provider is rejected
+//   - NotBefore / NotOnOrAfter condition window
+//   - InResponseTo matched against request IDs we issued
+//   - XML entity expansion disabled, closing XXE
+//
+// possibleRequestIDs carries the AuthnRequest IDs this browser session started.
+// An empty list means an unsolicited (identity-provider-initiated) response,
+// which crewjam rejects unless explicitly permitted — we do not permit it, so a
+// response must always answer a request we made.
+func validateAssertion(
+	sp *saml.ServiceProvider,
+	req *http.Request,
+	possibleRequestIDs []string,
+	cfg Config,
+) (*assertionResult, error) {
+	assertion, err := sp.ParseResponse(req, possibleRequestIDs)
+	if err != nil {
+		return nil, ierr.NewError("saml assertion rejected").
+			WithHint("The identity provider's response could not be validated").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	if assertion.Issuer.Value != cfg.IDPEntityID {
+		return nil, ierr.NewError("saml assertion issuer mismatch").
+			WithHint("The response came from a different identity provider than configured").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	email, err := extractEmail(assertion, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &assertionResult{Email: email}, nil
+}
+
+// extractEmail reads the user's email from the configured attribute, or the
+// NameID when no attribute is configured.
+//
+// An assertion that authenticates someone we cannot identify is useless and must
+// not fall back to a guess — a wrong email here would log the user into the
+// wrong account.
+func extractEmail(assertion *saml.Assertion, cfg Config) (string, error) {
+	if attr := strings.TrimSpace(cfg.EmailAttribute); attr != "" {
+		for _, stmt := range assertion.AttributeStatements {
+			for _, a := range stmt.Attributes {
+				if a.Name != attr && a.FriendlyName != attr {
+					continue
+				}
+				for _, v := range a.Values {
+					if value := strings.TrimSpace(v.Value); value != "" {
+						return normaliseEmail(value), nil
+					}
+				}
+			}
+		}
+		return "", ierr.NewErrorf("assertion has no %s attribute", attr).
+			WithHint("The identity provider did not send the configured email attribute").
+			Mark(ierr.ErrValidation)
+	}
+
+	if assertion.Subject == nil || assertion.Subject.NameID == nil {
+		return "", ierr.NewError("assertion has no NameID").
+			WithHint("Configure an email attribute, or have the identity provider send the email as NameID").
+			Mark(ierr.ErrValidation)
+	}
+
+	value := strings.TrimSpace(assertion.Subject.NameID.Value)
+	if value == "" || !strings.Contains(value, "@") {
+		return "", ierr.NewError("assertion NameID is not an email address").
+			WithHint("Configure an email attribute, or set the identity provider's NameID format to emailAddress").
+			Mark(ierr.ErrValidation)
+	}
+
+	return normaliseEmail(value), nil
+}
+
+// normaliseEmail lowercases so identity-provider casing cannot create a second
+// account for a user who already exists.
+func normaliseEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+// resolveUser finds the user an assertion authenticates, provisioning one if the
+// tenant has never seen them.
+//
+// The cross-tenant check is the important branch. Email is globally unique
+// (a partial unique index on users.email that is not scoped by tenant), so a
+// user belongs to exactly one tenant for the lifetime of the account. An
+// assertion validated for tenant A must never authenticate a user who belongs to
+// tenant B, and the failure has to be explicit rather than a silent login into
+// the wrong tenant.
+func (p *samlProvider) resolveUser(ctx context.Context, params service.ServiceParams, tenantID, email string, cfg Config) (string, error) {
+	existing, err := params.UserRepo.GetByEmail(ctx, email)
+	if err == nil && existing != nil {
+		if existing.TenantID != tenantID {
+			return "", ierr.NewError("user belongs to a different organisation").
+				WithHint("This email already has a Flexprice account under another organisation").
+				Mark(ierr.ErrPermissionDenied)
+		}
+		return existing.ID, nil
+	}
+	if err != nil && !ierr.IsNotFound(err) {
+		return "", err
+	}
+
+	return p.provisionUser(ctx, params, tenantID, email, cfg)
+}
+
+func (p *samlProvider) provisionUser(ctx context.Context, params service.ServiceParams, tenantID, email string, cfg Config) (string, error) {
+	role := cfg.DefaultRole
+	if role == "" {
+		role = string(types.RoleAllReader)
+	}
+	if err := validateDefaultRole(role); err != nil {
+		return "", ierr.WithError(err).
+			WithHint("The tenant's SAML default_role is not assignable").
+			Mark(ierr.ErrValidation)
+	}
+
+	// Provisioning is deliberately not routed through InviteUser: that path
+	// requires a super_admin in context to authorise the invite, and an
+	// assertion has no acting user. The identity provider is the authority here.
+	ctx = types.SetTenantID(ctx, tenantID)
+	newUser := user.NewUser(email, tenantID)
+	newUser.Roles = []string{role}
+
+	if err := params.UserRepo.Create(ctx, newUser); err != nil {
+		return "", fmt.Errorf("provision saml user: %w", err)
+	}
+	return newUser.ID, nil
+}

--- a/internal/ee/auth/saml/acs.go
+++ b/internal/ee/auth/saml/acs.go
@@ -2,6 +2,7 @@ package saml
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -46,7 +47,19 @@ func validateAssertion(
 ) (*assertionResult, error) {
 	assertion, err := sp.ParseResponse(req, possibleRequestIDs)
 	if err != nil {
-		return nil, ierr.NewError("saml assertion rejected").
+		// crewjam reports the real cause — expired condition window, audience
+		// mismatch, unknown InResponseTo, bad signature — on PrivateErr, and its
+		// Error() deliberately says nothing useful so it is safe to return to a
+		// caller. Keep the response generic, but carry the detail so an operator
+		// integrating an identity provider can see which check failed; without
+		// it every failure is indistinguishable and the only recourse is
+		// guessing.
+		cause := err
+		var invalid *saml.InvalidResponseError
+		if errors.As(err, &invalid) && invalid.PrivateErr != nil {
+			cause = invalid.PrivateErr
+		}
+		return nil, ierr.WithError(cause).
 			WithHint("The identity provider's response could not be validated").
 			Mark(ierr.ErrPermissionDenied)
 	}

--- a/internal/ee/auth/saml/acs_test.go
+++ b/internal/ee/auth/saml/acs_test.go
@@ -134,3 +134,28 @@ func TestResolveUserLooksUpAcrossTenants(t *testing.T) {
 			"cross-tenant refusal never fires")
 	}
 }
+
+// TestExtractEmailRejectsNonEmailAttribute closes the gap between the two
+// extraction paths. The NameID path has always required an "@"; the attribute
+// path did not, so an identity provider mapping the configured attribute to a
+// username or an employee number produced a user whose email column held that
+// value. users.email is globally unique, so the row is permanent and blocks the
+// real address from ever being provisioned.
+func TestExtractEmailRejectsNonEmailAttribute(t *testing.T) {
+	cfg := Config{EmailAttribute: "email"}
+
+	for _, value := range []string{"jsmith", "EMP-00417", "user1"} {
+		if _, err := extractEmail(assertionWithAttribute("email", value), cfg); err == nil {
+			t.Errorf("attribute value %q was accepted as an email address", value)
+		}
+	}
+
+	// A real address still works, and is still normalised.
+	got, err := extractEmail(assertionWithAttribute("email", "  Alice@Example.com "), cfg)
+	if err != nil {
+		t.Fatalf("a valid address must be accepted: %v", err)
+	}
+	if got != "alice@example.com" {
+		t.Errorf("extractEmail() = %q, want it trimmed and lowercased", got)
+	}
+}

--- a/internal/ee/auth/saml/acs_test.go
+++ b/internal/ee/auth/saml/acs_test.go
@@ -1,6 +1,8 @@
 package saml
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/crewjam/saml"
@@ -109,5 +111,26 @@ func TestConfiguredAttributeDoesNotFallBackToNameID(t *testing.T) {
 
 	if got, err := extractEmail(assertion, cfg); err == nil {
 		t.Errorf("configured attribute fell back to NameID, yielding %q", got)
+	}
+}
+
+// TestResolveUserLooksUpAcrossTenants pins the fix for a real failure found by
+// live testing: the lookup ran with the assertion's tenant in context, and
+// GetByEmail filters by tenant when one is set. A user belonging to another
+// organisation was therefore invisible, so the flow fell through to
+// provisioning and hit the global unique index on users.email — surfacing as a
+// 500 database error instead of the explicit 403 refusal.
+//
+// The lookup must clear the tenant so the cross-tenant branch is reachable.
+func TestResolveUserLooksUpAcrossTenants(t *testing.T) {
+	src, err := os.ReadFile("acs.go")
+	if err != nil {
+		t.Fatalf("read acs.go: %v", err)
+	}
+
+	if !strings.Contains(string(src), `GetByEmail(types.SetTenantID(ctx, "")`) {
+		t.Error("resolveUser must look the user up with no tenant in context, " +
+			"otherwise a user in another organisation is invisible and the " +
+			"cross-tenant refusal never fires")
 	}
 }

--- a/internal/ee/auth/saml/acs_test.go
+++ b/internal/ee/auth/saml/acs_test.go
@@ -1,11 +1,15 @@
 package saml
 
 import (
-	"os"
-	"strings"
+	"context"
 	"testing"
 
 	"github.com/crewjam/saml"
+
+	"github.com/flexprice/flexprice/internal/domain/user"
+	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
 )
 
 func assertionWithNameID(value string) *saml.Assertion {
@@ -123,16 +127,98 @@ func TestConfiguredAttributeDoesNotFallBackToNameID(t *testing.T) {
 //
 // The lookup must clear the tenant so the cross-tenant branch is reachable.
 func TestResolveUserLooksUpAcrossTenants(t *testing.T) {
-	src, err := os.ReadFile("acs.go")
-	if err != nil {
-		t.Fatalf("read acs.go: %v", err)
+	const (
+		ownerTenant = "tenant_owner"
+		otherTenant = "tenant_other"
+		email       = "person@example.com"
+	)
+
+	existing := user.NewUser(email, ownerTenant)
+	repo := &tenantScopedUserRepo{users: []*user.User{existing}}
+	params := service.ServiceParams{UserRepo: repo}
+	provider := newTestProvider("https://billing.example.com")
+
+	// The assertion's tenant is already in context by the time resolveUser runs,
+	// exactly as the ACS handler leaves it. That is what makes the bug possible:
+	// a lookup inheriting this tenant cannot see a user who belongs to another
+	// one. A context without a tenant would pass whether or not resolveUser
+	// clears it, and would test nothing.
+	ctx := types.SetTenantID(context.Background(), otherTenant)
+
+	// An assertion validated for a tenant that does not own this email must be
+	// refused, not silently logged into the wrong tenant and not surfaced as a
+	// database error from a duplicate insert.
+	_, err := provider.resolveUser(ctx, params, otherTenant, email, enabledConfig())
+	if err == nil {
+		t.Fatal("a user belonging to another organisation must not be authenticated")
+	}
+	if !ierr.IsPermissionDenied(err) {
+		t.Errorf("error = %v, want permission denied rather than a database failure", err)
+	}
+	if repo.created != 0 {
+		t.Errorf("provisioning ran %d time(s); the cross-tenant branch must refuse before provisioning", repo.created)
 	}
 
-	if !strings.Contains(string(src), `GetByEmail(types.SetTenantID(ctx, "")`) {
-		t.Error("resolveUser must look the user up with no tenant in context, " +
-			"otherwise a user in another organisation is invisible and the " +
-			"cross-tenant refusal never fires")
+	// The owning tenant still resolves to the existing user rather than
+	// provisioning a second one.
+	id, err := provider.resolveUser(types.SetTenantID(context.Background(), ownerTenant), params, ownerTenant, email, enabledConfig())
+	if err != nil {
+		t.Fatalf("the owning tenant must authenticate its own user: %v", err)
 	}
+	if id != existing.ID {
+		t.Errorf("resolved id = %q, want the existing user %q", id, existing.ID)
+	}
+	if repo.created != 0 {
+		t.Errorf("provisioning ran for a user that already exists")
+	}
+
+	// An unknown email in a configured tenant is provisioned.
+	if _, err := provider.resolveUser(ctx, params, otherTenant, "new@example.com", enabledConfig()); err != nil {
+		t.Fatalf("an unknown email must be provisioned: %v", err)
+	}
+	if repo.created != 1 {
+		t.Errorf("provisioning ran %d time(s), want exactly 1", repo.created)
+	}
+}
+
+// tenantScopedUserRepo reproduces the behaviour that made the bug possible:
+// GetByEmail filters by the tenant in context, so a lookup carrying a tenant
+// cannot see a user who belongs to another one. The in-memory store in
+// internal/testutil ignores tenant entirely and would pass whether or not
+// resolveUser clears it.
+type tenantScopedUserRepo struct {
+	users   []*user.User
+	created int
+}
+
+func (r *tenantScopedUserRepo) GetByEmail(ctx context.Context, email string) (*user.User, error) {
+	tenantID := types.GetTenantID(ctx)
+	for _, u := range r.users {
+		if u.Email != email {
+			continue
+		}
+		if tenantID != "" && u.TenantID != tenantID {
+			continue
+		}
+		return u, nil
+	}
+	return nil, ierr.NewError("user not found").Mark(ierr.ErrNotFound)
+}
+
+func (r *tenantScopedUserRepo) Create(ctx context.Context, u *user.User) error {
+	r.created++
+	r.users = append(r.users, u)
+	return nil
+}
+
+func (r *tenantScopedUserRepo) GetByID(context.Context, string) (*user.User, error) {
+	return nil, ierr.NewError("not implemented").Mark(ierr.ErrNotFound)
+}
+func (r *tenantScopedUserRepo) Update(context.Context, *user.User) error            { return nil }
+func (r *tenantScopedUserRepo) UpdateRoles(context.Context, string, []string) error { return nil }
+func (r *tenantScopedUserRepo) Delete(context.Context, string) error                { return nil }
+func (r *tenantScopedUserRepo) ListByFilter(context.Context, *types.UserFilter) ([]*user.User, int64, error) {
+	return nil, 0, nil
 }
 
 // TestExtractEmailRejectsNonEmailAttribute closes the gap between the two

--- a/internal/ee/auth/saml/acs_test.go
+++ b/internal/ee/auth/saml/acs_test.go
@@ -1,0 +1,113 @@
+package saml
+
+import (
+	"testing"
+
+	"github.com/crewjam/saml"
+)
+
+func assertionWithNameID(value string) *saml.Assertion {
+	return &saml.Assertion{
+		Subject: &saml.Subject{
+			NameID: &saml.NameID{Value: value},
+		},
+	}
+}
+
+func assertionWithAttribute(name, value string) *saml.Assertion {
+	return &saml.Assertion{
+		AttributeStatements: []saml.AttributeStatement{
+			{
+				Attributes: []saml.Attribute{
+					{
+						Name:   name,
+						Values: []saml.AttributeValue{{Value: value}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestExtractEmailFromNameID covers the default path, where the identity
+// provider sends the email as the NameID.
+func TestExtractEmailFromNameID(t *testing.T) {
+	got, err := extractEmail(assertionWithNameID("Alice@Example.com"), Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Casing is normalised so an identity provider that changes case cannot
+	// create a second account for someone who already exists.
+	if got != "alice@example.com" {
+		t.Errorf("got %q, want the lowercased address", got)
+	}
+}
+
+func TestExtractEmailFromConfiguredAttribute(t *testing.T) {
+	cfg := Config{EmailAttribute: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"}
+	assertion := assertionWithAttribute(cfg.EmailAttribute, "bob@example.com")
+
+	got, err := extractEmail(assertion, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "bob@example.com" {
+		t.Errorf("got %q, want bob@example.com", got)
+	}
+}
+
+// TestExtractEmailRejectsUnusableAssertions is the important one: an assertion
+// that authenticates someone we cannot identify must fail, never fall back to a
+// guess. A wrong answer here logs a user into the wrong account.
+func TestExtractEmailRejectsUnusableAssertions(t *testing.T) {
+	cases := []struct {
+		name      string
+		assertion *saml.Assertion
+		cfg       Config
+	}{
+		{
+			name:      "no subject at all",
+			assertion: &saml.Assertion{},
+		},
+		{
+			name:      "NameID is an opaque identifier, not an email",
+			assertion: assertionWithNameID("a7f3c9e1-persistent-id"),
+		},
+		{
+			name:      "NameID empty",
+			assertion: assertionWithNameID("   "),
+		},
+		{
+			name:      "configured attribute absent",
+			assertion: assertionWithAttribute("some_other_claim", "carol@example.com"),
+			cfg:       Config{EmailAttribute: "email"},
+		},
+		{
+			name:      "configured attribute present but empty",
+			assertion: assertionWithAttribute("email", "  "),
+			cfg:       Config{EmailAttribute: "email"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractEmail(tc.assertion, tc.cfg)
+			if err == nil {
+				t.Fatalf("expected rejection, got email %q", got)
+			}
+		})
+	}
+}
+
+// TestConfiguredAttributeDoesNotFallBackToNameID pins a deliberate choice: when
+// an administrator names an email attribute, a NameID must not silently satisfy
+// it. Falling back would mean a misconfigured attribute quietly authenticates
+// users off whatever the identity provider happens to put in the NameID.
+func TestConfiguredAttributeDoesNotFallBackToNameID(t *testing.T) {
+	assertion := assertionWithNameID("dave@example.com")
+	cfg := Config{EmailAttribute: "email"}
+
+	if got, err := extractEmail(assertion, cfg); err == nil {
+		t.Errorf("configured attribute fell back to NameID, yielding %q", got)
+	}
+}

--- a/internal/ee/auth/saml/config.go
+++ b/internal/ee/auth/saml/config.go
@@ -8,6 +8,7 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/utils"
+	"github.com/samber/lo"
 )
 
 // SettingKeySAML is the tenant-level settings key holding a tenant's identity
@@ -24,7 +25,32 @@ const SettingKeySAML types.SettingKey = "saml_config"
 // plain JSONB storage is appropriate. An SP private key would need
 // internal/security's EncryptionService instead.
 type Config struct {
+	// Enabled is the tenant's own switch, set by its super admin through the
+	// settings API.
 	Enabled bool `json:"enabled"`
+
+	// Active is the Flexprice-side approval, and is deliberately not settable
+	// through the API — it is flipped directly in the database once the tenant's
+	// claim to its identity provider has been checked out of band.
+	//
+	// It exists because a tenant configuring SSO for itself decides which
+	// identity provider Flexprice will trust for its users, and nothing in the
+	// settings write proves the tenant controls that provider. Both flags must
+	// be on before a login is served, so a tenant can turn its own SSO off but
+	// cannot turn it on unilaterally.
+	//
+	// This stands in for per-domain verification: when email-domain discovery
+	// arrives, a verified domain becomes the thing that grants Active
+	// automatically.
+	Active bool `json:"active"`
+
+	// EnforceSSO refuses password login for this tenant's users, so enabling SSO
+	// closes the password path rather than adding a second way in.
+	//
+	// Super admins stay exempt (see ShouldEnforceSSO): an identity provider
+	// outage would otherwise lock the tenant out of its own account with no way
+	// back that does not involve direct database access.
+	EnforceSSO bool `json:"enforce_sso"`
 
 	// IDPEntityID identifies the identity provider; it must match the Issuer of
 	// every assertion we accept.
@@ -47,12 +73,41 @@ type Config struct {
 func defaultConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"enabled":         false,
+		"active":          false,
+		"enforce_sso":     false,
 		"idp_entity_id":   "",
 		"idp_sso_url":     "",
 		"idp_certificate": "",
 		"email_attribute": "",
 		"default_role":    string(types.RoleAllReader),
 	}
+}
+
+// IsLive reports whether this tenant's SSO may actually serve a login.
+//
+// Both the tenant's own switch and the Flexprice-side approval must be on. Every
+// decision that turns on "is SAML usable for this tenant" goes through here, so
+// the two flags cannot fall out of step between the login redirect, the
+// assertion callback, and password enforcement.
+func (c Config) IsLive() bool {
+	return c.Enabled && c.Active
+}
+
+// ShouldEnforceSSO reports whether password login must be refused for a user
+// holding the given roles.
+//
+// Enforcement only applies once SSO is actually live: a tenant that set the flag
+// while still waiting for approval would otherwise lock itself out of a login
+// that SAML cannot yet serve.
+//
+// Super admins are exempt so an identity provider outage leaves a way back in.
+// The exemption is narrow by design — it is the same group already trusted to
+// configure SAML, and their password is the tenant's recovery path.
+func (c Config) ShouldEnforceSSO(roles []string) bool {
+	if !c.IsLive() || !c.EnforceSSO {
+		return false
+	}
+	return !lo.Contains(roles, types.RoleSuperAdmin.String())
 }
 
 // Validate rejects a configuration that cannot produce a safe login.

--- a/internal/ee/auth/saml/config.go
+++ b/internal/ee/auth/saml/config.go
@@ -105,7 +105,18 @@ func (c Config) Validate() error {
 // validateDefaultRole keeps just-in-time provisioning inside the roles a human
 // user may hold, so a configuration change cannot mint a role the RBAC model
 // does not recognise.
+//
+// super_admin is excluded even though a user may hold it. Provisioning happens
+// on the strength of an assertion alone, so a default of super_admin would grant
+// tenant administration to whoever the identity provider lets through — and to
+// anyone who can reach the ACS endpoint with an assertion it accepts. An
+// administrator is promoted deliberately afterwards, through the user-roles
+// endpoint, which is itself super_admin-only.
 func validateDefaultRole(role string) error {
+	if role == string(types.RoleSuperAdmin) {
+		return fmt.Errorf("default_role %q may not be granted by just-in-time provisioning; promote an administrator explicitly after their first login", role)
+	}
+
 	for _, allowed := range types.UserTypeUser.AllowedRoles() {
 		if string(allowed) == role {
 			return nil

--- a/internal/ee/auth/saml/config.go
+++ b/internal/ee/auth/saml/config.go
@@ -1,0 +1,154 @@
+package saml
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/flexprice/flexprice/internal/utils"
+)
+
+// SettingKeySAML is the tenant-level settings key holding a tenant's identity
+// provider configuration.
+const SettingKeySAML types.SettingKey = "saml_config"
+
+// Config is a tenant's SAML identity provider configuration.
+//
+// Stored as a tenant-level setting rather than its own table: an identity
+// provider is per-organisation, and tenant-level settings are readable without
+// an environment in context, which the pre-login endpoints require.
+//
+// Only the identity provider's public signing certificate is held here, so
+// plain JSONB storage is appropriate. An SP private key would need
+// internal/security's EncryptionService instead.
+type Config struct {
+	Enabled bool `json:"enabled"`
+
+	// IDPEntityID identifies the identity provider; it must match the Issuer of
+	// every assertion we accept.
+	IDPEntityID string `json:"idp_entity_id"`
+	// IDPSSOUrl is where a user is redirected to authenticate.
+	IDPSSOUrl string `json:"idp_sso_url"`
+	// IDPCertificate is the PEM-encoded X.509 certificate whose key signs
+	// assertions. Assertions signed by anything else are rejected.
+	IDPCertificate string `json:"idp_certificate"`
+
+	// EmailAttribute names the assertion attribute carrying the user's email.
+	// Empty means use the NameID.
+	EmailAttribute string `json:"email_attribute"`
+
+	// DefaultRole is granted to just-in-time provisioned users. An admin adjusts
+	// it afterwards.
+	DefaultRole string `json:"default_role"`
+}
+
+func defaultConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"enabled":         false,
+		"idp_entity_id":   "",
+		"idp_sso_url":     "",
+		"idp_certificate": "",
+		"email_attribute": "",
+		"default_role":    string(types.RoleAllReader),
+	}
+}
+
+// Validate rejects a configuration that cannot produce a safe login.
+//
+// The checks are deliberately strict about enablement: a half-configured
+// provider that is switched on would fail at assertion time, after the user has
+// already authenticated with their identity provider, which is a confusing place
+// to discover a typo.
+func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if strings.TrimSpace(c.IDPEntityID) == "" {
+		return fmt.Errorf("idp_entity_id is required when SAML is enabled")
+	}
+
+	if strings.TrimSpace(c.IDPSSOUrl) == "" {
+		return fmt.Errorf("idp_sso_url is required when SAML is enabled")
+	}
+	u, err := url.Parse(c.IDPSSOUrl)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("idp_sso_url must be an absolute URL")
+	}
+	// An assertion travels through the browser, so a plaintext identity
+	// provider exposes it in transit. The sole exemption is a loopback host,
+	// which never leaves the machine and is how a local identity provider is
+	// run during development — SimpleSAMLphp and friends serve plain http.
+	if u.Scheme != "https" && !isLoopbackHost(u.Hostname()) {
+		return fmt.Errorf("idp_sso_url must use https (plain http is allowed only for localhost)")
+	}
+
+	if strings.TrimSpace(c.IDPCertificate) == "" {
+		return fmt.Errorf("idp_certificate is required when SAML is enabled")
+	}
+	if _, err := parseCertificate(c.IDPCertificate); err != nil {
+		return fmt.Errorf("idp_certificate is not a valid PEM-encoded X.509 certificate: %w", err)
+	}
+
+	if c.DefaultRole == "" {
+		return fmt.Errorf("default_role is required when SAML is enabled")
+	}
+	if err := validateDefaultRole(c.DefaultRole); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateDefaultRole keeps just-in-time provisioning inside the roles a human
+// user may hold, so a configuration change cannot mint a role the RBAC model
+// does not recognise.
+func validateDefaultRole(role string) error {
+	for _, allowed := range types.UserTypeUser.AllowedRoles() {
+		if string(allowed) == role {
+			return nil
+		}
+	}
+	return fmt.Errorf("default_role %q is not assignable to a user", role)
+}
+
+// validateStoredConfig checks a value arriving through the settings API, where
+// it is an untyped map rather than a Config. Registered as the key's validator
+// so a bad identity provider configuration is rejected at write time instead of
+// at login, after the user has already authenticated.
+func validateStoredConfig(value map[string]interface{}) error {
+	cfg, err := configFromMap(value)
+	if err != nil {
+		return ierr.WithError(err).
+			WithHint("saml_config is not a valid SAML configuration").
+			Mark(ierr.ErrValidation)
+	}
+	if err := cfg.Validate(); err != nil {
+		// Marked as a validation failure so a rejected configuration is
+		// reported to the caller as a bad request rather than a server fault.
+		return ierr.WithError(err).
+			WithHint(err.Error()).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+// configFromMap decodes the stored JSONB blob into a Config.
+func configFromMap(value map[string]interface{}) (Config, error) {
+	cfg, err := utils.ToStruct[Config](value)
+	if err != nil {
+		return Config{}, fmt.Errorf("saml_config is not a valid SAML configuration: %w", err)
+	}
+	return cfg, nil
+}
+
+// isLoopbackHost reports whether the host never leaves this machine.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
+}

--- a/internal/ee/auth/saml/config_test.go
+++ b/internal/ee/auth/saml/config_test.go
@@ -86,6 +86,11 @@ func TestConfigValidateRejectsIncompleteEnabled(t *testing.T) {
 // role, or a typo that would otherwise be stored verbatim on the user row.
 func TestDefaultRoleMustBeAssignable(t *testing.T) {
 	for _, role := range types.UserTypeUser.AllowedRoles() {
+		// super_admin is assignable to a user but not by provisioning; it has
+		// its own test below.
+		if role == types.RoleSuperAdmin {
+			continue
+		}
 		if err := validateDefaultRole(string(role)); err != nil {
 			t.Errorf("role %q should be assignable to a user: %v", role, err)
 		}
@@ -95,6 +100,29 @@ func TestDefaultRoleMustBeAssignable(t *testing.T) {
 		if err := validateDefaultRole(role); err == nil {
 			t.Errorf("role %q must not be assignable to a user", role)
 		}
+	}
+}
+
+// TestDefaultRoleRejectsSuperAdmin covers the escalation path: provisioning
+// happens on the strength of an assertion alone, so a default of super_admin
+// would hand tenant administration to whoever the identity provider lets
+// through. An administrator is promoted deliberately after their first login.
+func TestDefaultRoleRejectsSuperAdmin(t *testing.T) {
+	if err := validateDefaultRole(string(types.RoleSuperAdmin)); err == nil {
+		t.Fatal("super_admin must not be grantable by just-in-time provisioning")
+	}
+
+	// The rule has to hold through the stored-config path too, since that is
+	// what an API write actually goes through.
+	value := defaultConfig()
+	value["enabled"] = true
+	value["idp_entity_id"] = "https://idp.example.com/metadata"
+	value["idp_sso_url"] = "https://idp.example.com/sso"
+	value["idp_certificate"] = testCertPEM
+	value["default_role"] = string(types.RoleSuperAdmin)
+
+	if err := validateStoredConfig(value); err == nil {
+		t.Fatal("a stored config defaulting to super_admin must be rejected at write time")
 	}
 }
 

--- a/internal/ee/auth/saml/config_test.go
+++ b/internal/ee/auth/saml/config_test.go
@@ -220,3 +220,32 @@ func TestShouldEnforceSSO(t *testing.T) {
 		t.Error("enforcement must not apply when the tenant has not asked for it")
 	}
 }
+
+// TestValidatorIsRegisteredWithTypes is the regression test for a bug that unit
+// tests could not have caught: every rule in this file was correct, and none of
+// them ran.
+//
+// The settings API validates through types.ValidateSettingValue, which had no
+// way to reach this package (importing it would be a cycle) and so accepted any
+// saml_config it could decode — a garbage certificate, a plaintext identity
+// provider, or default_role: super_admin. The registration in this package's
+// init is what connects the two, and nothing else fails if it is removed.
+func TestValidatorIsRegisteredWithTypes(t *testing.T) {
+	value := defaultConfig()
+	value["enabled"] = true
+	value["idp_entity_id"] = "https://idp.example.com/metadata"
+	value["idp_sso_url"] = "https://idp.example.com/sso"
+	value["idp_certificate"] = testCertPEM
+	value["default_role"] = string(types.RoleSuperAdmin)
+
+	// Goes through the generic settings path, exactly as an API write does.
+	if err := types.ValidateSettingValue(types.SettingKeySAMLConfig, value); err == nil {
+		t.Fatal("types.ValidateSettingValue accepted a super_admin default role — " +
+			"the SAML validator is not wired into the settings path")
+	}
+
+	value["default_role"] = string(types.RoleAllReader)
+	if err := types.ValidateSettingValue(types.SettingKeySAMLConfig, value); err != nil {
+		t.Fatalf("a valid config must pass the settings path: %v", err)
+	}
+}

--- a/internal/ee/auth/saml/config_test.go
+++ b/internal/ee/auth/saml/config_test.go
@@ -167,3 +167,56 @@ func TestLoopbackIdPAllowsPlainHTTP(t *testing.T) {
 		t.Error("plain http to a remote identity provider must be rejected")
 	}
 }
+
+// TestIsLiveRequiresBothFlags covers the ops gate: a tenant may switch its own
+// SSO off, but cannot switch it on without Flexprice's approval.
+func TestIsLiveRequiresBothFlags(t *testing.T) {
+	cases := []struct {
+		enabled, active, want bool
+	}{
+		{enabled: true, active: true, want: true},
+		{enabled: true, active: false, want: false},
+		{enabled: false, active: true, want: false},
+		{enabled: false, active: false, want: false},
+	}
+
+	for _, tc := range cases {
+		cfg := Config{Enabled: tc.enabled, Active: tc.active}
+		if got := cfg.IsLive(); got != tc.want {
+			t.Errorf("IsLive() with enabled=%v active=%v = %v, want %v",
+				tc.enabled, tc.active, got, tc.want)
+		}
+	}
+}
+
+// TestShouldEnforceSSO covers the breakglass rule. A super admin keeps password
+// login so an identity provider outage does not lock the tenant out of its own
+// account, and enforcement does not begin before SSO can actually serve a login.
+func TestShouldEnforceSSO(t *testing.T) {
+	live := Config{Enabled: true, Active: true, EnforceSSO: true}
+	reader := []string{string(types.RoleAllReader)}
+	admin := []string{string(types.RoleSuperAdmin)}
+
+	if !live.ShouldEnforceSSO(reader) {
+		t.Error("a regular user must be refused password login when SSO is enforced")
+	}
+	if live.ShouldEnforceSSO(admin) {
+		t.Error("a super admin must keep password login as the recovery path")
+	}
+	// A user carrying no roles is not a super admin, so enforcement applies.
+	if !live.ShouldEnforceSSO(nil) {
+		t.Error("a user with no roles is not a super admin and must be enforced")
+	}
+
+	// Not yet approved: enforcement must not begin, or the tenant locks itself
+	// out of a login SAML cannot yet perform.
+	pending := Config{Enabled: true, Active: false, EnforceSSO: true}
+	if pending.ShouldEnforceSSO(reader) {
+		t.Error("enforcement must not apply before Flexprice has approved the tenant")
+	}
+
+	off := Config{Enabled: true, Active: true, EnforceSSO: false}
+	if off.ShouldEnforceSSO(reader) {
+		t.Error("enforcement must not apply when the tenant has not asked for it")
+	}
+}

--- a/internal/ee/auth/saml/config_test.go
+++ b/internal/ee/auth/saml/config_test.go
@@ -1,0 +1,141 @@
+package saml
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// A self-signed certificate, generated for tests only. Never used outside them.
+const testCertPEM = `-----BEGIN CERTIFICATE-----
+MIIDUTCCAjmgAwIBAgIUajlTeNfQEKvyxPMs1o6B3MPIjngwDQYJKoZIhvcNAQEL
+BQAwODEcMBoGA1UECgwTRmxleHByaWNlIFNBTUwgVGVzdDEYMBYGA1UEAwwPaWRw
+LmV4YW1wbGUuY29tMB4XDTI2MDgxMjE1MjIxNFoXDTM2MDgwOTE1MjIxNFowODEc
+MBoGA1UECgwTRmxleHByaWNlIFNBTUwgVGVzdDEYMBYGA1UEAwwPaWRwLmV4YW1w
+bGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA9EppJAEYTsOY
+mrj+ZLQFEPZUsw9J4K70dClbcQuTsXyJWivmaQp8nVVj1BQaPfwGqeV2sarRqaGu
+CMf9dOTb/vYc+M3B9YDdzIPgIiWSvY1PmcTWErcmQBJolFqC+p1b3qKXtlt4sLXS
+VXd3zyP353IHKzdxuW4dWr19m0SXCzrJEwLcd93hthz+YMlcoAb0uICAV8QC9H20
+MHNEQZYeCtzm230P58kvcxPLJy1vAn/RJNbxrg2Cfu/3v0xdam6pJvW+mU/ldEPa
+ywiy1WD8P3C0kbbqZ3yIxlQsS2OCZx7RjTsuTXmJMa+c7ZkUorG4JnPA4Ep/w1Cp
+MAy57QfwHwIDAQABo1MwUTAdBgNVHQ4EFgQUjNSLgZR9vVZruMI1uArDrV5gXwEw
+HwYDVR0jBBgwFoAUjNSLgZR9vVZruMI1uArDrV5gXwEwDwYDVR0TAQH/BAUwAwEB
+/zANBgkqhkiG9w0BAQsFAAOCAQEAwmUmHHouLNqcciBxE9Gxh7LiZhRbCXj7GnYB
+SXA7SsB6t2S4gbUsEhayhS4ox9Gkj2YdWr3qX7Bki+xjQKXIw6+R4E+Y6frdRbGs
+I4i+zJ8u4XsCIAA2zGYtWreozUymhfmxmUnAgfzs2626yGoyY4fiZAgro/ZzP5Gw
+uoZEui3jI8z/+5G8RZ9JKRAQUXKV0fhWgiE8j/WuAYNr0QTyzYEZwsB+fT8ugPiQ
+2n+k84xiyB9DZJ3zm4U+aWWzpATtAxlqROLzXpFvCy/eAdphR4pfKKCOc1UE1KWF
+VuExJ38hE2lsaHRIkX4oGcu5SE34zlhW7w+nZo6+zYzN542fSw==
+-----END CERTIFICATE-----`
+
+func TestConfigValidateAllowsDisabled(t *testing.T) {
+	// A disabled config is the default state and must never block a settings
+	// write, otherwise a tenant cannot save partial progress while onboarding.
+	var cfg Config
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("a disabled config must validate: %v", err)
+	}
+}
+
+// TestConfigValidateRejectsIncompleteEnabled covers the failure this guards
+// against: a half-configured provider that is switched on fails at assertion
+// time, after the user has already authenticated with their IdP — a confusing
+// place to discover a typo.
+func TestConfigValidateRejectsIncompleteEnabled(t *testing.T) {
+	base := func() Config {
+		return Config{
+			Enabled:        true,
+			IDPEntityID:    "https://idp.example.com/metadata",
+			IDPSSOUrl:      "https://idp.example.com/sso",
+			IDPCertificate: testCertPEM,
+			DefaultRole:    string(types.RoleAllReader),
+		}
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{"missing entity id", func(c *Config) { c.IDPEntityID = "" }, "idp_entity_id"},
+		{"missing sso url", func(c *Config) { c.IDPSSOUrl = "" }, "idp_sso_url"},
+		{"missing certificate", func(c *Config) { c.IDPCertificate = "" }, "idp_certificate"},
+		{"missing default role", func(c *Config) { c.DefaultRole = "" }, "default_role"},
+		{"plaintext sso url", func(c *Config) { c.IDPSSOUrl = "http://idp.example.com/sso" }, "https"},
+		{"relative sso url", func(c *Config) { c.IDPSSOUrl = "/sso" }, "absolute"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base()
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected rejection mentioning %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestDefaultRoleMustBeAssignable stops a configuration change from minting a
+// role the RBAC model does not grant to humans — e.g. a service-account-only
+// role, or a typo that would otherwise be stored verbatim on the user row.
+func TestDefaultRoleMustBeAssignable(t *testing.T) {
+	for _, role := range types.UserTypeUser.AllowedRoles() {
+		if err := validateDefaultRole(string(role)); err != nil {
+			t.Errorf("role %q should be assignable to a user: %v", role, err)
+		}
+	}
+
+	for _, role := range []string{"event_ingestor", "root", "", "Reader"} {
+		if err := validateDefaultRole(role); err == nil {
+			t.Errorf("role %q must not be assignable to a user", role)
+		}
+	}
+}
+
+func TestConfigFromMapRoundTrip(t *testing.T) {
+	cfg, err := configFromMap(defaultConfig())
+	if err != nil {
+		t.Fatalf("default config must decode: %v", err)
+	}
+	if cfg.Enabled {
+		t.Error("SAML must default to disabled")
+	}
+	if cfg.DefaultRole != string(types.RoleAllReader) {
+		t.Errorf("default role = %q, want reader — a permissive default would over-grant JIT users", cfg.DefaultRole)
+	}
+}
+
+// TestLoopbackIdPAllowsPlainHTTP covers local development. An assertion travels
+// through the browser, so a plaintext identity provider would expose it in
+// transit — except on a loopback host, which never leaves the machine. Local
+// identity providers such as SimpleSAMLphp serve plain http, and requiring
+// https there makes the documented local test impossible to run.
+func TestLoopbackIdPAllowsPlainHTTP(t *testing.T) {
+	base := Config{
+		Enabled:        true,
+		IDPEntityID:    "http://localhost:8081/simplesaml/saml2/idp/metadata.php",
+		IDPCertificate: testCertPEM,
+		DefaultRole:    string(types.RoleAllReader),
+	}
+
+	for _, host := range []string{"localhost", "127.0.0.1"} {
+		cfg := base
+		cfg.IDPSSOUrl = "http://" + host + ":8081/sso"
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("plain http on %s must be allowed for local testing: %v", host, err)
+		}
+	}
+
+	// Anything non-loopback still requires https.
+	cfg := base
+	cfg.IDPSSOUrl = "http://idp.example.com/sso"
+	if err := cfg.Validate(); err == nil {
+		t.Error("plain http to a remote identity provider must be rejected")
+	}
+}

--- a/internal/ee/auth/saml/provider.go
+++ b/internal/ee/auth/saml/provider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/flexprice/flexprice/internal/auth"
 	"github.com/flexprice/flexprice/internal/config"
 	domainauth "github.com/flexprice/flexprice/internal/domain/auth"
-	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 )
 
@@ -52,26 +51,13 @@ func (p *samlProvider) baseURL() string {
 	return strings.TrimSuffix(p.cfg.Auth.SAML.BaseURL, "/")
 }
 
-// TenantAlias is the path segment a single-tenant deployment may use instead of
-// a tenant UUID.
-const TenantAlias = "default"
-
 // resolveTenant maps the tenant path segment to a tenant ID.
 //
-// A self-hosted install has exactly one tenant whose ID is identical on every
-// install, so requiring it in the URL means the operator hand-copies a UUID into
-// their identity provider — an easy thing to get subtly wrong, and the failure
-// (audience mismatch) does not point at the cause. Configuring
-// auth.saml.default_tenant_id lets those URLs read /v1/auth/saml/default/...
-//
-// The alias resolves only when configured. A multi-tenant deployment leaves it
-// empty, and "default" is then treated as an ordinary tenant ID that will not
-// match anything.
+// Every SAML URL names its tenant explicitly. There is no deployment-wide
+// default: SSO is configured per tenant, so a URL that did not say which tenant
+// it meant would have nothing to resolve against.
 func (p *samlProvider) resolveTenant(segment string) string {
-	if segment != TenantAlias {
-		return segment
-	}
-	return p.cfg.Auth.SAML.DefaultTenantID
+	return segment
 }
 
 func base64DER(cert *x509.Certificate) string {
@@ -83,15 +69,11 @@ func (p *samlProvider) GetProvider() types.AuthProvider { return ProviderName }
 // Login is not password-based for SAML. The browser flow runs through the
 // endpoints in routes.go and finishes at the ACS callback.
 //
-// Reaching this method means a user posted credentials to /auth/login while the
-// tenant is configured for SSO. Whether that is allowed is a deployment
-// decision, so it is gated by config rather than rejected outright.
+// Reaching this method means a user posted credentials to /auth/login. Whether
+// that is allowed is a per-tenant decision, enforced by the auth service against
+// the tenant's own saml_config before it gets here — a deployment-wide rule
+// would refuse password login for tenants that have never configured SSO.
 func (p *samlProvider) Login(ctx context.Context, req auth.AuthRequest, userAuthInfo *domainauth.Auth) (*auth.AuthResponse, error) {
-	if p.cfg.Auth.SAML.EnforceSSO {
-		return nil, ierr.NewError("password login is disabled for this deployment").
-			WithHint("Sign in through your identity provider").
-			Mark(ierr.ErrPermissionDenied)
-	}
 	return p.tokens.Login(ctx, req, userAuthInfo)
 }
 

--- a/internal/ee/auth/saml/provider.go
+++ b/internal/ee/auth/saml/provider.go
@@ -1,0 +1,136 @@
+// Package saml implements SAML 2.0 single sign-on so a self-managed customer
+// can authenticate dashboard users against their own identity provider.
+//
+// The provider does not mint its own tokens. After an assertion is validated it
+// delegates to the built-in flexprice provider, so the JWT claim schema, signing
+// secret, and every middleware that validates it stay exactly as they are for
+// password login.
+package saml
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"strings"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/auth"
+	"github.com/flexprice/flexprice/internal/config"
+	domainauth "github.com/flexprice/flexprice/internal/domain/auth"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// ProviderName is the value operators set as auth.provider.
+const ProviderName types.AuthProvider = "saml"
+
+// samlProvider implements auth.Provider. Private per the repo style guide; the
+// community build only ever holds it as an auth.Provider.
+type samlProvider struct {
+	cfg *config.Configuration
+	// tokens is the built-in provider. Everything that is not SSO-specific —
+	// token minting and validation, portal and checkout tokens — delegates to it
+	// so SAML never forks the claim schema.
+	tokens auth.Provider
+}
+
+// init registers this package as the SAML implementation. internal/auth cannot
+// import this package (it would be a cycle), so registration runs the other way.
+func init() {
+	auth.RegisterSAMLProvider(func(cfg *config.Configuration) auth.Provider {
+		return newSAMLProvider(cfg)
+	})
+}
+
+func newSAMLProvider(cfg *config.Configuration) *samlProvider {
+	return &samlProvider{cfg: cfg, tokens: auth.NewFlexpriceAuth(cfg)}
+}
+
+// baseURL is the externally reachable origin, used to build the SP entity ID and
+// ACS URL that appear in our metadata.
+func (p *samlProvider) baseURL() string {
+	return strings.TrimSuffix(p.cfg.Auth.SAML.BaseURL, "/")
+}
+
+// TenantAlias is the path segment a single-tenant deployment may use instead of
+// a tenant UUID.
+const TenantAlias = "default"
+
+// resolveTenant maps the tenant path segment to a tenant ID.
+//
+// A self-hosted install has exactly one tenant whose ID is identical on every
+// install, so requiring it in the URL means the operator hand-copies a UUID into
+// their identity provider — an easy thing to get subtly wrong, and the failure
+// (audience mismatch) does not point at the cause. Configuring
+// auth.saml.default_tenant_id lets those URLs read /v1/auth/saml/default/...
+//
+// The alias resolves only when configured. A multi-tenant deployment leaves it
+// empty, and "default" is then treated as an ordinary tenant ID that will not
+// match anything.
+func (p *samlProvider) resolveTenant(segment string) string {
+	if segment != TenantAlias {
+		return segment
+	}
+	return p.cfg.Auth.SAML.DefaultTenantID
+}
+
+func base64DER(cert *x509.Certificate) string {
+	return base64.StdEncoding.EncodeToString(cert.Raw)
+}
+
+func (p *samlProvider) GetProvider() types.AuthProvider { return ProviderName }
+
+// Login is not password-based for SAML. The browser flow runs through the
+// endpoints in routes.go and finishes at the ACS callback.
+//
+// Reaching this method means a user posted credentials to /auth/login while the
+// tenant is configured for SSO. Whether that is allowed is a deployment
+// decision, so it is gated by config rather than rejected outright.
+func (p *samlProvider) Login(ctx context.Context, req auth.AuthRequest, userAuthInfo *domainauth.Auth) (*auth.AuthResponse, error) {
+	if p.cfg.Auth.SAML.EnforceSSO {
+		return nil, ierr.NewError("password login is disabled for this deployment").
+			WithHint("Sign in through your identity provider").
+			Mark(ierr.ErrPermissionDenied)
+	}
+	return p.tokens.Login(ctx, req, userAuthInfo)
+}
+
+// SignUp is not reachable through SSO: a tenant is created by an administrator,
+// and its users arrive by just-in-time provisioning at the ACS endpoint.
+func (p *samlProvider) SignUp(ctx context.Context, req auth.AuthRequest) (*auth.AuthResponse, error) {
+	return p.tokens.SignUp(ctx, req)
+}
+
+// UserInvite returns no auth record, which is what makes just-in-time
+// provisioning clean: the user service only writes a password row when one is
+// returned, so an SSO user exists with no credential of its own.
+func (p *samlProvider) UserInvite(ctx context.Context, req auth.UserInviteRequest) (*auth.UserInviteResponse, error) {
+	return &auth.UserInviteResponse{}, nil
+}
+
+func (p *samlProvider) AssignUserToTenant(ctx context.Context, userID, tenantID string) error {
+	return nil
+}
+
+// The remaining methods are identity-provider agnostic and delegate unchanged.
+
+func (p *samlProvider) ValidateToken(ctx context.Context, token string) (*domainauth.Claims, error) {
+	return p.tokens.ValidateToken(ctx, token)
+}
+
+func (p *samlProvider) GenerateSessionToken(customerID, externalCustomerID, tenantID, environmentID string, timeoutHours int) (string, time.Time, error) {
+	return p.tokens.GenerateSessionToken(customerID, externalCustomerID, tenantID, environmentID, timeoutHours)
+}
+
+func (p *samlProvider) ValidateSessionToken(ctx context.Context, token string) (*domainauth.SessionClaims, error) {
+	return p.tokens.ValidateSessionToken(ctx, token)
+}
+
+func (p *samlProvider) GenerateDevToken(tenantID, environmentID, userID, email string, expiryHours int) (string, time.Time, error) {
+	return p.tokens.GenerateDevToken(tenantID, environmentID, userID, email, expiryHours)
+}
+
+func (p *samlProvider) GenerateCheckoutToken(extraClaims map[string]interface{}) (string, error) {
+	return p.tokens.GenerateCheckoutToken(extraClaims)
+}
+

--- a/internal/ee/auth/saml/provider.go
+++ b/internal/ee/auth/saml/provider.go
@@ -94,7 +94,12 @@ func (p *samlProvider) SignUp(ctx context.Context, req auth.AuthRequest) (*auth.
 // provisioning clean: the user service only writes a password row when one is
 // returned, so an SSO user exists with no credential of its own.
 func (p *samlProvider) UserInvite(ctx context.Context, req auth.UserInviteRequest) (*auth.UserInviteResponse, error) {
-	return &auth.UserInviteResponse{}, nil
+	// An ID is still required: the caller writes it as the new user's primary
+	// key, so returning an empty response persists a row keyed on "". No auth
+	// record accompanies it — that absence is what leaves the user with no
+	// credential of their own until they arrive through their identity
+	// provider.
+	return &auth.UserInviteResponse{ID: types.GenerateUUIDWithPrefix(types.UUID_PREFIX_USER)}, nil
 }
 
 func (p *samlProvider) AssignUserToTenant(ctx context.Context, userID, tenantID string) error {

--- a/internal/ee/auth/saml/provider.go
+++ b/internal/ee/auth/saml/provider.go
@@ -33,12 +33,19 @@ type samlProvider struct {
 	tokens auth.Provider
 }
 
-// init registers this package as the SAML implementation. internal/auth cannot
-// import this package (it would be a cycle), so registration runs the other way.
+// init registers this package as the SAML implementation. internal/auth and
+// internal/types cannot import this package (it would be a cycle), so
+// registration runs the other way.
 func init() {
 	auth.RegisterSAMLProvider(func(cfg *config.Configuration) auth.Provider {
 		return newSAMLProvider(cfg)
 	})
+
+	// Without this the settings API would accept any saml_config it could
+	// decode: the generic path has no way to parse a certificate or judge a
+	// role, so an unvalidated identity provider would be stored and only fail
+	// at login, after a user has already authenticated.
+	types.RegisterSAMLConfigValidator(validateStoredConfig)
 }
 
 func newSAMLProvider(cfg *config.Configuration) *samlProvider {

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -138,7 +138,7 @@ func (h *Handler) tenantConfig(c *gin.Context) (string, Config, error) {
 	tenantID := newSAMLProvider(h.cfg).resolveTenant(c.Param("tenant"))
 	if tenantID == "" {
 		return "", Config{}, ierr.NewError("tenant is required").
-			WithHint("Use the tenant ID in the path, or set auth.saml.default_tenant_id to use /default").
+			WithHint("Use the tenant ID in the path: /v1/auth/saml/{tenant_id}/...").
 			Mark(ierr.ErrValidation)
 	}
 
@@ -172,7 +172,7 @@ func (h *Handler) Metadata(c *gin.Context) {
 	tenantID := provider.resolveTenant(c.Param("tenant"))
 	if tenantID == "" {
 		c.Error(ierr.NewError("tenant is required").
-			WithHint("Use the tenant ID in the path, or set auth.saml.default_tenant_id to use /default").
+			WithHint("Use the tenant ID in the path: /v1/auth/saml/{tenant_id}/...").
 			Mark(ierr.ErrValidation))
 		return
 	}

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -2,20 +2,21 @@ package saml
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/crewjam/saml"
 	"github.com/gin-gonic/gin"
 
+	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/ee/service"
-	"github.com/flexprice/flexprice/internal/logger"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
 )
 
@@ -29,79 +30,101 @@ const (
 	tokenExpiryHours = 24 * 30
 )
 
-// requestTracker remembers the AuthnRequest IDs this deployment issued.
+// requestTracker records the AuthnRequest IDs this deployment issued, so an
+// assertion can be checked against a request we actually made.
 //
-// An assertion must answer a request we made: without that check an attacker who
-// obtains any valid assertion for our service provider can replay it at the ACS
-// endpoint. Entries expire with the request they describe.
+// Without that check an attacker holding any valid assertion for our service
+// provider can post it at the ACS endpoint and be logged in; with it, an
+// assertion is usable exactly once.
 //
-// This is process-local, which means a deployment running several API replicas
-// behind a load balancer can bounce a user whose callback lands on a different
-// replica. Moving it to Redis is the obvious next step; it is called out in the
-// handler so the limitation is not discovered in production.
+// State lives in Redis rather than in process memory. The redirect that starts a
+// login and the callback that finishes it are separate requests, and a load
+// balancer is free to send them to different replicas: with the IDs held in one
+// process, roughly (N-1)/N of logins would fail on an N-replica deployment, at
+// random, looking like an identity provider fault. Redis is therefore required
+// for SAML, which is enforced at boot rather than discovered here.
 type requestTracker struct {
-	mu  sync.Mutex
-	ids map[string]time.Time
+	cache cache.RedisCache
 }
 
-func newRequestTracker() *requestTracker {
-	return &requestTracker{ids: map[string]time.Time{}}
+func newRequestTracker(c cache.RedisCache) *requestTracker {
+	return &requestTracker{cache: c}
 }
 
-func (t *requestTracker) remember(id string, expiry time.Time) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+// trackerKeyPrefix namespaces outstanding requests. The tenant is part of the
+// key so one tenant's request can never satisfy another's assertion.
+const trackerKeyPrefix = "saml:authn_request:v1:"
 
-	t.evictExpiredLocked()
-	t.ids[id] = expiry
+func trackerKey(tenantID, id string) string {
+	return trackerKeyPrefix + tenantID + ":" + id
 }
 
-// claim atomically takes the outstanding request IDs and removes the one the
-// assertion answers, so a second post of the same assertion finds nothing to
-// match and is rejected.
+// remember records an outstanding request. It expires on its own, so an
+// abandoned login leaves nothing behind and the replay window stays bounded.
+func (t *requestTracker) remember(ctx context.Context, tenantID, id string) {
+	t.cache.Set(ctx, trackerKey(tenantID, id), true, authnRequestTTL)
+}
+
+// claim consumes the request an assertion answers, reporting whether it was
+// outstanding.
 //
-// Taking and removing under one lock is what makes this a replay defence rather
-// than a hint: two concurrent posts of the same assertion cannot both observe
-// the ID as outstanding.
-func (t *requestTracker) claim(inResponseTo string) []string {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	t.evictExpiredLocked()
-
-	out := make([]string, 0, len(t.ids))
-	for id := range t.ids {
-		out = append(out, id)
+// The delete is what makes this single-use: the ID is gone before validation
+// runs, so a second post of the same assertion finds nothing to consume. It
+// cannot be deferred until after validation — two concurrent replays would then
+// both observe the ID as outstanding and both succeed.
+//
+// The returned slice is what crewjam validates InResponseTo against. It holds
+// only the answered ID: an assertion answering anything else is rejected, which
+// is the same outcome as the previous behaviour of returning every outstanding
+// ID, without needing to enumerate them.
+func (t *requestTracker) claim(ctx context.Context, tenantID, inResponseTo string) ([]string, bool) {
+	if inResponseTo == "" {
+		return nil, false
 	}
 
-	// Remove the answered ID. An assertion carrying an unknown InResponseTo is
-	// left for crewjam/saml to reject against the list we just returned.
-	if inResponseTo != "" {
-		delete(t.ids, inResponseTo)
+	key := trackerKey(tenantID, inResponseTo)
+	if _, found := t.cache.Get(ctx, key); !found {
+		return nil, false
 	}
-	return out
+	t.cache.Delete(ctx, key)
+
+	return []string{inResponseTo}, true
 }
 
-func (t *requestTracker) evictExpiredLocked() {
-	now := time.Now()
-	for id, exp := range t.ids {
-		if now.After(exp) {
-			delete(t.ids, id)
-		}
+// restore puts back a request that claim consumed for a login that then failed
+// validation.
+//
+// Without it any rejected response burns the outstanding request, so an identity
+// provider retrying after a transient failure — or a browser reposting once a
+// clock skew resolves — has nothing left to answer and the login fails
+// permanently. Only called after validation has failed, so a consumed assertion
+// is never resurrected.
+//
+// The full TTL is granted again rather than the remainder. The window this
+// reopens is bounded by the same ten minutes, and tracking the original expiry
+// across replicas would cost more than it protects.
+func (t *requestTracker) restore(ctx context.Context, tenantID, id string) {
+	if id == "" {
+		return
 	}
+	t.cache.Set(ctx, trackerKey(tenantID, id), true, authnRequestTTL)
 }
-
-var tracker = newRequestTracker()
 
 // Handler serves the SAML browser-flow endpoints.
 type Handler struct {
 	cfg           *config.Configuration
 	serviceParams service.ServiceParams
 	logger        *logger.Logger
+	tracker       *requestTracker
 }
 
 func NewHandler(cfg *config.Configuration, serviceParams service.ServiceParams, logger *logger.Logger) *Handler {
-	return &Handler{cfg: cfg, serviceParams: serviceParams, logger: logger}
+	return &Handler{
+		cfg:           cfg,
+		serviceParams: serviceParams,
+		logger:        logger,
+		tracker:       newRequestTracker(serviceParams.RedisCache),
+	}
 }
 
 // RegisterRoutes mounts the SAML endpoints on the public group. They run before
@@ -122,7 +145,6 @@ func (h *Handler) RegisterRoutes(public *gin.RouterGroup) {
 		group.POST("/acs", h.ACS)
 	}
 }
-
 
 // tenantConfig loads a tenant's identity provider configuration.
 //
@@ -231,7 +253,7 @@ func (h *Handler) Login(c *gin.Context) {
 		return
 	}
 
-	tracker.remember(authnRequest.ID, time.Now().Add(authnRequestTTL))
+	h.tracker.remember(c.Request.Context(), tenantID, authnRequest.ID)
 
 	redirectURL, err := authnRequest.Redirect("", sp)
 	if err != nil {
@@ -264,10 +286,20 @@ func (h *Handler) ACS(c *gin.Context) {
 	// The InResponseTo is read before validation purely to know which
 	// outstanding request to retire; nothing is trusted from it, since the
 	// assertion is validated against the returned list immediately after.
-	possibleIDs := tracker.claim(inResponseTo(c.Request))
+	answeredID := inResponseTo(c.Request)
+	possibleIDs, consumed := h.tracker.claim(c.Request.Context(), tenantID, answeredID)
 
 	result, err := validateAssertion(sp, c.Request, possibleIDs, cfg)
 	if err != nil {
+		// Put the request back. It was consumed before validation so a
+		// concurrent replay could not also observe it, but this response never
+		// became a login: leaving it consumed would mean an identity provider
+		// retrying after a transient failure, or a browser reposting once a
+		// clock skew resolves, has nothing left to answer.
+		if consumed {
+			h.tracker.restore(c.Request.Context(), tenantID, answeredID)
+		}
+
 		h.logger.Error(c.Request.Context(), "saml assertion rejected",
 			"error", err, "tenant_id", tenantID)
 		c.Error(err)
@@ -299,6 +331,19 @@ func (h *Handler) ACS(c *gin.Context) {
 }
 
 // dashboardRedirect hands the token back to the browser application.
+//
+// The token travels in the URL fragment rather than the query string. A
+// fragment is never sent to a server: it stays out of access logs at every
+// proxy and CDN in the path, and out of the Referer header of every request the
+// dashboard makes once it loads. A query parameter reaches all of those, and
+// this token is valid for thirty days, so each of them is a durable copy of a
+// live credential.
+//
+// The fragment is still visible in browser history and to script on the page,
+// which is why the dashboard clears it from the URL as soon as it has read it.
+// Removing that exposure altogether needs a single-use code exchanged for the
+// token, or an HttpOnly cookie set by this handler — both change the contract
+// with the dashboard and are worth doing deliberately rather than here.
 func dashboardRedirect(cfg *config.Configuration, token string) string {
 	base := cfg.Auth.SAML.DashboardURL
 	if base == "" {
@@ -308,9 +353,7 @@ func dashboardRedirect(cfg *config.Configuration, token string) string {
 	if err != nil {
 		return "/"
 	}
-	q := u.Query()
-	q.Set("token", token)
-	u.RawQuery = q.Encode()
+	u.Fragment = "token=" + token
 	return u.String()
 }
 

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -107,7 +107,14 @@ func NewHandler(cfg *config.Configuration, serviceParams service.ServiceParams, 
 // RegisterRoutes mounts the SAML endpoints on the public group. They run before
 // a session exists: the login redirect starts the flow, and the ACS callback is
 // posted by the identity provider, which carries no Flexprice credentials.
+//
+// A deployment with SAML switched off mounts nothing, so the endpoints 404 as
+// though the feature did not exist rather than announcing a disabled one.
 func (h *Handler) RegisterRoutes(public *gin.RouterGroup) {
+	if !h.cfg.Auth.SAML.Enabled {
+		return
+	}
+
 	group := public.Group("/auth/saml/:tenant")
 	{
 		group.GET("/metadata", h.Metadata)
@@ -147,7 +154,10 @@ func (h *Handler) tenantConfig(c *gin.Context) (string, Config, error) {
 	if err != nil {
 		return "", Config{}, err
 	}
-	if !cfg.Enabled {
+	// Both the tenant's switch and the Flexprice-side approval must be on. The
+	// two are reported identically: whether a tenant is unapproved rather than
+	// unconfigured is not something an unauthenticated caller should learn.
+	if !cfg.IsLive() {
 		return "", Config{}, ierr.NewError("saml is not enabled for this organisation").
 			Mark(ierr.ErrNotFound)
 	}

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -1,11 +1,11 @@
 package saml
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/xml"
 	"net/http"
 	"net/url"
-	"regexp"
 	"sync"
 	"time"
 
@@ -317,6 +317,19 @@ func dashboardRedirect(cfg *config.Configuration, token string) string {
 // inResponseTo extracts the AuthnRequest ID an assertion claims to answer,
 // without validating anything — the value is used only to retire the matching
 // outstanding request.
+//
+// Parsed as XML rather than matched with a pattern. The value decides which
+// outstanding request is retired, so failing to find it silently disables the
+// replay defence: claim("") retires nothing and the same assertion can be
+// posted again until the request expires. A pattern would have to agree with
+// every identity provider's serialisation to avoid that — single-quoted
+// attributes and whitespace around "=" are both valid XML — and it would also
+// have to avoid matching InResponseTo on nested elements such as
+// SubjectConfirmationData, which appears before the Response attribute in some
+// documents and would retire the wrong ID.
+//
+// Only the root element's attribute is read; the decoder stops at the first
+// token, so a malformed or hostile document costs nothing to reject.
 func inResponseTo(r *http.Request) string {
 	raw := r.PostFormValue("SAMLResponse")
 	if raw == "" {
@@ -326,11 +339,24 @@ func inResponseTo(r *http.Request) string {
 	if err != nil {
 		return ""
 	}
-	m := inResponseToPattern.FindSubmatch(decoded)
-	if len(m) < 2 {
+
+	decoder := xml.NewDecoder(bytes.NewReader(decoded))
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok {
+			// Skip the XML declaration, comments and whitespace preceding the
+			// root element.
+			continue
+		}
+		for _, attr := range start.Attr {
+			if attr.Name.Local == "InResponseTo" {
+				return attr.Value
+			}
+		}
 		return ""
 	}
-	return string(m[1])
 }
-
-var inResponseToPattern = regexp.MustCompile(`InResponseTo="([^"]+)"`)

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -127,25 +127,6 @@ func NewHandler(cfg *config.Configuration, serviceParams service.ServiceParams, 
 	}
 }
 
-// RegisterRoutes mounts the SAML endpoints on the public group. They run before
-// a session exists: the login redirect starts the flow, and the ACS callback is
-// posted by the identity provider, which carries no Flexprice credentials.
-//
-// A deployment with SAML switched off mounts nothing, so the endpoints 404 as
-// though the feature did not exist rather than announcing a disabled one.
-func (h *Handler) RegisterRoutes(public *gin.RouterGroup) {
-	if !h.cfg.Auth.SAML.Enabled {
-		return
-	}
-
-	group := public.Group("/auth/saml/:tenant")
-	{
-		group.GET("/metadata", h.Metadata)
-		group.GET("/login", h.Login)
-		group.POST("/acs", h.ACS)
-	}
-}
-
 // tenantConfig loads a tenant's identity provider configuration.
 //
 // The tenant comes from the URL rather than a session, so it is attacker-chosen.

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -327,7 +327,7 @@ func (h *Handler) ACS(c *gin.Context) {
 	h.logger.Info(ctx, "saml login succeeded",
 		"tenant_id", tenantID, "user_id", userID)
 
-	c.Redirect(http.StatusFound, dashboardRedirect(h.cfg, token))
+	c.Redirect(http.StatusFound, dashboardRedirect(h.cfg, tenantID, token))
 }
 
 // dashboardRedirect hands the token back to the browser application.
@@ -344,7 +344,12 @@ func (h *Handler) ACS(c *gin.Context) {
 // Removing that exposure altogether needs a single-use code exchanged for the
 // token, or an HttpOnly cookie set by this handler — both change the contract
 // with the dashboard and are worth doing deliberately rather than here.
-func dashboardRedirect(cfg *config.Configuration, token string) string {
+// The tenant travels with it so the dashboard can confirm the callback answers
+// the login that browser started. It is not trusted as an identity — the
+// dashboard compares it against the tenant it recorded when it began the flow
+// and refuses a mismatch, which is what stops a token minted for one tenant
+// being planted on a browser mid-login to another.
+func dashboardRedirect(cfg *config.Configuration, tenantID, token string) string {
 	base := cfg.Auth.SAML.DashboardURL
 	if base == "" {
 		base = "/"
@@ -353,7 +358,11 @@ func dashboardRedirect(cfg *config.Configuration, token string) string {
 	if err != nil {
 		return "/"
 	}
-	u.Fragment = "token=" + token
+
+	fragment := url.Values{}
+	fragment.Set("token", token)
+	fragment.Set("tenant_id", tenantID)
+	u.Fragment = fragment.Encode()
 	return u.String()
 }
 

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -1,0 +1,322 @@
+package saml
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/gin-gonic/gin"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/ee/service"
+	"github.com/flexprice/flexprice/internal/logger"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+const (
+	// authnRequestTTL bounds how long an outstanding AuthnRequest is accepted.
+	// Short enough to limit the replay window, long enough for a user to type a
+	// password and clear MFA at their identity provider.
+	authnRequestTTL = 10 * time.Minute
+
+	// tokenExpiryHours matches the community login token lifetime.
+	tokenExpiryHours = 24 * 30
+)
+
+// requestTracker remembers the AuthnRequest IDs this deployment issued.
+//
+// An assertion must answer a request we made: without that check an attacker who
+// obtains any valid assertion for our service provider can replay it at the ACS
+// endpoint. Entries expire with the request they describe.
+//
+// This is process-local, which means a deployment running several API replicas
+// behind a load balancer can bounce a user whose callback lands on a different
+// replica. Moving it to Redis is the obvious next step; it is called out in the
+// handler so the limitation is not discovered in production.
+type requestTracker struct {
+	mu  sync.Mutex
+	ids map[string]time.Time
+}
+
+func newRequestTracker() *requestTracker {
+	return &requestTracker{ids: map[string]time.Time{}}
+}
+
+func (t *requestTracker) remember(id string, expiry time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.evictExpiredLocked()
+	t.ids[id] = expiry
+}
+
+// claim atomically takes the outstanding request IDs and removes the one the
+// assertion answers, so a second post of the same assertion finds nothing to
+// match and is rejected.
+//
+// Taking and removing under one lock is what makes this a replay defence rather
+// than a hint: two concurrent posts of the same assertion cannot both observe
+// the ID as outstanding.
+func (t *requestTracker) claim(inResponseTo string) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.evictExpiredLocked()
+
+	out := make([]string, 0, len(t.ids))
+	for id := range t.ids {
+		out = append(out, id)
+	}
+
+	// Remove the answered ID. An assertion carrying an unknown InResponseTo is
+	// left for crewjam/saml to reject against the list we just returned.
+	if inResponseTo != "" {
+		delete(t.ids, inResponseTo)
+	}
+	return out
+}
+
+func (t *requestTracker) evictExpiredLocked() {
+	now := time.Now()
+	for id, exp := range t.ids {
+		if now.After(exp) {
+			delete(t.ids, id)
+		}
+	}
+}
+
+var tracker = newRequestTracker()
+
+// Handler serves the SAML browser-flow endpoints.
+type Handler struct {
+	cfg           *config.Configuration
+	serviceParams service.ServiceParams
+	logger        *logger.Logger
+}
+
+func NewHandler(cfg *config.Configuration, serviceParams service.ServiceParams, logger *logger.Logger) *Handler {
+	return &Handler{cfg: cfg, serviceParams: serviceParams, logger: logger}
+}
+
+// RegisterRoutes mounts the SAML endpoints on the public group. They run before
+// a session exists: the login redirect starts the flow, and the ACS callback is
+// posted by the identity provider, which carries no Flexprice credentials.
+func (h *Handler) RegisterRoutes(public *gin.RouterGroup) {
+	group := public.Group("/auth/saml/:tenant")
+	{
+		group.GET("/metadata", h.Metadata)
+		group.GET("/login", h.Login)
+		group.POST("/acs", h.ACS)
+	}
+}
+
+
+// tenantConfig loads a tenant's identity provider configuration.
+//
+// The tenant comes from the URL rather than a session, so it is attacker-chosen.
+// That is safe because the configuration itself decides everything that follows:
+// an unconfigured or disabled tenant yields no provider, and the assertion is
+// verified against that tenant's certificate.
+func (h *Handler) tenantConfig(c *gin.Context) (string, Config, error) {
+	// The resolved ID is used for everything downstream — the settings lookup,
+	// the SP entity ID, and the ACS URL — so metadata and assertion validation
+	// always agree on who we are. Resolving in one place is what keeps them
+	// consistent.
+	tenantID := newSAMLProvider(h.cfg).resolveTenant(c.Param("tenant"))
+	if tenantID == "" {
+		return "", Config{}, ierr.NewError("tenant is required").
+			WithHint("Use the tenant ID in the path, or set auth.saml.default_tenant_id to use /default").
+			Mark(ierr.ErrValidation)
+	}
+
+	ctx := types.SetTenantID(c.Request.Context(), tenantID)
+	settingsSvc := service.NewSettingsService(h.serviceParams)
+
+	resp, err := settingsSvc.GetSettingByKey(ctx, SettingKeySAML)
+	if err != nil {
+		return "", Config{}, err
+	}
+
+	cfg, err := configFromMap(resp.Value)
+	if err != nil {
+		return "", Config{}, err
+	}
+	if !cfg.Enabled {
+		return "", Config{}, ierr.NewError("saml is not enabled for this organisation").
+			Mark(ierr.ErrNotFound)
+	}
+	return tenantID, cfg, nil
+}
+
+// metadataHandler serves SP metadata for the customer to upload into their
+// identity provider. It is the first endpoint a customer needs, and works before
+// any login has ever succeeded.
+func (h *Handler) Metadata(c *gin.Context) {
+	provider := newSAMLProvider(h.cfg)
+	tenantID := provider.resolveTenant(c.Param("tenant"))
+	if tenantID == "" {
+		c.Error(ierr.NewError("tenant is required").
+			WithHint("Use the tenant ID in the path, or set auth.saml.default_tenant_id to use /default").
+			Mark(ierr.ErrValidation))
+		return
+	}
+
+	// Deliberately not gated on a configured identity provider. Onboarding
+	// runs the other way round: the customer's administrator needs our ACS
+	// URL and entity ID to create the application in their identity
+	// provider, and only then can they hand back the entity ID, SSO URL,
+	// and certificate we would be validating here. Requiring configuration
+	// first is a deadlock.
+	//
+	// Nothing sensitive is exposed: this metadata is derived entirely from
+	// base_url and the tenant in the path, both of which the caller already
+	// knows.
+	sp, err := provider.metadataOnlyServiceProvider(tenantID)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	out, err := xml.MarshalIndent(sp.Metadata(), "", "  ")
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.Data(http.StatusOK, "application/samlmetadata+xml", out)
+}
+
+// Login starts SP-initiated login by redirecting to the identity provider with
+// a signed AuthnRequest.
+func (h *Handler) Login(c *gin.Context) {
+	tenantID, cfg, err := h.tenantConfig(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	provider := newSAMLProvider(h.cfg)
+	sp, err := provider.serviceProvider(tenantID, cfg)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	authnRequest, err := sp.MakeAuthenticationRequest(
+		sp.GetSSOBindingLocation(saml.HTTPRedirectBinding),
+		saml.HTTPRedirectBinding,
+		saml.HTTPPostBinding,
+	)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	tracker.remember(authnRequest.ID, time.Now().Add(authnRequestTTL))
+
+	redirectURL, err := authnRequest.Redirect("", sp)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.Redirect(http.StatusFound, redirectURL.String())
+}
+
+// ACS consumes the identity provider's assertion and completes login.
+func (h *Handler) ACS(c *gin.Context) {
+	tenantID, cfg, err := h.tenantConfig(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	if err := c.Request.ParseForm(); err != nil {
+		c.Error(ierr.NewError("malformed saml response").Mark(ierr.ErrValidation))
+		return
+	}
+
+	provider := newSAMLProvider(h.cfg)
+	sp, err := provider.serviceProvider(tenantID, cfg)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	// The InResponseTo is read before validation purely to know which
+	// outstanding request to retire; nothing is trusted from it, since the
+	// assertion is validated against the returned list immediately after.
+	possibleIDs := tracker.claim(inResponseTo(c.Request))
+
+	result, err := validateAssertion(sp, c.Request, possibleIDs, cfg)
+	if err != nil {
+		h.logger.Error(c.Request.Context(), "saml assertion rejected",
+			"error", err, "tenant_id", tenantID)
+		c.Error(err)
+		return
+	}
+
+	ctx := types.SetTenantID(c.Request.Context(), tenantID)
+	userID, err := provider.resolveUser(ctx, h.serviceParams, tenantID, result.Email, cfg)
+	if err != nil {
+		h.logger.Error(ctx, "saml login could not resolve a user",
+			"error", err, "tenant_id", tenantID)
+		c.Error(err)
+		return
+	}
+
+	// The token is minted by the built-in provider, so its claims are
+	// identical to a password login and every existing middleware validates
+	// it unchanged.
+	token, _, err := provider.tokens.GenerateDevToken(tenantID, "", userID, result.Email, tokenExpiryHours)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	h.logger.Info(ctx, "saml login succeeded",
+		"tenant_id", tenantID, "user_id", userID)
+
+	c.Redirect(http.StatusFound, dashboardRedirect(h.cfg, token))
+}
+
+// dashboardRedirect hands the token back to the browser application.
+func dashboardRedirect(cfg *config.Configuration, token string) string {
+	base := cfg.Auth.SAML.DashboardURL
+	if base == "" {
+		base = "/"
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "/"
+	}
+	q := u.Query()
+	q.Set("token", token)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// inResponseTo extracts the AuthnRequest ID an assertion claims to answer,
+// without validating anything — the value is used only to retire the matching
+// outstanding request.
+func inResponseTo(r *http.Request) string {
+	raw := r.PostFormValue("SAMLResponse")
+	if raw == "" {
+		return ""
+	}
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return ""
+	}
+	m := inResponseToPattern.FindSubmatch(decoded)
+	if len(m) < 2 {
+		return ""
+	}
+	return string(m[1])
+}
+
+var inResponseToPattern = regexp.MustCompile(`InResponseTo="([^"]+)"`)

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -44,11 +44,12 @@ const (
 // random, looking like an identity provider fault. Redis is therefore required
 // for SAML, which is enforced at boot rather than discovered here.
 type requestTracker struct {
-	cache cache.RedisCache
+	cache  cache.RedisCache
+	locker cache.Locker
 }
 
-func newRequestTracker(c cache.RedisCache) *requestTracker {
-	return &requestTracker{cache: c}
+func newRequestTracker(c cache.RedisCache, l cache.Locker) *requestTracker {
+	return &requestTracker{cache: c, locker: l}
 }
 
 // trackerKeyPrefix namespaces outstanding requests. The tenant is part of the
@@ -59,56 +60,56 @@ func trackerKey(tenantID, id string) string {
 	return trackerKeyPrefix + tenantID + ":" + id
 }
 
+// consumedKey marks a request as already answered. Separate from the
+// outstanding key so the two can be reasoned about independently: one records
+// that a login began, the other that it has been completed exactly once.
+func consumedKey(tenantID, id string) string {
+	return trackerKeyPrefix + "consumed:" + tenantID + ":" + id
+}
+
 // remember records an outstanding request. It expires on its own, so an
 // abandoned login leaves nothing behind and the replay window stays bounded.
 func (t *requestTracker) remember(ctx context.Context, tenantID, id string) {
 	t.cache.Set(ctx, trackerKey(tenantID, id), true, authnRequestTTL)
 }
 
-// claim consumes the request an assertion answers, reporting whether it was
-// outstanding.
+// claim consumes the request an assertion answers, reporting whether this
+// caller is the one that consumed it.
 //
-// The delete is what makes this single-use: the ID is gone before validation
-// runs, so a second post of the same assertion finds nothing to consume. It
-// cannot be deferred until after validation — two concurrent replays would then
-// both observe the ID as outstanding and both succeed.
+// Single use is enforced by taking a lock on the request ID, which is a Redis
+// SETNX: exactly one caller can create the key, so two concurrent posts of the
+// same assertion cannot both proceed. Reading the outstanding key and then
+// deleting it would not do — the two calls are separate round trips, and both
+// callers could observe the key as present before either removed it, which is
+// the race this defence exists to prevent.
+//
+// The lock is never released. It is not mutual exclusion around a critical
+// section; it is the record that this request has been answered, and it expires
+// with the request itself.
 //
 // The returned slice is what crewjam validates InResponseTo against. It holds
-// only the answered ID: an assertion answering anything else is rejected, which
-// is the same outcome as the previous behaviour of returning every outstanding
-// ID, without needing to enumerate them.
+// only the answered ID, so an assertion answering anything else is rejected.
 func (t *requestTracker) claim(ctx context.Context, tenantID, inResponseTo string) ([]string, bool) {
 	if inResponseTo == "" {
 		return nil, false
 	}
 
-	key := trackerKey(tenantID, inResponseTo)
-	if _, found := t.cache.Get(ctx, key); !found {
+	// The request must have been issued by this deployment.
+	if _, found := t.cache.Get(ctx, trackerKey(tenantID, inResponseTo)); !found {
 		return nil, false
 	}
-	t.cache.Delete(ctx, key)
+
+	lock, err := t.locker.AcquireLock(ctx, consumedKey(tenantID, inResponseTo), authnRequestTTL)
+	if err != nil || lock == nil || !lock.AcquiredSuccessfully() {
+		// Either Redis is unreachable or someone else already consumed this
+		// request. Both must refuse: allowing the login when the single-use
+		// check cannot be made is what a replay would rely on.
+		return nil, false
+	}
 
 	return []string{inResponseTo}, true
 }
 
-// restore puts back a request that claim consumed for a login that then failed
-// validation.
-//
-// Without it any rejected response burns the outstanding request, so an identity
-// provider retrying after a transient failure — or a browser reposting once a
-// clock skew resolves — has nothing left to answer and the login fails
-// permanently. Only called after validation has failed, so a consumed assertion
-// is never resurrected.
-//
-// The full TTL is granted again rather than the remainder. The window this
-// reopens is bounded by the same ten minutes, and tracking the original expiry
-// across replicas would cost more than it protects.
-func (t *requestTracker) restore(ctx context.Context, tenantID, id string) {
-	if id == "" {
-		return
-	}
-	t.cache.Set(ctx, trackerKey(tenantID, id), true, authnRequestTTL)
-}
 
 // Handler serves the SAML browser-flow endpoints.
 type Handler struct {
@@ -123,7 +124,7 @@ func NewHandler(cfg *config.Configuration, serviceParams service.ServiceParams, 
 		cfg:           cfg,
 		serviceParams: serviceParams,
 		logger:        logger,
-		tracker:       newRequestTracker(serviceParams.RedisCache),
+		tracker:       newRequestTracker(serviceParams.RedisCache, serviceParams.Locker),
 	}
 }
 
@@ -268,19 +269,17 @@ func (h *Handler) ACS(c *gin.Context) {
 	// outstanding request to retire; nothing is trusted from it, since the
 	// assertion is validated against the returned list immediately after.
 	answeredID := inResponseTo(c.Request)
-	possibleIDs, consumed := h.tracker.claim(c.Request.Context(), tenantID, answeredID)
+	possibleIDs, _ := h.tracker.claim(c.Request.Context(), tenantID, answeredID)
 
+	// A rejected response leaves the request consumed rather than reopening it.
+	// Reopening would mean releasing a marker taken atomically on whichever
+	// replica served this request, and no replica can release another's — so the
+	// alternative is a window in which the same assertion is claimable twice.
+	// The cost is that a genuine retry must start a fresh login, which is what
+	// the identity provider does anyway when the browser returns to the login
+	// endpoint.
 	result, err := validateAssertion(sp, c.Request, possibleIDs, cfg)
 	if err != nil {
-		// Put the request back. It was consumed before validation so a
-		// concurrent replay could not also observe it, but this response never
-		// became a login: leaving it consumed would mean an identity provider
-		// retrying after a transient failure, or a browser reposting once a
-		// clock skew resolves, has nothing left to answer.
-		if consumed {
-			h.tracker.restore(c.Request.Context(), tenantID, answeredID)
-		}
-
 		h.logger.Error(c.Request.Context(), "saml assertion rejected",
 			"error", err, "tenant_id", tenantID)
 		c.Error(err)

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -145,7 +145,11 @@ func (h *Handler) tenantConfig(c *gin.Context) (string, Config, error) {
 	ctx := types.SetTenantID(c.Request.Context(), tenantID)
 	settingsSvc := service.NewSettingsService(h.serviceParams)
 
-	resp, err := settingsSvc.GetSettingByKey(ctx, SettingKeySAML)
+	// Unchecked because these endpoints run before a session exists: there is no
+	// caller to authorise, and the browser arriving here is precisely the one
+	// trying to establish who it is. What the configuration permits is decided
+	// below, from the configuration itself.
+	resp, err := settingsSvc.GetSettingByKeyUnchecked(ctx, SettingKeySAML)
 	if err != nil {
 		return "", Config{}, err
 	}

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -28,6 +28,12 @@ const (
 
 	// tokenExpiryHours matches the community login token lifetime.
 	tokenExpiryHours = 24 * 30
+
+	// maxRelayStateBytes is the limit the SAML profile puts on RelayState
+	// (SAMLProfiles section 3.6.3.1). Identity providers are entitled to reject
+	// or truncate anything longer, so a value over this would break the login
+	// rather than protect it.
+	maxRelayStateBytes = 80
 )
 
 // requestTracker records the AuthnRequest IDs this deployment issued, so an
@@ -237,7 +243,24 @@ func (h *Handler) Login(c *gin.Context) {
 
 	h.tracker.remember(c.Request.Context(), tenantID, authnRequest.ID)
 
-	redirectURL, err := authnRequest.Redirect("", sp)
+	// The browser's own nonce, echoed through the identity provider as
+	// RelayState and handed back at the callback. It ties the response to the
+	// single login this browser started: the tenant alone cannot do that,
+	// because every login to a tenant carries the same value.
+	//
+	// Not trusted for anything else. RelayState is unauthenticated and capped at
+	// 80 bytes by the SAML profile, so it is only ever compared against a value
+	// the browser already holds — never read as an assertion about who the user
+	// is. It is bounded here so an over-long value cannot be reflected onward.
+	relayState := c.Query("state")
+	if len(relayState) > maxRelayStateBytes {
+		c.Error(ierr.NewError("state is too long").
+			WithHintf("state must be at most %d characters", maxRelayStateBytes).
+			Mark(ierr.ErrValidation))
+		return
+	}
+
+	redirectURL, err := authnRequest.Redirect(relayState, sp)
 	if err != nil {
 		c.Error(err)
 		return
@@ -307,7 +330,15 @@ func (h *Handler) ACS(c *gin.Context) {
 	h.logger.Info(ctx, "saml login succeeded",
 		"tenant_id", tenantID, "user_id", userID)
 
-	c.Redirect(http.StatusFound, dashboardRedirect(h.cfg, tenantID, token))
+	// RelayState comes back from the identity provider exactly as it was sent.
+	// It is passed straight through to the dashboard, which compares it against
+	// the nonce it generated before the redirect; nothing here trusts it.
+	relayState := c.Request.PostFormValue("RelayState")
+	if len(relayState) > maxRelayStateBytes {
+		relayState = ""
+	}
+
+	c.Redirect(http.StatusFound, dashboardRedirect(h.cfg, tenantID, token, relayState))
 }
 
 // dashboardRedirect hands the token back to the browser application.
@@ -329,7 +360,7 @@ func (h *Handler) ACS(c *gin.Context) {
 // dashboard compares it against the tenant it recorded when it began the flow
 // and refuses a mismatch, which is what stops a token minted for one tenant
 // being planted on a browser mid-login to another.
-func dashboardRedirect(cfg *config.Configuration, tenantID, token string) string {
+func dashboardRedirect(cfg *config.Configuration, tenantID, token, relayState string) string {
 	base := cfg.Auth.SAML.DashboardURL
 	if base == "" {
 		base = "/"
@@ -342,6 +373,9 @@ func dashboardRedirect(cfg *config.Configuration, tenantID, token string) string
 	fragment := url.Values{}
 	fragment.Set("token", token)
 	fragment.Set("tenant_id", tenantID)
+	if relayState != "" {
+		fragment.Set("state", relayState)
+	}
 	u.Fragment = fragment.Encode()
 	return u.String()
 }

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -255,7 +255,7 @@ func TestDashboardRedirectCarriesToken(t *testing.T) {
 	cfg := &config.Configuration{}
 	cfg.Auth.SAML.DashboardURL = "http://localhost:3000/auth/callback"
 
-	got := dashboardRedirect(cfg, "tenant_abc", "the-token")
+	got := dashboardRedirect(cfg, "tenant_abc", "the-token", "nonce-123")
 	if !strings.HasPrefix(got, "http://localhost:3000/auth/callback#") {
 		t.Errorf("redirect = %q, want the configured dashboard URL with a fragment", got)
 	}
@@ -286,7 +286,7 @@ func TestDashboardRedirectCarriesToken(t *testing.T) {
 	}
 
 	empty := &config.Configuration{}
-	if got := dashboardRedirect(empty, "tenant_abc", "t"); !strings.HasPrefix(got, "/") {
+	if got := dashboardRedirect(empty, "tenant_abc", "t", ""); !strings.HasPrefix(got, "/") {
 		t.Errorf("unconfigured redirect = %q, want a relative path rather than an absolute URL", got)
 	}
 }
@@ -492,5 +492,35 @@ func TestRequestTrackerClaimIsAtomicUnderConcurrency(t *testing.T) {
 	}
 	if won != 1 {
 		t.Errorf("%d of %d concurrent claims succeeded, want exactly 1 — a replayed assertion would mint that many sessions", won, attempts)
+	}
+}
+
+// TestDashboardRedirectCarriesRelayState covers the per-login nonce. The tenant
+// binds a callback to a tenant, but every login to that tenant carries the same
+// value; the nonce is what ties a response to one specific attempt. It travels
+// as SAML RelayState and must reach the dashboard unchanged.
+func TestDashboardRedirectCarriesRelayState(t *testing.T) {
+	cfg := &config.Configuration{}
+	cfg.Auth.SAML.DashboardURL = "http://localhost:3000/auth/callback"
+
+	got := dashboardRedirect(cfg, "tenant_abc", "the-token", "nonce-abc123")
+	fragment, err := url.ParseQuery(strings.TrimPrefix(got[strings.Index(got, "#"):], "#"))
+	if err != nil {
+		t.Fatalf("fragment is not parseable: %v", err)
+	}
+	if fragment.Get("state") != "nonce-abc123" {
+		t.Errorf("state = %q, want the nonce the browser generated", fragment.Get("state"))
+	}
+
+	// An identity provider that drops RelayState must not produce a literal
+	// empty state, which the dashboard would compare against its stored nonce
+	// and reject anyway — the absence is clearer than an empty string.
+	plain := dashboardRedirect(cfg, "tenant_abc", "the-token", "")
+	plainFragment, err := url.ParseQuery(strings.TrimPrefix(plain[strings.Index(plain, "#"):], "#"))
+	if err != nil {
+		t.Fatalf("fragment is not parseable: %v", err)
+	}
+	if _, present := plainFragment["state"]; present {
+		t.Error("an empty RelayState should be omitted rather than sent as an empty value")
 	}
 }

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -1,9 +1,11 @@
 package saml
 
 import (
+	"encoding/base64"
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -252,5 +254,58 @@ func TestMetadataCarriesTheTenantFromTheURL(t *testing.T) {
 	}
 	if !strings.Contains(string(xml), tenantID) {
 		t.Error("metadata does not carry the tenant ID from the URL")
+	}
+}
+
+// TestInResponseToAcceptsEveryValidSerialisation covers the replay defence
+// against identity providers that serialise XML differently from ours.
+//
+// The extracted ID decides which outstanding request is retired. Failing to
+// find it does not fail loudly — claim("") retires nothing, so the assertion
+// stays replayable for the request's whole lifetime. A pattern matching only
+// double-quoted attributes silently lost that defence against any provider
+// emitting single quotes or whitespace around "=", both valid XML.
+func TestInResponseToAcceptsEveryValidSerialisation(t *testing.T) {
+	cases := []struct {
+		name string
+		xml  string
+		want string
+	}{
+		{"double quotes", `<Response InResponseTo="id-abc" Version="2.0"></Response>`, "id-abc"},
+		{"single quotes", `<Response InResponseTo='id-abc' Version='2.0'></Response>`, "id-abc"},
+		{"whitespace around equals", `<Response InResponseTo = "id-abc"></Response>`, "id-abc"},
+		{"namespaced root", `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" InResponseTo="id-abc"></samlp:Response>`, "id-abc"},
+		{"xml declaration first", `<?xml version="1.0"?><Response InResponseTo="id-abc"></Response>`, "id-abc"},
+		{"absent attribute", `<Response Version="2.0"></Response>`, ""},
+		{"not xml at all", `this is not xml`, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := url.Values{"SAMLResponse": {base64.StdEncoding.EncodeToString([]byte(tc.xml))}}
+			req := httptest.NewRequest(http.MethodPost, "/acs", strings.NewReader(body.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			if got := inResponseTo(req); got != tc.want {
+				t.Errorf("inResponseTo() = %q, want %q — a missed ID leaves the assertion replayable", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInResponseToReadsTheRootElementOnly guards against retiring the wrong
+// request. SubjectConfirmationData also carries InResponseTo, and in a document
+// where it appears before the Response attribute a scan of the whole payload
+// would take that value instead, leaving the real request outstanding.
+func TestInResponseToReadsTheRootElementOnly(t *testing.T) {
+	doc := `<Response InResponseTo="id-correct"><Assertion><Subject><SubjectConfirmation>` +
+		`<SubjectConfirmationData InResponseTo="id-nested"/></SubjectConfirmation></Subject></Assertion></Response>`
+
+	body := url.Values{"SAMLResponse": {base64.StdEncoding.EncodeToString([]byte(doc))}}
+	req := httptest.NewRequest(http.MethodPost, "/acs", strings.NewReader(body.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if got := inResponseTo(req); got != "id-correct" {
+		t.Errorf("inResponseTo() = %q, want the root element's value", got)
 	}
 }

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -1,12 +1,14 @@
 package saml
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -121,43 +123,125 @@ func TestLoginRedirectsToIdentityProvider(t *testing.T) {
 // assertion twice produced two successful logins. Live testing against
 // SimpleSAMLphp caught it — the second post returned 302 instead of 403.
 func TestRequestTrackerClaimRetiresTheAnsweredID(t *testing.T) {
-	tr := newRequestTracker()
-	tr.remember("id-1", time.Now().Add(authnRequestTTL))
+	ctx := context.Background()
+	tr := newRequestTracker(newFakeRedis())
+	tr.remember(ctx, "tenant_a", "id-1")
 
-	ids := tr.claim("id-1")
-	if len(ids) != 1 || ids[0] != "id-1" {
-		t.Fatalf("first claim = %v, want [id-1] so the assertion validates", ids)
+	ids, consumed := tr.claim(ctx, "tenant_a", "id-1")
+	if !consumed || len(ids) != 1 || ids[0] != "id-1" {
+		t.Fatalf("first claim = %v (consumed=%v), want [id-1] so the assertion validates", ids, consumed)
 	}
 
-	if ids := tr.claim("id-1"); len(ids) != 0 {
-		t.Errorf("second claim = %v, want empty — the replayed assertion would validate again", ids)
+	if ids, consumed := tr.claim(ctx, "tenant_a", "id-1"); consumed || len(ids) != 0 {
+		t.Errorf("second claim = %v (consumed=%v), want nothing — the replayed assertion would validate again", ids, consumed)
+	}
+}
+
+// TestRequestTrackerIsScopedByTenant stops one tenant's outstanding request from
+// satisfying another tenant's assertion.
+func TestRequestTrackerIsScopedByTenant(t *testing.T) {
+	ctx := context.Background()
+	tr := newRequestTracker(newFakeRedis())
+	tr.remember(ctx, "tenant_a", "id-1")
+
+	if _, consumed := tr.claim(ctx, "tenant_b", "id-1"); consumed {
+		t.Error("a request issued for one tenant was consumed by another tenant's assertion")
+	}
+	if _, consumed := tr.claim(ctx, "tenant_a", "id-1"); !consumed {
+		t.Error("the owning tenant's request was disturbed by another tenant's attempt")
 	}
 }
 
 // TestRequestTrackerClaimKeepsOtherRequests makes sure retiring one request does
 // not disturb another browser's outstanding login.
 func TestRequestTrackerClaimKeepsOtherRequests(t *testing.T) {
-	tr := newRequestTracker()
-	tr.remember("id-1", time.Now().Add(authnRequestTTL))
-	tr.remember("id-2", time.Now().Add(authnRequestTTL))
+	ctx := context.Background()
+	tr := newRequestTracker(newFakeRedis())
+	tr.remember(ctx, "tenant_a", "id-1")
+	tr.remember(ctx, "tenant_a", "id-2")
 
-	tr.claim("id-1")
+	tr.claim(ctx, "tenant_a", "id-1")
 
-	ids := tr.claim("")
-	if len(ids) != 1 || ids[0] != "id-2" {
-		t.Errorf("after retiring id-1, outstanding = %v, want [id-2]", ids)
+	if _, consumed := tr.claim(ctx, "tenant_a", "id-2"); !consumed {
+		t.Error("retiring one request also retired another browser's outstanding login")
 	}
 }
 
-// TestRequestTrackerExpires stops an outstanding request from being accepted
-// forever, which would leave the replay window open indefinitely.
-func TestRequestTrackerExpires(t *testing.T) {
-	tr := newRequestTracker()
+// TestRequestTrackerRestoreReopensAFailedLogin covers the retry path: a response
+// that fails validation must not burn the request, or an identity provider
+// retrying — or a browser reposting once a clock skew resolves — has nothing
+// left to answer.
+func TestRequestTrackerRestoreReopensAFailedLogin(t *testing.T) {
+	ctx := context.Background()
+	tr := newRequestTracker(newFakeRedis())
+	tr.remember(ctx, "tenant_a", "id-1")
 
-	tr.remember("stale", time.Now().Add(-time.Minute))
-	if ids := tr.claim(""); len(ids) != 0 {
-		t.Errorf("expired request ID still offered: %v", ids)
+	tr.claim(ctx, "tenant_a", "id-1")
+	tr.restore(ctx, "tenant_a", "id-1")
+
+	if _, consumed := tr.claim(ctx, "tenant_a", "id-1"); !consumed {
+		t.Error("a restored request could not be claimed, so the retry would fail permanently")
 	}
+}
+
+// TestRequestTrackerIgnoresAnEmptyID covers an assertion carrying no
+// InResponseTo at all: there is nothing to consume, and it must not be treated
+// as answering an outstanding request.
+func TestRequestTrackerIgnoresAnEmptyID(t *testing.T) {
+	ctx := context.Background()
+	tr := newRequestTracker(newFakeRedis())
+	tr.remember(ctx, "tenant_a", "id-1")
+
+	if ids, consumed := tr.claim(ctx, "tenant_a", ""); consumed || len(ids) != 0 {
+		t.Errorf("claim(\"\") = %v (consumed=%v), want nothing", ids, consumed)
+	}
+}
+
+// fakeRedis is the slice of cache.RedisCache the tracker uses. Only Get, Set and
+// Delete are exercised; the rest satisfy the interface.
+type fakeRedis struct {
+	mu     sync.Mutex
+	values map[string]interface{}
+}
+
+func newFakeRedis() *fakeRedis { return &fakeRedis{values: map[string]interface{}{}} }
+
+func (f *fakeRedis) Get(_ context.Context, key string) (interface{}, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.values[key]
+	return v, ok
+}
+
+func (f *fakeRedis) Set(_ context.Context, key string, value interface{}, _ time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[key] = value
+}
+
+func (f *fakeRedis) Delete(_ context.Context, key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.values, key)
+}
+
+func (f *fakeRedis) IsEnabled() bool                        { return true }
+func (f *fakeRedis) IsRedisCache() bool                     { return true }
+func (f *fakeRedis) DeleteByPrefix(context.Context, string) {}
+func (f *fakeRedis) Flush(context.Context) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values = map[string]interface{}{}
+}
+func (f *fakeRedis) ForceCacheGetWithTTL(context.Context, string) (interface{}, time.Duration, bool) {
+	return nil, 0, false
+}
+func (f *fakeRedis) ForceCacheDelete(ctx context.Context, key string) { f.Delete(ctx, key) }
+func (f *fakeRedis) ForceCacheGet(ctx context.Context, key string) (interface{}, bool) {
+	return f.Get(ctx, key)
+}
+func (f *fakeRedis) ForceCacheSet(ctx context.Context, key string, value interface{}, ttl time.Duration) {
+	f.Set(ctx, key, value, ttl)
 }
 
 // TestDashboardRedirectCarriesToken checks the browser hand-back: the token has
@@ -168,11 +252,21 @@ func TestDashboardRedirectCarriesToken(t *testing.T) {
 	cfg.Auth.SAML.DashboardURL = "http://localhost:3000/auth/callback"
 
 	got := dashboardRedirect(cfg, "the-token")
-	if !strings.HasPrefix(got, "http://localhost:3000/auth/callback?") {
-		t.Errorf("redirect = %q, want the configured dashboard URL", got)
+	if !strings.HasPrefix(got, "http://localhost:3000/auth/callback#") {
+		t.Errorf("redirect = %q, want the configured dashboard URL with a fragment", got)
 	}
 	if !strings.Contains(got, "token=the-token") {
 		t.Errorf("redirect = %q, want it to carry the token", got)
+	}
+
+	// The token must be in the fragment, never the query. A fragment is not sent
+	// to a server, so it stays out of proxy and CDN access logs and out of the
+	// Referer header of every request the dashboard makes after it loads; a
+	// query parameter reaches all of those, and this token lasts thirty days.
+	if u, err := url.Parse(got); err != nil {
+		t.Fatalf("redirect is not a URL: %v", err)
+	} else if u.Query().Get("token") != "" {
+		t.Errorf("redirect = %q, want the token out of the query string", got)
 	}
 
 	empty := &config.Configuration{}

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -251,12 +251,24 @@ func TestDashboardRedirectCarriesToken(t *testing.T) {
 	cfg := &config.Configuration{}
 	cfg.Auth.SAML.DashboardURL = "http://localhost:3000/auth/callback"
 
-	got := dashboardRedirect(cfg, "the-token")
+	got := dashboardRedirect(cfg, "tenant_abc", "the-token")
 	if !strings.HasPrefix(got, "http://localhost:3000/auth/callback#") {
 		t.Errorf("redirect = %q, want the configured dashboard URL with a fragment", got)
 	}
 	if !strings.Contains(got, "token=the-token") {
 		t.Errorf("redirect = %q, want it to carry the token", got)
+	}
+
+	// The tenant must travel with the token. The dashboard compares it against
+	// the tenant it recorded when the login began and refuses a mismatch, and it
+	// treats a missing value as a refusal — so omitting it here would break every
+	// login rather than merely weakening the check.
+	fragment, err := url.ParseQuery(strings.TrimPrefix(got[strings.Index(got, "#"):], "#"))
+	if err != nil {
+		t.Fatalf("fragment is not parseable: %v", err)
+	}
+	if fragment.Get("tenant_id") != "tenant_abc" {
+		t.Errorf("fragment tenant_id = %q, want the tenant the login was served for", fragment.Get("tenant_id"))
 	}
 
 	// The token must be in the fragment, never the query. A fragment is not sent
@@ -270,7 +282,7 @@ func TestDashboardRedirectCarriesToken(t *testing.T) {
 	}
 
 	empty := &config.Configuration{}
-	if got := dashboardRedirect(empty, "t"); !strings.HasPrefix(got, "/") {
+	if got := dashboardRedirect(empty, "tenant_abc", "t"); !strings.HasPrefix(got, "/") {
 		t.Errorf("unconfigured redirect = %q, want a relative path rather than an absolute URL", got)
 	}
 }

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -213,72 +213,44 @@ func TestMetadataWorksBeforeConfiguration(t *testing.T) {
 	}
 }
 
-// TestDefaultTenantAlias covers the single-tenant convenience: a self-hosted
-// install has one tenant whose ID is identical everywhere, so requiring it in
-// the URL means hand-copying a UUID into an identity provider.
-func TestDefaultTenantAlias(t *testing.T) {
-	const onPremTenant = "00000000-0000-0000-0000-000000000000"
+// TestTenantComesOnlyFromTheURL pins the removal of the deployment-wide default
+// tenant. SSO is configured per tenant, so there is nothing for a URL that does
+// not name its tenant to resolve against, and "default" is now an ordinary
+// segment that will match no tenant rather than silently selecting one.
+func TestTenantComesOnlyFromTheURL(t *testing.T) {
+	provider := newTestProvider("https://billing.acme.com")
 
-	configured := newTestProvider("https://billing.acme.com")
-	configured.cfg.Auth.SAML.DefaultTenantID = onPremTenant
-
-	if got := configured.resolveTenant("default"); got != onPremTenant {
-		t.Errorf("resolveTenant(default) = %q, want the configured tenant", got)
+	for _, segment := range []string{"tenant_xyz", "00000000-0000-0000-0000-000000000000", "default"} {
+		if got := provider.resolveTenant(segment); got != segment {
+			t.Errorf("resolveTenant(%q) = %q, want it passed through unchanged", segment, got)
+		}
 	}
 
-	// An explicit ID is never rewritten, so a multi-tenant deployment behaves
-	// exactly as before.
-	if got := configured.resolveTenant("tenant_xyz"); got != "tenant_xyz" {
-		t.Errorf("resolveTenant(tenant_xyz) = %q, want it passed through", got)
-	}
-
-	// Unconfigured, the alias resolves to nothing rather than silently picking
-	// a tenant — the handler then rejects the request.
-	unconfigured := newTestProvider("https://billing.acme.com")
-	if got := unconfigured.resolveTenant("default"); got != "" {
-		t.Errorf("unconfigured alias = %q, want empty so the request is rejected", got)
+	// An empty segment stays empty so the handler rejects the request rather
+	// than falling back to some tenant.
+	if got := provider.resolveTenant(""); got != "" {
+		t.Errorf("resolveTenant(\"\") = %q, want empty so the request is rejected", got)
 	}
 }
 
-// TestAliasAndUUIDProduceIdenticalMetadata is the trap worth guarding. If the
-// alias produced metadata under the literal string "default" while the ACS
-// endpoint validated against the resolved UUID, every assertion would fail
-// audience validation — and the error would point at signatures, not at the
-// URL. Both paths must yield byte-identical metadata.
-func TestAliasAndUUIDProduceIdenticalMetadata(t *testing.T) {
-	const onPremTenant = "00000000-0000-0000-0000-000000000000"
+// TestMetadataCarriesTheTenantFromTheURL guards the trap that mattered when the
+// alias existed and still matters now: metadata must be published under the same
+// tenant the ACS endpoint validates against, or every assertion fails audience
+// validation with an error that points at signatures rather than the URL.
+func TestMetadataCarriesTheTenantFromTheURL(t *testing.T) {
+	const tenantID = "tenant_acme"
 
 	provider := newTestProvider("https://billing.acme.com")
-	provider.cfg.Auth.SAML.DefaultTenantID = onPremTenant
-
-	viaAlias, err := provider.metadataOnlyServiceProvider(provider.resolveTenant("default"))
+	sp, err := provider.metadataOnlyServiceProvider(provider.resolveTenant(tenantID))
 	if err != nil {
-		t.Fatalf("alias path: %v", err)
-	}
-	viaUUID, err := provider.metadataOnlyServiceProvider(provider.resolveTenant(onPremTenant))
-	if err != nil {
-		t.Fatalf("uuid path: %v", err)
+		t.Fatalf("metadata: %v", err)
 	}
 
-	// Compare identity, not the whole document: Metadata() stamps a validUntil
-	// from the clock, so two calls always differ by a few milliseconds.
-	if viaAlias.EntityID != viaUUID.EntityID {
-		t.Errorf("entity ID differs between alias and UUID paths: %q vs %q — assertions would fail audience validation",
-			viaAlias.EntityID, viaUUID.EntityID)
-	}
-	if viaAlias.AcsURL.String() != viaUUID.AcsURL.String() {
-		t.Errorf("ACS URL differs: %q vs %q — the identity provider would post to the wrong endpoint",
-			viaAlias.AcsURL.String(), viaUUID.AcsURL.String())
-	}
-
-	aliasXML, err := marshalMetadata(viaAlias)
+	xml, err := marshalMetadata(sp)
 	if err != nil {
-		t.Fatalf("marshal alias metadata: %v", err)
+		t.Fatalf("marshal metadata: %v", err)
 	}
-	if !strings.Contains(string(aliasXML), onPremTenant) {
-		t.Error("metadata does not carry the resolved tenant ID")
-	}
-	if strings.Contains(string(aliasXML), "/default/") {
-		t.Error("metadata leaks the alias instead of the resolved tenant ID")
+	if !strings.Contains(string(xml), tenantID) {
+		t.Error("metadata does not carry the tenant ID from the URL")
 	}
 }

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -1,0 +1,284 @@
+package saml
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/gin-gonic/gin"
+
+	"github.com/flexprice/flexprice/internal/config"
+)
+
+// newTestProvider builds a provider with the deployment-level settings the
+// endpoints depend on, without needing the full server graph.
+func newTestProvider(baseURL string) *samlProvider {
+	cfg := &config.Configuration{}
+	cfg.Auth.SAML.BaseURL = baseURL
+	cfg.Auth.SAML.DashboardURL = "http://localhost:3000/auth/callback"
+	return newSAMLProvider(cfg)
+}
+
+func enabledConfig() Config {
+	return Config{
+		Enabled:        true,
+		IDPEntityID:    "http://idp.example.com/metadata",
+		IDPSSOUrl:      "https://idp.example.com/sso",
+		IDPCertificate: testCertPEM,
+		DefaultRole:    "all_reader",
+	}
+}
+
+// TestMetadataEndpointServesValidSPMetadata exercises what a customer does
+// first: fetch our metadata and upload it into their identity provider. If the
+// entity ID or ACS URL is wrong here, every later assertion is rejected for
+// audience mismatch, which is a confusing way to discover a configuration typo.
+func TestMetadataEndpointServesValidSPMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	provider := newTestProvider("http://localhost:8080")
+	sp, err := provider.serviceProvider("tenant_abc", enabledConfig())
+	if err != nil {
+		t.Fatalf("serviceProvider: %v", err)
+	}
+
+	router := gin.New()
+	router.GET("/v1/auth/saml/:tenant/metadata", func(c *gin.Context) {
+		out, err := marshalMetadata(sp)
+		if err != nil {
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.Data(http.StatusOK, "application/samlmetadata+xml", out)
+	})
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/auth/saml/tenant_abc/metadata", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "samlmetadata+xml") {
+		t.Errorf("content type = %q, want SAML metadata", ct)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{
+		"EntityDescriptor",
+		"AssertionConsumerService",
+		"http://localhost:8080/v1/auth/saml/tenant_abc/acs",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metadata is missing %q", want)
+		}
+	}
+}
+
+// TestLoginRedirectsToIdentityProvider checks the SP-initiated entry point: the
+// browser must be sent to the configured SSO URL carrying a SAMLRequest.
+func TestLoginRedirectsToIdentityProvider(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	provider := newTestProvider("http://localhost:8080")
+	cfg := enabledConfig()
+	sp, err := provider.serviceProvider("tenant_abc", cfg)
+	if err != nil {
+		t.Fatalf("serviceProvider: %v", err)
+	}
+
+	authnRequest, err := sp.MakeAuthenticationRequest(
+		cfg.IDPSSOUrl,
+		"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+		"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+	)
+	if err != nil {
+		t.Fatalf("MakeAuthenticationRequest: %v", err)
+	}
+
+	redirectURL, err := authnRequest.Redirect("", sp)
+	if err != nil {
+		t.Fatalf("Redirect: %v", err)
+	}
+
+	if got := redirectURL.Host; got != "idp.example.com" {
+		t.Errorf("redirect host = %q, want the configured identity provider", got)
+	}
+	if redirectURL.Query().Get("SAMLRequest") == "" {
+		t.Error("redirect carries no SAMLRequest — the identity provider has nothing to answer")
+	}
+}
+
+// TestRequestTrackerClaimRetiresTheAnsweredID covers the replay defence.
+//
+// This is a regression test for a real failure: claim() previously returned the
+// outstanding IDs without removing the answered one, so posting the same
+// assertion twice produced two successful logins. Live testing against
+// SimpleSAMLphp caught it — the second post returned 302 instead of 403.
+func TestRequestTrackerClaimRetiresTheAnsweredID(t *testing.T) {
+	tr := newRequestTracker()
+	tr.remember("id-1", time.Now().Add(authnRequestTTL))
+
+	ids := tr.claim("id-1")
+	if len(ids) != 1 || ids[0] != "id-1" {
+		t.Fatalf("first claim = %v, want [id-1] so the assertion validates", ids)
+	}
+
+	if ids := tr.claim("id-1"); len(ids) != 0 {
+		t.Errorf("second claim = %v, want empty — the replayed assertion would validate again", ids)
+	}
+}
+
+// TestRequestTrackerClaimKeepsOtherRequests makes sure retiring one request does
+// not disturb another browser's outstanding login.
+func TestRequestTrackerClaimKeepsOtherRequests(t *testing.T) {
+	tr := newRequestTracker()
+	tr.remember("id-1", time.Now().Add(authnRequestTTL))
+	tr.remember("id-2", time.Now().Add(authnRequestTTL))
+
+	tr.claim("id-1")
+
+	ids := tr.claim("")
+	if len(ids) != 1 || ids[0] != "id-2" {
+		t.Errorf("after retiring id-1, outstanding = %v, want [id-2]", ids)
+	}
+}
+
+// TestRequestTrackerExpires stops an outstanding request from being accepted
+// forever, which would leave the replay window open indefinitely.
+func TestRequestTrackerExpires(t *testing.T) {
+	tr := newRequestTracker()
+
+	tr.remember("stale", time.Now().Add(-time.Minute))
+	if ids := tr.claim(""); len(ids) != 0 {
+		t.Errorf("expired request ID still offered: %v", ids)
+	}
+}
+
+// TestDashboardRedirectCarriesToken checks the browser hand-back: the token has
+// to reach the dashboard, and a missing configuration must not produce a
+// redirect to an attacker-controlled default.
+func TestDashboardRedirectCarriesToken(t *testing.T) {
+	cfg := &config.Configuration{}
+	cfg.Auth.SAML.DashboardURL = "http://localhost:3000/auth/callback"
+
+	got := dashboardRedirect(cfg, "the-token")
+	if !strings.HasPrefix(got, "http://localhost:3000/auth/callback?") {
+		t.Errorf("redirect = %q, want the configured dashboard URL", got)
+	}
+	if !strings.Contains(got, "token=the-token") {
+		t.Errorf("redirect = %q, want it to carry the token", got)
+	}
+
+	empty := &config.Configuration{}
+	if got := dashboardRedirect(empty, "t"); !strings.HasPrefix(got, "/") {
+		t.Errorf("unconfigured redirect = %q, want a relative path rather than an absolute URL", got)
+	}
+}
+
+// marshalMetadata mirrors what the metadata handler serves.
+func marshalMetadata(sp *saml.ServiceProvider) ([]byte, error) {
+	return xml.MarshalIndent(sp.Metadata(), "", "  ")
+}
+
+// TestMetadataWorksBeforeConfiguration pins the onboarding order. The customer's
+// administrator needs our ACS URL and entity ID to create the application in
+// their identity provider, and only then can they hand back the entity ID, SSO
+// URL, and certificate. Gating metadata on a configured provider deadlocks
+// onboarding, so this must keep working with no configuration at all.
+func TestMetadataWorksBeforeConfiguration(t *testing.T) {
+	provider := newTestProvider("https://billing.acme.com")
+
+	sp, err := provider.metadataOnlyServiceProvider("00000000-0000-0000-0000-000000000000")
+	if err != nil {
+		t.Fatalf("metadata must be available before configuration: %v", err)
+	}
+
+	out, err := marshalMetadata(sp)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	body := string(out)
+	for _, want := range []string{
+		"https://billing.acme.com/v1/auth/saml/00000000-0000-0000-0000-000000000000/acs",
+		"https://billing.acme.com/v1/auth/saml/00000000-0000-0000-0000-000000000000/metadata",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metadata missing %q — the identity provider would be configured to call the wrong endpoint", want)
+		}
+	}
+}
+
+// TestDefaultTenantAlias covers the single-tenant convenience: a self-hosted
+// install has one tenant whose ID is identical everywhere, so requiring it in
+// the URL means hand-copying a UUID into an identity provider.
+func TestDefaultTenantAlias(t *testing.T) {
+	const onPremTenant = "00000000-0000-0000-0000-000000000000"
+
+	configured := newTestProvider("https://billing.acme.com")
+	configured.cfg.Auth.SAML.DefaultTenantID = onPremTenant
+
+	if got := configured.resolveTenant("default"); got != onPremTenant {
+		t.Errorf("resolveTenant(default) = %q, want the configured tenant", got)
+	}
+
+	// An explicit ID is never rewritten, so a multi-tenant deployment behaves
+	// exactly as before.
+	if got := configured.resolveTenant("tenant_xyz"); got != "tenant_xyz" {
+		t.Errorf("resolveTenant(tenant_xyz) = %q, want it passed through", got)
+	}
+
+	// Unconfigured, the alias resolves to nothing rather than silently picking
+	// a tenant — the handler then rejects the request.
+	unconfigured := newTestProvider("https://billing.acme.com")
+	if got := unconfigured.resolveTenant("default"); got != "" {
+		t.Errorf("unconfigured alias = %q, want empty so the request is rejected", got)
+	}
+}
+
+// TestAliasAndUUIDProduceIdenticalMetadata is the trap worth guarding. If the
+// alias produced metadata under the literal string "default" while the ACS
+// endpoint validated against the resolved UUID, every assertion would fail
+// audience validation — and the error would point at signatures, not at the
+// URL. Both paths must yield byte-identical metadata.
+func TestAliasAndUUIDProduceIdenticalMetadata(t *testing.T) {
+	const onPremTenant = "00000000-0000-0000-0000-000000000000"
+
+	provider := newTestProvider("https://billing.acme.com")
+	provider.cfg.Auth.SAML.DefaultTenantID = onPremTenant
+
+	viaAlias, err := provider.metadataOnlyServiceProvider(provider.resolveTenant("default"))
+	if err != nil {
+		t.Fatalf("alias path: %v", err)
+	}
+	viaUUID, err := provider.metadataOnlyServiceProvider(provider.resolveTenant(onPremTenant))
+	if err != nil {
+		t.Fatalf("uuid path: %v", err)
+	}
+
+	// Compare identity, not the whole document: Metadata() stamps a validUntil
+	// from the clock, so two calls always differ by a few milliseconds.
+	if viaAlias.EntityID != viaUUID.EntityID {
+		t.Errorf("entity ID differs between alias and UUID paths: %q vs %q — assertions would fail audience validation",
+			viaAlias.EntityID, viaUUID.EntityID)
+	}
+	if viaAlias.AcsURL.String() != viaUUID.AcsURL.String() {
+		t.Errorf("ACS URL differs: %q vs %q — the identity provider would post to the wrong endpoint",
+			viaAlias.AcsURL.String(), viaUUID.AcsURL.String())
+	}
+
+	aliasXML, err := marshalMetadata(viaAlias)
+	if err != nil {
+		t.Fatalf("marshal alias metadata: %v", err)
+	}
+	if !strings.Contains(string(aliasXML), onPremTenant) {
+		t.Error("metadata does not carry the resolved tenant ID")
+	}
+	if strings.Contains(string(aliasXML), "/default/") {
+		t.Error("metadata leaks the alias instead of the resolved tenant ID")
+	}
+}

--- a/internal/ee/auth/saml/routes_test.go
+++ b/internal/ee/auth/saml/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/gin-gonic/gin"
 
+	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/config"
 )
 
@@ -124,7 +125,7 @@ func TestLoginRedirectsToIdentityProvider(t *testing.T) {
 // SimpleSAMLphp caught it — the second post returned 302 instead of 403.
 func TestRequestTrackerClaimRetiresTheAnsweredID(t *testing.T) {
 	ctx := context.Background()
-	tr := newRequestTracker(newFakeRedis())
+	tr := newRequestTracker(newFakeRedis(), newFakeLocker())
 	tr.remember(ctx, "tenant_a", "id-1")
 
 	ids, consumed := tr.claim(ctx, "tenant_a", "id-1")
@@ -141,7 +142,7 @@ func TestRequestTrackerClaimRetiresTheAnsweredID(t *testing.T) {
 // satisfying another tenant's assertion.
 func TestRequestTrackerIsScopedByTenant(t *testing.T) {
 	ctx := context.Background()
-	tr := newRequestTracker(newFakeRedis())
+	tr := newRequestTracker(newFakeRedis(), newFakeLocker())
 	tr.remember(ctx, "tenant_a", "id-1")
 
 	if _, consumed := tr.claim(ctx, "tenant_b", "id-1"); consumed {
@@ -156,7 +157,7 @@ func TestRequestTrackerIsScopedByTenant(t *testing.T) {
 // not disturb another browser's outstanding login.
 func TestRequestTrackerClaimKeepsOtherRequests(t *testing.T) {
 	ctx := context.Background()
-	tr := newRequestTracker(newFakeRedis())
+	tr := newRequestTracker(newFakeRedis(), newFakeLocker())
 	tr.remember(ctx, "tenant_a", "id-1")
 	tr.remember(ctx, "tenant_a", "id-2")
 
@@ -167,20 +168,23 @@ func TestRequestTrackerClaimKeepsOtherRequests(t *testing.T) {
 	}
 }
 
-// TestRequestTrackerRestoreReopensAFailedLogin covers the retry path: a response
-// that fails validation must not burn the request, or an identity provider
-// retrying — or a browser reposting once a clock skew resolves — has nothing
-// left to answer.
-func TestRequestTrackerRestoreReopensAFailedLogin(t *testing.T) {
+// TestRequestTrackerClaimIsFinal pins a deliberate choice: a consumed request
+// stays consumed even when the assertion that consumed it was then rejected.
+//
+// Reopening it would mean releasing a marker taken atomically on whichever
+// replica served the request, and no replica can release another's — so the
+// alternative is a window in which the same assertion is claimable twice. A
+// genuine retry starts a fresh login instead.
+func TestRequestTrackerClaimIsFinal(t *testing.T) {
 	ctx := context.Background()
-	tr := newRequestTracker(newFakeRedis())
+	tr := newRequestTracker(newFakeRedis(), newFakeLocker())
 	tr.remember(ctx, "tenant_a", "id-1")
 
-	tr.claim(ctx, "tenant_a", "id-1")
-	tr.restore(ctx, "tenant_a", "id-1")
-
 	if _, consumed := tr.claim(ctx, "tenant_a", "id-1"); !consumed {
-		t.Error("a restored request could not be claimed, so the retry would fail permanently")
+		t.Fatal("the first claim must succeed")
+	}
+	if _, consumed := tr.claim(ctx, "tenant_a", "id-1"); consumed {
+		t.Error("a consumed request was claimable again — the assertion could be replayed")
 	}
 }
 
@@ -189,7 +193,7 @@ func TestRequestTrackerRestoreReopensAFailedLogin(t *testing.T) {
 // as answering an outstanding request.
 func TestRequestTrackerIgnoresAnEmptyID(t *testing.T) {
 	ctx := context.Background()
-	tr := newRequestTracker(newFakeRedis())
+	tr := newRequestTracker(newFakeRedis(), newFakeLocker())
 	tr.remember(ctx, "tenant_a", "id-1")
 
 	if ids, consumed := tr.claim(ctx, "tenant_a", ""); consumed || len(ids) != 0 {
@@ -413,5 +417,80 @@ func TestInResponseToReadsTheRootElementOnly(t *testing.T) {
 
 	if got := inResponseTo(req); got != "id-correct" {
 		t.Errorf("inResponseTo() = %q, want the root element's value", got)
+	}
+}
+
+// fakeLocker reproduces the property the tracker depends on: AcquireLock is a
+// SETNX, so exactly one caller can take a given key. A fake that always
+// succeeded would hide the race this replaces.
+type fakeLocker struct {
+	mu   sync.Mutex
+	held map[string]bool
+}
+
+func newFakeLocker() *fakeLocker { return &fakeLocker{held: map[string]bool{}} }
+
+func (l *fakeLocker) AcquireLock(_ context.Context, key string, _ time.Duration) (cache.Lock, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.held[key] {
+		return &fakeLock{acquired: false}, nil
+	}
+	l.held[key] = true
+	return &fakeLock{acquired: true, locker: l, key: key}, nil
+}
+
+type fakeLock struct {
+	acquired bool
+	locker   *fakeLocker
+	key      string
+}
+
+func (k *fakeLock) AcquiredSuccessfully() bool { return k.acquired }
+func (k *fakeLock) Release(context.Context) error {
+	if k.locker != nil {
+		k.locker.mu.Lock()
+		delete(k.locker.held, k.key)
+		k.locker.mu.Unlock()
+	}
+	return nil
+}
+
+// TestRequestTrackerClaimIsAtomicUnderConcurrency is the regression test for a
+// real race: claim previously read the outstanding key and then deleted it in a
+// second round trip, so two concurrent posts of the same assertion could both
+// observe it as present before either removed it, and both logins succeeded.
+//
+// Exactly one caller must win, however many arrive at once.
+func TestRequestTrackerClaimIsAtomicUnderConcurrency(t *testing.T) {
+	ctx := context.Background()
+	tr := newRequestTracker(newFakeRedis(), newFakeLocker())
+	tr.remember(ctx, "tenant_a", "id-1")
+
+	const attempts = 32
+	var wg sync.WaitGroup
+	results := make([]bool, attempts)
+	start := make(chan struct{})
+
+	for i := range attempts {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release them together to maximise overlap
+			_, consumed := tr.claim(ctx, "tenant_a", "id-1")
+			results[i] = consumed
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	won := 0
+	for _, ok := range results {
+		if ok {
+			won++
+		}
+	}
+	if won != 1 {
+		t.Errorf("%d of %d concurrent claims succeeded, want exactly 1 — a replayed assertion would mint that many sessions", won, attempts)
 	}
 }

--- a/internal/ee/auth/saml/serviceprovider.go
+++ b/internal/ee/auth/saml/serviceprovider.go
@@ -1,0 +1,124 @@
+package saml
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/url"
+
+	"github.com/crewjam/saml"
+)
+
+// parseCertificate decodes the identity provider's PEM-encoded X.509 signing
+// certificate. Assertions are verified against this and only this — a
+// certificate carried inside a response is attacker-controlled and never used.
+func parseCertificate(pemData string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("expected a CERTIFICATE block, got %q", block.Type)
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// serviceProvider builds the SP for one tenant.
+//
+// crewjam/saml performs signature verification, XML signature wrapping
+// detection, audience restriction, and condition-window checks against the
+// IDPMetadata we supply here. Supplying the certificate through IDPMetadata,
+// rather than trusting the response, is what makes those checks meaningful.
+func (p *samlProvider) serviceProvider(tenantID string, cfg Config) (*saml.ServiceProvider, error) {
+	cert, err := parseCertificate(cfg.IDPCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("parse idp certificate: %w", err)
+	}
+
+	acsURL, err := url.Parse(p.acsURL(tenantID))
+	if err != nil {
+		return nil, fmt.Errorf("parse acs url: %w", err)
+	}
+	metadataURL, err := url.Parse(p.metadataURL(tenantID))
+	if err != nil {
+		return nil, fmt.Errorf("parse metadata url: %w", err)
+	}
+	ssoURL, err := url.Parse(cfg.IDPSSOUrl)
+	if err != nil {
+		return nil, fmt.Errorf("parse idp sso url: %w", err)
+	}
+
+	return &saml.ServiceProvider{
+		EntityID:    metadataURL.String(),
+		AcsURL:      *acsURL,
+		MetadataURL: *metadataURL,
+		IDPMetadata: &saml.EntityDescriptor{
+			EntityID: cfg.IDPEntityID,
+			IDPSSODescriptors: []saml.IDPSSODescriptor{
+				{
+					SSODescriptor: saml.SSODescriptor{
+						RoleDescriptor: saml.RoleDescriptor{
+							KeyDescriptors: []saml.KeyDescriptor{
+								{
+									Use: "signing",
+									KeyInfo: saml.KeyInfo{
+										X509Data: saml.X509Data{
+											X509Certificates: []saml.X509Certificate{
+												{Data: base64DER(cert)},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					SingleSignOnServices: []saml.Endpoint{
+						{
+							Binding:  saml.HTTPRedirectBinding,
+							Location: ssoURL.String(),
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+// URLs are derived from one configured base so the values in our SP metadata
+// always match the endpoints we actually serve. A mismatch here surfaces as an
+// audience or destination rejection at the identity provider, which is painful
+// to diagnose.
+func (p *samlProvider) metadataURL(tenantID string) string {
+	return fmt.Sprintf("%s/v1/auth/saml/%s/metadata", p.baseURL(), tenantID)
+}
+
+func (p *samlProvider) acsURL(tenantID string) string {
+	return fmt.Sprintf("%s/v1/auth/saml/%s/acs", p.baseURL(), tenantID)
+}
+
+// metadataOnlyServiceProvider builds an SP carrying just our own identifiers,
+// with no identity provider attached.
+//
+// It exists for the metadata endpoint, which has to work before a tenant has
+// configured anything: the customer's administrator needs our ACS URL and
+// entity ID in order to create the application that produces the values we
+// would otherwise be validating.
+//
+// It must never be used to consume an assertion — with no IDPMetadata there is
+// no certificate to verify a signature against.
+func (p *samlProvider) metadataOnlyServiceProvider(tenantID string) (*saml.ServiceProvider, error) {
+	acsURL, err := url.Parse(p.acsURL(tenantID))
+	if err != nil {
+		return nil, fmt.Errorf("parse acs url: %w", err)
+	}
+	metadataURL, err := url.Parse(p.metadataURL(tenantID))
+	if err != nil {
+		return nil, fmt.Errorf("parse metadata url: %w", err)
+	}
+
+	return &saml.ServiceProvider{
+		EntityID:    metadataURL.String(),
+		AcsURL:      *acsURL,
+		MetadataURL: *metadataURL,
+	}, nil
+}

--- a/internal/ee/auth/saml/serviceprovider_test.go
+++ b/internal/ee/auth/saml/serviceprovider_test.go
@@ -1,0 +1,46 @@
+package saml
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+)
+
+// TestServiceProviderMetadataIsWellFormed guards the misconfiguration that is
+// hardest to diagnose in the field: if base_url disagrees with what the identity
+// provider is told to call, the assertion is rejected for audience mismatch,
+// which reads like a signature failure but is not.
+func TestServiceProviderMetadataIsWellFormed(t *testing.T) {
+	p := &samlProvider{cfg: &config.Configuration{}}
+	p.cfg.Auth.SAML.BaseURL = "http://localhost:8080"
+
+	cfg := Config{
+		Enabled:        true,
+		IDPEntityID:    "http://idp.example.com/metadata",
+		IDPSSOUrl:      "https://idp.example.com/sso",
+		IDPCertificate: testCertPEM,
+		DefaultRole:    "all_reader",
+	}
+
+	sp, err := p.serviceProvider("tenant_abc", cfg)
+	if err != nil {
+		t.Fatalf("serviceProvider: %v", err)
+	}
+
+	out, err := xml.MarshalIndent(sp.Metadata(), "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	s := string(out)
+	for _, want := range []string{
+		"http://localhost:8080/v1/auth/saml/tenant_abc/acs",
+		"http://localhost:8080/v1/auth/saml/tenant_abc/metadata",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("metadata missing %q — the IdP would call the wrong endpoint", want)
+		}
+	}
+}

--- a/internal/ee/service/auth.go
+++ b/internal/ee/service/auth.go
@@ -192,6 +192,19 @@ func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.Au
 		return nil, err
 	}
 
+	// Refused before the credentials are checked, so no token is ever minted for
+	// a login the tenant does not allow. Doing it afterwards meant the provider
+	// had already issued one — discarded here, but for a provider that keeps
+	// server-side session state, established there.
+	//
+	// The cost is that a caller learns enforcement is on for an email that
+	// exists, without knowing the password. That is a narrow signal: the address
+	// has to be a real user's, and what it reveals — this organisation uses SSO —
+	// is something its own login page tells anyone who visits it.
+	if err := s.refusePasswordLoginUnderSSO(ctx, user); err != nil {
+		return nil, err
+	}
+
 	var auth *auth.Auth
 	if s.authProvider.GetProvider() == types.AuthProviderFlexprice {
 		auth, err = s.AuthRepo.GetAuthByUserID(ctx, user.ID)
@@ -219,13 +232,6 @@ func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.Au
 		return nil, ierr.NewError("invalid credentials").
 			WithHint("Invalid email or password").
 			Mark(ierr.ErrPermissionDenied)
-	}
-
-	// Checked only after the password has been verified, so the response cannot
-	// be used to discover which tenants enforce SSO: a wrong password fails
-	// identically whether or not enforcement is on.
-	if err := s.refusePasswordLoginUnderSSO(ctx, user); err != nil {
-		return nil, err
 	}
 
 	response := &dto.AuthResponse{

--- a/internal/ee/service/auth.go
+++ b/internal/ee/service/auth.go
@@ -144,7 +144,10 @@ func (s *authService) refusePasswordLoginUnderSSO(ctx context.Context, user *use
 	cfg, err := GetSetting[types.SAMLConfig](
 		NewSettingsService(s.ServiceParams).(*settingsService), tenantCtx, types.SettingKeySAMLConfig)
 	if err != nil {
-		s.Logger.Error(ctx, "could not read saml settings while checking sso enforcement; allowing password login",
+		// Info rather than Error: the login proceeds, so this records a decision
+		// the code recovered from rather than a failure. It is still worth
+		// seeing — a tenant that has enforcement on is not getting it.
+		s.Logger.Info(ctx, "could not read saml settings while checking sso enforcement; allowing password login",
 			"error", err,
 			"tenant_id", user.TenantID,
 			"user_id", user.ID,

--- a/internal/ee/service/auth.go
+++ b/internal/ee/service/auth.go
@@ -6,9 +6,11 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	authProvider "github.com/flexprice/flexprice/internal/auth"
 	"github.com/flexprice/flexprice/internal/domain/auth"
+	"github.com/flexprice/flexprice/internal/domain/user"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/pubsub"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
 
 type AuthService interface {
@@ -117,6 +119,58 @@ func (s *authService) SignUp(ctx context.Context, req *dto.SignUpRequest) (*dto.
 	return response, nil
 }
 
+// refusePasswordLoginUnderSSO blocks password login for a tenant that has SSO
+// enforced, so turning on single sign-on closes the password path rather than
+// adding a second way in alongside it.
+//
+// Super admins are exempt: an identity provider outage would otherwise lock the
+// tenant out of its own account entirely, with no recovery short of direct
+// database access. They are already the group trusted to configure SAML.
+//
+// A failure to read the setting lets the login proceed. The alternative fails
+// closed on every login for every tenant if the settings read breaks, which
+// turns a settings problem into a total outage; enforcement is a policy control
+// on an already-authenticated user, not the authentication itself.
+func (s *authService) refusePasswordLoginUnderSSO(ctx context.Context, user *user.User) error {
+	if s.Config == nil || !s.Config.Auth.SAML.Enabled {
+		return nil
+	}
+
+	// Login runs before a session exists, so the tenant is taken from the user
+	// row rather than the context, and SAML settings are tenant-level so no
+	// environment is needed.
+	tenantCtx := types.SetTenantID(ctx, user.TenantID)
+
+	cfg, err := GetSetting[types.SAMLConfig](
+		NewSettingsService(s.ServiceParams).(*settingsService), tenantCtx, types.SettingKeySAMLConfig)
+	if err != nil {
+		s.Logger.Error(ctx, "could not read saml settings while checking sso enforcement; allowing password login",
+			"error", err,
+			"tenant_id", user.TenantID,
+			"user_id", user.ID,
+		)
+		return nil
+	}
+
+	// Enforcement applies only once SSO can actually serve a login: a tenant
+	// that set the flag while still awaiting approval would otherwise lock
+	// itself out of a login SAML cannot yet perform.
+	if !cfg.Enabled || !cfg.Active || !cfg.EnforceSSO {
+		return nil
+	}
+	if lo.Contains(user.Roles, types.RoleSuperAdmin.String()) {
+		return nil
+	}
+
+	s.Logger.Info(ctx, "password login refused because the tenant enforces single sign-on",
+		"tenant_id", user.TenantID,
+		"user_id", user.ID,
+	)
+	return ierr.NewError("password login is disabled for this organisation").
+		WithHint("Your organisation requires single sign-on. Sign in through your identity provider.").
+		Mark(ierr.ErrPermissionDenied)
+}
+
 // Login authenticates a user and returns an auth token
 func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.AuthResponse, error) {
 	user, err := s.UserRepo.GetByEmail(ctx, req.Email)
@@ -162,6 +216,13 @@ func (s *authService) Login(ctx context.Context, req *dto.LoginRequest) (*dto.Au
 		return nil, ierr.NewError("invalid credentials").
 			WithHint("Invalid email or password").
 			Mark(ierr.ErrPermissionDenied)
+	}
+
+	// Checked only after the password has been verified, so the response cannot
+	// be used to discover which tenants enforce SSO: a wrong password fails
+	// identically whether or not enforcement is on.
+	if err := s.refusePasswordLoginUnderSSO(ctx, user); err != nil {
+		return nil, err
 	}
 
 	response := &dto.AuthResponse{

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -10,7 +10,6 @@ import (
 	workflowModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/utils"
-	"github.com/samber/lo"
 )
 
 type SettingsService interface {
@@ -59,48 +58,23 @@ func isTenantLevelSetting(key types.SettingKey) bool {
 		key == types.SettingKeySAMLConfig
 }
 
-// requireSuperAdminForAuthSetting refuses access to a setting that decides how
-// people authenticate unless the caller is a super_admin user.
+// requireSAMLEnabled refuses a saml_config request on a deployment that does not
+// offer SAML.
 //
-// The settings route is shared by every key, so its entity/action gate is the
-// same broad setting:write that an all_writer holds. That is too weak here: a
-// SAML configuration names the identity provider we trust, so an all_writer who
-// points it at a provider they control can have themselves provisioned into this
-// tenant. Gating on the key rather than the route keeps every other setting on
-// the existing permission.
-//
-// Deletes are covered as well as updates: removing the configuration turns SSO
-// off for the tenant, which is the same decision in the other direction.
-//
-// Reads are covered too. The settings GET carries no permission middleware at
-// all, so every authenticated member of the tenant could otherwise read this
-// key: which identity provider the tenant trusts, and whether it has been
-// approved. Nothing in it is secret today — the certificate is the provider's
-// public one — but it is a map of what to attack, and the fields most likely to
-// be added next (an SP private key, a directory-sync token) would be secret. A
-// caller who may not change how people log in has no reason to read it either.
-//
-// Service accounts are refused whatever roles their key carries, matching
-// middleware.SuperAdminOnly — administering how people log in is not a machine
-// action.
-func (s *settingsService) requireSuperAdminForAuthSetting(ctx context.Context, key types.SettingKey) error {
+// Who may reach this key is the router's business — every settings route
+// requires a super_admin user, so the permission is enforced there. What the
+// router cannot know is whether the feature exists at all: with
+// auth.saml.enabled false no SAML routes are served, and a stored configuration
+// could only sit there looking as though SSO were set up.
+func (s *settingsService) requireSAMLEnabled(key types.SettingKey) error {
 	if key != types.SettingKeySAMLConfig {
 		return nil
 	}
 
-	// A deployment with SAML switched off serves no SAML routes, so a stored
-	// configuration could only sit there looking as though SSO were set up.
-	// Refusing the write keeps the feature genuinely absent.
 	if s.Config == nil || !s.Config.Auth.SAML.Enabled {
 		return ierr.NewError("saml is not enabled for this deployment").
 			WithHint("SAML single sign-on is not available on this deployment").
 			Mark(ierr.ErrNotFound)
-	}
-
-	if types.IsServiceAccount(ctx) || !lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String()) {
-		return ierr.NewError("saml configuration requires a super admin user").
-			WithHint("This action requires a user account with Super Admin access").
-			Mark(ierr.ErrPermissionDenied)
 	}
 	return nil
 }
@@ -322,7 +296,7 @@ func UpdateSetting[T types.SettingConfig](s *settingsService, ctx context.Contex
 //   - Don't use if you need to work with the typed config directly
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) GetSettingByKey(ctx context.Context, key types.SettingKey) (*dto.SettingResponse, error) {
-	if err := s.requireSuperAdminForAuthSetting(ctx, key); err != nil {
+	if err := s.requireSAMLEnabled(key); err != nil {
 		return nil, err
 	}
 	return s.GetSettingByKeyUnchecked(ctx, key)
@@ -379,7 +353,7 @@ func (s *settingsService) GetSettingByKeyUnchecked(ctx context.Context, key type
 //   - Don't use in business logic if you want to replace the entire setting
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.SettingKey, req *dto.UpdateSettingRequest) (*dto.SettingResponse, error) {
-	if err := s.requireSuperAdminForAuthSetting(ctx, key); err != nil {
+	if err := s.requireSAMLEnabled(key); err != nil {
 		return nil, err
 	}
 
@@ -432,7 +406,7 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 // WHEN NOT TO USE:
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) DeleteSettingByKey(ctx context.Context, key types.SettingKey) error {
-	if err := s.requireSuperAdminForAuthSetting(ctx, key); err != nil {
+	if err := s.requireSAMLEnabled(key); err != nil {
 		return err
 	}
 

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -10,6 +10,7 @@ import (
 	workflowModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/utils"
+	"github.com/samber/lo"
 )
 
 type SettingsService interface {
@@ -61,11 +62,10 @@ func isTenantLevelSetting(key types.SettingKey) bool {
 // requireSAMLEnabled refuses a saml_config request on a deployment that does not
 // offer SAML.
 //
-// Who may reach this key is the router's business — every settings route
-// requires a super_admin user, so the permission is enforced there. What the
-// router cannot know is whether the feature exists at all: with
-// auth.saml.enabled false no SAML routes are served, and a stored configuration
-// could only sit there looking as though SSO were set up.
+// Writes are already restricted to super admins by the router. What the router
+// cannot know is whether the feature exists at all: with auth.saml.enabled
+// false no SAML routes are served, and a stored configuration could only sit
+// there looking as though SSO were set up.
 func (s *settingsService) requireSAMLEnabled(key types.SettingKey) error {
 	if key != types.SettingKeySAMLConfig {
 		return nil
@@ -75,6 +75,33 @@ func (s *settingsService) requireSAMLEnabled(key types.SettingKey) error {
 		return ierr.NewError("saml is not enabled for this deployment").
 			WithHint("SAML single sign-on is not available on this deployment").
 			Mark(ierr.ErrNotFound)
+	}
+	return nil
+}
+
+// requireSuperAdminToReadSAMLConfig keeps the identity provider configuration
+// away from callers who may not administer it.
+//
+// Settings reads carry the ordinary setting:read permission, which most keys
+// should: an invoice prefix is configuration the dashboard shows to any member.
+// This one is different. It names the identity provider the tenant trusts and
+// whether Flexprice has approved it, which is a map of what to attack, and the
+// fields most likely to be added next — an SP private key, a directory-sync
+// token — would be secret outright. Someone who may not change how people log
+// in has no reason to read it either.
+//
+// Checked here rather than on the route because the route is shared by every
+// key, and gating all of them on super_admin would take reads away from the
+// settings the dashboard legitimately shows to everyone.
+func requireSuperAdminToReadSAMLConfig(ctx context.Context, key types.SettingKey) error {
+	if key != types.SettingKeySAMLConfig {
+		return nil
+	}
+
+	if types.IsServiceAccount(ctx) || !lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String()) {
+		return ierr.NewError("saml configuration requires a super admin user").
+			WithHint("This action requires a user account with Super Admin access").
+			Mark(ierr.ErrPermissionDenied)
 	}
 	return nil
 }
@@ -297,6 +324,9 @@ func UpdateSetting[T types.SettingConfig](s *settingsService, ctx context.Contex
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) GetSettingByKey(ctx context.Context, key types.SettingKey) (*dto.SettingResponse, error) {
 	if err := s.requireSAMLEnabled(key); err != nil {
+		return nil, err
+	}
+	if err := requireSuperAdminToReadSAMLConfig(ctx, key); err != nil {
 		return nil, err
 	}
 	return s.GetSettingByKeyUnchecked(ctx, key)

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -38,7 +38,10 @@ func NewSettingsService(params ServiceParams) SettingsService {
 // isTenantLevelSetting checks if a setting is tenant-level (no environment_id)
 // Tenant-level settings apply across all environments for a tenant
 func isTenantLevelSetting(key types.SettingKey) bool {
-	return key == types.SettingKeyTenantConfig
+	// SAML is tenant-level because an identity provider is per-organisation, and
+	// because the pre-login endpoints run with no environment in context.
+	return key == types.SettingKeyTenantConfig ||
+		key == types.SettingKeySAMLConfig
 }
 
 // fetchSetting fetches a setting from the repository
@@ -239,6 +242,8 @@ func (s *settingsService) GetSettingByKey(ctx context.Context, key types.Setting
 		return getSettingByKey[types.BonusCreditsTopupConfig](s, ctx, key)
 	case types.SettingKeyDraftInvoiceRecomputeConfig:
 		return getSettingByKey[types.DraftInvoiceRecomputeConfig](s, ctx, key)
+	case types.SettingKeySAMLConfig:
+		return getSettingByKey[types.SAMLConfig](s, ctx, key)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).
@@ -289,6 +294,8 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 		return updateSettingByKey[types.BonusCreditsTopupConfig](s, ctx, key, req)
 	case types.SettingKeyDraftInvoiceRecomputeConfig:
 		return updateSettingByKey[types.DraftInvoiceRecomputeConfig](s, ctx, key, req)
+	case types.SettingKeySAMLConfig:
+		return updateSettingByKey[types.SAMLConfig](s, ctx, key, req)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -10,6 +10,7 @@ import (
 	workflowModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/utils"
+	"github.com/samber/lo"
 )
 
 type SettingsService interface {
@@ -42,6 +43,35 @@ func isTenantLevelSetting(key types.SettingKey) bool {
 	// because the pre-login endpoints run with no environment in context.
 	return key == types.SettingKeyTenantConfig ||
 		key == types.SettingKeySAMLConfig
+}
+
+// requireSuperAdminForAuthSetting refuses a write to a setting that decides how
+// people authenticate unless the caller is a super_admin user.
+//
+// The settings route is shared by every key, so its entity/action gate is the
+// same broad setting:write that an all_writer holds. That is too weak here: a
+// SAML configuration names the identity provider we trust, so an all_writer who
+// points it at a provider they control can have themselves provisioned into this
+// tenant. Gating on the key rather than the route keeps every other setting on
+// the existing permission.
+//
+// Deletes are covered as well as updates: removing the configuration turns SSO
+// off for the tenant, which is the same decision in the other direction.
+//
+// Service accounts are refused whatever roles their key carries, matching
+// middleware.SuperAdminOnly — administering how people log in is not a machine
+// action.
+func requireSuperAdminForAuthSetting(ctx context.Context, key types.SettingKey) error {
+	if key != types.SettingKeySAMLConfig {
+		return nil
+	}
+
+	if types.IsServiceAccount(ctx) || !lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String()) {
+		return ierr.NewError("saml configuration requires a super admin user").
+			WithHint("This action requires a user account with Super Admin access").
+			Mark(ierr.ErrPermissionDenied)
+	}
+	return nil
 }
 
 // fetchSetting fetches a setting from the repository
@@ -263,6 +293,10 @@ func (s *settingsService) GetSettingByKey(ctx context.Context, key types.Setting
 //   - Don't use in business logic if you want to replace the entire setting
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.SettingKey, req *dto.UpdateSettingRequest) (*dto.SettingResponse, error) {
+	if err := requireSuperAdminForAuthSetting(ctx, key); err != nil {
+		return nil, err
+	}
+
 	if err := req.Validate(key); err != nil {
 		return nil, err
 	}
@@ -312,6 +346,10 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 // WHEN NOT TO USE:
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) DeleteSettingByKey(ctx context.Context, key types.SettingKey) error {
+	if err := requireSuperAdminForAuthSetting(ctx, key); err != nil {
+		return err
+	}
+
 	// Check if setting exists
 	_, err := s.fetchSetting(ctx, key)
 	if ent.IsNotFound(err) {

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -16,7 +16,21 @@ import (
 type SettingsService interface {
 	// GetSettingByKey returns a setting as a DTO response (for API endpoints)
 	// Use this when you need the full Setting object with metadata (ID, timestamps, etc.)
+	//
+	// Access-checked: keys governing authentication are refused to callers who
+	// may not administer them. Server-side code acting with no user in context
+	// must use GetSettingByKeyUnchecked instead.
 	GetSettingByKey(ctx context.Context, key types.SettingKey) (*dto.SettingResponse, error)
+
+	// GetSettingByKeyUnchecked returns a setting without the caller checks that
+	// GetSettingByKey applies.
+	//
+	// It exists for work the server does on its own behalf, where there is no
+	// user to check: the SAML endpoints run before a session exists and must
+	// read the tenant's identity provider configuration to serve a login at all.
+	// Never call it while handling a request on behalf of a caller — that is
+	// what GetSettingByKey is for.
+	GetSettingByKeyUnchecked(ctx context.Context, key types.SettingKey) (*dto.SettingResponse, error)
 
 	// UpdateSettingByKey updates a setting with partial values (merges with existing)
 	// Use this for API endpoints that accept partial updates
@@ -45,7 +59,7 @@ func isTenantLevelSetting(key types.SettingKey) bool {
 		key == types.SettingKeySAMLConfig
 }
 
-// requireSuperAdminForAuthSetting refuses a write to a setting that decides how
+// requireSuperAdminForAuthSetting refuses access to a setting that decides how
 // people authenticate unless the caller is a super_admin user.
 //
 // The settings route is shared by every key, so its entity/action gate is the
@@ -57,6 +71,14 @@ func isTenantLevelSetting(key types.SettingKey) bool {
 //
 // Deletes are covered as well as updates: removing the configuration turns SSO
 // off for the tenant, which is the same decision in the other direction.
+//
+// Reads are covered too. The settings GET carries no permission middleware at
+// all, so every authenticated member of the tenant could otherwise read this
+// key: which identity provider the tenant trusts, and whether it has been
+// approved. Nothing in it is secret today — the certificate is the provider's
+// public one — but it is a map of what to attack, and the fields most likely to
+// be added next (an SP private key, a directory-sync token) would be secret. A
+// caller who may not change how people log in has no reason to read it either.
 //
 // Service accounts are refused whatever roles their key carries, matching
 // middleware.SuperAdminOnly — administering how people log in is not a machine
@@ -300,6 +322,15 @@ func UpdateSetting[T types.SettingConfig](s *settingsService, ctx context.Contex
 //   - Don't use if you need to work with the typed config directly
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) GetSettingByKey(ctx context.Context, key types.SettingKey) (*dto.SettingResponse, error) {
+	if err := s.requireSuperAdminForAuthSetting(ctx, key); err != nil {
+		return nil, err
+	}
+	return s.GetSettingByKeyUnchecked(ctx, key)
+}
+
+// GetSettingByKeyUnchecked is the read itself, with no caller checks. See the
+// interface for when it is legitimate to call.
+func (s *settingsService) GetSettingByKeyUnchecked(ctx context.Context, key types.SettingKey) (*dto.SettingResponse, error) {
 	switch key {
 	case types.SettingKeyInvoiceConfig:
 		return getSettingByKey[types.InvoiceConfig](s, ctx, key)

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -61,9 +61,18 @@ func isTenantLevelSetting(key types.SettingKey) bool {
 // Service accounts are refused whatever roles their key carries, matching
 // middleware.SuperAdminOnly — administering how people log in is not a machine
 // action.
-func requireSuperAdminForAuthSetting(ctx context.Context, key types.SettingKey) error {
+func (s *settingsService) requireSuperAdminForAuthSetting(ctx context.Context, key types.SettingKey) error {
 	if key != types.SettingKeySAMLConfig {
 		return nil
+	}
+
+	// A deployment with SAML switched off serves no SAML routes, so a stored
+	// configuration could only sit there looking as though SSO were set up.
+	// Refusing the write keeps the feature genuinely absent.
+	if s.Config == nil || !s.Config.Auth.SAML.Enabled {
+		return ierr.NewError("saml is not enabled for this deployment").
+			WithHint("SAML single sign-on is not available on this deployment").
+			Mark(ierr.ErrNotFound)
 	}
 
 	if types.IsServiceAccount(ctx) || !lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String()) {
@@ -72,6 +81,52 @@ func requireSuperAdminForAuthSetting(ctx context.Context, key types.SettingKey) 
 			Mark(ierr.ErrPermissionDenied)
 	}
 	return nil
+}
+
+// apiImmutableSettingFields lists the fields of a setting that the settings API
+// may never write, whatever the caller's role.
+//
+// The settings API is generic: it merges whatever keys a request carries into
+// the stored value. That is fine for configuration a tenant owns, but not for a
+// field that records a Flexprice-side decision about that tenant — the tenant
+// would be able to grant it to itself in the same request that sets everything
+// else.
+//
+// Fields listed here are carried over from the stored value on update and are
+// changed out of band, directly in the database.
+func apiImmutableSettingFields(key types.SettingKey) []string {
+	if key == types.SettingKeySAMLConfig {
+		// "active" is Flexprice's approval that this tenant may serve SSO at
+		// all, granted after its claim to the identity provider is checked.
+		// A tenant that could set it would be approving itself.
+		return []string{"active"}
+	}
+	return nil
+}
+
+// mergePreservingImmutableFields applies a partial update over the stored value
+// while holding the key's API-immutable fields at what is already stored.
+//
+// A request naming a protected field is ignored rather than rejected: the field
+// is not part of the API's contract, so a caller is not expected to know it
+// exists — a configuration blob round-tripped through GET and back through PUT
+// would otherwise fail on a field the caller never meant to set.
+func mergePreservingImmutableFields(key types.SettingKey, stored, update map[string]interface{}) map[string]interface{} {
+	protected := map[string]interface{}{}
+	for _, field := range apiImmutableSettingFields(key) {
+		if v, ok := stored[field]; ok {
+			protected[field] = v
+		}
+	}
+
+	for k, v := range update {
+		stored[k] = v
+	}
+
+	for field, v := range protected {
+		stored[field] = v
+	}
+	return stored
 }
 
 // fetchSetting fetches a setting from the repository
@@ -293,7 +348,7 @@ func (s *settingsService) GetSettingByKey(ctx context.Context, key types.Setting
 //   - Don't use in business logic if you want to replace the entire setting
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.SettingKey, req *dto.UpdateSettingRequest) (*dto.SettingResponse, error) {
-	if err := requireSuperAdminForAuthSetting(ctx, key); err != nil {
+	if err := s.requireSuperAdminForAuthSetting(ctx, key); err != nil {
 		return nil, err
 	}
 
@@ -346,7 +401,7 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 // WHEN NOT TO USE:
 //   - Don't call repository methods directly - always use service methods
 func (s *settingsService) DeleteSettingByKey(ctx context.Context, key types.SettingKey) error {
-	if err := requireSuperAdminForAuthSetting(ctx, key); err != nil {
+	if err := s.requireSuperAdminForAuthSetting(ctx, key); err != nil {
 		return err
 	}
 
@@ -418,9 +473,7 @@ func updateSettingByKey[T types.SettingConfig](s *settingsService, ctx context.C
 	}
 
 	// Merge request values with current values
-	for k, v := range req.Value {
-		currentMap[k] = v
-	}
+	currentMap = mergePreservingImmutableFields(key, currentMap, req.Value)
 
 	// Convert merged map back to typed struct for validation
 	merged, err := utils.ToStruct[T](currentMap)

--- a/internal/ee/service/settings_saml_permission_test.go
+++ b/internal/ee/service/settings_saml_permission_test.go
@@ -4,9 +4,19 @@ import (
 	"context"
 	"testing"
 
+	"github.com/flexprice/flexprice/internal/config"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
+
+// samlEnabledService builds the minimum service needed to exercise the gate on
+// a deployment that offers SAML.
+func samlEnabledService(enabled bool) *settingsService {
+	cfg := &config.Configuration{}
+	cfg.Auth.SAML.Enabled = enabled
+	return &settingsService{ServiceParams: ServiceParams{Config: cfg}}
+}
 
 func ctxWithRoles(userType types.UserType, roles ...string) context.Context {
 	ctx := context.WithValue(context.Background(), types.CtxRoles, roles)
@@ -65,9 +75,10 @@ func TestRequireSuperAdminForAuthSetting(t *testing.T) {
 		},
 	}
 
+	svc := samlEnabledService(true)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := requireSuperAdminForAuthSetting(tc.ctx, tc.key)
+			err := svc.requireSuperAdminForAuthSetting(tc.ctx, tc.key)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected the write to be refused")
@@ -83,5 +94,68 @@ func TestRequireSuperAdminForAuthSetting(t *testing.T) {
 				t.Fatalf("expected the write to be allowed, got %v", err)
 			}
 		})
+	}
+}
+
+// TestSAMLConfigRefusedWhenDeploymentDisablesSAML covers the deployment-level
+// kill switch: with SAML off, no tenant may store a configuration, so the
+// feature cannot look half-set-up on a deployment that serves no SAML routes.
+func TestSAMLConfigRefusedWhenDeploymentDisablesSAML(t *testing.T) {
+	svc := samlEnabledService(false)
+	ctx := ctxWithRoles(types.UserTypeUser, types.RoleSuperAdmin.String())
+
+	err := svc.requireSuperAdminForAuthSetting(ctx, types.SettingKeySAMLConfig)
+	if err == nil {
+		t.Fatal("a deployment with SAML disabled must refuse the write, even for a super admin")
+	}
+	// Reported as absent rather than forbidden: the feature does not exist here.
+	if !ierr.IsNotFound(err) {
+		t.Errorf("expected a not-found error, got %v", err)
+	}
+
+	// Other settings are untouched by the SAML switch.
+	if err := svc.requireSuperAdminForAuthSetting(ctx, types.SettingKeyInvoiceConfig); err != nil {
+		t.Errorf("an unrelated setting must not be gated on the SAML switch: %v", err)
+	}
+}
+
+// TestActiveIsNotSettableThroughTheAPI is the test that matters for the ops
+// gate: "active" is Flexprice's approval that a tenant may serve SSO, so a
+// tenant able to set it in an ordinary settings write would be approving itself.
+func TestActiveIsNotSettableThroughTheAPI(t *testing.T) {
+	protected := apiImmutableSettingFields(types.SettingKeySAMLConfig)
+	if !lo.Contains(protected, "active") {
+		t.Fatalf(`"active" must be protected from API writes, got %v`, protected)
+	}
+
+	stored := map[string]interface{}{"enabled": true, "active": false, "enforce_sso": false}
+	request := map[string]interface{}{"active": true, "enforce_sso": true}
+
+	merged := mergePreservingImmutableFields(types.SettingKeySAMLConfig, stored, request)
+
+	if merged["active"] != false {
+		t.Error("a request setting active:true must not grant approval")
+	}
+	// The tenant's own fields still apply — only the approval is pinned.
+	if merged["enforce_sso"] != true {
+		t.Error("enforce_sso is the tenant's own setting and must remain writable")
+	}
+	if merged["enabled"] != true {
+		t.Error("untouched fields must survive the merge")
+	}
+}
+
+// TestMergePreservingImmutableFieldsLeavesOtherKeysAlone confirms the merge is
+// unchanged for every setting that has no protected fields.
+func TestMergePreservingImmutableFieldsLeavesOtherKeysAlone(t *testing.T) {
+	stored := map[string]interface{}{"a": 1, "b": 2}
+	request := map[string]interface{}{"b": 3, "c": 4}
+
+	merged := mergePreservingImmutableFields(types.SettingKeyInvoiceConfig, stored, request)
+
+	for field, want := range map[string]interface{}{"a": 1, "b": 3, "c": 4} {
+		if merged[field] != want {
+			t.Errorf("field %q = %v, want %v", field, merged[field], want)
+		}
 	}
 }

--- a/internal/ee/service/settings_saml_permission_test.go
+++ b/internal/ee/service/settings_saml_permission_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/config"
@@ -10,112 +9,38 @@ import (
 	"github.com/samber/lo"
 )
 
-// samlEnabledService builds the minimum service needed to exercise the gate on
-// a deployment that offers SAML.
+// samlEnabledService builds the minimum service needed to exercise the
+// deployment switch.
 func samlEnabledService(enabled bool) *settingsService {
 	cfg := &config.Configuration{}
 	cfg.Auth.SAML.Enabled = enabled
 	return &settingsService{ServiceParams: ServiceParams{Config: cfg}}
 }
 
-func ctxWithRoles(userType types.UserType, roles ...string) context.Context {
-	ctx := context.WithValue(context.Background(), types.CtxRoles, roles)
-	return context.WithValue(ctx, types.CtxUserType, string(userType))
-}
-
-// TestRequireSuperAdminForAuthSetting covers the escalation path the gate
-// exists to close: the shared settings route is gated on setting:write, which
-// an all_writer holds, but a SAML configuration names the identity provider
-// this tenant trusts.
-func TestRequireSuperAdminForAuthSetting(t *testing.T) {
-	tests := []struct {
-		name    string
-		ctx     context.Context
-		key     types.SettingKey
-		wantErr bool
-	}{
-		{
-			name: "super_admin user may configure saml",
-			ctx:  ctxWithRoles(types.UserTypeUser, types.RoleSuperAdmin.String()),
-			key:  types.SettingKeySAMLConfig,
-		},
-		{
-			name:    "all_writer may not configure saml",
-			ctx:     ctxWithRoles(types.UserTypeUser, types.RoleAllWriter.String()),
-			key:     types.SettingKeySAMLConfig,
-			wantErr: true,
-		},
-		{
-			name:    "all_reader may not configure saml",
-			ctx:     ctxWithRoles(types.UserTypeUser, types.RoleAllReader.String()),
-			key:     types.SettingKeySAMLConfig,
-			wantErr: true,
-		},
-		{
-			name:    "caller with no roles may not configure saml",
-			ctx:     ctxWithRoles(types.UserTypeUser),
-			key:     types.SettingKeySAMLConfig,
-			wantErr: true,
-		},
-		{
-			// Administering how people log in is not a machine action, so a
-			// service account is refused even holding super_admin. Matches
-			// middleware.SuperAdminOnly.
-			name:    "service account may not configure saml even as super_admin",
-			ctx:     ctxWithRoles(types.UserTypeServiceAccount, types.RoleSuperAdmin.String()),
-			key:     types.SettingKeySAMLConfig,
-			wantErr: true,
-		},
-		{
-			// The gate is key-specific: every other setting keeps the broad
-			// setting:write permission the route already enforces.
-			name: "unrelated setting is unaffected for all_writer",
-			ctx:  ctxWithRoles(types.UserTypeUser, types.RoleAllWriter.String()),
-			key:  types.SettingKeyInvoiceConfig,
-		},
+// TestRequireSAMLEnabled covers the deployment-level kill switch. Who may reach
+// the key is the router's business — every settings route requires a super_admin
+// user — but the router cannot know whether the feature exists at all, and a
+// configuration stored on a deployment serving no SAML routes would only sit
+// there looking as though SSO were set up.
+func TestRequireSAMLEnabled(t *testing.T) {
+	if err := samlEnabledService(true).requireSAMLEnabled(types.SettingKeySAMLConfig); err != nil {
+		t.Fatalf("a deployment offering SAML must accept the key: %v", err)
 	}
 
-	svc := samlEnabledService(true)
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := svc.requireSuperAdminForAuthSetting(tc.ctx, tc.key)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected the write to be refused")
-				}
-				// Must surface as 403, not 500 — the caller needs to know it is
-				// a permission problem, not a server fault.
-				if !ierr.IsPermissionDenied(err) {
-					t.Errorf("expected a permission-denied error, got %v", err)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("expected the write to be allowed, got %v", err)
-			}
-		})
-	}
-}
-
-// TestSAMLConfigRefusedWhenDeploymentDisablesSAML covers the deployment-level
-// kill switch: with SAML off, no tenant may store a configuration, so the
-// feature cannot look half-set-up on a deployment that serves no SAML routes.
-func TestSAMLConfigRefusedWhenDeploymentDisablesSAML(t *testing.T) {
-	svc := samlEnabledService(false)
-	ctx := ctxWithRoles(types.UserTypeUser, types.RoleSuperAdmin.String())
-
-	err := svc.requireSuperAdminForAuthSetting(ctx, types.SettingKeySAMLConfig)
+	err := samlEnabledService(false).requireSAMLEnabled(types.SettingKeySAMLConfig)
 	if err == nil {
-		t.Fatal("a deployment with SAML disabled must refuse the write, even for a super admin")
+		t.Fatal("a deployment with SAML disabled must refuse the key")
 	}
 	// Reported as absent rather than forbidden: the feature does not exist here.
 	if !ierr.IsNotFound(err) {
 		t.Errorf("expected a not-found error, got %v", err)
 	}
 
-	// Other settings are untouched by the SAML switch.
-	if err := svc.requireSuperAdminForAuthSetting(ctx, types.SettingKeyInvoiceConfig); err != nil {
-		t.Errorf("an unrelated setting must not be gated on the SAML switch: %v", err)
+	// Every other setting is untouched by the SAML switch.
+	for _, key := range []types.SettingKey{types.SettingKeyInvoiceConfig, types.SettingKeyTenantConfig} {
+		if err := samlEnabledService(false).requireSAMLEnabled(key); err != nil {
+			t.Errorf("setting %q must not be gated on the SAML switch: %v", key, err)
+		}
 	}
 }
 

--- a/internal/ee/service/settings_saml_permission_test.go
+++ b/internal/ee/service/settings_saml_permission_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+func ctxWithRoles(userType types.UserType, roles ...string) context.Context {
+	ctx := context.WithValue(context.Background(), types.CtxRoles, roles)
+	return context.WithValue(ctx, types.CtxUserType, string(userType))
+}
+
+// TestRequireSuperAdminForAuthSetting covers the escalation path the gate
+// exists to close: the shared settings route is gated on setting:write, which
+// an all_writer holds, but a SAML configuration names the identity provider
+// this tenant trusts.
+func TestRequireSuperAdminForAuthSetting(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		key     types.SettingKey
+		wantErr bool
+	}{
+		{
+			name: "super_admin user may configure saml",
+			ctx:  ctxWithRoles(types.UserTypeUser, types.RoleSuperAdmin.String()),
+			key:  types.SettingKeySAMLConfig,
+		},
+		{
+			name:    "all_writer may not configure saml",
+			ctx:     ctxWithRoles(types.UserTypeUser, types.RoleAllWriter.String()),
+			key:     types.SettingKeySAMLConfig,
+			wantErr: true,
+		},
+		{
+			name:    "all_reader may not configure saml",
+			ctx:     ctxWithRoles(types.UserTypeUser, types.RoleAllReader.String()),
+			key:     types.SettingKeySAMLConfig,
+			wantErr: true,
+		},
+		{
+			name:    "caller with no roles may not configure saml",
+			ctx:     ctxWithRoles(types.UserTypeUser),
+			key:     types.SettingKeySAMLConfig,
+			wantErr: true,
+		},
+		{
+			// Administering how people log in is not a machine action, so a
+			// service account is refused even holding super_admin. Matches
+			// middleware.SuperAdminOnly.
+			name:    "service account may not configure saml even as super_admin",
+			ctx:     ctxWithRoles(types.UserTypeServiceAccount, types.RoleSuperAdmin.String()),
+			key:     types.SettingKeySAMLConfig,
+			wantErr: true,
+		},
+		{
+			// The gate is key-specific: every other setting keeps the broad
+			// setting:write permission the route already enforces.
+			name: "unrelated setting is unaffected for all_writer",
+			ctx:  ctxWithRoles(types.UserTypeUser, types.RoleAllWriter.String()),
+			key:  types.SettingKeyInvoiceConfig,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireSuperAdminForAuthSetting(tc.ctx, tc.key)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected the write to be refused")
+				}
+				// Must surface as 403, not 500 — the caller needs to know it is
+				// a permission problem, not a server fault.
+				if !ierr.IsPermissionDenied(err) {
+					t.Errorf("expected a permission-denied error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected the write to be allowed, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -320,7 +320,7 @@ func (r *settingsRepository) archiveSetting(ctx context.Context, key types.Setti
 				Mark(ierr.ErrDatabase)
 		}
 
-		_, err := client.Settings.Update().
+		archived, err := client.Settings.Update().
 			Where(
 				settings.Key(string(key)),
 				settings.TenantID(types.GetTenantID(ctx)),
@@ -333,17 +333,24 @@ func (r *settingsRepository) archiveSetting(ctx context.Context, key types.Setti
 			Save(ctx)
 
 		if err != nil {
-			if ent.IsNotFound(err) {
-				return ierr.WithError(err).
-					WithHintf("Setting with key %s was not found", string(key)).
-					WithReportableDetails(map[string]any{
-						"key": string(key),
-					}).
-					Mark(ierr.ErrNotFound)
-			}
 			return ierr.WithError(err).
 				WithHint(failureHint).
 				Mark(ierr.ErrDatabase)
+		}
+
+		// A bulk update matching nothing returns (0, nil) rather than a
+		// not-found error, so the count is the only way to notice. The caller
+		// checks the setting exists before getting here, but that check and this
+		// update are separate statements: a concurrent delete between them would
+		// otherwise clear the archived row, archive nothing, and report success —
+		// leaving the setting live while reporting it deleted.
+		if archived == 0 {
+			return ierr.NewErrorf("setting with key %s was not found", string(key)).
+				WithHintf("Setting with key %s was not found", string(key)).
+				WithReportableDetails(map[string]any{
+					"key": string(key),
+				}).
+				Mark(ierr.ErrNotFound)
 		}
 		return nil
 	})

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -263,6 +263,27 @@ func (r *settingsRepository) GetTenantLevelSettingByKey(ctx context.Context, key
 	return setting, nil
 }
 
+// clearArchivedSetting removes any already-archived row for a key before another
+// one is archived in its place.
+//
+// settings is uniquely indexed on (tenant_id, environment_id, status, key), so
+// status is part of the key: at most one archived row can exist per setting. A
+// second delete of the same key — delete, recreate, delete again — would archive
+// a row onto that slot and fail the constraint, surfacing as a 500 while the
+// setting stayed live. Discarding the older tombstone keeps the delete
+// idempotent; the retained row is always the most recent deletion.
+func clearArchivedSetting(ctx context.Context, client *ent.Client, key types.SettingKey, environmentID string) error {
+	_, err := client.Settings.Delete().
+		Where(
+			settings.Key(string(key)),
+			settings.TenantID(types.GetTenantID(ctx)),
+			settings.EnvironmentID(environmentID),
+			settings.Status(string(types.StatusArchived)),
+		).
+		Exec(ctx)
+	return err
+}
+
 func (r *settingsRepository) DeleteByKey(ctx context.Context, key types.SettingKey) error {
 	// Get the setting first for cache invalidation
 	setting, err := r.GetByKey(ctx, key)
@@ -273,6 +294,12 @@ func (r *settingsRepository) DeleteByKey(ctx context.Context, key types.SettingK
 	client := r.client.Writer(ctx)
 
 	r.log.Debug(ctx, "deleting setting by key", "key", string(key))
+
+	if err := clearArchivedSetting(ctx, client, key, types.GetEnvironmentID(ctx)); err != nil {
+		return ierr.WithError(err).
+			WithHint("Failed to delete setting by key").
+			Mark(ierr.ErrDatabase)
+	}
 
 	_, err = client.Settings.Update().
 		Where(
@@ -315,6 +342,14 @@ func (r *settingsRepository) DeleteTenantLevelSettingByKey(ctx context.Context, 
 	client := r.client.Writer(ctx)
 
 	r.log.Debug(ctx, "deleting tenant-level setting by key", "key", string(key))
+
+	// Tenant-level rows carry an empty environment_id; same unique-index
+	// collision as DeleteByKey (see clearArchivedSetting).
+	if err := clearArchivedSetting(ctx, client, key, ""); err != nil {
+		return ierr.WithError(err).
+			WithHint("Failed to delete tenant-level setting by key").
+			Mark(ierr.ErrDatabase)
+	}
 
 	_, err = client.Settings.Update().
 		Where(

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -291,45 +291,62 @@ func (r *settingsRepository) DeleteByKey(ctx context.Context, key types.SettingK
 		return err
 	}
 
-	client := r.client.Writer(ctx)
-
 	r.log.Debug(ctx, "deleting setting by key", "key", string(key))
 
-	if err := clearArchivedSetting(ctx, client, key, types.GetEnvironmentID(ctx)); err != nil {
-		return ierr.WithError(err).
-			WithHint("Failed to delete setting by key").
-			Mark(ierr.ErrDatabase)
-	}
-
-	_, err = client.Settings.Update().
-		Where(
-			settings.Key(string(key)),
-			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentID(types.GetEnvironmentID(ctx)),
-			settings.Status(string(types.StatusPublished)),
-		).
-		SetStatus(string(types.StatusArchived)).
-		SetUpdatedAt(time.Now().UTC()).
-		SetUpdatedBy(types.GetUserID(ctx)).
-		Save(ctx)
-
-	if err != nil {
-		if ent.IsNotFound(err) {
-			return ierr.WithError(err).
-				WithHintf("Setting with key %s was not found", string(key)).
-				WithReportableDetails(map[string]any{
-					"key": string(key),
-				}).
-				Mark(ierr.ErrNotFound)
-		}
-		return ierr.WithError(err).
-			WithHint("Failed to delete setting by key").
-			Mark(ierr.ErrDatabase)
+	if err := r.archiveSetting(ctx, key, types.GetEnvironmentID(ctx), "Failed to delete setting by key"); err != nil {
+		return err
 	}
 
 	// Delete from cache
 	r.DeleteCache(ctx, setting)
 	return nil
+}
+
+// archiveSetting retires the published row for a key, discarding any older
+// tombstone first.
+//
+// Both statements run in one transaction. settings is uniquely indexed on
+// (tenant_id, environment_id, status, key), so only one archived row can exist
+// per setting: if the cleanup committed and the archive then failed, the
+// previous deletion would be gone and the setting would still be live. Rolling
+// both back together keeps the stored state one or the other.
+func (r *settingsRepository) archiveSetting(ctx context.Context, key types.SettingKey, environmentID, failureHint string) error {
+	return r.client.WithTx(ctx, func(ctx context.Context) error {
+		client := r.client.Writer(ctx)
+
+		if err := clearArchivedSetting(ctx, client, key, environmentID); err != nil {
+			return ierr.WithError(err).
+				WithHint(failureHint).
+				Mark(ierr.ErrDatabase)
+		}
+
+		_, err := client.Settings.Update().
+			Where(
+				settings.Key(string(key)),
+				settings.TenantID(types.GetTenantID(ctx)),
+				settings.EnvironmentID(environmentID),
+				settings.Status(string(types.StatusPublished)),
+			).
+			SetStatus(string(types.StatusArchived)).
+			SetUpdatedAt(time.Now().UTC()).
+			SetUpdatedBy(types.GetUserID(ctx)).
+			Save(ctx)
+
+		if err != nil {
+			if ent.IsNotFound(err) {
+				return ierr.WithError(err).
+					WithHintf("Setting with key %s was not found", string(key)).
+					WithReportableDetails(map[string]any{
+						"key": string(key),
+					}).
+					Mark(ierr.ErrNotFound)
+			}
+			return ierr.WithError(err).
+				WithHint(failureHint).
+				Mark(ierr.ErrDatabase)
+		}
+		return nil
+	})
 }
 
 func (r *settingsRepository) DeleteTenantLevelSettingByKey(ctx context.Context, key types.SettingKey) error {
@@ -339,42 +356,11 @@ func (r *settingsRepository) DeleteTenantLevelSettingByKey(ctx context.Context, 
 		return err
 	}
 
-	client := r.client.Writer(ctx)
-
 	r.log.Debug(ctx, "deleting tenant-level setting by key", "key", string(key))
 
-	// Tenant-level rows carry an empty environment_id; same unique-index
-	// collision as DeleteByKey (see clearArchivedSetting).
-	if err := clearArchivedSetting(ctx, client, key, ""); err != nil {
-		return ierr.WithError(err).
-			WithHint("Failed to delete tenant-level setting by key").
-			Mark(ierr.ErrDatabase)
-	}
-
-	_, err = client.Settings.Update().
-		Where(
-			settings.Key(string(key)),
-			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentID(""),
-			settings.Status(string(types.StatusPublished)),
-		).
-		SetStatus(string(types.StatusArchived)).
-		SetUpdatedAt(time.Now().UTC()).
-		SetUpdatedBy(types.GetUserID(ctx)).
-		Save(ctx)
-
-	if err != nil {
-		if ent.IsNotFound(err) {
-			return ierr.WithError(err).
-				WithHintf("Tenant-level setting with key %s was not found", string(key)).
-				WithReportableDetails(map[string]any{
-					"key": string(key),
-				}).
-				Mark(ierr.ErrNotFound)
-		}
-		return ierr.WithError(err).
-			WithHint("Failed to delete tenant-level setting by key").
-			Mark(ierr.ErrDatabase)
+	// Tenant-level rows carry an empty environment_id.
+	if err := r.archiveSetting(ctx, key, "", "Failed to delete tenant-level setting by key"); err != nil {
+		return err
 	}
 
 	// Delete from cache

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -263,27 +263,6 @@ func (r *settingsRepository) GetTenantLevelSettingByKey(ctx context.Context, key
 	return setting, nil
 }
 
-// clearArchivedSetting removes any already-archived row for a key before another
-// one is archived in its place.
-//
-// settings is uniquely indexed on (tenant_id, environment_id, status, key), so
-// status is part of the key: at most one archived row can exist per setting. A
-// second delete of the same key — delete, recreate, delete again — would archive
-// a row onto that slot and fail the constraint, surfacing as a 500 while the
-// setting stayed live. Discarding the older tombstone keeps the delete
-// idempotent; the retained row is always the most recent deletion.
-func clearArchivedSetting(ctx context.Context, client *ent.Client, key types.SettingKey, environmentID string) error {
-	_, err := client.Settings.Delete().
-		Where(
-			settings.Key(string(key)),
-			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentID(environmentID),
-			settings.Status(string(types.StatusArchived)),
-		).
-		Exec(ctx)
-	return err
-}
-
 func (r *settingsRepository) DeleteByKey(ctx context.Context, key types.SettingKey) error {
 	// Get the setting first for cache invalidation
 	setting, err := r.GetByKey(ctx, key)
@@ -302,23 +281,14 @@ func (r *settingsRepository) DeleteByKey(ctx context.Context, key types.SettingK
 	return nil
 }
 
-// archiveSetting retires the published row for a key, discarding any older
-// tombstone first.
+// archiveSetting retires the published row for a key.
 //
-// Both statements run in one transaction. settings is uniquely indexed on
-// (tenant_id, environment_id, status, key), so only one archived row can exist
-// per setting: if the cleanup committed and the archive then failed, the
-// previous deletion would be gone and the setting would still be live. Rolling
-// both back together keeps the stored state one or the other.
+// Deletion history is kept: uniqueness applies only to published rows, so
+// archived rows accumulate and a key can be deleted, recreated and deleted
+// again without colliding with its own tombstone.
 func (r *settingsRepository) archiveSetting(ctx context.Context, key types.SettingKey, environmentID, failureHint string) error {
 	return r.client.WithTx(ctx, func(ctx context.Context) error {
 		client := r.client.Writer(ctx)
-
-		if err := clearArchivedSetting(ctx, client, key, environmentID); err != nil {
-			return ierr.WithError(err).
-				WithHint(failureHint).
-				Mark(ierr.ErrDatabase)
-		}
 
 		archived, err := client.Settings.Update().
 			Where(
@@ -341,9 +311,8 @@ func (r *settingsRepository) archiveSetting(ctx context.Context, key types.Setti
 		// A bulk update matching nothing returns (0, nil) rather than a
 		// not-found error, so the count is the only way to notice. The caller
 		// checks the setting exists before getting here, but that check and this
-		// update are separate statements: a concurrent delete between them would
-		// otherwise clear the archived row, archive nothing, and report success —
-		// leaving the setting live while reporting it deleted.
+		// update are separate statements, and a concurrent delete between them
+		// would otherwise archive nothing and report success.
 		if archived == 0 {
 			return ierr.NewErrorf("setting with key %s was not found", string(key)).
 				WithHintf("Setting with key %s was not found", string(key)).

--- a/internal/types/auth.go
+++ b/internal/types/auth.go
@@ -5,4 +5,5 @@ type AuthProvider string
 const (
 	AuthProviderFlexprice AuthProvider = "flexprice"
 	AuthProviderSupabase  AuthProvider = "supabase"
+	AuthProviderSAML      AuthProvider = "saml"
 )

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -32,6 +32,7 @@ const (
 	SettingKeyBonusCreditsTopupConfig     SettingKey = "bonus_credits_topup_config"
 	SettingKeyPaymentMandateLimits        SettingKey = "payment_mandate_limits"
 	SettingKeyDraftInvoiceRecomputeConfig SettingKey = "draft_invoice_recompute_config"
+	SettingKeySAMLConfig                  SettingKey = "saml_config"
 )
 
 func (s *SettingKey) Validate() error {
@@ -50,6 +51,7 @@ func (s *SettingKey) Validate() error {
 		SettingKeyBonusCreditsTopupConfig,
 		SettingKeyPaymentMandateLimits,
 		SettingKeyDraftInvoiceRecomputeConfig,
+		SettingKeySAMLConfig,
 	}
 
 	if !lo.Contains(allowedKeys, *s) {
@@ -754,6 +756,18 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			DefaultValue: defaultPaymentMandateLimitsMap,
 			Description:  "Per-rail auto-charge ceilings (e.g. UPI Autopay) used to cap mandate amounts; not an opt-in switch",
 		},
+		SettingKeySAMLConfig: {
+			Key: SettingKeySAMLConfig,
+			DefaultValue: map[string]interface{}{
+				"enabled":         false,
+				"idp_entity_id":   "",
+				"idp_sso_url":     "",
+				"idp_certificate": "",
+				"email_attribute": "",
+				"default_role":    string(RoleAllReader),
+			},
+			Description: "SAML 2.0 identity provider configuration for dashboard single sign-on",
+		},
 		SettingKeyDraftInvoiceRecomputeConfig: {
 			Key:          SettingKeyDraftInvoiceRecomputeConfig,
 			DefaultValue: defaultDraftInvoiceRecomputeConfigMap,
@@ -886,6 +900,13 @@ func ValidateSettingValue(key SettingKey, value map[string]interface{}) error {
 		}
 		return config.Validate()
 
+	case SettingKeySAMLConfig:
+		config, err := utils.ToStruct[SAMLConfig](value)
+		if err != nil {
+			return err
+		}
+		return config.Validate()
+
 	default:
 		return ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).
@@ -949,3 +970,36 @@ func ValidateTimezone(timezone string) error {
 	_, err := time.LoadLocation(resolvedTimezone)
 	return err
 }
+
+// SAMLConfig is a tenant's SAML identity provider configuration.
+//
+// Stored as a tenant-level setting rather than its own table: an identity
+// provider is per-organisation, and tenant-level settings are readable without
+// an environment in context, which the pre-login SSO endpoints require.
+//
+// Only the identity provider's public signing certificate is held here, so
+// plain JSONB storage is appropriate.
+type SAMLConfig struct {
+	Enabled bool `json:"enabled"`
+
+	// IDPEntityID identifies the identity provider; it must match the Issuer of
+	// every assertion we accept.
+	IDPEntityID string `json:"idp_entity_id"`
+	// IDPSSOUrl is where a user is redirected to authenticate.
+	IDPSSOUrl string `json:"idp_sso_url"`
+	// IDPCertificate is the PEM-encoded X.509 certificate whose key signs
+	// assertions. Assertions signed by anything else are rejected.
+	IDPCertificate string `json:"idp_certificate"`
+
+	// EmailAttribute names the assertion attribute carrying the user's email.
+	// Empty means use the NameID.
+	EmailAttribute string `json:"email_attribute"`
+
+	// DefaultRole is granted to just-in-time provisioned users.
+	DefaultRole string `json:"default_role"`
+}
+
+// Validate implements SettingConfig. The substantive checks live with the SAML
+// implementation, which owns the certificate parsing and URL rules; this keeps
+// the generic settings path satisfied.
+func (c SAMLConfig) Validate() error { return nil }

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -903,11 +903,10 @@ func ValidateSettingValue(key SettingKey, value map[string]interface{}) error {
 		return config.Validate()
 
 	case SettingKeySAMLConfig:
-		config, err := utils.ToStruct[SAMLConfig](value)
-		if err != nil {
-			return err
-		}
-		return config.Validate()
+		// Validated against the raw value rather than the decoded struct: the
+		// rules that matter (certificate parses, identity provider is https,
+		// role is one a user may actually hold) live in the SAML package.
+		return validateSAMLConfig(value)
 
 	default:
 		return ierr.NewErrorf("unknown setting key: %s", key).
@@ -1012,7 +1011,39 @@ type SAMLConfig struct {
 	DefaultRole string `json:"default_role"`
 }
 
-// Validate implements SettingConfig. The substantive checks live with the SAML
-// implementation, which owns the certificate parsing and URL rules; this keeps
-// the generic settings path satisfied.
+// samlConfigValidator holds the SAML package's validation function.
+//
+// The real checks — certificate parsing, the https rule, the assignable-role
+// rule — need the SAML implementation, which this package cannot import: the
+// SAML package already imports types, so a direct call would be a cycle.
+// Registration runs the other way instead, exactly as the auth provider does.
+var samlConfigValidator func(value map[string]interface{}) error
+
+// RegisterSAMLConfigValidator installs the SAML package's validator. Called from
+// that package's init, so importing it anywhere in the binary is enough.
+func RegisterSAMLConfigValidator(fn func(value map[string]interface{}) error) {
+	samlConfigValidator = fn
+}
+
+// validateSAMLConfig runs the registered validator against a raw settings value.
+//
+// A missing validator means the SAML package is not linked into this binary, so
+// the key cannot be configured here. Refusing is the safe direction: accepting
+// the write would store a configuration nothing had checked, which is precisely
+// how an unvalidated certificate or an http identity provider would get in.
+func validateSAMLConfig(value map[string]interface{}) error {
+	if samlConfigValidator == nil {
+		return ierr.NewError("saml is not available in this build").
+			WithHint("SAML single sign-on is not available on this deployment").
+			Mark(ierr.ErrNotFound)
+	}
+	return samlConfigValidator(value)
+}
+
+// Validate implements SettingConfig.
+//
+// It is deliberately empty: this type is the decoded shape, and the substantive
+// checks run through validateSAMLConfig against the raw value, which is what the
+// settings path calls. Putting rules here as well would mean two places to keep
+// in step.
 func (c SAMLConfig) Validate() error { return nil }

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -760,6 +760,8 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			Key: SettingKeySAMLConfig,
 			DefaultValue: map[string]interface{}{
 				"enabled":         false,
+				"active":          false,
+				"enforce_sso":     false,
 				"idp_entity_id":   "",
 				"idp_sso_url":     "",
 				"idp_certificate": "",
@@ -980,7 +982,18 @@ func ValidateTimezone(timezone string) error {
 // Only the identity provider's public signing certificate is held here, so
 // plain JSONB storage is appropriate.
 type SAMLConfig struct {
+	// Enabled is the tenant's own switch, set through the settings API.
 	Enabled bool `json:"enabled"`
+
+	// Active is Flexprice's approval that this tenant may serve SSO. It is not
+	// settable through the API (see apiImmutableSettingFields) and is flipped
+	// directly in the database once the tenant's claim to its identity provider
+	// has been checked. Both flags must be on before a login is served.
+	Active bool `json:"active"`
+
+	// EnforceSSO refuses password login for this tenant's users, super admins
+	// excepted so an identity provider outage is recoverable.
+	EnforceSSO bool `json:"enforce_sso"`
 
 	// IDPEntityID identifies the identity provider; it must match the Issuer of
 	// every assertion we accept.

--- a/migrations/postgres/V1__seed.sql
+++ b/migrations/postgres/V1__seed.sql
@@ -32,12 +32,17 @@ BEGIN
     WHERE table_schema = 'public' AND table_name = 'users'
   ) THEN
     INSERT INTO public.users (
-      id, email, tenant_id,
+      id, email, tenant_id, roles,
       created_at, updated_at, created_by, updated_by
     ) VALUES (
       '00000000-0000-0000-0000-000000000000',
       'admin@flexprice.dev',
       '00000000-0000-0000-0000-000000000000',
+      -- Without a role the seeded administrator holds no permissions, so a
+      -- fresh self-hosted deployment cannot write settings (SAML configuration
+      -- included) or invite anyone, and has to be bootstrapped through a
+      -- config-file API key instead.
+      '["super_admin"]',
       CURRENT_TIMESTAMP, CURRENT_TIMESTAMP,
       '00000000-0000-0000-0000-000000000000',
       '00000000-0000-0000-0000-000000000000'

--- a/migrations/postgres/V5__settings_unique_published_only.up.sql
+++ b/migrations/postgres/V5__settings_unique_published_only.up.sql
@@ -1,0 +1,22 @@
+-- Restrict the settings uniqueness constraint to live rows.
+--
+-- The old index included status, so status was part of the key and at most one
+-- archived row could exist per setting. Deleting a key twice — delete,
+-- recreate, delete again — archived a row onto the slot the previous tombstone
+-- held and failed the constraint: the caller saw a 500 and the setting stayed
+-- published. For saml_config that meant a tenant could not turn its own SSO
+-- off through the API.
+--
+-- The replacement applies only to published rows, so deletion history
+-- accumulates freely while the guarantee that matters is unchanged: one live
+-- configuration per tenant, environment and key.
+--
+-- Ent creates the new index from the schema but does not drop the old one, so
+-- the drop has to be explicit — without it both exist and the collision
+-- remains.
+
+CREATE UNIQUE INDEX IF NOT EXISTS settings_tenant_id_environment_id_key
+    ON public.settings USING btree (tenant_id, environment_id, key)
+    WHERE ((status)::text = 'published'::text);
+
+DROP INDEX IF EXISTS settings_tenant_id_environment_id_status_key;


### PR DESCRIPTION
## **User description**
SAML 2.0 single sign-on, configured per tenant.

A tenant's administrator points Flexprice at their identity provider; their users then sign in through it. Everything about how a tenant authenticates lives in that tenant's `saml_config` setting. The only deployment-level SAML policy is `auth.saml.enabled`, which turns the feature on.

Pairs with the dashboard work in flexprice/flexprice-front#1260. **Merge this first** — without it the settings key does not validate and the SAML routes are not mounted.

## How it works

Three endpoints, each naming its tenant: `/v1/auth/saml/{tenant}/{metadata,login,acs}`.

Onboarding runs in one order and the metadata endpoint is deliberately ungated so it can: the customer needs our ACS URL and entity ID to create the application in their identity provider, and only then can they hand back the entity ID, SSO URL, and certificate. Requiring configuration first is a deadlock.

The provider does not mint its own tokens. After an assertion validates it delegates to the built-in flexprice provider, so the JWT claim schema, signing secret, and every middleware that validates it are unchanged from password login.

## Two gates before a login is served

`enabled` is the tenant's own switch, set through the settings API. `active` is Flexprice's approval that this tenant may serve SSO — it is not settable through the API at all, and is granted out of band once the tenant's claim to its identity provider has been checked. Both must be on.

This exists because nothing in a settings write proves a tenant controls the identity provider it names. It stands in for per-domain verification until email-domain discovery lands, at which point a verified domain is what grants it.

Configuring SAML requires a **super_admin user**. The settings route is shared by every key and its permission is the broad `setting:write` that an `all_writer` holds, which is too weak for a key naming the identity provider we trust. Reading is gated the same way. Service accounts are refused whatever roles their key carries: administering how people log in is not a machine action.

`enforce_sso` refuses password login for the tenant's users, so enabling SSO closes the password path rather than adding a second way in. Super admins stay exempt — an identity provider outage would otherwise lock a tenant out of its own account with no recovery short of database access.

## Requirements

`auth.saml.enabled` requires `cache.redis.enabled`, and the server refuses to start without it. The outstanding AuthnRequest IDs that make an assertion single-use live in Redis: the redirect that starts a login and the callback that finishes it are separate requests, and a load balancer may route them to different replicas. Held in process memory, roughly (N-1)/N of logins fail on an N-replica deployment, at random, looking like an identity provider fault.

`auth.saml.base_url` and `auth.saml.dashboard_url` are validated at boot — absolute, and https away from loopback. Empty or relative values produce SP metadata whose endpoints an identity provider cannot call, and that surfaces much later as an audience mismatch on every assertion. Both checks apply only when SAML is enabled, so a deployment that does not offer SSO cannot be taken down by either.

## What the assertion check covers

Signature verified against the configured certificate only, never one carried inside the response; signature-wrapping detection; audience restriction; the condition window; `InResponseTo` matched against a request we issued; XML entity expansion disabled.

An assertion is usable once. The request ID is consumed before validation runs — deferring it would let two concurrent replays both succeed — and restored if validation then fails, so an identity provider retrying after a transient failure still completes.

A user belongs to exactly one tenant: `users.email` is globally unique, so an assertion validated for tenant A can never authenticate a user belonging to tenant B. That is refused explicitly rather than surfacing as a duplicate-insert error.

`default_role` may not be `super_admin`. Provisioning happens on the strength of an assertion alone, so it must not mint administrators; an administrator is promoted deliberately afterwards through the user-roles endpoint, which is itself super_admin-only.

## Verified against a running server

Not only unit tests — the two most serious bugs in this branch were found by driving a real identity provider and would have passed review otherwise.

Full flow against SimpleSAMLphp and Auth0: metadata, login redirect, assertion, JIT provisioning, token accepted on `/v1/users/me`. The `active` gate flipping login between 404 and a redirect. `enforce_sso` refusing a regular user while a super admin keeps password login. Tampered assertion, cross-tenant assertion, and an unapproved tenant all refused. Settings writes rejecting a plaintext identity provider, an unparseable certificate, an unassignable role, and `super_admin` as the provisioning default. `active` unchanged by every shape of API write, including a body containing only that field.

## Fixed during review

Four findings were real bugs that every existing test passed straight through:

- **The SAML config validator was never called.** `types.ValidateSettingValue` routed `saml_config` to a method returning `nil`, and the real checks had no caller anywhere in the tree. A plaintext identity provider, an unparseable certificate, and `default_role: super_admin` were all accepted and stored. The regression test goes through the settings path rather than calling the validator directly, so it fails if the wiring is removed.
- **`InResponseTo` was matched with a pattern requiring double quotes.** Single quotes and whitespace around `=` are both valid XML that crewjam accepts; against an identity provider emitting either, the extraction returned empty, which does not fail loudly — it silently disables the replay defence. Now parsed from the root element with the XML decoder.
- **Reading the config required no permission at all.** Any tenant member could fetch which identity provider a tenant trusts and whether it had been approved.
- **Deleting a setting worked only once.** `settings` is uniquely indexed on `status`, so archiving a second time collided and returned 500 while the setting stayed live — meaning a tenant could not turn its own SSO off. Not SAML-specific; every key had it.

Also: assertion rejections now record which check failed. Every failure previously logged the same sentence, which made integrating a second identity provider a guessing game.

## Not covered

- **Email-domain discovery.** A user needs their tenant's link; typing an email is not enough to find their identity provider. Needs a verified-domain table and a public-domain blocklist.
- **SP request signing and encrypted assertions.** Needs Flexprice to hold its own private key, which is a real secret and belongs in an encrypted column rather than this one. Not required by Auth0 or a standard Okta setup.
- **The stored certificate is not encrypted.** It is the identity provider's public certificate, published in their own metadata, so there is nothing to protect. That changes the moment an SP private key or a directory-sync token joins this config.
- **One email, one tenant.** Someone who works with two Flexprice customers cannot use the same address in both. Correct as a security boundary, and a product question worth answering before customers meet it.


___

## **CodeAnt-AI Description**
Add tenant-configured SAML single sign-on for dashboard users

### What Changed
- Tenants can sign users in through Okta, Azure AD, Google Workspace, or another SAML 2.0 identity provider using metadata, login, and assertion callback endpoints.
- SAML settings support provider details, email mapping, default user roles, SSO enforcement, and Flexprice approval before login is enabled.
- New SAML users are created on their first successful login, while existing users are prevented from signing in to a different tenant.
- Password login can be disabled for regular users when SSO is enforced; super admins retain password access for recovery.
- Login responses are validated against the configured provider, can only answer a login request issued by Flexprice once, and return the existing session token format.
- Invalid provider URLs, certificates, email values, and default roles are rejected before they can break login or grant excessive access.
- SAML requires Redis for reliable login completion across multiple server instances, and settings deletion can now be repeated without archived records blocking recreation.

### Impact
`✅ Tenant-managed SSO`
`✅ Safer first-login provisioning`
`✅ Fewer SAML replay and cross-tenant login risks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
