### PR TITLE
fix(imports): enforce the public-address guard on file downloads

### DIFF
--- a/internal/ee/service/file_download_ssrf_test.go
+++ b/internal/ee/service/file_download_ssrf_test.go
@@ -41,12 +41,12 @@ func TestFileDownloadRefusesLoopbackDestination(t *testing.T) {
 
 	t.Run("streaming processor", func(t *testing.T) {
 		serverHit.Store(false)
-		sp := NewStreamingProcessor(httpclient.NewDefaultClient(), log)
+		sp := NewStreamingProcessor(log)
 
 		start := time.Now()
 		body, err := sp.downloadFileStream(context.Background(), loopbackTask)
 		if err == nil {
-			body.Close()
+			require.NoError(t, body.Close())
 		}
 
 		require.Error(t, err, "loopback download should be refused")
@@ -60,7 +60,7 @@ func TestFileDownloadRefusesLoopbackDestination(t *testing.T) {
 
 	t.Run("file processor", func(t *testing.T) {
 		serverHit.Store(false)
-		fp := NewFileProcessor(httpclient.NewDefaultClient(), log)
+		fp := NewFileProcessor(log)
 
 		_, err := fp.DownloadFile(context.Background(), loopbackTask)
 

--- a/internal/ee/service/file_download_ssrf_test.go
+++ b/internal/ee/service/file_download_ssrf_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/task"
+	"github.com/flexprice/flexprice/internal/httpclient"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/flexprice/flexprice/internal/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A task file_url is caller-supplied and is fetched long after it was validated,
+// so the download clients must refuse a non-public destination at dial time
+// rather than trusting the earlier check (VAPT F16 / CWE-918).
+func TestFileDownloadRefusesLoopbackDestination(t *testing.T) {
+	log, err := logger.NewLogger(&config.Configuration{
+		Logging: config.LoggingConfig{Level: types.LogLevelDebug},
+	})
+	require.NoError(t, err)
+
+	var serverHit atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHit.Store(true)
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte("name,type,lookup_key,unit_singular,unit_plural\nx,boolean,x,,\n"))
+	}))
+	defer server.Close()
+
+	loopbackTask := &task.Task{FileURL: server.URL + "/features.csv"}
+
+	t.Run("streaming processor", func(t *testing.T) {
+		serverHit.Store(false)
+		sp := NewStreamingProcessor(httpclient.NewDefaultClient(), log)
+
+		start := time.Now()
+		body, err := sp.downloadFileStream(context.Background(), loopbackTask)
+		if err == nil {
+			body.Close()
+		}
+
+		require.Error(t, err, "loopback download should be refused")
+		assert.True(t, strings.Contains(err.Error(), httpclient.ErrBlockedAddress.Error()),
+			"expected blocked-address error, got: %v", err)
+		assert.False(t, serverHit.Load(), "internal server must not be reached")
+		// A blocked address is permanent, so it must not burn the retry budget.
+		assert.Less(t, time.Since(start), retryClientMinBackoff,
+			"blocked address should fail fast rather than retry")
+	})
+
+	t.Run("file processor", func(t *testing.T) {
+		serverHit.Store(false)
+		fp := NewFileProcessor(httpclient.NewDefaultClient(), log)
+
+		_, err := fp.DownloadFile(context.Background(), loopbackTask)
+
+		require.Error(t, err, "loopback download should be refused")
+		assert.True(t, strings.Contains(err.Error(), httpclient.ErrBlockedAddress.Error()),
+			"expected blocked-address error, got: %v", err)
+		assert.False(t, serverHit.Load(), "internal server must not be reached")
+	})
+}
+
+// The guard must reject only non-public destinations, so an ordinary public
+// import host is still allowed through the address check.
+func TestPublicImportHostIsNotBlocked(t *testing.T) {
+	assert.True(t, validator.IsPublicIP(net.ParseIP("93.184.216.34")),
+		"a public import host must not be classified as blocked")
+}

--- a/internal/ee/service/file_processor.go
+++ b/internal/ee/service/file_processor.go
@@ -41,9 +41,12 @@ type FileProcessor struct {
 // Default settings:
 // - MaxMemoryFileSize: 10MB (files smaller than this are processed in memory)
 // - MaxFileSize: 1GB (maximum file size allowed)
-func NewFileProcessor(client httpclient.Client, logger *logger.Logger) *FileProcessor {
+//
+// It takes no client for the same reason as NewStreamingProcessor: the URLs it
+// fetches are caller-supplied and must go through the guarded client.
+func NewFileProcessor(logger *logger.Logger) *FileProcessor {
 	return &FileProcessor{
-		StreamingProcessor: NewStreamingProcessor(client, logger),
+		StreamingProcessor: NewStreamingProcessor(logger),
 		ProviderRegistry:   NewFileProviderRegistry(),
 		CSVProcessor:       NewCSVProcessor(logger),
 		JSONProcessor:      NewJSONProcessor(logger),

--- a/internal/ee/service/file_processor.go
+++ b/internal/ee/service/file_processor.go
@@ -42,24 +42,12 @@ type FileProcessor struct {
 // - MaxMemoryFileSize: 10MB (files smaller than this are processed in memory)
 // - MaxFileSize: 1GB (maximum file size allowed)
 func NewFileProcessor(client httpclient.Client, logger *logger.Logger) *FileProcessor {
-	// Configure retryable HTTP client
-	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 3
-	retryClient.RetryWaitMin = 1 * time.Second
-	retryClient.RetryWaitMax = 30 * time.Second
-	retryClient.Logger = logger.GetRetryableHTTPLogger()
-	// Instrument outbound file downloads for SigNoz External API Monitoring.
-	retryClient.HTTPClient.Transport = httpclient.OtelTransport(retryClient.HTTPClient.Transport)
-	// Refuse redirects: file_url is caller-supplied and only the initial URL is
-	// validated, so a redirect would reach an unvalidated host (VAPT F16).
-	retryClient.HTTPClient.CheckRedirect = httpclient.RejectRedirects
-
 	return &FileProcessor{
 		StreamingProcessor: NewStreamingProcessor(client, logger),
 		ProviderRegistry:   NewFileProviderRegistry(),
 		CSVProcessor:       NewCSVProcessor(logger),
 		JSONProcessor:      NewJSONProcessor(logger),
-		RetryClient:        retryClient,
+		RetryClient:        newGuardedDownloadClient(logger),
 		MaxMemoryFileSize:  10 * 1024 * 1024,   // 10MB
 		MaxFileSize:        1024 * 1024 * 1024, // 1GB
 	}

--- a/internal/ee/service/file_provider.go
+++ b/internal/ee/service/file_provider.go
@@ -10,7 +10,7 @@
 //
 // Example usage:
 //
-//	processor := NewFileProcessor(httpClient, logger)
+//	processor := NewFileProcessor(logger)
 //	content, err := processor.DownloadFile(ctx, &task.Task{FileURL: "https://drive.google.com/file/d/123/view"})
 //	if err != nil {
 //	    // Handle error - simple error message, no complex error objects

--- a/internal/ee/service/streaming_processor.go
+++ b/internal/ee/service/streaming_processor.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +23,43 @@ import (
 	"github.com/flexprice/flexprice/internal/types"
 )
 
+// downloadTimeout bounds a single import download. Import files can be large and
+// are streamed, so this is well above a typical API call timeout.
+const downloadTimeout = 10 * time.Minute
+
+// retryClientMinBackoff is the shortest wait the download client sleeps before a
+// retry, so anything that fails faster than this did not retry at all.
+const retryClientMinBackoff = 1 * time.Second
+
+// newGuardedDownloadClient returns the retryable client used to fetch a
+// caller-supplied file_url.
+//
+// The URL is validated when the task is created but fetched much later, so the
+// destination is re-checked at dial time: a host that resolved to a public
+// address at validation time can resolve to an internal one by the time we dial
+// (DNS rebinding). The client also refuses redirects, which would otherwise
+// reach a host that was never validated (VAPT F16).
+func newGuardedDownloadClient(log *logger.Logger) *retryablehttp.Client {
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 3
+	retryClient.RetryWaitMin = retryClientMinBackoff
+	retryClient.RetryWaitMax = 30 * time.Second
+	retryClient.Logger = log.GetRetryableHTTPLogger()
+	retryClient.HTTPClient = httpclient.NewPublicOnlyClient(downloadTimeout)
+
+	// A blocked address is a permanent verdict, not a transient failure, so it
+	// must not consume the retry budget.
+	defaultRetry := retryClient.CheckRetry
+	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if errors.Is(err, httpclient.ErrBlockedAddress) {
+			return false, err
+		}
+		return defaultRetry(ctx, resp, err)
+	}
+
+	return retryClient
+}
+
 // StreamingProcessor handles streaming processing of large files
 type StreamingProcessor struct {
 	Client           httpclient.Client
@@ -32,25 +70,17 @@ type StreamingProcessor struct {
 	RetryClient      *retryablehttp.Client
 }
 
-// NewStreamingProcessor creates a new streaming processor
-func NewStreamingProcessor(client httpclient.Client, logger *logger.Logger) *StreamingProcessor {
-	// Configure retryable HTTP client
-	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 3
-	retryClient.RetryWaitMin = 1 * time.Second
-	retryClient.RetryWaitMax = 30 * time.Second
-	retryClient.Logger = logger.GetRetryableHTTPLogger()
-	// Instrument outbound file downloads for SigNoz External API Monitoring.
-	retryClient.HTTPClient.Transport = httpclient.OtelTransport(retryClient.HTTPClient.Transport)
-	// Refuse redirects: this client streams the caller-supplied file_url and only
-	// the initial URL is validated (VAPT F16).
-	retryClient.HTTPClient.CheckRedirect = httpclient.RejectRedirects
-
+// NewStreamingProcessor creates a new streaming processor.
+//
+// The injected client is ignored: it is the shared default one, which internal
+// callers also use against private hosts. Every URL fetched here is
+// caller-controlled, so this processor always uses the guarded client instead.
+func NewStreamingProcessor(_ httpclient.Client, logger *logger.Logger) *StreamingProcessor {
 	return &StreamingProcessor{
-		Client:           client,
+		Client:           httpclient.NewPublicOnlySendClient(downloadTimeout),
 		Logger:           logger,
 		ProviderRegistry: NewFileProviderRegistry(),
-		RetryClient:      retryClient,
+		RetryClient:      newGuardedDownloadClient(logger),
 	}
 }
 

--- a/internal/ee/service/streaming_processor.go
+++ b/internal/ee/service/streaming_processor.go
@@ -72,10 +72,11 @@ type StreamingProcessor struct {
 
 // NewStreamingProcessor creates a new streaming processor.
 //
-// The injected client is ignored: it is the shared default one, which internal
-// callers also use against private hosts. Every URL fetched here is
-// caller-controlled, so this processor always uses the guarded client instead.
-func NewStreamingProcessor(_ httpclient.Client, logger *logger.Logger) *StreamingProcessor {
+// It deliberately takes no client: every URL this processor fetches is the
+// caller-supplied file_url, so the destination must always be re-checked at
+// dial time. Accepting a client would let a caller substitute an unguarded one
+// and silently reopen the SSRF hole this guard closes (VAPT F16).
+func NewStreamingProcessor(logger *logger.Logger) *StreamingProcessor {
 	return &StreamingProcessor{
 		Client:           httpclient.NewPublicOnlySendClient(downloadTimeout),
 		Logger:           logger,

--- a/internal/ee/service/task.go
+++ b/internal/ee/service/task.go
@@ -40,7 +40,7 @@ func NewTaskService(
 ) TaskService {
 	return &taskService{
 		ServiceParams: serviceParams,
-		fileProcessor: NewFileProcessor(serviceParams.Client, serviceParams.Logger),
+		fileProcessor: NewFileProcessor(serviceParams.Logger),
 	}
 }
 

--- a/internal/httpclient/dialer.go
+++ b/internal/httpclient/dialer.go
@@ -104,3 +104,9 @@ func NewPublicOnlyClient(timeout time.Duration) *http.Client {
 		CheckRedirect: RejectRedirects,
 	}
 }
+
+// NewPublicOnlySendClient is NewPublicOnlyClient behind the Client interface,
+// for callers that go through Send rather than holding an *http.Client.
+func NewPublicOnlySendClient(timeout time.Duration) Client {
+	return &DefaultClient{client: NewPublicOnlyClient(timeout)}
+}


### PR DESCRIPTION
## **User description**
## What

Task `file_url` is caller-supplied and is fetched well after it was validated. The two download paths (streaming and in-memory) built their own retryable HTTP client that only refused redirects — the address actually dialed was never re-checked against the public-address guard the repo already has.

That leaves a validation-to-dial gap: a host that resolves to a public address when the task is created can resolve elsewhere by the time the file is fetched.

## Changes

- Route both download paths through the existing `httpclient.NewPublicOnlyClient`, so the destination is checked at connect time rather than only at creation time.
- Add `NewPublicOnlySendClient` so the `Send`-based caller can use the same guarded policy.
- Leave the injected shared client untouched for other callers — internal services and self-hosted provider endpoints legitimately reach private addresses, so the guard stays opt-in.
- Fold the duplicated client setup in both constructors into one helper.
- A blocked address is a permanent verdict, so it now short-circuits the retry budget instead of backing off three times.

Redirect refusal is unchanged and still in place.

## Testing

New `internal/ee/service/file_download_ssrf_test.go` covers both constructors:

- Fails before this change, passes after.
- Asserts the internal server is never reached, and that a blocked address fails fast rather than retrying.
- A companion assertion confirms an ordinary public import host is still allowed, so the guard is not simply rejecting everything.

Verified locally: `go build ./internal/...`, `make lint-ci`, and `go test ./internal/ee/service/ ./internal/httpclient/ ./internal/validator/ ./internal/api/...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for file downloads by blocking requests to private or loopback addresses.
  * Prevented redirects to blocked destinations during both standard and streaming downloads.
  * Ensured blocked download attempts fail immediately without unnecessary retries.
  * Confirmed that valid public import addresses remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Block unsafe destinations when importing files

### What Changed
- File downloads now re-check the destination when connecting, preventing caller-supplied URLs from reaching loopback or other private addresses.
- Streaming and in-memory imports use the guarded download policy while continuing to reject redirects.
- Blocked destinations fail immediately instead of consuming the retry budget.
- Download processors no longer accept a replaceable client that could bypass the destination check.
- Added coverage confirming blocked servers are never reached and public import hosts remain allowed.

### Impact
`✅ Prevented SSRF through file imports`
`✅ Fewer retries for blocked destinations`
`✅ Safer streaming and in-memory downloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
