### PR TITLE
fix(rbac): resolve roles.json against both source-tree and container layouts

### DIFF
--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/flexprice/flexprice/internal/config"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -30,16 +31,48 @@ type Role struct {
 
 // NewRBACService loads roles.json from config and optimizes for fast lookups
 func NewRBACService(cfg *config.Configuration) (*RBACService, error) {
-	// Get roles path from config or use default
-	configPath := cfg.RBAC.RolesConfigPath
-	if configPath == "" {
-		configPath = "./config/rbac/roles.json"
+	// Resolve roles.json against several working directories.
+	//
+	// The path in config.yaml is relative, and the correct relative path
+	// depends on where the process runs. From a source checkout the file is at
+	// internal/config/rbac/roles.json; in the container the Dockerfile copies
+	// internal/config to ./config, so it is at config/rbac/roles.json. One
+	// literal cannot satisfy both, and getting it wrong crashloops every pod at
+	// startup with
+	//
+	//   failed to read config: open internal/config/rbac/roles.json:
+	//   no such file or directory
+	//
+	// which reads as a packaging fault and is really a working-directory
+	// mismatch. This mirrors how viper already locates config.yaml itself: it
+	// registers several AddConfigPath candidates for exactly the same reason.
+	//
+	// The configured value is tried first, so an explicit absolute path still
+	// wins and nothing that works today changes behaviour.
+	candidates := make([]string, 0, 3)
+	if p := cfg.RBAC.RolesConfigPath; p != "" {
+		candidates = append(candidates, p)
 	}
+	candidates = append(candidates,
+		"config/rbac/roles.json",          // container: Dockerfile copies internal/config -> ./config
+		"internal/config/rbac/roles.json", // source checkout, run from the repo root
+	)
 
-	// Load JSON
-	data, err := os.ReadFile(configPath)
+	var (
+		data []byte
+		err  error
+	)
+	for _, p := range candidates {
+		data, err = os.ReadFile(p)
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config: %w", err)
+		return nil, fmt.Errorf(
+			"failed to read roles config (tried %s): %w",
+			strings.Join(candidates, ", "), err,
+		)
 	}
 
 	// Parse as: role_id -> role definition (with name, description, permissions)


### PR DESCRIPTION
## **User description**
## Problem

Every pod crashloops at startup on a container deploy:

```
[Fx] Error returned: received non-nil error from function "github.com/flexprice/flexprice/internal/rbac".NewRBACService
failed to read config: open internal/config/rbac/roles.json: no such file or directory
```

`internal/config/config.yaml` sets:

```yaml
rbac:
  roles_config_path: "internal/config/rbac/roles.json"
```

That path is correct from a source checkout and wrong in a container. The Dockerfile does:

```dockerfile
COPY --from=builder /app/internal/config ./config
```

so the file lands at `config/rbac/roles.json`. Verified inside a running pod — workdir `/app`, file present at `config/rbac/roles.json`, absent at `internal/config/rbac/roles.json`.

`NewRBACService` already has a fallback of `./config/rbac/roles.json`, but it only applies when the configured value is **empty** — and `config.yaml` sets it, so the fallback never runs.

It reads as a packaging fault and is really a working-directory mismatch.

## Why not just change the literal

Changing `config.yaml` to `config/rbac/roles.json` fixes containers and breaks running from the repo root, where that path does not exist. One relative literal cannot satisfy both layouts.

## Fix

Try the candidates in turn:

1. `cfg.RBAC.RolesConfigPath` (if set) — so an explicit absolute path still wins and nothing that works today changes behaviour
2. `config/rbac/roles.json` — container
3. `internal/config/rbac/roles.json` — source checkout from the repo root

This mirrors how viper already locates `config.yaml` itself, which registers several `AddConfigPath` candidates for exactly this reason.

The error message now lists every path tried rather than only the last one.

## Testing

- `go build ./internal/rbac/...` and `go vet ./internal/rbac/...` clean.
- Failure reproduced from the deployed `develop` image; the log above is from that run.
- `internal/ee/service/user_test.go` passes its own explicit path and is unaffected.
- **Not yet run end-to-end with this change** — needs an image build. Confirmed the container layout by exec'ing into a running pod.


___

## **CodeAnt-AI Description**
Load RBAC roles correctly in source checkouts and containers

### What Changed
- RBAC startup now finds `roles.json` in both container and source-tree layouts
- Explicitly configured paths are still tried first, including absolute paths
- Startup errors list all locations checked when the roles file cannot be found

### Impact
`✅ Prevents container startup crash loops`
`✅ Keeps RBAC working from source checkouts`
`✅ Clearer missing-roles configuration errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role configuration loading by trying additional fallback locations when the configured path is unavailable.
  * Enhanced error messages to list all locations that were checked when the roles file cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->