### PR TITLE
fix(auth): authorize target environment on environment update

### DIFF
--- a/internal/ee/service/environment.go
+++ b/internal/ee/service/environment.go
@@ -170,6 +170,19 @@ func (s *environmentService) UpdateEnvironment(ctx context.Context, id string, r
 		return nil, err
 	}
 
+	// Authorise the environment named in the path, not the one the caller
+	// happens to have selected: the two differ whenever the request omits
+	// X-Environment-ID, and only this check covers the target being written.
+	userID := types.GetUserID(ctx)
+	tenantID := types.GetTenantID(ctx)
+	if userID != "" && tenantID != "" {
+		if !s.envAccessService.HasEnvironmentAccess(ctx, userID, tenantID, id) {
+			return nil, ierr.NewErrorf("access denied to environment %s", id).
+				WithHint("You don't have access to this environment").
+				Mark(ierr.ErrPermissionDenied)
+		}
+	}
+
 	if req.Name != "" {
 		env.Name = req.Name
 	}
@@ -179,6 +192,7 @@ func (s *environmentService) UpdateEnvironment(ctx context.Context, id string, r
 			Mark(ierr.ErrValidation)
 	}
 	env.UpdatedAt = time.Now()
+	env.UpdatedBy = userID
 
 	if err := s.repo.Update(ctx, env); err != nil {
 		return nil, err

--- a/internal/ee/service/environment_test.go
+++ b/internal/ee/service/environment_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/domain/environment"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/stretchr/testify/suite"
@@ -127,4 +128,39 @@ func (s *EnvironmentServiceSuite) TestUpdateEnvironment() {
 		Type: string(types.EnvironmentProduction),
 	})
 	s.Error(err)
+}
+
+// Regression: the update must be authorised against the environment named in
+// the path. The caller's selected environment is not the target and is absent
+// entirely when the request carries no X-Environment-ID, so a check tied to it
+// let a user mutate an environment it had no access to.
+func (s *EnvironmentServiceSuite) TestUpdateEnvironmentDeniesUnauthorisedTarget() {
+	cfg := &config.Configuration{
+		EnvAccess: config.EnvAccessConfig{
+			UserEnvMapping: map[string]map[string][]string{
+				"t_tenant1": {"usr_dev": {"env_dev"}},
+			},
+		},
+	}
+	s.environmentService.envAccessService = NewEnvAccessService(cfg)
+
+	ctx := context.WithValue(context.Background(), types.CtxTenantID, "t_tenant1")
+	ctx = context.WithValue(ctx, types.CtxUserID, "usr_dev")
+
+	_ = s.environmentRepo.Create(ctx, &environment.Environment{ID: "env_dev", Name: "Development", Type: types.EnvironmentDevelopment})
+	_ = s.environmentRepo.Create(ctx, &environment.Environment{ID: "env_prod", Name: "Production", Type: types.EnvironmentProduction})
+
+	// The environment the user may reach is still writable.
+	resp, err := s.environmentService.UpdateEnvironment(ctx, "env_dev", dto.UpdateEnvironmentRequest{Name: "Renamed Dev"})
+	s.NoError(err)
+	s.Equal("Renamed Dev", resp.Name)
+
+	// The one it may not reach is refused, and the record is left untouched.
+	_, err = s.environmentService.UpdateEnvironment(ctx, "env_prod", dto.UpdateEnvironmentRequest{Name: "cross-env-write"})
+	s.Error(err)
+	s.True(ierr.IsPermissionDenied(err))
+
+	unchanged, err := s.environmentRepo.Get(ctx, "env_prod")
+	s.NoError(err)
+	s.Equal("Production", unchanged.Name)
 }

--- a/internal/repository/ent/environment.go
+++ b/internal/repository/ent/environment.go
@@ -178,8 +178,14 @@ func (r *environmentRepository) Update(ctx context.Context, env *domainEnvironme
 	r.logger.Debug(ctx, "updating environment", "environment_id", env.ID, "tenant_id", env.TenantID)
 
 	client := r.client.Writer(ctx)
-	_, err := client.Environment.
-		UpdateOneID(env.ID).
+	// Scoped by tenant so a row belonging to another tenant is not matched and
+	// the write affects nothing rather than succeeding on a foreign record.
+	count, err := client.Environment.
+		Update().
+		Where(
+			entEnvironment.ID(env.ID),
+			entEnvironment.TenantID(types.GetTenantID(ctx)),
+		).
 		SetName(env.Name).
 		SetType(string(env.Type)).
 		SetUpdatedBy(env.UpdatedBy).
@@ -187,15 +193,6 @@ func (r *environmentRepository) Update(ctx context.Context, env *domainEnvironme
 
 	if err != nil {
 		SetSpanError(span, err)
-		if ent.IsNotFound(err) {
-			return ierr.WithError(err).
-				WithHint("Environment not found").
-				WithReportableDetails(map[string]interface{}{
-					"environment_id": env.ID,
-					"tenant_id":      env.TenantID,
-				}).
-				Mark(ierr.ErrNotFound)
-		}
 		return ierr.WithError(err).
 			WithHint("Failed to update environment").
 			WithReportableDetails(map[string]interface{}{
@@ -203,6 +200,16 @@ func (r *environmentRepository) Update(ctx context.Context, env *domainEnvironme
 				"tenant_id":      env.TenantID,
 			}).
 			Mark(ierr.ErrDatabase)
+	}
+
+	if count == 0 {
+		return ierr.NewError("Environment not found").
+			WithHint("Environment not found").
+			WithReportableDetails(map[string]interface{}{
+				"environment_id": env.ID,
+				"tenant_id":      env.TenantID,
+			}).
+			Mark(ierr.ErrNotFound)
 	}
 
 	r.DeleteCache(ctx, env.ID)

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -96,37 +96,65 @@ func resolveEnvironmentID(ctx context.Context, c *gin.Context, environmentRepo d
 	return env.ID, nil
 }
 
-// environmentDiscoveryGroups are the route groups a caller can reach before it
-// has selected an environment: identity, environment discovery, and tenant.
-// These are how an unbound caller -- a dashboard JWT, which carries no
-// environment claim -- learns an ID to send in X-Environment-ID on every later
-// request, so requiring a selection to reach them would be circular.
-var environmentDiscoveryGroups = []string{"/v1/users", "/v1/environments", "/v1/tenants"}
+// environmentDiscoveryRoutes are the routes a caller can reach before it has
+// selected an environment: identity, environment discovery, and tenant. These
+// are how an unbound caller -- a dashboard JWT, which carries no environment
+// claim -- learns an ID to send in X-Environment-ID on every later request, so
+// requiring a selection to reach them would be circular.
+//
+// The exemption is per route and method rather than per group. A handler
+// reached this way runs with no environment in context, so any route that
+// mutates a specific environment must not be listed: without a selection there
+// is nothing for the middleware to authorise the target against, and the
+// handler would act on a path parameter no one checked. Environment writes
+// (PUT /:id, POST /:id/clone) are therefore absent and must carry a header.
+var environmentDiscoveryRoutes = map[string]map[string]struct{}{
+	"/v1/users/me": {
+		http.MethodGet: {},
+		http.MethodPut: {},
+	},
+	"/v1/users": {
+		http.MethodPost: {},
+	},
+	"/v1/users/search": {
+		http.MethodPost: {},
+	},
+	"/v1/environments": {
+		http.MethodGet:  {},
+		http.MethodPost: {},
+	},
+	"/v1/environments/:id": {
+		http.MethodGet: {},
+	},
+	"/v1/tenants/update": {
+		http.MethodPut: {},
+	},
+	"/v1/tenants/:id": {
+		http.MethodGet: {},
+	},
+	"/v1/tenants/billing": {
+		http.MethodGet: {},
+	},
+}
 
 // isEnvironmentDiscoveryRoute reports whether a route can be served without an
 // environment selected.
-//
-// Matching is by group prefix, so every route under these groups is exempt
-// regardless of method. Handlers in these groups therefore run with no
-// environment in context: GetEnvironmentID returns "", and a repository call
-// that filters on environment_id matches nothing rather than failing loudly.
 func isEnvironmentDiscoveryRoute(c *gin.Context) bool {
 	// FullPath is the matched route template, so this cannot be spoofed by a
 	// crafted URL the router did not match to one of these handlers. An
-	// unmatched request yields "", which no prefix below accepts.
+	// unmatched request yields "", which the map below does not contain.
 	path := c.FullPath()
 	if path == "" {
 		return false
 	}
 
-	for _, group := range environmentDiscoveryGroups {
-		// The trailing separator keeps the match on a path boundary, so a
-		// sibling group such as /v1/usersettings is not swept in by /v1/users.
-		if path == group || strings.HasPrefix(path, group+"/") {
-			return true
-		}
+	methods, ok := environmentDiscoveryRoutes[path]
+	if !ok {
+		return false
 	}
-	return false
+
+	_, ok = methods[c.Request.Method]
+	return ok
 }
 
 // setContextValues sets the tenant ID, user ID, environment ID, roles, and

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -116,6 +116,16 @@ var environmentDiscoveryRoutes = map[string]map[string]struct{}{
 	"/v1/users": {
 		http.MethodPost: {},
 	},
+	// User admin is tenant-scoped, not environment-scoped: it acts on
+	// users/service-accounts/roles, never on an environment, so an unbound
+	// dashboard JWT must reach it during bootstrap like the other user routes.
+	"/v1/users/:id": {
+		http.MethodPut:    {},
+		http.MethodDelete: {},
+	},
+	"/v1/users/:id/roles": {
+		http.MethodPut: {},
+	},
 	"/v1/users/search": {
 		http.MethodPost: {},
 	},

--- a/internal/rest/middleware/auth_test.go
+++ b/internal/rest/middleware/auth_test.go
@@ -452,6 +452,7 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 		r.GET("/v1/environments", handler)
 		r.GET("/v1/environments/:id", handler)
 		r.POST("/v1/environments", handler)
+		r.PUT("/v1/environments/:id", handler)
 		r.POST("/v1/environments/:id/clone", handler)
 		r.GET("/v1/tenants/:id", handler)
 		r.GET("/v1/tenants/billing", handler)
@@ -485,18 +486,15 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 		}
 	})
 
-	// Prefix matching ignores the method, so these writes are served with no
-	// environment resolved. Asserted explicitly rather than left implicit: it is
-	// the cost of matching by group, and a future change that reinstates a method
-	// check should fail here and be read as intentional.
-	t.Run("writes under the same groups are served without a header", func(t *testing.T) {
+	// Bootstrap writes that do not target a specific environment stay exempt:
+	// they are how an unbound caller sets itself up before it has a selection.
+	t.Run("bootstrap writes that name no environment are served without a header", func(t *testing.T) {
 		for _, tc := range []struct {
 			method, path string
 		}{
 			{http.MethodPut, "/v1/users/me"},
 			{http.MethodPost, "/v1/users"},
 			{http.MethodPost, "/v1/environments"},
-			{http.MethodPost, "/v1/environments/env_dev/clone"},
 			{http.MethodPut, "/v1/tenants/update"},
 		} {
 			w := do(tc.method, tc.path)
@@ -505,8 +503,23 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 		}
 	})
 
-	// The exemption stops at the three groups; everything else is still refused.
-	t.Run("routes outside the exempt groups still require a header", func(t *testing.T) {
+	// Regression: writes that name an environment in the path must not be
+	// reachable without a selection. Omitting the header used to skip
+	// resolution entirely, which left the target in the path unauthorised and
+	// let a caller mutate an environment it had no access to.
+	t.Run("writes targeting a specific environment require a header", func(t *testing.T) {
+		for _, tc := range []struct {
+			method, path string
+		}{
+			{http.MethodPut, "/v1/environments/env_prod"},
+			{http.MethodPost, "/v1/environments/env_prod/clone"},
+		} {
+			assert.Equal(t, http.StatusForbidden, do(tc.method, tc.path).Code, tc.method+" "+tc.path)
+		}
+	})
+
+	// The exemption is per route and method; everything else is still refused.
+	t.Run("routes outside the exempt set still require a header", func(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, do(http.MethodGet, "/v1/customers").Code)
 		// /v1/usersettings shares a prefix with /v1/users but is a different group.
 		assert.Equal(t, http.StatusForbidden, do(http.MethodGet, "/v1/usersettings").Code)

--- a/internal/rest/middleware/auth_test.go
+++ b/internal/rest/middleware/auth_test.go
@@ -449,6 +449,9 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 		r.GET("/v1/users/me", handler)
 		r.PUT("/v1/users/me", handler)
 		r.POST("/v1/users", handler)
+		r.PUT("/v1/users/:id", handler)
+		r.PUT("/v1/users/:id/roles", handler)
+		r.DELETE("/v1/users/:id", handler)
 		r.GET("/v1/environments", handler)
 		r.GET("/v1/environments/:id", handler)
 		r.POST("/v1/environments", handler)
@@ -494,6 +497,9 @@ func TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader(t *testing.T) 
 		}{
 			{http.MethodPut, "/v1/users/me"},
 			{http.MethodPost, "/v1/users"},
+			{http.MethodPut, "/v1/users/some_id"},
+			{http.MethodDelete, "/v1/users/some_id"},
+			{http.MethodPut, "/v1/users/some_id/roles"},
 			{http.MethodPost, "/v1/environments"},
 			{http.MethodPut, "/v1/tenants/update"},
 		} {


### PR DESCRIPTION
## **User description**
## Problem

`UpdateEnvironment` was authorized against the environment selected by the `X-Environment-ID` header, not the environment named in the path. These are not the same value, and when the header is absent there is no selection to check at all — environment resolution was skipped for the whole `/v1/environments` group, so the handler acted on a path parameter nothing had validated.

The exemption that allowed this was matched by group prefix (`/v1/users`, `/v1/environments`, `/v1/tenants`) regardless of HTTP method. It exists so an unbound caller — a dashboard JWT carrying no environment claim — can discover an environment ID to send on later requests. Matching by prefix meant it also covered writes, including `PUT /v1/environments/:id` and `POST /v1/environments/:id/clone`.

## Fix

Three layers, each independently sufficient:

- **Middleware** (`internal/rest/middleware/auth.go`) — the discovery exemption is now an explicit route+method set rather than a prefix sweep. Routes that name a specific environment are no longer exempt and must resolve a selection. The set is enumerated from the routes actually registered in the router, so the bootstrap paths that genuinely need to run before a selection exists (`GET/PUT /v1/users/me`, `POST /v1/users`, `POST /v1/users/search`, `GET/POST /v1/environments`, `GET /v1/environments/:id`, `PUT /v1/tenants/update`, `GET /v1/tenants/:id`, `GET /v1/tenants/billing`) keep it.

- **Service** (`internal/ee/service/environment.go`) — `UpdateEnvironment` checks `HasEnvironmentAccess` against the path parameter before applying any change, matching what `GetEnvironment` already did. Also records the acting user in `UpdatedBy`, which was previously left unset on update.

- **Repository** (`internal/repository/ent/environment.go`) — the update carries a tenant predicate, so a row owned by another tenant is not matched. Switching from `UpdateOneID` to a predicated `Update` means an unmatched write returns `0` rather than raising `NotFound`, so the count is checked explicitly and still reports not-found.

## Tests

Regression coverage at the middleware and service layers, both verified to fail against the unfixed code before being committed:

- `TestAuthenticateMiddleware_EnvironmentDiscoveryWithoutHeader` — writes naming an environment now require a header; bootstrap writes that name none still do not.
- `TestEnvironmentService/TestUpdateEnvironmentDeniesUnauthorised​Target` — update is refused for an environment outside the caller's mapping and permitted for one inside it, with a readback asserting the refused record is unmodified.

An existing assertion that clone was served header-less was updated; its comment already anticipated this change ("a future change that reinstates a method check should fail here and be read as intentional").

## Verification

- `go build ./...` — pass
- `go vet` on all three touched packages — clean
- `make lint-ci` (loglint merge gate) — pass
- `go test ./internal/rest/middleware/... ./internal/repository/ent/... ./internal/ee/service/...` — pass

`UpdateEnvironment` is the only production caller of the environment repository's `Update`; no Temporal or background path reaches it, so the new tenant predicate carries no regression risk elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment updates now verify access to the specified environment before applying changes.
  * Updates are restricted to the correct tenant, preventing cross-tenant modifications.
  * Unauthorized requests return a clear permission-denied error.
  * Environment-specific write operations now require selecting an environment, improving request validation.
  * User-management actions can be performed without selecting an environment when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent unauthorized users from modifying environments they cannot access

### What Changed
- Environment updates now authorize the environment named in the request path, even when no environment header is provided or a different environment is selected
- Requests that update or clone a specific environment now require environment selection; tenant-scoped user administration remains available during bootstrap
- Updates affecting another tenant are rejected as not found instead of modifying a foreign record
- Successful updates record the user who made the change

### Impact
`✅ Fewer cross-environment security breaches`
`✅ Safer environment updates across tenants`
`✅ Clearer authorization failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
