### PR TITLE
Mark paid while syncing zoho invoice

### DIFF
--- a/internal/integration/zoho/invoice.go
+++ b/internal/integration/zoho/invoice.go
@@ -88,6 +88,11 @@ func (s *InvoiceService) SyncInvoiceToZoho(ctx context.Context, req ZohoInvoiceS
 				"invoice_id", req.InvoiceID,
 				"zoho_invoice_id", zohoID)
 		}
+
+		if err := s.markPaidIfFlexpricePaid(ctx, req.InvoiceID); err != nil {
+			return nil, err
+		}
+
 		return &ZohoInvoiceSyncResponse{
 			ZohoInvoiceID: zohoID,
 			Status:        status,
@@ -174,12 +179,36 @@ func (s *InvoiceService) SyncInvoiceToZoho(ctx context.Context, req ZohoInvoiceS
 			"zoho_invoice_id", zohoInv.InvoiceID)
 	}
 
+	if err := s.markPaidIfFlexpricePaid(ctx, req.InvoiceID); err != nil {
+		return nil, err
+	}
+
 	return &ZohoInvoiceSyncResponse{
 		ZohoInvoiceID: zohoInv.InvoiceID,
 		Status:        zohoInv.Status,
 		Total:         zohoInv.Total,
 		Currency:      flexInvoice.Currency,
 	}, nil
+}
+
+// markPaidIfFlexpricePaid re-reads the FlexPrice invoice and records a Zoho customer
+// payment when it is already succeeded or overpaid. Re-fetch is required because
+// checkout can mark the invoice paid while CreateInvoice is still in flight.
+func (s *InvoiceService) markPaidIfFlexpricePaid(ctx context.Context, flexpriceInvoiceID string) error {
+	flex, err := s.invoiceRepo.Get(ctx, flexpriceInvoiceID)
+	if err != nil {
+		return err
+	}
+	if flex == nil {
+		return nil
+	}
+	
+	switch flex.PaymentStatus {
+	case types.PaymentStatusSucceeded, types.PaymentStatusOverpaid:
+		return s.MarkInvoicePaidInZoho(ctx, flex.ID)
+	default:
+		return nil
+	}
 }
 
 // MarkInvoicePaidInZoho records a Zoho customer payment for the invoice's current

--- a/internal/integration/zoho/invoice_sync_test.go
+++ b/internal/integration/zoho/invoice_sync_test.go
@@ -18,13 +18,33 @@ import (
 // fakeSyncZohoClient captures the InvoiceCreateRequest that SyncInvoiceToZoho builds.
 type fakeSyncZohoClient struct {
 	ZohoClient
-	createInvoiceReq *InvoiceCreateRequest
-	syncConfig       *types.SyncConfig
+	createInvoiceReq   *InvoiceCreateRequest
+	syncConfig         *types.SyncConfig
+	getInvoiceResp     *InvoiceResponse
+	createPaymentCalls int
+	createPaymentReq   *CustomerPaymentCreateRequest
 }
 
 func (f *fakeSyncZohoClient) CreateInvoice(_ context.Context, req *InvoiceCreateRequest) (*InvoiceResponse, error) {
 	f.createInvoiceReq = req
 	return &InvoiceResponse{InvoiceID: "zoho_inv_new", InvoiceNumber: "INV-000058", Status: "draft"}, nil
+}
+
+func (f *fakeSyncZohoClient) GetInvoice(_ context.Context, _ string) (*InvoiceResponse, error) {
+	if f.getInvoiceResp != nil {
+		return f.getInvoiceResp, nil
+	}
+	return &InvoiceResponse{
+		InvoiceID:  "zoho_inv_new",
+		CustomerID: "zoho_cust_1",
+		Balance:    decimal.NewFromInt(100),
+	}, nil
+}
+
+func (f *fakeSyncZohoClient) CreateCustomerPayment(_ context.Context, req *CustomerPaymentCreateRequest) (*CustomerPaymentResponse, error) {
+	f.createPaymentCalls++
+	f.createPaymentReq = req
+	return NewCustomerPaymentResponse("zoho_payment_1"), nil
 }
 
 func (f *fakeSyncZohoClient) ResolveInvoiceCurrency(_ context.Context, invoiceCurrency string) (string, float64, error) {
@@ -35,18 +55,28 @@ func (f *fakeSyncZohoClient) GetZohoBooksSyncConfig(_ context.Context) (*types.S
 	return f.syncConfig, nil
 }
 
-// fakeSyncMappingRepo reports no existing mapping so the sync path runs end to end.
+// fakeSyncMappingRepo stores mappings so MarkInvoicePaidInZoho can see a row
+// created earlier in the same SyncInvoiceToZoho call.
 type fakeSyncMappingRepo struct {
 	entityintegrationmapping.Repository
-	created *entityintegrationmapping.EntityIntegrationMapping
+	mappings []*entityintegrationmapping.EntityIntegrationMapping
+	created  *entityintegrationmapping.EntityIntegrationMapping
 }
 
-func (f *fakeSyncMappingRepo) List(_ context.Context, _ *types.EntityIntegrationMappingFilter) ([]*entityintegrationmapping.EntityIntegrationMapping, error) {
-	return nil, nil
+func (f *fakeSyncMappingRepo) List(_ context.Context, filter *types.EntityIntegrationMappingFilter) ([]*entityintegrationmapping.EntityIntegrationMapping, error) {
+	var out []*entityintegrationmapping.EntityIntegrationMapping
+	for _, m := range f.mappings {
+		if filter != nil && filter.EntityID != "" && m.EntityID != filter.EntityID {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
 }
 
 func (f *fakeSyncMappingRepo) Create(_ context.Context, m *entityintegrationmapping.EntityIntegrationMapping) error {
 	f.created = m
+	f.mappings = append(f.mappings, m)
 	return nil
 }
 
@@ -360,4 +390,96 @@ func TestTotalLineItemDiscount(t *testing.T) {
 		{Discount: decimal.NewFromInt(400)},
 		{Discount: decimal.NewFromInt(200)},
 	})))
+}
+
+func TestSyncInvoiceToZoho_MarksPaidWhenFlexpriceAlreadyPaid(t *testing.T) {
+	paidLine := []testLineItem{
+		{name: "Charge", priceID: "price_1", amount: "100", lineDisc: "0", invDisc: "0"},
+	}
+
+	tests := []struct {
+		name              string
+		paymentStatus     types.PaymentStatus
+		existingMapping   bool
+		wantCreateInvoice bool
+		wantCreatePayment bool
+	}{
+		{
+			name:              "pending first sync does not record payment",
+			paymentStatus:     types.PaymentStatusPending,
+			wantCreateInvoice: true,
+		},
+		{
+			name:              "succeeded first sync records payment after create",
+			paymentStatus:     types.PaymentStatusSucceeded,
+			wantCreateInvoice: true,
+			wantCreatePayment: true,
+		},
+		{
+			name:              "overpaid first sync records payment after create",
+			paymentStatus:     types.PaymentStatusOverpaid,
+			wantCreateInvoice: true,
+			wantCreatePayment: true,
+		},
+		{
+			name:              "succeeded existing mapping records payment without create",
+			paymentStatus:     types.PaymentStatusSucceeded,
+			existingMapping:   true,
+			wantCreatePayment: true,
+		},
+		{
+			name:            "pending existing mapping does not record payment",
+			paymentStatus:   types.PaymentStatusPending,
+			existingMapping: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := buildTestInvoice("INR", "0", "", "", paidLine)
+			inv.PaymentStatus = tc.paymentStatus
+
+			mappingRepo := &fakeSyncMappingRepo{}
+			if tc.existingMapping {
+				mappingRepo.mappings = []*entityintegrationmapping.EntityIntegrationMapping{
+					{EntityID: inv.ID, ProviderEntityID: "zoho_inv_existing"},
+				}
+			}
+
+			client := &fakeSyncZohoClient{
+				getInvoiceResp: &InvoiceResponse{
+					InvoiceID:  "zoho_inv_existing",
+					CustomerID: "zoho_cust_1",
+					Balance:    decimal.NewFromInt(100),
+				},
+			}
+			svc := &InvoiceService{
+				client:       client,
+				customerSvc:  fakeSyncCustomerSvc{},
+				itemSyncSvc:  fakeSyncItemSyncSvc{},
+				taxSvc:       fakeSyncTaxSvc{},
+				customerRepo: &fakeSyncCustomerRepo{},
+				invoiceRepo:  &fakeSyncInvoiceRepo{inv: inv},
+				mappingRepo:  mappingRepo,
+				logger:       logger.NewNoopLogger(),
+			}
+
+			_, err := svc.SyncInvoiceToZoho(context.Background(), ZohoInvoiceSyncRequest{InvoiceID: inv.ID})
+			require.NoError(t, err)
+
+			if tc.wantCreateInvoice {
+				require.NotNil(t, client.createInvoiceReq)
+			} else {
+				assert.Nil(t, client.createInvoiceReq)
+			}
+
+			if tc.wantCreatePayment {
+				assert.Equal(t, 1, client.createPaymentCalls)
+				require.NotNil(t, client.createPaymentReq)
+				assert.True(t, decimal.NewFromInt(100).Equal(client.createPaymentReq.Amount()))
+			} else {
+				assert.Equal(t, 0, client.createPaymentCalls)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## **User description**
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


___

## **CodeAnt-AI Description**
Mark Zoho invoices as paid when FlexPrice payment completes during synchronization

### What Changed
- After syncing an invoice, Zoho now records a customer payment when the FlexPrice invoice is already paid or overpaid.
- This payment step runs for both newly created Zoho invoices and invoices that were already linked to Zoho.
- Pending invoices are left unpaid until their payment succeeds.

### Impact
`✅ Fewer unpaid Zoho invoices after successful checkout`
`✅ Accurate payment status for invoices synced during payment processing`
`✅ No duplicate payment recorded for pending invoices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zoho invoices are now automatically marked as paid when the corresponding FlexPrice invoice is succeeded or overpaid.
  * Payment status is rechecked after both existing invoice mappings are reused and new Zoho invoices are created.
  * Payment amounts are synchronized accurately with the invoice status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->