### PR TITLE
fix(meter-usage): fail closed when a subscription's customer can't be resolved

### DIFF
--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -2231,6 +2231,12 @@ func (s *meterUsageService) ConvertToBillingCharges(
 // rows belong to a subscription. For Parent subscriptions the inherited-child
 // customers are folded in only when includeChildren is true; otherwise the
 // query stays scoped to the owning customer.
+//
+// It never returns an empty slice: callers feed the result straight into
+// MeterUsageQueryParams.ExternalCustomerIDs, and BuildWhereClause drops the
+// external_customer_id predicate when that slice is empty. An empty return
+// would therefore widen every downstream meter_usage query to the entire
+// tenant instead of narrowing it. Unresolvable customers are an error.
 func (s *meterUsageService) resolveExternalCustomerIDs(ctx context.Context, sub *subscription.Subscription, includeChildren bool) ([]string, error) {
 	internalIDs := []string{sub.CustomerID}
 	if includeChildren && sub.SubscriptionType == types.SubscriptionTypeParent {
@@ -2265,7 +2271,25 @@ func (s *meterUsageService) resolveExternalCustomerIDs(ctx context.Context, sub 
 			externalIDs = append(externalIDs, cust.ExternalID)
 		}
 	}
-	return lo.Uniq(externalIDs), nil
+	externalIDs = lo.Uniq(externalIDs)
+
+	// Fail closed rather than silently querying the whole tenant. CustomerRepo.List
+	// matches published customers only — CustomerQueryOptions.ApplyStatusFilter turns
+	// an unset status into status = 'published' — so a customer soft-deleted while its
+	// subscription stayed active resolves to zero rows and lands here.
+	if len(externalIDs) == 0 {
+		return nil, ierr.NewError("no resolvable customer for subscription").
+			WithHint("The subscription's customer could not be resolved. It may have been deleted while the subscription remained active.").
+			WithReportableDetails(map[string]any{
+				"subscription_id":        sub.ID,
+				"customer_id":            sub.CustomerID,
+				"looked_up_customer_ids": internalIDs,
+				"include_children":       includeChildren,
+			}).
+			Mark(ierr.ErrInvalidOperation)
+	}
+
+	return externalIDs, nil
 }
 
 // listLineItemsForUsageWindow retrieves line items active within the usage window.


### PR DESCRIPTION
## **User description**
## Problem

`resolveExternalCustomerIDs` returns an empty slice when `CustomerRepo.List` matches nothing. Callers pass that straight into `MeterUsageQueryParams.ExternalCustomerIDs`, and `BuildWhereClause` **omits** the `external_customer_id` predicate on an empty slice:

```go
// internal/repository/clickhouse/meter_usage_query_builder.go:143
if params.ExternalCustomerID != "" {
    conditions = append(conditions, "external_customer_id = ?")
} else if len(params.ExternalCustomerIDs) > 0 {
    // ... external_customer_id IN (...)
}
```

So instead of narrowing to one customer, the query silently widens to the **entire tenant**.

The list comes back empty because `CustomerRepo.List` matches published customers only — `CustomerQueryOptions.ApplyStatusFilter` turns an unset status into `status = 'published'` (`internal/repository/ent/customer.go:448`), and `NewNoLimitCustomerFilter()` leaves `Status` nil. A customer soft-deleted while its subscription stayed active therefore resolves to zero rows.

This is **not** about a missing `external_id` — `ent/schema/customer.go:37` declares it `NotEmpty()` with a unique index requiring `external_id <> ''`.

## Production impact (Sarvam)

| | |
|---|---|
| Active subscriptions with `customer.status = 'deleted'` | **34,496** (all deleted on 2026-07-28) |
| Same, with empty `external_id` | 0 |
| `ComputeInvoiceActivity` runs/day | ~39,900 |
| Failing/day with `context deadline exceeded` | ~1,270 (**1.0% → 3.2%** over 11 days) |
| Tenant-wide `meter_usage FINAL` scan | 598M rows, ~159 s, growing +81% in 9 days |
| Morning CPU attributable to these scans | ~97 of 145 CPU-h |

The daily `DailyDraftAndCompute` run turns each affected subscription into a whole-tenant `meter_usage FINAL` scan. Failures are `failed to query meter_usage for agg type SUM: context deadline exceeded` against the workflow's 10-minute `StartToCloseTimeout`. With `MaximumAttempts: 3`, each broken subscription costs up to three such scans.

**Correctness, not just cost:** any affected subscription that did *not* time out computed its charges from tenant-wide usage.

## Change

`resolveExternalCustomerIDs` now returns an error instead of an empty slice. The single call site (`meter_usage.go:390`) already propagates it, so `GetSubscriptionMeterUsage` returns before building any query. The invariant is documented on the function so the empty return isn't reintroduced.

`ErrInvalidOperation` (400), not `ErrNotFound` (404): the subscription exists and the request is well formed — the operation just can't be performed while the customer is unresolvable. 404 would wrongly imply the subscription is missing.

The error carries `subscription_id` and `customer_id`. Activity spans carry neither, so this makes affected subscriptions identifiable from traces for the first time.

## Behavior change to review

`GetUsageAnalytics` routes through the same function, so an API request for a deleted customer's usage now returns 400 instead of data. That data was whole-tenant usage, so this is a fix — but it is user-visible.

## Not included

- **Operational cleanup** of the 34,496 subscriptions whose customers were deleted on 2026-07-28. This PR makes them fail fast and cheaply; it does not fix the data.
- **Non-retryable classification.** Other activities wrap `ErrNotFound` in `temporal.NewNonRetryableApplicationError`; `ComputeInvoiceActivity` does not, so these permanent failures still retry 3×.
- **`FINAL` on the meter_usage read path** — separately ~36% of ClickHouse query CPU.

## Testing

`go build`, `go vet`, and `go test ./internal/ee/service/ -run 'MeterUsage|Subscription'` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent unscoped meter usage queries and provide a unified invoice modification workflow

### What Changed
- Meter usage processing now stops with a clear error when a subscription’s customer cannot be resolved, instead of querying usage for the entire tenant
- Invoice line-item additions, updates, and removals always mark the invoice as manually edited
- Added a unified invoice modification flow for adding or removing line items, with validation for unsupported actions and missing parameters
- Computed invoices with manual line-item edits are rejected with an actionable validation message
- Invoice webhooks now return the complete invoice response, including the customer environment

### Impact
`✅ Fewer tenant-wide meter usage scans`
`✅ Safer invoice recomputation after manual edits`
`✅ Clearer invoice modification and customer environment data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage query safety by removing duplicate customer identifiers.
  * Prevented queries from proceeding when no valid customer identifier can be resolved.
  * Added clearer diagnostics for invalid subscription or customer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->