### PR TITLE
chore(invoice): Skip error if invoice already exists

### DIFF
--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
 	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
@@ -121,6 +122,17 @@ func (s *BillingActivities) CreateDraftInvoicesActivity(
 	for _, period := range input.Periods {
 		draft, err := subscriptionService.CreateDraftInvoiceForSubscription(ctx, input.SubscriptionID, period)
 		if err != nil {
+			// Idempotent no-op: a finalized/paid invoice already exists for this period.
+			// The workflow's intent — "make sure invoices exist for these periods" — is
+			// satisfied. Skip and continue; if we propagated this Temporal would retry
+			// the activity forever since the state can never revert.
+			if ierr.IsAlreadyExists(err) {
+				s.logger.Info(ctx, "invoice already exists for period, skipping",
+					"subscription_id", input.SubscriptionID,
+					"period_start", period.Start,
+					"period_end", period.End)
+				continue
+			}
 			return nil, err
 		}
 		if draft == nil {

--- a/internal/temporal/activities/subscription/update_billing_period_activities_test.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addon"
 	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/invoice"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
@@ -242,4 +243,75 @@ func (s *BillingActivitiesSuite) TestCheckCancellationActivity_TerminatesResourc
 	for _, li := range lineItems {
 		s.False(li.EndDate.IsZero(), "line item %s must be terminated when CheckCancellationActivity fires the cancellation", li.ID)
 	}
+}
+
+// TestCreateDraftInvoicesActivity_SkipsPeriodWithFinalizedInvoice guards the retry-storm
+// root cause: when a period already has a finalized (non-draft) invoice, the underlying
+// service returns ErrAlreadyExists. The activity must treat that as an idempotent no-op
+// and continue with the remaining periods, otherwise Temporal retries the activity forever
+// because the state can never become "no invoice for this period" again.
+func (s *BillingActivitiesSuite) TestCreateDraftInvoicesActivity_SkipsPeriodWithFinalizedInvoice() {
+	ctx := types.SetEnvironmentID(s.GetContext(), "env_create_draft_invoices_skip")
+
+	// Minute-aligned so the service's Truncate(time.Minute) doesn't cause a mismatch
+	// when it later calls InvoiceRepo.GetForPeriod.
+	p1Start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	p1End := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	p2Start := p1End
+	p2End := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_create_draft_invoices_skip",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          p1Start,
+		CurrentPeriodStart: p2Start,
+		CurrentPeriodEnd:   p2End,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+		LineItems:          []*subscription.SubscriptionLineItem{},
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, sub.LineItems))
+
+	// Pre-existing finalized invoice for P1 — this is the state that causes
+	// CreateDraftInvoiceForSubscription to return ErrAlreadyExists.
+	existing := &invoice.Invoice{
+		ID:              "inv_finalized_p1",
+		CustomerID:      s.testData.customer.ID,
+		SubscriptionID:  lo.ToPtr(sub.ID),
+		InvoiceType:     types.InvoiceTypeSubscription,
+		InvoiceStatus:   types.InvoiceStatusFinalized,
+		PaymentStatus:   types.PaymentStatusSucceeded,
+		Currency:        "usd",
+		AmountDue:       decimal.Zero,
+		AmountPaid:      decimal.Zero,
+		AmountRemaining: decimal.Zero,
+		Subtotal:        decimal.Zero,
+		Total:           decimal.Zero,
+		PeriodStart:     &p1Start,
+		PeriodEnd:       &p1End,
+		BillingReason:   string(types.InvoiceBillingReasonSubscriptionCycle),
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().InvoiceRepo.Create(ctx, existing))
+
+	input := subscriptionModels.CreateInvoicesActivityInput{
+		SubscriptionID: sub.ID,
+		TenantID:       types.GetTenantID(ctx),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		UserID:         types.GetUserID(ctx),
+		Periods: []dto.Period{
+			{Start: p1Start, End: p1End},
+			{Start: p2Start, End: p2End},
+		},
+	}
+
+	output, err := s.activities.CreateDraftInvoicesActivity(ctx, input)
+	s.NoError(err, "activity must not fail when a period is already invoiced — Temporal would retry the permanent failure forever")
+	s.Require().NotNil(output)
+	s.Len(output.InvoiceIDs, 1, "P1 must be skipped (already invoiced), only P2 gets a new draft")
+	s.NotContains(output.InvoiceIDs, existing.ID, "output must contain newly-created draft IDs, not the pre-existing finalized invoice")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved invoice processing to safely skip billing periods that already have finalized invoices.
  - Processing now continues for subsequent periods instead of stopping with an error.
  - Newly created draft invoice results remain available without including previously finalized invoices.

- **Tests**
  - Added regression coverage for mixed finalized and newly created invoice periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->