### PR TITLE
fix(chart): give kafka-topics a --command-config so SASL/TLS brokers work

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -440,7 +440,16 @@ spec:
             # topic rather than one cause, and none of them mention memory.
             # Setting the heap explicitly decouples it from the limit.
             - name: KAFKA_HEAP_OPTS
-              value: {{ .Values.migration.kafkaTopics.heapOpts | default "-Xmx256m -Xms128m" | quote }}
+              value: {{ .Values.migration.kafkaTopics.heapOpts | default "-Xmx512m -Xms256m" | quote }}
+            {{- if and .Values.kafkaConfig.useSASL (ne .Values.kafkaConfig.saslMechanism "OAUTHBEARER") }}
+            # Injected rather than templated into the properties file, so the
+            # password is not readable in the rendered Job spec.
+            - name: KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "flexprice.secretName" . }}
+                  key: kafka-sasl-password
+            {{- end }}
           command:
             - sh
             - -c
@@ -453,6 +462,52 @@ spec:
               if command -v kafka-topics.sh >/dev/null 2>&1; then
                 KAFKA_TOPICS_CMD="kafka-topics.sh"
               fi
+
+              CMD_CONFIG=""
+              {{- if or .Values.kafkaConfig.useSASL .Values.kafkaConfig.tls }}
+              # Client config for the admin protocol.
+              #
+              # The app pods get SASL/TLS from their env, but kafka-topics is a
+              # separate JVM tool that reads NONE of that -- it needs a
+              # properties file. Without one it dials a SASL listener (MSK's
+              # 9096) with PLAINTEXT and no credentials.
+              #
+              # The failure does not look like auth. The TCP connect succeeds,
+              # so the wait-for-kafka port check passes and reports the broker
+              # ready; the handshake then never completes and the tool reports
+              #
+              #   Timed out waiting for a node assignment. Call: createTopics
+              #
+              # or, worse, reads the TLS server response as a Kafka frame
+              # length and allocates against it:
+              #
+              #   java.lang.OutOfMemoryError: Java heap space
+              #
+              # which sends you tuning the heap for a credentials problem.
+              CMD_CONFIG=/tmp/kafka-admin.properties
+              {{- if .Values.kafkaConfig.useSASL }}
+              cat > "${CMD_CONFIG}" <<'PROPS'
+              security.protocol={{ if .Values.kafkaConfig.tls }}SASL_SSL{{ else }}SASL_PLAINTEXT{{ end }}
+              sasl.mechanism={{ .Values.kafkaConfig.saslMechanism }}
+              PROPS
+              {{- $jaas := ternary "org.apache.kafka.common.security.scram.ScramLoginModule" "org.apache.kafka.common.security.plain.PlainLoginModule" (hasPrefix "SCRAM" .Values.kafkaConfig.saslMechanism) }}
+              # Written separately: the password comes from the environment and
+              # must not be baked into the rendered manifest, where it would be
+              # readable by anyone who can get the Job spec.
+              printf 'sasl.jaas.config=%s required username="%s" password="%s";\n' \
+                '{{ $jaas }}' \
+                '{{ .Values.kafkaConfig.saslUser }}' \
+                "${KAFKA_SASL_PASSWORD}" >> "${CMD_CONFIG}"
+              {{- else }}
+              cat > "${CMD_CONFIG}" <<'PROPS'
+              security.protocol=SSL
+              PROPS
+              {{- end }}
+              # The heredocs above are indented for template readability; strip
+              # it, or every key is parsed with leading spaces and ignored.
+              sed -i 's/^[[:space:]]*//' "${CMD_CONFIG}"
+              CMD_CONFIG="--command-config ${CMD_CONFIG}"
+              {{- end }}
 
               # Count failures rather than swallowing them.
               #
@@ -471,7 +526,7 @@ spec:
                 PARTITIONS=${2:-1}
                 REPLICATION=${3:-1}
                 echo "→ Creating topic: ${TOPIC} (partitions=${PARTITIONS}, replication=${REPLICATION})"
-                if ! $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" \
+                if ! $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" ${CMD_CONFIG} \
                   --create --if-not-exists \
                   --topic "${TOPIC}" \
                   --partitions "${PARTITIONS}" \
@@ -508,7 +563,7 @@ spec:
               # Listing is diagnostic only. It is a second admin-client session
               # and can OOM on its own after every topic was created, which
               # would fail the whole migration over a log line.
-              $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" --list || \
+              $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" ${CMD_CONFIG} --list || \
                 echo "(could not list topics; creation already succeeded)"
           # Must stay comfortably above KAFKA_HEAP_OPTS above: the limit has to
           # cover the heap plus JVM overhead (metaspace, thread stacks, direct


### PR DESCRIPTION
## **User description**
## Problem

`create-kafka-topics` cannot create a single topic against a SASL/TLS broker. On MSK with SCRAM enabled it invoked `kafka-topics` with only `--bootstrap-server`.

The app pods receive SASL and TLS settings through their environment, but `kafka-topics` is a **separate JVM tool that reads none of that** — it needs a properties file. So it dialled MSK's SASL_SSL listener (9096) with PLAINTEXT and no credentials.

Nothing about the failure points at authentication:

- The TCP connect **succeeds**, so the preceding `wait-for-kafka` port check passes and reports `✅ Kafka is ready!`
- The handshake then never completes:
  ```
  Error while executing topic command : Timed out waiting for a node assignment. Call: createTopics
  ```
- Or the TLS server response is read as a Kafka frame length and the client allocates against it:
  ```
  java.lang.OutOfMemoryError: Java heap space
    at org.apache.kafka.common.network.NetworkReceive.readFrom
  ```

That OOM is why #2598's heap increase appeared to help and then stopped: raising `-Xmx` only changes which topic dies first. The credentials were always the cause.

## Fix

Write a client properties file when `useSASL` or `tls` is set:

- `security.protocol`: `SASL_SSL` / `SASL_PLAINTEXT` / `SSL` to match the config
- `sasl.mechanism` from `kafkaConfig.saslMechanism`
- `ScramLoginModule` or `PlainLoginModule` selected by mechanism
- password injected via env from the existing `kafka-sasl-password` secret key, **not** templated into the file — it would otherwise be readable in the rendered Job spec

OAUTHBEARER carries no static password and is excluded, consistent with the app env helper.

Also corrects the template's inline heap default to `-Xmx512m`, which `values.yaml` already carried.

## Testing

Verified live against MSK (SCRAM-SHA-512 + TLS), where every prior run created zero topics:

```
Created topic events.
Created topic events_lazy.
Created topic events_bulk.
Created topic events_dlq.
Created topic events_post_processing.
Created topic events_post_processing_backfill.
Created topic system_events.
Created topic events_backfill.
Created topic wallet_alert.
Created topic onboarding_events.
✅ Kafka topics ready
```

10/10 created, migration Job `Complete 1/1`, all seven init containers exit 0.

Also verified by rendering:
- SCRAM-SHA-512 → `SASL_SSL` + `ScramLoginModule`
- PLAIN → `PlainLoginModule`
- no SASL → no `--command-config`, no password env (unchanged behaviour)
- password does not appear in the rendered spec
- `sh -n` on the generated script; `helm lint` passes

## Note for operators

A deployment against a SASL broker must set `kafkaConfig.useSASL`, `saslMechanism`, `saslUser` and `tls`. Without them this step silently produces no topics, and — where broker auto-creation is off, the MSK default — the app then fails at first publish.


___

## **CodeAnt-AI Description**
Enable Kafka topic creation with authenticated and encrypted Kafka brokers

### What Changed
- Kafka topic creation and listing now use the configured SASL or TLS connection settings instead of connecting without credentials.
- SASL passwords are supplied securely from the existing Kubernetes secret and are not exposed in the rendered Job configuration.
- The topic-creation job uses a larger default JVM heap to reduce failures while reading broker metadata over TLS.
- Topic-creation failures now cause the migration step to fail instead of allowing the application to start without required topics.

### Impact
`✅ Kafka topics created on SASL/TLS brokers`
`✅ Fewer migration failures caused by admin-client memory limits`
`✅ No silent startup with missing Kafka topics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved migration reliability for deployments using Kafka with SASL and/or TLS authentication.
  * Added configurable memory settings for Kafka administration tasks.
  * Enhanced secure handling of Kafka credentials during migrations.
  * Updated ClickHouse migrations to use the application’s migration process for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->