### PR TITLE
feat(hubspot): sync deal line items on subscription modification

### DIFF
--- a/internal/ee/service/checkout_session_actions.go
+++ b/internal/ee/service/checkout_session_actions.go
@@ -251,6 +251,7 @@ func (s *checkoutSessionService) completeModifySubscriptionCheckout(
 	}
 
 	modSvc.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, params.SubscriptionID)
+	triggerHubSpotDealSync(ctx, s.ServiceParams, params.SubscriptionID)
 	return nil
 }
 
@@ -280,6 +281,7 @@ func (s *checkoutSessionService) completeAddAddonCheckout(
 	}
 
 	subSvc.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, params.SubscriptionID)
+	triggerHubSpotDealSync(ctx, s.ServiceParams, params.SubscriptionID)
 	return nil
 }
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -608,7 +608,7 @@ func (s *subscriptionService) CreateSubscription(ctx context.Context, req dto.Cr
 		s.triggerHubSpotQuoteSyncWorkflow(ctx, result.Sub.ID, result.Customer.ID)
 		s.runPaddleSubscriptionSync(ctx, result.Sub)
 	} else {
-		s.triggerHubSpotDealSyncWorkflow(ctx, result.Sub.ID, result.Customer.ID)
+		triggerHubSpotDealSync(ctx, s.ServiceParams, result.Sub.ID)
 		s.runPaddleSubscriptionSync(ctx, result.Sub)
 	}
 	return response, nil
@@ -820,105 +820,86 @@ func (s *subscriptionService) ActivateDraftSubscription(ctx context.Context, sub
 	return response, nil
 }
 
-// triggerHubSpotDealSyncWorkflow triggers the Temporal workflow to sync subscription to HubSpot deal
-func (s *subscriptionService) triggerHubSpotDealSyncWorkflow(ctx context.Context, subscriptionID, customerID string) {
-	// Copy necessary context values
-	tenantID := types.GetTenantID(ctx)
-	envID := types.GetEnvironmentID(ctx)
-
-	s.Logger.Info(ctx, "triggering HubSpot deal sync workflow",
-		"subscription_id", subscriptionID,
-		"customer_id", customerID,
-		"tenant_id", tenantID,
-		"environment_id", envID)
-
-	// Check if HubSpot connection exists and deal outbound sync is enabled
-	if s.ConnectionRepo == nil {
-		s.Logger.Debug(ctx, "ConnectionRepo not available, skipping HubSpot deal sync",
-			"subscription_id", subscriptionID,
-			"customer_id", customerID)
+// triggerHubSpotDealSync starts the Temporal workflow that reconciles a subscription's line
+// items into its HubSpot deal. Never returns an error and never blocks the caller: a missing
+// connection, a customer with no deal, or an unavailable Temporal is a no-op, not a failure.
+func triggerHubSpotDealSync(ctx context.Context, sp ServiceParams, subscriptionID string) {
+	if sp.ConnectionRepo == nil {
 		return
 	}
 
-	conn, err := s.ConnectionRepo.GetByProvider(ctx, types.SecretProviderHubSpot)
+	conn, err := sp.ConnectionRepo.GetByProvider(ctx, types.SecretProviderHubSpot)
 	if err != nil || conn == nil {
-		s.Logger.Debug(ctx, "HubSpot connection not found, skipping deal sync",
-			"error", err,
-			"subscription_id", subscriptionID,
-			"customer_id", customerID)
+		sp.Logger.Debug(ctx, "HubSpot connection not found, skipping deal sync",
+			"subscription_id", subscriptionID)
 		return
 	}
 
 	if !conn.IsDealOutboundEnabled() {
-		s.Logger.Debug(ctx, "HubSpot deal outbound sync disabled, skipping deal sync",
+		sp.Logger.Debug(ctx, "HubSpot deal outbound sync disabled, skipping deal sync",
 			"subscription_id", subscriptionID,
-			"customer_id", customerID,
 			"connection_id", conn.ID)
 		return
 	}
 
-	// Fetch customer to check for HubSpot deal ID
-	cust, err := s.CustomerRepo.Get(ctx, customerID)
+	sub, err := sp.SubRepo.Get(ctx, subscriptionID)
 	if err != nil {
-		s.Logger.Error(ctx, "failed to fetch customer for HubSpot deal sync",
+		sp.Logger.Error(ctx, "failed to fetch subscription for HubSpot deal sync",
 			"error", err,
-			"customer_id", customerID,
 			"subscription_id", subscriptionID)
 		return
 	}
 
-	// Check if customer has HubSpot deal ID in metadata
+	cust, err := sp.CustomerRepo.Get(ctx, sub.CustomerID)
+	if err != nil {
+		sp.Logger.Error(ctx, "failed to fetch customer for HubSpot deal sync",
+			"error", err,
+			"customer_id", sub.CustomerID,
+			"subscription_id", subscriptionID)
+		return
+	}
+
 	dealID, ok := cust.Metadata["hubspot_deal_id"]
 	if !ok || dealID == "" {
-		s.Logger.Debug(ctx, "customer does not have HubSpot deal ID, skipping sync",
-			"customer_id", customerID,
+		sp.Logger.Debug(ctx, "customer has no HubSpot deal ID, skipping deal sync",
+			"customer_id", cust.ID,
 			"subscription_id", subscriptionID)
-		return // Not an error - customer might not be from HubSpot
+		return
 	}
 
-	// Prepare workflow input with all necessary IDs
 	input := &models.HubSpotDealSyncWorkflowInput{
 		SubscriptionID: subscriptionID,
-		CustomerID:     customerID,
+		CustomerID:     cust.ID,
 		DealID:         dealID,
-		TenantID:       tenantID,
-		EnvironmentID:  envID,
+		TenantID:       types.GetTenantID(ctx),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
 	}
 
-	// Validate input
 	if err := input.Validate(); err != nil {
-		s.Logger.Error(ctx, "invalid workflow input for HubSpot deal sync",
+		sp.Logger.Error(ctx, "invalid workflow input for HubSpot deal sync",
 			"error", err,
 			"subscription_id", subscriptionID,
-			"customer_id", customerID,
 			"deal_id", dealID)
 		return
 	}
 
-	// Get global temporal service
 	temporalSvc := temporalservice.GetGlobalTemporalService()
 	if temporalSvc == nil {
-		s.Logger.Info(ctx, "temporal service not available for HubSpot deal sync",
+		sp.Logger.Info(ctx, "temporal service not available for HubSpot deal sync",
 			"subscription_id", subscriptionID)
 		return
 	}
 
-	// Start workflow - Temporal handles async execution, no need for goroutines
-	workflowRun, err := temporalSvc.ExecuteWorkflow(
-		ctx,
-		types.TemporalHubSpotDealSyncWorkflow,
-		input,
-	)
+	workflowRun, err := temporalSvc.ExecuteWorkflow(ctx, types.TemporalHubSpotDealSyncWorkflow, input)
 	if err != nil {
-		s.Logger.Error(ctx, "failed to start HubSpot deal sync workflow",
+		sp.Logger.Error(ctx, "failed to start HubSpot deal sync workflow",
 			"error", err,
 			"subscription_id", subscriptionID,
-			"customer_id", customerID,
 			"deal_id", dealID)
 		return
 	}
 
-	s.Logger.Info(ctx, "HubSpot deal sync workflow started successfully",
+	sp.Logger.Info(ctx, "HubSpot deal sync workflow started",
 		"subscription_id", subscriptionID,
 		"workflow_id", workflowRun.GetID())
 }

--- a/internal/ee/service/subscription_modification.go
+++ b/internal/ee/service/subscription_modification.go
@@ -348,6 +348,7 @@ func (s *subscriptionModificationService) executeQuantityChange(
 	}
 
 	s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, subscriptionID)
+	triggerHubSpotDealSync(ctx, sp, subscriptionID)
 
 	subSvc := NewSubscriptionService(sp)
 	subResp, err := subSvc.GetSubscription(ctx, subscriptionID)

--- a/internal/ee/service/subscription_modification_addon.go
+++ b/internal/ee/service/subscription_modification_addon.go
@@ -43,6 +43,7 @@ func (s *subscriptionModificationService) executeAddonModification(
 	// items appear only once payment lands, so there is no subscription update to announce.
 	if !result.PaymentPending() {
 		s.publishSystemEvent(ctx, types.WebhookEventSubscriptionUpdated, subscriptionID)
+		triggerHubSpotDealSync(ctx, s.serviceParams, subscriptionID)
 	}
 
 	return s.addonModifyResponse(ctx, subscriptionID, result, false)

--- a/internal/integration/factory.go
+++ b/internal/integration/factory.go
@@ -234,6 +234,7 @@ func (f *Factory) GetHubSpotIntegration(ctx context.Context) (*HubSpotIntegratio
 		f.customerRepo,
 		f.subscriptionRepo,
 		f.priceRepo,
+		f.entityIntegrationMappingRepo,
 		f.logger,
 	)
 

--- a/internal/integration/hubspot/client.go
+++ b/internal/integration/hubspot/client.go
@@ -41,6 +41,7 @@ type HubSpotClient interface {
 	// Deal operations
 	UpdateDeal(ctx context.Context, dealID string, properties map[string]string) (*DealUpdateResponse, error)
 	CreateDealLineItem(ctx context.Context, req *DealLineItemCreateRequest) (*DealLineItemResponse, error)
+	UpdateDealLineItem(ctx context.Context, lineItemID string, properties *DealLineItemProperties) error
 	DeleteDealLineItem(ctx context.Context, lineItemID string) error
 
 	// Quote operations
@@ -740,6 +741,54 @@ func (c *Client) CreateDealLineItem(ctx context.Context, req *DealLineItemCreate
 	}
 
 	return &lineItem, nil
+}
+
+func (c *Client) UpdateDealLineItem(ctx context.Context, lineItemID string, properties *DealLineItemProperties) error {
+	config, err := c.GetHubSpotConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/crm/v3/objects/line_items/%s", HubSpotAPIBaseURL, lineItemID)
+
+	reqBody, err := json.Marshal(map[string]interface{}{"properties": properties})
+	if err != nil {
+		return ierr.NewError("failed to marshal line item update request").Mark(ierr.ErrInternal)
+	}
+
+	httpReq := &httpclient.Request{
+		Method: http.MethodPatch,
+		URL:    url,
+		Headers: map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", config.AccessToken),
+			"Content-Type":  "application/json",
+		},
+		Body: reqBody,
+	}
+
+	resp, err := c.httpClient.Send(ctx, httpReq)
+	if err != nil {
+		c.logger.Error(ctx, "http client error updating line item",
+			"error", err,
+			"url", url,
+			"line_item_id", lineItemID)
+		return ierr.NewError("failed to update line item in HubSpot").
+			WithHint("Check HubSpot API connectivity").
+			Mark(ierr.ErrHTTPClient)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error(ctx, "hubspot update line item error",
+			"error", fmt.Sprintf("unexpected status %d", resp.StatusCode),
+			"status", resp.StatusCode,
+			"url", url,
+			"line_item_id", lineItemID)
+		return ierr.NewError("failed to update line item in HubSpot").
+			WithHint(fmt.Sprintf("HubSpot API returned status %d", resp.StatusCode)).
+			Mark(ierr.ErrHTTPClient)
+	}
+
+	return nil
 }
 
 func (c *Client) DeleteDealLineItem(ctx context.Context, lineItemID string) error {

--- a/internal/integration/hubspot/deal.go
+++ b/internal/integration/hubspot/deal.go
@@ -2,7 +2,6 @@ package hubspot
 
 import (
 	"context"
-	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
@@ -11,7 +10,11 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 )
+
+// hubspotDateFormat is HubSpot's date-property format, matching QuoteProperties.ExpirationDate.
+const hubspotDateFormat = "2006-01-02"
 
 // DealSyncService handles synchronization of subscription data with HubSpot deals
 type DealSyncService struct {
@@ -42,92 +45,196 @@ func NewDealSyncService(
 	}
 }
 
-// SyncSubscriptionToDeal creates HubSpot line items from subscription and associates them with a deal
-func (s *DealSyncService) SyncSubscriptionToDeal(ctx context.Context, subscriptionID string) error {
-	s.logger.Info(ctx, "fetching subscription for deal sync",
-		"subscription_id", subscriptionID)
-
-	// Fetch subscription with line items
+// SyncSubscriptionLineItems makes a HubSpot deal's line items match the subscription's
+// FIXED-price line items. Mapped line items are updated in place; unmapped ones are created
+// and recorded. Safe to call repeatedly — this is the only sync entry point, and every
+// trigger site calls it with no further arguments.
+//
+// Mappings whose line item is no longer returned by the repository (it ended before the
+// current billing period) are deliberately left alone: their end date was already pushed to
+// HubSpot when they ended, so deleting them would wipe correct history off the deal.
+func (s *DealSyncService) SyncSubscriptionLineItems(ctx context.Context, subscriptionID string) error {
 	sub, lineItems, err := s.subscriptionRepo.GetWithLineItems(ctx, subscriptionID)
 	if err != nil {
-		s.logger.Error(ctx, "failed to fetch subscription with line items",
-			"error", err,
-			"subscription_id", subscriptionID)
 		return ierr.WithError(err).
 			WithHint("Failed to fetch subscription").
 			Mark(ierr.ErrInternal)
 	}
 
-	// Assign line items to the subscription
-	sub.LineItems = lineItems
-
-	s.logger.Info(ctx, "fetching customer for deal sync",
-		"customer_id", sub.CustomerID,
-		"subscription_id", subscriptionID,
-		"line_items_count", len(lineItems))
-
-	// Fetch customer to get deal ID from metadata
 	cust, err := s.customerRepo.Get(ctx, sub.CustomerID)
 	if err != nil {
-		s.logger.Error(ctx, "failed to fetch customer",
-			"error", err,
-			"customer_id", sub.CustomerID,
-			"subscription_id", subscriptionID)
 		return ierr.WithError(err).
 			WithHint("Failed to fetch customer").
 			Mark(ierr.ErrInternal)
 	}
 
-	// Get deal ID from customer metadata
 	dealID, ok := cust.Metadata["hubspot_deal_id"]
 	if !ok || dealID == "" {
-		s.logger.Info(ctx, "no HubSpot deal ID found in customer metadata",
+		s.logger.Info(ctx, "customer has no HubSpot deal ID, skipping line item sync",
 			"customer_id", cust.ID,
-			"subscription_id", subscriptionID,
-			"metadata", cust.Metadata)
-		return nil // Not an error - customer might not be from HubSpot
-	}
-
-	s.logger.Info(ctx, "found HubSpot deal ID, creating line items",
-		"deal_id", dealID,
-		"subscription_id", subscriptionID,
-		"line_items_count", len(sub.LineItems))
-
-	// Filter for ACTIVE and FIXED pricing only (flat rate)
-	var flatRateLineItems []*subscription.SubscriptionLineItem
-	now := time.Now()
-	for _, lineItem := range sub.LineItems {
-		if lineItem.PriceType == types.PRICE_TYPE_FIXED && lineItem.IsActive(now) {
-			flatRateLineItems = append(flatRateLineItems, lineItem)
-		}
-	}
-
-	if len(flatRateLineItems) == 0 {
-		s.logger.Info(ctx, "no active flat rate line items to sync",
-			"subscription_id", subscriptionID,
-			"deal_id", dealID,
-			"line_items_count", len(sub.LineItems))
+			"subscription_id", subscriptionID)
 		return nil
 	}
 
-	// Create HubSpot line items for each flat rate subscription line item
-	for _, lineItem := range flatRateLineItems {
-		if err := s.createHubSpotLineItem(ctx, lineItem, sub, dealID); err != nil {
-			s.logger.Error(ctx, "failed to create HubSpot line item",
+	fixedItems := lo.Filter(lineItems, func(li *subscription.SubscriptionLineItem, _ int) bool {
+		return li.PriceType == types.PRICE_TYPE_FIXED
+	})
+	if len(fixedItems) == 0 {
+		return nil
+	}
+
+	mappings, err := s.getLineItemMappings(ctx, lo.Map(fixedItems,
+		func(li *subscription.SubscriptionLineItem, _ int) string { return li.ID }))
+	if err != nil {
+		return err
+	}
+
+	// Attempt every line item; a retry redoes only what is still missing.
+	var firstErr error
+	for _, lineItem := range fixedItems {
+		if err := s.syncLineItem(ctx, sub, lineItem, dealID, mappings[lineItem.ID]); err != nil {
+			s.logger.Error(ctx, "failed to sync line item to HubSpot deal",
 				"error", err,
 				"line_item_id", lineItem.ID,
+				"subscription_id", subscriptionID,
 				"deal_id", dealID)
-			// Continue with other line items even if one fails
-			continue
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 
-	s.logger.Info(ctx, "successfully synced subscription line items to HubSpot deal",
-		"subscription_id", subscriptionID,
-		"deal_id", dealID,
-		"synced_items", len(flatRateLineItems))
+	return firstErr
+}
+
+// getLineItemMappings returns published HubSpot mappings for the given line items, keyed by
+// line item ID. Line items with no mapping are simply absent from the map.
+func (s *DealSyncService) getLineItemMappings(
+	ctx context.Context,
+	lineItemIDs []string,
+) (map[string]*entityintegrationmapping.EntityIntegrationMapping, error) {
+	filter := types.NewNoLimitEntityIntegrationMappingFilter()
+	filter.EntityIDs = lineItemIDs
+	filter.EntityType = types.IntegrationEntityTypeSubscriptionLineItem
+	filter.ProviderTypes = []string{string(types.SecretProviderHubSpot)}
+	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+
+	mappings, err := s.entityIntegrationMappingRepo.List(ctx, filter)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to look up HubSpot line item mappings").
+			Mark(ierr.ErrDatabase)
+	}
+
+	return lo.SliceToMap(mappings,
+		func(m *entityintegrationmapping.EntityIntegrationMapping) (string, *entityintegrationmapping.EntityIntegrationMapping) {
+			return m.EntityID, m
+		}), nil
+}
+
+// syncLineItem updates the mapped HubSpot line item, or creates one and records the mapping.
+func (s *DealSyncService) syncLineItem(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	lineItem *subscription.SubscriptionLineItem,
+	dealID string,
+	mapping *entityintegrationmapping.EntityIntegrationMapping,
+) error {
+	props, err := s.buildLineItemProperties(ctx, sub, lineItem)
+	if err != nil {
+		return err
+	}
+
+	if mapping != nil {
+		return s.client.UpdateDealLineItem(ctx, mapping.ProviderEntityID, props)
+	}
+
+	resp, err := s.client.CreateDealLineItem(ctx, &DealLineItemCreateRequest{
+		Properties: *props,
+		Associations: []LineItemAssociation{
+			{
+				To: AssociationTarget{ID: dealID},
+				Types: []AssociationType{
+					{
+						AssociationCategory: string(AssociationCategoryHubSpotDefined),
+						AssociationTypeID:   AssociationTypeLineItemToDeal,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	newMapping := &entityintegrationmapping.EntityIntegrationMapping{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITY_INTEGRATION_MAPPING),
+		EntityID:         lineItem.ID,
+		EntityType:       types.IntegrationEntityTypeSubscriptionLineItem,
+		ProviderType:     string(types.SecretProviderHubSpot),
+		ProviderEntityID: resp.ID,
+		EnvironmentID:    types.GetEnvironmentID(ctx),
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+
+	if err := s.entityIntegrationMappingRepo.Create(ctx, newMapping); err != nil {
+		// The HubSpot line item exists but we could not record it, so a retry would create a
+		// second one. Remove it and let the retry start clean. A concurrent reconcile losing
+		// the unique-index race lands here too.
+		if delErr := s.client.DeleteDealLineItem(ctx, resp.ID); delErr != nil && !ierr.IsNotFound(delErr) {
+			s.logger.Error(ctx, "failed to remove orphaned HubSpot line item after mapping persist failure",
+				"error", delErr,
+				"hubspot_line_item_id", resp.ID,
+				"line_item_id", lineItem.ID)
+		}
+		return ierr.WithError(err).
+			WithHint("Failed to persist HubSpot line item mapping").
+			Mark(ierr.ErrDatabase)
+	}
 
 	return nil
+}
+
+// buildLineItemProperties maps a subscription line item to HubSpot line item properties.
+// The end date is sent only when set — an unset date must not overwrite a real value, and
+// `omitempty` on the field drops the key entirely.
+func (s *DealSyncService) buildLineItemProperties(
+	ctx context.Context,
+	sub *subscription.Subscription,
+	lineItem *subscription.SubscriptionLineItem,
+) (*DealLineItemProperties, error) {
+	priceObj, err := s.priceRepo.Get(ctx, lineItem.PriceID)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Price not found; cannot build accurate HubSpot line item").
+			Mark(ierr.ErrInternal)
+	}
+
+	unitPrice := priceObj.Amount
+
+	description := string(lineItem.PriceType) + " pricing"
+	if lineItem.DisplayName != "" {
+		description = lineItem.DisplayName + " (" + string(lineItem.PriceType) + " pricing)"
+	}
+
+	props := &DealLineItemProperties{
+		Name:                 lineItem.DisplayName,
+		Price:                unitPrice.String(),
+		Quantity:             lineItem.Quantity.String(),
+		Amount:               unitPrice.Mul(lineItem.Quantity).String(),
+		Discount:             "0",
+		RecurringBillingFreq: s.mapBillingFrequency(sub.BillingPeriod),
+		Description:          description,
+	}
+
+	if !lineItem.StartDate.IsZero() {
+		props.RecurringBillingStartDate = lineItem.StartDate.UTC().Format(hubspotDateFormat)
+	}
+	if !lineItem.EndDate.IsZero() {
+		props.RecurringBillingEndDate = lineItem.EndDate.UTC().Format(hubspotDateFormat)
+	}
+
+	return props, nil
 }
 
 // UpdateDealAmountFromACV updates the deal amount based on HubSpot's calculated ACV
@@ -144,89 +251,6 @@ func (s *DealSyncService) UpdateDealAmountFromACV(ctx context.Context, customerI
 			"deal_id", dealID,
 			"customer_id", customerID)
 		return err
-	}
-
-	return nil
-}
-
-// createHubSpotLineItem creates a single HubSpot line item and associates it with a deal
-func (s *DealSyncService) createHubSpotLineItem(
-	ctx context.Context,
-	lineItem *subscription.SubscriptionLineItem,
-	sub *subscription.Subscription,
-	dealID string,
-) error {
-	// Fetch the price to get the actual amount
-	priceObj, err := s.priceRepo.Get(ctx, lineItem.PriceID)
-	if err != nil {
-		s.logger.Error(ctx, "failed to fetch price for line item; cannot create accurate HubSpot line item",
-			"error", err,
-			"price_id", lineItem.PriceID,
-			"line_item_id", lineItem.ID,
-			"deal_id", dealID)
-		return ierr.WithError(err).
-			WithHint("Price not found; cannot create accurate HubSpot line item").
-			Mark(ierr.ErrInternal)
-	}
-
-	// Calculate unit price and total amount
-	unitPrice := priceObj.Amount
-	totalAmount := unitPrice.Mul(lineItem.Quantity)
-
-	// Calculate discount (default to 0 if not applicable)
-	discount := "0"
-
-	// Map billing frequency to HubSpot format
-	billingFreq := s.mapBillingFrequency(sub.BillingPeriod)
-
-	// Build description with pricing model
-	description := string(lineItem.PriceType) + " pricing"
-	if lineItem.DisplayName != "" {
-		description = lineItem.DisplayName + " (" + string(lineItem.PriceType) + " pricing)"
-	}
-
-	// Create line item request with all fields
-	lineItemReq := &DealLineItemCreateRequest{
-		Properties: DealLineItemProperties{
-			Name:                 lineItem.DisplayName,
-			Price:                unitPrice.String(),         // Unit price
-			Quantity:             lineItem.Quantity.String(), // Quantity
-			Amount:               totalAmount.String(),       // Total amount
-			Discount:             discount,                   // Discount
-			RecurringBillingFreq: billingFreq,                // Billing frequency
-			Description:          description,                // Pricing model in description
-		},
-		Associations: []LineItemAssociation{
-			{
-				To: AssociationTarget{
-					ID: dealID,
-				},
-				Types: []AssociationType{
-					{
-						AssociationCategory: string(AssociationCategoryHubSpotDefined),
-						AssociationTypeID:   AssociationTypeLineItemToDeal,
-					},
-				},
-			},
-		},
-	}
-
-	s.logger.Info(ctx, "creating HubSpot line item",
-		"deal_id", dealID,
-		"line_item_name", lineItem.DisplayName,
-		"quantity", lineItem.Quantity.String(),
-		"unit_price", unitPrice.String(),
-		"total_amount", totalAmount.String(),
-		"discount", discount,
-		"billing_frequency", billingFreq,
-		"pricing_model", lineItem.PriceType)
-
-	// Create the line item in HubSpot
-	_, err = s.client.CreateDealLineItem(ctx, lineItemReq)
-	if err != nil {
-		return ierr.WithError(err).
-			WithHint("Failed to create HubSpot line item").
-			Mark(ierr.ErrHTTPClient)
 	}
 
 	return nil

--- a/internal/integration/hubspot/deal.go
+++ b/internal/integration/hubspot/deal.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -14,11 +15,12 @@ import (
 
 // DealSyncService handles synchronization of subscription data with HubSpot deals
 type DealSyncService struct {
-	client           HubSpotClient
-	customerRepo     customer.Repository
-	subscriptionRepo subscription.Repository
-	priceRepo        price.Repository
-	logger           *logger.Logger
+	client                       HubSpotClient
+	customerRepo                 customer.Repository
+	subscriptionRepo             subscription.Repository
+	priceRepo                    price.Repository
+	entityIntegrationMappingRepo entityintegrationmapping.Repository
+	logger                       *logger.Logger
 }
 
 // NewDealSyncService creates a new HubSpot deal sync service
@@ -27,14 +29,16 @@ func NewDealSyncService(
 	customerRepo customer.Repository,
 	subscriptionRepo subscription.Repository,
 	priceRepo price.Repository,
+	entityIntegrationMappingRepo entityintegrationmapping.Repository,
 	logger *logger.Logger,
 ) *DealSyncService {
 	return &DealSyncService{
-		client:           client,
-		customerRepo:     customerRepo,
-		subscriptionRepo: subscriptionRepo,
-		priceRepo:        priceRepo,
-		logger:           logger,
+		client:                       client,
+		customerRepo:                 customerRepo,
+		subscriptionRepo:             subscriptionRepo,
+		priceRepo:                    priceRepo,
+		entityIntegrationMappingRepo: entityIntegrationMappingRepo,
+		logger:                       logger,
 	}
 }
 

--- a/internal/integration/hubspot/dto.go
+++ b/internal/integration/hubspot/dto.go
@@ -165,6 +165,9 @@ type DealLineItemProperties struct {
 	Discount             string `json:"discount,omitempty"`                  // Discount amount or percentage
 	RecurringBillingFreq string `json:"recurringbillingfrequency,omitempty"` // Billing frequency (e.g., "monthly", "annually")
 	Description          string `json:"description,omitempty"`               // Line item description / pricing model
+	// Date format "YYYY-MM-DD", matching QuoteProperties.ExpirationDate's convention.
+	RecurringBillingStartDate string `json:"hs_recurring_billing_start_date,omitempty"`
+	RecurringBillingEndDate   string `json:"hs_recurring_billing_end_date,omitempty"`
 }
 
 // LineItemAssociation represents an association between a line item and another object (deal, quote, etc.)

--- a/internal/temporal/activities/hubspot/deal_sync_activities.go
+++ b/internal/temporal/activities/hubspot/deal_sync_activities.go
@@ -28,8 +28,9 @@ func NewDealSyncActivities(
 	}
 }
 
-// CreateLineItems creates HubSpot line items from subscription
-// This is the first step - it creates line items but doesn't update deal amount
+// CreateLineItems reconciles the subscription's line items into the HubSpot deal — updating
+// mapped ones and creating unmapped ones. The activity name is unchanged so that workflow
+// executions started before this change replay without a non-determinism error.
 func (a *DealSyncActivities) CreateLineItems(
 	ctx context.Context,
 	input models.HubSpotDealSyncWorkflowInput,
@@ -63,7 +64,7 @@ func (a *DealSyncActivities) CreateLineItems(
 	}
 
 	// Create line items - uses existing DealSyncService logic
-	err = hubspotIntegration.DealSyncSvc.SyncSubscriptionToDeal(ctx, input.SubscriptionID)
+	err = hubspotIntegration.DealSyncSvc.SyncSubscriptionLineItems(ctx, input.SubscriptionID)
 	if err != nil {
 		a.logger.Error(ctx, "failed to create line items",
 			"error", err,

--- a/internal/types/entityintegrationmapping.go
+++ b/internal/types/entityintegrationmapping.go
@@ -22,6 +22,9 @@ const (
 	// IntegrationEntityTypeInvoiceLineItem maps a flexprice invoice line item to a provider-side
 	// charge (e.g. a Tabs obligation), used to make per-line-item invoice sync idempotent.
 	IntegrationEntityTypeInvoiceLineItem IntegrationEntityType = "invoice_line_item"
+	// IntegrationEntityTypeSubscriptionLineItem maps a flexprice subscription line item to a
+	// provider-side line item (e.g. a HubSpot deal line item), making per-line-item sync idempotent.
+	IntegrationEntityTypeSubscriptionLineItem IntegrationEntityType = "subscription_line_item"
 )
 
 func (e IntegrationEntityType) String() string {
@@ -41,6 +44,7 @@ func (e IntegrationEntityType) Validate() error {
 		IntegrationEntityTypeItemPrice,
 		IntegrationEntityTypePrice,
 		IntegrationEntityTypeInvoiceLineItem,
+		IntegrationEntityTypeSubscriptionLineItem,
 	}
 	if !lo.Contains(allowed, e) {
 		return ierr.NewError("invalid entity type").


### PR DESCRIPTION
## **User description**
## Summary

HubSpot deal line-item sync currently fires once, at subscription creation, and never again — so any subscription modification leaves the deal permanently stale. It also persists nothing about what it created, so a Temporal retry duplicates line items, and a per-item failure is logged and `continue`d while the sync reports success.

This replaces the one-shot create with a reconcile: `DealSyncService.SyncSubscriptionLineItems(ctx, subscriptionID)` reads the subscription's line items and their `entity_integration_mapping` rows, updates mapped HubSpot line items in place, and creates unmapped ones. Idempotent by construction, so every trigger site is the same argument-free call.

## What changed

- **`SyncSubscriptionLineItems` replaces `SyncSubscriptionToDeal`.** Mapped → `UpdateDealLineItem`; unmapped → create and record an `entity_integration_mapping` row (`entity_type = subscription_line_item`). Failures are accumulated rather than swallowed, so Temporal retries and only redoes what is still missing.
- **Terminated line items are end-dated, not deleted.** A non-zero `EndDate` is sent as `hs_recurring_billing_end_date`; a zero one sends no key at all. This also handles future-dated changes for free — `applyQuantityChange` writes `endedItem.EndDate` and `newItem.StartDate` at the same instant, so both halves reach HubSpot immediately with their real terms and HubSpot holds the schedule.
- **No delete path.** `ListBySubscription` only returns line items with `EndDate >= CurrentPeriodStart`, so treating absent ones as orphans would wipe correctly-ended history off the deal on every period roll. `DeleteDealLineItem` is used only to compensate a failed mapping insert, which is also what makes the unique-index race between two concurrent reconciles converge.
- **New sync points.** The trigger becomes a package-level `triggerHubSpotDealSync(ctx, sp, subscriptionID)` — still `void`, still never blocking or failing the caller — called from subscription creation (existing behaviour), quantity change, addon add/remove, and both pay-first checkout completions.
- **`UpdateDealLineItem` added to the HubSpot client** (PATCH `/crm/v3/objects/line_items/{id}`), plus `hs_recurring_billing_start_date` / `hs_recurring_billing_end_date` on `DealLineItemProperties`.

The `HubSpotDealSyncWorkflow` body is unchanged — same activity names, same order. Only the `CreateLineItems` activity implementation is repointed, so no new workflow type, model, or activity is introduced.

No DB migration: `entity_type` is a string column and the partial unique index already exists in the Ent schema.

## Supersedes

Closes out the approach in #2550, which did this via `subscription.line_item.{created,deleted}` events plus a second parallel Temporal workflow (1845+/188-, stacked on the still-open #2539). This lands the same behaviour in ~150 net new lines with no event plumbing, no duplicated workflow, and nothing left behind for a follow-up cleanup PR.

## Test plan

- `go build ./internal/... ./cmd/...`, `go vet ./internal/... ./cmd/...`, and `make lint-ci` all clean.
- `go test ./internal/ee/service/... ./internal/integration/... ./internal/types/...` — all `ok`, no failures.
- No new unit tests, by decision.

## Before enabling for a tenant

Confirm in a HubSpot sandbox that `hs_acv` **excludes** line items whose recurring-billing end date has passed. `UpdateDealAmountFromACV` copies `hs_acv` straight into the deal's amount, so if ACV sums line items regardless of term, amounts will inflate as line-item generations accumulate and ended items would need deleting rather than end-dating. No tenant uses the HubSpot integration in production today, so there is no migration or duplicate-cleanup concern.


___

## **CodeAnt-AI Description**
Keep HubSpot deal line items synchronized with subscription changes

### What Changed
- Subscription creation, quantity changes, add-on changes, and completed modification checkouts now trigger HubSpot deal synchronization.
- Existing HubSpot line items are updated in place, while new subscription line items are created only once and tracked for future updates.
- Subscription start and end dates are sent to HubSpot, including end dates for terminated or scheduled line items.
- Synchronization retries report failures so incomplete items can be completed without duplicating successful ones.
- Subscriptions without a HubSpot deal or without an active HubSpot connection continue without blocking the subscription operation.

### Impact
`✅ Current HubSpot deal quantities and prices`
`✅ No duplicate deal line items after retries`
`✅ Accurate recurring billing dates in HubSpot`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HubSpot deal line items now stay synchronized after subscription quantity, add-on, and checkout updates.
  * Existing line items are updated and missing items are created automatically.
  * Subscription billing start and end dates are included in HubSpot line-item details.

* **Bug Fixes**
  * Improved synchronization handling prevents duplicate or orphaned HubSpot line items.
  * Synchronization continues processing available items while reporting any encountered errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->