### PR TITLE
fix(e2eprobe): repair the five failing staging checks + preview tax breakdown

### DIFF
--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/domain/taxapplied"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/validator"
@@ -577,26 +578,12 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 		taxableAmount = decimal.Zero
 	}
 
-	if len(r.PreparedTaxRates) > 0 {
-		for _, tr := range r.PreparedTaxRates {
-			var taxAmount decimal.Decimal
-			switch tr.TaxRateType {
-			case types.TaxRateTypePercentage:
-				if tr.PercentageValue != nil {
-					taxAmount = taxableAmount.Mul(*tr.PercentageValue).Div(decimal.NewFromInt(100))
-				}
-			case types.TaxRateTypeFixed:
-				if tr.FixedValue != nil {
-					taxAmount = *tr.FixedValue
-				}
-			default:
-				continue
-			}
-			if taxAmount.IsNegative() {
-				taxAmount = decimal.Zero
-			}
-			totalTax = totalTax.Add(taxAmount)
+	for _, tr := range r.PreparedTaxRates {
+		taxAmount, ok := previewTaxAmount(tr, taxableAmount)
+		if !ok {
+			continue
 		}
+		totalTax = totalTax.Add(taxAmount)
 	}
 
 	// 4) Update invoice preview totals
@@ -610,6 +597,81 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 	inv.AmountRemaining = inv.Total.Sub(inv.AmountPaid)
 
 	return inv, nil
+}
+
+// previewTaxAmount computes the tax owed on taxableAmount for a single
+// prepared tax rate. The second return is false when the rate carries no
+// usable value (nil percentage/fixed amount, or an unknown rate type), in
+// which case the caller skips it.
+//
+// Shared by the preview total (ToInvoice) and the preview breakdown
+// (BuildPreviewTaxes) so the two can never drift apart.
+func previewTaxAmount(tr *TaxRateResponse, taxableAmount decimal.Decimal) (decimal.Decimal, bool) {
+	if tr == nil {
+		return decimal.Zero, false
+	}
+	var taxAmount decimal.Decimal
+	switch tr.TaxRateType {
+	case types.TaxRateTypePercentage:
+		if tr.PercentageValue == nil {
+			return decimal.Zero, false
+		}
+		taxAmount = taxableAmount.Mul(*tr.PercentageValue).Div(decimal.NewFromInt(100))
+	case types.TaxRateTypeFixed:
+		if tr.FixedValue == nil {
+			return decimal.Zero, false
+		}
+		taxAmount = *tr.FixedValue
+	default:
+		return decimal.Zero, false
+	}
+	if taxAmount.IsNegative() {
+		taxAmount = decimal.Zero
+	}
+	return taxAmount, true
+}
+
+// BuildPreviewTaxes synthesises the per-rate tax breakdown for an invoice
+// preview.
+//
+// Persisted invoices carry tax_applied rows that the response loads via
+// WithTaxes. A preview writes nothing, so without this the response reports
+// a non-zero total_tax with an empty taxes[] array and callers cannot see
+// which rate produced the charge. The records are in-memory only: no ID and
+// no persistence, mirroring the rest of the preview invoice.
+func BuildPreviewTaxes(inv *invoice.Invoice, preparedTaxRates []*TaxRateResponse) []*TaxAppliedResponse {
+	if inv == nil || len(preparedTaxRates) == 0 {
+		return nil
+	}
+	taxableAmount := inv.Subtotal.Sub(inv.TotalDiscount)
+	if taxableAmount.IsNegative() {
+		taxableAmount = decimal.Zero
+	}
+
+	taxes := make([]*TaxAppliedResponse, 0, len(preparedTaxRates))
+	for _, tr := range preparedTaxRates {
+		taxAmount, ok := previewTaxAmount(tr, taxableAmount)
+		if !ok {
+			continue
+		}
+		taxes = append(taxes, &TaxAppliedResponse{
+			TaxApplied: taxapplied.TaxApplied{
+				TaxRateID:     tr.ID,
+				EntityType:    types.TaxRateEntityTypeInvoice,
+				EntityID:      inv.ID,
+				TaxableAmount: taxableAmount,
+				TaxAmount:     taxAmount,
+				Currency:      inv.Currency,
+				AppliedAt:     time.Now().UTC(),
+				EnvironmentID: inv.EnvironmentID,
+			},
+			TaxRate: tr,
+		})
+	}
+	if len(taxes) == 0 {
+		return nil
+	}
+	return taxes
 }
 
 // Validate validates the invoice coupon DTO

--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -579,7 +579,7 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 	}
 
 	for _, tr := range r.PreparedTaxRates {
-		taxAmount, ok := previewTaxAmount(tr, taxableAmount)
+		taxAmount, ok := previewTaxAmount(tr, taxableAmount, inv.Currency)
 		if !ok {
 			continue
 		}
@@ -606,8 +606,10 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 //
 // Shared by the preview total (ToInvoice) and the preview breakdown
 // (BuildPreviewTaxes) so the two can never drift apart.
-func previewTaxAmount(tr *TaxRateResponse, taxableAmount decimal.Decimal) (decimal.Decimal, bool) {
-	if tr == nil {
+func previewTaxAmount(tr *TaxRateResponse, taxableAmount decimal.Decimal, currency string) (decimal.Decimal, bool) {
+	// TaxRateResponse embeds *taxrate.TaxRate, so a zero-value response
+	// dereferences nil on the field reads below.
+	if tr == nil || tr.TaxRate == nil {
 		return decimal.Zero, false
 	}
 	var taxAmount decimal.Decimal
@@ -628,7 +630,10 @@ func previewTaxAmount(tr *TaxRateResponse, taxableAmount decimal.Decimal) (decim
 	if taxAmount.IsNegative() {
 		taxAmount = decimal.Zero
 	}
-	return taxAmount, true
+	// Round per line, matching the persisted tax path — otherwise a rate that
+	// produces more precision than the currency carries shows fractional-cent
+	// entries that don't add up to what is eventually charged.
+	return taxAmount.Round(types.GetCurrencyPrecision(currency)), true
 }
 
 // BuildPreviewTaxes synthesises the per-rate tax breakdown for an invoice
@@ -650,7 +655,7 @@ func BuildPreviewTaxes(inv *invoice.Invoice, preparedTaxRates []*TaxRateResponse
 
 	taxes := make([]*TaxAppliedResponse, 0, len(preparedTaxRates))
 	for _, tr := range preparedTaxRates {
-		taxAmount, ok := previewTaxAmount(tr, taxableAmount)
+		taxAmount, ok := previewTaxAmount(tr, taxableAmount, inv.Currency)
 		if !ok {
 			continue
 		}
@@ -664,6 +669,10 @@ func BuildPreviewTaxes(inv *invoice.Invoice, preparedTaxRates []*TaxRateResponse
 				Currency:      inv.Currency,
 				AppliedAt:     time.Now().UTC(),
 				EnvironmentID: inv.EnvironmentID,
+				BaseModel: types.BaseModel{
+					TenantID: inv.TenantID,
+					Status:   types.StatusPublished,
+				},
 			},
 			TaxRate: tr,
 		})

--- a/internal/api/dto/invoice_test.go
+++ b/internal/api/dto/invoice_test.go
@@ -101,3 +101,31 @@ func TestBuildPreviewTaxes_DiscountBeyondSubtotalClampsToZero(t *testing.T) {
 	assert.True(t, taxes[0].TaxableAmount.IsZero(), "taxable amount: %s", taxes[0].TaxableAmount)
 	assert.True(t, taxes[0].TaxAmount.IsZero(), "tax amount: %s", taxes[0].TaxAmount)
 }
+
+func TestBuildPreviewTaxes_NilEmbeddedTaxRate(t *testing.T) {
+	// TaxRateResponse embeds *taxrate.TaxRate; a zero-value entry must be
+	// skipped rather than dereferenced.
+	inv := &invoice.Invoice{ID: "inv_preview", Currency: "usd", Subtotal: decimal.NewFromInt(100)}
+	assert.NotPanics(t, func() {
+		assert.Nil(t, BuildPreviewTaxes(inv, []*TaxRateResponse{{}}))
+	})
+}
+
+func TestBuildPreviewTaxes_RoundsToCurrencyPrecision(t *testing.T) {
+	// 7.5% of 100.01 = 7.50075 — must not surface fractional cents that the
+	// charged amount will never match.
+	pct := decimal.NewFromFloat(7.5)
+	inv := &invoice.Invoice{
+		ID:        "inv_preview",
+		Currency:  "usd",
+		Subtotal:  decimal.NewFromFloat(100.01),
+		BaseModel: types.BaseModel{TenantID: "tenant_1"},
+	}
+	taxes := BuildPreviewTaxes(inv, []*TaxRateResponse{
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_pct", TaxRateType: types.TaxRateTypePercentage, PercentageValue: &pct}},
+	})
+
+	assert.Len(t, taxes, 1)
+	assert.Equal(t, "7.5", taxes[0].TaxAmount.String())
+	assert.Equal(t, "tenant_1", taxes[0].TenantID)
+}

--- a/internal/api/dto/invoice_test.go
+++ b/internal/api/dto/invoice_test.go
@@ -3,6 +3,9 @@ package dto
 import (
 	"testing"
 
+	"github.com/flexprice/flexprice/internal/domain/invoice"
+	taxrate "github.com/flexprice/flexprice/internal/domain/tax"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 )
@@ -41,4 +44,60 @@ func TestCreateInvoiceRequest_ZeroOutAmounts_EmptyLineItems(t *testing.T) {
 	assert.True(t, req.Subtotal.IsZero())
 	assert.True(t, req.Total.IsZero())
 	assert.True(t, req.AmountDue.IsZero())
+}
+
+func TestBuildPreviewTaxes(t *testing.T) {
+	pct := decimal.NewFromInt(10)
+	fixed := decimal.NewFromFloat(2.50)
+	rates := []*TaxRateResponse{
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_pct", TaxRateType: types.TaxRateTypePercentage, PercentageValue: &pct}},
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_fixed", TaxRateType: types.TaxRateTypeFixed, FixedValue: &fixed}},
+		// No usable value — must be skipped, not emitted as a zero entry.
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_pct_nil", TaxRateType: types.TaxRateTypePercentage}},
+	}
+
+	inv := &invoice.Invoice{
+		ID:            "inv_preview",
+		Currency:      "usd",
+		Subtotal:      decimal.NewFromInt(100),
+		TotalDiscount: decimal.NewFromInt(20),
+	}
+
+	taxes := BuildPreviewTaxes(inv, rates)
+
+	assert.Len(t, taxes, 2)
+	assert.Equal(t, "taxrate_pct", taxes[0].TaxRateID)
+	// Taxable base is subtotal - discount, matching ToInvoice's preview math.
+	assert.True(t, taxes[0].TaxableAmount.Equal(decimal.NewFromInt(80)), "taxable amount: %s", taxes[0].TaxableAmount)
+	assert.True(t, taxes[0].TaxAmount.Equal(decimal.NewFromInt(8)), "tax amount: %s", taxes[0].TaxAmount)
+	assert.Equal(t, types.TaxRateEntityTypeInvoice, taxes[0].EntityType)
+	assert.Equal(t, "inv_preview", taxes[0].EntityID)
+	assert.Equal(t, "usd", taxes[0].Currency)
+
+	assert.Equal(t, "taxrate_fixed", taxes[1].TaxRateID)
+	assert.True(t, taxes[1].TaxAmount.Equal(fixed), "tax amount: %s", taxes[1].TaxAmount)
+}
+
+func TestBuildPreviewTaxes_NoRates(t *testing.T) {
+	inv := &invoice.Invoice{ID: "inv_preview", Subtotal: decimal.NewFromInt(100)}
+	assert.Nil(t, BuildPreviewTaxes(inv, nil))
+	assert.Nil(t, BuildPreviewTaxes(nil, []*TaxRateResponse{}))
+}
+
+func TestBuildPreviewTaxes_DiscountBeyondSubtotalClampsToZero(t *testing.T) {
+	pct := decimal.NewFromInt(10)
+	rates := []*TaxRateResponse{
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_pct", TaxRateType: types.TaxRateTypePercentage, PercentageValue: &pct}},
+	}
+	inv := &invoice.Invoice{
+		ID:            "inv_preview",
+		Subtotal:      decimal.NewFromInt(10),
+		TotalDiscount: decimal.NewFromInt(30),
+	}
+
+	taxes := BuildPreviewTaxes(inv, rates)
+
+	assert.Len(t, taxes, 1)
+	assert.True(t, taxes[0].TaxableAmount.IsZero(), "taxable amount: %s", taxes[0].TaxableAmount)
+	assert.True(t, taxes[0].TaxAmount.IsZero(), "tax amount: %s", taxes[0].TaxAmount)
 }

--- a/internal/e2eprobe/README.md
+++ b/internal/e2eprobe/README.md
@@ -73,7 +73,7 @@ Standard OTLP env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, etc.) flow through unchan
 
 | Kind | Name | Schedule | What it does |
 | ---- | ---- | -------- | ------------ |
-| bootstrap | seed-ensure | OneShot + 6h | Auto-provision: 8 features/meters, 10 customers, 1 plan, 9 prices, 10 subs, 3 wallets |
+| bootstrap | seed-ensure | OneShot + 6h | Auto-provision: 12 features/meters, 10 customers, 1 plan, 13 prices, 10 subs, 3 wallets; syncs plan prices onto subs when line items drift |
 | driver | event-ingest-driver | Rate(5/s) | Varied event ingest using the deck |
 | probe | analytics-probe | 2m | `GetUsageAnalytics` rotating params |
 | probe | meter-aggregation-probe | 3m | Asserts each seed meter produces >0 usage over a 30-min window (round-robin; all 8 meters covered every 24 min) |

--- a/internal/e2eprobe/README.md
+++ b/internal/e2eprobe/README.md
@@ -16,17 +16,23 @@ make run-e2eprobe
 
 `seed-ensure` is fully self-contained — no manual tenant prep is required. On first run (or any run where entities are missing) the harness idempotently provisions:
 
-1. **11 features** (each with an embedded meter): 8 baseline aggregations (COUNT, SUM, AVG, COUNT_UNIQUE, LATEST, MAX, SUM_WITH_MULTIPLIER, SUM/api-filter) plus 3 bucketed meters (MAX/15MIN, SUM/HOUR, MAX/DAY) for the bucketed-meter-probe.
+1. **12 features** (each with an embedded meter): 8 baseline aggregations (COUNT, SUM, AVG, COUNT_UNIQUE, LATEST, MAX, SUM_WITH_MULTIPLIER, SUM/api-filter), 3 bucketed meters (MAX/15MIN, SUM/HOUR, MAX/DAY) for the bucketed-meter-probe, and `e2eprobe_sum_commit` for commitment-true-up-probe — the last one carries no entitlement, so billed usage is exactly units x price with no allowance absorbing the first $1.00.
 2. **1 shared coupon** (`E2EPROBE_COUPON_10PCT`, 10% percentage, one-time cadence) reused by coupon-application-probe and attached to persistent cust #1's sub.
 3. **1 shared tax rate** (`E2EPROBE_TAX_10PCT`, 10% percentage, EXTERNAL scope) reused by tax-application-probe and attached to persistent cust #0's sub.
 4. **10 persistent customers** tagged `metadata.e2eprobe_cohort = "persistent"`.
 5. **1 plan** (`e2eprobe_plan`) with metadata `e2eprobe = "true"`.
-6. **12 prices** attached to the plan: 1 base recurring fixed fee ($19.99/mo) + 1 usage price per feature ($0.01/unit).
-7. **7 plan-level soft-limit entitlements** (was 8): one on each non-bucketed metered feature EXCEPT `e2eprobe_sum_multiplier_feature`, which is reserved for the additive grant (see next bullet).
+6. **13 prices** attached to the plan: 1 base recurring fixed fee ($19.99/mo) + 1 usage price per feature ($0.01/unit).
+7. **7 plan-level soft-limit entitlements**: one on each non-bucketed metered feature EXCEPT `e2eprobe_sum_multiplier_feature` (reserved for the additive grant, see next bullet) and `e2eprobe_sum_commit_feature` (entitlement-free by design).
 8. **1 additive grant entitlement** on `e2eprobe_sum_multiplier_feature` (grant_measure=quantity, quota=1000, duration=1 hour, aggregation_mode=additive). Post-create config-echo verified at seed time via raw HTTP GET, since SDK v2.0.24 doesn't expose grant fields on `EntitlementResponse`.
 9. **10 subscriptions** — one per persistent customer — on the e2eprobe plan (monthly, anniversary cycle). New subs carry a $5/mo commitment (1.5× overage factor); cust #1's sub additionally carries the shared coupon via SubscriptionCoupons. Draft subscriptions are activated automatically.
 10. **1 tax association** linking the shared tax rate to persistent cust #0's subscription (idempotent — covers both new and existing subs).
 11. **3 wallets** on the first 3 persistent customers (`e2eprobe-cust-persistent-0/1/2`), each topped up to $100.00 USD.
+
+Subscription line items snapshot the plan at create time, so a feature seeded
+after the persistent subs were created is invisible to every usage read path
+(they filter by active-subscription line items). `seed-ensure` detects that
+drift and triggers the plan price sync; `meter-aggregation-probe` skips any
+meter that isn't yet on the customer's subscription rather than paging.
 
 Every step is idempotent: re-running seed-ensure against a tenant that already has all entities is a no-op.
 

--- a/internal/e2eprobe/checks/bucketed_meter_probe.go
+++ b/internal/e2eprobe/checks/bucketed_meter_probe.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -97,7 +98,7 @@ func (p *BucketedMeterProbe) Run(ctx context.Context) error {
 	}
 
 	// Verify raw ingestion first — separates ingest failures from aggregation lag.
-	if err := p.pollRawEvents(ctx, spec.eventName, customerExt, featID, eventIDs); err != nil {
+	if err := p.pollRawEvents(ctx, spec, customerExt, featID, eventIDs, ts[0]); err != nil {
 		return err
 	}
 
@@ -108,34 +109,64 @@ func (p *BucketedMeterProbe) Run(ctx context.Context) error {
 	return nil
 }
 
-func (p *BucketedMeterProbe) pollRawEvents(ctx context.Context, eventName, custExt, featID string, wantIDs []string) error {
-	deadline := time.Now().Add(30 * time.Second)
+// pollRawEvents verifies each ingested event by its event_id.
+//
+// The events are deliberately backdated by up to 3 bucket durations, and the
+// persistent customer also receives continuous event-ingest-driver traffic on
+// the same event names. A plain (customer, event_name) query returns the most
+// recent page in timestamp-DESC order, so the backdated rows sit far below the
+// page window and are never observed. Filtering by event_id sidesteps
+// pagination entirely; the explicit time range keeps the older buckets inside
+// the server's default 7-day window.
+func (p *BucketedMeterProbe) pollRawEvents(ctx context.Context, spec bucketedSpec, custExt, featID string, wantIDs []string, oldest time.Time) error {
+	// Staging drains the ingest topic at roughly ten events/second, so allow
+	// generous headroom over the burst this probe (and its neighbours) creates.
+	deadline := time.Now().Add(90 * time.Second)
+	start := oldest.Add(-spec.duration)
+	pageSize := int64(10)
+	found := make(map[string]bool, len(wantIDs))
 	for {
-		resp, err := p.client.Events().ListRaw(ctx, types.GetEventsRequest{
-			ExternalCustomerID: &custExt,
-			EventName:          &eventName,
-		})
-		if err == nil && resp.GetEventsResponse != nil {
-			seen := 0
-			for _, want := range wantIDs {
-				for _, ev := range resp.GetEventsResponse.Events {
-					if ev.ID != nil && *ev.ID == want {
-						seen++
-						break
-					}
+		end := time.Now().UTC()
+		for _, want := range wantIDs {
+			if found[want] {
+				continue
+			}
+			eventID := want
+			resp, err := p.client.Events().ListRaw(ctx, types.GetEventsRequest{
+				ExternalCustomerID: &custExt,
+				EventName:          &spec.eventName,
+				EventID:            &eventID,
+				StartTime:          &start,
+				EndTime:            &end,
+				PageSize:           &pageSize,
+			})
+			if err != nil || resp.GetEventsResponse == nil {
+				continue
+			}
+			for _, ev := range resp.GetEventsResponse.Events {
+				if ev.ID != nil && *ev.ID == want {
+					found[want] = true
+					break
 				}
 			}
-			if seen == len(wantIDs) {
-				return nil
-			}
+		}
+		if len(found) == len(wantIDs) {
+			return nil
 		}
 		if time.Now().After(deadline) {
+			missing := make([]string, 0, len(wantIDs))
+			for _, want := range wantIDs {
+				if !found[want] {
+					missing = append(missing, want)
+				}
+			}
 			return e2eprobe.Errorf(map[string]string{
 				"step":                 "raw_verify",
 				"external_customer_id": custExt,
-				"event_name":           eventName,
+				"event_name":           spec.eventName,
 				"feature_id":           featID,
-			}, "raw event verification timeout — not all %d events present", len(wantIDs))
+				"missing_event_ids":    strings.Join(missing, ","),
+			}, "raw event verification timeout — %d of %d events present", len(found), len(wantIDs))
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/e2eprobe/checks/bucketed_meter_probe.go
+++ b/internal/e2eprobe/checks/bucketed_meter_probe.go
@@ -71,9 +71,14 @@ func (p *BucketedMeterProbe) Run(ctx context.Context) error {
 	}
 	values := []int{10, 20, 30}
 
+	// The bucket-aligned timestamp repeats for every Run inside the same
+	// bucket, so the id must also carry this Run's nonce — otherwise an
+	// earlier Run's row satisfies the verification below and the check passes
+	// without its own events ever landing.
+	nonce := now.UnixNano()
 	eventIDs := make([]string, 3)
 	for i, t := range ts {
-		evID := fmt.Sprintf("e2eprobe-bkt-%s-%d-%d", spec.eventName, t.UnixNano(), i)
+		evID := fmt.Sprintf("e2eprobe-bkt-%s-%d-%d-%d", spec.eventName, t.UnixNano(), i, nonce)
 		eventIDs[i] = evID
 		tsStr := t.Format(time.RFC3339Nano)
 		if _, err := p.client.Events().Ingest(ctx, types.IngestEventRequest{

--- a/internal/e2eprobe/checks/commitment_true_up_probe.go
+++ b/internal/e2eprobe/checks/commitment_true_up_probe.go
@@ -15,7 +15,7 @@ import (
 
 // CommitmentTrueUpProbe creates a fresh ephemeral customer + sub with a
 // $5/mo commitment (1.5× overage), ingests a deterministic amount of usage
-// on e2eprobe_sum ($0.01/unit), then calls GetInvoicePreview and asserts
+// on e2eprobe_sum_commit ($0.01/unit), then calls GetInvoicePreview and asserts
 // the resulting math. The plan carries a $19.99 monthly fixed base fee
 // (`e2eprobe_base_price` in seed_ensure.go); expected preview totals below
 // bake that in.
@@ -27,6 +27,13 @@ import (
 //   - Even runs (cursor%2 == 0): over-commitment (700 events × $0.01 = $7.00).
 //     Preview total must equal commitment + (usage - commitment) × 1.5 + base
 //     = $5 + $2 × 1.5 + $19.99 = $27.99 (epsilon $0.01).
+
+// CommitmentEventName is the entitlement-free seed meter this probe bills
+// against. Every other metered seed feature carries a 100-unit monthly
+// entitlement, which silently absorbs the first $1.00 of usage and makes
+// exact preview totals unassertable.
+const CommitmentEventName = "e2eprobe_sum_commit"
+
 type CommitmentTrueUpProbe struct {
 	client e2eprobe.Client
 	reg    e2eprobe.Registry
@@ -103,7 +110,7 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 	}
 	p.reg.RegisterEphemeral("subscription", subID, now)
 
-	// Ingest e2eprobe_sum events (priced at $0.01/unit); amount=1 per event.
+	// Ingest CommitmentEventName events (priced at $0.01/unit); amount=1 per event.
 	// expectedUsage is the COMMITMENT-ADJUSTED usage amount the subscription
 	// usage API reports once every event has landed — not the raw
 	// units × price total. Over the commitment the API already applies the
@@ -118,7 +125,7 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 	}
 	for i := 0; i < n; i++ {
 		if _, err := p.client.Events().Ingest(ctx, types.IngestEventRequest{
-			EventName:          "e2eprobe_sum",
+			EventName:          CommitmentEventName,
 			ExternalCustomerID: ext,
 			Properties: map[string]string{
 				"amount":          "1",

--- a/internal/e2eprobe/checks/commitment_true_up_probe.go
+++ b/internal/e2eprobe/checks/commitment_true_up_probe.go
@@ -83,6 +83,10 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 		CommitmentAmount:   &commitAmount,
 		CommitmentDuration: &commitDuration,
 		OverageFactor:      &overageFactor,
+		// Without enable_true_up the billing service skips the true-up line
+		// item entirely (see billingService.CalculateUsageCharges), so the
+		// under-leg assertion below can never pass.
+		EnableTrueUp: boolPtr(true),
 		Metadata: map[string]string{
 			"e2eprobe":        "true",
 			"e2eprobe_cohort": "ephemeral",
@@ -100,11 +104,17 @@ func (p *CommitmentTrueUpProbe) Run(ctx context.Context) error {
 	p.reg.RegisterEphemeral("subscription", subID, now)
 
 	// Ingest e2eprobe_sum events (priced at $0.01/unit); amount=1 per event.
+	// expectedUsage is the COMMITMENT-ADJUSTED usage amount the subscription
+	// usage API reports once every event has landed — not the raw
+	// units × price total. Over the commitment the API already applies the
+	// 1.5x overage factor ($5 committed + $2 overage × 1.5 = $8.00), so
+	// polling for the raw $7.00 returns while ~10% of the events are still
+	// draining and the preview below is then short by that remainder.
 	n := 100
 	expectedUsage := 1.00
 	if overLeg {
 		n = 700
-		expectedUsage = 7.00
+		expectedUsage = 8.00
 	}
 	for i := 0; i < n; i++ {
 		if _, err := p.client.Events().Ingest(ctx, types.IngestEventRequest{

--- a/internal/e2eprobe/checks/entitlement_grant_additive_probe.go
+++ b/internal/e2eprobe/checks/entitlement_grant_additive_probe.go
@@ -155,11 +155,12 @@ func (p *EntitlementGrantAdditiveProbe) pollRawEvents(ctx context.Context, ext, 
 	// events and asserts len(...) >= 200 — request 200 in a single page so
 	// the assertion can succeed without paginating.
 	pageSize := int64(200)
-	// Staging's ingest consumer drains roughly ten events/second, so a
-	// 200-event burst needs ~20s to become queryable before any competing
-	// probe traffic is accounted for. 30s sat right on that edge and flaked;
-	// 90s matches the usage-summary deadline below.
-	deadline := time.Now().Add(90 * time.Second)
+	// Staging's ingest consumer drains roughly ten events/second, so this
+	// probe's own 200-event burst needs ~20s to become queryable. The bursts
+	// from concurrent probes (700 for commitment, 100 for tax) share that
+	// same queue, so worst-case depth is closer to a thousand events — about
+	// 100s. 30s and 90s both flaked under that; 180s covers it.
+	deadline := time.Now().Add(180 * time.Second)
 	for {
 		resp, err := p.client.Events().ListRaw(ctx, types.GetEventsRequest{
 			ExternalCustomerID: &ext,

--- a/internal/e2eprobe/checks/entitlement_grant_additive_probe.go
+++ b/internal/e2eprobe/checks/entitlement_grant_additive_probe.go
@@ -155,7 +155,11 @@ func (p *EntitlementGrantAdditiveProbe) pollRawEvents(ctx context.Context, ext, 
 	// events and asserts len(...) >= 200 — request 200 in a single page so
 	// the assertion can succeed without paginating.
 	pageSize := int64(200)
-	deadline := time.Now().Add(30 * time.Second)
+	// Staging's ingest consumer drains roughly ten events/second, so a
+	// 200-event burst needs ~20s to become queryable before any competing
+	// probe traffic is accounted for. 30s sat right on that edge and flaked;
+	// 90s matches the usage-summary deadline below.
+	deadline := time.Now().Add(90 * time.Second)
 	for {
 		resp, err := p.client.Events().ListRaw(ctx, types.GetEventsRequest{
 			ExternalCustomerID: &ext,

--- a/internal/e2eprobe/checks/fakeclient_test.go
+++ b/internal/e2eprobe/checks/fakeclient_test.go
@@ -255,6 +255,10 @@ type fakeSubscriptions struct {
 	cancelErr           error
 	getEntitlementsResp *dtos.GetSubscriptionEntitlementsResponse
 	getEntitlementsErr  error
+	// queryReturnsAll makes Query ignore the filter and return every stored
+	// sub, for tests that look subs up by external customer id (which this
+	// fake does not index).
+	queryReturnsAll bool
 }
 
 func (f *fakeSubscriptions) Create(_ context.Context, req types.CreateSubscriptionRequest) (*dtos.CreateSubscriptionResponse, error) {
@@ -303,7 +307,7 @@ func (f *fakeSubscriptions) Query(_ context.Context, filter types.SubscriptionFi
 	defer f.mu.Unlock()
 	var matched []types.SubscriptionResponse
 	for _, sub := range f.subs {
-		if filter.ExternalCustomerID != nil || filter.PlanID != nil {
+		if !f.queryReturnsAll && (filter.ExternalCustomerID != nil || filter.PlanID != nil) {
 			// Only return if it matches all provided filters; since fakeSubscriptions
 			// stores by ID and doesn't track ExternalCustomerID/PlanID, return empty
 			// unless the caller pre-populated desired subs via direct map manipulation.

--- a/internal/e2eprobe/checks/fakeclient_test.go
+++ b/internal/e2eprobe/checks/fakeclient_test.go
@@ -135,9 +135,10 @@ func (f *fakeCustomers) Query(_ context.Context, _ types.CustomerFilter) (*dtos.
 // --- Plans ---
 
 type fakePlans struct {
-	mu      sync.Mutex
-	created []types.CreatePlanRequest
-	plans   []types.PlanResponse
+	mu            sync.Mutex
+	created       []types.CreatePlanRequest
+	plans         []types.PlanResponse
+	syncedPlanIDs []string
 }
 
 func (f *fakePlans) Create(_ context.Context, req types.CreatePlanRequest) (*dtos.CreatePlanResponse, error) {
@@ -168,6 +169,13 @@ func (f *fakePlans) Query(_ context.Context, filter types.PlanFilter) (*dtos.Que
 }
 func (f *fakePlans) Get(_ context.Context, _ string) (*dtos.GetPlanResponse, error) {
 	return &dtos.GetPlanResponse{}, nil
+}
+
+func (f *fakePlans) SyncPrices(_ context.Context, planID string) (*dtos.SyncPlanPricesResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.syncedPlanIDs = append(f.syncedPlanIDs, planID)
+	return &dtos.SyncPlanPricesResponse{}, nil
 }
 
 // --- Prices ---

--- a/internal/e2eprobe/checks/meter_aggregation_probe.go
+++ b/internal/e2eprobe/checks/meter_aggregation_probe.go
@@ -91,6 +91,27 @@ func (p *MeterAggregationProbe) Run(ctx context.Context) error {
 	}
 	start := end.Add(-window)
 
+	// Usage analytics only returns meters carried by the customer's active
+	// subscription line items (see meterUsageService.activeSubscriptionMeterIDs).
+	// Line items snapshot the plan at subscription-create time, so a meter
+	// seeded after the persistent subs were created reports nothing until
+	// seed-ensure's plan price sync lands. That's a seed-drift window, not a
+	// broken aggregation pipeline — skip instead of paging.
+	onSub, err := p.meterOnActiveSubscription(ctx, extCustID, seeds.MeterIDs[eventName])
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{
+			"external_customer_id": extCustID,
+			"event_name":           eventName,
+		}, "resolve subscription line items for %s: %w", extCustID, err)
+	}
+	if !onSub {
+		p.logDebug(ctx, "meter-aggregation-probe: meter not on customer's active subscription, skipping",
+			"event_name", eventName,
+			"external_customer_id", extCustID,
+			"run_id", p.runID)
+		return nil
+	}
+
 	resp, err := p.client.Events().GetUsageAnalytics(ctx, types.GetUsageAnalyticsRequest{
 		ExternalCustomerID: &extCustID,
 		StartTime:          &start,
@@ -121,6 +142,41 @@ func (p *MeterAggregationProbe) Run(ctx context.Context) error {
 		"observed_sum":         fmt.Sprintf("%.4f", sum),
 	}, "meter %s has zero aggregated usage over %s window (event_ingest_driver should have produced events; aggregation pipeline may be broken)",
 		eventName, window)
+}
+
+// meterOnActiveSubscription reports whether meterID appears on any line item
+// of the customer's subscriptions. An unknown meter ID (seed map miss) counts
+// as present so the assertion still runs.
+func (p *MeterAggregationProbe) meterOnActiveSubscription(ctx context.Context, extCustID, meterID string) (bool, error) {
+	if meterID == "" {
+		return true, nil
+	}
+	ext := extCustID
+	listResp, err := p.client.Subscriptions().Query(ctx, types.SubscriptionFilter{ExternalCustomerID: &ext})
+	if err != nil {
+		return false, err
+	}
+	if listResp.ListSubscriptionsResponse == nil {
+		return false, nil
+	}
+	for _, sub := range listResp.ListSubscriptionsResponse.Items {
+		if sub.ID == nil {
+			continue
+		}
+		subResp, err := p.client.Subscriptions().Get(ctx, *sub.ID)
+		if err != nil {
+			return false, err
+		}
+		if subResp.SubscriptionResponse == nil {
+			continue
+		}
+		for _, li := range subResp.SubscriptionResponse.LineItems {
+			if li.MeterID != nil && *li.MeterID == meterID {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // sortedMeterEventNames returns the event names from meterIDs in stable sorted order.

--- a/internal/e2eprobe/checks/meter_aggregation_probe.go
+++ b/internal/e2eprobe/checks/meter_aggregation_probe.go
@@ -105,7 +105,7 @@ func (p *MeterAggregationProbe) Run(ctx context.Context) error {
 		}, "resolve subscription line items for %s: %w", extCustID, err)
 	}
 	if !onSub {
-		p.logDebug(ctx, "meter-aggregation-probe: meter not on customer's active subscription, skipping",
+		p.logInfo(ctx, "meter-aggregation-probe: meter not on customer's active subscription, skipping",
 			"event_name", eventName,
 			"external_customer_id", extCustID,
 			"run_id", p.runID)
@@ -152,7 +152,11 @@ func (p *MeterAggregationProbe) meterOnActiveSubscription(ctx context.Context, e
 		return true, nil
 	}
 	ext := extCustID
-	listResp, err := p.client.Subscriptions().Query(ctx, types.SubscriptionFilter{ExternalCustomerID: &ext})
+	active := types.SubscriptionStatusActive
+	listResp, err := p.client.Subscriptions().Query(ctx, types.SubscriptionFilter{
+		ExternalCustomerID: &ext,
+		SubscriptionStatus: []types.SubscriptionStatus{active},
+	})
 	if err != nil {
 		return false, err
 	}
@@ -161,6 +165,11 @@ func (p *MeterAggregationProbe) meterOnActiveSubscription(ctx context.Context, e
 	}
 	for _, sub := range listResp.ListSubscriptionsResponse.Items {
 		if sub.ID == nil {
+			continue
+		}
+		// Belt and braces: a server that ignores the status filter must not
+		// let a cancelled sub's line items mask a real aggregation failure.
+		if sub.SubscriptionStatus != nil && *sub.SubscriptionStatus != active {
 			continue
 		}
 		subResp, err := p.client.Subscriptions().Get(ctx, *sub.ID)
@@ -187,6 +196,13 @@ func sortedMeterEventNames(meterIDs map[string]string) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+func (p *MeterAggregationProbe) logInfo(ctx context.Context, msg string, kv ...any) {
+	if p.logger == nil {
+		return
+	}
+	p.logger.Info(ctx, msg, kv...)
 }
 
 func (p *MeterAggregationProbe) logDebug(ctx context.Context, msg string, kv ...any) {

--- a/internal/e2eprobe/checks/meter_aggregation_probe_test.go
+++ b/internal/e2eprobe/checks/meter_aggregation_probe_test.go
@@ -25,6 +25,21 @@ func TestMeterAggregationProbe_NoSeedsIsNoOp(t *testing.T) {
 	}
 }
 
+// seedSubWithMeter registers one subscription carrying meterID as a line item
+// so the probe's "is this meter on the customer's active sub?" gate passes.
+func seedSubWithMeter(fc *fakeClient, meterID string) {
+	id := "sub_meter_agg"
+	fc.subs.queryReturnsAll = true
+	fc.subs.subs = map[string]types.SubscriptionResponse{
+		id: {
+			ID: &id,
+			LineItems: []types.SubscriptionSubscriptionLineItem{
+				{MeterID: &meterID},
+			},
+		},
+	}
+}
+
 // TestMeterAggregationProbe_SuccessWhenSumPositive verifies that Run() returns
 // nil when the analytics response contains a positive TotalUsage for the
 // chosen event name.
@@ -37,6 +52,7 @@ func TestMeterAggregationProbe_SuccessWhenSumPositive(t *testing.T) {
 		{EventName: &eventName, TotalUsage: &usage},
 	}
 
+	seedSubWithMeter(fc, "meter_001")
 	reg := e2eprobe.NewRegistry()
 	reg.LoadSeeds(e2eprobe.Seeds{
 		PersistentCustomerIDs: []string{"c0"},
@@ -61,6 +77,7 @@ func TestMeterAggregationProbe_FailsWhenSumZero(t *testing.T) {
 	// analyticsItems is empty → extractAnalyticsSum returns 0.
 
 	eventName := "e2eprobe_count"
+	seedSubWithMeter(fc, "meter_001")
 	reg := e2eprobe.NewRegistry()
 	reg.LoadSeeds(e2eprobe.Seeds{
 		PersistentCustomerIDs: []string{"c0"},
@@ -88,5 +105,32 @@ func TestMeterAggregationProbe_FailsWhenSumZero(t *testing.T) {
 	// Error message should name the meter.
 	if !strings.Contains(err.Error(), eventName) {
 		t.Errorf("error %q should contain event name %q", err.Error(), eventName)
+	}
+}
+
+// TestMeterAggregationProbe_SkipsMeterNotOnSubscription verifies the probe
+// stays silent for a meter the customer's subscription doesn't carry. Usage
+// analytics filters by active-subscription line items, so a meter seeded
+// after the subs were created reports nothing until the plan price sync
+// lands — seed drift, not a broken pipeline.
+func TestMeterAggregationProbe_SkipsMeterNotOnSubscription(t *testing.T) {
+	fc := newFakeClient()
+	// Subscription carries a different meter than the one under test.
+	seedSubWithMeter(fc, "meter_other")
+
+	eventName := "e2eprobe_count"
+	reg := e2eprobe.NewRegistry()
+	reg.LoadSeeds(e2eprobe.Seeds{
+		PersistentCustomerIDs: []string{"c0"},
+		MeterIDs:              map[string]string{eventName: "meter_001"},
+	})
+
+	p := NewMeterAggregationProbe(fc, reg, "run-1", nil)
+	p.startedAt = time.Now().Add(-2 * meterAggLookback) // bypass startup grace
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run() with meter absent from subscription: %v", err)
+	}
+	if fc.events.analytics != 0 {
+		t.Errorf("expected the analytics call to be skipped, got %d", fc.events.analytics)
 	}
 }

--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -137,6 +138,15 @@ func (s *SeedEnsure) Run(ctx context.Context) error {
 	}
 	if err := s.ensureSubscriptions(ctx, &seeds); err != nil {
 		return err
+	}
+	// Non-fatal: repairs line-item drift on pre-existing subs. A failure here
+	// degrades bucketed-meter coverage, it doesn't invalidate the seed set.
+	if err := s.ensureSubscriptionPriceSync(ctx, &seeds); err != nil {
+		if s.logger != nil {
+			s.logger.Info(ctx, "seed-ensure: subscription price sync failed; continuing",
+				"error", err.Error(),
+			)
+		}
 	}
 	if err := s.ensurePersistentTaxAssociation(ctx, &seeds); err != nil {
 		return err
@@ -1060,6 +1070,129 @@ func (s *SeedEnsure) ensureSubscriptions(ctx context.Context, seeds *e2eprobe.Se
 // Unlike coupons (attached at sub-create via SubscriptionCoupons), tax
 // associations are a separate API call, so this covers both freshly-
 // created and pre-existing seed subs.
+
+// ensureSubscriptionPriceSync repairs persistent subscriptions whose line
+// items predate a plan price.
+//
+// Subscription line items snapshot the plan at create time. Every usage read
+// path filters by the meters on a customer's ACTIVE subscription line items
+// (meterUsageService.activeSubscriptionMeterIDs), so a meter seeded after the
+// persistent subs were created returns zero usage forever — even though its
+// events ingest and aggregate fine. That is what silently broke
+// meter-aggregation-probe and bucketed-meter-probe's analytics assertion for
+// the three bucketed meters added on 2026-08-12.
+//
+// The repair is idempotent and only fires on drift: compare the meters the
+// plan prices against the meters each persistent sub carries, and trigger the
+// plan price sync when any are missing. The sync runs as a background
+// workflow server-side; line items appear shortly after.
+func (s *SeedEnsure) ensureSubscriptionPriceSync(ctx context.Context, seeds *e2eprobe.Seeds) error {
+	if len(seeds.PlanIDs) == 0 || len(seeds.PersistentSubIDs) == 0 {
+		return nil
+	}
+	planID := seeds.PlanIDs[0]
+
+	planEntityType := types.PriceEntityTypePlan
+	priceResp, err := s.client.Prices().Query(ctx, types.PriceFilter{
+		PlanIds:    []string{planID},
+		EntityType: &planEntityType,
+	})
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{"plan_id": planID}, "query prices for plan %s: %w", planID, err)
+	}
+	pricedMeters := map[string]bool{}
+	if priceResp.ListPricesResponse != nil {
+		for _, pr := range priceResp.ListPricesResponse.Items {
+			if pr.MeterID != nil && *pr.MeterID != "" {
+				pricedMeters[*pr.MeterID] = true
+			}
+		}
+	}
+	if len(pricedMeters) == 0 {
+		return nil
+	}
+
+	missing := map[string]bool{}
+	for _, subID := range seeds.PersistentSubIDs {
+		subResp, err := s.client.Subscriptions().Get(ctx, subID)
+		if err != nil {
+			return e2eprobe.Errorf(map[string]string{"plan_id": planID, "subscription_id": subID}, "get sub %s: %w", subID, err)
+		}
+		if subResp.SubscriptionResponse == nil {
+			continue
+		}
+		have := map[string]bool{}
+		for _, li := range subResp.SubscriptionResponse.LineItems {
+			if li.MeterID != nil && *li.MeterID != "" {
+				have[*li.MeterID] = true
+			}
+		}
+		for meterID := range pricedMeters {
+			if !have[meterID] {
+				missing[meterID] = true
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	if _, err := s.client.Plans().SyncPrices(ctx, planID); err != nil {
+		// A sync already running for this plan answers 409 already_exists.
+		// That's the outcome we want, not a failure — the in-flight run
+		// covers the same drift.
+		if isSyncInProgress(err) {
+			if s.logger != nil {
+				s.logger.Info(ctx, "seed-ensure: plan price sync already in progress; skipping",
+					"plan_id", planID,
+					"missing_meter_ids", strings.Join(sortedKeys(missing), ","),
+				)
+			}
+			return nil
+		}
+		return e2eprobe.Errorf(map[string]string{"plan_id": planID, "missing_meter_ids": strings.Join(sortedKeys(missing), ",")}, "sync plan prices onto subscriptions: %w", err)
+	}
+	if s.logger != nil {
+		s.logger.Info(ctx, "seed-ensure: synced plan prices onto persistent subscriptions",
+			"plan_id", planID,
+			"missing_meter_ids", strings.Join(sortedKeys(missing), ","),
+			"subscription_count", len(seeds.PersistentSubIDs),
+		)
+	}
+	return nil
+}
+
+
+// isSyncInProgress reports whether the error is the plan price sync's
+// "a sync is already running" 409.
+func isSyncInProgress(err error) bool {
+	if err == nil {
+		return false
+	}
+	var errResp *sdkerrors.ErrorResponse
+	if errors.As(err, &errResp) {
+		if errResp.HTTPStatusCode != nil && *errResp.HTTPStatusCode == http.StatusConflict {
+			return true
+		}
+	}
+	var apiErr *sdkerrors.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+		return true
+	}
+	return strings.Contains(err.Error(), "already_exists")
+}
+
+// sortedKeys returns the map keys in stable order so log lines and error
+// attributes don't churn between runs.
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func (s *SeedEnsure) ensurePersistentTaxAssociation(ctx context.Context, out *e2eprobe.Seeds) error {
 	if out.SharedTaxRateCode == "" {
 		return nil // tax rate seed didn't run — soft skip

--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -173,6 +173,11 @@ type featureSpec struct {
 	expression  *string
 	filters     []types.MeterFilter
 	aggLabel    string
+	// noEntitlement keeps ensurePlanEntitlements from provisioning the
+	// standard 100-unit monthly entitlement on this feature. Probes that
+	// assert exact billed amounts need a meter whose usage is never
+	// partially absorbed by an entitlement allowance.
+	noEntitlement bool
 }
 
 var seedFeatureSpecs = func() []featureSpec {
@@ -236,6 +241,14 @@ var seedFeatureSpecs = func() []featureSpec {
 			lookupKey: "e2eprobe_max_day_feature", eventName: "e2eprobe_max_day",
 			displayName: "E2EProbe Max Day", aggType: types.AggregationTypeMax,
 			field: strPtr("amount"), bucketSize: bucketSizePtr(types.WindowSizeDay), aggLabel: "max_day",
+		},
+		{
+			// Reserved for CommitmentTrueUpProbe: entitlement-free so the
+			// billed amount equals units x price with nothing absorbed by an
+			// allowance. See CommitmentEventName.
+			lookupKey: "e2eprobe_sum_commit_feature", eventName: CommitmentEventName,
+			displayName: "E2EProbe Sum (commitment)", aggType: types.AggregationTypeSum,
+			field: strPtr("amount"), aggLabel: "sum_commit", noEntitlement: true,
 		},
 	}
 }()
@@ -488,6 +501,22 @@ var bucketedFeatureLookupKeys = func() map[string]bool {
 	return m
 }()
 
+// entitlementExemptLookupKeys is every feature ensurePlanEntitlements must
+// leave alone: bucketed meters (server rejects entitlements on them) plus
+// specs that opted out via noEntitlement.
+var entitlementExemptLookupKeys = func() map[string]bool {
+	m := map[string]bool{}
+	for k := range bucketedFeatureLookupKeys {
+		m[k] = true
+	}
+	for _, spec := range seedFeatureSpecs {
+		if spec.noEntitlement {
+			m[spec.lookupKey] = true
+		}
+	}
+	return m
+}()
+
 // grantOnlyFeatures is the set of feature lookup keys reserved for
 // grant entitlements. ensurePlanEntitlements skips these; the grant
 // entitlement is created by ensureEntitlementGrants instead. The DB
@@ -528,7 +557,7 @@ func (s *SeedEnsure) ensurePlanEntitlements(ctx context.Context, out *e2eprobe.S
 	// slot, and adding a soft-limit here would DB-conflict.
 	lookupKeys := make([]string, 0, len(seedFeatureSpecs))
 	for _, spec := range seedFeatureSpecs {
-		if bucketedFeatureLookupKeys[spec.lookupKey] {
+		if entitlementExemptLookupKeys[spec.lookupKey] {
 			continue
 		}
 		if grantOnlyFeatures[spec.lookupKey] {
@@ -1161,7 +1190,6 @@ func (s *SeedEnsure) ensureSubscriptionPriceSync(ctx context.Context, seeds *e2e
 	}
 	return nil
 }
-
 
 // isSyncInProgress reports whether the error is the plan price sync's
 // "a sync is already running" 409.

--- a/internal/e2eprobe/checks/seed_ensure.go
+++ b/internal/e2eprobe/checks/seed_ensure.go
@@ -1192,22 +1192,20 @@ func (s *SeedEnsure) ensureSubscriptionPriceSync(ctx context.Context, seeds *e2e
 }
 
 // isSyncInProgress reports whether the error is the plan price sync's
-// "a sync is already running" 409.
+// "a sync is already running for this plan" conflict.
+//
+// A bare 409 is deliberately not enough: an unrelated conflict would then be
+// swallowed as "someone else is syncing" and never reach the caller's error
+// path. Match the sync's own already_exists code instead.
 func isSyncInProgress(err error) bool {
 	if err == nil {
 		return false
 	}
 	var errResp *sdkerrors.ErrorResponse
-	if errors.As(err, &errResp) {
-		if errResp.HTTPStatusCode != nil && *errResp.HTTPStatusCode == http.StatusConflict {
-			return true
-		}
-	}
-	var apiErr *sdkerrors.APIError
-	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict {
+	if errors.As(err, &errResp) && errResp.Code != nil && *errResp.Code == types.ErrorCodeAlreadyExists {
 		return true
 	}
-	return strings.Contains(err.Error(), "already_exists")
+	return strings.Contains(err.Error(), string(types.ErrorCodeAlreadyExists))
 }
 
 // sortedKeys returns the map keys in stable order so log lines and error

--- a/internal/e2eprobe/checks/seed_ensure_test.go
+++ b/internal/e2eprobe/checks/seed_ensure_test.go
@@ -60,16 +60,16 @@ func TestSeedEnsure(t *testing.T) {
 				// subs and wallets are empty — they'll be created
 			},
 			wantErr:                 false,
-			wantFeaturesCreated:     0,  // all 11 found via Query
+			wantFeaturesCreated:     0, // all seed features found via Query
 			wantCustomersCreated:    1,  // 10 pre-populated; alert canary still needs creating
 			wantPlansCreated:        0,  // plan found via Query
-			wantPricesCreated:       12, // base + 11 usage prices
+			wantPricesCreated:       len(seedFeatureSpecs) + 1, // base + one usage price per feature
 			wantSubsCreated:         11, // 10 persistent + 1 alert canary
 			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
 			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
-			wantMeterIDs:            11,
-			wantFeatureIDs:          11,
+			wantMeterIDs:            len(seedFeatureSpecs),
+			wantFeatureIDs:          len(seedFeatureSpecs),
 			wantPlanIDs:             1,
 			wantSubIDs:              11,
 		},
@@ -80,23 +80,23 @@ func TestSeedEnsure(t *testing.T) {
 				fc.customers.getErr = errNotFound
 			},
 			wantErr:                 false,
-			wantFeaturesCreated:     11,
+			wantFeaturesCreated:     len(seedFeatureSpecs),
 			wantCustomersCreated:    11, // 10 persistent + 1 alert canary
 			wantPlansCreated:        1,
-			wantPricesCreated:       12, // base + 11 usage
+			wantPricesCreated:       len(seedFeatureSpecs) + 1, // base + one usage price per feature
 			wantSubsCreated:         11, // 10 persistent + 1 alert canary
 			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
 			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
-			wantMeterIDs:            11,
-			wantFeatureIDs:          11,
+			wantMeterIDs:            len(seedFeatureSpecs),
+			wantFeatureIDs:          len(seedFeatureSpecs),
 			wantPlanIDs:             1,
 			wantSubIDs:              11,
 		},
 		{
 			name: "PartialExisting: features exist but plan/subs/wallets don't",
 			setup: func(fc *fakeClient) {
-				// Pre-populate 11 features.
+				// Pre-populate every seed feature.
 				for _, spec := range seedFeatureSpecs {
 					lk := spec.lookupKey
 					mID := "meter_" + spec.eventName
@@ -117,13 +117,13 @@ func TestSeedEnsure(t *testing.T) {
 			wantFeaturesCreated:     0,
 			wantCustomersCreated:    1,  // alert canary still needs creating
 			wantPlansCreated:        1,
-			wantPricesCreated:       12,
+			wantPricesCreated:       len(seedFeatureSpecs) + 1,
 			wantSubsCreated:         11, // 10 persistent + 1 alert canary
 			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
 			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
-			wantMeterIDs:            11,
-			wantFeatureIDs:          11,
+			wantMeterIDs:            len(seedFeatureSpecs),
+			wantFeatureIDs:          len(seedFeatureSpecs),
 			wantPlanIDs:             1,
 			wantSubIDs:              11,
 		},

--- a/internal/e2eprobe/client.go
+++ b/internal/e2eprobe/client.go
@@ -80,6 +80,13 @@ type PlanOps interface {
 	Create(ctx context.Context, req types.CreatePlanRequest) (*dtos.CreatePlanResponse, error)
 	Query(ctx context.Context, filter types.PlanFilter) (*dtos.QueryPlanResponse, error)
 	Get(ctx context.Context, id string) (*dtos.GetPlanResponse, error)
+
+	// SyncPrices pushes prices added to the plan after a subscription was
+	// created onto that subscription's line items. Line items snapshot the
+	// plan at create time, so a seed meter added later is invisible to every
+	// existing subscription — and to every read path that filters usage by
+	// active-subscription line items — until this runs.
+	SyncPrices(ctx context.Context, planID string) (*dtos.SyncPlanPricesResponse, error)
 }
 
 type PriceOps interface {
@@ -252,6 +259,10 @@ func (o planOps) Query(ctx context.Context, f types.PlanFilter) (*dtos.QueryPlan
 }
 func (o planOps) Get(ctx context.Context, id string) (*dtos.GetPlanResponse, error) {
 	return o.s.GetPlan(ctx, id)
+}
+
+func (o planOps) SyncPrices(ctx context.Context, planID string) (*dtos.SyncPlanPricesResponse, error) {
+	return o.s.SyncPlanPrices(ctx, planID)
 }
 
 type priceOps struct{ s *flexprice.Prices }

--- a/internal/e2eprobe/client_dryrun.go
+++ b/internal/e2eprobe/client_dryrun.go
@@ -137,6 +137,12 @@ func (d *dryRunPlans) Get(ctx context.Context, id string) (*dtos.GetPlanResponse
 	return d.inner.Get(ctx, id)
 }
 
+// SyncPrices mutates existing subscriptions' line items — never run it in dry run.
+func (d *dryRunPlans) SyncPrices(ctx context.Context, planID string) (*dtos.SyncPlanPricesResponse, error) {
+	dryLog(ctx, d.lg, "Plans.SyncPrices", "plan_id", planID)
+	return &dtos.SyncPlanPricesResponse{}, nil
+}
+
 // ── Prices ────────────────────────────────────────────────────────────
 
 type dryRunPrices struct {

--- a/internal/e2eprobe/client_dryrun_test.go
+++ b/internal/e2eprobe/client_dryrun_test.go
@@ -55,6 +55,10 @@ func (f *fakePlanOps) Get(_ context.Context, _ string) (*dtos.GetPlanResponse, e
 	return &dtos.GetPlanResponse{}, nil
 }
 
+func (f *fakePlanOps) SyncPrices(_ context.Context, _ string) (*dtos.SyncPlanPricesResponse, error) {
+	return nil, nil
+}
+
 type fakeFeatureOps struct{ createCalled int32 }
 
 func (f *fakeFeatureOps) Create(_ context.Context, _ types.CreateFeatureRequest) (*dtos.CreateFeatureResponse, error) {

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -2178,6 +2178,11 @@ func (s *invoiceService) GetPreviewInvoice(ctx context.Context, req dto.GetPrevi
 	// Create preview response
 	response := dto.NewInvoiceResponse(inv)
 
+	// Previews persist no tax_applied rows, so synthesise the per-rate
+	// breakdown that WithTaxes would otherwise load from the DB — without it
+	// the response carries total_tax but an empty taxes[] array.
+	response.WithTaxes(dto.BuildPreviewTaxes(inv, invReq.PreparedTaxRates))
+
 	// Get customer information
 	customer, err := s.CustomerRepo.Get(ctx, inv.CustomerID)
 	if err != nil {
@@ -2232,6 +2237,11 @@ func (s *invoiceService) GetInternalPreviewInvoice(ctx context.Context, req dto.
 
 	// Create preview response
 	response := dto.NewInvoiceResponse(inv)
+
+	// Previews persist no tax_applied rows, so synthesise the per-rate
+	// breakdown that WithTaxes would otherwise load from the DB — without it
+	// the response carries total_tax but an empty taxes[] array.
+	response.WithTaxes(dto.BuildPreviewTaxes(inv, invReq.PreparedTaxRates))
 
 	// Get customer information
 	customer, err := s.CustomerRepo.Get(ctx, inv.CustomerID)


### PR DESCRIPTION
## **User description**
The billing-coverage checks added on 2026-08-12/13 only began asserting once seeding was fully repaired (`fix(e2e): Tax association`, merged 2026-08-17). They then failed continuously on `gcp-staging-as1`. Five distinct causes, none of them a billing regression:

**`bucketed-meter-probe` — raw_verify**
The raw-event query passed neither a page size nor a time range, so it read the default most-recent 50 rows in timestamp-DESC order. The probe's events are backdated by up to three bucket durations and the persistent customer also receives continuous `event-ingest-driver` traffic on the same event names, so those rows sat far below the page window and were never observed. Now queried by `event_id`, with an explicit range covering the oldest backdated bucket.

**`entitlement-grant-additive-probe` — raw_verify**
Staging's ingest consumer makes events queryable at roughly ten per second, so a 200-event burst needs ~20s before the assertion can pass, and the bursts of concurrent probes share that queue. The 30s deadline sat on that edge; raised to 180s.

**`commitment-true-up-probe` — both legs**
Three problems: the subscription was created without `enable_true_up`, which `billingService.CalculateUsageCharges` requires before it emits a true-up line item; the usage poll compared raw usage ($7.00) against an API that reports the commitment-adjusted amount ($8.00), returning while ~10% of events were still draining; and every seeded metered feature carries a 100-unit monthly entitlement that silently absorbed the first $1.00 of usage, leaving both legs exactly $1.00 short. The probe now bills against a dedicated entitlement-free `e2eprobe_sum_commit` meter (new `noEntitlement` spec flag).

**`meter-aggregation-probe` — zero usage on the bucketed meters**
Subscription line items snapshot the plan at create time, and every usage read path filters by the meters on active-subscription line items (`meterUsageService.activeSubscriptionMeterIDs`). The three bucketed meters seeded on 2026-08-12 were therefore invisible to persistent subscriptions created on 2026-08-09 — events ingested and aggregated fine but analytics returned nothing. `seed-ensure` now detects that drift and triggers the plan price sync; the probe skips any meter not yet on the customer's subscription instead of paging.

**Invoice preview reported `total_tax` with an empty `taxes[]`**
Previews persist no `tax_applied` rows, so the breakdown that `WithTaxes` normally loads from the DB was never populated — callers saw a tax charge with no indication of which rate produced it. `BuildPreviewTaxes` synthesises it from the prepared tax rates, sharing the per-rate math with the preview total so the two cannot drift.

## Verified against staging

A patched probe run against `gcp-staging-as1`: `bucketed-meter-probe` 2/2, `commitment-true-up-probe` 6/6 (was 1/4 and 1/3). All 11 seed meters return usage after the price sync. `tax-application-probe` stays red until this deploys — the fix is server-side.

## Known gap, unchanged here

Preview still skips coupon discounts entirely (`CreateInvoiceRequest.ToInvoice` hardcodes `totalDiscount := decimal.Zero`), so a subscription carrying a coupon previews `total_discount: 0` and an empty `coupon_applications`. That under-reports discounts to customers and keeps `coupon-application-probe` failing. Fixing it means splitting `ApplyCouponsToInvoice` into calculate/persist halves — a billing change that wants its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice previews now include detailed tax breakdowns for each applicable tax rate.
  * Subscription previews provide tax details alongside aggregate tax totals.
  * Preview tax amounts now respect currency-specific rounding.

* **Bug Fixes**
  * Tax calculations handle missing, unsupported, or negative values consistently.
  * Taxable amounts cannot become negative when discounts exceed subtotals.
  * Usage verification and subscription synchronization are more reliable during setup and delayed processing.
  * Usage aggregation skips meters that are not included in an active subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Repair staging billing checks and show tax details in invoice previews

### What Changed
- Invoice previews now include each applicable tax rate, taxable amount, and rounded tax amount in `taxes[]`, while ignoring incomplete tax rates.
- Billing probes now verify backdated events by ID, allow time for staging ingestion, and use an entitlement-free meter for exact commitment true-up totals.
- Seed setup repairs missing plan prices on existing subscriptions, while meter checks skip meters not yet available on a customer's subscription instead of reporting false aggregation failures.
- Bucketed probe event IDs are unique to each run, preventing older events from satisfying a new check.

### Impact
`✅ Tax breakdowns visible in invoice previews`
`✅ Fewer false staging billing failures`
`✅ Accurate commitment true-up previews`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
