### PR TITLE
Multiple payment retries handling for payment link

### DIFF
--- a/internal/api/dto/payment.go
+++ b/internal/api/dto/payment.go
@@ -87,6 +87,12 @@ type UpdatePaymentRequest struct {
 	ErrorMessage     *string          `json:"error_message,omitempty"`
 }
 
+// RecordFailedAttemptRequest captures a gateway decline for a single attempt.
+type RecordFailedAttemptRequest struct {
+	ErrorMessage     string `json:"error_message,omitempty"`
+	GatewayAttemptID string `json:"gateway_attempt_id,omitempty"`
+}
+
 // PaymentResponse represents a payment response
 type PaymentResponse struct {
 	ID                     string                       `json:"id"`

--- a/internal/api/dto/payment.go
+++ b/internal/api/dto/payment.go
@@ -87,10 +87,11 @@ type UpdatePaymentRequest struct {
 	ErrorMessage     *string          `json:"error_message,omitempty"`
 }
 
-// RecordFailedAttemptRequest captures a gateway decline for a single attempt.
-type RecordFailedAttemptRequest struct {
-	ErrorMessage     string `json:"error_message,omitempty"`
-	GatewayAttemptID string `json:"gateway_attempt_id,omitempty"`
+// RecordAttemptRequest captures the gateway's outcome for a single charge attempt.
+type RecordAttemptRequest struct {
+	PaymentStatus    types.PaymentStatus `json:"payment_status"`
+	ErrorMessage     string              `json:"error_message,omitempty"`
+	GatewayAttemptID string              `json:"gateway_attempt_id,omitempty"`
 }
 
 // PaymentResponse represents a payment response

--- a/internal/domain/payment/model.go
+++ b/internal/domain/payment/model.go
@@ -150,7 +150,7 @@ func (pa *PaymentAttempt) Validate() error {
 			WithHint("Attempt number is invalid").
 			Mark(ierr.ErrValidation)
 	}
-	
+
 	switch pa.PaymentStatus {
 	case types.PaymentStatusProcessing, types.PaymentStatusSucceeded, types.PaymentStatusFailed:
 	default:

--- a/internal/domain/payment/model.go
+++ b/internal/domain/payment/model.go
@@ -150,6 +150,16 @@ func (pa *PaymentAttempt) Validate() error {
 			WithHint("Attempt number is invalid").
 			Mark(ierr.ErrValidation)
 	}
+	
+	switch pa.PaymentStatus {
+	case types.PaymentStatusProcessing, types.PaymentStatusSucceeded, types.PaymentStatusFailed:
+	default:
+		return ierr.NewError("invalid payment attempt status").
+			WithHintf("A payment attempt may only be %s, %s or %s",
+				types.PaymentStatusProcessing, types.PaymentStatusSucceeded, types.PaymentStatusFailed).
+			WithReportableDetails(map[string]any{"payment_status": pa.PaymentStatus}).
+			Mark(ierr.ErrValidation)
+	}
 	return nil
 }
 

--- a/internal/domain/payment/model.go
+++ b/internal/domain/payment/model.go
@@ -152,11 +152,11 @@ func (pa *PaymentAttempt) Validate() error {
 	}
 
 	switch pa.PaymentStatus {
-	case types.PaymentStatusProcessing, types.PaymentStatusSucceeded, types.PaymentStatusFailed:
+	case types.PaymentStatusSucceeded, types.PaymentStatusFailed:
 	default:
 		return ierr.NewError("invalid payment attempt status").
-			WithHintf("A payment attempt may only be %s, %s or %s",
-				types.PaymentStatusProcessing, types.PaymentStatusSucceeded, types.PaymentStatusFailed).
+			WithHintf("A payment attempt may only be %s or %s",
+				types.PaymentStatusSucceeded, types.PaymentStatusFailed).
 			WithReportableDetails(map[string]any{"payment_status": pa.PaymentStatus}).
 			Mark(ierr.ErrValidation)
 	}

--- a/internal/ee/service/checkout_session_actions.go
+++ b/internal/ee/service/checkout_session_actions.go
@@ -382,6 +382,29 @@ func (s *checkoutSessionService) finalizeCheckoutInvoiceAndPayment(
 	paymentID string,
 	providerResult *types.CheckoutProviderResult,
 ) error {
+	statusStr := string(types.PaymentStatusSucceeded)
+	now := time.Now().UTC()
+	updateReq := dto.UpdatePaymentRequest{
+		PaymentStatus: &statusStr,
+		SucceededAt:   &now,
+	}
+	attemptReq := dto.RecordAttemptRequest{PaymentStatus: types.PaymentStatusSucceeded}
+	if providerResult != nil && providerResult.ProviderPaymentIntentID != "" {
+		id := providerResult.ProviderPaymentIntentID
+		updateReq.GatewayPaymentID = &id
+		attemptReq.GatewayAttemptID = id
+	}
+
+	paySvc := NewPaymentService(s.ServiceParams)
+	if err := paySvc.RecordAttempt(ctx, paymentID, attemptReq); err != nil {
+		s.Logger.Error(ctx, "failed to record succeeded attempt",
+			"payment_id", paymentID, "error", err)
+	}
+
+	if _, err := paySvc.UpdatePayment(ctx, paymentID, updateReq); err != nil {
+		return err
+	}
+
 	invSvc := NewInvoiceService(s.ServiceParams)
 	invResp, err := invSvc.GetInvoice(ctx, invoiceID)
 	if err != nil {
@@ -391,32 +414,6 @@ func (s *checkoutSessionService) finalizeCheckoutInvoiceAndPayment(
 		if err := invSvc.FinalizeInvoice(ctx, invoiceID); err != nil {
 			return err
 		}
-	}
-
-	statusStr := string(types.PaymentStatusSucceeded)
-	now := time.Now().UTC()
-	updateReq := dto.UpdatePaymentRequest{
-		PaymentStatus: &statusStr,
-		SucceededAt:   &now,
-	}
-	if providerResult != nil && providerResult.ProviderPaymentIntentID != "" {
-		id := providerResult.ProviderPaymentIntentID
-		updateReq.GatewayPaymentID = &id
-	}
-
-	paySvc := NewPaymentService(s.ServiceParams)
-	attemptReq := dto.RecordAttemptRequest{PaymentStatus: types.PaymentStatusSucceeded}
-	if providerResult != nil {
-		attemptReq.GatewayAttemptID = providerResult.ProviderPaymentIntentID
-	}
-	
-	if err := paySvc.RecordAttempt(ctx, paymentID, attemptReq); err != nil {
-		s.Logger.Error(ctx, "failed to record succeeded attempt",
-			"payment_id", paymentID, "error", err)
-	}
-
-	if _, err := paySvc.UpdatePayment(ctx, paymentID, updateReq); err != nil {
-		return err
 	}
 
 	return invSvc.ReconcilePaymentStatus(ctx, invoiceID, types.PaymentStatusSucceeded, nil)

--- a/internal/ee/service/checkout_session_actions.go
+++ b/internal/ee/service/checkout_session_actions.go
@@ -382,6 +382,17 @@ func (s *checkoutSessionService) finalizeCheckoutInvoiceAndPayment(
 	paymentID string,
 	providerResult *types.CheckoutProviderResult,
 ) error {
+	invSvc := NewInvoiceService(s.ServiceParams)
+	invResp, err := invSvc.GetInvoice(ctx, invoiceID)
+	if err != nil {
+		return err
+	}
+	if invResp.InvoiceStatus != types.InvoiceStatusFinalized {
+		if err := invSvc.FinalizeInvoice(ctx, invoiceID); err != nil {
+			return err
+		}
+	}
+
 	statusStr := string(types.PaymentStatusSucceeded)
 	now := time.Now().UTC()
 	updateReq := dto.UpdatePaymentRequest{
@@ -396,24 +407,14 @@ func (s *checkoutSessionService) finalizeCheckoutInvoiceAndPayment(
 	}
 
 	paySvc := NewPaymentService(s.ServiceParams)
-	if err := paySvc.RecordAttempt(ctx, paymentID, attemptReq); err != nil {
-		s.Logger.Error(ctx, "failed to record succeeded attempt",
-			"payment_id", paymentID, "error", err)
-	}
-
 	if _, err := paySvc.UpdatePayment(ctx, paymentID, updateReq); err != nil {
 		return err
 	}
 
-	invSvc := NewInvoiceService(s.ServiceParams)
-	invResp, err := invSvc.GetInvoice(ctx, invoiceID)
-	if err != nil {
-		return err
-	}
-	if invResp.InvoiceStatus != types.InvoiceStatusFinalized {
-		if err := invSvc.FinalizeInvoice(ctx, invoiceID); err != nil {
-			return err
-		}
+	// After the settle, so a payment that never succeeded leaves no succeeded attempt.
+	if err := paySvc.RecordAttempt(ctx, paymentID, attemptReq); err != nil {
+		s.Logger.Error(ctx, "failed to record succeeded attempt",
+			"payment_id", paymentID, "error", err)
 	}
 
 	return invSvc.ReconcilePaymentStatus(ctx, invoiceID, types.PaymentStatusSucceeded, nil)

--- a/internal/ee/service/checkout_session_actions.go
+++ b/internal/ee/service/checkout_session_actions.go
@@ -403,7 +403,18 @@ func (s *checkoutSessionService) finalizeCheckoutInvoiceAndPayment(
 		id := providerResult.ProviderPaymentIntentID
 		updateReq.GatewayPaymentID = &id
 	}
+
 	paySvc := NewPaymentService(s.ServiceParams)
+	attemptReq := dto.RecordAttemptRequest{PaymentStatus: types.PaymentStatusSucceeded}
+	if providerResult != nil {
+		attemptReq.GatewayAttemptID = providerResult.ProviderPaymentIntentID
+	}
+	
+	if err := paySvc.RecordAttempt(ctx, paymentID, attemptReq); err != nil {
+		s.Logger.Error(ctx, "failed to record succeeded attempt",
+			"payment_id", paymentID, "error", err)
+	}
+
 	if _, err := paySvc.UpdatePayment(ctx, paymentID, updateReq); err != nil {
 		return err
 	}

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -471,10 +471,10 @@ func (s *paymentService) UpdatePayment(ctx context.Context, id string, req dto.U
 	return dto.NewPaymentResponse(p), nil
 }
 
-// RecordFailedAttempt appends a FAILED PaymentAttempt for a gateway decline without
-// touching the parent payment's status. A decline is the gateway's outcome for one
-// try, not our decision to stop, so the parent stays open for a retry to settle it.
-func (s *paymentService) RecordFailedAttempt(ctx context.Context, paymentID string, req dto.RecordFailedAttemptRequest) error {
+// RecordAttempt appends a PaymentAttempt carrying the gateway's outcome for one charge
+// attempt, without touching the parent payment's status. A per-attempt outcome is the
+// gateway's verdict on one try, not our decision about the payment as a whole.
+func (s *paymentService) RecordAttempt(ctx context.Context, paymentID string, req dto.RecordAttemptRequest) error {
 	if paymentID == "" {
 		return ierr.NewError("payment_id is required").
 			WithHint("Payment ID is required").
@@ -504,7 +504,7 @@ func (s *paymentService) RecordFailedAttempt(ctx context.Context, paymentID stri
 		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PAYMENT_ATTEMPT),
 		PaymentID:     paymentID,
 		AttemptNumber: attemptNumber,
-		PaymentStatus: types.PaymentStatusFailed,
+		PaymentStatus: req.PaymentStatus,
 		Metadata:      types.Metadata{},
 		EnvironmentID: types.GetEnvironmentID(ctx),
 		BaseModel:     types.GetDefaultBaseModel(ctx),
@@ -516,13 +516,18 @@ func (s *paymentService) RecordFailedAttempt(ctx context.Context, paymentID stri
 		attempt.GatewayAttemptID = lo.ToPtr(req.GatewayAttemptID)
 	}
 
+	if err := attempt.Validate(); err != nil {
+		return err
+	}
+
 	if err := s.PaymentRepo.CreateAttempt(ctx, attempt); err != nil {
 		return err
 	}
 
-	s.Logger.Info(ctx, "recorded declined payment attempt",
+	s.Logger.Info(ctx, "recorded payment attempt",
 		"payment_id", paymentID,
 		"attempt_number", attemptNumber,
+		"attempt_status", req.PaymentStatus,
 		"gateway_attempt_id", req.GatewayAttemptID,
 	)
 

--- a/internal/ee/service/payment.go
+++ b/internal/ee/service/payment.go
@@ -471,6 +471,64 @@ func (s *paymentService) UpdatePayment(ctx context.Context, id string, req dto.U
 	return dto.NewPaymentResponse(p), nil
 }
 
+// RecordFailedAttempt appends a FAILED PaymentAttempt for a gateway decline without
+// touching the parent payment's status. A decline is the gateway's outcome for one
+// try, not our decision to stop, so the parent stays open for a retry to settle it.
+func (s *paymentService) RecordFailedAttempt(ctx context.Context, paymentID string, req dto.RecordFailedAttemptRequest) error {
+	if paymentID == "" {
+		return ierr.NewError("payment_id is required").
+			WithHint("Payment ID is required").
+			Mark(ierr.ErrValidation)
+	}
+
+	p, err := s.PaymentRepo.Get(ctx, paymentID)
+	if err != nil {
+		return err
+	}
+
+	if !p.TrackAttempts {
+		return nil
+	}
+
+	latestAttempt, err := s.PaymentRepo.GetLatestAttempt(ctx, paymentID)
+	if err != nil && !ierr.IsNotFound(err) {
+		return err
+	}
+
+	attemptNumber := 1
+	if latestAttempt != nil {
+		attemptNumber = latestAttempt.AttemptNumber + 1
+	}
+
+	attempt := &payment.PaymentAttempt{
+		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PAYMENT_ATTEMPT),
+		PaymentID:     paymentID,
+		AttemptNumber: attemptNumber,
+		PaymentStatus: types.PaymentStatusFailed,
+		Metadata:      types.Metadata{},
+		EnvironmentID: types.GetEnvironmentID(ctx),
+		BaseModel:     types.GetDefaultBaseModel(ctx),
+	}
+	if req.ErrorMessage != "" {
+		attempt.ErrorMessage = lo.ToPtr(req.ErrorMessage)
+	}
+	if req.GatewayAttemptID != "" {
+		attempt.GatewayAttemptID = lo.ToPtr(req.GatewayAttemptID)
+	}
+
+	if err := s.PaymentRepo.CreateAttempt(ctx, attempt); err != nil {
+		return err
+	}
+
+	s.Logger.Info(ctx, "recorded declined payment attempt",
+		"payment_id", paymentID,
+		"attempt_number", attemptNumber,
+		"gateway_attempt_id", req.GatewayAttemptID,
+	)
+
+	return nil
+}
+
 // ListPayments lists payments based on filter
 func (s *paymentService) ListPayments(ctx context.Context, filter *types.PaymentFilter) (*dto.ListPaymentsResponse, error) {
 	if filter == nil {
@@ -829,7 +887,7 @@ func (s *paymentService) CreatePaymentForCheckout(ctx context.Context, req *dto.
 		Amount:            req.Invoice.AmountDue,
 		Currency:          req.Invoice.Currency,
 		PaymentStatus:     types.PaymentStatusInitiated,
-		TrackAttempts:     false, // checkout payments are promoted via webhook callback, not attempt tracking
+		TrackAttempts:     true, // gateway declines are recorded as attempts, leaving the payment open for a retry
 		EnvironmentID:     types.GetEnvironmentID(ctx),
 		BaseModel:         types.GetDefaultBaseModel(ctx),
 	}

--- a/internal/ee/service/payment_processor.go
+++ b/internal/ee/service/payment_processor.go
@@ -69,15 +69,6 @@ func (p *paymentProcessor) ProcessPayment(ctx context.Context, id string) (*paym
 		}
 	}
 
-	// Create a new payment attempt if tracking is enabled
-	var attempt *payment.PaymentAttempt
-	if paymentObj.TrackAttempts {
-		attempt, err = p.createNewAttempt(ctx, paymentObj)
-		if err != nil {
-			return paymentObj, err
-		}
-	}
-
 	// For payment links, if status is INITIATED, we need to create the payment link
 	// If status is already PENDING, we don't need to do anything more
 	if paymentObj.PaymentMethodType == types.PaymentMethodTypePaymentLink && paymentObj.PaymentStatus == types.PaymentStatusInitiated {
@@ -133,31 +124,6 @@ func (p *paymentProcessor) ProcessPayment(ctx context.Context, id string) (*paym
 				"payment_id": paymentObj.ID,
 			}).
 			Mark(ierr.ErrInvalidOperation)
-	}
-
-	// Update attempt status if tracking is enabled
-	if paymentObj.TrackAttempts && attempt != nil {
-		if processErr != nil {
-			// For payment links, keep attempt as pending even on error
-			if paymentObj.PaymentMethodType == types.PaymentMethodTypePaymentLink {
-				attempt.PaymentStatus = types.PaymentStatusPending
-				attempt.ErrorMessage = lo.ToPtr(processErr.Error())
-			} else {
-				attempt.PaymentStatus = types.PaymentStatusFailed
-				attempt.ErrorMessage = lo.ToPtr(processErr.Error())
-			}
-		} else {
-			// For payment links, keep attempt as pending
-			if paymentObj.PaymentMethodType == types.PaymentMethodTypePaymentLink {
-				attempt.PaymentStatus = types.PaymentStatusPending
-			} else {
-				attempt.PaymentStatus = types.PaymentStatusSucceeded
-			}
-		}
-		attempt.UpdatedAt = time.Now().UTC()
-		if err := p.PaymentRepo.UpdateAttempt(ctx, attempt); err != nil {
-			p.Logger.Error(ctx, "failed to update payment attempt", "error", err)
-		}
 	}
 
 	// Update payment status based on processing result
@@ -747,35 +713,6 @@ func (p *paymentProcessor) handleInvoicePostProcessing(ctx context.Context, paym
 	}
 
 	return nil
-}
-
-func (p *paymentProcessor) createNewAttempt(ctx context.Context, paymentObj *payment.Payment) (*payment.PaymentAttempt, error) {
-	// Get latest attempt to determine attempt number
-	latestAttempt, err := p.PaymentRepo.GetLatestAttempt(ctx, paymentObj.ID)
-	if err != nil && !ierr.IsNotFound(err) {
-		return nil, err
-	}
-
-	attemptNumber := 1
-	if latestAttempt != nil {
-		attemptNumber = latestAttempt.AttemptNumber + 1
-	}
-
-	attempt := &payment.PaymentAttempt{
-		ID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PAYMENT_ATTEMPT),
-		PaymentID:     paymentObj.ID,
-		AttemptNumber: attemptNumber,
-		PaymentStatus: types.PaymentStatusProcessing,
-		Metadata:      types.Metadata{},
-		EnvironmentID: types.GetEnvironmentID(ctx),
-		BaseModel:     types.GetDefaultBaseModel(ctx),
-	}
-
-	if err := p.PaymentRepo.CreateAttempt(ctx, attempt); err != nil {
-		return nil, err
-	}
-
-	return attempt, nil
 }
 
 func (p *paymentProcessor) dispatchWhopMarkPaid(ctx context.Context, invoiceID string) {

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -527,6 +527,37 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_CleanupArchive
 	s.Equal(types.CheckoutStatusExpired, cleaned.CheckoutStatus)
 }
 
+// The payment must settle before the invoice is finalized. With the old order a failure
+// in the payment update left a finalized, unreconciled invoice whose subscription never
+// activated — money collected at the gateway with nothing in our books saying so.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_FinalizeSettlesPaymentBeforeInvoice() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_finalize_order", decimal.NewFromInt(50), 0)
+
+	session, _, draft := s.seedPayFirstSubscriptionCheckout("plan_finalize_order")
+	paymentID := *session.CheckoutPaymentID
+
+	checkoutSvc := &checkoutSessionService{ServiceParams: subService.ServiceParams}
+	s.Require().NoError(checkoutSvc.finalizeCheckoutInvoiceAndPayment(ctx, draft.ID, paymentID,
+		&types.CheckoutProviderResult{ProviderPaymentIntentID: "pay_order_001"}))
+
+	settled, err := s.GetStores().PaymentRepo.Get(ctx, paymentID)
+	s.Require().NoError(err)
+	s.Equal(types.PaymentStatusSucceeded, settled.PaymentStatus)
+	s.Equal("pay_order_001", lo.FromPtr(settled.GatewayPaymentID))
+
+	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, paymentID)
+	s.Require().NoError(err)
+	s.Require().Len(attempts, 1, "the settling charge must appear in the attempt ledger")
+	s.Equal(types.PaymentStatusSucceeded, attempts[0].PaymentStatus)
+
+	inv, err := s.GetStores().InvoiceRepo.Get(ctx, draft.ID)
+	s.Require().NoError(err)
+	s.Equal(types.InvoiceStatusFinalized, inv.InvoiceStatus)
+	s.Equal(types.PaymentStatusSucceeded, inv.PaymentStatus, "the invoice must end reconciled")
+}
+
 // A session that completed and only later expired must leave the live subscription alone.
 func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_CleanupSkipsActivatedSubscription() {
 	ctx := s.GetContext()

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -527,10 +527,42 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_CleanupArchive
 	s.Equal(types.CheckoutStatusExpired, cleaned.CheckoutStatus)
 }
 
-// The payment must settle before the invoice is finalized. With the old order a failure
-// in the payment update left a finalized, unreconciled invoice whose subscription never
-// activated — money collected at the gateway with nothing in our books saying so.
-func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_FinalizeSettlesPaymentBeforeInvoice() {
+// Ordering guard. The end state is identical whichever way round these run, so this
+// asserts the thing that actually differs: when the invoice step fails, the payment must
+// still be unsettled. Settling first would strand a SUCCEEDED payment against an
+// unfinalized invoice — the gateway sync skips SUCCEEDED rows and the already-SUCCEEDED
+// webhook guard blocks replays, so nothing could repair it.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_InvoiceFailureLeavesPaymentUnsettled() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_finalize_guard", decimal.NewFromInt(50), 0)
+
+	session, _, _ := s.seedPayFirstSubscriptionCheckout("plan_finalize_guard")
+	paymentID := *session.CheckoutPaymentID
+
+	before, err := s.GetStores().PaymentRepo.Get(ctx, paymentID)
+	s.Require().NoError(err)
+	s.Require().NotEqual(types.PaymentStatusSucceeded, before.PaymentStatus)
+
+	checkoutSvc := &checkoutSessionService{ServiceParams: subService.ServiceParams}
+	err = checkoutSvc.finalizeCheckoutInvoiceAndPayment(ctx, "inv_does_not_exist", paymentID,
+		&types.CheckoutProviderResult{ProviderPaymentIntentID: "pay_never_collected"})
+	s.Require().Error(err, "an unresolvable invoice must abort before the payment is touched")
+
+	after, err := s.GetStores().PaymentRepo.Get(ctx, paymentID)
+	s.Require().NoError(err)
+	s.Equal(before.PaymentStatus, after.PaymentStatus,
+		"the payment must not settle when the invoice step fails")
+	s.Nil(after.GatewayPaymentID, "no transaction may be claimed by a failed finalize")
+
+	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, paymentID)
+	s.NoError(err)
+	s.Empty(attempts, "a payment that never settled must not carry a succeeded attempt")
+}
+
+// Happy path: the invoice ends finalized AND reconciled, the payment settled, and the
+// collecting transaction is recorded once in the attempt ledger.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_FinalizeSettlesAndReconciles() {
 	ctx := s.GetContext()
 	subService := s.service.(*subscriptionService)
 	s.seedFixedPricePlan("plan_finalize_order", decimal.NewFromInt(50), 0)
@@ -556,6 +588,30 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_FinalizeSettle
 	s.Require().NoError(err)
 	s.Equal(types.InvoiceStatusFinalized, inv.InvoiceStatus)
 	s.Equal(types.PaymentStatusSucceeded, inv.PaymentStatus, "the invoice must end reconciled")
+}
+
+// Re-delivery must be safe: the checkout reconcile passes a nil amount, which is absolute
+// (AmountPaid = AmountDue) rather than additive, so replaying cannot overpay the invoice.
+func (s *SubscriptionServiceSuite) TestCreateSubscriptionCheckout_FinalizeIsReplaySafe() {
+	ctx := s.GetContext()
+	subService := s.service.(*subscriptionService)
+	s.seedFixedPricePlan("plan_finalize_replay", decimal.NewFromInt(50), 0)
+
+	session, _, draft := s.seedPayFirstSubscriptionCheckout("plan_finalize_replay")
+	paymentID := *session.CheckoutPaymentID
+	checkoutSvc := &checkoutSessionService{ServiceParams: subService.ServiceParams}
+	res := &types.CheckoutProviderResult{ProviderPaymentIntentID: "pay_replay_001"}
+
+	s.Require().NoError(checkoutSvc.finalizeCheckoutInvoiceAndPayment(ctx, draft.ID, paymentID, res))
+	first, err := s.GetStores().InvoiceRepo.Get(ctx, draft.ID)
+	s.Require().NoError(err)
+
+	s.Require().NoError(checkoutSvc.finalizeCheckoutInvoiceAndPayment(ctx, draft.ID, paymentID, res))
+	again, err := s.GetStores().InvoiceRepo.Get(ctx, draft.ID)
+	s.Require().NoError(err)
+
+	s.True(first.AmountPaid.Equal(again.AmountPaid), "replay must not change amount_paid")
+	s.Equal(types.PaymentStatusSucceeded, again.PaymentStatus, "replay must not flip to OVERPAID")
 }
 
 // A session that completed and only later expired must leave the live subscription alone.

--- a/internal/integration/factory.go
+++ b/internal/integration/factory.go
@@ -305,6 +305,7 @@ func (f *Factory) GetRazorpayIntegration(ctx context.Context) (*RazorpayIntegrat
 		razorpayClient,
 		paymentSvc,
 		f.entityIntegrationMappingRepo,
+		f.lifecycle,
 		f.logger,
 	)
 
@@ -314,6 +315,7 @@ func (f *Factory) GetRazorpayIntegration(ctx context.Context) (*RazorpayIntegrat
 		PaymentSvc:     paymentSvc,
 		InvoiceSyncSvc: invoiceSyncSvc,
 		WebhookHandler: webhookHandler,
+		Lifecycle:      f.lifecycle,
 	}, nil
 }
 
@@ -847,6 +849,7 @@ type RazorpayIntegration struct {
 	PaymentSvc     *razorpay.PaymentService
 	InvoiceSyncSvc *razorpay.InvoiceSyncService
 	WebhookHandler *razorpaywebhook.Handler
+	Lifecycle      *payments.PaymentLifecycle
 }
 
 func (r *RazorpayIntegration) PullAndUpdateInvoice(ctx context.Context, invoiceID string) error {

--- a/internal/integration/payments/dto.go
+++ b/internal/integration/payments/dto.go
@@ -30,6 +30,14 @@ type RecordPaymentSuccessParams struct {
 	SucceededAt        time.Time
 }
 
+// RecordFailedAttemptParams holds inputs for recording a single gateway failure
+// while the payment vehicle is still open.
+type RecordFailedAttemptParams struct {
+	FlexpricePaymentID string
+	GatewayPaymentID   string
+	ErrorMessage       string
+}
+
 // RecordPaymentFailureParams holds inputs for marking a payment FAILED.
 type RecordPaymentFailureParams struct {
 	FlexpricePaymentID string

--- a/internal/integration/payments/dto.go
+++ b/internal/integration/payments/dto.go
@@ -30,6 +30,13 @@ type RecordPaymentSuccessParams struct {
 	SucceededAt        time.Time
 }
 
+// RecordSucceededAttemptParams holds inputs for recording the charge attempt that
+// settled a payment.
+type RecordSucceededAttemptParams struct {
+	FlexpricePaymentID string
+	GatewayPaymentID   string
+}
+
 // RecordFailedAttemptParams holds inputs for recording a single gateway failure
 // while the payment vehicle is still open.
 type RecordFailedAttemptParams struct {

--- a/internal/integration/payments/lifecycle.go
+++ b/internal/integration/payments/lifecycle.go
@@ -320,23 +320,6 @@ func (l *PaymentLifecycle) RecordFailedAttempt(ctx context.Context, params Recor
 			Mark(ierr.ErrSystem)
 	}
 
-	if params.ErrorMessage != "" {
-		updateReq := apidto.UpdatePaymentRequest{ErrorMessage: lo.ToPtr(params.ErrorMessage)}
-		if _, err := l.paymentService.UpdatePayment(ctx, params.FlexpricePaymentID, updateReq); err != nil {
-			l.logger.Error(ctx, "failed to persist failed details on payment",
-				"flexprice_payment_id", params.FlexpricePaymentID,
-				"gateway_payment_id", params.GatewayPaymentID,
-				"error", err,
-			)
-			return ierr.WithError(err).
-				WithHint("Failed to persist failed details on payment").
-				WithReportableDetails(map[string]any{
-					"flexprice_payment_id": params.FlexpricePaymentID,
-				}).
-				Mark(ierr.ErrSystem)
-		}
-	}
-
 	l.logger.Info(ctx, "payment attempt failed, payment left open for retry",
 		"flexprice_payment_id", params.FlexpricePaymentID,
 		"gateway_payment_id", params.GatewayPaymentID,

--- a/internal/integration/payments/lifecycle.go
+++ b/internal/integration/payments/lifecycle.go
@@ -270,9 +270,54 @@ func (l *PaymentLifecycle) RecordPaymentSuccess(ctx context.Context, params Reco
 	return nil
 }
 
-// RecordPaymentFailure transitions the payment to FAILED. Called from the
-// webhook handler on payment_failed or equivalent gateway event.
-//
+func (l *PaymentLifecycle) RecordFailedAttempt(ctx context.Context, params RecordFailedAttemptParams) error {
+	if params.FlexpricePaymentID == "" {
+		return ierr.NewError("flexprice_payment_id is required").Mark(ierr.ErrValidation)
+	}
+
+	if err := l.paymentService.RecordFailedAttempt(ctx, params.FlexpricePaymentID, apidto.RecordFailedAttemptRequest{
+		ErrorMessage:     params.ErrorMessage,
+		GatewayAttemptID: params.GatewayPaymentID,
+	}); err != nil {
+		l.logger.Error(ctx, "failed to record failed payment attempt",
+			"flexprice_payment_id", params.FlexpricePaymentID,
+			"gateway_payment_id", params.GatewayPaymentID,
+			"error", err,
+		)
+		return ierr.WithError(err).
+			WithHint("Failed to record failed payment attempt").
+			WithReportableDetails(map[string]any{
+				"flexprice_payment_id": params.FlexpricePaymentID,
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	if params.ErrorMessage != "" {
+		updateReq := apidto.UpdatePaymentRequest{ErrorMessage: lo.ToPtr(params.ErrorMessage)}
+		if _, err := l.paymentService.UpdatePayment(ctx, params.FlexpricePaymentID, updateReq); err != nil {
+			l.logger.Error(ctx, "failed to persist failed details on payment",
+				"flexprice_payment_id", params.FlexpricePaymentID,
+				"gateway_payment_id", params.GatewayPaymentID,
+				"error", err,
+			)
+			return ierr.WithError(err).
+				WithHint("Failed to persist failed details on payment").
+				WithReportableDetails(map[string]any{
+					"flexprice_payment_id": params.FlexpricePaymentID,
+				}).
+				Mark(ierr.ErrSystem)
+		}
+	}
+
+	l.logger.Info(ctx, "payment attempt failed, payment left open for retry",
+		"flexprice_payment_id", params.FlexpricePaymentID,
+		"gateway_payment_id", params.GatewayPaymentID,
+		"error_message", params.ErrorMessage,
+	)
+
+	return nil
+}
+
 // Idempotent: if the payment is already FAILED, logs and returns nil.
 func (l *PaymentLifecycle) RecordPaymentFailure(ctx context.Context, params RecordPaymentFailureParams) error {
 	l.logger.Info(ctx, "recording payment failure",
@@ -322,10 +367,13 @@ func (l *PaymentLifecycle) RecordPaymentFailure(ctx context.Context, params Reco
 		failedAt = time.Now().UTC()
 	}
 	updateReq := apidto.UpdatePaymentRequest{
-		PaymentStatus:    lo.ToPtr(string(types.PaymentStatusFailed)),
-		GatewayPaymentID: lo.ToPtr(params.GatewayPaymentID),
-		FailedAt:         lo.ToPtr(failedAt),
-		ErrorMessage:     lo.ToPtr(params.ErrorMessage),
+		PaymentStatus: lo.ToPtr(string(types.PaymentStatusFailed)),
+		FailedAt:      lo.ToPtr(failedAt),
+		ErrorMessage:  lo.ToPtr(params.ErrorMessage),
+	}
+
+	if params.GatewayPaymentID != "" {
+		updateReq.GatewayPaymentID = lo.ToPtr(params.GatewayPaymentID)
 	}
 
 	_, err = l.paymentService.UpdatePayment(ctx, params.FlexpricePaymentID, updateReq)

--- a/internal/integration/payments/lifecycle.go
+++ b/internal/integration/payments/lifecycle.go
@@ -270,12 +270,40 @@ func (l *PaymentLifecycle) RecordPaymentSuccess(ctx context.Context, params Reco
 	return nil
 }
 
+// RecordSucceededAttempt records the charge attempt that settled the payment. It only
+// appends the attempt; moving the parent to SUCCEEDED is RecordPaymentSuccess's job.
+func (l *PaymentLifecycle) RecordSucceededAttempt(ctx context.Context, params RecordSucceededAttemptParams) error {
+	if params.FlexpricePaymentID == "" {
+		return ierr.NewError("flexprice_payment_id is required").Mark(ierr.ErrValidation)
+	}
+
+	if err := l.paymentService.RecordAttempt(ctx, params.FlexpricePaymentID, apidto.RecordAttemptRequest{
+		PaymentStatus:    types.PaymentStatusSucceeded,
+		GatewayAttemptID: params.GatewayPaymentID,
+	}); err != nil {
+		l.logger.Error(ctx, "failed to record succeeded payment attempt",
+			"flexprice_payment_id", params.FlexpricePaymentID,
+			"gateway_payment_id", params.GatewayPaymentID,
+			"error", err,
+		)
+		return ierr.WithError(err).
+			WithHint("Failed to record succeeded payment attempt").
+			WithReportableDetails(map[string]any{
+				"flexprice_payment_id": params.FlexpricePaymentID,
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	return nil
+}
+
 func (l *PaymentLifecycle) RecordFailedAttempt(ctx context.Context, params RecordFailedAttemptParams) error {
 	if params.FlexpricePaymentID == "" {
 		return ierr.NewError("flexprice_payment_id is required").Mark(ierr.ErrValidation)
 	}
 
-	if err := l.paymentService.RecordFailedAttempt(ctx, params.FlexpricePaymentID, apidto.RecordFailedAttemptRequest{
+	if err := l.paymentService.RecordAttempt(ctx, params.FlexpricePaymentID, apidto.RecordAttemptRequest{
+		PaymentStatus:    types.PaymentStatusFailed,
 		ErrorMessage:     params.ErrorMessage,
 		GatewayAttemptID: params.GatewayPaymentID,
 	}); err != nil {

--- a/internal/integration/payments/lifecycle_test.go
+++ b/internal/integration/payments/lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/integration/payments"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/suite"
 )
@@ -17,7 +18,7 @@ import (
 type PaymentLifecycleSuite struct {
 	testutil.BaseServiceTestSuite
 	lifecycle *payments.PaymentLifecycle
-	testData struct {
+	testData  struct {
 		customer *customer.Customer
 		invoice  *invoice.Invoice
 	}
@@ -296,6 +297,117 @@ func (s *PaymentLifecycleSuite) TestRecordPaymentSuccess_TerminalStateError() {
 		GatewayPaymentID:   "gw_pay_004",
 	})
 	s.Error(err)
+}
+
+// ── RecordDeclinedAttempt ────────────────────────────────────────────────────
+
+func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_LeavesPaymentOpen() {
+	ctx := s.GetContext()
+	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
+	s.NoError(err)
+	s.NoError(s.lifecycle.ConfirmGatewayPayment(ctx, id, "gw_pay_020"))
+
+	err = s.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_pay_020",
+		ErrorMessage:       "card declined",
+	})
+	s.NoError(err)
+
+	payment, err := s.GetStores().PaymentRepo.Get(ctx, id)
+	s.NoError(err)
+	s.Equal(types.PaymentStatusPending, payment.PaymentStatus,
+		"a decline must not move the parent out of its open status")
+	s.Require().NotNil(payment.ErrorMessage)
+	s.Equal("card declined", *payment.ErrorMessage)
+
+	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, id)
+	s.NoError(err)
+	s.Require().Len(attempts, 1)
+	s.Equal(types.PaymentStatusFailed, attempts[0].PaymentStatus)
+	s.Equal(1, attempts[0].AttemptNumber)
+}
+
+func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_IncrementsAttemptNumber() {
+	ctx := s.GetContext()
+	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
+	s.NoError(err)
+	s.NoError(s.lifecycle.ConfirmGatewayPayment(ctx, id, "gw_pay_021"))
+
+	declineParams := payments.RecordFailedAttemptParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_pay_021",
+		ErrorMessage:       "insufficient funds",
+	}
+	s.NoError(s.lifecycle.RecordFailedAttempt(ctx, declineParams))
+	s.NoError(s.lifecycle.RecordFailedAttempt(ctx, declineParams))
+
+	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, id)
+	s.NoError(err)
+	s.Require().Len(attempts, 2)
+	s.ElementsMatch([]int{1, 2}, []int{attempts[0].AttemptNumber, attempts[1].AttemptNumber})
+
+	payment, err := s.GetStores().PaymentRepo.Get(ctx, id)
+	s.NoError(err)
+	s.Equal(types.PaymentStatusPending, payment.PaymentStatus)
+}
+
+func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_ThenSuccessSettlesPayment() {
+	ctx := s.GetContext()
+	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
+	s.NoError(err)
+	s.NoError(s.lifecycle.ConfirmGatewayPayment(ctx, id, "gw_pay_022"))
+
+	s.NoError(s.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_pay_022",
+		ErrorMessage:       "card declined",
+	}))
+
+	s.NoError(s.lifecycle.RecordPaymentSuccess(ctx, payments.RecordPaymentSuccessParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_pay_023",
+		SucceededAt:        time.Now().UTC(),
+	}))
+
+	payment, err := s.GetStores().PaymentRepo.Get(ctx, id)
+	s.NoError(err)
+	s.Equal(types.PaymentStatusSucceeded, payment.PaymentStatus)
+
+	inv, err := s.GetStores().InvoiceRepo.Get(ctx, s.testData.invoice.ID)
+	s.NoError(err)
+	s.Equal(types.PaymentStatusSucceeded, inv.PaymentStatus)
+}
+
+// A declined transaction must not land on the parent's GatewayPaymentID: that field
+// names the transaction that settled the payment, and syncPaymentStatusFromGateway
+// prefers it over GatewayTrackingID. Pointing it at a dead transaction would make the
+// sync fetch FAILED and seal a payment the customer can still retry.
+func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_DoesNotClaimGatewayPaymentID() {
+	ctx := s.GetContext()
+	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
+	s.NoError(err)
+
+	s.NoError(s.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_declined_txn",
+		ErrorMessage:       "card declined",
+	}))
+
+	payment, err := s.GetStores().PaymentRepo.Get(ctx, id)
+	s.NoError(err)
+	s.NotEqual("gw_declined_txn", lo.FromPtr(payment.GatewayPaymentID))
+
+	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, id)
+	s.NoError(err)
+	s.Require().Len(attempts, 1)
+	s.Require().NotNil(attempts[0].GatewayAttemptID)
+	s.Equal("gw_declined_txn", *attempts[0].GatewayAttemptID,
+		"the declined transaction belongs on the attempt")
+}
+
+func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_RequiresPaymentID() {
+	s.Error(s.lifecycle.RecordFailedAttempt(s.GetContext(), payments.RecordFailedAttemptParams{}))
 }
 
 // ── RecordPaymentFailure ─────────────────────────────────────────────────────

--- a/internal/integration/payments/lifecycle_test.go
+++ b/internal/integration/payments/lifecycle_test.go
@@ -299,9 +299,9 @@ func (s *PaymentLifecycleSuite) TestRecordPaymentSuccess_TerminalStateError() {
 	s.Error(err)
 }
 
-// ── RecordDeclinedAttempt ────────────────────────────────────────────────────
+// ── RecordFailedAttempt ────────────────────────────────────────────────────
 
-func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_LeavesPaymentOpen() {
+func (s *PaymentLifecycleSuite) TestRecordFailedAttempt_LeavesPaymentOpen() {
 	ctx := s.GetContext()
 	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
 	s.NoError(err)
@@ -328,7 +328,7 @@ func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_LeavesPaymentOpen() {
 	s.Equal(1, attempts[0].AttemptNumber)
 }
 
-func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_IncrementsAttemptNumber() {
+func (s *PaymentLifecycleSuite) TestRecordFailedAttempt_IncrementsAttemptNumber() {
 	ctx := s.GetContext()
 	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
 	s.NoError(err)
@@ -352,7 +352,7 @@ func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_IncrementsAttemptNumbe
 	s.Equal(types.PaymentStatusPending, payment.PaymentStatus)
 }
 
-func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_ThenSuccessSettlesPayment() {
+func (s *PaymentLifecycleSuite) TestRecordFailedAttempt_ThenSuccessSettlesPayment() {
 	ctx := s.GetContext()
 	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
 	s.NoError(err)
@@ -383,7 +383,7 @@ func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_ThenSuccessSettlesPaym
 // names the transaction that settled the payment, and syncPaymentStatusFromGateway
 // prefers it over GatewayTrackingID. Pointing it at a dead transaction would make the
 // sync fetch FAILED and seal a payment the customer can still retry.
-func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_DoesNotClaimGatewayPaymentID() {
+func (s *PaymentLifecycleSuite) TestRecordFailedAttempt_DoesNotClaimGatewayPaymentID() {
 	ctx := s.GetContext()
 	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
 	s.NoError(err)
@@ -406,7 +406,40 @@ func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_DoesNotClaimGatewayPay
 		"the declined transaction belongs on the attempt")
 }
 
-func (s *PaymentLifecycleSuite) TestRecordDeclinedAttempt_RequiresPaymentID() {
+func (s *PaymentLifecycleSuite) TestRecordSucceededAttempt_AppendsWithoutSettlingParent() {
+	ctx := s.GetContext()
+	id, err := s.lifecycle.InitiatePayment(ctx, s.invoiceParams())
+	s.NoError(err)
+	s.NoError(s.lifecycle.ConfirmGatewayPayment(ctx, id, "gw_pay_030"))
+
+	s.NoError(s.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_pay_030",
+		ErrorMessage:       "card declined",
+	}))
+	s.NoError(s.lifecycle.RecordSucceededAttempt(ctx, payments.RecordSucceededAttemptParams{
+		FlexpricePaymentID: id,
+		GatewayPaymentID:   "gw_pay_031",
+	}))
+
+	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, id)
+	s.NoError(err)
+	s.Require().Len(attempts, 2)
+
+	byNumber := map[int]types.PaymentStatus{}
+	for _, a := range attempts {
+		byNumber[a.AttemptNumber] = a.PaymentStatus
+	}
+	s.Equal(types.PaymentStatusFailed, byNumber[1])
+	s.Equal(types.PaymentStatusSucceeded, byNumber[2])
+
+	payment, err := s.GetStores().PaymentRepo.Get(ctx, id)
+	s.NoError(err)
+	s.Equal(types.PaymentStatusPending, payment.PaymentStatus,
+		"recording an attempt must not settle the parent — that is RecordPaymentSuccess's job")
+}
+
+func (s *PaymentLifecycleSuite) TestRecordFailedAttempt_RequiresPaymentID() {
 	s.Error(s.lifecycle.RecordFailedAttempt(s.GetContext(), payments.RecordFailedAttemptParams{}))
 }
 

--- a/internal/integration/payments/lifecycle_test.go
+++ b/internal/integration/payments/lifecycle_test.go
@@ -318,8 +318,6 @@ func (s *PaymentLifecycleSuite) TestRecordFailedAttempt_LeavesPaymentOpen() {
 	s.NoError(err)
 	s.Equal(types.PaymentStatusPending, payment.PaymentStatus,
 		"a decline must not move the parent out of its open status")
-	s.Require().NotNil(payment.ErrorMessage)
-	s.Equal("card declined", *payment.ErrorMessage)
 
 	attempts, err := s.GetStores().PaymentRepo.ListAttempts(ctx, id)
 	s.NoError(err)

--- a/internal/integration/razorpay/webhook/handler.go
+++ b/internal/integration/razorpay/webhook/handler.go
@@ -154,7 +154,11 @@ func (h *Handler) handlePaymentCaptured(ctx context.Context, event *RazorpayWebh
 	}
 
 	// Mandate checkouts only send payment.captured — handle like payment_link.paid below.
-	if h.handleCheckoutSessionForPayment(ctx, flexpricePaymentID, payment.ID, services) {
+	handled, err := h.handleCheckoutSessionForPayment(ctx, flexpricePaymentID, payment.ID, services)
+	if err != nil {
+		return err
+	}
+	if handled {
 		return nil
 	}
 
@@ -292,30 +296,31 @@ func (h *Handler) handlePaymentFailed(ctx context.Context, event *RazorpayWebhoo
 		errorMsg = payment.ErrorDescription
 	}
 
-	session, err := h.findCheckoutSessionForPayment(ctx, flexpricePaymentID, services)
-	if err != nil {
-		h.logger.Error(ctx, "failed to look up checkout session, leaving payment open",
-			"error", err,
-			"flexprice_payment_id", flexpricePaymentID,
-			"razorpay_payment_id", payment.ID)
-		return nil
-	}
-
-	canRetryPayment := paymentRecord.PaymentMethodType == types.PaymentMethodTypePaymentLink &&
-		(session == nil || session.CheckoutStatus == types.CheckoutStatusPending)
-
-	if canRetryPayment {
-		if err := h.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
-			FlexpricePaymentID: flexpricePaymentID,
-			GatewayPaymentID:   payment.ID,
-			ErrorMessage:       errorMsg,
-		}); err != nil {
-			h.logger.Error(ctx, "failed to record failed attempt for payment link",
+	if paymentRecord.PaymentMethodType == types.PaymentMethodTypePaymentLink {
+		session, err := h.findCheckoutSessionForPayment(ctx, flexpricePaymentID, services)
+		if err != nil {
+			h.logger.Error(ctx, "failed to look up checkout session, leaving payment open",
 				"error", err,
 				"flexprice_payment_id", flexpricePaymentID,
 				"razorpay_payment_id", payment.ID)
+			return nil
 		}
-		return nil
+
+		// A session that is no longer pending has already been cleaned up, so nothing
+		// can settle this payment now and the decline is final.
+		if session == nil || session.CheckoutStatus == types.CheckoutStatusPending {
+			if err := h.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
+				FlexpricePaymentID: flexpricePaymentID,
+				GatewayPaymentID:   payment.ID,
+				ErrorMessage:       errorMsg,
+			}); err != nil {
+				h.logger.Error(ctx, "failed to record failed attempt for payment link",
+					"error", err,
+					"flexprice_payment_id", flexpricePaymentID,
+					"razorpay_payment_id", payment.ID)
+			}
+			return nil
+		}
 	}
 
 	// Update payment status to failed
@@ -390,8 +395,8 @@ func (h *Handler) handlePaymentLinkPaid(ctx context.Context, event *RazorpayWebh
 		return nil
 	}
 
-	h.handleCheckoutSessionForPayment(ctx, mappings.Items[0].EntityID, event.Payload.Payment.Entity.ID, services)
-	return nil
+	_, err = h.handleCheckoutSessionForPayment(ctx, mappings.Items[0].EntityID, event.Payload.Payment.Entity.ID, services)
+	return err
 }
 
 // handlePaymentLinkFailed processes payment_link.cancelled and payment_link.expired webhook events.
@@ -455,7 +460,7 @@ func (h *Handler) handleCheckoutSessionForPayment(
 	flexpricePaymentID string,
 	razorpayPaymentID string,
 	services *ServiceDependencies,
-) bool {
+) (bool, error) {
 	session, err := h.findCheckoutSessionForPayment(ctx, flexpricePaymentID, services)
 	if err != nil {
 		h.logger.Error(ctx, "failed to look up checkout session for payment",
@@ -463,10 +468,10 @@ func (h *Handler) handleCheckoutSessionForPayment(
 			"flexprice_payment_id", flexpricePaymentID,
 			"razorpay_payment_id", razorpayPaymentID,
 		)
-		return false
+		return false, err
 	}
 	if session == nil {
-		return false
+		return false, nil
 	}
 
 	switch session.CheckoutStatus {
@@ -497,7 +502,8 @@ func (h *Handler) handleCheckoutSessionForPayment(
 			"razorpay_payment_id", razorpayPaymentID,
 		)
 	}
-	return true
+
+	return true, nil
 }
 
 // Checkout session for this payment ID, any status. Nil if not a checkout.

--- a/internal/integration/razorpay/webhook/handler.go
+++ b/internal/integration/razorpay/webhook/handler.go
@@ -186,6 +186,16 @@ func (h *Handler) handlePaymentCaptured(ctx context.Context, event *RazorpayWebh
 		"payment_method_id", paymentMethodID,
 		"amount", amount.String())
 
+	if err := h.lifecycle.RecordSucceededAttempt(ctx, payments.RecordSucceededAttemptParams{
+		FlexpricePaymentID: flexpricePaymentID,
+		GatewayPaymentID:   payment.ID,
+	}); err != nil {
+		h.logger.Error(ctx, "failed to record succeeded attempt",
+			"error", err,
+			"flexprice_payment_id", flexpricePaymentID,
+			"razorpay_payment_id", payment.ID)
+	}
+
 	_, err = services.PaymentService.UpdatePayment(ctx, flexpricePaymentID, updateReq)
 	if err != nil {
 		h.logger.Error(ctx, "failed to update payment",

--- a/internal/integration/razorpay/webhook/handler.go
+++ b/internal/integration/razorpay/webhook/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/integration/payments"
 	"github.com/flexprice/flexprice/internal/integration/razorpay"
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -21,6 +22,7 @@ type Handler struct {
 	client                       razorpay.RazorpayClient
 	paymentSvc                   *razorpay.PaymentService
 	entityIntegrationMappingRepo entityintegrationmapping.Repository
+	lifecycle                    *payments.PaymentLifecycle
 	logger                       *logger.Logger
 }
 
@@ -29,12 +31,14 @@ func NewHandler(
 	client razorpay.RazorpayClient,
 	paymentSvc *razorpay.PaymentService,
 	entityIntegrationMappingRepo entityintegrationmapping.Repository,
+	lifecycle *payments.PaymentLifecycle,
 	logger *logger.Logger,
 ) *Handler {
 	return &Handler{
 		client:                       client,
 		paymentSvc:                   paymentSvc,
 		entityIntegrationMappingRepo: entityIntegrationMappingRepo,
+		lifecycle:                    lifecycle,
 		logger:                       logger,
 	}
 }
@@ -278,6 +282,32 @@ func (h *Handler) handlePaymentFailed(ctx context.Context, event *RazorpayWebhoo
 		errorMsg = payment.ErrorDescription
 	}
 
+	session, err := h.findCheckoutSessionForPayment(ctx, flexpricePaymentID, services)
+	if err != nil {
+		h.logger.Error(ctx, "failed to look up checkout session, leaving payment open",
+			"error", err,
+			"flexprice_payment_id", flexpricePaymentID,
+			"razorpay_payment_id", payment.ID)
+		return nil
+	}
+
+	canRetryPayment := paymentRecord.PaymentMethodType == types.PaymentMethodTypePaymentLink &&
+		(session == nil || session.CheckoutStatus == types.CheckoutStatusPending)
+
+	if canRetryPayment {
+		if err := h.lifecycle.RecordFailedAttempt(ctx, payments.RecordFailedAttemptParams{
+			FlexpricePaymentID: flexpricePaymentID,
+			GatewayPaymentID:   payment.ID,
+			ErrorMessage:       errorMsg,
+		}); err != nil {
+			h.logger.Error(ctx, "failed to record failed attempt for payment link",
+				"error", err,
+				"flexprice_payment_id", flexpricePaymentID,
+				"razorpay_payment_id", payment.ID)
+		}
+		return nil
+	}
+
 	// Update payment status to failed
 	paymentStatus := string(types.PaymentStatusFailed)
 	now := time.Now()
@@ -416,7 +446,15 @@ func (h *Handler) handleCheckoutSessionForPayment(
 	razorpayPaymentID string,
 	services *ServiceDependencies,
 ) bool {
-	session := h.findCheckoutSessionForPayment(ctx, flexpricePaymentID, services)
+	session, err := h.findCheckoutSessionForPayment(ctx, flexpricePaymentID, services)
+	if err != nil {
+		h.logger.Error(ctx, "failed to look up checkout session for payment",
+			"error", err,
+			"flexprice_payment_id", flexpricePaymentID,
+			"razorpay_payment_id", razorpayPaymentID,
+		)
+		return false
+	}
 	if session == nil {
 		return false
 	}
@@ -457,17 +495,21 @@ func (h *Handler) findCheckoutSessionForPayment(
 	ctx context.Context,
 	flexpricePaymentID string,
 	services *ServiceDependencies,
-) *dto.CheckoutSessionResponse {
+) (*dto.CheckoutSessionResponse, error) {
 	filter := types.NewDefaultCheckoutSessionFilter()
 	filter.CheckoutPaymentIDs = []string{flexpricePaymentID}
 	filter.Limit = lo.ToPtr(1)
 	filter.Status = lo.ToPtr(types.StatusPublished)
 
 	sessions, err := services.CheckoutSessionService.List(ctx, filter)
-	if err != nil || sessions == nil || len(sessions.Items) == 0 {
-		return nil
+	if err != nil {
+		return nil, err
 	}
-	return sessions.Items[0]
+	if sessions == nil || len(sessions.Items) == 0 {
+		return nil, nil
+	}
+
+	return sessions.Items[0], nil
 }
 
 // convertPaymentToMap converts a Payment struct to a map using JSON marshaling

--- a/internal/integration/razorpay/webhook/handler_test.go
+++ b/internal/integration/razorpay/webhook/handler_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/integration/payments"
 	"github.com/flexprice/flexprice/internal/integration/razorpay"
 	"github.com/flexprice/flexprice/internal/interfaces"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/suite"
 )
@@ -78,8 +80,9 @@ func (webhookTestMappingStore) Delete(_ context.Context, _ *entityintegrationmap
 
 type webhookTestPaymentService struct {
 	interfaces.PaymentService
-	payment     *dto.PaymentResponse
-	updateCalls []dto.UpdatePaymentRequest
+	payment        *dto.PaymentResponse
+	updateCalls    []dto.UpdatePaymentRequest
+	failedAttempts []dto.RecordFailedAttemptRequest
 }
 
 func (s *webhookTestPaymentService) GetPayment(_ context.Context, _ string) (*dto.PaymentResponse, error) {
@@ -90,6 +93,18 @@ func (s *webhookTestPaymentService) UpdatePayment(_ context.Context, _ string, r
 	s.updateCalls = append(s.updateCalls, req)
 	if req.PaymentStatus != nil {
 		s.payment.PaymentStatus = types.PaymentStatus(*req.PaymentStatus)
+	}
+	return s.payment, nil
+}
+
+func (s *webhookTestPaymentService) RecordFailedAttempt(_ context.Context, _ string, req dto.RecordFailedAttemptRequest) error {
+	s.failedAttempts = append(s.failedAttempts, req)
+	return nil
+}
+
+func (s *webhookTestPaymentService) GetPaymentByGatewayTrackingID(_ context.Context, trackingID, _ string) (*dto.PaymentResponse, error) {
+	if s.payment == nil || lo.FromPtr(s.payment.GatewayTrackingID) != trackingID {
+		return nil, nil
 	}
 	return s.payment, nil
 }
@@ -115,10 +130,14 @@ func (webhookTestInvoiceService) ReconcilePaymentStatus(_ context.Context, _ str
 type webhookTestCheckoutSessionService struct {
 	interfaces.CheckoutSessionService
 	session       *dto.CheckoutSessionResponse // returned by List, matched by session.ID (see note on suite below)
+	listErr       error
 	completeCalls []string
 }
 
 func (s *webhookTestCheckoutSessionService) List(_ context.Context, filter *types.CheckoutSessionFilter) (*dto.ListCheckoutSessionsResponse, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
 	if s.session == nil || len(filter.CheckoutPaymentIDs) == 0 || filter.CheckoutPaymentIDs[0] != s.session.ID {
 		return &dto.ListCheckoutSessionsResponse{}, nil
 	}
@@ -176,7 +195,12 @@ func (s *WebhookCheckoutBranchingSuite) SetupTest() {
 
 	s.client = &webhookTestRazorpayClient{}
 	s.paymentSvc = &webhookTestPaymentService{
-		payment: &dto.PaymentResponse{ID: "pay_flex_001", PaymentStatus: types.PaymentStatusInitiated},
+		payment: &dto.PaymentResponse{
+			ID:                "pay_flex_001",
+			PaymentStatus:     types.PaymentStatusInitiated,
+			PaymentMethodType: types.PaymentMethodTypePaymentLink,
+			GatewayTrackingID: lo.ToPtr("plink_test001"),
+		},
 	}
 	s.checkoutSvc = &webhookTestCheckoutSessionService{}
 	s.mappingSvc = &webhookTestMappingService{
@@ -186,7 +210,8 @@ func (s *WebhookCheckoutBranchingSuite) SetupTest() {
 	razorpayPaymentSvc := razorpay.NewPaymentService(
 		s.client, nil, nil, webhookTestLocker{}, logger.NewNoopLogger(),
 	)
-	s.handler = NewHandler(s.client, razorpayPaymentSvc, webhookTestMappingStore{}, logger.NewNoopLogger())
+	lifecycle := payments.NewPaymentLifecycle(s.paymentSvc, webhookTestInvoiceService{}, logger.NewNoopLogger())
+	s.handler = NewHandler(s.client, razorpayPaymentSvc, webhookTestMappingStore{}, lifecycle, logger.NewNoopLogger())
 
 	s.services = &ServiceDependencies{
 		PaymentService:                  s.paymentSvc,
@@ -295,6 +320,151 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentCaptured_FailedSession_Refund
 	s.NoError(err)
 	s.Require().Len(s.client.refundCalls, 1)
 	s.Equal("pay_rzp_001", s.client.refundCalls[0])
+}
+
+// ── payment.failed: a decline is one attempt, not our decision to stop ───────
+
+func (s *WebhookCheckoutBranchingSuite) makeFailedEvent() *RazorpayWebhookEvent {
+	event := &RazorpayWebhookEvent{Event: string(EventPaymentFailed)}
+	event.Payload.Payment.Entity.ID = "pay_rzp_001"
+	event.Payload.Payment.Entity.ErrorDescription = "card declined"
+	event.Payload.Payment.Entity.Notes = map[string]interface{}{"flexprice_payment_id": "pay_flex_001"}
+	return event
+}
+
+func (s *WebhookCheckoutBranchingSuite) pendingSession() {
+	s.checkoutSvc.session = &dto.CheckoutSessionResponse{
+		CheckoutSession: &domainCheckout.CheckoutSession{ID: "pay_flex_001", CheckoutStatus: types.CheckoutStatusPending},
+	}
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_PendingSession_RecordsAttemptAndLeavesPaymentOpen() {
+	s.pendingSession()
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
+
+	s.NoError(err)
+	s.Require().Len(s.paymentSvc.failedAttempts, 1)
+	s.Equal("card declined", s.paymentSvc.failedAttempts[0].ErrorMessage)
+	s.Equal("pay_rzp_001", s.paymentSvc.failedAttempts[0].GatewayAttemptID)
+	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
+		"a decline on an open checkout session must not seal the payment")
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_RepeatedDeclines_RecordEachAttempt() {
+	s.pendingSession()
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	s.NoError(s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services))
+	s.NoError(s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services))
+
+	s.Len(s.paymentSvc.failedAttempts, 2)
+	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus)
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_StandaloneLink_LeavesPaymentOpen() {
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
+
+	s.NoError(err)
+	s.Require().Len(s.paymentSvc.failedAttempts, 1)
+	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
+		"a standalone payment link stays open too — the customer can retry on the same link")
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_NonLinkPayment_SealsPayment() {
+	s.paymentSvc.payment.PaymentMethodType = types.PaymentMethodTypeCard
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
+
+	s.NoError(err)
+	s.Empty(s.paymentSvc.failedAttempts)
+	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus,
+		"a one-shot card charge has no retry vehicle, so a decline is final")
+}
+
+func (s *WebhookCheckoutBranchingSuite) makeLinkExpiredEvent(paymentLinkID string) *RazorpayWebhookEvent {
+	event := &RazorpayWebhookEvent{Event: string(EventPaymentLinkExpired)}
+	event.Payload.PaymentLink.Entity.ID = paymentLinkID
+	return event
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentLinkExpired_StandaloneLink_ClosesPayment() {
+	// No mapping for this link id, so it resolves via gateway_tracking_id instead.
+	s.mappingSvc.entityIDByProviderEntityID = map[string]string{}
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentLinkFailed(s.ctx, s.makeLinkExpiredEvent("plink_test001"), s.services)
+
+	s.NoError(err)
+	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus,
+		"a dead link is the point at which we have stopped trying")
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentLinkExpired_StandaloneLink_KeepsSucceededPayment() {
+	s.mappingSvc.entityIDByProviderEntityID = map[string]string{}
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusSucceeded
+
+	err := s.handler.handlePaymentLinkFailed(s.ctx, s.makeLinkExpiredEvent("plink_test001"), s.services)
+
+	s.NoError(err)
+	s.Equal(types.PaymentStatusSucceeded, s.paymentSvc.payment.PaymentStatus)
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentLinkExpired_UnknownLink_NoOp() {
+	s.mappingSvc.entityIDByProviderEntityID = map[string]string{}
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentLinkFailed(s.ctx, s.makeLinkExpiredEvent("plink_unknown"), s.services)
+
+	s.NoError(err)
+	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus)
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_NonPendingSession_SealsPayment() {
+	s.checkoutSvc.session = &dto.CheckoutSessionResponse{
+		CheckoutSession: &domainCheckout.CheckoutSession{ID: "pay_flex_001", CheckoutStatus: types.CheckoutStatusExpired},
+	}
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
+
+	s.NoError(err)
+	s.Empty(s.paymentSvc.failedAttempts)
+	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus)
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_SessionLookupError_DoesNotSeal() {
+	s.checkoutSvc.listErr = ierr.NewError("db unavailable").Mark(ierr.ErrDatabase)
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
+
+	s.NoError(err)
+	s.Empty(s.paymentSvc.failedAttempts)
+	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
+		"an unreadable session must fail open: sealing a live payment loses the capture")
+}
+
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_ThenCaptured_Succeeds() {
+	s.pendingSession()
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	s.NoError(s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services))
+
+	captured := &RazorpayWebhookEvent{Event: string(EventPaymentCaptured)}
+	captured.Payload.Payment.Entity.ID = "pay_rzp_002"
+	captured.Payload.Payment.Entity.Amount = 50000
+	captured.Payload.Payment.Entity.Currency = "INR"
+	captured.Payload.Payment.Entity.Notes = map[string]interface{}{"flexprice_payment_id": "pay_flex_001"}
+
+	s.NoError(s.handler.handlePaymentCaptured(s.ctx, captured, s.services))
+
+	s.Require().Len(s.checkoutSvc.completeCalls, 1,
+		"the retry must still complete the checkout session")
 }
 
 func (s *WebhookCheckoutBranchingSuite) TestPaymentCaptured_NoSessionFound_FallsThroughToStandalone() {

--- a/internal/integration/razorpay/webhook/handler_test.go
+++ b/internal/integration/razorpay/webhook/handler_test.go
@@ -416,6 +416,41 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_SessionLookupError_Doe
 		"an unreadable session must fail open: sealing a live payment loses the capture")
 }
 
+// A card charge is finished when it declines, so a checkout-session outage must not
+// stop it sealing. Only payment links need the lookup at all.
+func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_NonLinkSealsEvenIfSessionLookupFails() {
+	s.checkoutSvc.listErr = ierr.NewError("db unavailable").Mark(ierr.ErrDatabase)
+	s.paymentSvc.payment.PaymentMethodType = types.PaymentMethodTypeCard
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
+
+	s.NoError(err)
+	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus,
+		"a card decline must seal regardless of checkout-session availability")
+}
+
+// If the lookup fails we cannot tell whether this payment belongs to a dead checkout.
+// Falling through to the standalone branch would settle it and reconcile an archived
+// invoice instead of refunding the late capture; leaving it PENDING is recoverable.
+func (s *WebhookCheckoutBranchingSuite) TestPaymentCaptured_SessionLookupError_DoesNotSettle() {
+	s.checkoutSvc.listErr = ierr.NewError("db unavailable").Mark(ierr.ErrDatabase)
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	captured := &RazorpayWebhookEvent{Event: string(EventPaymentCaptured)}
+	captured.Payload.Payment.Entity.ID = "pay_rzp_late"
+	captured.Payload.Payment.Entity.Amount = 50000
+	captured.Payload.Payment.Entity.Currency = "INR"
+	captured.Payload.Payment.Entity.Notes = map[string]interface{}{"flexprice_payment_id": "pay_flex_001"}
+
+	err := s.handler.handlePaymentCaptured(s.ctx, captured, s.services)
+
+	s.Error(err, "an unreadable session is surfaced, not swallowed")
+	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
+		"an unreadable session must not be treated as 'no session' and settled")
+	s.Empty(s.client.refundCalls)
+}
+
 func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_ThenCaptured_Succeeds() {
 	s.pendingSession()
 	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending

--- a/internal/integration/razorpay/webhook/handler_test.go
+++ b/internal/integration/razorpay/webhook/handler_test.go
@@ -80,9 +80,9 @@ func (webhookTestMappingStore) Delete(_ context.Context, _ *entityintegrationmap
 
 type webhookTestPaymentService struct {
 	interfaces.PaymentService
-	payment        *dto.PaymentResponse
-	updateCalls    []dto.UpdatePaymentRequest
-	failedAttempts []dto.RecordFailedAttemptRequest
+	payment     *dto.PaymentResponse
+	updateCalls []dto.UpdatePaymentRequest
+	attempts    []dto.RecordAttemptRequest
 }
 
 func (s *webhookTestPaymentService) GetPayment(_ context.Context, _ string) (*dto.PaymentResponse, error) {
@@ -97,16 +97,21 @@ func (s *webhookTestPaymentService) UpdatePayment(_ context.Context, _ string, r
 	return s.payment, nil
 }
 
-func (s *webhookTestPaymentService) RecordFailedAttempt(_ context.Context, _ string, req dto.RecordFailedAttemptRequest) error {
-	s.failedAttempts = append(s.failedAttempts, req)
+func (s *webhookTestPaymentService) RecordAttempt(_ context.Context, _ string, req dto.RecordAttemptRequest) error {
+	s.attempts = append(s.attempts, req)
 	return nil
 }
 
-func (s *webhookTestPaymentService) GetPaymentByGatewayTrackingID(_ context.Context, trackingID, _ string) (*dto.PaymentResponse, error) {
-	if s.payment == nil || lo.FromPtr(s.payment.GatewayTrackingID) != trackingID {
-		return nil, nil
+// failedAttempts returns only the declined attempts, so assertions stay focused on
+// charge failures rather than every attempt the handler records.
+func (s *webhookTestPaymentService) failedAttempts() []dto.RecordAttemptRequest {
+	var out []dto.RecordAttemptRequest
+	for _, a := range s.attempts {
+		if a.PaymentStatus == types.PaymentStatusFailed {
+			out = append(out, a)
+		}
 	}
-	return s.payment, nil
+	return out
 }
 
 // ── fake interfaces.InvoiceService — used only by handlePaymentCaptured's standalone fallback ──
@@ -345,9 +350,9 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_PendingSession_Records
 	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
 
 	s.NoError(err)
-	s.Require().Len(s.paymentSvc.failedAttempts, 1)
-	s.Equal("card declined", s.paymentSvc.failedAttempts[0].ErrorMessage)
-	s.Equal("pay_rzp_001", s.paymentSvc.failedAttempts[0].GatewayAttemptID)
+	s.Require().Len(s.paymentSvc.failedAttempts(), 1)
+	s.Equal("card declined", s.paymentSvc.failedAttempts()[0].ErrorMessage)
+	s.Equal("pay_rzp_001", s.paymentSvc.failedAttempts()[0].GatewayAttemptID)
 	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
 		"a decline on an open checkout session must not seal the payment")
 }
@@ -359,7 +364,7 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_RepeatedDeclines_Recor
 	s.NoError(s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services))
 	s.NoError(s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services))
 
-	s.Len(s.paymentSvc.failedAttempts, 2)
+	s.Len(s.paymentSvc.failedAttempts(), 2)
 	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus)
 }
 
@@ -369,7 +374,7 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_StandaloneLink_LeavesP
 	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
 
 	s.NoError(err)
-	s.Require().Len(s.paymentSvc.failedAttempts, 1)
+	s.Require().Len(s.paymentSvc.failedAttempts(), 1)
 	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
 		"a standalone payment link stays open too — the customer can retry on the same link")
 }
@@ -381,47 +386,9 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_NonLinkPayment_SealsPa
 	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
 
 	s.NoError(err)
-	s.Empty(s.paymentSvc.failedAttempts)
+	s.Empty(s.paymentSvc.failedAttempts())
 	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus,
 		"a one-shot card charge has no retry vehicle, so a decline is final")
-}
-
-func (s *WebhookCheckoutBranchingSuite) makeLinkExpiredEvent(paymentLinkID string) *RazorpayWebhookEvent {
-	event := &RazorpayWebhookEvent{Event: string(EventPaymentLinkExpired)}
-	event.Payload.PaymentLink.Entity.ID = paymentLinkID
-	return event
-}
-
-func (s *WebhookCheckoutBranchingSuite) TestPaymentLinkExpired_StandaloneLink_ClosesPayment() {
-	// No mapping for this link id, so it resolves via gateway_tracking_id instead.
-	s.mappingSvc.entityIDByProviderEntityID = map[string]string{}
-	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
-
-	err := s.handler.handlePaymentLinkFailed(s.ctx, s.makeLinkExpiredEvent("plink_test001"), s.services)
-
-	s.NoError(err)
-	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus,
-		"a dead link is the point at which we have stopped trying")
-}
-
-func (s *WebhookCheckoutBranchingSuite) TestPaymentLinkExpired_StandaloneLink_KeepsSucceededPayment() {
-	s.mappingSvc.entityIDByProviderEntityID = map[string]string{}
-	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusSucceeded
-
-	err := s.handler.handlePaymentLinkFailed(s.ctx, s.makeLinkExpiredEvent("plink_test001"), s.services)
-
-	s.NoError(err)
-	s.Equal(types.PaymentStatusSucceeded, s.paymentSvc.payment.PaymentStatus)
-}
-
-func (s *WebhookCheckoutBranchingSuite) TestPaymentLinkExpired_UnknownLink_NoOp() {
-	s.mappingSvc.entityIDByProviderEntityID = map[string]string{}
-	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
-
-	err := s.handler.handlePaymentLinkFailed(s.ctx, s.makeLinkExpiredEvent("plink_unknown"), s.services)
-
-	s.NoError(err)
-	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus)
 }
 
 func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_NonPendingSession_SealsPayment() {
@@ -433,7 +400,7 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_NonPendingSession_Seal
 	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
 
 	s.NoError(err)
-	s.Empty(s.paymentSvc.failedAttempts)
+	s.Empty(s.paymentSvc.failedAttempts())
 	s.Equal(types.PaymentStatusFailed, s.paymentSvc.payment.PaymentStatus)
 }
 
@@ -444,7 +411,7 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_SessionLookupError_Doe
 	err := s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services)
 
 	s.NoError(err)
-	s.Empty(s.paymentSvc.failedAttempts)
+	s.Empty(s.paymentSvc.failedAttempts())
 	s.Equal(types.PaymentStatusPending, s.paymentSvc.payment.PaymentStatus,
 		"an unreadable session must fail open: sealing a live payment loses the capture")
 }
@@ -465,6 +432,28 @@ func (s *WebhookCheckoutBranchingSuite) TestPaymentFailed_ThenCaptured_Succeeds(
 
 	s.Require().Len(s.checkoutSvc.completeCalls, 1,
 		"the retry must still complete the checkout session")
+}
+
+// The winning charge belongs in the ledger too: without it the attempt history shows
+// only declines and never says which transaction actually collected the money.
+func (s *WebhookCheckoutBranchingSuite) TestPaymentCaptured_Standalone_RecordsSucceededAttempt() {
+	s.paymentSvc.payment.PaymentStatus = types.PaymentStatusPending
+
+	s.NoError(s.handler.handlePaymentFailed(s.ctx, s.makeFailedEvent(), s.services))
+
+	captured := &RazorpayWebhookEvent{Event: string(EventPaymentCaptured)}
+	captured.Payload.Payment.Entity.ID = "pay_rzp_002"
+	captured.Payload.Payment.Entity.Amount = 50000
+	captured.Payload.Payment.Entity.Currency = "INR"
+	captured.Payload.Payment.Entity.Notes = map[string]interface{}{"flexprice_payment_id": "pay_flex_001"}
+	s.NoError(s.handler.handlePaymentCaptured(s.ctx, captured, s.services))
+
+	s.Require().Len(s.paymentSvc.attempts, 2, "one decline then one capture")
+	s.Equal(types.PaymentStatusFailed, s.paymentSvc.attempts[0].PaymentStatus)
+	s.Equal(types.PaymentStatusSucceeded, s.paymentSvc.attempts[1].PaymentStatus)
+	s.Equal("pay_rzp_002", s.paymentSvc.attempts[1].GatewayAttemptID,
+		"the succeeded attempt names the transaction that collected")
+	s.Equal(types.PaymentStatusSucceeded, s.paymentSvc.payment.PaymentStatus)
 }
 
 func (s *WebhookCheckoutBranchingSuite) TestPaymentCaptured_NoSessionFound_FallsThroughToStandalone() {

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -34,6 +34,9 @@ type PaymentService interface {
 	DeletePayment(ctx context.Context, id string) error
 	GetPaymentByGatewayTrackingID(ctx context.Context, gatewayTrackingID, gateway string) (*dto.PaymentResponse, error)
 	PaymentExistsByGatewayPaymentID(ctx context.Context, gatewayPaymentID string) (bool, error)
+	// RecordFailedAttempt records a gateway decline as a FAILED attempt, leaving the
+	// parent payment's status untouched so a retry can still settle it.
+	RecordFailedAttempt(ctx context.Context, paymentID string, req dto.RecordFailedAttemptRequest) error
 	// CreatePaymentForCheckout creates a minimal INITIATED payment record for a checkout
 	// session without triggering payment lifecycle processing.
 	// TODO: migrate to full payment lifecycle method when payment lifecycle service is released

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -34,9 +34,9 @@ type PaymentService interface {
 	DeletePayment(ctx context.Context, id string) error
 	GetPaymentByGatewayTrackingID(ctx context.Context, gatewayTrackingID, gateway string) (*dto.PaymentResponse, error)
 	PaymentExistsByGatewayPaymentID(ctx context.Context, gatewayPaymentID string) (bool, error)
-	// RecordFailedAttempt records a gateway decline as a FAILED attempt, leaving the
-	// parent payment's status untouched so a retry can still settle it.
-	RecordFailedAttempt(ctx context.Context, paymentID string, req dto.RecordFailedAttemptRequest) error
+	// RecordAttempt appends the gateway's outcome for one charge attempt, leaving the
+	// parent payment's status untouched.
+	RecordAttempt(ctx context.Context, paymentID string, req dto.RecordAttemptRequest) error
 	// CreatePaymentForCheckout creates a minimal INITIATED payment record for a checkout
 	// session without triggering payment lifecycle processing.
 	// TODO: migrate to full payment lifecycle method when payment lifecycle service is released

--- a/internal/repository/ent/payment.go
+++ b/internal/repository/ent/payment.go
@@ -429,7 +429,9 @@ func (r *paymentRepository) delete(ctx context.Context, id string, expectedStatu
 
 	affected, err := client.Payment.Update().
 		Where(predicates...).
-		SetPaymentStatus(string(types.StatusArchived)).
+		SetStatus(string(types.StatusArchived)).
+		SetUpdatedBy(types.GetUserID(ctx)).
+		SetUpdatedAt(time.Now().UTC()).
 		Save(ctx)
 
 	if err != nil {

--- a/internal/testutil/inmemory_payment_store.go
+++ b/internal/testutil/inmemory_payment_store.go
@@ -190,31 +190,21 @@ func (m *InMemoryPaymentStore) DeleteWithExpectedStatus(ctx context.Context, id 
 	return m.Delete(ctx, id)
 }
 
+// Delete archives the payment, mirroring the real repository: the row survives with
+// status=archived and its payment_status intact, so callers can still read why the
+// payment ended.
 func (m *InMemoryPaymentStore) Delete(ctx context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// First check if the payment exists
-	_, err := m.InMemoryStore.Get(ctx, id)
+	p, err := m.InMemoryStore.Get(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	// Remove from InMemoryStore
-	err = m.InMemoryStore.Delete(ctx, id)
-	if err != nil {
-		return err
-	}
+	p.Status = types.StatusArchived
 
-	// Remove from createdInOrder
-	for i, payment := range m.createdInOrder {
-		if payment.ID == id {
-			m.createdInOrder = append(m.createdInOrder[:i], m.createdInOrder[i+1:]...)
-			break
-		}
-	}
-
-	return nil
+	return m.InMemoryStore.Update(ctx, id, p)
 }
 
 // GetByIdempotencyKey retrieves a payment by idempotency key

--- a/internal/testutil/inmemory_payment_store.go
+++ b/internal/testutil/inmemory_payment_store.go
@@ -207,17 +207,21 @@ func (m *InMemoryPaymentStore) Delete(ctx context.Context, id string) error {
 	return m.InMemoryStore.Update(ctx, id, p)
 }
 
-// GetByIdempotencyKey retrieves a payment by idempotency key
+// GetByIdempotencyKey retrieves a payment by idempotency key.
+//
+// This scans directly rather than going through List: the real repository matches
+// only on (idempotency_key, tenant_id, environment_id) with no status predicate, so
+// it still finds an archived payment. List applies the published-only default, which
+// would hide one and turn an idempotency conflict into a spurious not-found.
 func (m *InMemoryPaymentStore) GetByIdempotencyKey(ctx context.Context, key string) (*payment.Payment, error) {
-	payments, err := m.List(ctx, &types.PaymentFilter{
-		QueryFilter: types.NewNoLimitQueryFilter(),
-	})
-	if err != nil {
-		return nil, err
-	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
-	for _, p := range payments {
-		if p.IdempotencyKey == key {
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	for _, p := range m.createdInOrder {
+		if p.IdempotencyKey == key && p.TenantID == tenantID && p.EnvironmentID == environmentID {
 			return p, nil
 		}
 	}
@@ -400,6 +404,16 @@ func paymentFilterFn(ctx context.Context, p *payment.Payment, filter interface{}
 
 	// Apply environment filter
 	if !CheckEnvironmentFilter(ctx, p.EnvironmentID) {
+		return false
+	}
+
+	// Mirror PaymentQueryOptions.ApplyStatusFilter: an unset status means published only,
+	// so archived payments drop out of listings here exactly as they do in the repository.
+	if f.GetStatus() == "" {
+		if p.Status != types.StatusPublished {
+			return false
+		}
+	} else if string(p.Status) != f.GetStatus() {
 		return false
 	}
 

--- a/internal/testutil/inmemory_payment_store.go
+++ b/internal/testutil/inmemory_payment_store.go
@@ -334,11 +334,9 @@ func (m *InMemoryPaymentStore) ListAttempts(ctx context.Context, paymentID strin
 		}
 	}
 
-	if len(result) == 0 {
-		return nil, ierr.NewError("no attempts found").
-			WithHint(fmt.Sprintf("No attempts found for payment: %s", paymentID)).
-			Mark(ierr.ErrNotFound)
-	}
+	// No not-found here: the real repository runs a plain query and returns an empty
+	// slice for a payment with no attempts. Inventing an error would let code that
+	// mishandles "no attempts yet" pass against this store and fail against Postgres.
 
 	// Sort by attempt number (ascending)
 	sort.Slice(result, func(i, j int) bool {


### PR DESCRIPTION
## **User description**
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added payment-attempt tracking for successful and failed gateway transactions.
  * Failed attempts retain error details and keep payments open for retry.
  * Successful retries settle payments and finalize checkout invoices correctly.
  * Attempt history records sequential outcomes and gateway payment identifiers.

* **Bug Fixes**
  * Improved webhook handling for declines, retries, and checkout lookup errors.
  * Archived payments remain available with payment status preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Keep retryable payment links open after declines and record every charge outcome

### What Changed
- Declined charges on active payment links are recorded as failed attempts while the payment remains open for another retry.
- Successful retries record the charge that collected payment, then settle the payment and reconcile the invoice.
- Attempt history now keeps sequential gateway IDs and decline messages without assigning failed transactions as the payment’s final gateway transaction.
- Non-retryable payments and inactive checkout sessions still become failed after a decline.
- Payment lookup and webhook handling preserve payment state when checkout-session data cannot be read, and archived payments retain their status and idempotency records.

### Impact
`✅ Payment links remain retryable after declined charges`
`✅ Complete failed and successful charge history`
`✅ Fewer unreconciled payments and invoices`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
