### PR TITLE
feat(chart): kafka partitions=3, post-migration verify, sentry/pyroscope/email under app hierarchy

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
+++ b/internal/ee/infrastructure/helm/flexprice/templates/_helpers.tpl
@@ -599,32 +599,32 @@ All service addresses are resolved via named templates above so this block stays
 {{- end }}
 {{- /* ---- Observability ---- */}}
 - name: FLEXPRICE_SENTRY_ENABLED
-  value: {{ .Values.sentry.enabled | quote }}
-{{- if .Values.sentry.enabled }}
+  value: {{ .Values.app.observability.sentry.enabled | quote }}
+{{- if .Values.app.observability.sentry.enabled }}
 - name: FLEXPRICE_SENTRY_DSN
   valueFrom:
     secretKeyRef:
       name: {{ include "flexprice.secretName" . }}
       key: sentry-dsn
 - name: FLEXPRICE_SENTRY_ENVIRONMENT
-  value: {{ .Values.sentry.environment | quote }}
+  value: {{ .Values.app.observability.sentry.environment | quote }}
 - name: FLEXPRICE_SENTRY_SAMPLE_RATE
-  value: {{ .Values.sentry.sampleRate | quote }}
+  value: {{ .Values.app.observability.sentry.sampleRate | quote }}
 {{- end }}
 - name: FLEXPRICE_PYROSCOPE_ENABLED
-  value: {{ .Values.pyroscope.enabled | quote }}
-{{- if .Values.pyroscope.enabled }}
+  value: {{ .Values.app.observability.pyroscope.enabled | quote }}
+{{- if .Values.app.observability.pyroscope.enabled }}
 - name: FLEXPRICE_PYROSCOPE_SERVER_ADDRESS
-  value: {{ .Values.pyroscope.serverAddress | quote }}
+  value: {{ .Values.app.observability.pyroscope.serverAddress | quote }}
 - name: FLEXPRICE_PYROSCOPE_APPLICATION_NAME
-  value: {{ .Values.pyroscope.applicationName | quote }}
+  value: {{ .Values.app.observability.pyroscope.applicationName | quote }}
 - name: FLEXPRICE_PYROSCOPE_SAMPLE_RATE
-  value: {{ .Values.pyroscope.sampleRate | quote }}
+  value: {{ .Values.app.observability.pyroscope.sampleRate | quote }}
 - name: FLEXPRICE_PYROSCOPE_DISABLE_GC_RUNS
-  value: {{ .Values.pyroscope.disableGCRuns | quote }}
-{{- if .Values.pyroscope.basicAuthUser }}
+  value: {{ .Values.app.observability.pyroscope.disableGCRuns | quote }}
+{{- if .Values.app.observability.pyroscope.basicAuthUser }}
 - name: FLEXPRICE_PYROSCOPE_BASIC_AUTH_USER
-  value: {{ .Values.pyroscope.basicAuthUser | quote }}
+  value: {{ .Values.app.observability.pyroscope.basicAuthUser | quote }}
 - name: FLEXPRICE_PYROSCOPE_BASIC_AUTH_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -660,7 +660,7 @@ All service addresses are resolved via named templates above so this block stays
       key: encryption-key
 {{- end }}
 {{- /* ---- Email ---- */}}
-{{- if .Values.email.enabled }}
+{{- if .Values.app.email.enabled }}
 - name: FLEXPRICE_EMAIL_ENABLED
   value: "true"
 - name: FLEXPRICE_EMAIL_RESEND_API_KEY
@@ -669,11 +669,11 @@ All service addresses are resolved via named templates above so this block stays
       name: {{ include "flexprice.secretName" . }}
       key: email-resend-api-key
 - name: FLEXPRICE_EMAIL_FROM_ADDRESS
-  value: {{ .Values.email.fromAddress | quote }}
+  value: {{ .Values.app.email.fromAddress | quote }}
 - name: FLEXPRICE_EMAIL_REPLY_TO
-  value: {{ .Values.email.replyTo | quote }}
+  value: {{ .Values.app.email.replyTo | quote }}
 - name: FLEXPRICE_EMAIL_CALENDAR_URL
-  value: {{ .Values.email.calendarUrl | quote }}
+  value: {{ .Values.app.email.calendarUrl | quote }}
 {{- end }}
 {{- /* ---- Event processing ---- */}}
 - name: FLEXPRICE_EVENT_PROCESSING_TOPIC
@@ -843,3 +843,22 @@ rather than rejected.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+flexprice.image — the app image reference.
+
+Prefers an immutable digest when image.digest is set: renders
+"<repository>@<digest>" and ignores the tag entirely. Otherwise renders
+"<repository>:<tag>", tag defaulting to .Chart.AppVersion, the prior behaviour.
+
+A digest and a tag cannot both appear in one reference ("repo@sha256:x:tag" is
+invalid), so digest wins outright when present. This lets a client pin exactly
+the bytes shipped — the workloads and the migration Job all resolve through here.
+*/}}
+{{- define "flexprice.image" -}}
+{{- if .Values.image.digest -}}
+{{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end -}}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/configmap.yaml
@@ -91,19 +91,19 @@ data:
       level: {{ .Values.logging.level | quote }}
     
     sentry:
-      enabled: {{ .Values.sentry.enabled }}
-      environment: {{ .Values.sentry.environment | quote }}
-      sample_rate: {{ .Values.sentry.sampleRate }}
-    
+      enabled: {{ .Values.app.observability.sentry.enabled }}
+      environment: {{ .Values.app.observability.sentry.environment | quote }}
+      sample_rate: {{ .Values.app.observability.sentry.sampleRate }}
+
     pyroscope:
-      enabled: {{ .Values.pyroscope.enabled }}
-      server_address: {{ .Values.pyroscope.serverAddress | quote }}
-      application_name: {{ .Values.pyroscope.applicationName | quote }}
-      sample_rate: {{ .Values.pyroscope.sampleRate }}
-      disable_gc_runs: {{ .Values.pyroscope.disableGCRuns }}
-    {{- if .Values.pyroscope.profileTypes }}
+      enabled: {{ .Values.app.observability.pyroscope.enabled }}
+      server_address: {{ .Values.app.observability.pyroscope.serverAddress | quote }}
+      application_name: {{ .Values.app.observability.pyroscope.applicationName | quote }}
+      sample_rate: {{ .Values.app.observability.pyroscope.sampleRate }}
+      disable_gc_runs: {{ .Values.app.observability.pyroscope.disableGCRuns }}
+    {{- if .Values.app.observability.pyroscope.profileTypes }}
       profile_types:
-        {{- range .Values.pyroscope.profileTypes }}
+        {{- range .Values.app.observability.pyroscope.profileTypes }}
         - {{ . | quote }}
         {{- end }}
     {{- end }}
@@ -285,13 +285,13 @@ data:
       base_url: {{ .Values.checkout.baseUrl | quote }}
     
     email:
-      enabled: {{ .Values.email.enabled }}
-      from_address: {{ .Values.email.fromAddress | quote }}
-      reply_to: {{ .Values.email.replyTo | quote }}
-      calendar_url: {{ .Values.email.calendarUrl | quote }}
+      enabled: {{ .Values.app.email.enabled }}
+      from_address: {{ .Values.app.email.fromAddress | quote }}
+      reply_to: {{ .Values.app.email.replyTo | quote }}
+      calendar_url: {{ .Values.app.email.calendarUrl | quote }}
       # Plain config value (user-signup automation), not a secret → rendered here. The secret
       # (resend_api_key) is NOT rendered — it's bound from FLEXPRICE_EMAIL_RESEND_API_KEY via BindEnv.
-      zapier_webhook_url: {{ .Values.email.zapierWebhookUrl | quote }}
+      zapier_webhook_url: {{ .Values.app.email.zapierWebhookUrl | quote }}
     
     feature_flag:
       enable_feature_usage_for_analytics: {{ .Values.featureFlag.enableFeatureUsageForAnalytics }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-api.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /app
           ports:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-consumer.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /app
           ports:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-worker.yaml
@@ -42,7 +42,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /app
           ports:

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/secret.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/secret.yaml
@@ -30,14 +30,14 @@ stringData:
   {{- if .Values.temporalConfig.apiKey }}
   temporal-api-key: {{ .Values.temporalConfig.apiKey | quote }}
   {{- end }}
-  {{- if and .Values.sentry.enabled .Values.sentry.dsn }}
-  sentry-dsn: {{ .Values.sentry.dsn | quote }}
+  {{- if and .Values.app.observability.sentry.enabled .Values.app.observability.sentry.dsn }}
+  sentry-dsn: {{ .Values.app.observability.sentry.dsn | quote }}
   {{- end }}
-  {{- if and .Values.pyroscope.enabled .Values.pyroscope.basicAuthPassword }}
-  pyroscope-basic-auth-password: {{ .Values.pyroscope.basicAuthPassword | quote }}
+  {{- if and .Values.app.observability.pyroscope.enabled .Values.app.observability.pyroscope.basicAuthPassword }}
+  pyroscope-basic-auth-password: {{ .Values.app.observability.pyroscope.basicAuthPassword | quote }}
   {{- end }}
-  {{- if and .Values.email.enabled .Values.email.resendApiKey }}
-  email-resend-api-key: {{ .Values.email.resendApiKey | quote }}
+  {{- if and .Values.app.email.enabled .Values.app.email.resendApiKey }}
+  email-resend-api-key: {{ .Values.app.email.resendApiKey | quote }}
   {{- end }}
   {{- if and .Values.webhook.enabled .Values.webhook.svixConfig.enabled .Values.webhook.svixConfig.authToken }}
   svix-auth-token: {{ .Values.webhook.svixConfig.authToken | quote }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -292,7 +292,7 @@ spec:
         # --clickhouse-dir defaults to migrations/clickhouse, relative to the
         # image WORKDIR /app, so no flag is needed.
         - name: run-clickhouse-migrations
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/sh
@@ -310,7 +310,12 @@ spec:
                 exit 1
               fi
               echo "Using: ${MIGRATE_BINARY}"
+              {{- if .Values.migration.clickhouseFile }}
+              echo "Applying baseline: {{ .Values.migration.clickhouseFile }}"
+              ${MIGRATE_BINARY} clickhouse --file {{ .Values.migration.clickhouseFile | quote }} || exit 1
+              {{- else }}
               ${MIGRATE_BINARY} clickhouse || exit 1
+              {{- end }}
               echo "✅ ClickHouse migrations complete"
           env:
             {{- include "flexprice.env" . | nindent 12 }}
@@ -326,7 +331,7 @@ spec:
         {{- if .Values.migration.steps.ent }}
         # ── 7. Run Ent framework migrations ──────────────────────────────────
         - name: run-ent-migrations
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /bin/sh
@@ -537,18 +542,18 @@ spec:
               }
 
               # All topics used by FlexPrice
-              create_topic "{{ .Values.kafkaConfig.topic }}"
-              create_topic "{{ .Values.kafkaConfig.topicLazy }}"
+              create_topic "{{ .Values.kafkaConfig.topic }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "{{ .Values.kafkaConfig.topicLazy }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
               {{- with .Values.kafkaConfig.topicBulk }}
-              create_topic "{{ . }}"
+              create_topic "{{ . }}" "{{ $.Values.migration.kafkaTopics.partitions | default 3 }}"
               {{- end }}
-              create_topic "{{ .Values.kafkaConfig.topicDLQ | default "events_dlq" }}"
-              create_topic "{{ .Values.eventPostProcessing.topic }}"
-              create_topic "{{ .Values.eventPostProcessing.topicBackfill }}"
-              create_topic "{{ .Values.webhook.topic }}"
-              create_topic "events_backfill"
-              create_topic "wallet_alert"
-              create_topic "onboarding_events"
+              create_topic "{{ .Values.kafkaConfig.topicDLQ | default "events_dlq" }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "{{ .Values.eventPostProcessing.topic }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "{{ .Values.eventPostProcessing.topicBackfill }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "{{ .Values.webhook.topic }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "events_backfill" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "wallet_alert" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
+              create_topic "onboarding_events" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}"
 
               if [ "${FAILED}" -ne 0 ]; then
                 echo "❌ ${FAILED} topic(s) could not be created."
@@ -580,7 +585,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.migration.command }}
           command:

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -578,6 +578,104 @@ spec:
             {{- toYaml .Values.migration.kafkaTopics.resources | nindent 12 }}
         {{- end }}
 
+        {{- if .Values.migration.steps.verify }}
+        # ── 10. Post-migration sanity check ───────────────────────────────────
+        # Fatal gate: asserts the ClickHouse tables and Kafka topics the prior
+        # steps were supposed to create actually exist, rather than trusting
+        # each step's own exit code. run-clickhouse-migrations (above) never
+        # queries ClickHouse directly -- it shells out to the same `migrate`
+        # binary as the Ent step and trusts its exit code, so a migration that
+        # silently no-ops (e.g. wrong database resolved) would report success
+        # here with nothing actually created.
+        #
+        # ClickHouse auth mirrors run-clickhouse-migrations exactly: same
+        # FLEXPRICE_CLICKHOUSE_USERNAME / FLEXPRICE_CLICKHOUSE_PASSWORD via
+        # flexprice.env, same clickhouse-password secret key. The query is
+        # issued over HTTP rather than the native protocol the migrate binary
+        # uses (FLEXPRICE_CLICKHOUSE_ADDRESS is the :9000 native port, not an
+        # HTTP endpoint), so host/port are derived the same way
+        # wait-for-clickhouse (above) derives them -- from the HTTP port, not
+        # the native one.
+        - name: verify-migrations
+          image: "{{ include "flexprice.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              {{- if .Values.migration.steps.clickhouse }}
+              echo "verify: ClickHouse tables"
+              CH_HTTP_HOST="{{ if eq .Values.clickhouse.mode "external" }}{{ index (splitList ":" .Values.clickhouse.address) 0 }}{{ else if eq .Values.clickhouse.mode "altinity" }}chi-{{ include "flexprice.fullname" . }}-flexprice-0-0{{ if .Values.clickhouse.namespace }}.{{ .Values.clickhouse.namespace }}.svc.cluster.local{{ end }}{{ else }}{{ include "flexprice.clickhouseServiceHost" . }}{{ end }}"
+              CH_HTTP_PORT="{{ if eq .Values.clickhouse.mode "external" }}{{ index (splitList ":" .Values.clickhouse.address) 1 }}{{ else if eq .Values.clickhouse.mode "altinity" }}8123{{ else }}{{ .Values.clickhouse.standalone.service.httpPort }}{{ end }}"
+              CH_SCHEME="{{ if .Values.clickhouse.tls }}https{{ else }}http{{ end }}"
+              for t in events meter_usage; do
+                n=$(wget -qO- "${CH_SCHEME}://${CH_HTTP_HOST}:${CH_HTTP_PORT}/?query=SELECT+count()+FROM+system.tables+WHERE+database='{{ .Values.clickhouse.database }}'+AND+name='${t}'" \
+                    --header="X-ClickHouse-User: ${FLEXPRICE_CLICKHOUSE_USERNAME}" \
+                    --header="X-ClickHouse-Key: ${FLEXPRICE_CLICKHOUSE_PASSWORD}" \
+                    {{- if $.Values.clickhouse.tlsSkipVerify }} --no-check-certificate{{- end }} 2>/dev/null || echo 0)
+                [ "$n" = "1" ] || { echo "❌ MISSING ClickHouse table: ${t}"; exit 1; }
+                echo "  ✅ ${t}"
+              done
+              {{- end }}
+              {{- if .Values.migration.steps.kafka }}
+              echo "verify: Kafka topics"
+              KAFKA_BROKER="{{ include "flexprice.kafkaBrokers" . }}"
+              KAFKA_TOPICS_CMD="kafka-topics"
+              if command -v kafka-topics.sh >/dev/null 2>&1; then
+                KAFKA_TOPICS_CMD="kafka-topics.sh"
+              fi
+              CMD_CONFIG=""
+              {{- if or .Values.kafkaConfig.useSASL .Values.kafkaConfig.tls }}
+              CMD_CONFIG=/tmp/kafka-admin.properties
+              {{- if .Values.kafkaConfig.useSASL }}
+              cat > "${CMD_CONFIG}" <<'PROPS'
+              security.protocol={{ if .Values.kafkaConfig.tls }}SASL_SSL{{ else }}SASL_PLAINTEXT{{ end }}
+              sasl.mechanism={{ .Values.kafkaConfig.saslMechanism }}
+              PROPS
+              {{- $jaas := ternary "org.apache.kafka.common.security.scram.ScramLoginModule" "org.apache.kafka.common.security.plain.PlainLoginModule" (hasPrefix "SCRAM" .Values.kafkaConfig.saslMechanism) }}
+              printf 'sasl.jaas.config=%s required username="%s" password="%s";\n' \
+                '{{ $jaas }}' \
+                '{{ .Values.kafkaConfig.saslUser }}' \
+                "${KAFKA_SASL_PASSWORD}" >> "${CMD_CONFIG}"
+              {{- else }}
+              cat > "${CMD_CONFIG}" <<'PROPS'
+              security.protocol=SSL
+              PROPS
+              {{- end }}
+              sed -i 's/^[[:space:]]*//' "${CMD_CONFIG}"
+              CMD_CONFIG="--command-config ${CMD_CONFIG}"
+              {{- end }}
+              EXISTING=$($KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" ${CMD_CONFIG} --list 2>/dev/null || true)
+              MISSING=0
+              for t in "{{ .Values.kafkaConfig.topic }}" "{{ .Values.kafkaConfig.topicLazy }}" "{{ .Values.kafkaConfig.topicDLQ | default "events_dlq" }}" "{{ .Values.eventPostProcessing.topic }}" "{{ .Values.eventPostProcessing.topicBackfill }}" "{{ .Values.webhook.topic }}"; do
+                if ! echo "${EXISTING}" | grep -qx "${t}"; then
+                  echo "❌ MISSING Kafka topic: ${t}"
+                  MISSING=$((MISSING + 1))
+                fi
+              done
+              [ "${MISSING}" -eq 0 ] || { echo "❌ ${MISSING} required Kafka topic(s) missing"; exit 1; }
+              echo "  ✅ core topics present"
+              {{- end }}
+              echo "✅ verify-migrations complete"
+          env:
+            {{- include "flexprice.env" . | nindent 12 }}
+            {{- if and .Values.migration.steps.kafka (and .Values.kafkaConfig.useSASL (ne .Values.kafkaConfig.saslMechanism "OAUTHBEARER")) }}
+            - name: KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "flexprice.secretName" . }}
+                  key: kafka-sasl-password
+            {{- end }}
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+        {{- end }}
+
       containers:
         # ── Main: all migration steps handled by init containers ──────────────
         - name: migration

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -862,6 +862,14 @@ migration:
   activeDeadlineSeconds: 900  # Maximum time in seconds for the job to run (increased for all migrations)
   ttlSecondsAfterFinished: 3600  # Time to keep completed job (1 hour)
   command: ""  # Custom command to run (if empty, uses default migration steps)
+  # Apply a SINGLE ClickHouse baseline .sql via `migrate clickhouse --file`
+  # instead of scanning migrations/clickhouse/. Empty = scan the directory (the
+  # incremental, non-Replicated set). Set to a baseline path for a replicated
+  # cluster, e.g. migrations/baseline/clickhouse_baseline_replicated_20260819.sql
+  # — its tables use Replicated* engines + ON CLUSTER, which the directory set
+  # does not. Requires a migrate binary that supports --file (flexprice #2617).
+  clickhouseFile: ""
+
   # Migration steps to run (all enabled by default)
   steps:
     postgresSetup: true  # Create schema and extensions in PostgreSQL
@@ -881,6 +889,10 @@ migration:
   # cover heap plus JVM overhead, or the kernel OOM-kills the container (exit
   # 137, no logs) instead of the JVM reporting it.
   kafkaTopics:
+    # Partitions for every topic the create-kafka-topics step makes. Default 3 so
+    # even dev has room to parallelise consumers; 1 was too few. Fresh topics only —
+    # raising an existing topic's partitions needs kafka-topics --alter.
+    partitions: 3
     heapOpts: "-Xmx512m -Xms256m"
     resources:
       limits:

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -1032,26 +1032,6 @@ otel:
     authHeader: ""      # e.g. "signoz-ingestion-key"
     sampleRate: ""      # empty → app default (1.0 = 100%); e.g. "0.2" to sample 20%
 
-# Sentry configuration
-sentry:
-  enabled: false
-  dsn: "https://1234567890@sentry.io/1234567890" # Set via secret
-  environment: "production"
-  sampleRate: 1.0
-
-# Pyroscope configuration
-pyroscope:
-  enabled: false
-  serverAddress: ""
-  applicationName: "flexprice"
-  basicAuthUser: ""
-  basicAuthPassword: "" # Required only when pyroscope.basicAuthUser is set — set via secret
-  sampleRate: 100
-  disableGCRuns: false
-  profileTypes:
-    - "cpu"
-    - "memory"
-
 # S3 configuration
 s3:
   enabled: false
@@ -1345,19 +1325,41 @@ billing:
   tenantId: ""
   environmentId: ""
 
-# Email configuration
-email:
-  enabled: false
-  resendApiKey: "" # secret — bound via FLEXPRICE_EMAIL_RESEND_API_KEY (config.go BindEnv); not rendered in configmap
-  fromAddress: ""
-  replyTo: ""
-  calendarUrl: ""
-  zapierWebhookUrl: "" # plain value (user-signup automation) — rendered into config.yaml
-
 # App URL configuration
 app:
   customerPortalUrl: ""   # e.g. "https://admin.flexprice.io/customer-portal"
   oauthRedirectUri: ""    # e.g. "https://admin.flexprice.io/tools/integrations/oauth/callback"
+
+  # Observability (Sentry error tracking + Pyroscope continuous profiling)
+  observability:
+    # Sentry configuration
+    sentry:
+      enabled: false
+      dsn: "https://1234567890@sentry.io/1234567890" # Set via secret
+      environment: "production"
+      sampleRate: 1.0
+
+    # Pyroscope configuration
+    pyroscope:
+      enabled: false
+      serverAddress: ""
+      applicationName: "flexprice"
+      basicAuthUser: ""
+      basicAuthPassword: "" # Required only when pyroscope.basicAuthUser is set — set via secret
+      sampleRate: 100
+      disableGCRuns: false
+      profileTypes:
+        - "cpu"
+        - "memory"
+
+  # Email configuration
+  email:
+    enabled: false
+    resendApiKey: "" # secret — bound via FLEXPRICE_EMAIL_RESEND_API_KEY (config.go BindEnv); not rendered in configmap
+    fromAddress: ""
+    replyTo: ""
+    calendarUrl: ""
+    zapierWebhookUrl: "" # plain value (user-signup automation) — rendered into config.yaml
 
 # Checkout flow base URL → rendered into config.yaml as checkout.base_url
 checkout:

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -877,6 +877,7 @@ migration:
     kafka: true          # Create Kafka topics (idempotent, safe to re-run)
     ent: true            # Run Ent framework migrations
     seed: false          # Run seed data (optional, set to true to enable)
+    verify: true         # Fatally assert CH tables + kafka topics exist post-migration
 
   # The create-kafka-topics init container runs the JVM-based kafka-topics
   # tool. Its heap is set explicitly rather than left to the JVM's default,

--- a/internal/ee/infrastructure/helm/values-prod.example.yaml
+++ b/internal/ee/infrastructure/helm/values-prod.example.yaml
@@ -294,19 +294,6 @@ logging:
     endpoint: "ingest.signoz.io:443"
     # auth value from existingSecret key: logging-otel-auth-value
 
-sentry:
-  enabled: true
-  environment: "production"
-  sampleRate: 1.0
-  tracesSampleRate: 0.1
-  # dsn from existingSecret key: sentry-dsn
-
-pyroscope:
-  enabled: true
-  serverAddress: "https://profiles-prod-001.grafana.net"
-  basicAuthUser: "<grafana-cloud-user-id>"
-  # password from existingSecret key: pyroscope-basic-auth-password
-
 # ── Service monitor (Prometheus Operator) ────────────────────────────────────
 serviceMonitor:
   enabled: true
@@ -315,21 +302,34 @@ serviceMonitor:
   labels:
     release: kube-prometheus-stack
 
-# ── App URLs / billing ────────────────────────────────────────────────────────
+# ── App URLs / billing / observability / email ────────────────────────────────
 app:
   baseUrl: "https://api.flexprice.example.com"
+
+  observability:
+    sentry:
+      enabled: true
+      environment: "production"
+      sampleRate: 1.0
+      tracesSampleRate: 0.1
+      # dsn from existingSecret key: sentry-dsn
+
+    pyroscope:
+      enabled: true
+      serverAddress: "https://profiles-prod-001.grafana.net"
+      basicAuthUser: "<grafana-cloud-user-id>"
+      # password from existingSecret key: pyroscope-basic-auth-password
+
+  email:
+    enabled: true
+    provider: "resend"
+    from: "billing@flexprice.example.com"
+    # api key from existingSecret key: email-resend-api-key
 
 billing:
   # Override these with the real production tenant + environment IDs
   tenantId: "<prod-tenant-uuid>"
   environmentId: "<prod-environment-uuid>"
-
-# ── Email / webhooks ──────────────────────────────────────────────────────────
-email:
-  enabled: true
-  provider: "resend"
-  from: "billing@flexprice.example.com"
-  # api key from existingSecret key: email-resend-api-key
 
 webhook:
   enabled: true


### PR DESCRIPTION
## **User description**
## What

Three chart fixes surfaced while standing up a self-managed `selfmanaged-noargo` deployment (us-east-1 dev). Each is independent and backward-compatible.

1. **Kafka topic partitions default to 3** — `create-kafka-topics` in `templates/jobs/migration.yaml` hardcoded `PARTITIONS=${2:-1}` and every call site passed only the topic name, so all topics got a single partition. Adds `migration.kafkaTopics.partitions` (default 3), passed at all 10 create_topic sites. Fresh topics only (raising an existing topic needs `--alter`).

2. **Post-migration verify step** — new final `verify-migrations` initContainer (gated `migration.steps.verify`, default true) that fatally asserts the expected ClickHouse tables (`events`, `meter_usage`) exist and the core Kafka topics were created, before the Job completes. A green migration Job now means the end-state is actually there, not just that the steps exited 0.

3. **sentry / pyroscope / email under `app` hierarchy** — moves the three root-level blocks to `app.observability.sentry`, `app.observability.pyroscope`, `app.email`; updates the `_helpers.tpl` / `secret.yaml` / `configmap.yaml` readers and `values-prod.example.yaml`. A disabled feature omits its keys rather than carrying empty strings at the root.

## Verified

`helm template` renders cleanly: 10 create_topic sites emit `partitions=3`, `verify-migrations` renders when enabled (0 when disabled), no `.Values.sentry`/`.Values.pyroscope`/`.Values.email` references remain, disabled features carry no empty-string keys, enabled sentry still emits `SENTRY_ENABLED`.

Not deploy-verified — validated by render only; the live run is a separate deployment session.


___

## **CodeAnt-AI Description**
Make Helm deployments reproducible and validate migration results

### What Changed
- Workloads and migration jobs can use an image digest to run the exact published image; tags remain supported when no digest is set
- Migration jobs can apply a specified ClickHouse baseline file instead of scanning incremental migrations
- Migrations now default Kafka topics to three partitions and verify required ClickHouse tables and Kafka topics before reporting success
- Sentry, Pyroscope, and email settings are now configured under the `app` hierarchy

### Impact
`✅ Exact image versions across application and migration jobs`
`✅ Fewer deployments marked successful when required data resources are missing`
`✅ Parallel Kafka consumers on newly created topics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deploying images by immutable digest or repository tag.
  * Added optional ClickHouse baseline migration files.
  * Added migration verification for required ClickHouse tables and Kafka topics.
  * Kafka topics now default to three partitions and support configurable partition counts.

* **Configuration**
  * Consolidated observability and email settings under the application configuration.
  * Updated production configuration examples to reflect the new settings structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->