### PR TITLE
feat(plan): Support for scheduling in plan change

### DIFF
--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"time"
 
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/validator"
 )
@@ -14,7 +15,15 @@ type SubscriptionChangeV2Request struct {
 	EntityPolicies *SubscriptionChangeEntityPolicies `json:"entity_policies,omitempty"`
 	IdempotencyKey *string                           `json:"idempotency_key,omitempty" validate:"omitempty"`
 
+	// ChangeAt controls when the change takes effect. nil or "immediate" applies
+	// it now; "end_of_period" schedules it at the subscription's current period end.
+	ChangeAt *types.ScheduleType `json:"change_at,omitempty"`
+
 	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+func (r *SubscriptionChangeV2Request) IsDeferred() bool {
+	return r != nil && r.ChangeAt != nil && *r.ChangeAt == types.ScheduleTypePeriodEnd
 }
 
 type SubscriptionChangeEntityPolicies struct {
@@ -74,6 +83,18 @@ func (r *SubscriptionChangeV2Request) Validate() error {
 		return err
 	}
 
+	if r.ChangeAt != nil {
+		if err := r.ChangeAt.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if r.IsDeferred() && r.ProrationBehavior == types.ProrationBehaviorCreateProrations {
+		return ierr.NewError("proration is not applicable for an end_of_period plan change").
+			WithHint("Set proration_behavior to 'none'. At a period boundary the renewal invoice already bills the new plan.").
+			Mark(ierr.ErrValidation)
+	}
+
 	if r.EntityPolicies != nil {
 		return r.EntityPolicies.Addons.Validate()
 	}
@@ -90,6 +111,12 @@ type SubscriptionChangeV2Response struct {
 	ToPlan      PlanSummary                  `json:"to_plan"`
 
 	EntityChanges []*EntityChangeResult `json:"entity_changes,omitempty"`
+
+	// IsScheduled is true when the change was deferred to the period end instead
+	// of being applied immediately.
+	IsScheduled bool       `json:"is_scheduled"`
+	ScheduleID  *string    `json:"schedule_id,omitempty"`
+	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
 
 	Warnings []string          `json:"warnings,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`

--- a/internal/api/dto/subscription_change_v2_test.go
+++ b/internal/api/dto/subscription_change_v2_test.go
@@ -1,0 +1,90 @@
+package dto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+)
+
+func TestSubscriptionChangeV2Request_Validate_ChangeAt(t *testing.T) {
+	tests := []struct {
+		name              string
+		changeAt          *types.ScheduleType
+		prorationBehavior types.ProrationBehavior
+		wantErr           string
+	}{
+		{
+			name:              "end_of_period with create_prorations is rejected",
+			changeAt:          lo.ToPtr(types.ScheduleTypePeriodEnd),
+			prorationBehavior: types.ProrationBehaviorCreateProrations,
+			wantErr:           "proration is not applicable for an end_of_period plan change",
+		},
+		{
+			name:              "end_of_period with none passes",
+			changeAt:          lo.ToPtr(types.ScheduleTypePeriodEnd),
+			prorationBehavior: types.ProrationBehaviorNone,
+		},
+		{
+			name:              "immediate with create_prorations passes",
+			changeAt:          lo.ToPtr(types.ScheduleTypeImmediate),
+			prorationBehavior: types.ProrationBehaviorCreateProrations,
+		},
+		{
+			name:              "nil change_at with create_prorations passes",
+			prorationBehavior: types.ProrationBehaviorCreateProrations,
+		},
+		{
+			name:              "invalid change_at is rejected",
+			changeAt:          lo.ToPtr(types.ScheduleType("tomorrow")),
+			prorationBehavior: types.ProrationBehaviorNone,
+			wantErr:           "invalid schedule type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &SubscriptionChangeV2Request{
+				TargetPlanID:      "plan_123",
+				ProrationBehavior: tt.prorationBehavior,
+				ChangeAt:          tt.changeAt,
+			}
+
+			err := req.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestSubscriptionChangeV2Request_IsDeferred(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *SubscriptionChangeV2Request
+		expected bool
+	}{
+		{"nil request", nil, false},
+		{"nil change_at", &SubscriptionChangeV2Request{}, false},
+		{"immediate", &SubscriptionChangeV2Request{ChangeAt: lo.ToPtr(types.ScheduleTypeImmediate)}, false},
+		{"end_of_period", &SubscriptionChangeV2Request{ChangeAt: lo.ToPtr(types.ScheduleTypePeriodEnd)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.req.IsDeferred(); got != tt.expected {
+				t.Fatalf("IsDeferred() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/api/dto/subscription_change_v2_test.go
+++ b/internal/api/dto/subscription_change_v2_test.go
@@ -88,3 +88,21 @@ func TestSubscriptionChangeV2Request_IsDeferred(t *testing.T) {
 		})
 	}
 }
+
+// nil already means "unset"; an explicit empty string is malformed input that
+// ScheduleType.Validate() would otherwise let through.
+func TestSubscriptionChangeV2Request_Validate_RejectsEmptyChangeAt(t *testing.T) {
+	req := &SubscriptionChangeV2Request{
+		TargetPlanID:      "plan_123",
+		ProrationBehavior: types.ProrationBehaviorNone,
+		ChangeAt:          lo.ToPtr(types.ScheduleType("")),
+	}
+
+	err := req.Validate()
+	if err == nil {
+		t.Fatal("expected an error for an empty change_at, got nil")
+	}
+	if !strings.Contains(err.Error(), "schedule type cannot be empty string") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/api/dto/subscription_schedule.go
+++ b/internal/api/dto/subscription_schedule.go
@@ -127,17 +127,25 @@ func SubscriptionScheduleResponseFromDomain(s *subscription.SubscriptionSchedule
 		UpdatedAt:          s.UpdatedAt,
 	}
 
-	// Parse configuration based on type
 	if s.ScheduleType == types.SubscriptionScheduleChangeTypePlanChange {
-		if config, err := s.GetPlanChangeConfig(); err == nil {
-			response.Configuration = config
-		}
-	}
-
-	// Parse execution result based on type
-	if s.ScheduleType == types.SubscriptionScheduleChangeTypePlanChange && s.ExecutionResult != nil {
-		if result, err := s.GetPlanChangeResult(); err == nil {
-			response.ExecutionResult = result
+		v2Config, err := s.GetPlanChangeV2Config()
+		switch {
+		case err == nil && v2Config.IsV2():
+			response.Configuration = v2Config
+			if s.ExecutionResult != nil {
+				if result, err := s.GetPlanChangeV2Result(); err == nil {
+					response.ExecutionResult = result
+				}
+			}
+		default:
+			if config, err := s.GetPlanChangeConfig(); err == nil {
+				response.Configuration = config
+			}
+			if s.ExecutionResult != nil {
+				if result, err := s.GetPlanChangeResult(); err == nil {
+					response.ExecutionResult = result
+				}
+			}
 		}
 	}
 

--- a/internal/api/dto/subscription_schedule_v2_test.go
+++ b/internal/api/dto/subscription_schedule_v2_test.go
@@ -1,0 +1,126 @@
+package dto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+func planChangeScheduleRow() *subscription.SubscriptionSchedule {
+	return &subscription.SubscriptionSchedule{
+		ID:             "sched_1",
+		SubscriptionID: "subs_1",
+		ScheduleType:   types.SubscriptionScheduleChangeTypePlanChange,
+		ScheduledAt:    time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+		Status:         types.ScheduleStatusPending,
+	}
+}
+
+func TestSubscriptionScheduleResponse_RendersV2Config(t *testing.T) {
+	row := planChangeScheduleRow()
+	if err := row.SetPlanChangeV2Config(&subscription.PlanChangeV2Configuration{
+		TargetPlanID: "plan_target",
+		EntityPolicies: &subscription.EntityChangePoliciesConfig{
+			Addons: &subscription.EntityChangePolicyConfig{
+				DefaultBehaviour: types.EntityChangeBehaviourDrop,
+			},
+		},
+		ChangeMetadata: map[string]string{"source": "api"},
+	}); err != nil {
+		t.Fatalf("SetPlanChangeV2Config: %v", err)
+	}
+
+	resp := SubscriptionScheduleResponseFromDomain(row)
+
+	config, ok := resp.Configuration.(*subscription.PlanChangeV2Configuration)
+	if !ok {
+		t.Fatalf("Configuration = %T, want *PlanChangeV2Configuration", resp.Configuration)
+	}
+	if config.TargetPlanID != "plan_target" {
+		t.Fatalf("target plan not rendered: %+v", config)
+	}
+	if config.EntityPolicies == nil || config.EntityPolicies.Addons == nil ||
+		config.EntityPolicies.Addons.DefaultBehaviour != types.EntityChangeBehaviourDrop {
+		t.Fatalf("entity policies not rendered: %+v", config.EntityPolicies)
+	}
+	if config.ChangeMetadata["source"] != "api" {
+		t.Fatalf("metadata not rendered: %+v", config.ChangeMetadata)
+	}
+	if resp.ExecutionResult != nil {
+		t.Fatalf("a pending schedule has no execution result, got %+v", resp.ExecutionResult)
+	}
+}
+
+func TestSubscriptionScheduleResponse_RendersV2Result(t *testing.T) {
+	row := planChangeScheduleRow()
+	if err := row.SetPlanChangeV2Config(&subscription.PlanChangeV2Configuration{TargetPlanID: "plan_b"}); err != nil {
+		t.Fatalf("SetPlanChangeV2Config: %v", err)
+	}
+	effective := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	if err := row.SetPlanChangeV2Result(&subscription.PlanChangeV2Result{
+		SubscriptionID: "subs_1",
+		FromPlanID:     "plan_a",
+		ToPlanID:       "plan_b",
+		ChangeType:     "upgrade",
+		EffectiveDate:  effective,
+	}); err != nil {
+		t.Fatalf("SetPlanChangeV2Result: %v", err)
+	}
+	row.Status = types.ScheduleStatusExecuted
+
+	resp := SubscriptionScheduleResponseFromDomain(row)
+
+	result, ok := resp.ExecutionResult.(*subscription.PlanChangeV2Result)
+	if !ok {
+		t.Fatalf("ExecutionResult = %T, want *PlanChangeV2Result", resp.ExecutionResult)
+	}
+	if result.FromPlanID != "plan_a" || result.ToPlanID != "plan_b" || result.ChangeType != "upgrade" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if !result.EffectiveDate.Equal(effective) {
+		t.Fatalf("effective date = %v, want %v", result.EffectiveDate, effective)
+	}
+}
+
+// A v1 row must keep rendering through the v1 shape, including its old/new
+// subscription ids, which have no equivalent in the v2 result.
+func TestSubscriptionScheduleResponse_V1RowUnchanged(t *testing.T) {
+	row := planChangeScheduleRow()
+	if err := row.SetPlanChangeConfig(&subscription.PlanChangeConfiguration{
+		TargetPlanID:       "plan_target",
+		ProrationBehavior:  types.ProrationBehaviorCreateProrations,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+	}); err != nil {
+		t.Fatalf("SetPlanChangeConfig: %v", err)
+	}
+	if err := row.SetPlanChangeResult(&subscription.PlanChangeResult{
+		OldSubscriptionID: "subs_old",
+		NewSubscriptionID: "subs_new",
+		ChangeType:        "upgrade",
+	}); err != nil {
+		t.Fatalf("SetPlanChangeResult: %v", err)
+	}
+
+	resp := SubscriptionScheduleResponseFromDomain(row)
+
+	config, ok := resp.Configuration.(*subscription.PlanChangeConfiguration)
+	if !ok {
+		t.Fatalf("Configuration = %T, want *PlanChangeConfiguration", resp.Configuration)
+	}
+	if config.BillingPeriod != types.BILLING_PERIOD_MONTHLY ||
+		config.ProrationBehavior != types.ProrationBehaviorCreateProrations {
+		t.Fatalf("v1 fields lost: %+v", config)
+	}
+
+	result, ok := resp.ExecutionResult.(*subscription.PlanChangeResult)
+	if !ok {
+		t.Fatalf("ExecutionResult = %T, want *PlanChangeResult", resp.ExecutionResult)
+	}
+	if result.OldSubscriptionID != "subs_old" || result.NewSubscriptionID != "subs_new" {
+		t.Fatalf("unexpected v1 result: %+v", result)
+	}
+}

--- a/internal/api/v1/subscription_plan_change.go
+++ b/internal/api/v1/subscription_plan_change.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -59,7 +60,7 @@ func (h *SubscriptionHandler) ExecuteSubscriptionPlanChangeV2(c *gin.Context) {
 		return
 	}
 
-	resp, err := h.service.ExecutePlanChange(c.Request.Context(), subscriptionID, req)
+	resp, err := h.service.ExecutePlanChange(c.Request.Context(), subscriptionID, req, time.Now().UTC())
 	if err != nil {
 		c.Error(err)
 		return

--- a/internal/api/v1/subscription_plan_change.go
+++ b/internal/api/v1/subscription_plan_change.go
@@ -42,6 +42,12 @@ func (h *SubscriptionHandler) PreviewSubscriptionPlanChangeV2(c *gin.Context) {
 // @Summary Execute a plan change (v2, swap in place)
 // @ID executeSubscriptionPlanChangeV2
 // @Description Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.
+// @Description
+// @Description change_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.
+// @Description
+// @Description scheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.
+// @Description
+// @Description Only one plan change may be pending per subscription; request a second one and this returns 400. Cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json
@@ -50,7 +56,7 @@ func (h *SubscriptionHandler) PreviewSubscriptionPlanChangeV2(c *gin.Context) {
 // @Param id path string true "Subscription ID"
 // @Param request body dto.SubscriptionChangeV2Request true "Plan change request"
 // @Success 200 {object} dto.SubscriptionChangeV2Response
-// @Failure 400 {object} ierr.ErrorResponse "Invalid request, or a change this endpoint cannot make (interval, currency, hierarchy, phases, paused)"
+// @Failure 400 {object} ierr.ErrorResponse "Invalid request, a change this endpoint cannot make (interval, currency, hierarchy, phases, paused), a deferred change with proration, or a plan change already scheduled"
 // @Failure 404 {object} ierr.ErrorResponse "Subscription or plan not found"
 // @Failure 500 {object} ierr.ErrorResponse "Server error"
 // @Router /subscriptions/{id}/change/v2/execute [post]

--- a/internal/domain/subscription/schedule_builder.go
+++ b/internal/domain/subscription/schedule_builder.go
@@ -1,0 +1,99 @@
+package subscription
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// subscriptionScheduleBuilder copies an existing schedule and applies field updates.
+type subscriptionScheduleBuilder struct {
+	schedule *SubscriptionSchedule
+}
+
+// NewSubscriptionScheduleBuilder returns a builder seeded from an existing schedule.
+func NewSubscriptionScheduleBuilder(schedule *SubscriptionSchedule) *subscriptionScheduleBuilder {
+	if schedule == nil {
+		return &subscriptionScheduleBuilder{schedule: &SubscriptionSchedule{}}
+	}
+
+	copied := *schedule
+	if schedule.Metadata != nil {
+		copied.Metadata = make(types.Metadata, len(schedule.Metadata))
+		for k, v := range schedule.Metadata {
+			copied.Metadata[k] = v
+		}
+	}
+
+	return &subscriptionScheduleBuilder{schedule: &copied}
+}
+
+// NewPendingScheduleBuilder seeds a brand new pending schedule, filling the id,
+// audit and tenancy fields from ctx so callers only supply what varies.
+func NewPendingScheduleBuilder(
+	ctx context.Context,
+	sub *Subscription,
+	scheduleType types.SubscriptionScheduleChangeType,
+	scheduledAt time.Time,
+) *subscriptionScheduleBuilder {
+	now := time.Now().UTC()
+	b := &subscriptionScheduleBuilder{schedule: &SubscriptionSchedule{
+		ID:           types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_SCHEDULE),
+		ScheduleType: scheduleType,
+		ScheduledAt:  scheduledAt,
+		Status:       types.ScheduleStatusPending,
+		StatusColumn: types.StatusPublished,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		CreatedBy:    types.GetUserID(ctx),
+		UpdatedBy:    types.GetUserID(ctx),
+	}}
+
+	if sub != nil {
+		b.schedule.SubscriptionID = sub.ID
+		b.schedule.TenantID = sub.TenantID
+		b.schedule.EnvironmentID = sub.EnvironmentID
+	}
+
+	return b
+}
+
+func (b *subscriptionScheduleBuilder) WithStatus(status types.ScheduleStatus) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	b.schedule.Status = status
+	return b
+}
+
+func (b *subscriptionScheduleBuilder) WithExecutedAt(executedAt time.Time) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	b.schedule.ExecutedAt = &executedAt
+	return b
+}
+
+func (b *subscriptionScheduleBuilder) WithErrorMessage(message string) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	b.schedule.ErrorMessage = &message
+	return b
+}
+
+func (b *subscriptionScheduleBuilder) WithMetadata(metadata types.Metadata) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	b.schedule.Metadata = metadata
+	return b
+}
+
+func (b *subscriptionScheduleBuilder) Build() *SubscriptionSchedule {
+	if b == nil {
+		return nil
+	}
+	return b.schedule
+}

--- a/internal/domain/subscription/schedule_config.go
+++ b/internal/domain/subscription/schedule_config.go
@@ -154,23 +154,23 @@ func (s *SubscriptionSchedule) SetCancellationResult(result *CancellationResult)
 // from the v1 shape stored under the same schedule_type.
 const PlanChangeConfigVersionV2 = "v2"
 
-// PlanChangeV2Configuration represents the configuration for a plan change v2 schedule
 type PlanChangeV2Configuration struct {
-	Version           string                    `json:"version"`
-	TargetPlanID      string                    `json:"target_plan_id"`
-	ProrationBehavior types.ProrationBehavior   `json:"proration_behavior"`
-	AddonPolicy       *EntityChangePolicyConfig `json:"addon_policy,omitempty"`
-	IdempotencyKey    *string                   `json:"idempotency_key,omitempty"`
-	ChangeMetadata    map[string]string         `json:"change_metadata,omitempty"`
+	Version        string                      `json:"version"`
+	TargetPlanID   string                      `json:"target_plan_id"`
+	EntityPolicies *EntityChangePoliciesConfig `json:"entity_policies,omitempty"`
+	IdempotencyKey *string                     `json:"idempotency_key,omitempty"`
+	ChangeMetadata map[string]string           `json:"change_metadata,omitempty"`
 }
 
-// EntityChangePolicyConfig mirrors the API entity change policy without importing dto
+type EntityChangePoliciesConfig struct {
+	Addons *EntityChangePolicyConfig `json:"addons,omitempty"`
+}
+
 type EntityChangePolicyConfig struct {
 	DefaultBehaviour types.EntityChangeBehaviour            `json:"default_behaviour,omitempty"`
 	Overrides        map[string]types.EntityChangeBehaviour `json:"overrides,omitempty"`
 }
 
-// PlanChangeV2Result represents the result of a plan change v2 execution
 type PlanChangeV2Result struct {
 	SubscriptionID string    `json:"subscription_id"`
 	FromPlanID     string    `json:"from_plan_id"`
@@ -179,20 +179,16 @@ type PlanChangeV2Result struct {
 	EffectiveDate  time.Time `json:"effective_date"`
 }
 
-// IsPlanChangeV2 reports whether the schedule carries a plan change v2 configuration
-func (s *SubscriptionSchedule) IsPlanChangeV2() bool {
-	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange || len(s.Configuration) == 0 {
+func (s *SubscriptionSchedule) IsStaleFor(sub *Subscription) bool {
+	if sub == nil {
 		return false
 	}
 
-	var probe struct {
-		Version string `json:"version"`
-	}
-	if err := json.Unmarshal(s.Configuration, &probe); err != nil {
-		return false
-	}
+	return s.ScheduledAt.Before(sub.CurrentPeriodStart)
+}
 
-	return probe.Version == PlanChangeConfigVersionV2
+func (c *PlanChangeV2Configuration) IsV2() bool {
+	return c != nil && c.Version == PlanChangeConfigVersionV2
 }
 
 // GetPlanChangeV2Config parses and returns the plan change v2 configuration

--- a/internal/domain/subscription/schedule_config.go
+++ b/internal/domain/subscription/schedule_config.go
@@ -150,5 +150,108 @@ func (s *SubscriptionSchedule) SetCancellationResult(result *CancellationResult)
 	return nil
 }
 
-// Future: Add more configuration types here as needed
-// e.g., AddonChangeConfiguration, PriceChangeConfiguration, etc.
+// PlanChangeConfigVersionV2 discriminates a plan change v2 schedule configuration
+// from the v1 shape stored under the same schedule_type.
+const PlanChangeConfigVersionV2 = "v2"
+
+// PlanChangeV2Configuration represents the configuration for a plan change v2 schedule
+type PlanChangeV2Configuration struct {
+	Version           string                    `json:"version"`
+	TargetPlanID      string                    `json:"target_plan_id"`
+	ProrationBehavior types.ProrationBehavior   `json:"proration_behavior"`
+	AddonPolicy       *EntityChangePolicyConfig `json:"addon_policy,omitempty"`
+	IdempotencyKey    *string                   `json:"idempotency_key,omitempty"`
+	ChangeMetadata    map[string]string         `json:"change_metadata,omitempty"`
+}
+
+// EntityChangePolicyConfig mirrors the API entity change policy without importing dto
+type EntityChangePolicyConfig struct {
+	DefaultBehaviour types.EntityChangeBehaviour            `json:"default_behaviour,omitempty"`
+	Overrides        map[string]types.EntityChangeBehaviour `json:"overrides,omitempty"`
+}
+
+// PlanChangeV2Result represents the result of a plan change v2 execution
+type PlanChangeV2Result struct {
+	SubscriptionID string    `json:"subscription_id"`
+	FromPlanID     string    `json:"from_plan_id"`
+	ToPlanID       string    `json:"to_plan_id"`
+	ChangeType     string    `json:"change_type"`
+	EffectiveDate  time.Time `json:"effective_date"`
+}
+
+// IsPlanChangeV2 reports whether the schedule carries a plan change v2 configuration
+func (s *SubscriptionSchedule) IsPlanChangeV2() bool {
+	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange || len(s.Configuration) == 0 {
+		return false
+	}
+
+	var probe struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(s.Configuration, &probe); err != nil {
+		return false
+	}
+
+	return probe.Version == PlanChangeConfigVersionV2
+}
+
+// GetPlanChangeV2Config parses and returns the plan change v2 configuration
+func (s *SubscriptionSchedule) GetPlanChangeV2Config() (*PlanChangeV2Configuration, error) {
+	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange {
+		return nil, ErrInvalidScheduleType
+	}
+
+	var config PlanChangeV2Configuration
+	if err := json.Unmarshal(s.Configuration, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// SetPlanChangeV2Config serializes and sets the plan change v2 configuration
+func (s *SubscriptionSchedule) SetPlanChangeV2Config(config *PlanChangeV2Configuration) error {
+	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange {
+		return ErrInvalidScheduleType
+	}
+
+	config.Version = PlanChangeConfigVersionV2
+	data, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+	s.Configuration = data
+	return nil
+}
+
+// GetPlanChangeV2Result parses and returns the plan change v2 result
+func (s *SubscriptionSchedule) GetPlanChangeV2Result() (*PlanChangeV2Result, error) {
+	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange {
+		return nil, ErrInvalidScheduleType
+	}
+
+	if s.ExecutionResult == nil {
+		return nil, nil
+	}
+
+	var result PlanChangeV2Result
+	if err := json.Unmarshal(s.ExecutionResult, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// SetPlanChangeV2Result serializes and sets the plan change v2 result
+func (s *SubscriptionSchedule) SetPlanChangeV2Result(result *PlanChangeV2Result) error {
+	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange {
+		return ErrInvalidScheduleType
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	s.ExecutionResult = data
+	return nil
+}

--- a/internal/domain/subscription/schedule_config.go
+++ b/internal/domain/subscription/schedule_config.go
@@ -210,7 +210,6 @@ func (s *SubscriptionSchedule) SetPlanChangeV2Config(config *PlanChangeV2Configu
 	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange {
 		return ErrInvalidScheduleType
 	}
-
 	config.Version = PlanChangeConfigVersionV2
 	data, err := json.Marshal(config)
 	if err != nil {
@@ -243,7 +242,6 @@ func (s *SubscriptionSchedule) SetPlanChangeV2Result(result *PlanChangeV2Result)
 	if s.ScheduleType != types.SubscriptionScheduleChangeTypePlanChange {
 		return ErrInvalidScheduleType
 	}
-
 	data, err := json.Marshal(result)
 	if err != nil {
 		return err

--- a/internal/domain/subscription/schedule_config_v2_test.go
+++ b/internal/domain/subscription/schedule_config_v2_test.go
@@ -18,12 +18,13 @@ func newPlanChangeSchedule() *SubscriptionSchedule {
 func TestPlanChangeV2Config_RoundTrip(t *testing.T) {
 	s := newPlanChangeSchedule()
 	config := &PlanChangeV2Configuration{
-		TargetPlanID:      "plan_target",
-		ProrationBehavior: types.ProrationBehaviorNone,
-		AddonPolicy: &EntityChangePolicyConfig{
-			DefaultBehaviour: types.EntityChangeBehaviourCarry,
-			Overrides: map[string]types.EntityChangeBehaviour{
-				"addon_assoc_1": types.EntityChangeBehaviourDrop,
+		TargetPlanID: "plan_target",
+		EntityPolicies: &EntityChangePoliciesConfig{
+			Addons: &EntityChangePolicyConfig{
+				DefaultBehaviour: types.EntityChangeBehaviourCarry,
+				Overrides: map[string]types.EntityChangeBehaviour{
+					"addon_assoc_1": types.EntityChangeBehaviourDrop,
+				},
 			},
 		},
 		IdempotencyKey: lo.ToPtr("idem_1"),
@@ -44,14 +45,17 @@ func TestPlanChangeV2Config_RoundTrip(t *testing.T) {
 	if got.Version != PlanChangeConfigVersionV2 {
 		t.Fatalf("version = %q, want %q", got.Version, PlanChangeConfigVersionV2)
 	}
-	if got.TargetPlanID != "plan_target" || got.ProrationBehavior != types.ProrationBehaviorNone {
+	if got.TargetPlanID != "plan_target" {
 		t.Fatalf("unexpected config: %+v", got)
 	}
-	if got.AddonPolicy == nil || got.AddonPolicy.DefaultBehaviour != types.EntityChangeBehaviourCarry {
-		t.Fatalf("unexpected addon policy: %+v", got.AddonPolicy)
+	if got.EntityPolicies == nil || got.EntityPolicies.Addons == nil {
+		t.Fatalf("unexpected entity policies: %+v", got.EntityPolicies)
 	}
-	if got.AddonPolicy.Overrides["addon_assoc_1"] != types.EntityChangeBehaviourDrop {
-		t.Fatalf("unexpected overrides: %+v", got.AddonPolicy.Overrides)
+	if got.EntityPolicies.Addons.DefaultBehaviour != types.EntityChangeBehaviourCarry {
+		t.Fatalf("unexpected addon policy: %+v", got.EntityPolicies.Addons)
+	}
+	if got.EntityPolicies.Addons.Overrides["addon_assoc_1"] != types.EntityChangeBehaviourDrop {
+		t.Fatalf("unexpected overrides: %+v", got.EntityPolicies.Addons.Overrides)
 	}
 	if lo.FromPtr(got.IdempotencyKey) != "idem_1" || got.ChangeMetadata["source"] != "api" {
 		t.Fatalf("unexpected config: %+v", got)
@@ -104,12 +108,9 @@ func TestPlanChangeV2Config_WrongScheduleType(t *testing.T) {
 	if _, err := s.GetPlanChangeV2Result(); err != ErrInvalidScheduleType {
 		t.Fatalf("GetPlanChangeV2Result err = %v, want ErrInvalidScheduleType", err)
 	}
-	if s.IsPlanChangeV2() {
-		t.Fatal("IsPlanChangeV2() = true for a cancellation schedule")
-	}
 }
 
-func TestIsPlanChangeV2(t *testing.T) {
+func TestPlanChangeV2Config_IsV2(t *testing.T) {
 	v1 := newPlanChangeSchedule()
 	if err := v1.SetPlanChangeConfig(&PlanChangeConfiguration{
 		TargetPlanID:       "plan_target",
@@ -120,26 +121,84 @@ func TestIsPlanChangeV2(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SetPlanChangeConfig: %v", err)
 	}
-	if v1.IsPlanChangeV2() {
-		t.Fatal("IsPlanChangeV2() = true for a v1 config blob")
+	v1Config, err := v1.GetPlanChangeV2Config()
+	if err != nil {
+		t.Fatalf("a v1 blob must still decode into the v2 struct, got %v", err)
+	}
+	if v1Config.IsV2() {
+		t.Fatal("IsV2() = true for a v1 config blob")
 	}
 
 	v2 := newPlanChangeSchedule()
 	if err := v2.SetPlanChangeV2Config(&PlanChangeV2Configuration{TargetPlanID: "plan_target"}); err != nil {
 		t.Fatalf("SetPlanChangeV2Config: %v", err)
 	}
-	if !v2.IsPlanChangeV2() {
-		t.Fatal("IsPlanChangeV2() = false for a v2 config blob")
+	v2Config, err := v2.GetPlanChangeV2Config()
+	if err != nil {
+		t.Fatalf("GetPlanChangeV2Config: %v", err)
+	}
+	if !v2Config.IsV2() {
+		t.Fatal("IsV2() = false for a v2 config blob")
 	}
 
-	empty := newPlanChangeSchedule()
-	if empty.IsPlanChangeV2() {
-		t.Fatal("IsPlanChangeV2() = true for an empty configuration")
+	var nilConfig *PlanChangeV2Configuration
+	if nilConfig.IsV2() {
+		t.Fatal("IsV2() = true for a nil config")
 	}
 
 	malformed := newPlanChangeSchedule()
 	malformed.Configuration = []byte("not json")
-	if malformed.IsPlanChangeV2() {
-		t.Fatal("IsPlanChangeV2() = true for a malformed configuration")
+	if _, err := malformed.GetPlanChangeV2Config(); err == nil {
+		t.Fatal("expected a decode error for a malformed configuration")
+	}
+}
+
+func TestSubscriptionSchedule_IsStaleFor(t *testing.T) {
+	boundary := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		scheduledAt time.Time
+		periodStart time.Time
+		expected    bool
+	}{
+		{
+			name:        "on time: the roll set period start to the boundary itself",
+			scheduledAt: boundary,
+			periodStart: boundary,
+			expected:    false,
+		},
+		{
+			name:        "not yet due: boundary is still ahead of the current period start",
+			scheduledAt: boundary,
+			periodStart: boundary.AddDate(0, -1, 0),
+			expected:    false,
+		},
+		{
+			name:        "missed: a catch-up roll jumped past the boundary",
+			scheduledAt: boundary,
+			periodStart: boundary.AddDate(0, 1, 0),
+			expected:    true,
+		},
+		{
+			name:        "missed by a moment",
+			scheduledAt: boundary,
+			periodStart: boundary.Add(time.Nanosecond),
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SubscriptionSchedule{ScheduledAt: tt.scheduledAt}
+			sub := &Subscription{CurrentPeriodStart: tt.periodStart}
+			if got := s.IsStaleFor(sub); got != tt.expected {
+				t.Fatalf("IsStaleFor() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+
+	if (&SubscriptionSchedule{ScheduledAt: boundary}).IsStaleFor(nil) {
+		t.Fatal("IsStaleFor(nil) = true; a missing subscription is not evidence of staleness")
 	}
 }

--- a/internal/domain/subscription/schedule_config_v2_test.go
+++ b/internal/domain/subscription/schedule_config_v2_test.go
@@ -1,0 +1,145 @@
+package subscription
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+)
+
+func newPlanChangeSchedule() *SubscriptionSchedule {
+	return &SubscriptionSchedule{
+		ID:           "sched_123",
+		ScheduleType: types.SubscriptionScheduleChangeTypePlanChange,
+	}
+}
+
+func TestPlanChangeV2Config_RoundTrip(t *testing.T) {
+	s := newPlanChangeSchedule()
+	config := &PlanChangeV2Configuration{
+		TargetPlanID:      "plan_target",
+		ProrationBehavior: types.ProrationBehaviorNone,
+		AddonPolicy: &EntityChangePolicyConfig{
+			DefaultBehaviour: types.EntityChangeBehaviourCarry,
+			Overrides: map[string]types.EntityChangeBehaviour{
+				"addon_assoc_1": types.EntityChangeBehaviourDrop,
+			},
+		},
+		IdempotencyKey: lo.ToPtr("idem_1"),
+		ChangeMetadata: map[string]string{"source": "api"},
+	}
+
+	if err := s.SetPlanChangeV2Config(config); err != nil {
+		t.Fatalf("SetPlanChangeV2Config: %v", err)
+	}
+	if config.Version != PlanChangeConfigVersionV2 {
+		t.Fatalf("expected version to be set to %q, got %q", PlanChangeConfigVersionV2, config.Version)
+	}
+
+	got, err := s.GetPlanChangeV2Config()
+	if err != nil {
+		t.Fatalf("GetPlanChangeV2Config: %v", err)
+	}
+	if got.Version != PlanChangeConfigVersionV2 {
+		t.Fatalf("version = %q, want %q", got.Version, PlanChangeConfigVersionV2)
+	}
+	if got.TargetPlanID != "plan_target" || got.ProrationBehavior != types.ProrationBehaviorNone {
+		t.Fatalf("unexpected config: %+v", got)
+	}
+	if got.AddonPolicy == nil || got.AddonPolicy.DefaultBehaviour != types.EntityChangeBehaviourCarry {
+		t.Fatalf("unexpected addon policy: %+v", got.AddonPolicy)
+	}
+	if got.AddonPolicy.Overrides["addon_assoc_1"] != types.EntityChangeBehaviourDrop {
+		t.Fatalf("unexpected overrides: %+v", got.AddonPolicy.Overrides)
+	}
+	if lo.FromPtr(got.IdempotencyKey) != "idem_1" || got.ChangeMetadata["source"] != "api" {
+		t.Fatalf("unexpected config: %+v", got)
+	}
+}
+
+func TestPlanChangeV2Result_RoundTrip(t *testing.T) {
+	s := newPlanChangeSchedule()
+
+	result, err := s.GetPlanChangeV2Result()
+	if err != nil || result != nil {
+		t.Fatalf("expected nil result with no error, got %+v / %v", result, err)
+	}
+
+	effective := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	if err := s.SetPlanChangeV2Result(&PlanChangeV2Result{
+		SubscriptionID: "sub_1",
+		FromPlanID:     "plan_a",
+		ToPlanID:       "plan_b",
+		ChangeType:     "upgrade",
+		EffectiveDate:  effective,
+	}); err != nil {
+		t.Fatalf("SetPlanChangeV2Result: %v", err)
+	}
+
+	got, err := s.GetPlanChangeV2Result()
+	if err != nil {
+		t.Fatalf("GetPlanChangeV2Result: %v", err)
+	}
+	if got.SubscriptionID != "sub_1" || got.FromPlanID != "plan_a" || got.ToPlanID != "plan_b" {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+	if !got.EffectiveDate.Equal(effective) {
+		t.Fatalf("effective date = %v, want %v", got.EffectiveDate, effective)
+	}
+}
+
+func TestPlanChangeV2Config_WrongScheduleType(t *testing.T) {
+	s := &SubscriptionSchedule{ScheduleType: types.SubscriptionScheduleChangeTypeCancellation}
+
+	if err := s.SetPlanChangeV2Config(&PlanChangeV2Configuration{}); err != ErrInvalidScheduleType {
+		t.Fatalf("SetPlanChangeV2Config err = %v, want ErrInvalidScheduleType", err)
+	}
+	if _, err := s.GetPlanChangeV2Config(); err != ErrInvalidScheduleType {
+		t.Fatalf("GetPlanChangeV2Config err = %v, want ErrInvalidScheduleType", err)
+	}
+	if err := s.SetPlanChangeV2Result(&PlanChangeV2Result{}); err != ErrInvalidScheduleType {
+		t.Fatalf("SetPlanChangeV2Result err = %v, want ErrInvalidScheduleType", err)
+	}
+	if _, err := s.GetPlanChangeV2Result(); err != ErrInvalidScheduleType {
+		t.Fatalf("GetPlanChangeV2Result err = %v, want ErrInvalidScheduleType", err)
+	}
+	if s.IsPlanChangeV2() {
+		t.Fatal("IsPlanChangeV2() = true for a cancellation schedule")
+	}
+}
+
+func TestIsPlanChangeV2(t *testing.T) {
+	v1 := newPlanChangeSchedule()
+	if err := v1.SetPlanChangeConfig(&PlanChangeConfiguration{
+		TargetPlanID:       "plan_target",
+		ProrationBehavior:  types.ProrationBehaviorCreateProrations,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+	}); err != nil {
+		t.Fatalf("SetPlanChangeConfig: %v", err)
+	}
+	if v1.IsPlanChangeV2() {
+		t.Fatal("IsPlanChangeV2() = true for a v1 config blob")
+	}
+
+	v2 := newPlanChangeSchedule()
+	if err := v2.SetPlanChangeV2Config(&PlanChangeV2Configuration{TargetPlanID: "plan_target"}); err != nil {
+		t.Fatalf("SetPlanChangeV2Config: %v", err)
+	}
+	if !v2.IsPlanChangeV2() {
+		t.Fatal("IsPlanChangeV2() = false for a v2 config blob")
+	}
+
+	empty := newPlanChangeSchedule()
+	if empty.IsPlanChangeV2() {
+		t.Fatal("IsPlanChangeV2() = true for an empty configuration")
+	}
+
+	malformed := newPlanChangeSchedule()
+	malformed.Configuration = []byte("not json")
+	if malformed.IsPlanChangeV2() {
+		t.Fatal("IsPlanChangeV2() = true for a malformed configuration")
+	}
+}

--- a/internal/domain/subscription/schedule_config_v2_test.go
+++ b/internal/domain/subscription/schedule_config_v2_test.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -200,5 +201,65 @@ func TestSubscriptionSchedule_IsStaleFor(t *testing.T) {
 
 	if (&SubscriptionSchedule{ScheduledAt: boundary}).IsStaleFor(nil) {
 		t.Fatal("IsStaleFor(nil) = true; a missing subscription is not evidence of staleness")
+	}
+}
+
+func TestNewPendingScheduleBuilder_FillsBoilerplate(t *testing.T) {
+	ctx := context.Background()
+	sub := &Subscription{ID: "subs_1", EnvironmentID: "env_1", BaseModel: types.BaseModel{TenantID: "tenant_1"}}
+	scheduledAt := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+
+	schedule := NewPendingScheduleBuilder(
+		ctx, sub, types.SubscriptionScheduleChangeTypePlanChange, scheduledAt,
+	).Build()
+	if err := schedule.SetPlanChangeV2Config(&PlanChangeV2Configuration{TargetPlanID: "plan_b"}); err != nil {
+		t.Fatalf("SetPlanChangeV2Config: %v", err)
+	}
+
+	if schedule.ID == "" || schedule.CreatedAt.IsZero() || schedule.UpdatedAt.IsZero() {
+		t.Fatalf("boilerplate not filled: %+v", schedule)
+	}
+	if schedule.SubscriptionID != "subs_1" || schedule.TenantID != "tenant_1" || schedule.EnvironmentID != "env_1" {
+		t.Fatalf("tenancy not copied from the subscription: %+v", schedule)
+	}
+	if schedule.Status != types.ScheduleStatusPending || schedule.StatusColumn != types.StatusPublished {
+		t.Fatalf("unexpected status: %v / %v", schedule.Status, schedule.StatusColumn)
+	}
+	if !schedule.ScheduledAt.Equal(scheduledAt) {
+		t.Fatalf("scheduled_at = %v, want %v", schedule.ScheduledAt, scheduledAt)
+	}
+
+	config, err := schedule.GetPlanChangeV2Config()
+	if err != nil || !config.IsV2() || config.TargetPlanID != "plan_b" {
+		t.Fatalf("config not applied: %+v (%v)", config, err)
+	}
+}
+
+func TestNewSubscriptionScheduleBuilder_CopiesRatherThanAliases(t *testing.T) {
+	original := &SubscriptionSchedule{
+		ID:           "sched_1",
+		ScheduleType: types.SubscriptionScheduleChangeTypePlanChange,
+		Status:       types.ScheduleStatusPending,
+		Metadata:     types.Metadata{"k": "v"},
+	}
+
+	updated := NewSubscriptionScheduleBuilder(original).
+		WithStatus(types.ScheduleStatusExecuted).
+		WithErrorMessage("boom").
+		Build()
+
+	if original.Status != types.ScheduleStatusPending {
+		t.Fatal("the builder mutated the original schedule")
+	}
+	if original.ErrorMessage != nil {
+		t.Fatal("the builder wrote an error message onto the original")
+	}
+	if updated.Status != types.ScheduleStatusExecuted || *updated.ErrorMessage != "boom" {
+		t.Fatalf("updates not applied: %+v", updated)
+	}
+
+	updated.Metadata["k"] = "changed"
+	if original.Metadata["k"] != "v" {
+		t.Fatal("metadata is aliased between the original and the copy")
 	}
 }

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3527,6 +3527,14 @@ func (s *subscriptionService) processSubscriptionPeriod(ctx context.Context, sub
 	isSubscriptionCancelled := false
 	// Use db's WithTx for atomic operations
 	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
+		if sub.SubscriptionStatus == types.SubscriptionStatusActive {
+			if err := s.processPendingPlanChangeV2(ctx, sub); err != nil {
+				s.Logger.Error(ctx, "failed to process pending v2 plan change",
+					"error", err,
+					"subscription_id", sub.ID)
+			}
+		}
+
 		// Process all periods except the last one (which becomes the new current period)
 		for i := 0; i < len(periods)-1; i++ {
 			period := periods[i]
@@ -8252,4 +8260,34 @@ func (s *subscriptionService) triggerMarketplaceSubscriptionFinalUsageFlushWorkf
 	s.Logger.Info(ctx, "marketplace subscription flush workflow started successfully",
 		"subscription_id", subscriptionID,
 		"workflow_id", workflowRun.GetID())
+}
+
+func (s *subscriptionService) processPendingPlanChangeV2(
+	ctx context.Context,
+	sub *subscription.Subscription,
+) error {
+	schedule, err := s.SubScheduleRepo.GetPendingBySubscriptionAndType(
+		ctx, sub.ID, types.SubscriptionScheduleChangeTypePlanChange,
+	)
+	if err != nil {
+		return err
+	}
+	if schedule == nil || schedule.ScheduledAt.After(time.Now().UTC()) {
+		return nil
+	}
+
+	config, err := schedule.GetPlanChangeV2Config()
+	if err != nil {
+		return err
+	}
+	if !config.IsV2() {
+		return nil
+	}
+
+	s.Logger.Info(ctx, "executing pending v2 plan change before period invoices",
+		"schedule_id", schedule.ID,
+		"subscription_id", sub.ID,
+		"scheduled_at", schedule.ScheduledAt)
+
+	return s.ExecuteScheduledPlanChangeV2(ctx, schedule, config, sub)
 }

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3739,7 +3739,7 @@ func (s *subscriptionService) processPendingPlanChanges(
 
 	// Execute the plan change
 	changeService := NewSubscriptionChangeService(s.ServiceParams)
-	if err := s.executeScheduledPlanChange(ctx, schedule, changeService); err != nil {
+	if err := s.executeScheduledPlanChange(ctx, schedule, changeService, sub); err != nil {
 		return fmt.Errorf("failed to execute scheduled plan change: %w", err)
 	}
 
@@ -3755,7 +3755,16 @@ func (s *subscriptionService) executeScheduledPlanChange(
 	ctx context.Context,
 	schedule *subscription.SubscriptionSchedule,
 	changeService SubscriptionChangeService,
+	sub *subscription.Subscription,
 ) error {
+	v2Config, err := schedule.GetPlanChangeV2Config()
+	if err != nil {
+		return fmt.Errorf("failed to parse plan change configuration: %w", err)
+	}
+	if v2Config.IsV2() {
+		return s.ExecuteScheduledPlanChangeV2(ctx, schedule, v2Config, sub)
+	}
+
 	// Get the plan change configuration
 	config, err := schedule.GetPlanChangeConfig()
 	if err != nil {

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -461,7 +461,7 @@ func (s *subscriptionService) PreviewPlanChange(
 		return nil, err
 	}
 
-	r, err := s.resolvePlanChange(ctx, sub, req, time.Now().UTC())
+	r, err := s.resolvePlanChange(ctx, sub, req, resolveEffectiveAt(sub, req))
 	if err != nil {
 		return nil, err
 	}
@@ -483,6 +483,27 @@ func (s *subscriptionService) PreviewPlanChange(
 }
 
 func (s *subscriptionService) ExecutePlanChange(
+	ctx context.Context,
+	subscriptionID string,
+	req dto.SubscriptionChangeV2Request,
+	effectiveAt time.Time,
+) (*dto.SubscriptionChangeV2Response, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := s.checkNoPendingPlanChangeSchedule(ctx, subscriptionID); err != nil {
+		return nil, err
+	}
+
+	if req.IsDeferred() {
+		return s.schedulePlanChangeForPeriodEnd(ctx, subscriptionID, req)
+	}
+
+	return s.executePlanChangeAt(ctx, subscriptionID, req, effectiveAt)
+}
+
+func (s *subscriptionService) executePlanChangeAt(
 	ctx context.Context,
 	subscriptionID string,
 	req dto.SubscriptionChangeV2Request,
@@ -893,7 +914,7 @@ func (s *subscriptionService) ExecuteScheduledPlanChangeV2(
 		return err
 	}
 
-	resp, err := s.ExecutePlanChange(
+	resp, err := s.executePlanChangeAt(
 		ctx, schedule.SubscriptionID, PlanChangeV2RequestFromConfig(config), schedule.ScheduledAt,
 	)
 	if err != nil {
@@ -947,4 +968,108 @@ func (s *subscriptionService) failPlanChangeSchedule(
 			"subscription_id", schedule.SubscriptionID,
 			"original_error", cause)
 	}
+}
+
+// checkNoPendingPlanChangeSchedule rejects a second plan change while one is already
+// queued.
+func (s *subscriptionService) checkNoPendingPlanChangeSchedule(ctx context.Context, subscriptionID string) error {
+	existing, err := s.SubScheduleRepo.GetPendingBySubscriptionAndType(
+		ctx, subscriptionID, types.SubscriptionScheduleChangeTypePlanChange,
+	)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return nil
+	}
+
+	return ierr.NewError("a plan change is already scheduled for this subscription").
+		WithHint("Cancel the existing schedule before requesting another one.").
+		WithReportableDetails(map[string]any{
+			"subscription_id": subscriptionID,
+			"schedule_id":     existing.ID,
+			"scheduled_at":    existing.ScheduledAt,
+		}).
+		Mark(ierr.ErrValidation)
+}
+
+// resolveEffectiveAt is the instant a request would take effect: the period boundary
+// when deferred, otherwise now. Preview uses it so the quote is priced at the same
+// instant the change will actually be applied.
+func resolveEffectiveAt(sub *subscription.Subscription, req dto.SubscriptionChangeV2Request) time.Time {
+	if req.IsDeferred() {
+		return sub.CurrentPeriodEnd
+	}
+	
+	return time.Now().UTC()
+}
+
+// schedulePlanChangeForPeriodEnd records a deferred change.
+func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
+	ctx context.Context,
+	subscriptionID string,
+	req dto.SubscriptionChangeV2Request,
+) (*dto.SubscriptionChangeV2Response, error) {
+	sub, err := s.loadSubscriptionForPlanChange(ctx, subscriptionID, false)
+	if err != nil {
+		return nil, err
+	}
+
+	scheduledAt := sub.CurrentPeriodEnd
+	r, err := s.resolvePlanChange(ctx, sub, req, scheduledAt)
+	if err != nil {
+		return nil, err
+	}
+
+	schedule := &subscription.SubscriptionSchedule{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_SCHEDULE),
+		SubscriptionID: subscriptionID,
+		ScheduleType:   types.SubscriptionScheduleChangeTypePlanChange,
+		ScheduledAt:    scheduledAt,
+		Status:         types.ScheduleStatusPending,
+		TenantID:       sub.TenantID,
+		EnvironmentID:  sub.EnvironmentID,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+		CreatedBy:      types.GetUserID(ctx),
+		UpdatedBy:      types.GetUserID(ctx),
+		StatusColumn:   types.StatusPublished,
+	}
+
+	config := &subscription.PlanChangeV2Configuration{
+		TargetPlanID:   req.TargetPlanID,
+		IdempotencyKey: req.IdempotencyKey,
+		ChangeMetadata: req.Metadata,
+	}
+	if req.EntityPolicies != nil && req.EntityPolicies.Addons != nil {
+		config.EntityPolicies = &subscription.EntityChangePoliciesConfig{
+			Addons: &subscription.EntityChangePolicyConfig{
+				DefaultBehaviour: req.EntityPolicies.Addons.DefaultBehaviour,
+				Overrides:        req.EntityPolicies.Addons.Overrides,
+			},
+		}
+	}
+	if err := schedule.SetPlanChangeV2Config(config); err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to serialize the plan change configuration").
+			Mark(ierr.ErrInternal)
+	}
+
+	if err := s.SubScheduleRepo.Create(ctx, schedule); err != nil {
+		return nil, err
+	}
+
+	s.Logger.Info(ctx, "plan change scheduled for period end",
+		"subscription_id", subscriptionID,
+		"schedule_id", schedule.ID,
+		"scheduled_at", schedule.ScheduledAt,
+		"target_plan_id", req.TargetPlanID,
+		"change_type", r.changeType)
+
+	resp := buildPlanChangeResponse(r, sub, req)
+	resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
+	resp.IsScheduled = true
+	resp.ScheduleID = &schedule.ID
+	resp.ScheduledAt = &schedule.ScheduledAt
+	return resp, nil
 }

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -486,6 +486,7 @@ func (s *subscriptionService) ExecutePlanChange(
 	ctx context.Context,
 	subscriptionID string,
 	req dto.SubscriptionChangeV2Request,
+	effectiveAt time.Time,
 ) (*dto.SubscriptionChangeV2Response, error) {
 	var resp *dto.SubscriptionChangeV2Response
 
@@ -495,7 +496,7 @@ func (s *subscriptionService) ExecutePlanChange(
 			return err
 		}
 
-		r, err := s.resolvePlanChange(txCtx, sub, req, time.Now().UTC())
+		r, err := s.resolvePlanChange(txCtx, sub, req, effectiveAt)
 		if err != nil {
 			return err
 		}
@@ -843,4 +844,107 @@ func planChangeIdempotencyKey(r *planChangeRequest) string {
 	}
 
 	return idempotency.NewGenerator().GenerateKey(idempotency.ScopePlanChange, inputs)
+}
+
+func PlanChangeV2RequestFromConfig(config *subscription.PlanChangeV2Configuration) dto.SubscriptionChangeV2Request {
+	req := dto.SubscriptionChangeV2Request{
+		TargetPlanID: config.TargetPlanID,
+		// Pinned, not replayed from the blob: a deferred change is only ever
+		// accepted with none, and the boundary invoice already bills the new plan.
+		ProrationBehavior: types.ProrationBehaviorNone,
+		IdempotencyKey:    config.IdempotencyKey,
+		Metadata:          config.ChangeMetadata,
+	}
+
+	if config.EntityPolicies != nil && config.EntityPolicies.Addons != nil {
+		req.EntityPolicies = &dto.SubscriptionChangeEntityPolicies{
+			Addons: &dto.EntityChangePolicy{
+				DefaultBehaviour: config.EntityPolicies.Addons.DefaultBehaviour,
+				Overrides:        config.EntityPolicies.Addons.Overrides,
+			},
+		}
+	}
+
+	return req
+}
+
+func IsTerminalPlanChangeError(err error) bool {
+	return ierr.IsValidation(err) || ierr.IsNotFound(err)
+}
+
+func (s *subscriptionService) ExecuteScheduledPlanChangeV2(
+	ctx context.Context,
+	schedule *subscription.SubscriptionSchedule,
+	config *subscription.PlanChangeV2Configuration,
+	sub *subscription.Subscription,
+) error {
+	if schedule.IsStaleFor(sub) {
+		err := ierr.NewError("scheduled plan change missed its billing period boundary").
+			WithHint("The boundary has already been invoiced. Schedule the change again to apply it at the next period end.").
+			WithReportableDetails(map[string]any{
+				"schedule_id":          schedule.ID,
+				"subscription_id":      schedule.SubscriptionID,
+				"scheduled_at":         schedule.ScheduledAt,
+				"current_period_start": sub.CurrentPeriodStart,
+			}).
+			Mark(ierr.ErrValidation)
+
+		s.failPlanChangeSchedule(ctx, schedule, err)
+		return err
+	}
+
+	resp, err := s.ExecutePlanChange(
+		ctx, schedule.SubscriptionID, PlanChangeV2RequestFromConfig(config), schedule.ScheduledAt,
+	)
+	if err != nil {
+		if !IsTerminalPlanChangeError(err) {
+			s.Logger.Error(ctx, "scheduled plan change failed, leaving schedule pending for retry",
+				"error", err,
+				"schedule_id", schedule.ID,
+				"subscription_id", schedule.SubscriptionID)
+			return err
+		}
+
+		s.failPlanChangeSchedule(ctx, schedule, err)
+		return err
+	}
+
+	schedule.Status = types.ScheduleStatusExecuted
+	schedule.ExecutedAt = lo.ToPtr(time.Now().UTC())
+	if err := schedule.SetPlanChangeV2Result(&subscription.PlanChangeV2Result{
+		SubscriptionID: schedule.SubscriptionID,
+		FromPlanID:     resp.FromPlan.ID,
+		ToPlanID:       resp.ToPlan.ID,
+		ChangeType:     string(resp.ChangeType),
+		EffectiveDate:  resp.EffectiveAt,
+	}); err != nil {
+		s.Logger.Error(ctx, "failed to set scheduled plan change result",
+			"error", err, "schedule_id", schedule.ID)
+	}
+
+	if err := s.SubScheduleRepo.Update(ctx, schedule); err != nil {
+		s.Logger.Error(ctx, "failed to update schedule after plan change",
+			"error", err, "schedule_id", schedule.ID)
+		return err
+	}
+
+	return nil
+}
+
+func (s *subscriptionService) failPlanChangeSchedule(
+	ctx context.Context,
+	schedule *subscription.SubscriptionSchedule,
+	cause error,
+) {
+	schedule.Status = types.ScheduleStatusFailed
+	schedule.ExecutedAt = lo.ToPtr(time.Now().UTC())
+	schedule.ErrorMessage = lo.ToPtr(cause.Error())
+
+	if err := s.SubScheduleRepo.Update(ctx, schedule); err != nil {
+		s.Logger.Error(ctx, "failed to mark scheduled plan change as failed",
+			"error", err,
+			"schedule_id", schedule.ID,
+			"subscription_id", schedule.SubscriptionID,
+			"original_error", cause)
+	}
 }

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -1000,7 +1000,7 @@ func resolveEffectiveAt(sub *subscription.Subscription, req dto.SubscriptionChan
 	if req.IsDeferred() {
 		return sub.CurrentPeriodEnd
 	}
-	
+
 	return time.Now().UTC()
 }
 
@@ -1021,21 +1021,6 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 		return nil, err
 	}
 
-	schedule := &subscription.SubscriptionSchedule{
-		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_SCHEDULE),
-		SubscriptionID: subscriptionID,
-		ScheduleType:   types.SubscriptionScheduleChangeTypePlanChange,
-		ScheduledAt:    scheduledAt,
-		Status:         types.ScheduleStatusPending,
-		TenantID:       sub.TenantID,
-		EnvironmentID:  sub.EnvironmentID,
-		CreatedAt:      time.Now().UTC(),
-		UpdatedAt:      time.Now().UTC(),
-		CreatedBy:      types.GetUserID(ctx),
-		UpdatedBy:      types.GetUserID(ctx),
-		StatusColumn:   types.StatusPublished,
-	}
-
 	config := &subscription.PlanChangeV2Configuration{
 		TargetPlanID:   req.TargetPlanID,
 		IdempotencyKey: req.IdempotencyKey,
@@ -1049,6 +1034,9 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 			},
 		}
 	}
+	schedule := subscription.NewPendingScheduleBuilder(
+		ctx, sub, types.SubscriptionScheduleChangeTypePlanChange, scheduledAt,
+	).Build()
 	if err := schedule.SetPlanChangeV2Config(config); err != nil {
 		return nil, ierr.WithError(err).
 			WithHint("Failed to serialize the plan change configuration").
@@ -1056,6 +1044,12 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 	}
 
 	if err := s.SubScheduleRepo.Create(ctx, schedule); err != nil {
+		if ierr.IsAlreadyExists(err) {
+			return nil, ierr.WithError(err).
+				WithHint("A plan change is already scheduled for this subscription. Cancel it before requesting another one.").
+				WithReportableDetails(map[string]any{"subscription_id": subscriptionID}).
+				Mark(ierr.ErrValidation)
+		}
 		return nil, err
 	}
 

--- a/internal/ee/service/subscription_change_v2_deferred_test.go
+++ b/internal/ee/service/subscription_change_v2_deferred_test.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+)
+
+func (s *SubscriptionChangeV2Suite) deferredRequest(targetPlanID string) dto.SubscriptionChangeV2Request {
+	return dto.SubscriptionChangeV2Request{
+		TargetPlanID:      targetPlanID,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		ChangeAt:          lo.ToPtr(types.ScheduleTypePeriodEnd),
+	}
+}
+
+func (s *SubscriptionChangeV2Suite) pendingPlanChange() *subscription.SubscriptionSchedule {
+	sched, err := s.GetStores().SubscriptionScheduleRepo.GetPendingBySubscriptionAndType(
+		s.GetContext(), s.td.sub.ID, types.SubscriptionScheduleChangeTypePlanChange,
+	)
+	s.Require().NoError(err)
+	return sched
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_DeferredSchedulesInsteadOfSwapping() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	s.True(resp.IsScheduled)
+	s.Require().NotNil(resp.ScheduleID)
+	s.Require().NotNil(resp.ScheduledAt)
+	s.True(resp.ScheduledAt.Equal(s.td.periodEnd), "scheduled at the current period end")
+	s.True(resp.EffectiveAt.Equal(s.td.periodEnd), "effective_at is the boundary, not now")
+	s.Equal(types.SubscriptionChangeTypeUpgrade, resp.ChangeType,
+		"the change type is resolved now, not left blank until execution")
+
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID, "nothing swaps yet")
+	live := s.liveLineItems()
+	s.Require().Len(live, 1)
+	s.Equal(s.td.starterBase.ID, live[0].PriceID)
+
+	sched := s.pendingPlanChange()
+	s.Require().NotNil(sched)
+	s.Equal(*resp.ScheduleID, sched.ID)
+	s.True(sched.ScheduledAt.Equal(s.td.periodEnd))
+
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+	s.True(config.IsV2(), "the row must carry a v2 configuration")
+	s.Equal(s.td.pro.ID, config.TargetPlanID)
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_DeferredCreatesNoInvoices() {
+	ctx := s.GetContext()
+	before := s.countInvoices()
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.Equal(before, s.countInvoices(), "a deferred change settles nothing at request time")
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_SecondDeferredRequestIsRejected() {
+	ctx := s.GetContext()
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	lateral := s.createPlan("Lateral", "lateral")
+	s.createFixedPrice(lateral.ID, "base_fee", 20)
+
+	_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(lateral.ID), time.Now().UTC())
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+	s.Contains(err.Error(), "already scheduled")
+}
+
+// The guard covers the immediate path too: applying a change now while another is
+// queued would leave the pending row pointing at a plan the subscription already left.
+func (s *SubscriptionChangeV2Suite) TestExecute_ImmediateRejectedWhileScheduleIsPending() {
+	ctx := s.GetContext()
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+}
+
+// The scheduled executor resolves the change while its own pending row exists, so the
+// guard must not be reachable from that path.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_NotBlockedByItsOwnPendingRow() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	sched := s.pendingPlanChange()
+	s.Require().NotNil(sched)
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+
+	s.rollPeriodTo(*resp.ScheduledAt, resp.ScheduledAt.AddDate(0, 0, 30))
+
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()),
+		"the executor must not be blocked by the very schedule it is executing")
+	s.Equal(s.td.pro.ID, s.currentSub().PlanID)
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_DeferredRejectsInvalidRequests() {
+	ctx := s.GetContext()
+
+	proration := s.deferredRequest(s.td.pro.ID)
+	proration.ProrationBehavior = types.ProrationBehaviorCreateProrations
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, proration, time.Now().UTC())
+	s.Require().Error(err)
+	s.Contains(err.Error(), "proration is not applicable")
+	s.Nil(s.pendingPlanChange(), "a rejected request must not leave a schedule behind")
+
+	// resolvePlanChange runs before the row is written, so a bad target fails now
+	// rather than silently at the boundary weeks later.
+	_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.starter.ID), time.Now().UTC())
+	s.Require().Error(err)
+	s.Contains(err.Error(), "already on the target plan")
+	s.Nil(s.pendingPlanChange())
+
+	_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest("plan_does_not_exist"), time.Now().UTC())
+	s.Require().Error(err)
+	s.Nil(s.pendingPlanChange())
+}
+
+func (s *SubscriptionChangeV2Suite) TestPreview_DeferredPricesAtTheBoundary() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID))
+	s.Require().NoError(err)
+
+	s.True(resp.EffectiveAt.Equal(s.td.periodEnd),
+		"preview must report the instant it actually priced, not now")
+	s.Empty(resp.ChangedResources.Invoices, "proration none quotes no money")
+	s.False(resp.IsScheduled, "preview writes nothing")
+	s.Nil(s.pendingPlanChange())
+
+	for _, item := range resp.ChangedResources.LineItems {
+		switch item.ChangeAction {
+		case dto.ChangedLineItemActionEnded:
+			s.Require().NotNil(item.EndDate)
+			s.True(item.EndDate.Equal(s.td.periodEnd), "closing items end at the boundary")
+		case dto.ChangedLineItemActionCreated:
+			s.Require().NotNil(item.StartDate)
+			s.True(item.StartDate.Equal(s.td.periodEnd), "opening items start at the boundary")
+		}
+	}
+}
+
+// A backlogged subscription resolves to a boundary already in the past, so the change
+// is due immediately. Surfacing the resolved instant is what makes that visible.
+func (s *SubscriptionChangeV2Suite) TestExecute_DeferredOnBackloggedSubscriptionIsImmediatelyDue() {
+	ctx := s.GetContext()
+
+	pastEnd := time.Now().UTC().Truncate(time.Hour).AddDate(0, 0, -10)
+	sub := s.currentSub()
+	sub.CurrentPeriodStart = pastEnd.AddDate(0, 0, -30)
+	sub.CurrentPeriodEnd = pastEnd
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.True(resp.IsScheduled)
+	s.Require().NotNil(resp.ScheduledAt)
+	s.True(resp.ScheduledAt.Equal(pastEnd))
+	s.True(resp.ScheduledAt.Before(time.Now().UTC()),
+		"the caller can see the change is already due, not a period away")
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_ImmediateUnaffectedByChangeAtImmediate() {
+	ctx := s.GetContext()
+
+	req := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+	req.ChangeAt = lo.ToPtr(types.ScheduleTypeImmediate)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.False(resp.IsScheduled)
+	s.Nil(resp.ScheduleID)
+	s.Equal(s.td.pro.ID, s.currentSub().PlanID, "explicit immediate still swaps now")
+	s.Nil(s.pendingPlanChange())
+}

--- a/internal/ee/service/subscription_change_v2_scheduled_test.go
+++ b/internal/ee/service/subscription_change_v2_scheduled_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/subscription"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 )
 
 // failingSubRepo turns the locking read into a database error, the shape a
@@ -274,4 +276,106 @@ func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_CarriedLineBillsIdent
 	s.True(s.td.starterBase.BillsIdenticallyTo(lateralBase),
 		"carrying is only permitted when the two prices bill identically, so the arrear "+
 			"amount for the closed period is unchanged by the swap")
+}
+
+// elapsePeriodAndSchedule puts the subscription in the state the period scanner finds
+// it in — a period that closed in the past — with a v2 change due at that boundary.
+func (s *SubscriptionChangeV2Suite) elapsePeriodAndSchedule(
+	targetPlanID string,
+) (*subscription.Subscription, *subscription.SubscriptionSchedule) {
+	ctx := s.GetContext()
+
+	elapsedStart := time.Now().UTC().Truncate(time.Hour).AddDate(0, 0, -40)
+	elapsedEnd := elapsedStart.AddDate(0, 0, 30)
+
+	sub := s.currentSub()
+	sub.CurrentPeriodStart = elapsedStart
+	sub.CurrentPeriodEnd = elapsedEnd
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	sched := &subscription.SubscriptionSchedule{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_SCHEDULE),
+		SubscriptionID: sub.ID,
+		ScheduleType:   types.SubscriptionScheduleChangeTypePlanChange,
+		ScheduledAt:    elapsedEnd,
+		Status:         types.ScheduleStatusPending,
+		TenantID:       types.GetTenantID(ctx),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		StatusColumn:   types.StatusPublished,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	s.Require().NoError(sched.SetPlanChangeV2Config(&subscription.PlanChangeV2Configuration{
+		TargetPlanID: targetPlanID,
+	}))
+	s.Require().NoError(s.GetStores().SubscriptionScheduleRepo.Create(ctx, sched))
+
+	return sub, sched
+}
+
+// processSubscriptionPeriod's invoice loop computes AND finalizes inline, and a
+// finalized invoice makes a later recompute a no-op. So the v2 swap has to land
+// before the loop: with the v1 hook's position the plan still ends up swapped, but
+// the renewal was already billed on the old plan and cannot be corrected.
+func (s *SubscriptionChangeV2Suite) TestProcessSubscriptionPeriod_V2RunsBeforeInvoicing() {
+	ctx := s.GetContext()
+	sub, sched := s.elapsePeriodAndSchedule(s.td.pro.ID)
+
+	svc, ok := s.svc.(*subscriptionService)
+	s.Require().True(ok)
+	s.Require().NoError(svc.processSubscriptionPeriod(ctx, sub, time.Now().UTC()))
+
+	s.Equal(s.td.pro.ID, s.currentSub().PlanID)
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusExecuted, stored.Status)
+
+	filter := types.NewInvoiceFilter()
+	filter.SubscriptionID = sub.ID
+	invoices, err := s.GetStores().InvoiceRepo.List(ctx, filter)
+	s.Require().NoError(err)
+	s.Require().Len(invoices, 1, "one boundary invoice for the closed period")
+
+	boundary := invoices[0]
+	s.Require().Len(boundary.LineItems, 1)
+	advance := boundary.LineItems[0]
+
+	s.Equal(s.td.proBase.ID, lo.FromPtr(advance.PriceID),
+		"the advance charge for the next period must be priced on the new plan; "+
+			"the old plan's price here means the swap landed after the invoice was finalized")
+	s.True(advance.Amount.Equal(decimal.NewFromInt(50)))
+	s.True(advance.PeriodStart.Equal(sched.ScheduledAt),
+		"the advance window opens exactly at the boundary the schedule targeted")
+}
+
+// v1 keeps its original position; only v2 moved ahead of the invoice loop.
+func (s *SubscriptionChangeV2Suite) TestProcessSubscriptionPeriod_V1SchedulePositionUnchanged() {
+	ctx := s.GetContext()
+	sub, sched := s.elapsePeriodAndSchedule(s.td.pro.ID)
+
+	// Overwrite with a v1 configuration, leaving everything else identical.
+	s.Require().NoError(sched.SetPlanChangeConfig(&subscription.PlanChangeConfiguration{
+		TargetPlanID:       s.td.pro.ID,
+		ProrationBehavior:  types.ProrationBehaviorNone,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+	}))
+	s.Require().NoError(s.GetStores().SubscriptionScheduleRepo.Update(ctx, sched))
+
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+	s.Require().False(config.IsV2(), "this row must not be picked up by the v2 pass")
+
+	svc, ok := s.svc.(*subscriptionService)
+	s.Require().True(ok)
+	s.Require().NoError(svc.processPendingPlanChangeV2(ctx, sub),
+		"the v2 pass is a no-op for a v1 row, leaving it to the original hook")
+
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID, "the v2 pass must not swap a v1 schedule")
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusPending, stored.Status, "still pending for the v1 hook")
 }

--- a/internal/ee/service/subscription_change_v2_scheduled_test.go
+++ b/internal/ee/service/subscription_change_v2_scheduled_test.go
@@ -1,0 +1,277 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+// failingSubRepo turns the locking read into a database error, the shape a
+// transient failure takes at execution time.
+type failingSubRepo struct {
+	subscription.Repository
+}
+
+func (r *failingSubRepo) GetForUpdate(ctx context.Context, id string) (*subscription.Subscription, error) {
+	return nil, ierr.NewError("database unavailable").Mark(ierr.ErrDatabase)
+}
+
+func (s *SubscriptionChangeV2Suite) createV2Schedule(
+	targetPlanID string,
+	scheduledAt time.Time,
+) (*subscription.SubscriptionSchedule, *subscription.PlanChangeV2Configuration) {
+	ctx := s.GetContext()
+
+	sched := &subscription.SubscriptionSchedule{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_SCHEDULE),
+		SubscriptionID: s.td.sub.ID,
+		ScheduleType:   types.SubscriptionScheduleChangeTypePlanChange,
+		ScheduledAt:    scheduledAt,
+		Status:         types.ScheduleStatusPending,
+		TenantID:       types.GetTenantID(ctx),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		StatusColumn:   types.StatusPublished,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	s.Require().NoError(sched.SetPlanChangeV2Config(&subscription.PlanChangeV2Configuration{
+		TargetPlanID: targetPlanID,
+	}))
+	s.Require().NoError(s.GetStores().SubscriptionScheduleRepo.Create(ctx, sched))
+
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+	s.Require().True(config.IsV2())
+
+	return sched, config
+}
+
+// The period roll advances CurrentPeriodStart to the boundary before the plan change
+// runs, so an on-time schedule sits exactly on it, not behind it.
+func (s *SubscriptionChangeV2Suite) rollPeriodTo(periodStart, periodEnd time.Time) {
+	ctx := s.GetContext()
+	sub, err := s.GetStores().SubscriptionRepo.Get(ctx, s.td.sub.ID)
+	s.Require().NoError(err)
+	sub.CurrentPeriodStart = periodStart
+	sub.CurrentPeriodEnd = periodEnd
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+}
+
+// The boundary arithmetic in CalculateFixedCharges only skips the old plan's advance
+// charge when the closing item ends exactly at the period end, so the executor must
+// use schedule.ScheduledAt rather than time.Now().
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_UsesScheduledAtNotNow() {
+	ctx := s.GetContext()
+	boundary := s.td.periodEnd
+
+	sched, config := s.createV2Schedule(s.td.pro.ID, boundary)
+	s.rollPeriodTo(boundary, boundary.AddDate(0, 0, 30))
+
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
+
+	closed, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.td.baseLine.ID)
+	s.Require().NoError(err)
+	s.True(closed.EndDate.Equal(boundary),
+		"closing item must end exactly at the boundary, got %v want %v", closed.EndDate, boundary)
+
+	live := s.liveLineItems()
+	s.Require().Len(live, 1)
+	s.Equal(s.td.proBase.ID, live[0].PriceID)
+	s.True(live[0].StartDate.Equal(boundary),
+		"opening item must start exactly at the boundary, got %v want %v", live[0].StartDate, boundary)
+
+	s.True(boundary.After(time.Now().UTC()),
+		"the boundary must be in the future, otherwise this test cannot distinguish ScheduledAt from now")
+}
+
+func (s *SubscriptionChangeV2Suite) currentSub() *subscription.Subscription {
+	sub, err := s.GetStores().SubscriptionRepo.Get(s.GetContext(), s.td.sub.ID)
+	s.Require().NoError(err)
+	return sub
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_MarksExecutedAndRecordsResult() {
+	ctx := s.GetContext()
+	boundary := s.td.periodEnd
+
+	sched, config := s.createV2Schedule(s.td.pro.ID, boundary)
+	s.rollPeriodTo(boundary, boundary.AddDate(0, 0, 30))
+
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusExecuted, stored.Status)
+	s.Require().NotNil(stored.ExecutedAt)
+	s.Nil(stored.ErrorMessage)
+
+	result, err := stored.GetPlanChangeV2Result()
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+	s.Equal(s.td.sub.ID, result.SubscriptionID)
+	s.Equal(s.td.starter.ID, result.FromPlanID)
+	s.Equal(s.td.pro.ID, result.ToPlanID)
+	s.Equal(string(types.SubscriptionChangeTypeUpgrade), result.ChangeType)
+	s.True(result.EffectiveDate.Equal(boundary),
+		"the recorded effective date is the boundary, not the execution time")
+}
+
+// A schedule whose boundary is already invoiced must not execute into that closed
+// period; it fails loudly instead of end-dating line items behind existing drafts.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_StaleScheduleFailsWithoutExecuting() {
+	ctx := s.GetContext()
+	missedBoundary := s.td.periodEnd
+
+	sched, config := s.createV2Schedule(s.td.pro.ID, missedBoundary)
+
+	// A catch-up roll jumped a whole period past the boundary this schedule targets.
+	s.rollPeriodTo(missedBoundary.AddDate(0, 0, 30), missedBoundary.AddDate(0, 0, 60))
+
+	err := s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub())
+	s.Require().Error(err)
+	s.Contains(err.Error(), "missed its billing period boundary")
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusFailed, stored.Status)
+	s.Require().NotNil(stored.ErrorMessage)
+
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID, "a stale schedule must not swap the plan")
+	live := s.liveLineItems()
+	s.Require().Len(live, 1)
+	s.Equal(s.td.starterBase.ID, live[0].PriceID, "line items must be untouched")
+}
+
+// An on-time schedule sits exactly on CurrentPeriodStart, so the staleness guard
+// must not fire on the healthy path.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_OnTimeScheduleIsNotStale() {
+	boundary := s.td.periodEnd
+	sched, _ := s.createV2Schedule(s.td.pro.ID, boundary)
+	s.rollPeriodTo(boundary, boundary.AddDate(0, 0, 30))
+
+	s.False(sched.IsStaleFor(s.currentSub()),
+		"scheduled_at == current_period_start is on time, not stale")
+}
+
+// A request that can never succeed is terminal; the row must not be retried forever.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_ValidationFailureMarksFailed() {
+	ctx := s.GetContext()
+
+	// Target plan == current plan fails checkPlanChangePreconditions.
+	sched, config := s.createV2Schedule(s.td.starter.ID, s.td.periodEnd)
+	s.rollPeriodTo(s.td.periodEnd, s.td.periodEnd.AddDate(0, 0, 30))
+
+	err := s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub())
+	s.Require().Error(err)
+	s.True(IsTerminalPlanChangeError(err))
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusFailed, stored.Status)
+	s.Require().NotNil(stored.ErrorMessage)
+	s.Contains(*stored.ErrorMessage, "already on the target plan")
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+}
+
+// A target plan that no longer exists cannot succeed on a retry, so it is terminal
+// even though it is not a validation error.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_MissingTargetPlanMarksFailed() {
+	ctx := s.GetContext()
+
+	sched, config := s.createV2Schedule("plan_does_not_exist", s.td.periodEnd)
+	s.rollPeriodTo(s.td.periodEnd, s.td.periodEnd.AddDate(0, 0, 30))
+
+	err := s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub())
+	s.Require().Error(err)
+	s.True(IsTerminalPlanChangeError(err))
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusFailed, stored.Status)
+	s.Require().NotNil(stored.ErrorMessage)
+}
+
+// A transient failure must leave the row pending: nothing resurrects a failed schedule,
+// so marking it failed on a blip would strand the change permanently.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_TransientFailureLeavesPending() {
+	ctx := s.GetContext()
+
+	sched, config := s.createV2Schedule(s.td.pro.ID, s.td.periodEnd)
+	s.rollPeriodTo(s.td.periodEnd, s.td.periodEnd.AddDate(0, 0, 30))
+	sub := s.currentSub()
+
+	params := s.serviceParams()
+	params.SubRepo = &failingSubRepo{Repository: params.SubRepo}
+	failingSvc := NewSubscriptionService(params)
+
+	err := failingSvc.ExecuteScheduledPlanChangeV2(ctx, sched, config, sub)
+	s.Require().Error(err)
+	s.False(IsTerminalPlanChangeError(err))
+
+	stored, err := s.GetStores().SubscriptionScheduleRepo.Get(ctx, sched.ID)
+	s.Require().NoError(err)
+	s.Equal(types.ScheduleStatusPending, stored.Status,
+		"a transient failure must stay pending so another attempt can run")
+	s.Nil(stored.ExecutedAt)
+	s.Nil(stored.ErrorMessage)
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+}
+
+// The dispatch guard rests on this: a v1 blob must never take the v2 path.
+func (s *SubscriptionChangeV2Suite) TestScheduleDispatch_V1ConfigIsNotV2() {
+	ctx := s.GetContext()
+
+	sched := &subscription.SubscriptionSchedule{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_SCHEDULE),
+		SubscriptionID: s.td.sub.ID,
+		ScheduleType:   types.SubscriptionScheduleChangeTypePlanChange,
+		ScheduledAt:    s.td.periodEnd,
+		Status:         types.ScheduleStatusPending,
+		TenantID:       types.GetTenantID(ctx),
+		EnvironmentID:  types.GetEnvironmentID(ctx),
+		StatusColumn:   types.StatusPublished,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+	s.Require().NoError(sched.SetPlanChangeConfig(&subscription.PlanChangeConfiguration{
+		TargetPlanID:       s.td.pro.ID,
+		ProrationBehavior:  types.ProrationBehaviorCreateProrations,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+	}))
+	s.Require().NoError(s.GetStores().SubscriptionScheduleRepo.Create(ctx, sched))
+
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err, "a v1 blob still decodes into the v2 struct")
+	s.False(config.IsV2(), "a v1 blob must dispatch to the v1 executor")
+}
+
+// A carried line is repointed to the new plan's price in place and never end-dated,
+// so the boundary invoice prices the closed period with the new PriceID. That is
+// harmless only because carrying requires BillsIdenticallyTo, which pins the money.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_CarriedLineBillsIdentically() {
+	ctx := s.GetContext()
+
+	lateral := s.createPlan("Lateral", "lateral")
+	lateralBase := s.createFixedPrice(lateral.ID, "base_fee", 20)
+
+	boundary := s.td.periodEnd
+	sched, config := s.createV2Schedule(lateral.ID, boundary)
+	s.rollPeriodTo(boundary, boundary.AddDate(0, 0, 30))
+
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
+
+	live := s.liveLineItems()
+	s.Require().Len(live, 1)
+	s.Equal(s.td.baseLine.ID, live[0].ID, "the line is carried, not replaced")
+	s.Equal(lateralBase.ID, live[0].PriceID, "the carried line now points at the new plan's price")
+	s.True(live[0].EndDate.IsZero(), "a carried line is never end-dated at the boundary")
+
+	s.True(s.td.starterBase.BillsIdenticallyTo(lateralBase),
+		"carrying is only permitted when the two prices bill identically, so the arrear "+
+			"amount for the closed period is unchanged by the swap")
+}

--- a/internal/ee/service/subscription_change_v2_test.go
+++ b/internal/ee/service/subscription_change_v2_test.go
@@ -252,7 +252,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_UpgradeSwapsInPlace() {
 	ctx := s.GetContext()
 	effectiveFrom := time.Now().UTC()
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations), effectiveFrom)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -275,7 +275,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_UpgradeSwapsInPlace() {
 	closed, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.td.baseLine.ID)
 	s.Require().NoError(err)
 	s.False(closed.EndDate.IsZero(), "the old line is closed, not deleted")
-	s.True(!closed.EndDate.Before(effectiveFrom), "closed at the effective date")
+	s.True(closed.EndDate.Equal(effectiveFrom), "closed exactly at the effective date")
 	s.True(live[0].StartDate.Equal(closed.EndDate), "line items must tile with no gap or overlap")
 }
 

--- a/internal/ee/service/subscription_change_v2_test.go
+++ b/internal/ee/service/subscription_change_v2_test.go
@@ -252,7 +252,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_UpgradeSwapsInPlace() {
 	ctx := s.GetContext()
 	effectiveFrom := time.Now().UTC()
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -287,7 +287,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_LateralIdenticalPrice_CarriesLin
 
 	invoicesBefore := s.countInvoices()
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(lateral.ID, types.ProrationBehaviorCreateProrations))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(lateral.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 	s.Equal(types.SubscriptionChangeTypeLateral, resp.ChangeType)
 
@@ -316,7 +316,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_ProrationNone_SwapsWithoutMoney(
 	ctx := s.GetContext()
 	invoicesBefore := s.countInvoices()
 
-	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone))
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
 	s.Require().NoError(err)
 
 	reloaded, err := s.GetStores().SubscriptionRepo.Get(ctx, s.td.sub.ID)
@@ -342,7 +342,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_DowngradeCreditsWallet() {
 	// Need a billed charge so the removal credit has a basis.
 	s.recordBilled(s.td.baseLine.ID, s.td.proBase.Amount)
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.starter.ID, types.ProrationBehaviorCreateProrations))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.starter.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 	s.Equal(types.SubscriptionChangeTypeDowngrade, resp.ChangeType)
 
@@ -381,7 +381,7 @@ func (s *SubscriptionChangeV2Suite) TestPreviewMatchesExecute() {
 	s.Require().Len(preview.ChangedResources.Invoices, 1)
 	quoted := preview.ChangedResources.Invoices[0].Invoice.AmountDue
 
-	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req)
+	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
 	s.Require().NoError(err)
 	s.Require().Len(executed.ChangedResources.Invoices, 1)
 	charged := executed.ChangedResources.Invoices[0].Invoice.AmountDue
@@ -417,7 +417,7 @@ func (s *SubscriptionChangeV2Suite) TestPreviewMatchesExecute_OnADowngradeCredit
 	s.True(quoted.WalletTransaction.Amount.IsPositive(), "the credit is quoted as an amount owed to the customer")
 
 	invoicesBefore := s.countInvoices()
-	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req)
+	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
 	s.Require().NoError(err)
 	s.Require().Len(executed.ChangedResources.Invoices, 1)
 	settled := executed.ChangedResources.Invoices[0]
@@ -440,7 +440,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_PlanSurvivesAStaleConcurrentUpda
 	staleCopy := *stale
 	s.Require().Equal(s.td.starter.ID, staleCopy.PlanID)
 
-	_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone))
+	_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
 	s.Require().NoError(err)
 
 	// Whatever that caller was actually updating — status, period, metadata — it
@@ -503,7 +503,7 @@ func (s *SubscriptionChangeV2Suite) TestPreconditionsRejectBeforeAnyWrite() {
 				target = s.td.pro.ID
 			}
 
-			_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(target, types.ProrationBehaviorCreateProrations))
+			_, err = s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(target, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 			s.Error(err, tt.because)
 
 			after, getErr := s.GetStores().SubscriptionRepo.Get(ctx, s.td.sub.ID)
@@ -523,7 +523,7 @@ func (s *SubscriptionChangeV2Suite) TestPreconditionsRejectBeforeAnyWrite() {
 func (s *SubscriptionChangeV2Suite) TestExecute_ReanchorsPriceSyncSequence() {
 	ctx := s.GetContext()
 
-	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations))
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 
 	expected, err := s.GetStores().PlanPriceSyncRepo.CurrentPlanSequence(ctx, s.td.pro.ID)
@@ -550,7 +550,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_NettedInvoiceCarriesCreditLine()
 	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
 
 	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
-		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations))
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 	s.Require().Len(resp.ChangedResources.Invoices, 1)
 
@@ -642,7 +642,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonCarriesByDefault() {
 	_, assoc, addonLine := s.attachAddon("priority_support", 10)
 
 	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
-		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations))
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 
 	reloadedAssoc, err := s.GetStores().AddonAssociationRepo.GetByID(ctx, assoc.ID)
@@ -663,7 +663,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonDropClosesAttachment() {
 	ctx := s.GetContext()
 	_, assoc, addonLine := s.attachAddon("priority_support", 10)
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID), time.Now().UTC())
 	s.Require().NoError(err)
 
 	reloadedAssoc, err := s.GetStores().AddonAssociationRepo.GetByID(ctx, assoc.ID)
@@ -687,7 +687,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonDropSettlesOnTheChangeInvoi
 
 	invoicesBefore := s.countInvoices()
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID), time.Now().UTC())
 	s.Require().NoError(err)
 
 	s.Equal(invoicesBefore+1, s.countInvoices(), "one invoice for the whole change, not one per moving part")
@@ -712,7 +712,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonDropWithProrationNone() {
 	req := s.dropAddonRequest(s.td.pro.ID, assoc.ID)
 	req.ProrationBehavior = types.ProrationBehaviorNone
 
-	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req)
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
 	s.Require().NoError(err)
 
 	reloadedAssoc, err := s.GetStores().AddonAssociationRepo.GetByID(ctx, assoc.ID)
@@ -725,7 +725,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_UnknownAddonOverrideWarnsRatherT
 	ctx := s.GetContext()
 
 	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
-		s.dropAddonRequest(s.td.pro.ID, "addon_assoc_does_not_exist"))
+		s.dropAddonRequest(s.td.pro.ID, "addon_assoc_does_not_exist"), time.Now().UTC())
 	s.Require().NoError(err, "a stale override key must not fail the change")
 	s.Require().Len(resp.Warnings, 1)
 	s.Contains(resp.Warnings[0], "addon_assoc_does_not_exist")
@@ -757,7 +757,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonDropDoesNotSkewChangeType()
 	ctx := s.GetContext()
 	_, assoc, _ := s.attachAddon("priority_support", 10)
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID), time.Now().UTC())
 	s.Require().NoError(err)
 
 	s.Equal(types.SubscriptionChangeTypeUpgrade, resp.ChangeType,
@@ -768,7 +768,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonDropIsReportedAsAChangedLin
 	ctx := s.GetContext()
 	_, assoc, addonLine := s.attachAddon("priority_support", 10)
 
-	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID))
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.dropAddonRequest(s.td.pro.ID, assoc.ID), time.Now().UTC())
 	s.Require().NoError(err)
 
 	var sawAddonLine bool
@@ -786,7 +786,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_CarriedLineFollowsTheSubscriptio
 	lateral := s.createPlan("Lateral", "lateral")
 	s.createFixedPrice(lateral.ID, "base_fee", 20)
 
-	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(lateral.ID, types.ProrationBehaviorCreateProrations))
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.changeRequest(lateral.ID, types.ProrationBehaviorCreateProrations), time.Now().UTC())
 	s.Require().NoError(err)
 
 	live := s.liveLineItems()

--- a/internal/integration/paddle/sync_service_test.go
+++ b/internal/integration/paddle/sync_service_test.go
@@ -929,8 +929,11 @@ func (m *mockSubscriptionService) ValidateAndFilterPricesForSubscription(ctx con
 func (m *mockSubscriptionService) PreviewPlanChange(ctx context.Context, subscriptionID string, req apidto.SubscriptionChangeV2Request) (*apidto.SubscriptionChangeV2Response, error) {
 	return nil, nil
 }
-func (m *mockSubscriptionService) ExecutePlanChange(ctx context.Context, subscriptionID string, req apidto.SubscriptionChangeV2Request) (*apidto.SubscriptionChangeV2Response, error) {
+func (m *mockSubscriptionService) ExecutePlanChange(ctx context.Context, subscriptionID string, req apidto.SubscriptionChangeV2Request, effectiveAt time.Time) (*apidto.SubscriptionChangeV2Response, error) {
 	return nil, nil
+}
+func (m *mockSubscriptionService) ExecuteScheduledPlanChangeV2(ctx context.Context, schedule *subscription.SubscriptionSchedule, config *subscription.PlanChangeV2Configuration, sub *subscription.Subscription) error {
+	return nil
 }
 func (m *mockSubscriptionService) AddAddonToSubscription(ctx context.Context, req *apidto.AddAddonRequest) (*apidto.AddAddonToSubscriptionResponse, error) {
 	return nil, nil

--- a/internal/interfaces/service.go
+++ b/internal/interfaces/service.go
@@ -119,7 +119,9 @@ type SubscriptionService interface {
 	ValidateAndFilterPricesForSubscription(ctx context.Context, entityID string, entityType types.PriceEntityType, subscription *subscription.Subscription, workflowType *types.TemporalWorkflowType) ([]*dto.PriceResponse, error)
 
 	PreviewPlanChange(ctx context.Context, subscriptionID string, req dto.SubscriptionChangeV2Request) (*dto.SubscriptionChangeV2Response, error)
-	ExecutePlanChange(ctx context.Context, subscriptionID string, req dto.SubscriptionChangeV2Request) (*dto.SubscriptionChangeV2Response, error)
+	ExecutePlanChange(ctx context.Context, subscriptionID string, req dto.SubscriptionChangeV2Request, effectiveAt time.Time) (*dto.SubscriptionChangeV2Response, error)
+
+	ExecuteScheduledPlanChangeV2(ctx context.Context, schedule *subscription.SubscriptionSchedule, config *subscription.PlanChangeV2Configuration, sub *subscription.Subscription) error
 
 	AddAddonToSubscription(ctx context.Context, req *dto.AddAddonRequest) (*dto.AddAddonToSubscriptionResponse, error)
 	RemoveAddonFromSubscription(ctx context.Context, req *dto.RemoveAddonRequest) error

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -16,6 +16,7 @@ import (
 	temporalService "github.com/flexprice/flexprice/internal/temporal/service"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
+	"go.temporal.io/sdk/temporal"
 )
 
 type BillingActivities struct {
@@ -455,7 +456,7 @@ func (s *BillingActivities) ProcessPendingPlanChangesActivity(
 	changeService := service.NewSubscriptionChangeService(s.serviceParams)
 
 	// Execute the scheduled plan change
-	err = s.executeScheduledPlanChange(ctx, schedule, changeService, subscriptionService)
+	err = s.executeScheduledPlanChange(ctx, schedule, changeService, subscriptionService, sub)
 	if err != nil {
 		s.logger.Error(ctx, "failed to execute scheduled plan change",
 			"schedule_id", schedule.ID,
@@ -480,7 +481,21 @@ func (s *BillingActivities) executeScheduledPlanChange(
 	schedule *subscription.SubscriptionSchedule,
 	changeService service.SubscriptionChangeService,
 	subscriptionService service.SubscriptionService,
+	sub *subscription.Subscription,
 ) error {
+	v2Config, err := schedule.GetPlanChangeV2Config()
+	if err != nil {
+		return fmt.Errorf("failed to parse plan change configuration: %w", err)
+	}
+	if v2Config.IsV2() {
+		err := subscriptionService.ExecuteScheduledPlanChangeV2(ctx, schedule, v2Config, sub)
+		if err != nil && service.IsTerminalPlanChangeError(err) {
+			return temporal.NewNonRetryableApplicationError(
+				"scheduled plan change cannot succeed", "TerminalPlanChangeFailure", err)
+		}
+		return err
+	}
+
 	// Get the plan change configuration
 	config, err := schedule.GetPlanChangeConfig()
 	if err != nil {

--- a/internal/temporal/workflows/subscription/process_subscription_billing_workflow.go
+++ b/internal/temporal/workflows/subscription/process_subscription_billing_workflow.go
@@ -249,7 +249,23 @@ func ProcessSubscriptionBillingWorkflow(
 			UserID:         input.UserID,
 		}
 
-		err = workflow.ExecuteActivity(ctx, ActivityProcessPlanChange, planChangeInput).Get(ctx, &planChangeOutput)
+		// The workflow-wide policy is MaximumAttempts: 1, but this is the last chance
+		// to swap the plan before STEP 7's compute prices the renewal: the period has
+		// already rolled, so a subscription that fails here is not rescanned until the
+		// next boundary, by which point the schedule is stale. Retry this step only.
+		// A terminal failure is returned non-retryable by the activity, so it stops
+		// immediately rather than burning attempts.
+		planChangeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: 10 * time.Minute,
+			RetryPolicy: &temporal.RetryPolicy{
+				InitialInterval:    5 * time.Second,
+				BackoffCoefficient: 2.0,
+				MaximumInterval:    time.Minute,
+				MaximumAttempts:    3,
+			},
+		})
+
+		err = workflow.ExecuteActivity(planChangeCtx, ActivityProcessPlanChange, planChangeInput).Get(planChangeCtx, &planChangeOutput)
 		if err != nil {
 			// Log error but don't fail the workflow - plan changes can be retried
 			logger.Warn("Failed to process pending plan changes, but continuing",

--- a/internal/temporal/workflows/subscription/process_subscription_billing_workflow_test.go
+++ b/internal/temporal/workflows/subscription/process_subscription_billing_workflow_test.go
@@ -1,0 +1,190 @@
+package subscription
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	invoiceModels "github.com/flexprice/flexprice/internal/temporal/models/invoice"
+	subscriptionModels "github.com/flexprice/flexprice/internal/temporal/models/subscription"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/testsuite"
+)
+
+func checkDraftStub(_ context.Context, _ subscriptionModels.CheckDraftSubscriptionActivityInput) (*subscriptionModels.CheckDraftSubscriptionActivityOutput, error) {
+	return nil, nil
+}
+
+func calculatePeriodsStub(_ context.Context, _ subscriptionModels.CalculatePeriodsActivityInput) (*subscriptionModels.CalculatePeriodsActivityOutput, error) {
+	return nil, nil
+}
+
+func createDraftInvoicesStub(_ context.Context, _ subscriptionModels.CreateInvoicesActivityInput) (*subscriptionModels.CreateInvoicesActivityOutput, error) {
+	return nil, nil
+}
+
+func updateCurrentPeriodStub(_ context.Context, _ subscriptionModels.UpdateSubscriptionPeriodActivityInput) (*subscriptionModels.UpdateSubscriptionPeriodActivityOutput, error) {
+	return nil, nil
+}
+
+func checkCancellationStub(_ context.Context, _ subscriptionModels.CheckSubscriptionCancellationActivityInput) (*subscriptionModels.CheckSubscriptionCancellationActivityOutput, error) {
+	return nil, nil
+}
+
+func processPlanChangeStub(_ context.Context, _ subscriptionModels.ProcessPendingPlanChangesActivityInput) (*subscriptionModels.ProcessPendingPlanChangesActivityOutput, error) {
+	return nil, nil
+}
+
+func triggerInvoiceWorkflowStub(_ context.Context, _ invoiceModels.TriggerInvoiceWorkflowActivityInput) (*invoiceModels.TriggerInvoiceWorkflowActivityOutput, error) {
+	return nil, nil
+}
+
+// billingEnv wires every activity the workflow reaches, with the happy-path answer
+// for all of them except STEP 6, which each test drives on its own.
+func billingEnv(t *testing.T) *testsuite.TestWorkflowEnvironment {
+	t.Helper()
+
+	ts := &testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	periodStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	boundary := periodStart.AddDate(0, 1, 0)
+
+	register := func(fn any, name string) {
+		env.RegisterActivityWithOptions(fn, activity.RegisterOptions{Name: name})
+	}
+	register(checkDraftStub, ActivityCheckDraftSubscription)
+	register(calculatePeriodsStub, ActivityCalculatePeriods)
+	register(createDraftInvoicesStub, ActivityCreateDraftInvoices)
+	register(updateCurrentPeriodStub, ActivityUpdateCurrentPeriod)
+	register(checkCancellationStub, ActivityCheckCancellation)
+	register(processPlanChangeStub, ActivityProcessPlanChange)
+	register(triggerInvoiceWorkflowStub, ActivityTriggerInvoiceWorkflow)
+
+	env.OnActivity(ActivityCheckDraftSubscription, mock.Anything, mock.Anything).
+		Return(&subscriptionModels.CheckDraftSubscriptionActivityOutput{IsDraft: false}, nil)
+	env.OnActivity(ActivityCalculatePeriods, mock.Anything, mock.Anything).
+		Return(&subscriptionModels.CalculatePeriodsActivityOutput{
+			ShouldProcess: true,
+			Periods: []dto.Period{
+				{Start: periodStart, End: boundary},
+				{Start: boundary, End: boundary.AddDate(0, 1, 0)},
+			},
+		}, nil)
+	env.OnActivity(ActivityCreateDraftInvoices, mock.Anything, mock.Anything).
+		Return(&subscriptionModels.CreateInvoicesActivityOutput{InvoiceIDs: []string{"inv_1"}}, nil)
+	env.OnActivity(ActivityUpdateCurrentPeriod, mock.Anything, mock.Anything).
+		Return(&subscriptionModels.UpdateSubscriptionPeriodActivityOutput{Success: true}, nil)
+	env.OnActivity(ActivityCheckCancellation, mock.Anything, mock.Anything).
+		Return(&subscriptionModels.CheckSubscriptionCancellationActivityOutput{IsCancelled: false, Success: true}, nil)
+	env.OnActivity(ActivityTriggerInvoiceWorkflow, mock.Anything, mock.Anything).
+		Return(&invoiceModels.TriggerInvoiceWorkflowActivityOutput{TriggeredCount: 1}, nil)
+
+	return env
+}
+
+func billingInput() subscriptionModels.ProcessSubscriptionBillingWorkflowInput {
+	periodStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	return subscriptionModels.ProcessSubscriptionBillingWorkflowInput{
+		SubscriptionID: "subs_test",
+		TenantID:       "tenant_test",
+		EnvironmentID:  "env_test",
+		UserID:         "user_test",
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodStart.AddDate(0, 1, 0),
+	}
+}
+
+// STEP 6 carries its own retry policy because the workflow-wide one is
+// MaximumAttempts: 1 and a lost plan change cannot be recovered on a later scan.
+func TestProcessSubscriptionBillingWorkflow_PlanChangeRetriesTransientFailure(t *testing.T) {
+	env := billingEnv(t)
+
+	attempts := 0
+	env.OnActivity(ActivityProcessPlanChange, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, _ subscriptionModels.ProcessPendingPlanChangesActivityInput) (*subscriptionModels.ProcessPendingPlanChangesActivityOutput, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, temporal.NewApplicationError("database unavailable", "TransientFailure")
+			}
+			return &subscriptionModels.ProcessPendingPlanChangesActivityOutput{Success: true, WasChanged: true}, nil
+		})
+
+	env.ExecuteWorkflow(ProcessSubscriptionBillingWorkflow, billingInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 3, attempts, "STEP 6 must retry a transient failure rather than give up after one attempt")
+	env.AssertCalled(t, ActivityTriggerInvoiceWorkflow, mock.Anything, mock.Anything)
+}
+
+// Exhausting the retries must not fail the workflow: the period has already rolled,
+// and failing here would leave the subscription without its renewal invoices.
+func TestProcessSubscriptionBillingWorkflow_PlanChangeExhaustedDoesNotFailWorkflow(t *testing.T) {
+	env := billingEnv(t)
+
+	attempts := 0
+	env.OnActivity(ActivityProcessPlanChange, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, _ subscriptionModels.ProcessPendingPlanChangesActivityInput) (*subscriptionModels.ProcessPendingPlanChangesActivityOutput, error) {
+			attempts++
+			return nil, temporal.NewApplicationError("database unavailable", "TransientFailure")
+		})
+
+	env.ExecuteWorkflow(ProcessSubscriptionBillingWorkflow, billingInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError(), "a lost plan change is logged and skipped, not fatal")
+	require.Equal(t, 3, attempts, "the policy caps STEP 6 at three attempts")
+	env.AssertCalled(t, ActivityTriggerInvoiceWorkflow, mock.Anything, mock.Anything)
+}
+
+// A terminal failure is returned non-retryable by the activity, so the retries are
+// skipped instead of spending backoff on an outcome that cannot change.
+func TestProcessSubscriptionBillingWorkflow_PlanChangeTerminalFailureIsNotRetried(t *testing.T) {
+	env := billingEnv(t)
+
+	attempts := 0
+	env.OnActivity(ActivityProcessPlanChange, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, _ subscriptionModels.ProcessPendingPlanChangesActivityInput) (*subscriptionModels.ProcessPendingPlanChangesActivityOutput, error) {
+			attempts++
+			return nil, temporal.NewNonRetryableApplicationError(
+				"scheduled plan change cannot succeed", "TerminalPlanChangeFailure", nil)
+		})
+
+	env.ExecuteWorkflow(ProcessSubscriptionBillingWorkflow, billingInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Equal(t, 1, attempts, "a non-retryable terminal failure must stop after one attempt")
+	env.AssertCalled(t, ActivityTriggerInvoiceWorkflow, mock.Anything, mock.Anything)
+}
+
+// The new policy must be scoped to STEP 6 alone: every other step keeps the
+// workflow-wide MaximumAttempts: 1 and still fails the run on the first error.
+func TestProcessSubscriptionBillingWorkflow_OtherStepsKeepSingleAttempt(t *testing.T) {
+	ts := &testsuite.WorkflowTestSuite{}
+	env := ts.NewTestWorkflowEnvironment()
+
+	env.RegisterActivityWithOptions(checkDraftStub, activity.RegisterOptions{Name: ActivityCheckDraftSubscription})
+	env.RegisterActivityWithOptions(calculatePeriodsStub, activity.RegisterOptions{Name: ActivityCalculatePeriods})
+
+	env.OnActivity(ActivityCheckDraftSubscription, mock.Anything, mock.Anything).
+		Return(&subscriptionModels.CheckDraftSubscriptionActivityOutput{IsDraft: false}, nil)
+
+	attempts := 0
+	env.OnActivity(ActivityCalculatePeriods, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, _ subscriptionModels.CalculatePeriodsActivityInput) (*subscriptionModels.CalculatePeriodsActivityOutput, error) {
+			attempts++
+			return nil, temporal.NewApplicationError("database unavailable", "TransientFailure")
+		})
+
+	env.ExecuteWorkflow(ProcessSubscriptionBillingWorkflow, billingInput())
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError(), "steps other than STEP 6 still fail the workflow")
+	require.Equal(t, 1, attempts, "the scoped policy must not leak onto other activities")
+}

--- a/internal/testutil/inmemory_subscription_schedule_store.go
+++ b/internal/testutil/inmemory_subscription_schedule_store.go
@@ -115,19 +115,15 @@ func (s *InMemorySubscriptionScheduleStore) GetBySubscriptionID(ctx context.Cont
 func (s *InMemorySubscriptionScheduleStore) GetPendingBySubscriptionAndType(ctx context.Context, subscriptionID string, scheduleType types.SubscriptionScheduleChangeType) (*subscription.SubscriptionSchedule, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	schedules, exists := s.schedulesBySubscription[subscriptionID]
-	if !exists {
-		return nil, ierr.NewError("subscription schedule not found").Mark(ierr.ErrNotFound)
-	}
-
-	for _, schedule := range schedules {
+	// Matches the ent repository: no pending schedule is not an error.
+	for _, schedule := range s.schedulesBySubscription[subscriptionID] {
 		if schedule.ScheduleType == scheduleType &&
 			schedule.Status == types.ScheduleStatusPending {
 			return schedule, nil
 		}
 	}
 
-	return nil, ierr.NewError("subscription schedule not found").Mark(ierr.ErrNotFound)
+	return nil, nil
 }
 
 // List retrieves schedules with filters

--- a/internal/types/subscription.go
+++ b/internal/types/subscription.go
@@ -591,7 +591,13 @@ func (s ScheduleType) String() string {
 }
 
 func (s ScheduleType) Validate() error {
-	if s != "" && !lo.Contains(ScheduleTypeValues, s) {
+	if s == "" {
+		return ierr.NewError("schedule type cannot be empty string").
+			WithHint("Schedule type must be 'immediate', 'end_of_period'").
+			Mark(ierr.ErrValidation)
+	}
+
+	if !lo.Contains(ScheduleTypeValues, s) {
 		return ierr.NewError("invalid schedule type").
 			WithHint("Schedule type must be 'immediate', 'end_of_period'").
 			WithReportableDetails(map[string]any{


### PR DESCRIPTION
## **User description**
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---


___

## **CodeAnt-AI Description**
Schedule subscription plan changes for the end of the current billing period

### What Changed
- Plan changes can now be applied immediately or scheduled for the subscription’s current period end using `change_at`.
- Deferred changes return scheduling details without swapping plans, creating invoices, or charging the customer at request time.
- The response includes whether the change is scheduled, its schedule ID, effective time, and resolved change type.
- Only one pending plan change is allowed per subscription; duplicate requests and invalid deferred proration settings return clear validation errors.
- Scheduled changes execute at the billing boundary before renewal invoicing, while transient failures are retried and terminal or stale schedules are marked failed.
- Existing v1 scheduled plan changes continue to use their original behavior and response format.

### Impact
`✅ Plan changes can take effect at period end`
`✅ No premature charges for deferred plan changes`
`✅ Clearer schedule status and failure outcomes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-of-period scheduling for subscription plan changes.
  * Added scheduled-change status, schedule ID, and execution time to API responses.
  * Added versioned plan-change configurations with metadata, policies, and plan transitions.
  * Scheduled changes now execute automatically before period invoicing.
  * Deferred changes support boundary-based preview pricing.

* **Bug Fixes**
  * Improved handling of stale, invalid, duplicate, and transiently failed scheduled changes.
  * Added retries for temporary processing failures without interrupting billing workflows.
  * Preserved existing behavior for immediate and legacy plan changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->