### PR TITLE
fix(migrate): don't double-close the bootstrap ClickHouse connection

### DIFF
--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -77,18 +77,30 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 	// The native protocol works over ClickHouse Cloud PrivateLink now that
 	// GetClientOptions sets a DialTimeout (without it, the in-order dial to a
 	// PrivateLink AZ ENI could block forever).
-	bootstrap := *opts
-	bootstrap.Auth.Database = "default"
-	conn, err := clickhouse_go.Open(&bootstrap)
-	if err != nil {
-		return fmt.Errorf("open clickhouse: %w", err)
-	}
-	defer conn.Close()
+	// Scoped so the bootstrap connection is closed exactly once, on every path.
+	//
+	// A `defer conn.Close()` alongside an explicit `conn.Close()` closes the
+	// same pool twice, and clickhouse-go v2's Close blocks on a channel send
+	// once the pool is already shut down -- the process then deadlocks with
+	// "all goroutines are asleep" before a single migration file is applied.
+	// That is not a timeout: nothing recovers, and the Job burns its full
+	// deadline producing no output past the first log line.
+	if err := func() error {
+		bootstrap := *opts
+		bootstrap.Auth.Database = "default"
+		conn, err := clickhouse_go.Open(&bootstrap)
+		if err != nil {
+			return fmt.Errorf("open clickhouse: %w", err)
+		}
+		defer conn.Close()
 
-	if err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)); err != nil {
-		return fmt.Errorf("create database %q: %w", db, err)
+		if err := conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", db)); err != nil {
+			return fmt.Errorf("create database %q: %w", db, err)
+		}
+		return nil
+	}(); err != nil {
+		return err
 	}
-	conn.Close()
 
 	// Reconnect scoped to the target database so unqualified names resolve.
 	dbConn, err := clickhouse_go.Open(opts)


### PR DESCRIPTION
## **User description**
## Problem

`migrate clickhouse` deadlocks on every run and applies **zero** migration files.

`runClickHouseMigrations` opens a connection without a pinned database so it can `CREATE DATABASE IF NOT EXISTS`, registers `defer conn.Close()`, and then *also* calls `conn.Close()` explicitly before reconnecting scoped to the target database.

clickhouse-go v2's `Close` blocks on a channel send once the pool is already shut down, so the second close never returns:

```
Running ClickHouse migrations...
{"level":"info","msg":"Running ClickHouse migrations...","address":"...:9000","database":"flexprice","tls":false}
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan send, 5 minutes]:
github.com/ClickHouse/clickhouse-go/v2.(*clickhouse).Close(0xc00040f9e0)
	github.com/ClickHouse/clickhouse-go/v2@v2.35.0/clickhouse.go:373 +0x54
main.runClickHouseMigrations(...)
	github.com/flexprice/flexprice/cmd/migrate/clickhouse.go:126 +0xbfa
```

The migration Job emits one log line and then burns its entire `activeDeadlineSeconds`. It reads as a slow migration and is really a hang on exit from the bootstrap phase — nothing recovers, and no `.sql` file is ever applied.

Found while bringing up a fresh environment on `ghcr.io/flexprice/flexprice:develop`; the Job was killed by its deadline having created nothing. Reproduces on every run, so any environment brought up from a current image has an empty ClickHouse schema.

## Fix

Scope the bootstrap phase in a closure so the deferred close runs exactly once, on every path, at the point the reconnect needs it to have happened. No behaviour change beyond not closing twice.

## Testing

- `go build ./cmd/migrate/...` and `go vet ./cmd/migrate/...` clean.
- Deadlock reproduced from the deployed `develop` image; stack trace above is from that run.
- **Not yet run end-to-end against ClickHouse with this fix** — needs an image build. Happy to confirm once CI publishes one.


___

## **CodeAnt-AI Description**
Prevent ClickHouse migrations from hanging before applying migrations

### What Changed
- The temporary ClickHouse connection used to create the target database now closes exactly once
- Migrations reconnect to the target database without triggering a deadlock during the bootstrap phase
- Database creation errors still stop the migration with a clear error

### Impact
`✅ ClickHouse migrations complete instead of hanging`
`✅ Migration files are applied on fresh databases`
`✅ Migration jobs avoid exhausting their deadline`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by preventing connection shutdown issues during initial database setup.
  * Ensured errors encountered while opening the setup connection or creating the database are properly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->