### PR TITLE
perf(meters): route MeterIDs list fetches through cached ListByIDs

### DIFF
--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -463,10 +463,8 @@ func (s *billingService) CalculateUsageCharges(
 	}
 	meterIDs = lo.Uniq(meterIDs)
 
-	// Fetch all meters at once
-	meterFilter := types.NewNoLimitMeterFilter()
-	meterFilter.MeterIDs = meterIDs
-	meters, err := s.MeterRepo.List(ctx, meterFilter)
+	// Fetch all meters at once (routes through per-id cache).
+	meters, err := s.MeterRepo.ListByIDs(ctx, meterIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -104,9 +104,7 @@ func (s *billingService) CalculateMeterUsageCharges(
 	}
 	meterIDs = lo.Uniq(meterIDs)
 
-	meterFilter := types.NewNoLimitMeterFilter()
-	meterFilter.MeterIDs = meterIDs
-	meters, err := s.MeterRepo.List(ctx, meterFilter)
+	meters, err := s.MeterRepo.ListByIDs(ctx, meterIDs)
 	if err != nil {
 		return nil, decimal.Zero, err
 	}

--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -120,9 +120,7 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 
 	// STEP4: Resolve meter metadata in bulk so we know how to interpret the
 	// usage value (regular vs bucketed) when calling PriceService.
-	meterFilter := types.NewNoLimitMeterFilter()
-	meterFilter.MeterIDs = meterIDs
-	meters, err := s.MeterRepo.List(ctx, meterFilter)
+	meters, err := s.MeterRepo.ListByIDs(ctx, meterIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ee/service/entitlement_grant.go
+++ b/internal/ee/service/entitlement_grant.go
@@ -386,9 +386,7 @@ func (s *entitlementGrantService) buildGrantEvalMeta(
 		return f.MeterID, f.MeterID != ""
 	}))
 	if len(meterIDs) > 0 {
-		meterFilter := types.NewNoLimitMeterFilter()
-		meterFilter.MeterIDs = meterIDs
-		meters, err := s.MeterRepo.List(ctx, meterFilter)
+		meters, err := s.MeterRepo.ListByIDs(ctx, meterIDs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ee/service/feature.go
+++ b/internal/ee/service/feature.go
@@ -191,10 +191,8 @@ func (s *featureService) GetFeatures(ctx context.Context, filter *types.FeatureF
 		}
 
 		if len(meterIDs) > 0 {
-			// Create a filter to fetch all meters
-			meterFilter := types.NewNoLimitMeterFilter()
-			meterFilter.MeterIDs = meterIDs
-			meters, err := s.MeterRepo.List(ctx, meterFilter)
+			// Route through per-id cache instead of a raw List filter.
+			meters, err := s.MeterRepo.ListByIDs(ctx, meterIDs)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/ee/service/meter_usage.go
+++ b/internal/ee/service/meter_usage.go
@@ -1994,26 +1994,29 @@ func (s *meterUsageService) toUsageAnalyticsResponseDTO(
 
 // fetchMeters fetches meter configurations for the requested meter IDs.
 func (s *meterUsageService) fetchMeters(ctx context.Context, params *events.MeterUsageDetailedAnalyticsParams) ([]*meter.Meter, error) {
-	filter := types.NewNoLimitMeterFilter()
+	// Known ID set → per-id cache path. Empty set → fall back to full tenant list.
 	if len(params.MeterIDs) > 0 {
-		filter.MeterIDs = params.MeterIDs
+		meters, err := s.MeterRepo.ListByIDs(ctx, params.MeterIDs)
+		if err != nil {
+			return nil, ierr.WithError(err).
+				WithHint("Failed to fetch meters for detailed analytics").
+				Mark(ierr.ErrDatabase)
+		}
+		return meters, nil
 	}
 
-	meters, err := s.MeterRepo.List(ctx, filter)
+	meters, err := s.MeterRepo.List(ctx, types.NewNoLimitMeterFilter())
 	if err != nil {
 		return nil, ierr.WithError(err).
 			WithHint("Failed to fetch meters for detailed analytics").
 			Mark(ierr.ErrDatabase)
 	}
 
-	if len(params.MeterIDs) == 0 {
-		meterIDs := make([]string, len(meters))
-		for i, m := range meters {
-			meterIDs[i] = m.ID
-		}
-		params.MeterIDs = meterIDs
+	meterIDs := make([]string, len(meters))
+	for i, m := range meters {
+		meterIDs[i] = m.ID
 	}
-
+	params.MeterIDs = meterIDs
 	return meters, nil
 }
 


### PR DESCRIPTION
## **User description**
## Summary

- Six service-layer call sites do `MeterRepo.List(ctx, filter{MeterIDs=…})` directly, bypassing `ListByIDs`'s per-id cache. `pg_stat_statements` in production shows the `meters` SELECT as **~46% of total cluster DB time** (193 M calls, avg 2.5 ms). Cache is already enabled in prod but only `GetMeter` / `ListByIDs` use it — `List` doesn't.
- Route those callers to `MeterRepo.ListByIDs` (existing method) so per-id cache hits skip the DB round-trip. Same semantics: `ListByIDs` delegates to `List(filter{MeterIDs=missing})` for cache misses, and the in-memory test store implements both identically.

Touched:
- `internal/ee/service/billing.go` (`CalculateUsageCharges`)
- `internal/ee/service/billing_meter_usage.go` (`CalculateMeterUsageCharges`)
- `internal/ee/service/costsheet_usage_tracking.go` (`GetCostAnalyticsFromMeterUsage`)
- `internal/ee/service/entitlement_grant.go` (`buildGrantEvalMeta`)
- `internal/ee/service/feature.go` (`GetFeatures` meter expand path)
- `internal/ee/service/meter_usage.go` (`fetchMeters`, keeps `List` fallback when no `MeterIDs`)

## Test plan
- [ ] `go build ./internal/...`
- [ ] `go vet ./internal/ee/service/...`
- [ ] `go test -race ./internal/ee/service/... ./internal/repository/...`
- [ ] Manual: after deploy, watch pg_stat_statements — the `meters` SELECT total_time share should drop meaningfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Reduce database reads when loading meters

### What Changed
- Meter lookups by known IDs now use the per-meter cache across billing, feature expansion, entitlement, and usage analytics flows
- Detailed analytics still loads all meters when no IDs are provided
- Existing error handling and meter lookup behavior remain unchanged

### Impact
`✅ Fewer database reads for repeated meter lookups`
`✅ Faster billing and feature-loading requests`
`✅ Lower database load during meter analytics`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved meter lookups across billing, usage tracking, cost analytics, entitlements, and feature lists.
  - Requests for specific meters now use direct ID-based retrieval, reducing unnecessary filtering and improving cache usage.
  - Unrestricted meter searches continue to return the complete available list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->