### PR TITLE
ci: decouple SDK registry publish from GitHub push

### DIFF
--- a/.github/workflows/generate-sdks.yml
+++ b/.github/workflows/generate-sdks.yml
@@ -280,8 +280,11 @@ jobs:
   # Summary (runs once after all publish matrix cells)
   # ---------------------------------------------------------------------------
   publish-summary:
-    needs: [version-check, generate, publish-to-github]
-    if: success() && github.event_name == 'release'
+    needs: [version-check, generate, publish-to-github, publish-to-registries]
+    if: |
+      always() &&
+      github.event_name == 'release' &&
+      needs.version-check.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -291,6 +294,9 @@ jobs:
       SDK_TYPESCRIPT_REPO: ${{ vars.SDK_TYPESCRIPT_REPO }}
       SDK_MCP_REPO: ${{ vars.SDK_MCP_REPO }}
       VERSION: ${{ needs.version-check.outputs.version }}  # resolved version only
+      GENERATE_RESULT: ${{ needs.generate.result }}
+      PUBLISH_GITHUB_RESULT: ${{ needs.publish-to-github.result }}
+      PUBLISH_REGISTRIES_RESULT: ${{ needs.publish-to-registries.result }}
     steps:
       - name: Summary
         run: |
@@ -298,23 +304,44 @@ jobs:
           PY_REPO="${SDK_PYTHON_REPO:-flexprice/python-sdk}"
           TS_REPO="${SDK_TYPESCRIPT_REPO:-flexprice/javascript-sdk}"
           MCP_REPO="${SDK_MCP_REPO:-flexprice/mcp-server}"
-          echo "## SDKs pushed to GitHub" >> $GITHUB_STEP_SUMMARY
-          echo "**Resolved version:** v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Go: https://github.com/$GO_REPO" >> $GITHUB_STEP_SUMMARY
-          echo "- Python: https://github.com/$PY_REPO" >> $GITHUB_STEP_SUMMARY
-          echo "- TypeScript: https://github.com/$TS_REPO" >> $GITHUB_STEP_SUMMARY
-          echo "- MCP: https://github.com/$MCP_REPO" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## Install (published packages)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Python:** \`pip install flexprice\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **TypeScript:** \`npm i @flexprice/sdk\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **MCP:** \`npm i @flexprice/mcp-server\`" >> $GITHUB_STEP_SUMMARY
+
+          status_icon() {
+            case "$1" in
+              success) echo "✅ succeeded" ;;
+              failure) echo "❌ failed" ;;
+              skipped) echo "⏭️ skipped" ;;
+              *) echo "⚠️ $1" ;;
+            esac
+          }
+
+          {
+            echo "## SDK publish summary"
+            echo ""
+            echo "| Step | Result |"
+            echo "|---|---|"
+            echo "| Generate SDKs | $(status_icon "$GENERATE_RESULT") |"
+            echo "| Push to GitHub (go, python, typescript, mcp) | $(status_icon "$PUBLISH_GITHUB_RESULT") |"
+            echo "| Publish to npm/PyPI (typescript, python, mcp) | $(status_icon "$PUBLISH_REGISTRIES_RESULT") |"
+            echo ""
+            echo "GitHub push and npm/PyPI publish run independently — one failing does not skip or block the other. Each is also its own per-language matrix (\`fail-fast: false\`), so if a row above shows failed, open that job to see which specific language failed and why."
+            echo ""
+            echo "**Resolved version:** v${{ env.VERSION }}"
+            echo "- Go: https://github.com/$GO_REPO"
+            echo "- Python: https://github.com/$PY_REPO"
+            echo "- TypeScript: https://github.com/$TS_REPO"
+            echo "- MCP: https://github.com/$MCP_REPO"
+            echo ""
+            echo "## Install (published packages)"
+            echo "- **Python:** \`pip install flexprice\`"
+            echo "- **TypeScript:** \`npm i @flexprice/sdk\`"
+            echo "- **MCP:** \`npm i @flexprice/mcp-server\`"
+          } >> $GITHUB_STEP_SUMMARY
 
   # ---------------------------------------------------------------------------
   # Publishes via npm/twine here; .speakeasy/workflow.yaml publish config is for Speakeasy CLI/action only and is not used by this workflow.
   # ---------------------------------------------------------------------------
   publish-to-registries:
-    needs: [generate, publish-to-github]
+    needs: [generate]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## **User description**
## Summary
- `publish-to-registries` (npm/PyPI) no longer `needs` `publish-to-github` — a failed GitHub push no longer skips npm/PyPI publish, and vice versa. Both still run to completion independently, and each is already its own `fail-fast: false` matrix internally (per SDK language/target).
- `publish-summary` now always runs (still skipped for the version-unchanged no-op release case) and reports `generate` / `publish-to-github` / `publish-to-registries` results via GitHub's built-in `needs.<job>.result`, so a partial failure is visible in the step summary instead of the job being silently skipped.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/generate-sdks.yml'))"` — YAML parses cleanly
- [ ] Verify on the next real SDK release: confirm npm/PyPI still publishes if a GitHub push fails (and vice versa), and that the step summary shows the 3-row status table


___

## **CodeAnt-AI Description**
Keep SDK package publishing independent and show complete release status

### What Changed
- npm/PyPI publishing continues even if pushing SDKs to GitHub fails, and GitHub publishing continues independently if a package publish fails
- Release summaries now run after publishing attempts and show whether SDK generation, GitHub pushes, and npm/PyPI publishing succeeded, failed, or were skipped
- Summaries identify that failures may affect individual SDK languages and retain repository links and install commands

### Impact
`✅ Fewer blocked SDK releases`
`✅ Clearer partial-publish status`
`✅ Easier diagnosis of failed SDK targets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * SDK releases can now be published to package registries independently of GitHub release publishing.
  * Release summaries are generated even when one publishing step encounters an error.
  * Workflow summaries now provide clearer status information for SDK generation and publishing, along with repository and installation details.
  * Release processing is more resilient while preserving visibility into each stage’s outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->