### PR TITLE
fix(invoice): bound void refunds by remaining unreimbursed value

### DIFF
--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -1268,9 +1268,13 @@ func (s *invoiceService) VoidInvoice(ctx context.Context, id string, req dto.Inv
 			}
 		}
 
-		// Refund AmountPaid + TotalPrepaidCreditsApplied back to the customer's wallet.
-		// Both represent value the customer already provided for this invoice.
-		refundAmount := inv.AmountPaid.Add(inv.TotalPrepaidCreditsApplied)
+		// Refund only the remaining customer value that has not already been returned.
+		// RefundedAmount tracks prior refunds (e.g. refund credit notes), so voiding must
+		// not credit more than the total value provided for the invoice.
+		refundAmount := inv.AmountPaid.Add(inv.TotalPrepaidCreditsApplied).Sub(inv.RefundedAmount)
+		if refundAmount.IsNegative() {
+			refundAmount = decimal.Zero
+		}
 		if refundAmount.IsPositive() {
 			walletService := NewWalletService(s.ServiceParams)
 

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -1217,17 +1217,9 @@ func (s *invoiceService) updateMetadata(inv *invoice.Invoice, req dto.InvoiceVoi
 	return nil
 }
 
-func (s *invoiceService) VoidInvoice(ctx context.Context, id string, req dto.InvoiceVoidRequest) error {
-
-	if err := req.Validate(); err != nil {
-		return err
-	}
-
-	inv, err := s.InvoiceRepo.Get(ctx, id)
-	if err != nil {
-		return err
-	}
-
+// validateInvoiceVoidable checks the invoice and payment statuses that allow voiding.
+// It runs both before the transaction and again on the row-locked invoice inside it.
+func validateInvoiceVoidable(inv *invoice.Invoice) error {
 	allowedInvoiceStatuses := []types.InvoiceStatus{
 		types.InvoiceStatusDraft,
 		types.InvoiceStatusFinalized,
@@ -1258,7 +1250,35 @@ func (s *invoiceService) VoidInvoice(ctx context.Context, id string, req dto.Inv
 			Mark(ierr.ErrValidation)
 	}
 
+	return nil
+}
+
+func (s *invoiceService) VoidInvoice(ctx context.Context, id string, req dto.InvoiceVoidRequest) error {
+
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	inv, err := s.InvoiceRepo.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := validateInvoiceVoidable(inv); err != nil {
+		return err
+	}
+
 	err = s.DB.WithTx(ctx, func(tx context.Context) error {
+		// Re-read under a row lock so a concurrent refund cannot make RefundedAmount
+		// stale between the pre-check and the refund calculation below.
+		inv, err = s.InvoiceRepo.GetForUpdate(tx, id)
+		if err != nil {
+			return err
+		}
+		if err := validateInvoiceVoidable(inv); err != nil {
+			return err
+		}
+
 		now := time.Now().UTC()
 		inv.InvoiceStatus = types.InvoiceStatusVoided
 		inv.VoidedAt = &now
@@ -1271,7 +1291,8 @@ func (s *invoiceService) VoidInvoice(ctx context.Context, id string, req dto.Inv
 		// Refund only the remaining customer value that has not already been returned.
 		// RefundedAmount tracks prior refunds (e.g. refund credit notes), so voiding must
 		// not credit more than the total value provided for the invoice.
-		refundAmount := inv.AmountPaid.Add(inv.TotalPrepaidCreditsApplied).Sub(inv.RefundedAmount)
+		fundedAmount := inv.AmountPaid.Add(inv.TotalPrepaidCreditsApplied)
+		refundAmount := fundedAmount.Sub(inv.RefundedAmount)
 		if refundAmount.IsNegative() {
 			refundAmount = decimal.Zero
 		}
@@ -1316,6 +1337,12 @@ func (s *invoiceService) VoidInvoice(ctx context.Context, id string, req dto.Inv
 			}
 
 			inv.RefundedAmount = inv.RefundedAmount.Add(refundAmount)
+		}
+
+		// Once voided, any invoice whose funded value has been fully returned is
+		// terminally REFUNDED — including the case where prior refunds already
+		// covered it and this void issued no additional credit.
+		if fundedAmount.IsPositive() && inv.RefundedAmount.GreaterThanOrEqual(fundedAmount) {
 			inv.PaymentStatus = types.PaymentStatusRefunded
 		}
 

--- a/internal/ee/service/invoice_void_recalculate_test.go
+++ b/internal/ee/service/invoice_void_recalculate_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -650,6 +651,71 @@ func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_FullyRefundedValueYieldsNo
 	s.True(amountPaid.Equal(updated.RefundedAmount),
 		"expected refunded_amount to stay at %s, got=%s", amountPaid, updated.RefundedAmount)
 	s.Len(s.walletsByCustomer(), 0, "no wallet credit when nothing remains to refund")
+	// The funded value is fully returned, so the invoice must land on the terminal
+	// refunded status even though this void issued no additional credit.
+	s.Equal(types.PaymentStatusRefunded, updated.PaymentStatus)
+}
+
+// A refund credit note can land between the pre-transaction status check and the
+// refund calculation. The void must read the invoice under a row lock inside the
+// transaction so it credits the remaining value, not a stale larger one.
+func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_ConcurrentRefundDoesNotOverRefund() {
+	amountPaid := decimal.NewFromFloat(120.00)
+	concurrentRefund := decimal.NewFromFloat(50.00)
+
+	initialBalance := decimal.NewFromFloat(10.00)
+	existingWallet := s.buildPrepaidWallet("wallet_concurrent_refund", initialBalance)
+
+	inv := s.buildFinalizedInvoice("inv_concurrent_refund", amountPaid, decimal.Zero, types.PaymentStatusSucceeded)
+
+	// Simulate a refund credit note committing after VoidInvoice's initial read
+	// but before it takes the lock.
+	var once sync.Once
+	s.invoiceRepo.BeforeGetForUpdate = func(id string) {
+		if id != inv.ID {
+			return
+		}
+		once.Do(func() {
+			stored, err := s.invoiceRepo.Get(s.GetContext(), id)
+			s.NoError(err)
+			stored.RefundedAmount = concurrentRefund
+			stored.PaymentStatus = types.PaymentStatusPartiallyRefunded
+			s.NoError(s.invoiceRepo.Update(s.GetContext(), stored))
+		})
+	}
+	defer func() { s.invoiceRepo.BeforeGetForUpdate = nil }()
+
+	err := s.service.VoidInvoice(s.GetContext(), inv.ID, dto.InvoiceVoidRequest{})
+	s.NoError(err)
+
+	updated, err := s.invoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.Equal(types.InvoiceStatusVoided, updated.InvoiceStatus)
+	s.True(amountPaid.Equal(updated.RefundedAmount),
+		"cumulative refunded_amount must settle at funded value %s, got=%s", amountPaid, updated.RefundedAmount)
+
+	expectedRefund := amountPaid.Sub(concurrentRefund) // $70, not the stale $120
+	txns := s.refundTxns(existingWallet.ID)
+	s.Len(txns, 1)
+	s.True(expectedRefund.Equal(txns[0].CreditAmount),
+		"expected txn credit amount=%s, got=%s", expectedRefund, txns[0].CreditAmount)
+
+	updatedWallet, err := s.walletRepo.GetWalletByID(s.GetContext(), existingWallet.ID)
+	s.NoError(err)
+	s.True(initialBalance.Add(expectedRefund).Equal(updatedWallet.Balance),
+		"expected wallet balance=%s, got=%s", initialBalance.Add(expectedRefund), updatedWallet.Balance)
+}
+
+// The refund calculation must read invoice state only after the row lock is taken.
+func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_TakesRowLockBeforeRefund() {
+	inv := s.buildFinalizedInvoice("inv_lock_order", decimal.NewFromFloat(40.00), decimal.Zero, types.PaymentStatusSucceeded)
+	s.buildPrepaidWallet("wallet_lock_order", decimal.Zero)
+	s.invoiceRepo.ResetInvoiceAccessLog(inv.ID)
+
+	s.NoError(s.service.VoidInvoice(s.GetContext(), inv.ID, dto.InvoiceVoidRequest{}))
+
+	s.Contains(s.invoiceRepo.InvoiceAccessLog(inv.ID), "get_for_update",
+		"void must re-read the invoice under a row lock inside the transaction")
 }
 
 func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_Idempotency() {

--- a/internal/ee/service/invoice_void_recalculate_test.go
+++ b/internal/ee/service/invoice_void_recalculate_test.go
@@ -559,7 +559,9 @@ func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_PrepaidCreditsOnlyRefund()
 }
 
 func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_PartiallyRefundedStatus() {
-	// PARTIALLY_REFUNDED is an allowed payment status for voiding
+	// PARTIALLY_REFUNDED is an allowed payment status for voiding.
+	// Voiding must only return the value that has NOT already been refunded,
+	// so cumulative RefundedAmount can never exceed the funded value.
 	prevRefunded := decimal.NewFromFloat(10.00)
 	amountPaid := decimal.NewFromFloat(60.00)
 	inv := s.buildFinalizedInvoice("inv_partial_refund", amountPaid, decimal.Zero, types.PaymentStatusPartiallyRefunded)
@@ -578,10 +580,76 @@ func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_PartiallyRefundedStatus() 
 	s.Equal(types.InvoiceStatusVoided, updated.InvoiceStatus)
 	s.Equal(types.PaymentStatusRefunded, updated.PaymentStatus)
 
-	// RefundedAmount = previous ($10) + new refund ($60)
-	expectedTotal := prevRefunded.Add(amountPaid)
-	s.True(expectedTotal.Equal(updated.RefundedAmount),
-		"expected refunded_amount=%s, got=%s", expectedTotal, updated.RefundedAmount)
+	// Cumulative refunded value must equal the funded value ($60), not $60 on top of $10.
+	s.True(amountPaid.Equal(updated.RefundedAmount),
+		"expected refunded_amount=%s, got=%s", amountPaid, updated.RefundedAmount)
+}
+
+func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_PartiallyRefundedDoesNotOverRefund() {
+	// Regression: voiding a partially refunded invoice must credit only the
+	// remaining unreimbursed value, never the full historical funded value.
+	// Funded = AmountPaid $100 + prepaid credits $20 = $120; $30 already refunded
+	// via a refund credit note, so voiding may return at most $90.
+	prevRefunded := decimal.NewFromFloat(30.00)
+	amountPaid := decimal.NewFromFloat(100.00)
+	prepaidCredits := decimal.NewFromFloat(20.00)
+	funded := amountPaid.Add(prepaidCredits)
+
+	existingWallet := s.buildPrepaidWallet("wallet_over_refund", decimal.NewFromFloat(40.00))
+	initialBalance := existingWallet.Balance
+
+	inv := s.buildFinalizedInvoice("inv_over_refund", amountPaid, prepaidCredits, types.PaymentStatusPartiallyRefunded)
+	stored, err := s.invoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	stored.RefundedAmount = prevRefunded
+	s.NoError(s.invoiceRepo.Update(s.GetContext(), stored))
+
+	err = s.service.VoidInvoice(s.GetContext(), inv.ID, dto.InvoiceVoidRequest{})
+	s.NoError(err)
+
+	updated, err := s.invoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.Equal(types.InvoiceStatusVoided, updated.InvoiceStatus)
+
+	// Cumulative refunded value must never exceed the total funded value.
+	s.True(funded.Equal(updated.RefundedAmount),
+		"expected cumulative refunded_amount=%s, got=%s", funded, updated.RefundedAmount)
+	s.False(updated.RefundedAmount.GreaterThan(funded),
+		"cumulative refunded amount %s exceeds funded value %s", updated.RefundedAmount, funded)
+
+	expectedRefund := funded.Sub(prevRefunded) // $90
+	expectedBalance := initialBalance.Add(expectedRefund)
+	updatedWallet, err := s.walletRepo.GetWalletByID(s.GetContext(), existingWallet.ID)
+	s.NoError(err)
+	s.True(expectedBalance.Equal(updatedWallet.Balance),
+		"expected wallet balance=%s, got=%s", expectedBalance, updatedWallet.Balance)
+
+	txns := s.refundTxns(existingWallet.ID)
+	s.Len(txns, 1, "expected exactly one INVOICE_VOID_REFUND transaction")
+	s.True(expectedRefund.Equal(txns[0].CreditAmount),
+		"expected txn credit amount=%s, got=%s", expectedRefund, txns[0].CreditAmount)
+}
+
+func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_FullyRefundedValueYieldsNoWalletCredit() {
+	// Everything the customer funded has already been returned, so voiding
+	// must not credit the wallet again.
+	amountPaid := decimal.NewFromFloat(80.00)
+	inv := s.buildFinalizedInvoice("inv_fully_refunded_value", amountPaid, decimal.Zero, types.PaymentStatusPartiallyRefunded)
+
+	stored, err := s.invoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	stored.RefundedAmount = amountPaid
+	s.NoError(s.invoiceRepo.Update(s.GetContext(), stored))
+
+	err = s.service.VoidInvoice(s.GetContext(), inv.ID, dto.InvoiceVoidRequest{})
+	s.NoError(err)
+
+	updated, err := s.invoiceRepo.Get(s.GetContext(), inv.ID)
+	s.NoError(err)
+	s.Equal(types.InvoiceStatusVoided, updated.InvoiceStatus)
+	s.True(amountPaid.Equal(updated.RefundedAmount),
+		"expected refunded_amount to stay at %s, got=%s", amountPaid, updated.RefundedAmount)
+	s.Len(s.walletsByCustomer(), 0, "no wallet credit when nothing remains to refund")
 }
 
 func (s *InvoiceVoidRecalculateSuite) TestVoidInvoice_Idempotency() {


### PR DESCRIPTION
## **User description**
## Problem

`VoidInvoice` computed the wallet refund as the full historical funded value:

```go
refundAmount := inv.AmountPaid.Add(inv.TotalPrepaidCreditsApplied)
```

This ignores `RefundedAmount`. A refund credit note increments `RefundedAmount` **without** reducing `AmountPaid` (`RecalculateInvoiceAmountsForCreditNote`), and `PARTIALLY_REFUNDED` is an allowed payment status for voiding. So voiding an invoice that had already been partially refunded returned the already-refunded portion a second time, letting the cumulative refunded value exceed the amount the customer originally funded.

## Fix

Refund only the remaining unreimbursed value, clamped at zero:

```go
refundAmount := inv.AmountPaid.Add(inv.TotalPrepaidCreditsApplied).Sub(inv.RefundedAmount)
if refundAmount.IsNegative() {
    refundAmount = decimal.Zero
}
```

The clamp guards against inconsistent stored data producing a negative refund. This is the same invariant the credit note path already enforces in `calculateMaxCreditableAmount` (`AmountPaid - RefundedAmount`) — the void path was the only unbounded writer of `RefundedAmount`.

## Tests

`TestVoidInvoice_PartiallyRefundedStatus` previously asserted the unbounded behaviour (expecting prior refund + full `AmountPaid`); it now asserts cumulative refunded value settles at the funded amount. Two cases added:

- `TestVoidInvoice_PartiallyRefundedDoesNotOverRefund` — funded \$120, \$30 already refunded; asserts the wallet credit is \$90 and cumulative refunded value never exceeds \$120.
- `TestVoidInvoice_FullyRefundedValueYieldsNoWalletCredit` — nothing left to return, so no wallet credit is issued.

All three fail against the previous implementation and pass with this change.

## Verification

- `go build ./internal/... ./cmd/...` — clean
- `go test ./internal/ee/service` — `ok` (full package, no regressions in the credit note suites)
- `make lint-ci` — passes

## Adjacent flows reviewed

Gateway refund paths (`razorpay/payment.go`, `payments/lifecycle.go`) guard on payment status and do not write invoice `RefundedAmount`. The credit note refund path is already bounded by `calculateMaxCreditableAmount`. No other unbounded writers found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected invoice void refunds to credit only the remaining eligible amount after previous refunds.
  - Prevented duplicate wallet credits when an invoice has already been fully refunded.
  - Improved handling of partial refunds involving prepaid credits.
  - Prevented over-refunding when multiple refunds are processed concurrently.

- **Tests**
  - Added coverage for cumulative, partial, and fully refunded invoice scenarios.
  - Added regression tests for prepaid-credit refunds and concurrent refund processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent over-refunding when voiding invoices

### What Changed
- Voiding an invoice now refunds only the amount that has not already been returned, including prior refunds and prepaid credits.
- Invoices that were fully refunded before voiding receive no additional wallet credit and are marked as refunded.
- Concurrent refunds are accounted for before the void refund is calculated, preventing stale data from issuing excess credit.
- Added coverage for partial refunds, full refunds, and concurrent refund scenarios.

### Impact
`✅ No duplicate wallet refunds`
`✅ Accurate balances after partial refunds`
`✅ Correct terminal refunded status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
