### PR TITLE
feat(chart): migration.asHook, and gate migration-prereqs on migration.enabled

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration-prereqs.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration-prereqs.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.migration.enabled }}
 {{- /*
   Dedicated pre-install/pre-upgrade ServiceAccount for the migration Job.
 
@@ -32,8 +33,10 @@ metadata:
     {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if .Values.migration.asHook }}
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-10"
+    {{- end }}
     {{- /*
       NO hook-delete-policy on purpose. This is what makes the migration run
       under ArgoCD at all.
@@ -63,3 +66,4 @@ metadata:
       credentials of its own, only Workload-Identity / IRSA annotations
       mirroring the app SA, and re-applying it is an ordinary in-place update.
     */}}
+{{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -43,6 +43,7 @@ metadata:
   annotations:
     checksum/config: {{ include "flexprice/templates/app/configmap.yaml" . | sha256sum }}
     checksum/secret: {{ include "flexprice/templates/app/secret.yaml" . | sha256sum }}
+    {{- if .Values.migration.asHook }}
     "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-weight": "-5"
     {{- /*
@@ -79,6 +80,7 @@ metadata:
       look while it is still running.
     */}}
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    {{- end }}
 spec:
   backoffLimit: {{ .Values.migration.backoffLimit | default 3 }}
   {{- if .Values.migration.activeDeadlineSeconds }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -714,6 +714,21 @@ kafkaConfig:
 # Set enabled=true to run database migrations as a Kubernetes Job
 migration:
   enabled: true  # Set to true to enable migration job
+
+  # Install the migration Job as a Helm pre-install/pre-upgrade HOOK (default),
+  # or as an ordinary chart resource.
+  #
+  # true  — ArgoCD and plain `helm install`. The Job runs before the app rolls
+  #         out and Helm owns its lifecycle.
+  #
+  # false — for delivery models where the Job is applied by something else, as
+  #         its own terraform unit ordered before the release. The hook's
+  #         delete-policy (hook-succeeded,hook-failed) removes the Job and its
+  #         logs the moment it fails, which is correct when a controller can
+  #         retry immediately and wrong when a human needs to read why it broke.
+  #         Set false ONLY when something else applies the Job; leaving both this
+  #         false and no external applier means migrations never run.
+  asHook: true
   timeout: 300  # Timeout in seconds for migration
   backoffLimit: 3  # Number of retries before marking job as failed
   activeDeadlineSeconds: 900  # Maximum time in seconds for the job to run (increased for all migrations)


### PR DESCRIPTION
## **User description**
Two backward-compatible changes to the migration templates. The default render is byte-identical to `develop`, so ArgoCD environments are unaffected.

## 1. `migration.asHook` (default `true`)

Controls whether the migration Job and its ServiceAccount install as Helm `pre-install`/`pre-upgrade` hooks.

Set `false` where the Job is applied by something else — as its own terraform unit ordered before the release, which is how the self-hosted / no-ArgoCD delivery works.

The reason this needs to be optional: the hook's `hook-delete-policy: hook-succeeded,hook-failed` removes the Job **and its logs** the moment it fails. That is correct when a controller can retry immediately. It is wrong when a human has to read why it broke and has no access to the cluster afterwards — they get a bare timeout with nothing left to inspect.

Applied as an ordinary resource the Job persists on failure, `kubectl logs` works, and the release never applies if migrations did not succeed. That last part closes the silent failure this file already documents twice: pods coming up `Running` against an unmigrated database, with `/health` not touching Postgres so nothing surfaces it.

## 2. `migration-prereqs.yaml` had no `if` guard at all

The `-migration` ServiceAccount rendered even with `migration.enabled=false` — an orphan `pre-install` hook for a Job that does not exist. Now wrapped in the same `enabled` guard as the Job, and its hook annotations gated on `asHook` alongside it.

## Verification

All four combinations rendered with `helm template`:

| `enabled` | `asHook` | migration objects | hook annotations | SA |
|---|---|---|---|---|
| true | true | 2 | 5 | 2 |
| true | false | 2 | **0** | 2 |
| false | true | **0** | 0 | **0** |
| false | false | 0 | 0 | 0 |

Row 1 is current behaviour. Row 2 is the new path. Rows 3–4 are the orphan-SA fix.

And the default render diffs clean against `develop`:

```
$ diff <(git stash; helm template t .) <(git stash pop; helm template t .)
IDENTICAL
```

## Not covered here

The extracted Job is render-verified only. It has not yet been executed by the terraform unit that will apply it — that is being proven separately in a rehearsal environment, and this PR is a prerequisite for it rather than a consequence.


___

## **CodeAnt-AI Description**
Make migration deployment configurable and prevent unused migration resources

### What Changed
- Migration Jobs and their ServiceAccounts can now run as regular resources instead of Helm hooks for delivery setups that manage the Job separately
- Migration hook annotations are applied only when hook-based execution is enabled
- Migration prerequisites are no longer created when migrations are disabled
- Hook-based behavior remains the default

### Impact
`✅ Migration failures remain available for inspection in externally managed deployments`
`✅ No orphaned migration ServiceAccounts when migrations are disabled`
`✅ Existing Helm and ArgoCD migration behavior remains unchanged by default`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a migration deployment option to run migrations as Helm lifecycle hooks or as regular chart resources.
  * Migration resources are created only when migrations are enabled.
  * Documented the configuration and external job requirements when hook behavior is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->