### PR TITLE
feat(migrate): support applying a single baseline SQL file

### DIFF
--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -21,6 +21,7 @@ import (
 func newClickHouseCmd() *cobra.Command {
 	var timeout int
 	var chDir string
+	var chFile string
 
 	cmd := &cobra.Command{
 		Use:   "clickhouse",
@@ -39,7 +40,7 @@ func newClickHouseCmd() *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 			defer cancel()
 			l.Info(ctx, "Running ClickHouse migrations...", "address", cfg.ClickHouse.Address, "database", cfg.ClickHouse.Database, "tls", cfg.ClickHouse.TLS)
-			if err := runClickHouseMigrations(ctx, cfg, chDir, l); err != nil {
+			if err := runClickHouseMigrations(ctx, cfg, chDir, chFile, l); err != nil {
 				l.Fatal(ctx, "ClickHouse migration failed", "error", err)
 			}
 			l.Info(ctx, "ClickHouse migrations completed successfully")
@@ -50,6 +51,7 @@ func newClickHouseCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&timeout, "timeout", 300, "Timeout in seconds for the migration")
 	cmd.Flags().StringVar(&chDir, "clickhouse-dir", "migrations/clickhouse", "Directory of ClickHouse .sql migration files")
+	cmd.Flags().StringVar(&chFile, "file", "", "Apply a single .sql file (e.g. a baseline) instead of scanning --clickhouse-dir")
 
 	return cmd
 }
@@ -65,7 +67,10 @@ var validCHIdent = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 //
 // It ensures the target database exists first, then executes each statement in
 // each file individually (the native protocol runs one statement per Exec).
-func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir string, log *logger.Logger) error {
+//
+// When file is non-empty, only that single .sql file is applied and dir is
+// ignored -- used to apply a baseline snapshot instead of the whole directory.
+func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir, file string, log *logger.Logger) error {
 	opts := cfg.ClickHouse.GetClientOptions()
 	db := cfg.ClickHouse.Database
 
@@ -109,13 +114,21 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 	}
 	defer dbConn.Close()
 
-	files, err := filepath.Glob(filepath.Join(dir, "*.sql"))
-	if err != nil {
-		return fmt.Errorf("glob %s: %w", dir, err)
-	}
-	sort.Strings(files)
-	if len(files) == 0 {
-		return fmt.Errorf("no .sql files found in %s", dir)
+	var files []string
+	if file != "" {
+		if _, err := os.Stat(file); err != nil {
+			return fmt.Errorf("stat %s: %w", file, err)
+		}
+		files = []string{file}
+	} else {
+		files, err = filepath.Glob(filepath.Join(dir, "*.sql"))
+		if err != nil {
+			return fmt.Errorf("glob %s: %w", dir, err)
+		}
+		sort.Strings(files)
+		if len(files) == 0 {
+			return fmt.Errorf("no .sql files found in %s", dir)
+		}
 	}
 
 	for _, f := range files {

--- a/cmd/migrate/postgres.go
+++ b/cmd/migrate/postgres.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"time"
@@ -17,19 +18,87 @@ import (
 func newPostgresCmd() *cobra.Command {
 	var dryRun bool
 	var timeout int
+	var file string
 
 	cmd := &cobra.Command{
 		Use:   "postgres",
 		Short: "Run Ent/PostgreSQL schema migrations",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if file != "" {
+				return runPostgresSQLFile(file, dryRun, timeout)
+			}
 			return runPostgresMigration(dryRun, timeout)
 		},
 	}
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print migration SQL without executing it")
 	cmd.Flags().IntVar(&timeout, "timeout", 300, "Timeout in seconds for the migration")
+	cmd.Flags().StringVar(&file, "file", "", "Apply a raw .sql file (e.g. a baseline) instead of Ent auto-migration")
 
 	return cmd
+}
+
+// runPostgresSQLFile applies a raw .sql file (e.g. the schema baseline) instead
+// of running Ent auto-migration. The file is executed as a single query so
+// pg_dump artifacts -- dollar-quoted function bodies, multi-statement bodies --
+// replay exactly as `psql -f` would, without a fragile statement splitter.
+func runPostgresSQLFile(file string, dryRun bool, timeout int) error {
+	cfg, err := config.NewConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	l, err := logger.NewLogger(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create logger: %w", err)
+	}
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", file, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	if dryRun {
+		l.Info(ctx, "Dry run mode - printing SQL file without executing", "file", file)
+		fmt.Print(string(raw))
+		fmt.Println("Migration process completed")
+		return nil
+	}
+
+	l.Info(ctx, "Applying PostgreSQL SQL file", "host", cfg.Postgres.Host, "file", file)
+
+	db, err := sql.Open("postgres", cfg.Postgres.GetDSN())
+	if err != nil {
+		return fmt.Errorf("failed to connect to postgres: %w", err)
+	}
+	defer db.Close()
+
+	// The baseline is a from-empty snapshot with no IF NOT EXISTS on CREATE TABLE,
+	// so it must not be replayed over an existing schema. Refuse rather than fail
+	// half-way through the file. Mirrors migrations/baseline/apply.sh.
+	var existing int
+	if err := db.QueryRowContext(ctx,
+		"SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE'",
+	).Scan(&existing); err != nil {
+		return fmt.Errorf("check existing schema: %w", err)
+	}
+	if existing != 0 {
+		return fmt.Errorf("target database already has %d tables in schema public; the baseline expects an empty database (point at a fresh one or drop the schema first)", existing)
+	}
+
+	// A single Exec of the whole file uses lib/pq's simple query protocol, which
+	// runs every statement in one implicit transaction -- so a failure part-way
+	// rolls the whole file back rather than half-applying it.
+	if _, err := db.ExecContext(ctx, string(raw)); err != nil {
+		return fmt.Errorf("apply %s: %w", file, err)
+	}
+
+	l.Info(ctx, "PostgreSQL SQL file applied successfully", "file", file)
+	fmt.Println("Migration process completed")
+	return nil
 }
 
 func runPostgresMigration(dryRun bool, timeout int) error {


### PR DESCRIPTION
## **User description**
## What

Adds a `--file` flag to both `migrate postgres` and `migrate clickhouse` so a from-empty schema **baseline** (`migrations/baseline/*.sql`) can be applied instead of scanning the whole migrations directory / running Ent auto-migration.

## Why

`migrations/baseline/` now ships from-empty snapshots for standing up a fresh DB, but the migrate command could only run the incremental dir (`clickhouse`) or Ent auto-migrate (`postgres`). There was no way to point the command at a baseline file.

## Changes

- **`clickhouse --file <f>`** — apply one `.sql` file (existing split + per-statement exec + DB auto-create) instead of globbing `--clickhouse-dir`. Empty flag → unchanged directory scan.
- **`postgres --file <f>`** — apply a raw `.sql` file via a single lib/pq simple-query `Exec` (matches `psql -f`: dollar-quoted function bodies and multi-statement bodies replay correctly in one implicit transaction), bypassing Ent auto-migration. Guards against a non-empty target (the baseline has no `IF NOT EXISTS` on `CREATE TABLE`), mirroring `migrations/baseline/apply.sh`. Honors `--dry-run` and `--timeout`. Empty flag → unchanged Ent auto-migrate.

## Usage

```bash
go run ./cmd/migrate postgres   --file migrations/baseline/postgres_baseline_20260819.sql
go run ./cmd/migrate clickhouse --file migrations/baseline/clickhouse_baseline_20260819.sql
```

## Verification (local Docker)

- `postgres --file` on fresh DB → **56 tables, 1 sequence, 3 functions** (matches baseline README); dollar-quoted functions + multi-statement single-Exec replay confirmed.
- `postgres --file` on non-empty DB → empty-DB guard aborts with a table count, no DDL attempted.
- `clickhouse --file` → applies the single baseline file, all statements exec, completes.
- `clickhouse` (no flag) → still scans the dir (9 files applied); default paths unchanged.

## Notes

- ClickHouse baseline qualifies objects as `flexprice.<table>`; `--file` applies it verbatim and does not retarget a differently-named database (only `apply.sh` sed-rewrites). Fine when the DB is `flexprice`.


___

## **CodeAnt-AI Description**
Add baseline database setup and preserve complete webhook data

### What Changed
- PostgreSQL and ClickHouse migrations can now apply one baseline SQL file to a new database instead of replaying incremental migrations
- Baseline setup includes single-node and replicated ClickHouse schemas, empty-database checks for PostgreSQL, dry-run support, and a command-line script for applying either database or both
- Invoice webhooks now return the complete invoice response, including fields that were previously omitted
- Customer webhook data now includes the customer’s environment ID

### Impact
`✅ Faster setup for new databases`
`✅ Fewer partial PostgreSQL baseline migrations`
`✅ Complete invoice and customer webhook payloads`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--file` option to ClickHouse migrations for applying a specific SQL file.
  - Added support for applying raw SQL files to PostgreSQL, including schema baseline scripts.
  - PostgreSQL dry-run mode now displays the selected SQL without executing it.

- **Bug Fixes**
  - Added validation for missing migration files.
  - PostgreSQL baseline execution is blocked when base tables already exist, helping prevent unsafe application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->