### PR TITLE
fix(saml): validate SSO tokens against the schema that mints them

### DIFF
--- a/internal/auth/sso_token.go
+++ b/internal/auth/sso_token.go
@@ -1,0 +1,187 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/flexprice/flexprice/internal/config"
+	domainauth "github.com/flexprice/flexprice/internal/domain/auth"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+// ssoTokenClaim marks a token as minted by the SSO flow.
+//
+// This claim decides nothing on its own. It is checked AFTER the signature and
+// only on a deployment that has SAML switched on, so it distinguishes an SSO
+// token from an ordinary one — it never grants trust by itself. Treating a claim
+// as authority would be the mistake this design exists to avoid: claims travel
+// inside the token, so anyone able to mint one could set it.
+const ssoTokenClaim = "flexprice_sso"
+
+// SSO tokens carry the flexprice claim schema — user_id and tenant_id — rather
+// than the Supabase one, because the user they name exists only in our own
+// database. An identity provider assertion creates a Flexprice user; there is no
+// corresponding Supabase account for Supabase to have issued a token for.
+const (
+	ssoClaimTenantID      = "tenant_id"
+	ssoClaimUserID        = "user_id"
+	ssoClaimEnvironmentID = "environment_id"
+)
+
+// SSOTokenIssuer mints the token handed to the browser after an assertion is
+// accepted.
+type SSOTokenIssuer struct {
+	secret string
+}
+
+func NewSSOTokenIssuer(cfg *config.Configuration) *SSOTokenIssuer {
+	return &SSOTokenIssuer{secret: cfg.Auth.Secret}
+}
+
+// Issue mints a token for a user an identity provider has just authenticated.
+//
+// Both identities are required. The middleware scopes every request by the
+// tenant and user a token names, so a token naming neither would widen that
+// scope rather than narrow it — better to fail at the point of minting than to
+// hand out a token whose scope is undefined.
+func (i *SSOTokenIssuer) Issue(tenantID, userID string, expiryHours int) (string, time.Time, error) {
+	if strings.TrimSpace(tenantID) == "" {
+		return "", time.Time{}, ierr.NewError("tenantID is required").
+			WithHint("A SSO token must name the tenant it belongs to").
+			Mark(ierr.ErrValidation)
+	}
+	if strings.TrimSpace(userID) == "" {
+		return "", time.Time{}, ierr.NewError("userID is required").
+			WithHint("A SSO token must name the user it belongs to").
+			Mark(ierr.ErrValidation)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(expiryHours) * time.Hour)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		ssoClaimTenantID: tenantID,
+		ssoClaimUserID:   userID,
+		ssoTokenClaim:    true,
+		"exp":            expiresAt.Unix(),
+		"iat":            time.Now().Unix(),
+	})
+
+	signed, err := token.SignedString([]byte(i.secret))
+	if err != nil {
+		return "", time.Time{}, ierr.WithError(err).
+			WithHint("Failed to sign the SSO token").
+			Mark(ierr.ErrSystem)
+	}
+	return signed, expiresAt, nil
+}
+
+// SSOTokenValidator accepts tokens minted by SSOTokenIssuer.
+//
+// It exists because the provider that handles password login is not necessarily
+// the one that can validate an SSO token. A deployment using Supabase for
+// passwords validates those tokens against the Supabase claim schema (`sub`,
+// `app_metadata.tenant_id`); a SAML login mints Flexprice claims for a user that
+// has no Supabase account at all, so that validator rejected them and every
+// request after a successful SSO login came back 401.
+type SSOTokenValidator struct {
+	secret      string
+	samlEnabled bool
+}
+
+func NewSSOTokenValidator(cfg *config.Configuration) *SSOTokenValidator {
+	return &SSOTokenValidator{
+		secret:      cfg.Auth.Secret,
+		samlEnabled: cfg.Auth.SAML.Enabled,
+	}
+}
+
+// Validate accepts only a token this deployment's SSO flow could have minted.
+//
+// Three conditions, in this order, none of which the caller controls:
+//
+//  1. The deployment offers SAML. A deployment with SSO switched off accepts no
+//     SSO token at all, so turning SAML on is the only thing that widens what
+//     the API accepts — a deployment that does not use SSO is unaffected by any
+//     of this.
+//  2. The signature verifies against auth.secret, with the algorithm pinned to
+//     HMAC. Pinning matters: `alg=none` and an RSA-public-key-as-HMAC-secret
+//     confusion are both standard JWT forgeries.
+//  3. The token carries the SSO marker. Both providers sign with the same
+//     secret, so without this check the SSO path would become a second way to
+//     validate any token signed with it — including a session or checkout token
+//     never meant to authenticate a dashboard request.
+//
+// A token that passes still authenticates nothing by itself: the middleware
+// loads the named user, refuses one that is archived or missing, and takes the
+// session's roles from that record rather than from any claim. So a token can
+// name an identity but never grant itself privileges.
+func (v *SSOTokenValidator) Validate(_ context.Context, tokenString string) (*domainauth.Claims, error) {
+	if !v.samlEnabled {
+		return nil, ierr.NewError("sso is not enabled on this deployment").
+			WithHint("Single sign-on is not available").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	parsed, err := jwt.Parse(tokenString, func(token *jwt.Token) (any, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, ierr.NewError("unexpected signing method").
+				WithHint("Unexpected signing method").
+				Mark(ierr.ErrPermissionDenied)
+		}
+		return []byte(v.secret), nil
+	})
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Invalid token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok || !parsed.Valid {
+		return nil, ierr.NewError("invalid token claims").
+			WithHint("Invalid token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	if marker, ok := claims[ssoTokenClaim].(bool); !ok || !marker {
+		return nil, ierr.NewError("token was not issued by the sso flow").
+			WithHint("Invalid token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	tenantID, _ := claims[ssoClaimTenantID].(string)
+	userID, _ := claims[ssoClaimUserID].(string)
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(userID) == "" {
+		return nil, ierr.NewError("token missing identity claims").
+			WithHint("Invalid token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	environmentID, _ := claims[ssoClaimEnvironmentID].(string)
+
+	return &domainauth.Claims{
+		UserID:        userID,
+		TenantID:      tenantID,
+		EnvironmentID: environmentID,
+	}, nil
+}
+
+// IsSSOToken reports whether a token claims to have come from the SSO flow.
+//
+// Used only to decide WHICH validator to run, never whether to trust the token:
+// the chosen validator then verifies the signature and re-checks this marker
+// itself. Reading an unverified claim is safe for routing precisely because
+// being routed to the SSO validator is not an advantage — that validator is
+// strictly stricter than the ordinary one, requiring both a valid signature and
+// the marker.
+func IsSSOToken(tokenString string) bool {
+	parser := jwt.Parser{SkipClaimsValidation: true}
+	claims := jwt.MapClaims{}
+	if _, _, err := parser.ParseUnverified(tokenString, claims); err != nil {
+		return false
+	}
+	marker, ok := claims[ssoTokenClaim].(bool)
+	return ok && marker
+}

--- a/internal/auth/sso_token.go
+++ b/internal/auth/sso_token.go
@@ -58,14 +58,26 @@ func (i *SSOTokenIssuer) Issue(tenantID, userID string, expiryHours int) (string
 			WithHint("A SSO token must name the user it belongs to").
 			Mark(ierr.ErrValidation)
 	}
+	// A non-positive expiry mints a token that is already expired while still
+	// returning a future expiresAt to the caller, so the login appears to
+	// succeed and fails as a 401 on the first dashboard request — the same
+	// mint-succeeds-verify-fails shape this type exists to prevent.
+	if expiryHours <= 0 {
+		return "", time.Time{}, ierr.NewError("expiryHours must be positive").
+			WithHint("A SSO token must expire in the future").
+			Mark(ierr.ErrValidation)
+	}
 
-	expiresAt := time.Now().Add(time.Duration(expiryHours) * time.Hour)
+	// One clock reading for both claims: taken separately, iat can land after
+	// exp for a sufficiently small expiry.
+	now := time.Now()
+	expiresAt := now.Add(time.Duration(expiryHours) * time.Hour)
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		ssoClaimTenantID: tenantID,
 		ssoClaimUserID:   userID,
 		ssoTokenClaim:    true,
 		"exp":            expiresAt.Unix(),
-		"iat":            time.Now().Unix(),
+		"iat":            now.Unix(),
 	})
 
 	signed, err := token.SignedString([]byte(i.secret))

--- a/internal/auth/sso_token_test.go
+++ b/internal/auth/sso_token_test.go
@@ -1,0 +1,278 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+const testSecret = "test-secret-key-32-bytes-minimum!"
+
+func ssoTestConfig(provider types.AuthProvider, samlEnabled bool) *config.Configuration {
+	cfg := &config.Configuration{}
+	cfg.Auth.Provider = provider
+	cfg.Auth.Secret = testSecret
+	cfg.Auth.SAML.Enabled = samlEnabled
+	return cfg
+}
+
+// mintSSOToken produces what the SAML ACS handler issues.
+func mintSSOToken(t *testing.T, cfg *config.Configuration, tenantID, userID string) string {
+	t.Helper()
+	token, _, err := NewSSOTokenIssuer(cfg).Issue(tenantID, userID, 24)
+	require.NoError(t, err)
+	return token
+}
+
+// TestSSOTokenRoundTrip is the bug this exists for: a deployment whose password
+// provider is Supabase could not validate the token its own SAML login minted,
+// because the two use different claim names. The SSO validator has to accept it
+// regardless of which provider handles password login.
+func TestSSOTokenRoundTrip(t *testing.T) {
+	for _, provider := range []types.AuthProvider{types.AuthProviderSupabase, types.AuthProviderFlexprice} {
+		t.Run(string(provider), func(t *testing.T) {
+			cfg := ssoTestConfig(provider, true)
+			token := mintSSOToken(t, cfg, "tenant_1", "user_1")
+
+			claims, err := NewSSOTokenValidator(cfg).Validate(context.Background(), token)
+			require.NoError(t, err)
+			assert.Equal(t, "tenant_1", claims.TenantID)
+			assert.Equal(t, "user_1", claims.UserID)
+		})
+	}
+}
+
+// ── Security properties ─────────────────────────────────────────────────────
+//
+// Both providers sign with the same auth.secret, so a signature alone cannot
+// prove a token came from the SSO flow. These cover what must hold anyway.
+
+// A deployment that does not offer SAML must not accept an SSO token at all,
+// so enabling SAML is the only thing that widens what the API accepts.
+func TestSSOTokenRejectedWhenSAMLDisabled(t *testing.T) {
+	minting := ssoTestConfig(types.AuthProviderSupabase, true)
+	token := mintSSOToken(t, minting, "tenant_1", "user_1")
+
+	disabled := ssoTestConfig(types.AuthProviderSupabase, false)
+	_, err := NewSSOTokenValidator(disabled).Validate(context.Background(), token)
+
+	require.Error(t, err, "a deployment with SAML off must refuse an SSO token")
+}
+
+// An ordinary token — one without the SSO marker — must NOT be accepted by the
+// SSO validator. Otherwise the SSO path would become a second, weaker way to
+// validate any token signed with the shared secret.
+func TestSSOValidatorRejectsNonSSOToken(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	plain := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"tenant_id": "tenant_1",
+		"user_id":   "user_1",
+		"exp":       time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := plain.SignedString([]byte(testSecret))
+	require.NoError(t, err)
+
+	_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+	require.Error(t, err, "a token without the SSO marker must not validate as SSO")
+}
+
+// A token signed with a different secret must never validate, marker or not.
+func TestSSOValidatorRejectsForeignSignature(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	forged := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"tenant_id":   "tenant_1",
+		"user_id":     "attacker",
+		ssoTokenClaim: true,
+		"exp":         time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := forged.SignedString([]byte("a-completely-different-secret-key"))
+	require.NoError(t, err)
+
+	_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+	require.Error(t, err, "a token signed with another secret must be refused")
+}
+
+// alg=none must be refused; accepting it would let anyone mint any identity.
+func TestSSOValidatorRejectsUnsignedToken(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	unsigned := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"tenant_id":   "tenant_1",
+		"user_id":     "attacker",
+		ssoTokenClaim: true,
+		"exp":         time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := unsigned.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+	require.Error(t, err, "an unsigned token must be refused")
+}
+
+func TestSSOValidatorRejectsExpiredToken(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	expired := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"tenant_id":   "tenant_1",
+		"user_id":     "user_1",
+		ssoTokenClaim: true,
+		"exp":         time.Now().Add(-time.Hour).Unix(),
+	})
+	signed, err := expired.SignedString([]byte(testSecret))
+	require.NoError(t, err)
+
+	_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+	require.Error(t, err, "an expired token must be refused")
+}
+
+// Claims that name no user or no tenant must be refused: the middleware uses
+// both to scope the session, and an empty value would widen that scope.
+func TestSSOValidatorRequiresIdentityClaims(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	for name, claims := range map[string]jwt.MapClaims{
+		"no user":    {"tenant_id": "tenant_1", ssoTokenClaim: true, "exp": time.Now().Add(time.Hour).Unix()},
+		"no tenant":  {"user_id": "user_1", ssoTokenClaim: true, "exp": time.Now().Add(time.Hour).Unix()},
+		"empty user": {"tenant_id": "tenant_1", "user_id": "", ssoTokenClaim: true, "exp": time.Now().Add(time.Hour).Unix()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(testSecret))
+			require.NoError(t, err)
+
+			_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+			require.Error(t, err)
+		})
+	}
+}
+
+// The issuer must refuse to mint without an identity, so a bug upstream cannot
+// produce a token that names nobody.
+func TestSSOIssuerRequiresIdentity(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	_, _, err := NewSSOTokenIssuer(cfg).Issue("", "user_1", 24)
+	require.Error(t, err, "minting without a tenant must fail")
+
+	_, _, err = NewSSOTokenIssuer(cfg).Issue("tenant_1", "", 24)
+	require.Error(t, err, "minting without a user must fail")
+}
+
+// ── Adversarial cases ───────────────────────────────────────────────────────
+//
+// Both providers sign with the same auth.secret, so these establish that
+// routing by an unverified marker cannot be turned into an advantage.
+
+func TestAttackMarkerDoesNotBypassValidation(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	// A Supabase-shaped token (sub, app_metadata) that the ordinary validator
+	// WOULD accept, with the SSO marker bolted on to force SSO routing.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":          "supabase-user",
+		"app_metadata": map[string]any{"tenant_id": "tenant_1"},
+		ssoTokenClaim:  true,
+		"exp":          time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := tok.SignedString([]byte(testSecret))
+	require.NoError(t, err)
+
+	require.True(t, IsSSOToken(signed), "marker should route this to the SSO validator")
+
+	// The SSO validator must refuse it: it carries no user_id/tenant_id claims.
+	_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+	require.Error(t, err, "SSO routing must not accept a token lacking SSO identity claims")
+}
+
+// ATTACK 2: on a deployment with SAML OFF, can an attacker who somehow obtains
+// a validly-signed SSO token get in? Must be refused outright.
+func TestAttackSSOTokenOnNonSAMLDeployment(t *testing.T) {
+	minting := ssoTestConfig(types.AuthProviderFlexprice, true)
+	stolen := mintSSOToken(t, minting, "tenant_1", "victim")
+
+	for _, provider := range []types.AuthProvider{types.AuthProviderSupabase, types.AuthProviderFlexprice} {
+		victim := ssoTestConfig(provider, false) // SAML disabled
+		_, err := NewSSOTokenValidator(victim).Validate(context.Background(), stolen)
+		require.Error(t, err, "provider=%s with SAML off must refuse an SSO token", provider)
+	}
+}
+
+// ATTACK 3: a checkout/session token signed with the same secret must not be
+// usable as a dashboard credential just by carrying the marker.
+func TestAttackForeignTokenTypeRejected(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	// Session-token shaped claims, no user_id.
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"customer_id": "cust_1",
+		"tenant_id":   "tenant_1",
+		ssoTokenClaim: true,
+		"exp":         time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := tok.SignedString([]byte(testSecret))
+	require.NoError(t, err)
+
+	_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+	require.Error(t, err, "a session-shaped token must not authenticate a dashboard request")
+}
+
+// ATTACK 4: algorithm confusion — HMAC-signing using a value an attacker might
+// guess is still refused unless it is the real secret.
+func TestAttackWrongSecretRejectedAcrossAlgs(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	for _, method := range []jwt.SigningMethod{jwt.SigningMethodHS256, jwt.SigningMethodHS384, jwt.SigningMethodHS512} {
+		tok := jwt.NewWithClaims(method, jwt.MapClaims{
+			"tenant_id":   "tenant_1",
+			"user_id":     "attacker",
+			ssoTokenClaim: true,
+			"exp":         time.Now().Add(time.Hour).Unix(),
+		})
+		signed, err := tok.SignedString([]byte("guessed-secret"))
+		require.NoError(t, err)
+
+		_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+		require.Error(t, err, "alg=%s with a wrong secret must be refused", method.Alg())
+	}
+}
+
+// ATTACK 5: a non-SSO token must still work normally — the change must not
+// break password login by hijacking ordinary tokens.
+func TestOrdinaryTokenNotRoutedToSSO(t *testing.T) {
+	plain := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "u", "exp": time.Now().Add(time.Hour).Unix(),
+	})
+	signed, err := plain.SignedString([]byte(testSecret))
+	require.NoError(t, err)
+
+	require.False(t, IsSSOToken(signed), "an ordinary token must not be routed to the SSO validator")
+}
+
+// ATTACK 6: marker as a non-bool (string "true", 1) must not satisfy the check.
+func TestAttackMarkerTypeConfusion(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	for name, marker := range map[string]any{"string": "true", "number": 1, "nonempty": "yes"} {
+		t.Run(name, func(t *testing.T) {
+			tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+				"tenant_id":   "tenant_1",
+				"user_id":     "attacker",
+				ssoTokenClaim: marker,
+				"exp":         time.Now().Add(time.Hour).Unix(),
+			})
+			signed, err := tok.SignedString([]byte(testSecret))
+			require.NoError(t, err)
+
+			_, err = NewSSOTokenValidator(cfg).Validate(context.Background(), signed)
+			require.Error(t, err, "a non-bool marker must not satisfy the SSO check")
+		})
+	}
+}

--- a/internal/auth/sso_token_test.go
+++ b/internal/auth/sso_token_test.go
@@ -166,6 +166,18 @@ func TestSSOIssuerRequiresIdentity(t *testing.T) {
 	require.Error(t, err, "minting without a user must fail")
 }
 
+// A non-positive expiry would mint an already-expired token while returning a
+// future expiresAt, so the login looks successful and fails on the first
+// request instead — the shape this type exists to prevent.
+func TestSSOIssuerRejectsNonPositiveExpiry(t *testing.T) {
+	cfg := ssoTestConfig(types.AuthProviderSupabase, true)
+
+	for _, hours := range []int{0, -1, -24} {
+		_, _, err := NewSSOTokenIssuer(cfg).Issue("tenant_1", "user_1", hours)
+		require.Error(t, err, "expiryHours=%d must be refused", hours)
+	}
+}
+
 // ── Adversarial cases ───────────────────────────────────────────────────────
 //
 // Both providers sign with the same auth.secret, so these establish that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,6 +272,21 @@ func (c Configuration) validateSAMLDependencies() error {
 			"SAML keeps outstanding login requests in Redis so a login started on one replica " +
 			"can be completed on another")
 	}
+
+	// auth.secret is the HMAC key the SSO token is signed with. An empty key
+	// still produces a verifiable signature, so a deployment that boots without
+	// one accepts a token anybody can mint — the forger names any user in any
+	// tenant, and the middleware then loads that user and grants their roles.
+	//
+	// The warn-only validateSecrets does not cover this: it checks auth.secret
+	// only under the Flexprice provider, so a Supabase deployment offering SSO
+	// with no secret set started silently. Hard-failing is safe here for the
+	// same reason as the checks above — it applies only when SSO is switched
+	// on, so it cannot take down a deployment that does not offer it.
+	if strings.TrimSpace(c.Auth.Secret) == "" {
+		return fmt.Errorf("auth.saml.enabled requires a non-empty auth.secret (FLEXPRICE_AUTH_SECRET): " +
+			"it signs the SSO token, and an empty key lets anyone mint one naming any user")
+	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -72,6 +72,7 @@ func TestSAMLConfigValidate(t *testing.T) {
 func TestValidateSAMLDependencies(t *testing.T) {
 	withRedis := Configuration{}
 	withRedis.Auth.SAML.Enabled = true
+	withRedis.Auth.Secret = "a-real-signing-secret-at-least-32b!"
 	withRedis.Cache.Enabled = true
 	withRedis.Cache.Redis.Enabled = true
 
@@ -101,5 +102,46 @@ func TestValidateSAMLDependencies(t *testing.T) {
 	off := Configuration{}
 	if err := off.validateSAMLDependencies(); err != nil {
 		t.Errorf("a non-SAML deployment must not require Redis: %v", err)
+	}
+}
+
+// TestValidateSAMLDependenciesRequiresSigningSecret pins the signing secret as a
+// hard requirement whenever SSO is on.
+//
+// auth.secret is the HMAC key for the SSO token. An empty key still produces a
+// verifiable signature, so a deployment that boots without one accepts a token
+// anybody can mint: the forger names any user in any tenant and the middleware
+// then loads that user and grants their roles. validateSecrets does not cover
+// this — it is warn-only, and checks auth.secret only under the Flexprice
+// provider, so a Supabase deployment with SSO enabled and no secret started
+// silently.
+//
+// The check is scoped to SAML being enabled, so it cannot take down a
+// deployment that does not offer SSO — the same reasoning that keeps the rest
+// of the secret validation warn-only.
+func TestValidateSAMLDependenciesRequiresSigningSecret(t *testing.T) {
+	base := Configuration{}
+	base.Auth.SAML.Enabled = true
+	base.Cache.Enabled = true
+	base.Cache.Redis.Enabled = true
+
+	for _, secret := range []string{"", "   ", "\t"} {
+		cfg := base
+		cfg.Auth.Secret = secret
+		if err := cfg.validateSAMLDependencies(); err == nil {
+			t.Errorf("SAML must not start with a blank auth.secret (%q)", secret)
+		}
+	}
+
+	cfg := base
+	cfg.Auth.Secret = "a-real-signing-secret-at-least-32b!"
+	if err := cfg.validateSAMLDependencies(); err != nil {
+		t.Errorf("SAML with a signing secret must start: %v", err)
+	}
+
+	// A deployment that does not offer SSO is unaffected, even with no secret.
+	off := Configuration{}
+	if err := off.validateSAMLDependencies(); err != nil {
+		t.Errorf("a non-SAML deployment must not require a signing secret: %v", err)
 	}
 }

--- a/internal/ee/auth/saml/routes.go
+++ b/internal/ee/auth/saml/routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/gin-gonic/gin"
 
+	"github.com/flexprice/flexprice/internal/auth"
 	"github.com/flexprice/flexprice/internal/cache"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/ee/service"
@@ -318,10 +319,14 @@ func (h *Handler) ACS(c *gin.Context) {
 		return
 	}
 
-	// The token is minted by the built-in provider, so its claims are
-	// identical to a password login and every existing middleware validates
-	// it unchanged.
-	token, _, err := provider.tokens.GenerateDevToken(tenantID, "", userID, result.Email, tokenExpiryHours)
+	// Minted by the SSO issuer rather than the deployment's password-login
+	// provider. The user an assertion authenticates exists only in our own
+	// database — there is no Supabase account for Supabase to have issued a
+	// token for — so a deployment using Supabase for password login could not
+	// validate a token minted through that provider, and every request after a
+	// successful SSO login was refused. The issuer marks the token so
+	// AuthenticateMiddleware routes it to the matching validator.
+	token, _, err := auth.NewSSOTokenIssuer(provider.cfg).Issue(tenantID, userID, tokenExpiryHours)
 	if err != nil {
 		c.Error(err)
 		return

--- a/internal/rest/middleware/auth.go
+++ b/internal/rest/middleware/auth.go
@@ -234,6 +234,17 @@ func APIKeyAuthMiddleware(cfg *config.Configuration, secretService service.Secre
 func AuthenticateMiddleware(cfg *config.Configuration, secretService service.SecretService, environmentRepo domainEnvironment.Repository, userRepo domainUser.Repository, logger *logger.Logger) gin.HandlerFunc {
 	authProvider := auth.NewProvider(cfg)
 
+	// SSO tokens are validated separately from password-login tokens because the
+	// provider handling password login cannot necessarily validate them: a
+	// deployment using Supabase validates against the Supabase claim schema,
+	// while a SAML login mints Flexprice claims for a user that has no Supabase
+	// account, so every request after a successful SSO login came back 401.
+	//
+	// This validator is strictly stricter than the ordinary one — it additionally
+	// requires SAML to be enabled on the deployment and the token to carry the
+	// SSO marker — so routing a token to it can never be an advantage.
+	ssoValidator := auth.NewSSOTokenValidator(cfg)
+
 	return func(c *gin.Context) {
 		// First check for API key
 		apiKey := c.GetHeader(cfg.Auth.APIKey.Header)
@@ -263,7 +274,19 @@ func AuthenticateMiddleware(cfg *config.Configuration, secretService service.Sec
 		}
 
 		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
-		claims, err := authProvider.ValidateToken(c.Request.Context(), tokenString)
+
+		// Which validator to run is decided by an unverified claim, which is safe
+		// because it decides only that — being sent to the SSO validator is not an
+		// advantage, since that validator verifies the same signature and then
+		// requires the marker again along with SAML being enabled. A caller
+		// setting the marker on a token the ordinary provider would have accepted
+		// only causes their own token to be refused.
+		validate := authProvider.ValidateToken
+		if auth.IsSSOToken(tokenString) {
+			validate = ssoValidator.Validate
+		}
+
+		claims, err := validate(c.Request.Context(), tokenString)
 		if err != nil {
 			logger.Error(c.Request.Context(), "failed to validate token", "error", err)
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})


### PR DESCRIPTION
## **User description**
A completed SSO login was refused by the API. Observed on GCP staging:

```
saml login succeeded      user_id=user_01M09SRKR4PJS5ZY68KC2V9J2N
failed to validate token  error="token missing user ID"
  internal/auth.(*supabaseAuth).ValidateToken  supabase.go:125
```

The assertion validated, the token was minted, and then every request after it
came back 401.

## Cause

The mint and the verify used different claim schemas.

| | user claim | tenant claim |
|---|---|---|
| SAML minted (Flexprice provider) | `user_id` | `tenant_id` |
| Middleware verified (Supabase provider) | `sub` | `app_metadata.tenant_id` |

The SAML handler minted through the built-in Flexprice provider, while
`AuthenticateMiddleware` builds its validator from `auth.provider` — Supabase on
that deployment. Both sign with the same `auth.secret`, so the signature was
fine; the claim names were not.

Delegating to the configured provider instead is not an option: an assertion
authenticates a user that exists only in our database, so there is no Supabase
account for Supabase to have issued a token for. SSO needs its own issuer and
validator, which is what this adds.

## Security

This widens what the middleware accepts, so the reasoning is worth stating
plainly.

Both providers sign with the same secret, so **a signature alone cannot prove a
token came from the SSO flow**, and the marker claim travels inside the token
where anyone able to mint one could set it. The marker is therefore never
treated as authority. It selects which validator runs; that validator then
independently requires all of:

1. `auth.saml.enabled` on the deployment — config, not caller-controlled
2. a valid signature, algorithm **pinned to HMAC** (blocks `alg=none` and
   key-confusion forgeries)
3. the marker, re-checked after verification
4. non-empty `user_id` and `tenant_id`

**Routing to the SSO validator can never be an advantage**, because it is
strictly stricter than the ordinary one. A caller who bolts the marker onto a
token the ordinary provider would have accepted only gets their own token
refused.

Two existing safeguards still apply on top: the middleware loads the named user
and refuses one archived or missing, and the session's roles come from that user
record rather than from any claim. A token can name an identity but never grant
itself privileges.

**Blast radius:** a deployment with `auth.saml.enabled=false` accepts no SSO
token at all, so enabling SAML is the only thing that changes what the API
accepts. Existing password logins are untouched — a token without the marker
takes exactly the path it takes today (covered by a test).

## Tests

Round trip under **both** providers, plus adversarial cases:

- marker bolted onto a Supabase-shaped token the ordinary validator would accept
- a valid SSO token replayed at a deployment with SAML off
- a session-shaped token carrying the marker
- wrong secret across HS256 / HS384 / HS512
- `alg=none`
- expired token
- missing / empty identity claims
- marker type confusion (`"true"`, `1`)
- an ordinary token is still routed to the ordinary validator

## Verification

- `go build ./internal/...` clean
- `make lint-ci` (loglint merge gate) exit 0
- full `go test ./internal/...` — **61 ok, 0 FAIL**, exit 0
- rebased on `develop` and re-verified after (fresh `-count=1` run, not cached)

`gofmt -l` flags four files in the touched packages; all four are identical on
`develop`, so they are pre-existing and deliberately not reformatted here.

The SAML ACS handler was the only production caller of `GenerateDevToken`, so
nothing else changes behaviour.

## Known gap, not addressed here

`enforce_sso` has **no effect on a Supabase-backed deployment**.
`refusePasswordLoginUnderSSO` is reached only from `authService.Login`, but such
a deployment's frontend calls `supabase.auth.signInWithPassword()` directly and
never touches that path. A tenant enabling enforcement today still has every
user able to sign in with a password, bypassing their identity provider.

Fixing it means moving the check to `AuthenticateMiddleware` — the one chokepoint
both login paths cross — which changes behaviour for every authenticated request
and belongs in its own PR. Until then `enforce_sso` should be treated as
additive-only on hosted deployments, not offered as an enforcement control.

Related: `resolveUser` logs in any existing user with a matching email without
regard to how that account was created, so one person can hold both a password
and an IdP identity with no way to retire the password.


___

## **CodeAnt-AI Description**
Restore authenticated requests after SAML login across supported auth providers

### What Changed
- SAML login now issues tokens with the identity claims expected by SSO validation, so users can access the API after signing in.
- SSO tokens are validated separately from password-login tokens, allowing SAML to work when Supabase handles regular password authentication.
- SSO tokens are rejected when SAML is disabled, expired, unsigned, incorrectly signed, missing identity data, or missing the SSO marker.
- Added coverage for valid SSO login flows, ordinary token handling, and forged or malformed tokens.

### Impact
`✅ SAML users can make API requests after login`
`✅ SSO works alongside Supabase password authentication`
`✅ Fewer unauthorized responses after successful SSO login`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure SSO token issuance and validation for SAML authentication.
  * SSO tokens include tenant and user identities, expiration, and signature protection.
  * Authentication automatically routes SSO tokens through the appropriate validation process.

* **Bug Fixes**
  * Improved rejection of expired, unsigned, incorrectly signed, malformed, or misclassified tokens.
  * Prevented SSO tokens from being accepted when SAML authentication is disabled.
  * SAML authentication now requires a configured signing secret at startup.

* **Tests**
  * Added comprehensive coverage for valid flows, token separation, identity requirements, configuration, and security edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->