### PR TITLE
fix(invoice): compute coupon discounts on invoice previews

### DIFF
--- a/internal/api/dto/invoice.go
+++ b/internal/api/dto/invoice.go
@@ -571,14 +571,36 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 	// be handled at the service layer. For now, we skip coupon preview calculations here.
 	totalDiscount := decimal.Zero
 
-	// 3) Taxes on (subtotal - totalDiscount) using prepared tax rates
-	totalTax := decimal.Zero
-	taxableAmount := inv.Subtotal.Sub(totalDiscount)
+	// 3) Taxes are applied on (subtotal - totalDiscount) by
+	// RecalculatePreviewTotals below.
+
+	// 4) Update invoice preview totals
+	inv.TotalDiscount = totalDiscount
+	RecalculatePreviewTotals(inv, r.PreparedTaxRates)
+
+	return inv, nil
+}
+
+// RecalculatePreviewTotals recomputes a preview invoice's tax and totals from
+// its current subtotal and TotalDiscount, in the order a real invoice applies
+// them: discounts first, tax on what remains.
+//
+// Coupon discounts are resolved at the service layer (they need coupon
+// validation and the coupon repository), so the preview path sets
+// inv.TotalDiscount afterwards and calls this to bring tax and totals back in
+// step. Without the second pass, tax would stay computed against the
+// undiscounted subtotal.
+func RecalculatePreviewTotals(inv *invoice.Invoice, preparedTaxRates []*TaxRateResponse) {
+	if inv == nil {
+		return
+	}
+	taxableAmount := inv.Subtotal.Sub(inv.TotalDiscount)
 	if taxableAmount.IsNegative() {
 		taxableAmount = decimal.Zero
 	}
 
-	for _, tr := range r.PreparedTaxRates {
+	totalTax := decimal.Zero
+	for _, tr := range preparedTaxRates {
 		taxAmount, ok := previewTaxAmount(tr, taxableAmount, inv.Currency)
 		if !ok {
 			continue
@@ -586,17 +608,13 @@ func (r *CreateInvoiceRequest) ToInvoice(ctx context.Context) (*invoice.Invoice,
 		totalTax = totalTax.Add(taxAmount)
 	}
 
-	// 4) Update invoice preview totals
-	inv.TotalDiscount = totalDiscount
 	inv.TotalTax = totalTax
-	inv.Total = inv.Subtotal.Sub(totalDiscount).Add(totalTax)
+	inv.Total = taxableAmount.Add(totalTax)
 	if inv.Total.IsNegative() {
 		inv.Total = decimal.Zero
 	}
 	inv.AmountDue = inv.Total
 	inv.AmountRemaining = inv.Total.Sub(inv.AmountPaid)
-
-	return inv, nil
 }
 
 // previewTaxAmount computes the tax owed on taxableAmount for a single

--- a/internal/api/dto/invoice_test.go
+++ b/internal/api/dto/invoice_test.go
@@ -129,3 +129,44 @@ func TestBuildPreviewTaxes_RoundsToCurrencyPrecision(t *testing.T) {
 	assert.Equal(t, "7.5", taxes[0].TaxAmount.String())
 	assert.Equal(t, "tenant_1", taxes[0].TenantID)
 }
+
+func TestRecalculatePreviewTotals_TaxesTheDiscountedSubtotal(t *testing.T) {
+	// A coupon resolved at the service layer sets TotalDiscount after
+	// ToInvoice has already taxed the full subtotal, so the second pass must
+	// tax what remains — not the original amount.
+	pct := decimal.NewFromInt(10)
+	rates := []*TaxRateResponse{
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_pct", TaxRateType: types.TaxRateTypePercentage, PercentageValue: &pct}},
+	}
+	inv := &invoice.Invoice{
+		ID:            "inv_preview",
+		Currency:      "usd",
+		Subtotal:      decimal.NewFromInt(100),
+		TotalDiscount: decimal.NewFromInt(20),
+	}
+
+	RecalculatePreviewTotals(inv, rates)
+
+	assert.Equal(t, "8", inv.TotalTax.String(), "tax must be 10%% of 80, not of 100")
+	assert.Equal(t, "88", inv.Total.String())
+	assert.Equal(t, "88", inv.AmountDue.String())
+	assert.Equal(t, "88", inv.AmountRemaining.String())
+}
+
+func TestRecalculatePreviewTotals_DiscountBeyondSubtotal(t *testing.T) {
+	pct := decimal.NewFromInt(10)
+	rates := []*TaxRateResponse{
+		{TaxRate: &taxrate.TaxRate{ID: "taxrate_pct", TaxRateType: types.TaxRateTypePercentage, PercentageValue: &pct}},
+	}
+	inv := &invoice.Invoice{
+		ID:            "inv_preview",
+		Currency:      "usd",
+		Subtotal:      decimal.NewFromInt(10),
+		TotalDiscount: decimal.NewFromInt(30),
+	}
+
+	RecalculatePreviewTotals(inv, rates)
+
+	assert.True(t, inv.TotalTax.IsZero(), "tax: %s", inv.TotalTax)
+	assert.True(t, inv.Total.IsZero(), "total: %s", inv.Total)
+}

--- a/internal/e2eprobe/checks/wallet_debit_verification.go
+++ b/internal/e2eprobe/checks/wallet_debit_verification.go
@@ -49,8 +49,11 @@ type WalletDebitOpts struct {
 
 	// LandedPollInterval / LandedPollTimeout bound the wait for synchronously-
 	// ingested events to show up in the raw events table before the probe
-	// starts polling the aggregation pipeline. Short by design — if events
-	// haven't landed in 30s the ingestion path is broken, not just slow.
+	// starts polling the aggregation pipeline. The budget has to cover queue
+	// depth, not just this batch: the scenario probes burst on the same
+	// minute and staging's consumer drains ~10 events/second, so ten events
+	// can sit behind a thousand queued ones. 30s flagged that as dropped
+	// data.
 	LandedPollInterval time.Duration
 	LandedPollTimeout  time.Duration
 }
@@ -63,7 +66,7 @@ func defaultWalletDebitOpts() WalletDebitOpts {
 		AnalyticsPollInterval: 10 * time.Second,
 		AnalyticsPollTimeout:  5 * time.Minute,
 		LandedPollInterval:    2 * time.Second,
-		LandedPollTimeout:     30 * time.Second,
+		LandedPollTimeout:     120 * time.Second,
 	}
 }
 
@@ -83,12 +86,12 @@ func NewWalletDebitVerification(c e2eprobe.Client, r e2eprobe.Registry, runID st
 		opts.LandedPollInterval = 2 * time.Second
 	}
 	if opts.LandedPollTimeout == 0 {
-		opts.LandedPollTimeout = 30 * time.Second
+		opts.LandedPollTimeout = 120 * time.Second
 	}
 	return &WalletDebitVerification{client: c, reg: r, runID: runID, opts: opts}
 }
 
-func (v *WalletDebitVerification) Name() string         { return "wallet-debit-verification" }
+func (v *WalletDebitVerification) Name() string        { return "wallet-debit-verification" }
 func (v *WalletDebitVerification) Kind() e2eprobe.Kind { return e2eprobe.KindProbe }
 
 func (v *WalletDebitVerification) Run(ctx context.Context) error {
@@ -183,8 +186,8 @@ func (v *WalletDebitVerification) phase1TopUp(ctx context.Context, extCustID, in
 //   - landed_count < N:                       ingestion path dropped events
 //   - landed_count == N, analytics_sum == 0:  aggregation pipeline never processed them
 //   - landed_count == N, analytics_sum < N:   partial aggregation drop (the
-//                                             real failure mode the probe has
-//                                             been catching in production)
+//     real failure mode the probe has
+//     been catching in production)
 func (v *WalletDebitVerification) phase2Analytics(ctx context.Context, extCustID string) error {
 	amountPerEvent, err := parseFloat(v.opts.EventAmount)
 	if err != nil {
@@ -225,9 +228,9 @@ func (v *WalletDebitVerification) phase2Analytics(ctx context.Context, extCustID
 	// brief retry budget — the ingest API returns 2xx before the synchronous
 	// write completes in some deployments, so a single ListRaw call right
 	// after the loop occasionally undercounts. Retry for up to 30s.
-	landedCount := v.confirmEventsLanded(ctx, extCustID, batchTag, ingestTime)
+	landedCount, lastQueryErr := v.confirmEventsLanded(ctx, extCustID, batchTag, ingestTime)
 	if landedCount < v.opts.EventCount {
-		return e2eprobe.Errorf(map[string]string{
+		attrs := map[string]string{
 			"external_customer_id": extCustID,
 			"event_name":           "e2eprobe_sum",
 			"debit_batch":          batchTag,
@@ -235,8 +238,20 @@ func (v *WalletDebitVerification) phase2Analytics(ctx context.Context, extCustID
 			"landed_count":         fmt.Sprintf("%d", landedCount),
 			"first_event_id":       eventIDs[0],
 			"last_event_id":        eventIDs[len(eventIDs)-1],
-		}, "ingest dropped events: only %d of %d landed in events table within 30s",
-			landedCount, v.opts.EventCount)
+			"landed_timeout":       v.opts.LandedPollTimeout.String(),
+		}
+		// "not visible yet" is not the same as "dropped": staging's ingest
+		// consumer drains ~10 events/second and the scenario probes burst
+		// together on the same minute, so a batch can sit behind a thousand
+		// queued events. Say what was observed and surface the last query
+		// error — a failing read used to render identically to data loss.
+		if lastQueryErr != nil {
+			attrs["last_query_error"] = lastQueryErr.Error()
+			return e2eprobe.Errorf(attrs, "only %d of %d events visible within %s; last query failed: %w",
+				landedCount, v.opts.EventCount, v.opts.LandedPollTimeout, lastQueryErr)
+		}
+		return e2eprobe.Errorf(attrs, "only %d of %d events visible in the events table within %s",
+			landedCount, v.opts.EventCount, v.opts.LandedPollTimeout)
 	}
 
 	// Step 2: poll analytics until sum ≥ expectedTotal or timeout.
@@ -289,11 +304,12 @@ func (v *WalletDebitVerification) phase2Analytics(ctx context.Context, extCustID
 // the raw events table. Polls for up to 30s to allow for ingest-side write
 // lag. Errors during the query are treated as 0 landed so the caller can
 // alert on ingestion regressions even when ListRaw itself is misbehaving.
-func (v *WalletDebitVerification) confirmEventsLanded(ctx context.Context, extCustID, batchTag string, ingestTime time.Time) int {
+func (v *WalletDebitVerification) confirmEventsLanded(ctx context.Context, extCustID, batchTag string, ingestTime time.Time) (int, error) {
 	deadline := time.Now().Add(v.opts.LandedPollTimeout)
 	eventName := "e2eprobe_sum"
 	startTime := ingestTime.Add(-1 * time.Minute).UTC()
 	var maxSeen int
+	var lastErr error
 	for {
 		endTime := time.Now().UTC()
 		pageSize := int64(v.opts.EventCount * 2)
@@ -305,6 +321,9 @@ func (v *WalletDebitVerification) confirmEventsLanded(ctx context.Context, extCu
 			EndTime:            &endTime,
 			PageSize:           &pageSize,
 		})
+		if err != nil {
+			lastErr = err
+		}
 		if err == nil && resp != nil {
 			inner := resp.GetGetEventsResponse()
 			if inner != nil {
@@ -313,16 +332,16 @@ func (v *WalletDebitVerification) confirmEventsLanded(ctx context.Context, extCu
 					maxSeen = n
 				}
 				if n >= v.opts.EventCount {
-					return n
+					return n, nil
 				}
 			}
 		}
 		if time.Now().After(deadline) {
-			return maxSeen
+			return maxSeen, lastErr
 		}
 		select {
 		case <-ctx.Done():
-			return maxSeen
+			return maxSeen, lastErr
 		case <-time.After(v.opts.LandedPollInterval):
 		}
 	}

--- a/internal/ee/service/coupon_application.go
+++ b/internal/ee/service/coupon_application.go
@@ -19,12 +19,25 @@ type CouponCalculationResult struct {
 	TotalDiscountAmount          decimal.Decimal
 	TotalInvoiceLineItemDiscount decimal.Decimal
 	TotalInvoiceLevelDiscount    decimal.Decimal
+	// AppliedCoupons is populated by CalculateCouponsForInvoice so a preview
+	// can surface the same per-coupon breakdown a persisted invoice carries.
+	// ApplyCouponsToInvoice leaves it nil — its callers read the totals and
+	// the persisted rows instead.
+	AppliedCoupons []*dto.CouponApplicationResponse
 }
 
 type CouponApplicationService interface {
 	CreateCouponApplication(ctx context.Context, req dto.CreateCouponApplicationRequest) (*dto.CouponApplicationResponse, error)
 	GetCouponApplication(ctx context.Context, id string) (*dto.CouponApplicationResponse, error)
 	ApplyCouponsToInvoice(ctx context.Context, req dto.ApplyCouponsToInvoiceRequest) (*CouponCalculationResult, error)
+
+	// CalculateCouponsForInvoice runs the same discount computation as
+	// ApplyCouponsToInvoice and stops before any persistence: nothing is
+	// written, no redemption is counted. It exists for invoice previews,
+	// which must show the discounts a real invoice would carry without
+	// consuming the coupon. Line-item discounts are still set on the passed
+	// invoice's in-memory line items.
+	CalculateCouponsForInvoice(ctx context.Context, req dto.ApplyCouponsToInvoiceRequest) (*CouponCalculationResult, error)
 }
 
 type couponApplicationService struct {
@@ -115,10 +128,38 @@ func resolveInvoiceLineItemToBeDiscounted(
 	return target, ok
 }
 
-// ApplyCouponsToInvoice applies both invoice-level and line item-level coupons to an invoice.
-// This is the unified method that handles all coupon application logic.
-// CouponService.ApplyDiscount() handles all validation and calculation.
-func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, req dto.ApplyCouponsToInvoiceRequest) (*CouponCalculationResult, error) {
+// couponPreparation is the outcome of the pure computation phase: the totals,
+// the entities that would be persisted, and the coupons keyed by id (needed by
+// the persistence phase for redemption limits).
+type couponPreparation struct {
+	appliedCoupons                 []*dto.CouponApplicationResponse
+	lineItemCouponApplications     []*coupon_application.CouponApplication
+	invoiceLevelCouponApplications []*coupon_application.CouponApplication
+	couponsMap                     map[string]*coupon.Coupon
+	totalLineItemDiscount          decimal.Decimal
+	totalInvoiceLevelDiscount      decimal.Decimal
+}
+
+// CalculateCouponsForInvoice computes the discounts without writing anything.
+// See the interface for why previews need this.
+func (s *couponApplicationService) CalculateCouponsForInvoice(ctx context.Context, req dto.ApplyCouponsToInvoiceRequest) (*CouponCalculationResult, error) {
+	prep, err := s.prepareCouponApplications(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return &CouponCalculationResult{
+		TotalDiscountAmount:          prep.totalLineItemDiscount.Add(prep.totalInvoiceLevelDiscount),
+		TotalInvoiceLineItemDiscount: prep.totalLineItemDiscount,
+		TotalInvoiceLevelDiscount:    prep.totalInvoiceLevelDiscount,
+		AppliedCoupons:               prep.appliedCoupons,
+	}, nil
+}
+
+// prepareCouponApplications runs the computation shared by
+// ApplyCouponsToInvoice and CalculateCouponsForInvoice. It writes nothing; the
+// only mutation is LineItemDiscount on the passed invoice's in-memory line
+// items, which both callers rely on.
+func (s *couponApplicationService) prepareCouponApplications(ctx context.Context, req dto.ApplyCouponsToInvoiceRequest) (*couponPreparation, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
@@ -127,13 +168,12 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 	invoiceCoupons := req.InvoiceCoupons
 	lineItemCoupons := req.LineItemCoupons
 
-	result := &CouponCalculationResult{
-		TotalDiscountAmount:          decimal.Zero,
-		TotalInvoiceLineItemDiscount: decimal.Zero,
-		TotalInvoiceLevelDiscount:    decimal.Zero,
-	}
 	if len(invoiceCoupons) == 0 && len(lineItemCoupons) == 0 {
-		return result, nil
+		return &couponPreparation{
+			couponsMap:                make(map[string]*coupon.Coupon),
+			totalLineItemDiscount:     decimal.Zero,
+			totalInvoiceLevelDiscount: decimal.Zero,
+		}, nil
 	}
 
 	s.Logger.Info(ctx, "applying coupons to invoice",
@@ -353,6 +393,31 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 			"final_subtotal", discountResult.FinalPrice)
 	}
 
+	return &couponPreparation{
+		appliedCoupons:                 appliedCoupons,
+		lineItemCouponApplications:     lineItemCouponApplications,
+		invoiceLevelCouponApplications: invoiceLevelCouponApplications,
+		couponsMap:                     couponsMap,
+		totalLineItemDiscount:          totalLineItemDiscount,
+		totalInvoiceLevelDiscount:      totalInvoiceLevelDiscount,
+	}, nil
+}
+
+// ApplyCouponsToInvoice applies both invoice-level and line item-level coupons to an invoice.
+// This is the unified method that handles all coupon application logic.
+// CouponService.ApplyDiscount() handles all validation and calculation.
+func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, req dto.ApplyCouponsToInvoiceRequest) (*CouponCalculationResult, error) {
+	prep, err := s.prepareCouponApplications(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	inv := req.Invoice
+	appliedCoupons := prep.appliedCoupons
+	couponsMap := prep.couponsMap
+	totalLineItemDiscount := prep.totalLineItemDiscount
+	totalInvoiceLevelDiscount := prep.totalInvoiceLevelDiscount
+
 	// Step 3: Apply mutations in transaction (mutations at boundaries)
 	// Computation was pure, now we apply the results
 	totalDiscountAmount := totalLineItemDiscount.Add(totalInvoiceLevelDiscount)
@@ -457,7 +522,7 @@ func (s *couponApplicationService) ApplyCouponsToInvoice(ctx context.Context, re
 	}
 
 	// Build result after mutations are applied
-	result = &CouponCalculationResult{
+	result := &CouponCalculationResult{
 		TotalDiscountAmount:          totalDiscountAmount,
 		TotalInvoiceLineItemDiscount: totalLineItemDiscount,
 		TotalInvoiceLevelDiscount:    totalInvoiceLevelDiscount,

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -2134,6 +2134,38 @@ func (s *invoiceService) CreatePreviewInvoice(ctx context.Context, req dto.Creat
 	return dto.NewInvoiceResponse(inv), nil
 }
 
+// applyPreviewCoupons computes the coupon discounts a preview invoice would
+// carry and updates its totals. Nothing is persisted and no redemption is
+// counted — previewing an invoice must not consume a coupon.
+//
+// Returns the per-coupon breakdown for the response.
+func (s *invoiceService) applyPreviewCoupons(ctx context.Context, inv *invoice.Invoice, invReq *dto.CreateInvoiceRequest) ([]*dto.CouponApplicationResponse, error) {
+	if inv == nil || invReq == nil {
+		return nil, nil
+	}
+	if len(invReq.InvoiceCoupons) == 0 && len(invReq.LineItemCoupons) == 0 {
+		return nil, nil
+	}
+
+	couponApplicationService := NewCouponApplicationService(s.ServiceParams)
+	result, err := couponApplicationService.CalculateCouponsForInvoice(ctx, dto.ApplyCouponsToInvoiceRequest{
+		Invoice:         inv,
+		InvoiceCoupons:  invReq.InvoiceCoupons,
+		LineItemCoupons: invReq.LineItemCoupons,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	inv.TotalDiscount = result.TotalDiscountAmount
+	dto.RecalculatePreviewTotals(inv, invReq.PreparedTaxRates)
+
+	return result.AppliedCoupons, nil
+}
+
 func (s *invoiceService) GetPreviewInvoice(ctx context.Context, req dto.GetPreviewInvoiceRequest) (*dto.InvoiceResponse, error) {
 	billingService := NewBillingService(s.ServiceParams)
 
@@ -2175,13 +2207,25 @@ func (s *invoiceService) GetPreviewInvoice(ctx context.Context, req dto.GetPrevi
 		return nil, err
 	}
 
+	// Coupons: compute (never persist) the discounts this invoice would carry,
+	// then bring tax and totals back in step — ToInvoice taxed the
+	// undiscounted subtotal because discounts resolve at this layer.
+	couponApplications, err := s.applyPreviewCoupons(ctx, inv, invReq)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create preview response
 	response := dto.NewInvoiceResponse(inv)
 
-	// Previews persist no tax_applied rows, so synthesise the per-rate
-	// breakdown that WithTaxes would otherwise load from the DB — without it
-	// the response carries total_tax but an empty taxes[] array.
+	// Previews persist no tax_applied or coupon_application rows, so
+	// synthesise the breakdowns that WithTaxes / the DB load would otherwise
+	// provide — without them the response carries totals with nothing to
+	// explain them.
 	response.WithTaxes(dto.BuildPreviewTaxes(inv, invReq.PreparedTaxRates))
+	if len(couponApplications) > 0 {
+		response.CouponApplications = couponApplications
+	}
 
 	// Get customer information
 	customer, err := s.CustomerRepo.Get(ctx, inv.CustomerID)
@@ -2235,13 +2279,25 @@ func (s *invoiceService) GetInternalPreviewInvoice(ctx context.Context, req dto.
 		return nil, err
 	}
 
+	// Coupons: compute (never persist) the discounts this invoice would carry,
+	// then bring tax and totals back in step — ToInvoice taxed the
+	// undiscounted subtotal because discounts resolve at this layer.
+	couponApplications, err := s.applyPreviewCoupons(ctx, inv, invReq)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create preview response
 	response := dto.NewInvoiceResponse(inv)
 
-	// Previews persist no tax_applied rows, so synthesise the per-rate
-	// breakdown that WithTaxes would otherwise load from the DB — without it
-	// the response carries total_tax but an empty taxes[] array.
+	// Previews persist no tax_applied or coupon_application rows, so
+	// synthesise the breakdowns that WithTaxes / the DB load would otherwise
+	// provide — without them the response carries totals with nothing to
+	// explain them.
 	response.WithTaxes(dto.BuildPreviewTaxes(inv, invReq.PreparedTaxRates))
+	if len(couponApplications) > 0 {
+		response.CouponApplications = couponApplications
+	}
 
 	// Get customer information
 	customer, err := s.CustomerRepo.Get(ctx, inv.CustomerID)


### PR DESCRIPTION
## **User description**
Preview invoices reported no discount at all. `CreateInvoiceRequest.ToInvoice` hardcoded `totalDiscount := decimal.Zero` with a note that coupon calculation belongs at the service layer, and the service layer never picked it up. A subscription carrying a coupon previewed `total_discount: 0`, an empty `coupon_applications`, and a total **higher than the invoice the customer eventually receives**. `coupon-application-probe` has been failing on this continuously on staging — it is the last red check after #2588.

Verified on staging before the fix, on a subscription with the seeded 10% coupon attached:

```
{"subtotal":"7156990.13","total_discount":"0","total_tax":"0","total":"7156990.13","coupons":0}
```

## What changed

**The discounts were already resolved.** `PrepareSubscriptionInvoiceRequest` attaches `InvoiceCoupons` and `LineItemCoupons` for the preview reference point exactly as it does for a real invoice. Only the computation was missing.

`couponApplicationService.ApplyCouponsToInvoice` already had a clean seam — a pure computation phase building the applications and totals, then a `WithTx` phase that increments redemptions and persists. This splits it there: `prepareCouponApplications` holds the computation, `ApplyCouponsToInvoice` keeps its exact previous behaviour on top of it, and the new `CalculateCouponsForInvoice` exposes the computation alone. Nothing is written and no redemption is counted — previewing an invoice must not consume a coupon.

**Ordering.** `ToInvoice` taxes `(subtotal - discount)`, but the discount is only known after the service layer runs, so a naive fix would tax the undiscounted subtotal. `RecalculatePreviewTotals` now owns that pass — discounts first, tax on what remains, then totals — and `ToInvoice` calls the same function, so the two orders cannot drift apart. Covered by `TestRecalculatePreviewTotals_TaxesTheDiscountedSubtotal` (10% on 100 with a 20 discount must be 8, not 10).

## Also in here

`wallet-debit-verification` reported `ingest dropped events: only 0 of 10 landed in events table within 30s` for batches that were fully present a minute later — I checked two failing batches and both had all ten rows. The 30s budget only covered the batch itself, but the scenario probes burst on the same minute and staging's ingest consumer drains ~10 events/second, so ten events queue behind roughly a thousand. Raised to 120s, and `confirmEventsLanded` now returns its last query error instead of swallowing it: a failing read used to render identically to real data loss, which is the worst possible thing for that message to say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Calculate coupon discounts correctly in invoice previews

### What Changed
- Invoice previews now include applicable coupon discounts and per-coupon breakdowns.
- Taxes and totals are recalculated after discounts, so tax applies to the discounted amount and cannot exceed the invoice subtotal.
- Previewing an invoice computes discounts without saving coupon applications or consuming redemptions.
- Wallet debit verification waits longer for queued events and reports query failures separately from missing events.

### Impact
`✅ Accurate preview totals`
`✅ Correct tax after coupon discounts`
`✅ Coupons remain unused during preview`
`✅ Clearer wallet event ingestion failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invoice previews now include coupon discounts and applied coupon details without consuming coupons.
  * Preview totals accurately reflect discounts, taxes, amount due, and remaining balance.
* **Bug Fixes**
  * Discounts exceeding the subtotal are safely clamped.
  * Tax calculations now use the discounted subtotal.
* **Reliability**
  * Wallet debit verification allows additional time for raw events to become visible and reports clearer timeout or query-failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->