### PR TITLE
fix(chart): give create-kafka-topics an explicit heap and configurable resources

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -426,6 +426,21 @@ spec:
         # This init container creates all required topics idempotently.
         - name: create-kafka-topics
           image: "{{ if .Values.kafkaConfig.enabled }}bitnami/kafka:latest{{ else }}confluentinc/cp-kafka:{{ .Values.kafkaConfig.internal.image.tag | default "7.7.1" }}{{ end }}"
+          env:
+            # The JVM sizes its default max heap from the cgroup memory limit --
+            # roughly a quarter of it. At the 256Mi limit this container used to
+            # carry, that is ~64Mi, and the admin client exhausts it while
+            # reading broker metadata over TLS:
+            #
+            #   java.lang.OutOfMemoryError: Java heap space
+            #     at org.apache.kafka.common.network.NetworkReceive.readFrom
+            #   ERROR ... The AdminClient thread has exited. Call: createTopics
+            #
+            # Every topic then fails in turn, so the step reports errors per
+            # topic rather than one cause, and none of them mention memory.
+            # Setting the heap explicitly decouples it from the limit.
+            - name: KAFKA_HEAP_OPTS
+              value: {{ .Values.migration.kafkaTopics.heapOpts | default "-Xmx256m -Xms128m" | quote }}
           command:
             - sh
             - -c
@@ -465,13 +480,12 @@ spec:
 
               echo "✅ Kafka topics ready"
               $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" --list
+          # Must stay comfortably above KAFKA_HEAP_OPTS above: the limit has to
+          # cover the heap plus JVM overhead (metaspace, thread stacks, direct
+          # buffers), or the kernel OOM-kills the container instead of the JVM
+          # throwing -- which surfaces as exit code 137 and no log line at all.
           resources:
-            limits:
-              cpu: "200m"
-              memory: "256Mi"
-            requests:
-              cpu: "100m"
-              memory: "128Mi"
+            {{- toYaml .Values.migration.kafkaTopics.resources | nindent 12 }}
         {{- end }}
 
       containers:

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -741,6 +741,26 @@ migration:
     kafka: true          # Create Kafka topics (idempotent, safe to re-run)
     ent: true            # Run Ent framework migrations
     seed: false          # Run seed data (optional, set to true to enable)
+
+  # The create-kafka-topics init container runs the JVM-based kafka-topics
+  # tool. Its heap is set explicitly rather than left to the JVM's default,
+  # which derives from the cgroup limit (~1/4 of it) and at the previous
+  # hardcoded 256Mi came to ~64Mi -- too little for the admin client to read
+  # broker metadata over TLS. It died with OutOfMemoryError once per topic, and
+  # no message named memory as the cause.
+  #
+  # Keep `resources.limits.memory` well above the -Xmx value: the limit must
+  # cover heap plus JVM overhead, or the kernel OOM-kills the container (exit
+  # 137, no logs) instead of the JVM reporting it.
+  kafkaTopics:
+    heapOpts: "-Xmx256m -Xms128m"
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
   # Pinned helper images used by the migration Job init containers. Override
   # `registry` per image if your cluster only allows pulls from a private
   # mirror (common in regulated AWS accounts). All three images are multi-arch.


### PR DESCRIPTION
## **User description**
## Problem

The `create-kafka-topics` init container fails to create any topic on a cluster where topic auto-creation is off (MSK default):

```
→ Creating topic: events_dlq (partitions=1, replication=1)
[ERROR] org.apache.kafka.common.errors.TimeoutException: The AdminClient thread has exited. Call: createTopics
Error while executing topic command : The AdminClient thread has exited. Call: createTopics
[ERROR] Uncaught exception in thread 'kafka-admin-client-thread | adminclient-1':
java.lang.OutOfMemoryError: Java heap space
	at org.apache.kafka.common.memory.MemoryPool$1.tryAllocate(MemoryPool.java:30)
	at org.apache.kafka.common.network.NetworkReceive.readFrom(NetworkReceive.java:102)
	at org.apache.kafka.common.network.KafkaChannel.receive(KafkaChannel.java:452)
```

Observed: **9 topics attempted, 0 created, 10 `OutOfMemoryError`s**, then the container exits 1 and the whole migration Job fails.

The container had a hardcoded `256Mi` limit and no `KAFKA_HEAP_OPTS`. A modern JVM sizes its default max heap from the cgroup limit — about a quarter of it — so the admin client ran with roughly **64Mi**, which is not enough to read broker metadata over TLS.

What makes this expensive to diagnose is that the failure is reported per topic, and none of the per-topic errors mention memory. It reads as a broker connectivity or auth problem; the `OutOfMemoryError` is interleaved further down the log.

## Fix

- Set `KAFKA_HEAP_OPTS` explicitly (default `-Xmx256m -Xms128m`) so the heap no longer tracks the cgroup limit.
- Move the hardcoded `resources` block to `migration.kafkaTopics.resources` (default limits `500m` / `512Mi`) so a deployment with more topics or a larger cluster can raise both.

The memory limit is deliberately kept well above `-Xmx`: it must cover heap plus JVM overhead (metaspace, thread stacks, direct buffers). If they are set equal, the kernel OOM-kills the container — exit 137 with no log line — which is even harder to read than this was.

## Testing

- Rendered with chart defaults: `KAFKA_HEAP_OPTS=-Xmx256m -Xms128m`, limits `500m`/`512Mi`.
- Rendered with an override (`-Xmx1g -Xms512m`, `1`/`2Gi`): both applied correctly.
- Rendered against a real deployment's values that does *not* set the new key: defaults flow through, all other init containers unchanged.
- `helm lint`: passes.
- **Not yet run against a live cluster with this change** — needs a chart release. The OOM above is from a live run of the current chart.


___

## **CodeAnt-AI Description**
Prevent Kafka topic creation failures caused by insufficient JVM memory

### What Changed
- Kafka topic creation now uses a fixed JVM heap instead of deriving heap size from the container memory limit
- The topic-creation container now has 512Mi memory and configurable CPU and memory requests and limits
- Deployments can adjust the Kafka topic creator's heap and resources for larger topic sets or clusters

### Impact
`✅ Fewer Kafka migration failures`
`✅ Kafka metadata creation works within container limits`
`✅ Configurable resources for larger deployments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable JVM heap settings for Kafka topic initialization.
  * Added configurable CPU and memory requests and limits for the initialization process.
  * Documented heap sizing options and out-of-memory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->