### PR TITLE
fix(api): require customer write permission to create a portal session

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -264,8 +264,11 @@ func NewRouter(
 			customer.GET("/:id/invoices/summary", handlers.Invoice.GetCustomerInvoiceSummary)
 			customer.GET("/wallets", handlers.Wallet.GetCustomerWallets)
 
-			// Customer Dashboard - Session creation (requires tenant auth)
-			customer.GET("/portal/:external_id", handlers.CustomerPortal.CreateSession)
+			// Customer Dashboard - Session creation. Minting a session token is an
+			// impersonation-style action: the token places its bearer inside the
+			// target customer's portal context, so it is gated on customer write
+			// rather than read. A read-only principal must not be able to mint one.
+			customer.GET("/portal/:external_id", write(types.EntityCustomer, types.ActionWrite), handlers.CustomerPortal.CreateSession)
 		}
 
 		plan := v1Private.Group("/plans")

--- a/internal/rest/middleware/permission_test.go
+++ b/internal/rest/middleware/permission_test.go
@@ -263,3 +263,80 @@ func TestRequirePermission_AllowsServiceAccountWithRole(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "service account with the right role must be allowed through")
 }
+
+// newPortalSessionTestRouter mirrors the real route shape of
+// GET /v1/customers/portal/:external_id, which is gated on customer:write
+// because minting a portal session is an impersonation-style action.
+func newPortalSessionTestRouter(t *testing.T, rbacSvc *rbac.RBACService, userType string, roles []string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	pm := NewPermissionMiddleware(rbacSvc, newTestLogger(t))
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if userType != "" {
+			ctx = context.WithValue(ctx, types.CtxUserType, userType)
+		}
+		if roles != nil {
+			ctx = context.WithValue(ctx, types.CtxRoles, roles)
+		}
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.GET("/customers/portal/:external_id",
+		pm.RequirePermission(types.EntityCustomer, types.ActionWrite),
+		func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"token": "portal-jwt"})
+		})
+
+	return r
+}
+
+// TestPortalSession_DeniesReadOnlyPrincipal pins the authorization-bypass fix:
+// GET /v1/customers/portal/:external_id previously carried no permission
+// middleware, so any authenticated principal in the tenant could mint a portal
+// session for another customer by supplying that customer's external_id. A
+// read-only principal must be refused before any token is signed.
+func TestPortalSession_DeniesReadOnlyPrincipal(t *testing.T) {
+	rbacSvc := realRBACService(t)
+	router := newPortalSessionTestRouter(t, rbacSvc, string(types.UserTypeUser),
+		[]string{types.RoleAllReader.String()})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/customers/portal/victim-ext", nil))
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "a read-only principal must not mint a portal session")
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "insufficient permissions", body["message"])
+	assert.NotContains(t, w.Body.String(), "portal-jwt", "no session token may be signed on the denied path")
+}
+
+// TestPortalSession_DeniesServiceAccountWithoutRole covers the API-key caller:
+// an event-scoped key holds neither customer:write nor any wildcard grant.
+func TestPortalSession_DeniesServiceAccountWithoutRole(t *testing.T) {
+	rbacSvc := realRBACService(t)
+	router := newPortalSessionTestRouter(t, rbacSvc, string(types.UserTypeServiceAccount),
+		[]string{"event_ingestor", "event_reader"})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/customers/portal/victim-ext", nil))
+
+	assert.Equal(t, http.StatusForbidden, w.Code, "event-scoped service account must not mint a portal session")
+}
+
+// TestPortalSession_AllowsWriter confirms the legitimate path still works:
+// a principal holding customer write access can still create a portal session.
+func TestPortalSession_AllowsWriter(t *testing.T) {
+	rbacSvc := realRBACService(t)
+	router := newPortalSessionTestRouter(t, rbacSvc, string(types.UserTypeUser),
+		[]string{types.RoleAllWriter.String()})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/customers/portal/victim-ext", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code, "a writer principal must still be able to create a portal session")
+}

--- a/internal/rest/middleware/permission_test.go
+++ b/internal/rest/middleware/permission_test.go
@@ -339,4 +339,19 @@ func TestPortalSession_AllowsWriter(t *testing.T) {
 	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/customers/portal/victim-ext", nil))
 
 	assert.Equal(t, http.StatusOK, w.Code, "a writer principal must still be able to create a portal session")
+	assert.Contains(t, w.Body.String(), "portal-jwt", "the session token must be returned on the allowed path")
+}
+
+// TestPortalSession_AllowsSuperAdmin confirms a super_admin principal (wildcard
+// grant in the real roles.json) can also create a portal session.
+func TestPortalSession_AllowsSuperAdmin(t *testing.T) {
+	rbacSvc := realRBACService(t)
+	router := newPortalSessionTestRouter(t, rbacSvc, string(types.UserTypeUser),
+		[]string{types.RoleSuperAdmin.String()})
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/customers/portal/victim-ext", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code, "a super_admin principal must be able to create a portal session")
+	assert.Contains(t, w.Body.String(), "portal-jwt", "the session token must be returned on the allowed path")
 }


### PR DESCRIPTION
## **User description**
## Problem

`GET /v1/customers/portal/:external_id` sits in the authenticated private API group but carries no permission middleware. Every other state-changing customer route in that group is gated with `write(types.EntityCustomer, types.ActionWrite)`; this one was missed.

The handler resolves the caller-supplied `external_id` and signs a portal session token for whichever customer it matches. The portal middleware then trusts that token's claims to scope every `/v1/customer/portal/*` request. Creating a session is therefore an impersonation-style action, not a read — but it was reachable by any principal that could authenticate to the tenant, including read-only ones.

## Fix

Gate the route on `customer:write`, consistent with the rest of the customer group.

```go
customer.GET("/portal/:external_id", write(types.EntityCustomer, types.ActionWrite), handlers.CustomerPortal.CreateSession)
```

Under the shipped `config/rbac/roles.json` this refuses `all_reader`, `event_ingestor` and `event_reader` before any token is signed, while `all_writer` and `super_admin` continue to work. The middleware aborts with 403, so the denial happens ahead of the customer lookup and the token-signing call.

## Scope and limits

- The tenant/environment filters in `GetCustomerByLookupKey` are unchanged. They scope which customers are resolvable, but they were never an authorization decision about the caller, and this change does not treat them as one.
- This is a role-level gate, which is the granularity the current RBAC service supports (`HasPermission(roles, entity, action)`). It does not express per-customer object-level authorization — a principal legitimately holding `customer:write` can still create a session for any customer in its own tenant and environment. That is consistent with what `customer:write` already grants elsewhere (creating, updating and deleting any customer in scope), so the gate closes the privilege gap without introducing a new authorization model. Object-level scoping would need a per-principal customer binding that does not exist today.

## Tests

Added to `internal/rest/middleware/permission_test.go`, using the real `roles.json` via the existing `realRBACService` helper:

- `TestPortalSession_DeniesReadOnlyPrincipal` — `all_reader` gets 403, and asserts no session token appears in the response body on the denied path.
- `TestPortalSession_DeniesServiceAccountWithoutRole` — event-scoped API key gets 403.
- `TestPortalSession_AllowsWriter` — `all_writer` still gets 200, so the legitimate path is unaffected.

## Verification

- `go build ./internal/...` — exit 0
- `go test ./internal/rest/middleware/ -run 'TestPortalSession|TestRequirePermission' -v` — all pass, including the pre-existing permission tests
- `go vet ./internal/api/... ./internal/rest/...` — clean
- `make lint-ci` (loglint merge gate) — clean
- `gofmt` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted customer portal session creation to accounts with customer write permission.
  * Requests from read-only accounts and event-scoped service accounts are now denied.
  * Authorized accounts with customer write access can continue creating portal sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Restrict customer portal session creation to users with customer write access

### What Changed
- Customer portal sessions can now be created only by principals with `customer:write` permission
- Read-only users and event-scoped service accounts receive a 403 response, and no portal token is issued
- Writers and super administrators can still create portal sessions successfully
- Added coverage for denied and allowed access paths

### Impact
`✅ Prevented unauthorized portal impersonation`
`✅ No portal tokens issued to read-only callers`
`✅ Preserved portal access for authorized writers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
