### PR TITLE
fix(secrets): bind API-key issuance to the authenticated caller

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -178,7 +178,9 @@ func NewRouter(
 			user.PUT("/:id", write(types.EntityUser, types.ActionWrite), handlers.User.UpdateServiceAccount)
 			user.PUT("/:id/roles", write(types.EntityUser, types.ActionWrite, superAdminOnly), handlers.User.UpdateUserRoles)
 			user.DELETE("/:id", write(types.EntityUser, types.ActionWrite), handlers.User.DeleteUser)
-			user.POST("/search", handlers.User.QueryUsers)
+			// Enumerating users and service accounts exposes the principals whose
+			// roles an API key can inherit, so it is an administrative read.
+			user.POST("/search", read(types.EntityUser, types.ActionRead, superAdminOnly), handlers.User.QueryUsers)
 			user.POST("/chat/verify", handlers.User.CreateSupportChatToken)
 		}
 
@@ -531,7 +533,9 @@ func NewRouter(
 			// API Key routes
 			apiKeys := secrets.Group("/api/keys")
 			{
-				apiKeys.GET("", handlers.Secret.ListAPIKeys)
+				// Results are scoped to the caller in the service layer; a
+				// super_admin sees the whole environment.
+				apiKeys.GET("", read(types.EntitySecret, types.ActionRead), handlers.Secret.ListAPIKeys)
 				apiKeys.POST("", write(types.EntitySecret, types.ActionWrite), handlers.Secret.CreateAPIKey)
 				apiKeys.DELETE("/:id", write(types.EntitySecret, types.ActionWrite), handlers.Secret.DeleteAPIKey)
 			}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -178,9 +178,7 @@ func NewRouter(
 			user.PUT("/:id", write(types.EntityUser, types.ActionWrite), handlers.User.UpdateServiceAccount)
 			user.PUT("/:id/roles", write(types.EntityUser, types.ActionWrite, superAdminOnly), handlers.User.UpdateUserRoles)
 			user.DELETE("/:id", write(types.EntityUser, types.ActionWrite), handlers.User.DeleteUser)
-			// Enumerating users and service accounts exposes the principals whose
-			// roles an API key can inherit, so it is an administrative read.
-			user.POST("/search", read(types.EntityUser, types.ActionRead, superAdminOnly), handlers.User.QueryUsers)
+			user.POST("/search", read(types.EntityUser, types.ActionRead), handlers.User.QueryUsers)
 			user.POST("/chat/verify", handlers.User.CreateSupportChatToken)
 		}
 

--- a/internal/ee/service/secret.go
+++ b/internal/ee/service/secret.go
@@ -88,6 +88,15 @@ func generateAPIKey(prefix string) string {
 	return types.GenerateUUIDWithPrefix(prefix)
 }
 
+// isSuperAdminUser reports whether the caller may act administratively over
+// other principals' credentials. It mirrors the superAdminOnly route guard: a
+// service account is never administrative, however its stored roles read, so a
+// leaked machine key cannot mint or enumerate credentials beyond its own.
+func isSuperAdminUser(ctx context.Context) bool {
+	return !types.IsServiceAccount(ctx) &&
+		lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String())
+}
+
 func (s *secretService) CreateAPIKey(ctx context.Context, req *dto.CreateAPIKeyRequest) (*secret.Secret, string, error) {
 	if err := req.Validate(); err != nil {
 		return nil, "", err
@@ -100,11 +109,18 @@ func (s *secretService) CreateAPIKey(ctx context.Context, req *dto.CreateAPIKeyR
 	// Hash the entire API key for storage
 	hashedKey := s.encryptionService.Hash(apiKey)
 
-	// Determine which user to get roles from
-	userID := req.ServiceAccountID
-	if userID == "" {
-		// No service_account_id provided - use authenticated user from context
-		userID = types.GetUserID(ctx)
+	// A key is minted for the authenticated caller by default. Naming another
+	// principal hands that principal's stored roles to a fresh secret, so it is
+	// an administrative act: only a super_admin user may do it, and never a
+	// service account acting through its own key.
+	userID := types.GetUserID(ctx)
+	if req.ServiceAccountID != "" {
+		if !isSuperAdminUser(ctx) {
+			return nil, "", ierr.NewError("only super_admin users can create keys for another principal").
+				WithHint("Ask a tenant super_admin to mint or rotate service-account API keys").
+				Mark(ierr.ErrPermissionDenied)
+		}
+		userID = req.ServiceAccountID
 	}
 
 	// Fetch user to get roles and type
@@ -178,6 +194,13 @@ func (s *secretService) ListAPIKeys(ctx context.Context, filter *types.SecretFil
 	filter.Type = lo.ToPtr(types.SecretTypePrivateKey)
 	filter.Provider = lo.ToPtr(types.SecretProviderFlexPrice)
 	filter.Status = lo.ToPtr(types.StatusPublished)
+
+	// Only an administrator sees the whole environment's keys. Everyone else is
+	// pinned to their own, overriding any user_id the caller supplied so the
+	// filter cannot be used to read around the scoping.
+	if !isSuperAdminUser(ctx) {
+		filter.UserID = lo.ToPtr(types.GetUserID(ctx))
+	}
 
 	secrets, err := s.repo.List(ctx, filter)
 	if err != nil {
@@ -295,6 +318,22 @@ func (s *secretService) ListIntegrations(ctx context.Context, filter *types.Secr
 }
 
 func (s *secretService) Delete(ctx context.Context, id string) error {
+	// Revoking a credential the caller does not own is administrative: without
+	// this a writer could disable another principal's key by guessing its id.
+	if !isSuperAdminUser(ctx) {
+		existing, err := s.repo.Get(ctx, id)
+		if err != nil {
+			return err
+		}
+		// Integration secrets are tenant-wide and carry no owning principal, so
+		// only API keys minted for someone else are withheld.
+		if existing.UserID != "" && existing.UserID != types.GetUserID(ctx) {
+			return ierr.NewError("cannot delete a secret owned by another principal").
+				WithHint("Ask a tenant super_admin to revoke this API key").
+				Mark(ierr.ErrPermissionDenied)
+		}
+	}
+
 	if err := s.repo.Delete(ctx, id); err != nil {
 		return err
 	}

--- a/internal/ee/service/secret.go
+++ b/internal/ee/service/secret.go
@@ -88,15 +88,6 @@ func generateAPIKey(prefix string) string {
 	return types.GenerateUUIDWithPrefix(prefix)
 }
 
-// isSuperAdminUser reports whether the caller may act administratively over
-// other principals' credentials. It mirrors the superAdminOnly route guard: a
-// service account is never administrative, however its stored roles read, so a
-// leaked machine key cannot mint or enumerate credentials beyond its own.
-func isSuperAdminUser(ctx context.Context) bool {
-	return !types.IsServiceAccount(ctx) &&
-		lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String())
-}
-
 func (s *secretService) CreateAPIKey(ctx context.Context, req *dto.CreateAPIKeyRequest) (*secret.Secret, string, error) {
 	if err := req.Validate(); err != nil {
 		return nil, "", err
@@ -115,7 +106,7 @@ func (s *secretService) CreateAPIKey(ctx context.Context, req *dto.CreateAPIKeyR
 	// service account acting through its own key.
 	userID := types.GetUserID(ctx)
 	if req.ServiceAccountID != "" {
-		if !isSuperAdminUser(ctx) {
+		if !types.IsSuperAdminUser(ctx) {
 			return nil, "", ierr.NewError("only super_admin users can create keys for another principal").
 				WithHint("Ask a tenant super_admin to mint or rotate service-account API keys").
 				Mark(ierr.ErrPermissionDenied)
@@ -198,7 +189,7 @@ func (s *secretService) ListAPIKeys(ctx context.Context, filter *types.SecretFil
 	// Only an administrator sees the whole environment's keys. Everyone else is
 	// pinned to their own, overriding any user_id the caller supplied so the
 	// filter cannot be used to read around the scoping.
-	if !isSuperAdminUser(ctx) {
+	if !types.IsSuperAdminUser(ctx) {
 		filter.UserID = lo.ToPtr(types.GetUserID(ctx))
 	}
 
@@ -320,7 +311,7 @@ func (s *secretService) ListIntegrations(ctx context.Context, filter *types.Secr
 func (s *secretService) Delete(ctx context.Context, id string) error {
 	// Revoking a credential the caller does not own is administrative: without
 	// this a writer could disable another principal's key by guessing its id.
-	if !isSuperAdminUser(ctx) {
+	if !types.IsSuperAdminUser(ctx) {
 		existing, err := s.repo.Get(ctx, id)
 		if err != nil {
 			return err

--- a/internal/ee/service/secret_test.go
+++ b/internal/ee/service/secret_test.go
@@ -596,6 +596,10 @@ func (s *SecretServiceSuite) TestListAPIKeysScopedToCaller() {
 		QueryFilter: types.NewDefaultQueryFilter(),
 	})
 	s.Require().NoError(err)
+	s.Require().NotEmpty(resp.Items, "writer must still see its own key")
+	ids := lo.Map(resp.Items, func(item *dto.SecretResponse, _ int) string { return item.ID })
+	s.Contains(ids, own.ID)
+	s.NotContains(ids, foreign.ID)
 	for _, item := range resp.Items {
 		s.Equal("user_attacker", item.UserID, "writer listed a key owned by another principal")
 	}
@@ -606,6 +610,10 @@ func (s *SecretServiceSuite) TestListAPIKeysScopedToCaller() {
 		UserID:      lo.ToPtr("user_victim"),
 	})
 	s.Require().NoError(err)
+	s.Require().NotEmpty(resp.Items, "the user_id filter must be replaced, not intersected away")
+	ids = lo.Map(resp.Items, func(item *dto.SecretResponse, _ int) string { return item.ID })
+	s.Contains(ids, own.ID)
+	s.NotContains(ids, foreign.ID)
 	for _, item := range resp.Items {
 		s.Equal("user_attacker", item.UserID, "writer read another principal's keys via a user_id filter")
 	}

--- a/internal/ee/service/secret_test.go
+++ b/internal/ee/service/secret_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/domain/secret"
 	domainUser "github.com/flexprice/flexprice/internal/domain/user"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/security"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
@@ -96,6 +98,7 @@ func (s *SecretServiceSuite) setupTestData() {
 		DisplayID: "test1",
 		Roles:     []string{}, // Empty roles = full access
 		UserType:  "user",     // Default user type
+		UserID:    types.DefaultUserID,
 		BaseModel: types.BaseModel{
 			TenantID:  types.DefaultTenantID,
 			Status:    types.StatusPublished,
@@ -444,6 +447,207 @@ func (s *SecretServiceSuite) TestListIntegrations() {
 			s.Len(resp.Items, tt.expectedTotal)
 		})
 	}
+}
+
+// writerCtx returns a context for a non-super_admin human user holding the
+// wildcard all_writer role, the weakest principal that passes write(secret).
+func (s *SecretServiceSuite) writerCtx(userID string) context.Context {
+	ctx := context.WithValue(s.GetContext(), types.CtxUserID, userID)
+	ctx = context.WithValue(ctx, types.CtxUserType, string(types.UserTypeUser))
+	return context.WithValue(ctx, types.CtxRoles, []string{types.RoleAllWriter.String()})
+}
+
+func (s *SecretServiceSuite) superAdminCtx(userID string) context.Context {
+	ctx := context.WithValue(s.GetContext(), types.CtxUserID, userID)
+	ctx = context.WithValue(ctx, types.CtxUserType, string(types.UserTypeUser))
+	return context.WithValue(ctx, types.CtxRoles, []string{types.RoleSuperAdmin.String()})
+}
+
+// createServiceAccount persists a privileged service account owned by nobody in
+// particular, standing in for the target a writer must not be able to hijack.
+func (s *SecretServiceSuite) createServiceAccount(id string) *domainUser.User {
+	sa := &domainUser.User{
+		ID:    id,
+		Email: id + "@example.com",
+		Type:  types.UserTypeServiceAccount,
+		Roles: []string{types.RoleSuperAdmin.String()},
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+	s.Require().NoError(s.GetStores().UserRepo.Create(s.GetContext(), sa))
+	return sa
+}
+
+// A writer must not be able to mint a key that inherits another principal's
+// roles by naming it in service_account_id.
+func (s *SecretServiceSuite) TestCreateAPIKeyRejectsCrossPrincipalMinting() {
+	sa := s.createServiceAccount("user_privileged_sa")
+
+	writer := s.writerCtx("user_attacker")
+	_, _, err := s.service.CreateAPIKey(writer, &dto.CreateAPIKeyRequest{
+		Name:             "stolen",
+		Type:             types.SecretTypePrivateKey,
+		ServiceAccountID: sa.ID,
+	})
+	s.Require().Error(err, "writer must not mint a key for another service account")
+	s.True(ierr.IsPermissionDenied(err), "expected permission denied, got: %v", err)
+
+	// A service account may not escalate via its own key either, even when its
+	// stored roles include super_admin.
+	saCtx := context.WithValue(s.GetContext(), types.CtxUserID, sa.ID)
+	saCtx = context.WithValue(saCtx, types.CtxUserType, string(types.UserTypeServiceAccount))
+	saCtx = context.WithValue(saCtx, types.CtxRoles, []string{types.RoleSuperAdmin.String()})
+	_, _, err = s.service.CreateAPIKey(saCtx, &dto.CreateAPIKeyRequest{
+		Name:             "self-mint",
+		Type:             types.SecretTypePrivateKey,
+		ServiceAccountID: sa.ID,
+	})
+	s.Require().Error(err, "service account must not mint service-account keys")
+	s.True(ierr.IsPermissionDenied(err), "expected permission denied, got: %v", err)
+}
+
+// A super_admin retains the ability to mint service-account keys, and the key
+// still inherits the target's roles.
+func (s *SecretServiceSuite) TestCreateAPIKeyAllowsSuperAdminCrossPrincipalMinting() {
+	sa := s.createServiceAccount("user_sa_for_admin")
+
+	resp, apiKey, err := s.service.CreateAPIKey(s.superAdminCtx("user_admin"), &dto.CreateAPIKeyRequest{
+		Name:             "legit",
+		Type:             types.SecretTypePrivateKey,
+		ServiceAccountID: sa.ID,
+	})
+	s.Require().NoError(err)
+	s.NotEmpty(apiKey)
+	s.Equal(sa.ID, resp.UserID)
+	s.Equal(string(types.UserTypeServiceAccount), resp.UserType)
+	s.Equal(sa.Roles, resp.Roles)
+}
+
+// A writer creating a key without service_account_id is bound to itself.
+func (s *SecretServiceSuite) TestCreateAPIKeyBindsToCaller() {
+	caller := &domainUser.User{
+		ID:    "user_self_writer",
+		Email: "self@example.com",
+		Type:  types.UserTypeUser,
+		Roles: []string{types.RoleAllWriter.String()},
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+	s.Require().NoError(s.GetStores().UserRepo.Create(s.GetContext(), caller))
+
+	resp, _, err := s.service.CreateAPIKey(s.writerCtx(caller.ID), &dto.CreateAPIKeyRequest{
+		Name: "own key",
+		Type: types.SecretTypePrivateKey,
+	})
+	s.Require().NoError(err)
+	s.Equal(caller.ID, resp.UserID)
+}
+
+// Listing must not expose keys belonging to other principals, and a supplied
+// user_id filter must not let a writer read around that scoping.
+func (s *SecretServiceSuite) TestListAPIKeysScopedToCaller() {
+	foreign := &secret.Secret{
+		ID:        "secret_foreign_key",
+		Name:      "Foreign Key",
+		Type:      types.SecretTypePrivateKey,
+		Provider:  types.SecretProviderFlexPrice,
+		Value:     s.encryptionSvc.Hash("foreign_api_key"),
+		DisplayID: "frgn1",
+		UserID:    "user_victim",
+		UserType:  string(types.UserTypeUser),
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+	s.Require().NoError(s.secretRepo.Create(s.GetContext(), foreign))
+
+	own := &secret.Secret{
+		ID:        "secret_own_key",
+		Name:      "Own Key",
+		Type:      types.SecretTypePrivateKey,
+		Provider:  types.SecretProviderFlexPrice,
+		Value:     s.encryptionSvc.Hash("own_api_key"),
+		DisplayID: "own01",
+		UserID:    "user_attacker",
+		UserType:  string(types.UserTypeUser),
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+	s.Require().NoError(s.secretRepo.Create(s.GetContext(), own))
+
+	writer := s.writerCtx("user_attacker")
+
+	resp, err := s.service.ListAPIKeys(writer, &types.SecretFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.Require().NoError(err)
+	for _, item := range resp.Items {
+		s.Equal("user_attacker", item.UserID, "writer listed a key owned by another principal")
+	}
+
+	// An attacker-supplied user_id must not widen the scope back out.
+	resp, err = s.service.ListAPIKeys(writer, &types.SecretFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+		UserID:      lo.ToPtr("user_victim"),
+	})
+	s.Require().NoError(err)
+	for _, item := range resp.Items {
+		s.Equal("user_attacker", item.UserID, "writer read another principal's keys via a user_id filter")
+	}
+
+	// A super_admin still sees the whole environment.
+	resp, err = s.service.ListAPIKeys(s.superAdminCtx("user_admin"), &types.SecretFilter{
+		QueryFilter: types.NewDefaultQueryFilter(),
+	})
+	s.Require().NoError(err)
+	s.GreaterOrEqual(len(resp.Items), 2, "super_admin must still see all keys")
+}
+
+// A writer must not be able to revoke a credential it does not own.
+func (s *SecretServiceSuite) TestDeleteRejectsForeignSecret() {
+	foreign := &secret.Secret{
+		ID:        "secret_foreign_delete",
+		Name:      "Foreign Key",
+		Type:      types.SecretTypePrivateKey,
+		Provider:  types.SecretProviderFlexPrice,
+		Value:     s.encryptionSvc.Hash("foreign_delete_key"),
+		DisplayID: "frgn2",
+		UserID:    "user_victim",
+		UserType:  string(types.UserTypeUser),
+		BaseModel: types.BaseModel{
+			TenantID:  types.DefaultTenantID,
+			Status:    types.StatusPublished,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+	s.Require().NoError(s.secretRepo.Create(s.GetContext(), foreign))
+
+	err := s.service.Delete(s.writerCtx("user_attacker"), foreign.ID)
+	s.Require().Error(err, "writer must not revoke another principal's key")
+	s.True(ierr.IsPermissionDenied(err), "expected permission denied, got: %v", err)
+
+	// The key survives, and a super_admin can still revoke it.
+	still, err := s.secretRepo.Get(s.GetContext(), foreign.ID)
+	s.Require().NoError(err)
+	s.Equal(types.StatusPublished, still.Status)
+
+	s.Require().NoError(s.service.Delete(s.superAdminCtx("user_admin"), foreign.ID))
 }
 
 func (s *SecretServiceSuite) TestDelete() {

--- a/internal/rest/middleware/permission.go
+++ b/internal/rest/middleware/permission.go
@@ -7,7 +7,6 @@ import (
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
-	"github.com/samber/lo"
 )
 
 // PermissionMiddleware handles RBAC permission checks
@@ -68,7 +67,7 @@ func (pm *PermissionMiddleware) RequirePermission(entity types.Entity, action ty
 			return
 		}
 
-		if rules.superAdminOnly && (types.IsServiceAccount(ctx) || !lo.Contains(types.GetRoles(ctx), types.RoleSuperAdmin.String())) {
+		if rules.superAdminOnly && !types.IsSuperAdminUser(ctx) {
 			pm.logger.Info(ctx, "access denied: administrative action requires a super_admin user",
 				"user_id", types.GetUserID(ctx),
 				"tenant_id", types.GetTenantID(ctx),

--- a/internal/types/rbac.go
+++ b/internal/types/rbac.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"context"
+
+	"github.com/samber/lo"
+)
+
 type Role string
 
 func (r Role) String() string { return string(r) }
@@ -25,6 +31,16 @@ func (ut UserType) AllowedRoles() []Role {
 	default:
 		return nil
 	}
+}
+
+// IsSuperAdminUser reports whether the caller may act administratively over
+// other principals. A service account is never administrative, however its
+// stored roles read, so a leaked machine key cannot mint or enumerate
+// credentials beyond its own. This is the single definition of the rule shared
+// by the route guard and the service layer.
+func IsSuperAdminUser(ctx context.Context) bool {
+	return !IsServiceAccount(ctx) &&
+		lo.Contains(GetRoles(ctx), RoleSuperAdmin.String())
 }
 
 // RoleFilter filters the roles returned by GET /rbac/roles. Bound via


### PR DESCRIPTION
## **User description**
## Problem

API-key management did not check *which* principal a request was acting on behalf of.

`CreateAPIKey` took `service_account_id` from the request body and minted a key that inherited that account's stored roles, gated only by `write(secret)` — a permission the wildcard `all_writer` role already grants. A non-administrative writer could therefore obtain credentials more privileged than its own session.

Two supporting gaps widened the surface: API-key listing returned every key in the environment regardless of owner, and revocation by id was not owner-checked. Service-account enumeration was reachable without any RBAC guard.

## Fix

- **Issuance is bound to the caller.** A key is minted for the authenticated principal by default. Naming another principal via `service_account_id` is treated as an administrative act and reserved for a `super_admin` user.
- **Listing is scoped to the caller.** Non-administrators see only their own keys. The owner filter is applied *after* the request-supplied filter, so a caller-provided `user_id` cannot widen the result set. A `super_admin` still sees the whole environment.
- **Revocation is owner-checked.** Deleting a secret owned by another principal is refused. Integration secrets are tenant-wide and carry no owning principal, so they are unaffected.
- **Route guards added** on user/service-account search and API-key listing (both ordinary RBAC read).

The shared `isSuperAdminUser` helper mirrors the existing `superAdminOnly` route guard: a service account is never administrative however its stored roles read, so a leaked machine key cannot mint or enumerate credentials beyond its own.

## Compatibility

Existing per-caller key creation, listing, and revocation are unchanged. Behaviour changes only for cross-principal operations, which now require a tenant `super_admin`. `POST /users/search` previously had no RBAC guard and now requires `read(user)`; no in-repo callers were found.

## Tests

Four regression tests in `internal/ee/service/secret_test.go` cover cross-principal minting, service-account self-escalation, caller-scoped listing (including the supplied-`user_id` path), and foreign-secret revocation — each asserting the `super_admin` path still works.

Verified these tests fail when the authorization helper is neutered and pass with it in place, so they detect the regression rather than merely passing.

`go build ./internal/... ./cmd/...`, `go vet`, `make lint-ci` (loglint merge gate), and the full `go test ./internal/...` suite all pass on this base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SAML metadata, login, and assertion consumer service routes when SAML is configured.
* **Security**
  * Added permission checks for user search, API key access, and settings.
  * Restricted settings changes and deletions to super administrators.
  * Limited API key creation, listing, and deletion to authorized callers.
  * Prevented service accounts from performing unauthorized key operations.
* **Bug Fixes**
  * Ensured newly created API keys are associated with the correct caller.
  * Removed the obsolete analytics costsheet route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Restrict API-key administration to authorized principals

### What Changed
- API keys are created for the authenticated caller by default; creating one for another principal now requires a human `super_admin`.
- Non-administrators can list and revoke only their own API keys, while `super_admin` users retain environment-wide access.
- Service accounts cannot use stored `super_admin` roles to perform administrative key actions.
- User search and API-key listing now require the appropriate read permission.

### Impact
`✅ Prevents cross-principal API-key privilege escalation`
`✅ Prevents unauthorized API-key discovery and revocation`
`✅ Preserves controlled service-account key management for super admins`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
