### PR TITLE
perf(cancel): hoist invoice creation + wallet top-up out of cancel tx

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2031,55 +2031,64 @@ func (s *subscriptionService) CancelSubscription(
 	// non-zero invoice on cancellation is incorrect — skip invoice creation.
 	isTrialing := subscription.SubscriptionStatus == types.SubscriptionStatusTrialing
 
-	// Step 5: Execute in transaction
+	// Step 6 (pre-tx, pure computation): Calculate proration.
+	// Trialing subscriptions have not been charged yet, so proration is not applicable.
+	// This is a read-only aggregation over the live subscription state; running it
+	// outside the tx does not change semantics.
+	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations && !isTrialing {
+		prorationService := NewProrationService(s.ServiceParams)
+		prorationResult, err := prorationService.CalculateSubscriptionCancellationProration(
+			ctx, subscription, lineItems, req.CancellationType, effectiveDate, req.Reason, req.ProrationBehavior)
+		if err != nil {
+			return nil, err
+		}
+		prorationDetails, totalCreditAmount = s.convertProrationResultToDetails(prorationResult)
+	}
+
+	// Determine whether this cancellation should generate a final usage invoice.
+	// Default to skip (no final invoice) when policy is empty; only generate when explicitly requested.
+	invoicePolicy := req.CancelImmediatelyInvoicePolicy
+	if invoicePolicy == "" {
+		invoicePolicy = types.CancelImmediatelyInvoicePolicySkip
+	}
+	// Scheduled cancellations (end_of_period and scheduled_date) do not generate an
+	// immediate invoice — billing continues until the effective date.
+	isScheduled := req.CancellationType == types.CancellationTypeEndOfPeriod ||
+		req.CancellationType == types.CancellationTypeScheduledDate
+	shouldCreateInvoice := !isScheduled &&
+		invoicePolicy == types.CancelImmediatelyInvoicePolicyGenerateInvoice
+
+	// Pre-tx (before the atomic cancel block): Create the final usage invoice.
+	// Runs outside the cancel tx so a Postgres connection is not held during the
+	// synchronous Stripe HTTP charge inside ProcessDraftInvoice → attemptPaymentForSubscriptionInvoice.
+	// Called BEFORE TerminateSubscriptionResources so invoice computation reads
+	// still-active line items.
+	// Fail-open: a failure here does not roll back the cancel; log and continue,
+	// mirroring cancelAllPendingSchedules / createCancellationSchedule below.
+	if shouldCreateInvoice {
+		invoiceService := NewInvoiceService(s.ServiceParams)
+		paymentParams := dto.NewPaymentParametersFromSubscription(subscription.CollectionMethod, subscription.PaymentBehavior, subscription.GatewayPaymentMethodID)
+		paymentParams = paymentParams.NormalizePaymentParameters()
+		inv, _, invErr := invoiceService.CreateSubscriptionInvoice(ctx, &dto.CreateSubscriptionInvoiceRequest{
+			SubscriptionID: subscription.ID,
+			PeriodStart:    subscription.CurrentPeriodStart,
+			PeriodEnd:      effectiveDate,
+			ReferencePoint: types.ReferencePointCancel,
+		}, paymentParams, types.InvoiceFlowCancel, false)
+		if invErr != nil {
+			logger.Error(ctx, "failed to create cancellation invoice; continuing with cancel",
+				"error", invErr,
+				"subscription_id", subscription.ID)
+		} else if inv != nil {
+			logger.Info(ctx, "created invoice for subscription",
+				"subscription_id", subscription.ID,
+				"invoice_id", inv.ID)
+		}
+	}
+
+	// Step 5: Atomic cancel core — status change + resource termination + scheduling.
+	// Kept small so the connection is held only for the short critical section.
 	err = s.DB.WithTx(ctx, func(ctx context.Context) error {
-
-		// Step 6: Calculate proration using unified function
-		// Trialing subscriptions have not been charged yet, so proration is not applicable.
-		if req.ProrationBehavior == types.ProrationBehaviorCreateProrations && !isTrialing {
-			prorationService := NewProrationService(s.ServiceParams)
-			prorationResult, err := prorationService.CalculateSubscriptionCancellationProration(
-				ctx, subscription, lineItems, req.CancellationType, effectiveDate, req.Reason, req.ProrationBehavior)
-			if err != nil {
-				return err
-			}
-
-			// Convert proration result to response format
-			prorationDetails, totalCreditAmount = s.convertProrationResultToDetails(prorationResult)
-		}
-
-		// Default to skip (no final invoice) when policy is empty; only generate when explicitly requested
-		invoicePolicy := req.CancelImmediatelyInvoicePolicy
-		if invoicePolicy == "" {
-			invoicePolicy = types.CancelImmediatelyInvoicePolicySkip
-		}
-		// Scheduled cancellations (end_of_period and scheduled_date) do not generate an
-		// immediate invoice — billing continues until the effective date.
-		isScheduled := req.CancellationType == types.CancellationTypeEndOfPeriod ||
-			req.CancellationType == types.CancellationTypeScheduledDate
-		shouldCreateInvoice := !isScheduled &&
-			invoicePolicy == types.CancelImmediatelyInvoicePolicyGenerateInvoice
-		if shouldCreateInvoice {
-			invoiceService := NewInvoiceService(s.ServiceParams)
-			paymentParams := dto.NewPaymentParametersFromSubscription(subscription.CollectionMethod, subscription.PaymentBehavior, subscription.GatewayPaymentMethodID)
-			paymentParams = paymentParams.NormalizePaymentParameters()
-			inv, _, err := invoiceService.CreateSubscriptionInvoice(ctx, &dto.CreateSubscriptionInvoiceRequest{
-				SubscriptionID: subscription.ID,
-				PeriodStart:    subscription.CurrentPeriodStart,
-				PeriodEnd:      effectiveDate,
-				ReferencePoint: types.ReferencePointCancel,
-			}, paymentParams, types.InvoiceFlowCancel, false)
-			if err != nil {
-				return err
-			}
-
-			if inv != nil {
-				s.Logger.Info(ctx, "created invoice for subscription",
-					"subscription_id", subscription.ID,
-					"invoice_id", inv.ID)
-			}
-
-		}
 
 		// Step 6.5: Capture original state BEFORE modification (for scheduled cancellations)
 		var originalState *subscriptionOriginalState
@@ -2132,16 +2141,6 @@ func (s *subscriptionService) CancelSubscription(
 			}
 		}
 
-		// Step 9: Top up wallet for proration credit (only if there's a credit amount)
-		if totalCreditAmount.GreaterThan(decimal.Zero) && !req.SkipProrationWalletCredit {
-			walletService := NewWalletService(s.ServiceParams)
-			cancelKey := s.buildCancellationProrationKey(subscription, req, effectiveDate)
-			_, err = walletService.TopUpWalletForProratedCharge(ctx, subscription.GetInvoicingCustomerID(), totalCreditAmount.Abs(), subscription.Currency, cancelKey)
-			if err != nil {
-				return err
-			}
-		}
-
 		return nil
 	})
 
@@ -2150,6 +2149,20 @@ func (s *subscriptionService) CancelSubscription(
 		return nil, ierr.WithError(err).
 			WithHint("Failed to process subscription cancellation").
 			Mark(ierr.ErrDatabase)
+	}
+
+	// Step 9 (post-tx): Top up wallet for proration credit. Uses an idempotency key
+	// (cancelKey) so a retry after transient failure is safe. Fail-open like the
+	// invoice creation above — the atomic cancel has already committed.
+	if totalCreditAmount.GreaterThan(decimal.Zero) && !req.SkipProrationWalletCredit {
+		walletService := NewWalletService(s.ServiceParams)
+		cancelKey := s.buildCancellationProrationKey(subscription, req, effectiveDate)
+		if _, walletErr := walletService.TopUpWalletForProratedCharge(ctx, subscription.GetInvoicingCustomerID(), totalCreditAmount.Abs(), subscription.Currency, cancelKey); walletErr != nil {
+			logger.Error(ctx, "failed to top up wallet for proration credit; cancel already committed",
+				"error", walletErr,
+				"subscription_id", subscription.ID,
+				"credit_amount", totalCreditAmount.Abs().String())
+		}
 	}
 
 	if !req.SuppressWebhook {


### PR DESCRIPTION
## **User description**
## Summary

`CancelSubscription` previously ran `CreateSubscriptionInvoice` and `TopUpWalletForProratedCharge` inside the outer `s.DB.WithTx`. Both are heavy:

- `CreateSubscriptionInvoice → ProcessDraftInvoice → attemptPayment` issues a **synchronous HTTP charge to Stripe**, holding the outer Postgres connection for the full round-trip.
- The invoice pipeline itself fans out to many PG + ClickHouse queries plus tax recalculation.

Under load (e2eprobe hammering cancel), the app's Postgres connection pool exhausted while Postgres itself was idle — every other request queued for a connection, producing a sitewide p99 spike. Root cause: the cancel endpoint holding one connection for many seconds per call.

Restructure the flow so the atomic tx holds a connection only for the short critical section:

**Pre-tx** (unchanged code, moved out):
- Proration calculation (already pure)
- `CreateSubscriptionInvoice` — runs before `TerminateSubscriptionResources` so invoice line-item computation reads still-active line items

**Tx (atomic core):**
- `updateSubscriptionForCancellation`
- `CascadeCancelToInheritedSubscriptions`
- `TerminateSubscriptionResources` (immediate only)
- `createCancellationSchedule` (scheduled only)

**Post-tx:**
- `TopUpWalletForProratedCharge` — already idempotent via `buildCancellationProrationKey`
- `publishCancellationEvents` (already outside)

## Failure semantics

Invoice creation and wallet top-up now **fail-open**: they log and continue if they fail, mirroring `cancelAllPendingSchedules` and `createCancellationSchedule` which already behave this way. Rationale: the cancel is the user's primary intent; a downstream billing/wallet failure is recoverable via retry or manual reconciliation, but blocking the cancel on it forces the caller into retry loops that produce the exact pool-exhaustion pattern seen in production. If we want retry-safe invoice creation later, a follow-up PR can wire it through a Temporal workflow.

## Test plan
- [ ] `go build ./internal/ee/service/`
- [ ] `go vet ./internal/ee/service/`
- [ ] `go test -race ./internal/ee/service/ -run 'TestSubscription|TestCancel|TestInvoice|TestProration|TestBilling'`
- [ ] Manual (staging): cancel a subscription with `cancel_immediately_invoice_policy=generate_invoice` and confirm invoice is created, payment attempted, subscription cancelled
- [ ] Manual (staging): kill Stripe reachability, confirm cancel still succeeds and invoice failure is logged
- [ ] Post-deploy: watch p99 of `POST /v1/subscriptions/:id/cancel` in SigNoz; expect drop from ~40 s → ~1 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent cancellation billing work from blocking subscription cancellations

### What Changed
- Subscription cancellations now commit the status change, resource termination, and scheduling without waiting for invoice creation or wallet credit processing.
- Final invoice creation runs before termination so it can use active subscription data; if it fails, the cancellation still proceeds and the failure is logged.
- Proration wallet credits are processed after the cancellation commits; temporary failures no longer roll back the cancellation.
- Proration calculations run outside the cancellation transaction while preserving existing cancellation and invoice policies.

### Impact
`✅ Fewer cancellation timeouts under load`
`✅ Cancellations complete when billing services fail`
`✅ Lower database connection usage during cancellation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subscription cancellation reliability when invoice creation encounters an error.
  - Cancellations now complete successfully without being blocked by optional final invoices.
  - Proration credits are applied after cancellation and recorded appropriately.
  - Resource termination and cancellation scheduling now proceed more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->