### PR TITLE
fix(meter_usage): Timezone in clickhouse queries

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -8058,11 +8058,12 @@ func (s *subscriptionService) processAutoInvoiceThresholdSubscription(
 	item *dto.AutoInvoiceThresholdBillingResultItem,
 ) error {
 
-	// Calculate current-period usage amount.
-	usageResp, err := s.GetUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
+	// Calculate current-period usage amount from meter_usage.
+	usageResp, err := s.GetMeterUsageBySubscription(ctx, &dto.GetUsageBySubscriptionRequest{
 		SubscriptionID: sub.ID,
 		StartTime:      sub.CurrentPeriodStart,
 		EndTime:        effectiveTime,
+		Source:         string(types.UsageSourceInvoiceCreation),
 	})
 	if err != nil {
 		return err

--- a/internal/ee/service/subscription_threshold_billing_test.go
+++ b/internal/ee/service/subscription_threshold_billing_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -63,6 +64,7 @@ func (s *SubscriptionThresholdBillingTestSuite) setupService() {
 		PriceRepo:                  s.GetStores().PriceRepo,
 		PriceUnitRepo:              s.GetStores().PriceUnitRepo,
 		EventRepo:                  s.GetStores().EventRepo,
+		MeterUsageRepo:             s.GetStores().MeterUsageRepo,
 		MeterRepo:                  s.GetStores().MeterRepo,
 		CustomerRepo:               s.GetStores().CustomerRepo,
 		InvoiceRepo:                s.GetStores().InvoiceRepo,
@@ -207,19 +209,34 @@ func (s *SubscriptionThresholdBillingTestSuite) setupTestData() {
 	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, s.testData.subB, []*subscription.SubscriptionLineItem{}))
 }
 
-// insertEvents inserts n COUNT events for subA's customer, all at the given timestamp.
+// insertEvents inserts n COUNT events for subA's customer, all at the given timestamp,
+// and mirrors each into meter_usage — the source ProcessAutoInvoiceThresholdBilling and
+// the invoice-creation path both read from. In prod this mirroring is done by the
+// meter-usage tracking Kafka consumer; the test path bypasses that consumer.
 func (s *SubscriptionThresholdBillingTestSuite) insertEvents(n int, ts time.Time) {
 	ctx := s.GetContext()
+	meterUsageRecords := make([]*events.MeterUsage, 0, n)
 	for i := 0; i < n; i++ {
-		s.NoError(s.GetStores().EventRepo.InsertEvent(ctx, &events.Event{
-			ID:                 s.GetUUID(),
+		id := s.GetUUID()
+		evt := &events.Event{
+			ID:                 id,
 			TenantID:           s.testData.subA.TenantID,
+			EnvironmentID:      s.testData.subA.EnvironmentID,
 			EventName:          s.testData.meter.EventName,
 			ExternalCustomerID: s.testData.customer.ExternalID,
 			Timestamp:          ts,
+			IngestedAt:         ts,
 			Properties:         map[string]interface{}{},
-		}))
+		}
+		s.NoError(s.GetStores().EventRepo.InsertEvent(ctx, evt))
+		meterUsageRecords = append(meterUsageRecords, &events.MeterUsage{
+			Event:      *evt,
+			MeterID:    s.testData.meter.ID,
+			QtyTotal:   decimal.NewFromInt(1),
+			UniqueHash: fmt.Sprintf("%s:%s", s.testData.meter.EventName, id),
+		})
 	}
+	s.NoError(s.GetStores().MeterUsageRepo.BulkInsertMeterUsage(ctx, meterUsageRecords))
 }
 
 // TestThresholdBilling_InvoiceCreatedWhenThresholdExceeded verifies that when

--- a/internal/repository/clickhouse/aggregators.go
+++ b/internal/repository/clickhouse/aggregators.go
@@ -133,10 +133,6 @@ func buildUsageEventCustomerFilters(params *events.UsageParams) (externalCustome
 	return externalCustomerFilter, customerFilter, args
 }
 
-func formatClickHouseDateTime(t time.Time) string {
-	return t.UTC().Format("2006-01-02 15:04:05.000")
-}
-
 // normalizeCHTimezone returns a valid IANA timezone name for ClickHouse
 // toStartOf* functions, defaulting to UTC for empty, "UTC", or unresolvable
 // values. Passing an invalid name straight to ClickHouse would error the query,
@@ -291,18 +287,24 @@ func appendArgs(base []interface{}, groups ...[]interface{}) []interface{} {
 	return base
 }
 
+// parseTimeConditions binds start/end time.Time values directly to `?` placeholders.
+// The clickhouse-go driver's formatTime emits an explicit `'UTC'` third arg when the
+// value's location doesn't match the server's, so the timestamp is compared as a UTC
+// instant regardless of server timezone. Formatting to a string first and wrapping in
+// toDateTime64('...', 3) omits the timezone and lets the server reinterpret the value
+// in its local tz — the exact bug this replaces.
 func parseTimeConditions(params *events.UsageParams) ([]string, []interface{}) {
 	var conditions []string
 	var args []interface{}
 
 	if !params.StartTime.IsZero() {
-		conditions = append(conditions, "timestamp >= toDateTime64(?, 3)")
-		args = append(args, formatClickHouseDateTime(params.StartTime))
+		conditions = append(conditions, "timestamp >= ?")
+		args = append(args, params.StartTime.UTC())
 	}
 
 	if !params.EndTime.IsZero() {
-		conditions = append(conditions, "timestamp < toDateTime64(?, 3)")
-		args = append(args, formatClickHouseDateTime(params.EndTime))
+		conditions = append(conditions, "timestamp < ?")
+		args = append(args, params.EndTime.UTC())
 	}
 
 	return conditions, args
@@ -880,8 +882,8 @@ func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.Usa
 
 	query := fmt.Sprintf(`
         WITH
-            toDateTime64(?, 3) AS period_start,
-            toDateTime64(?, 3) AS period_end,
+            ? AS period_start,
+            ? AS period_end,
             dateDiff('second', period_start, period_end) AS total_seconds
         SELECT
             %s sum(
@@ -912,9 +914,11 @@ func (a *WeightedSumAggregator) GetQuery(ctx context.Context, params *events.Usa
 		groupByClause,
 	)
 
+	// Bind period_start/period_end as time.Time so the driver emits an explicit UTC
+	// timezone. See parseTimeConditions for the full rationale.
 	args := appendArgs([]interface{}{
-		formatClickHouseDateTime(params.StartTime),
-		formatClickHouseDateTime(params.EndTime),
+		params.StartTime.UTC(),
+		params.EndTime.UTC(),
 		params.PropertyName,
 		types.GetTenantID(ctx),
 		types.GetEnvironmentID(ctx),

--- a/internal/repository/clickhouse/builder/query_builder.go
+++ b/internal/repository/clickhouse/builder/query_builder.go
@@ -225,18 +225,24 @@ func (qb *QueryBuilder) Build() (string, map[string]interface{}) {
 	return query, qb.args
 }
 
+// parseTimeConditions builds timestamp WHERE fragments with an explicit `'UTC'` third
+// arg to toDateTime64. Without it, ClickHouse parses the literal in the server's local
+// timezone, so a formatted UTC clock time (e.g. "2026-08-14 15:05:55") gets reinterpreted
+// as Europe/Rome and stored as 13:05:55 UTC internally — silently shifting the window by
+// the server's tz offset. This builder interpolates strings directly (no `?` binding),
+// so the safe form is the explicit-timezone literal rather than driver-bound time.Time.
 func parseTimeConditions(params *events.UsageParams) []string {
 	var conditions []string
 
 	if !params.StartTime.IsZero() {
 		conditions = append(conditions,
-			fmt.Sprintf("timestamp >= toDateTime64('%s', 3)",
+			fmt.Sprintf("timestamp >= toDateTime64('%s', 3, 'UTC')",
 				formatClickHouseDateTime(params.StartTime)))
 	}
 
 	if !params.EndTime.IsZero() {
 		conditions = append(conditions,
-			fmt.Sprintf("timestamp < toDateTime64('%s', 3)",
+			fmt.Sprintf("timestamp < toDateTime64('%s', 3, 'UTC')",
 				formatClickHouseDateTime(params.EndTime)))
 	}
 
@@ -259,8 +265,8 @@ WITH base_events AS (
     FROM events
     WHERE event_name = 'images_processed'
       AND tenant_id = '00000000-0000-0000-0000-000000000000'
-      AND timestamp >= toDateTime64('2024-12-01 08:03:02.000', 3)
-      AND timestamp < toDateTime64('2025-01-01 08:03:02.000', 3)
+      AND timestamp >= toDateTime64('2024-12-01 08:03:02.000', 3, 'UTC')
+      AND timestamp < toDateTime64('2025-01-01 08:03:02.000', 3, 'UTC')
       AND external_customer_id = 'cus_loadtest_1'
       AND JSONExtractString(properties, 'image_size') IN ('512x512','768x768','1024x1024')
 ),

--- a/internal/repository/clickhouse/builder/query_builder_test.go
+++ b/internal/repository/clickhouse/builder/query_builder_test.go
@@ -31,7 +31,7 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				CustomerID:         "cust_123",
 				ExternalCustomerID: "ext_123",
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'audio_transcription' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3) AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3) AND external_customer_id = 'ext_123' AND customer_id = 'cust_123' ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'audio_transcription' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3, 'UTC') AND external_customer_id = 'ext_123' AND customer_id = 'cust_123' ORDER BY tenant_id, environment_id, timestamp, id DESC))",
 		},
 		{
 			name: "base filters without customer ID",
@@ -40,7 +40,7 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				StartTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				EndTime:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'api_calls' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3) AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3) ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'api_calls' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3, 'UTC') ORDER BY tenant_id, environment_id, timestamp, id DESC))",
 		},
 	}
 


### PR DESCRIPTION
## **CodeAnt-AI Description**
Fix timezone handling in usage queries and threshold billing

### What Changed
- Usage time windows are now interpreted explicitly as UTC, preventing server timezone settings from shifting billing and reporting periods.
- Threshold-based invoice checks now calculate current-period usage from recorded meter usage, matching the data used during invoice creation.
- Threshold billing tests now include meter usage records so they reflect production behavior.

### Impact
`✅ Accurate usage windows across server timezones`
`✅ Correct threshold invoice decisions`
`✅ Consistent usage totals during invoice creation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic invoice threshold evaluation by using current-period meter usage.
  * Standardized timestamp handling in usage queries with explicit UTC interpretation.
  * Improved accuracy and consistency for time-range and weighted-sum billing calculations.

* **Tests**
  * Updated billing and query coverage to validate meter usage records and UTC timestamp behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->