### PR TITLE
perf(invoice): add InvoiceLineItemRepo.UpdateBulk, use it in reconcileLineItems

### DIFF
--- a/internal/domain/invoice/line_item_repository.go
+++ b/internal/domain/invoice/line_item_repository.go
@@ -25,6 +25,11 @@ type LineItemRepository interface {
 	// LineItemDiscount, InvoiceLevelDiscount, Metadata, Status, timestamps.
 	Update(ctx context.Context, item *InvoiceLineItem) error
 
+	// UpdateBulk applies Update to many line items in a single SQL round-trip.
+	// Missing IDs are silently skipped (unlike Update, which returns ErrNotFound).
+	// Tenant/environment scoping is enforced.
+	UpdateBulk(ctx context.Context, items []*InvoiceLineItem) error
+
 	// Delete soft-deletes a line item.
 	Delete(ctx context.Context, id string) error
 

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -3229,9 +3229,10 @@ func (s *invoiceService) reconcileLineItems(
 		}
 	}
 
-	// Update matched items in-place
-	for _, item := range toUpdate {
-		if err := s.InvoiceLineItemRepo.Update(ctx, item); err != nil {
+	// Update matched items in-place. Single SQL round-trip via UpdateBulk so
+	// recalculates with many line items don't fan out into N sequential UPDATEs.
+	if len(toUpdate) > 0 {
+		if err := s.InvoiceLineItemRepo.UpdateBulk(ctx, toUpdate); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/repository/ent/invoice_line_item.go
+++ b/internal/repository/ent/invoice_line_item.go
@@ -2,6 +2,7 @@ package ent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -298,6 +299,137 @@ func (r *invoiceLineItemRepository) Update(ctx context.Context, item *domaininvo
 			Mark(ierr.ErrDatabase)
 	}
 
+	SetSpanSuccess(span)
+	return nil
+}
+
+// UpdateBulk updates the mutable field set of many invoice line items in a single
+// SQL round-trip via UPDATE ... FROM (VALUES ...). Mirrors Update: amount, quantity,
+// prepaid_credits_applied, line_item_discount, invoice_level_discount, metadata,
+// commitment_info, status, updated_at, updated_by, and adjusted_entitlement_quantity
+// (SET when non-nil, CLEAR when nil). Missing IDs are silently skipped; tenant and
+// environment scoping is enforced in the outer WHERE.
+func (r *invoiceLineItemRepository) UpdateBulk(ctx context.Context, items []*domaininvoice.InvoiceLineItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	span := StartRepositorySpan(ctx, "invoice_line_item", "update_bulk", map[string]interface{}{
+		"item_count": len(items),
+	})
+	defer FinishSpan(span)
+
+	tenantID := types.GetTenantID(ctx)
+	envID := types.GetEnvironmentID(ctx)
+	updatedAt := time.Now().UTC()
+	updatedBy := types.GetUserID(ctx)
+
+	// 12 placeholders per row (id + 11 mutable columns) plus 2 constant params.
+	// pq's per-statement parameter limit is 65 535; cap chunks to 5000 rows.
+	const paramsPerRow = 12
+	const maxRowsPerChunk = 5000
+
+	err := r.client.WithTx(ctx, func(ctx context.Context) error {
+		writer := r.client.Writer(ctx)
+		for start := 0; start < len(items); start += maxRowsPerChunk {
+			end := start + maxRowsPerChunk
+			if end > len(items) {
+				end = len(items)
+			}
+			chunk := items[start:end]
+
+			valuesRows := make([]string, 0, len(chunk))
+			args := make([]interface{}, 0, paramsPerRow*len(chunk)+2)
+			args = append(args, tenantID, envID)
+			argIdx := 3
+
+			for _, it := range chunk {
+				metadataJSON, mErr := json.Marshal(it.Metadata)
+				if mErr != nil {
+					return ierr.WithError(mErr).
+						WithHint("failed to marshal invoice line item metadata").
+						WithReportableDetails(map[string]any{"line_item_id": it.ID}).
+						Mark(ierr.ErrValidation)
+				}
+				var commitmentArg interface{}
+				if it.CommitmentInfo != nil {
+					cInfoJSON, cErr := json.Marshal(it.CommitmentInfo)
+					if cErr != nil {
+						return ierr.WithError(cErr).
+							WithHint("failed to marshal invoice line item commitment_info").
+							WithReportableDetails(map[string]any{"line_item_id": it.ID}).
+							Mark(ierr.ErrValidation)
+					}
+					commitmentArg = cInfoJSON
+				}
+				var adjQtyArg interface{}
+				if it.AdjustedEntitlementQuantity != nil {
+					adjQtyArg = it.AdjustedEntitlementQuantity.String()
+				}
+
+				valuesRows = append(valuesRows, fmt.Sprintf(
+					"($%d::text, $%d::numeric, $%d::numeric, $%d::numeric, $%d::numeric, $%d::numeric, $%d::jsonb, $%d::jsonb, $%d::text, $%d::timestamptz, $%d::text, $%d::numeric)",
+					argIdx, argIdx+1, argIdx+2, argIdx+3, argIdx+4, argIdx+5,
+					argIdx+6, argIdx+7, argIdx+8, argIdx+9, argIdx+10, argIdx+11,
+				))
+				argIdx += paramsPerRow
+
+				args = append(args,
+					it.ID,
+					it.Amount.String(),
+					it.Quantity.String(),
+					it.PrepaidCreditsApplied.String(),
+					it.LineItemDiscount.String(),
+					it.InvoiceLevelDiscount.String(),
+					metadataJSON,
+					commitmentArg,
+					string(it.Status),
+					updatedAt,
+					updatedBy,
+					adjQtyArg,
+				)
+			}
+
+			query := fmt.Sprintf(`
+				UPDATE invoice_line_items AS t SET
+					amount                        = v.amount,
+					quantity                      = v.quantity,
+					prepaid_credits_applied       = v.prepaid_credits_applied,
+					line_item_discount            = v.line_item_discount,
+					invoice_level_discount        = v.invoice_level_discount,
+					metadata                      = v.metadata,
+					commitment_info               = v.commitment_info,
+					status                        = v.status,
+					updated_at                    = v.updated_at,
+					updated_by                    = v.updated_by,
+					adjusted_entitlement_quantity = v.adjusted_entitlement_quantity
+				FROM (VALUES %s) AS v(
+					id, amount, quantity, prepaid_credits_applied, line_item_discount,
+					invoice_level_discount, metadata, commitment_info, status,
+					updated_at, updated_by, adjusted_entitlement_quantity
+				)
+				WHERE t.id             = v.id
+				  AND t.tenant_id      = $1
+				  AND t.environment_id = $2
+			`, strings.Join(valuesRows, ", "))
+
+			if _, err := writer.ExecContext(ctx, query, args...); err != nil {
+				return ierr.WithError(err).
+					WithHint("failed to bulk update invoice line items").
+					WithReportableDetails(map[string]any{
+						"count":       len(chunk),
+						"batch_start": start,
+					}).
+					Mark(ierr.ErrDatabase)
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		SetSpanError(span, err)
+		return err
+	}
 	SetSpanSuccess(span)
 	return nil
 }

--- a/internal/testutil/inmemory_invoice_line_item_store.go
+++ b/internal/testutil/inmemory_invoice_line_item_store.go
@@ -64,6 +64,23 @@ func (s *InMemoryInvoiceLineItemStore) Update(ctx context.Context, item *invoice
 	return nil
 }
 
+// UpdateBulk mirrors the ent repo semantics: missing IDs are silently skipped.
+func (s *InMemoryInvoiceLineItemStore) UpdateBulk(ctx context.Context, items []*invoice.InvoiceLineItem) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		if _, exists := s.data[item.ID]; !exists {
+			continue
+		}
+		cp := *item
+		s.data[item.ID] = &cp
+	}
+	return nil
+}
+
 func (s *InMemoryInvoiceLineItemStore) Delete(ctx context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## **User description**
## Summary

`reconcileLineItems` (`invoice.go:3415`) previously updated matched `invoice_line_items` one row at a time via a for-loop of `Update` calls. On the update-in-place path (fires on invoice **recalculate** — not on first-cancel), an invoice with N sub-line-item matches emitted N sequential UPDATE round-trips. At 5–50 ms RTT per round-trip this adds meaningful latency for multi-line-item recalculates and holds a Postgres connection for the full duration.

Add `UpdateBulk` on the `LineItemRepository` interface. The ent implementation emits **one** `UPDATE ... FROM (VALUES ...)` per chunk (up to 5000 rows), preserving the exact mutable-field set of `Update`, including:
- SET-or-CLEAR semantics for `adjusted_entitlement_quantity`
- JSONB round-trips for `metadata` and `commitment_info`
- Tenant / environment scoping enforced in the outer WHERE

Missing IDs are silently skipped — matches what SQL naturally does, and callers here always source IDs from an in-scope prior read.

The in-memory test store implements `UpdateBulk` with the same silent-skip semantics; existing service tests continue to pass.

## Note on scope

This does **not** affect the subscription cancellation pool-exhaustion incident (see #2624). The first cancel uses the delete+CreateBulk fallback path, which was already batched. This helps the invoice recalculate flow specifically. Bundled with the perf series for consistency.

## Test plan
- [ ] `go build ./internal/...`
- [ ] `go vet ./internal/repository/ent/... ./internal/ee/service/... ./internal/testutil/... ./internal/domain/invoice/...`
- [ ] `go test -race ./internal/ee/service/ ./internal/repository/ent/`
- [ ] Manual (staging): recalculate an invoice with 10+ line items, confirm behavior matches (line items updated in-place, same field values)
- [ ] Verify PG log shows a single UPDATE for the batch, not N

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Batch invoice line-item updates during recalculation

### What Changed
- Invoice recalculations now update matched line items in batches instead of issuing one database update per item
- Updates preserve existing line-item values, metadata, commitment details, status, and entitlement quantity clearing behavior
- Updates remain limited to the current tenant and environment, while missing line items are skipped

### Impact
`✅ Faster recalculation for invoices with many line items`
`✅ Fewer database round-trips`
`✅ Lower database connection usage during recalculation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Invoice line-item reconciliation now updates multiple items in a single operation, improving processing efficiency.
* **Reliability**
  * Updates remain scoped appropriately and handle missing line items without failing.
  * Nullable values and database errors are handled consistently during bulk updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->