### PR TITLE
fix(chart): create events_bulk, and stop reporting topic failures as success

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -479,6 +479,17 @@ All service addresses are resolved via named templates above so this block stays
   value: {{ .Values.kafkaConfig.topic | quote }}
 - name: FLEXPRICE_KAFKA_TOPIC_LAZY
   value: {{ .Values.kafkaConfig.topicLazy | quote }}
+{{- /*
+  topic_bulk has no default in the Go config (unlike topic/topic_lazy, which are
+  `validate:"required"` and fail fast when unset). An empty TopicBulk therefore
+  passes validation and only surfaces when a batched-ingest publish is attempted
+  against topic "", so emit it only when configured rather than emitting an
+  empty string.
+*/}}
+{{- with .Values.kafkaConfig.topicBulk }}
+- name: FLEXPRICE_KAFKA_TOPIC_BULK
+  value: {{ . | quote }}
+{{- end }}
 - name: FLEXPRICE_KAFKA_TLS
   value: {{ .Values.kafkaConfig.tls | quote }}
 {{- /*

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -454,22 +454,39 @@ spec:
                 KAFKA_TOPICS_CMD="kafka-topics.sh"
               fi
 
-              # Helper: create topic if it does not exist
+              # Count failures rather than swallowing them.
+              #
+              # `|| true` on its own makes this step report success no matter
+              # what: a run where the admin client died on the FIRST topic and
+              # created none still printed "✅ Kafka topics ready" and exited 0.
+              # The app then starts against a broker with no topics and, where
+              # auto-creation is off (the MSK default), fails at first publish
+              # -- a long way from the step that was actually at fault.
+              #
+              # --if-not-exists already makes a re-run a no-op, so a non-zero
+              # exit here means a real failure and not a pre-existing topic.
+              FAILED=0
               create_topic() {
                 TOPIC=$1
                 PARTITIONS=${2:-1}
                 REPLICATION=${3:-1}
                 echo "→ Creating topic: ${TOPIC} (partitions=${PARTITIONS}, replication=${REPLICATION})"
-                $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" \
+                if ! $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" \
                   --create --if-not-exists \
                   --topic "${TOPIC}" \
                   --partitions "${PARTITIONS}" \
-                  --replication-factor "${REPLICATION}" || true
+                  --replication-factor "${REPLICATION}"; then
+                  echo "  ✗ FAILED to create ${TOPIC}"
+                  FAILED=$((FAILED + 1))
+                fi
               }
 
               # All topics used by FlexPrice
               create_topic "{{ .Values.kafkaConfig.topic }}"
               create_topic "{{ .Values.kafkaConfig.topicLazy }}"
+              {{- with .Values.kafkaConfig.topicBulk }}
+              create_topic "{{ . }}"
+              {{- end }}
               create_topic "{{ .Values.kafkaConfig.topicDLQ | default "events_dlq" }}"
               create_topic "{{ .Values.eventPostProcessing.topic }}"
               create_topic "{{ .Values.eventPostProcessing.topicBackfill }}"
@@ -478,8 +495,21 @@ spec:
               create_topic "wallet_alert"
               create_topic "onboarding_events"
 
+              if [ "${FAILED}" -ne 0 ]; then
+                echo "❌ ${FAILED} topic(s) could not be created."
+                echo "   OutOfMemoryError above means the admin client heap is too"
+                echo "   small: raise migration.kafkaTopics.heapOpts (and keep"
+                echo "   resources.limits.memory comfortably above it)."
+                exit 1
+              fi
+
               echo "✅ Kafka topics ready"
-              $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" --list
+
+              # Listing is diagnostic only. It is a second admin-client session
+              # and can OOM on its own after every topic was created, which
+              # would fail the whole migration over a log line.
+              $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" --list || \
+                echo "(could not list topics; creation already succeeded)"
           # Must stay comfortably above KAFKA_HEAP_OPTS above: the limit has to
           # cover the heap plus JVM overhead (metaspace, thread stacks, direct
           # buffers), or the kernel OOM-kills the container instead of the JVM

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -645,6 +645,17 @@ kafkaConfig:
   consumerGroup: "flexprice-consumer"
   topic: "events"
   topicLazy: "events_lazy"
+  # Batched-ingest topic, read by the app as FLEXPRICE_KAFKA_TOPIC_BULK.
+  #
+  # Unlike topic/topicLazy this has no default in the Go config and is not
+  # `validate:"required"`, so leaving it unset passes startup validation and
+  # only fails later, when a batched publish targets the empty topic name.
+  #
+  # It is also created by the migration Job's topic step. Brokers with
+  # auto-creation disabled (the MSK default) will not create it on first
+  # publish, so an unset value there is a runtime failure rather than a
+  # first-use delay.
+  topicBulk: "events_bulk"
   tls: false
   # Broker CA for private/self-signed Kafka certificates. Leave name empty for
   # brokers with publicly-trusted certs (MSK, Confluent Cloud) — the pods then
@@ -753,14 +764,14 @@ migration:
   # cover heap plus JVM overhead, or the kernel OOM-kills the container (exit
   # 137, no logs) instead of the JVM reporting it.
   kafkaTopics:
-    heapOpts: "-Xmx256m -Xms128m"
+    heapOpts: "-Xmx512m -Xms256m"
     resources:
       limits:
         cpu: "500m"
-        memory: "512Mi"
+        memory: "1Gi"
       requests:
         cpu: "100m"
-        memory: "256Mi"
+        memory: "512Mi"
   # Pinned helper images used by the migration Job init containers. Override
   # `registry` per image if your cluster only allows pulls from a private
   # mirror (common in regulated AWS accounts). All three images are multi-arch.


### PR DESCRIPTION
## **User description**
Follow-up to #2598. Three related gaps in the migration Job's Kafka topic step.

## 1. `events_bulk` was never created

`internal/config` declares `TopicBulk` (`topic_bulk`), but the chart had **no** `kafkaConfig.topicBulk` key, never emitted `FLEXPRICE_KAFKA_TOPIC_BULK`, and never created the topic. The step creates nine topics; the bulk topic is not among them.

On a broker with auto-creation disabled — the MSK default — batched ingest publishes to a topic that does not exist.

Adds the value (default `events_bulk`), the env var, and the `create_topic` call.

Note `topic_bulk` is *not* `validate:"required"`, unlike `topic` and `topic_lazy`. An unset value passes startup validation and only fails at first batched publish, so the env var is emitted only when configured rather than as an empty string.

## 2. Topic failures were reported as success

`create_topic` ended in `|| true`. A run whose admin client died on the first topic still printed:

```
✅ Kafka topics ready
```

and exited 0 — **nine topics attempted, zero created, migration green**. The app then starts against a broker with no topics and fails at first publish, a long way from the step actually at fault. This is how the OOM in #2598 stayed invisible until someone read the full log.

Failures are now counted, and the step exits non-zero naming the heap as the likely cause. `--if-not-exists` already makes re-runs no-ops, so a non-zero exit means a real failure rather than a pre-existing topic.

The trailing `--list` stays best-effort — it opens a second admin client session and can fail on its own *after* every topic was created, which should not fail the migration over a diagnostic log line.

## 3. `-Xmx256m` was still too small

Even with #2598, the admin client OOMed against MSK:

```
✅ Kafka topics ready
Error while executing topic command : The AdminClient thread has exited. Call: listTopics
java.lang.OutOfMemoryError: Java heap space
```

Raised the defaults to `-Xmx512m -Xms256m` with a `1Gi` limit. Observed sufficient where `256m`/`512Mi` was not.

## Testing

- `helm lint`: passes.
- Rendered against a real deployment's values: heap `-Xmx512m -Xms256m`, limits `500m`/`1Gi`, **10** `create_topic` calls including `events_bulk`, failure guard present.
- `sh -n` on the generated script: valid.
- `topicBulk: null` renders 9 topics and omits the env var — no empty-string topic.
- **Not yet run end-to-end against a live broker with this change.** The failures quoted above are from live runs of the current chart.


___

## **CodeAnt-AI Description**
Create the bulk Kafka topic and fail migrations when topic setup fails

### What Changed
- Adds the `events_bulk` topic configuration and passes it to the application when configured
- Creates the bulk topic during migration, including on brokers where automatic topic creation is disabled
- Kafka topic setup now reports failures and exits unsuccessfully instead of declaring migration success
- Raises the topic creation memory allocation to reduce admin-client out-of-memory failures
- Treats topic listing as diagnostic, so a listing failure does not fail an otherwise successful migration

### Impact
`✅ Batched events can publish to a pre-created topic`
`✅ Failed topic setup stops the migration immediately`
`✅ Fewer Kafka topic creation out-of-memory failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and creating a dedicated Kafka topic for bulk events.
  * The bulk topic is emitted only when configured, preventing empty topic settings.

* **Bug Fixes**
  * Kafka topic creation failures now stop migrations and report actionable errors instead of being silently ignored.
  * Improved migration reliability by increasing resources for Kafka topic initialization.
  * Kafka topic listing is now diagnostic and no longer causes migrations to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->