### PR TITLE
refactor(invoice): enhance invoice recalculation to auto-void non-voided invoices

### DIFF
--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -3551,7 +3551,7 @@ func (s *invoiceService) RecalculateInvoiceV2(ctx context.Context, id string, fi
 	return s.GetInvoice(ctx, id)
 }
 
-// RecalculateVoidedInvoice voids the subscription invoice (if not already voided) and creates a
+// RecalculateInvoice voids the subscription invoice (if not already voided) and creates a
 // fresh replacement invoice covering the same billing period. It validates that:
 //   - The invoice is of type SUBSCRIPTION
 //   - The invoice has never been recalculated (RecalculatedInvoiceID == nil)
@@ -3571,16 +3571,6 @@ func (s *invoiceService) RecalculateInvoice(ctx context.Context, id string) (*dt
 		return nil, ierr.NewError("invoice type is not supported").
 			WithHintf("only SUBSCRIPTION invoices can be recalculated, got %s", inv.InvoiceType).
 			Mark(ierr.ErrValidation)
-	}
-
-	if inv.InvoiceStatus != types.InvoiceStatusVoided {
-		if err := s.VoidInvoice(ctx, id, dto.InvoiceVoidRequest{}); err != nil {
-			return nil, err
-		}
-		inv, err = s.InvoiceRepo.Get(ctx, id)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if inv.RecalculatedInvoiceID != nil {
@@ -3606,6 +3596,17 @@ func (s *invoiceService) RecalculateInvoice(ctx context.Context, id string) (*dt
 	sub, _, err := s.SubRepo.GetWithLineItems(ctx, *inv.SubscriptionID)
 	if err != nil {
 		return nil, err
+	}
+
+	// All non-mutating prerequisites passed — safe to void now.
+	if inv.InvoiceStatus != types.InvoiceStatusVoided {
+		if err := s.VoidInvoice(ctx, id, dto.InvoiceVoidRequest{}); err != nil {
+			return nil, err
+		}
+		inv, err = s.InvoiceRepo.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Use the same method as subscription billing (processSubscriptionPeriod): CreateSubscriptionInvoice

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -3551,15 +3551,16 @@ func (s *invoiceService) RecalculateInvoiceV2(ctx context.Context, id string, fi
 	return s.GetInvoice(ctx, id)
 }
 
-// RecalculateVoidedInvoice creates a fresh replacement invoice for a voided subscription invoice
-// covering the same billing period. It validates that:
+// RecalculateVoidedInvoice voids the subscription invoice (if not already voided) and creates a
+// fresh replacement invoice covering the same billing period. It validates that:
 //   - The invoice is of type SUBSCRIPTION
-//   - The invoice status is VOIDED
 //   - The invoice has never been recalculated (RecalculatedInvoiceID == nil)
 //
+// If voiding succeeds but the replacement invoice fails to create, the invoice is left voided —
+// that's the safe terminal state; it is not un-voided, so this is logged as an error for manual retry.
 // On success it links the original voided invoice to the new invoice via RecalculatedInvoiceID.
 func (s *invoiceService) RecalculateInvoice(ctx context.Context, id string) (*dto.InvoiceResponse, error) {
-	s.Logger.Info(ctx, "recalculating voided invoice", "invoice_id", id)
+	s.Logger.Info(ctx, "recalculating invoice", "invoice_id", id)
 
 	inv, err := s.InvoiceRepo.Get(ctx, id)
 	if err != nil {
@@ -3573,10 +3574,13 @@ func (s *invoiceService) RecalculateInvoice(ctx context.Context, id string) (*dt
 	}
 
 	if inv.InvoiceStatus != types.InvoiceStatusVoided {
-		return nil, ierr.NewError("invoice is not voided").
-			WithHint("only VOIDED invoices can be recalculated").
-			WithReportableDetails(map[string]any{"current_status": inv.InvoiceStatus}).
-			Mark(ierr.ErrValidation)
+		if err := s.VoidInvoice(ctx, id, dto.InvoiceVoidRequest{}); err != nil {
+			return nil, err
+		}
+		inv, err = s.InvoiceRepo.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if inv.RecalculatedInvoiceID != nil {
@@ -3623,9 +3627,13 @@ func (s *invoiceService) RecalculateInvoice(ctx context.Context, id string) (*dt
 		ReferencePoint: types.ReferencePointPeriodEnd,
 	}, paymentParams, types.InvoiceFlowManual, false)
 	if err != nil {
+		s.Logger.Error(ctx, "invoice recalculation failed after voiding, invoice left voided with no replacement",
+			"invoice_id", id, "error", err)
 		return nil, err
 	}
 	if newInv == nil {
+		s.Logger.Error(ctx, "invoice recalculation produced no replacement invoice, invoice left voided",
+			"invoice_id", id, "error", "zero subtotal for period")
 		return nil, ierr.NewError("recalculation produced no invoice").
 			WithHint("recalculation resulted in zero subtotal for this period").
 			Mark(ierr.ErrValidation)

--- a/internal/ee/service/invoice_void_recalculate_test.go
+++ b/internal/ee/service/invoice_void_recalculate_test.go
@@ -808,12 +808,7 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoice_AutoVoidsNonVoidedI
 			inv := tt.build()
 
 			newInv, err := s.service.RecalculateInvoice(s.GetContext(), inv.ID)
-			if err != nil {
-				// Billing mock may produce no charges for this fixture; accept gracefully,
-				// same as TestRecalculateInvoice_HappyPath.
-				s.T().Logf("RecalculateInvoice returned error (possible mock limitation): %v", err)
-				return
-			}
+			s.Require().NoError(err, "auto-void-then-recalculate must succeed for this fixture")
 			s.NotNil(newInv)
 			s.NotEqual(inv.ID, newInv.ID, "new invoice must have a different ID")
 

--- a/internal/ee/service/invoice_void_recalculate_test.go
+++ b/internal/ee/service/invoice_void_recalculate_test.go
@@ -615,22 +615,6 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoice_Validation() {
 			expectedError: "not found",
 		},
 		{
-			name: "invoice_is_draft",
-			setup: func() string {
-				inv := s.buildDraftInvoice("inv_draft_recalc")
-				return inv.ID
-			},
-			expectedError: "not voided",
-		},
-		{
-			name: "invoice_is_finalized",
-			setup: func() string {
-				inv := s.buildFinalizedInvoice("inv_fin_recalc", decimal.Zero, decimal.Zero, types.PaymentStatusPending)
-				return inv.ID
-			},
-			expectedError: "not voided",
-		},
-		{
 			name: "invoice_type_one_off",
 			setup: func() string {
 				now := s.testData.now
@@ -794,6 +778,53 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoice_HappyPath() {
 	s.Equal(s.testData.subscription.ID, lo.FromPtr(newInv.SubscriptionID))
 	s.Equal(types.InvoiceTypeSubscription, newInv.InvoiceType)
 	s.NotEqual(types.InvoiceStatusVoided, newInv.InvoiceStatus)
+}
+
+// TestRecalculateInvoice_AutoVoidsNonVoidedInvoice verifies that calling RecalculateInvoice on a
+// DRAFT or FINALIZED subscription invoice voids it first (via VoidInvoice) instead of erroring,
+// then proceeds with the same replacement-invoice flow as an already-voided invoice.
+func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoice_AutoVoidsNonVoidedInvoice() {
+	tests := []struct {
+		name  string
+		build func() *invoice.Invoice
+	}{
+		{
+			name:  "draft",
+			build: func() *invoice.Invoice { return s.buildDraftInvoice("inv_draft_autovoid") },
+		},
+		{
+			name: "finalized",
+			build: func() *invoice.Invoice {
+				return s.buildFinalizedInvoice("inv_fin_autovoid", decimal.Zero, decimal.Zero, types.PaymentStatusPending)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.BaseServiceTestSuite.ClearStores()
+			s.setupTestData()
+
+			inv := tt.build()
+
+			newInv, err := s.service.RecalculateInvoice(s.GetContext(), inv.ID)
+			if err != nil {
+				// Billing mock may produce no charges for this fixture; accept gracefully,
+				// same as TestRecalculateInvoice_HappyPath.
+				s.T().Logf("RecalculateInvoice returned error (possible mock limitation): %v", err)
+				return
+			}
+			s.NotNil(newInv)
+			s.NotEqual(inv.ID, newInv.ID, "new invoice must have a different ID")
+
+			// Original invoice must have been auto-voided and linked to the new invoice.
+			original, err := s.invoiceRepo.Get(s.GetContext(), inv.ID)
+			s.NoError(err)
+			s.Equal(types.InvoiceStatusVoided, original.InvoiceStatus)
+			s.NotNil(original.RecalculatedInvoiceID)
+			s.Equal(newInv.ID, *original.RecalculatedInvoiceID)
+		})
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## **CodeAnt-AI Description**
Automatically void subscription invoices before recalculation

### What Changed
- Recalculation now automatically voids draft and finalized subscription invoices instead of rejecting them
- The original invoice is linked to its replacement after a successful recalculation
- If replacement creation fails, the invoice remains voided and the failure is logged for follow-up
- Added coverage for recalculating draft and finalized invoices

### Impact
`✅ Fewer failed invoice recalculations`
`✅ Automatic handling of non-voided subscription invoices`
`✅ Safer recovery when replacement creation fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription invoices can be recalculated from draft or finalized states.
  * Eligible invoices are automatically voided after validation and subscription checks complete.
  * Replacement invoices are created and linked to the original invoices.

* **Bug Fixes**
  * Prevented invoices from being voided prematurely when recalculation prerequisites fail.
  * Improved handling and logging when replacement invoice creation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->