### PR TITLE
chore(temporal): log errors at activity boundary before returning

### DIFF
--- a/internal/api/v1/price.go
+++ b/internal/api/v1/price.go
@@ -223,6 +223,7 @@ func (h *PriceHandler) DeletePrice(c *gin.Context) {
 // @Param lookup_key path string true "Lookup key"
 // @Success 200 {object} dto.PriceResponse
 // @Failure 400 {object} ierr.ErrorResponse "Invalid request"
+// @Failure 404 {object} ierr.ErrorResponse "Price not found"
 // @Failure 500 {object} ierr.ErrorResponse "Server error"
 // @Router /prices/lookup/{lookup_key} [get]
 func (h *PriceHandler) GetByLookupKey(c *gin.Context) {

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -650,6 +650,16 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 
 			subFilter := types.NewNoLimitSubscriptionFilter()
 			subFilter.SubscriptionIDs = subscriptionIDs
+			// Must mirror the discovery query in ListPlanLineItemsToCreateV2 —
+			// SubRepo.List defaults to subscription_status=active when unset,
+			// which would silently drop trialing/draft/incomplete subs and
+			// surface as "price or subscription not found for v2 sync".
+			subFilter.SubscriptionStatus = []types.SubscriptionStatus{
+				types.SubscriptionStatusActive,
+				types.SubscriptionStatusTrialing,
+				types.SubscriptionStatusDraft,
+				types.SubscriptionStatusIncomplete,
+			}
 			subs, serr := s.SubRepo.List(ctx, subFilter)
 			if serr != nil {
 				return nil, serr

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -803,6 +803,14 @@ func (r *priceRepository) GetByLookupKey(ctx context.Context, lookupKey string) 
 		).
 		Only(ctx)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, ierr.WithError(err).
+				WithHintf("Price with lookup key %s was not found", lookupKey).
+				WithReportableDetails(map[string]interface{}{
+					"lookup_key": lookupKey,
+				}).
+				Mark(ierr.ErrNotFound)
+		}
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get price by lookup key").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/temporal/activities/alerts/alerts.go
+++ b/internal/temporal/activities/alerts/alerts.go
@@ -55,6 +55,12 @@ func (a *AlertActivities) SpendAndEntitlementAlertsActivity(ctx context.Context,
 
 	ctx, cust, err := a.prepare(ctx, input.TenantID, input.EnvironmentID, input.CustomerID)
 	if err != nil {
+		a.logger.Error(ctx, "SpendAndEntitlementAlertsActivity failed to prepare",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+			"customer_id", input.CustomerID,
+		)
 		return err
 	}
 	if cust == nil {
@@ -62,7 +68,16 @@ func (a *AlertActivities) SpendAndEntitlementAlertsActivity(ctx context.Context,
 		return nil
 	}
 
-	return service.NewAlertService(a.serviceParams).EvaluateSpendAndEntitlementAlertsForCustomer(ctx, cust, input.SpendAlertsEnabled, input.EntitlementAlertsEnabled)
+	if err := service.NewAlertService(a.serviceParams).EvaluateSpendAndEntitlementAlertsForCustomer(ctx, cust, input.SpendAlertsEnabled, input.EntitlementAlertsEnabled); err != nil {
+		a.logger.Error(ctx, "SpendAndEntitlementAlertsActivity failed",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+			"customer_id", input.CustomerID,
+		)
+		return err
+	}
+	return nil
 }
 
 // WalletAlertsActivity evaluates wallet-balance alerts and auto-topup.
@@ -75,6 +90,12 @@ func (a *AlertActivities) WalletAlertsActivity(ctx context.Context, input models
 
 	ctx, cust, err := a.prepare(ctx, input.TenantID, input.EnvironmentID, input.CustomerID)
 	if err != nil {
+		a.logger.Error(ctx, "WalletAlertsActivity failed to prepare",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+			"customer_id", input.CustomerID,
+		)
 		return err
 	}
 	if cust == nil {
@@ -84,5 +105,14 @@ func (a *AlertActivities) WalletAlertsActivity(ctx context.Context, input models
 
 	// Run-id-seeded idempotency: retries within the same firing dedupe to one topup.
 	autoTopupSeed := activity.GetInfo(ctx).WorkflowExecution.RunID
-	return service.NewAlertService(a.serviceParams).EvaluateWalletAlertsForCustomer(ctx, cust, autoTopupSeed)
+	if err := service.NewAlertService(a.serviceParams).EvaluateWalletAlertsForCustomer(ctx, cust, autoTopupSeed); err != nil {
+		a.logger.Error(ctx, "WalletAlertsActivity failed",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+			"customer_id", input.CustomerID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/chargebee/customer_sync_activities.go
+++ b/internal/temporal/activities/chargebee/customer_sync_activities.go
@@ -30,9 +30,23 @@ func (a *CustomerSyncActivities) SyncCustomerToChargebee(ctx context.Context, in
 
 	chargebeeIntegration, err := a.integrationFactory.GetChargebeeIntegration(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "SyncCustomerToChargebee activity failed: get integration",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = chargebeeIntegration.CustomerSvc.EnsureCustomerSyncedToChargebee(ctx, input.CustomerID)
-	return err
+	if _, err = chargebeeIntegration.CustomerSvc.EnsureCustomerSyncedToChargebee(ctx, input.CustomerID); err != nil {
+		a.logger.Error(ctx, "SyncCustomerToChargebee activity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/cron/checkout_session_expiry_activities.go
+++ b/internal/temporal/activities/cron/checkout_session_expiry_activities.go
@@ -27,6 +27,9 @@ func (a *CheckoutSessionExpiryActivities) ExpireCheckoutSessionsActivity(ctx con
 	now := time.Now().UTC()
 	r, err := a.checkoutSvc.CleanupAllExpiredSessions(ctx, &now)
 	if err != nil {
+		a.logger.Error(ctx, "ExpireCheckoutSessionsActivity failed",
+			"error", err,
+		)
 		return nil, err
 	}
 	return &cronModels.CheckoutSessionExpiryWorkflowResult{

--- a/internal/temporal/activities/cron/creditgrant_activities.go
+++ b/internal/temporal/activities/cron/creditgrant_activities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/flexprice/flexprice/internal/ee/service"
+	"github.com/flexprice/flexprice/internal/logger"
 	cronModels "github.com/flexprice/flexprice/internal/temporal/models"
 	"go.temporal.io/sdk/activity"
 )
@@ -11,11 +12,12 @@ import (
 // CreditGrantActivities wraps credit-grant cron logic as Temporal activities.
 type CreditGrantActivities struct {
 	creditGrantService service.CreditGrantService
+	logger             *logger.Logger
 }
 
 // NewCreditGrantActivities builds credit-grant cron activities.
-func NewCreditGrantActivities(creditGrantService service.CreditGrantService) *CreditGrantActivities {
-	return &CreditGrantActivities{creditGrantService: creditGrantService}
+func NewCreditGrantActivities(creditGrantService service.CreditGrantService, log *logger.Logger) *CreditGrantActivities {
+	return &CreditGrantActivities{creditGrantService: creditGrantService, logger: log}
 }
 
 // ProcessScheduledCreditGrantApplicationsActivity processes all scheduled credit grant applications.
@@ -25,6 +27,9 @@ func (a *CreditGrantActivities) ProcessScheduledCreditGrantApplicationsActivity(
 
 	resp, err := a.creditGrantService.ProcessScheduledCreditGrantApplications(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "ProcessScheduledCreditGrantApplicationsActivity failed",
+			"error", err,
+		)
 		return nil, err
 	}
 

--- a/internal/temporal/activities/cron/daily_draft_and_compute_activities.go
+++ b/internal/temporal/activities/cron/daily_draft_and_compute_activities.go
@@ -46,6 +46,9 @@ func (a *DailyDraftAndComputeActivities) DailyDraftAndComputeActivity(
 	subs, err := a.invoiceService.ListSubscriptionsDueForDailyDraftCompute(ctx)
 	if err != nil {
 		log.Error("Failed to list subscriptions due for daily draft-and-compute", "error", err)
+		a.logger.Error(ctx, "DailyDraftAndComputeActivity failed to list subscriptions",
+			"error", err,
+		)
 		return nil, err
 	}
 	result.TotalDueSubscriptions = len(subs)
@@ -82,7 +85,14 @@ func (a *DailyDraftAndComputeActivities) DailyDraftAndComputeActivity(
 		"failed", result.FailedCount)
 
 	if result.FailedCount > 0 {
-		return nil, fmt.Errorf("failed to trigger %d daily draft-and-compute workflows", result.FailedCount)
+		err := fmt.Errorf("failed to trigger %d daily draft-and-compute workflows", result.FailedCount)
+		a.logger.Error(ctx, "DailyDraftAndComputeActivity had subscription failures",
+			"error", err,
+			"failed_count", result.FailedCount,
+			"triggered_count", result.TriggeredCount,
+			"total_due_subscriptions", result.TotalDueSubscriptions,
+		)
+		return nil, err
 	}
 
 	return result, nil

--- a/internal/temporal/activities/cron/subscription_activities.go
+++ b/internal/temporal/activities/cron/subscription_activities.go
@@ -31,6 +31,9 @@ func (a *SubscriptionCronActivities) ProcessAutoCancellationActivity(ctx context
 	log.Info("Processing subscription auto-cancellations")
 
 	if err := a.subscriptionService.ProcessAutoCancellationSubscriptions(ctx); err != nil {
+		a.logger.Error(ctx, "ProcessAutoCancellationActivity failed",
+			"error", err,
+		)
 		return nil, err
 	}
 
@@ -45,6 +48,9 @@ func (a *SubscriptionCronActivities) UpdateBillingPeriodsActivity(ctx context.Co
 	log.Info("Updating subscription billing periods (cron activity)")
 	_, err := a.subscriptionService.UpdateBillingPeriods(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "UpdateBillingPeriodsActivity failed",
+			"error", err,
+		)
 		return nil, err
 	}
 	return &cronModels.SubscriptionBillingPeriodsWorkflowResult{}, nil
@@ -56,6 +62,9 @@ func (a *SubscriptionCronActivities) ProcessTrialEndDueActivity(ctx context.Cont
 	log.Info("Processing trial end due subscriptions (cron activity)")
 	resp, err := a.subscriptionService.ProcessTrialEndDue(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "ProcessTrialEndDueActivity failed",
+			"error", err,
+		)
 		return nil, err
 	}
 	return &cronModels.SubscriptionTrialEndDueWorkflowResult{
@@ -73,6 +82,10 @@ func (a *SubscriptionCronActivities) ProcessRenewalDueAlertsActivity(ctx context
 		runTime = time.Now()
 	}
 	if err := a.subscriptionService.ProcessSubscriptionRenewalDueAlert(ctx, runTime); err != nil {
+		a.logger.Error(ctx, "ProcessRenewalDueAlertsActivity failed",
+			"error", err,
+			"run_time", runTime,
+		)
 		return nil, err
 	}
 	return &cronModels.SubscriptionRenewalDueAlertsWorkflowResult{}, nil
@@ -85,6 +98,9 @@ func (a *SubscriptionCronActivities) ProcessAutoInvoiceThresholdBillingActivity(
 
 	result, err := a.subscriptionService.ProcessAutoInvoiceThresholdBilling(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "ProcessAutoInvoiceThresholdBillingActivity failed",
+			"error", err,
+		)
 		return nil, err
 	}
 

--- a/internal/temporal/activities/customer/customer_activities.go
+++ b/internal/temporal/activities/customer/customer_activities.go
@@ -78,6 +78,12 @@ func (a *CustomerActivities) CreateCustomerActivity(ctx context.Context, input m
 
 	customerResp, err := customerService.CreateCustomer(ctx, createCustomerReq)
 	if err != nil {
+		a.logger.Error(ctx, "CreateCustomerActivity failed",
+			"error", err,
+			"external_id", input.ExternalID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to create customer").
 			WithReportableDetails(map[string]interface{}{
@@ -133,6 +139,13 @@ func (a *CustomerActivities) CreateWalletActivity(ctx context.Context, input mod
 	// Create the wallet
 	walletResp, err := walletService.CreateWallet(ctx, walletDTOReq)
 	if err != nil {
+		a.logger.Error(ctx, "CreateWalletActivity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"currency", input.WalletConfig.Currency,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to create wallet").
 			WithReportableDetails(map[string]interface{}{
@@ -178,6 +191,13 @@ func (a *CustomerActivities) CreateSubscriptionActivity(ctx context.Context, inp
 		PlanID: input.SubscriptionConfig.PlanID,
 	})
 	if err != nil {
+		a.logger.Error(ctx, "CreateSubscriptionActivity failed to get prices for plan",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"plan_id", input.SubscriptionConfig.PlanID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get prices for plan").
 			WithReportableDetails(map[string]interface{}{
@@ -219,6 +239,14 @@ func (a *CustomerActivities) CreateSubscriptionActivity(ctx context.Context, inp
 	// Create the subscription
 	subResp, err := subscriptionService.CreateSubscription(ctx, *subDTOReq)
 	if err != nil {
+		a.logger.Error(ctx, "CreateSubscriptionActivity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"plan_id", input.SubscriptionConfig.PlanID,
+			"currency", currency,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to create subscription").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/temporal/activities/environment/environment_activities.go
+++ b/internal/temporal/activities/environment/environment_activities.go
@@ -77,6 +77,12 @@ func (a *EnvironmentActivities) CloneEnvironmentFeatures(ctx context.Context, in
 	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
 	sourceFeatures, err := a.params.FeatureRepo.List(sourceCtx, filter)
 	if err != nil {
+		a.params.Logger.Error(ctx, "CloneEnvironmentFeatures failed to list source features",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"source_environment_id", input.SourceEnvironmentID,
+			"target_environment_id", input.TargetEnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to list features from source environment").
 			Mark(ierr.ErrDatabase)
@@ -85,6 +91,12 @@ func (a *EnvironmentActivities) CloneEnvironmentFeatures(ctx context.Context, in
 	// Build index of existing target features by lookup_key for idempotency check
 	targetFeatures, err := a.params.FeatureRepo.List(targetCtx, filter)
 	if err != nil {
+		a.params.Logger.Error(ctx, "CloneEnvironmentFeatures failed to list target features",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"source_environment_id", input.SourceEnvironmentID,
+			"target_environment_id", input.TargetEnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to list features from target environment").
 			Mark(ierr.ErrDatabase)
@@ -249,6 +261,12 @@ func (a *EnvironmentActivities) CloneEnvironmentPlans(ctx context.Context, input
 	// Build feature/meter ID maps: source → target by lookup_key
 	featureIDMap, meterIDMap, err := a.buildCrossEnvIDMaps(sourceCtx, targetCtx)
 	if err != nil {
+		a.params.Logger.Error(ctx, "CloneEnvironmentPlans failed to build cross-env ID maps",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"source_environment_id", input.SourceEnvironmentID,
+			"target_environment_id", input.TargetEnvironmentID,
+		)
 		return nil, err
 	}
 
@@ -260,6 +278,12 @@ func (a *EnvironmentActivities) CloneEnvironmentPlans(ctx context.Context, input
 	planFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
 	sourcePlans, err := a.params.PlanRepo.List(sourceCtx, planFilter)
 	if err != nil {
+		a.params.Logger.Error(ctx, "CloneEnvironmentPlans failed to list source plans",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"source_environment_id", input.SourceEnvironmentID,
+			"target_environment_id", input.TargetEnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to list plans from source environment").
 			Mark(ierr.ErrDatabase)
@@ -268,6 +292,12 @@ func (a *EnvironmentActivities) CloneEnvironmentPlans(ctx context.Context, input
 	// Build index of existing target plans by lookup_key for idempotency
 	targetPlans, err := a.params.PlanRepo.List(targetCtx, planFilter)
 	if err != nil {
+		a.params.Logger.Error(ctx, "CloneEnvironmentPlans failed to list target plans",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"source_environment_id", input.SourceEnvironmentID,
+			"target_environment_id", input.TargetEnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to list plans from target environment").
 			Mark(ierr.ErrDatabase)

--- a/internal/temporal/activities/events/reprocess_raw_events_activity.go
+++ b/internal/temporal/activities/events/reprocess_raw_events_activity.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/flexprice/flexprice/internal/domain/events"
-	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
 	models "github.com/flexprice/flexprice/internal/temporal/models/events"
 	"github.com/flexprice/flexprice/internal/types"
 	"go.temporal.io/sdk/activity"
@@ -16,12 +17,14 @@ const RawEventsActivityPrefix = "RawEventsActivities"
 // ReprocessRawEventsActivities contains all raw event reprocessing activities
 type ReprocessRawEventsActivities struct {
 	rawEventsReprocessingService service.RawEventsReprocessingService
+	logger                       *logger.Logger
 }
 
 // NewReprocessRawEventsActivities creates a new ReprocessRawEventsActivities instance
-func NewReprocessRawEventsActivities(rawEventsReprocessingService service.RawEventsReprocessingService) *ReprocessRawEventsActivities {
+func NewReprocessRawEventsActivities(rawEventsReprocessingService service.RawEventsReprocessingService, log *logger.Logger) *ReprocessRawEventsActivities {
 	return &ReprocessRawEventsActivities{
 		rawEventsReprocessingService: rawEventsReprocessingService,
+		logger:                       log,
 	}
 }
 
@@ -73,6 +76,13 @@ func (a *ReprocessRawEventsActivities) ReprocessRawEvents(ctx context.Context, i
 			"external_customer_ids", input.ExternalCustomerIDs,
 			"event_names", input.EventNames,
 			"error", err)
+		a.logger.Error(ctx, "ReprocessRawEvents activity failed",
+			"error", err,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+			"external_customer_ids", input.ExternalCustomerIDs,
+			"event_names", input.EventNames,
+		)
 		return response, ierr.WithError(err).
 			WithHint("Failed to reprocess raw events").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/temporal/activities/export/task_activity.go
+++ b/internal/temporal/activities/export/task_activity.go
@@ -137,6 +137,12 @@ func (a *TaskActivity) UpdateTaskStatus(ctx context.Context, input UpdateTaskSta
 
 	existingTask, err := a.taskRepo.Get(ctx, input.TaskID)
 	if err != nil {
+		a.logger.Error(ctx, "UpdateTaskStatus activity failed",
+			"error", err,
+			"task_id", input.TaskID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvID,
+		)
 		return ierr.WithError(err).
 			WithHint("Failed to get task").
 			Mark(ierr.ErrDatabase)
@@ -218,6 +224,12 @@ func (a *TaskActivity) CompleteTask(ctx context.Context, input CompleteTaskInput
 
 	existingTask, err := a.taskRepo.Get(ctx, input.TaskID)
 	if err != nil {
+		a.logger.Error(ctx, "CompleteTask activity failed",
+			"error", err,
+			"task_id", input.TaskID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvID,
+		)
 		return ierr.WithError(err).
 			WithHint("Failed to get task").
 			Mark(ierr.ErrDatabase)

--- a/internal/temporal/activities/invoice/invoice_activities.go
+++ b/internal/temporal/activities/invoice/invoice_activities.go
@@ -74,6 +74,12 @@ func (s *InvoiceActivities) CreateDraftForCurrentSubscriptionPeriodActivity(
 
 	sub, err := s.serviceParams.SubRepo.Get(ctx, input.SubscriptionID)
 	if err != nil {
+		s.logger.Error(ctx, "CreateDraftForCurrentSubscriptionPeriodActivity failed",
+			"error", err,
+			"subscription_id", input.SubscriptionID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 	periodStart := sub.CurrentPeriodStart

--- a/internal/temporal/activities/nomod/customer_sync_activities.go
+++ b/internal/temporal/activities/nomod/customer_sync_activities.go
@@ -34,9 +34,23 @@ func (a *CustomerSyncActivities) SyncCustomerToNomod(ctx context.Context, input 
 
 	nomodIntegration, err := a.integrationFactory.GetNomodIntegration(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "SyncCustomerToNomod activity failed: get integration",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = nomodIntegration.CustomerSvc.EnsureCustomerSyncedToNomod(ctx, input.CustomerID, a.customerService)
-	return err
+	if _, err = nomodIntegration.CustomerSvc.EnsureCustomerSyncedToNomod(ctx, input.CustomerID, a.customerService); err != nil {
+		a.logger.Error(ctx, "SyncCustomerToNomod activity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/paddle/customer_sync_activities.go
+++ b/internal/temporal/activities/paddle/customer_sync_activities.go
@@ -44,13 +44,27 @@ func (a *CustomerSyncActivities) SyncCustomerToPaddle(ctx context.Context, input
 	paddleIntegration, err := a.integrationFactory.GetPaddleIntegration(ctx)
 	if err != nil {
 		// Let Temporal retry transient integration lookup failures.
+		a.logger.Error(ctx, "SyncCustomerToPaddle activity failed: get integration",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = paddleIntegration.SyncSvc.EnsureCustomerSynced(ctx, paddleintg.EnsureCustomerSyncedRequest{
+	if _, err = paddleIntegration.SyncSvc.EnsureCustomerSynced(ctx, paddleintg.EnsureCustomerSyncedRequest{
 		CustomerID: input.CustomerID,
-	})
-	return err
+	}); err != nil {
+		a.logger.Error(ctx, "SyncCustomerToPaddle activity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }
 
 // EnsureCustomerSyncedToPaddle is called from PaddleInvoiceSyncWorkflow as an explicit pre-check

--- a/internal/temporal/activities/paddle/subscription_sync_activities.go
+++ b/internal/temporal/activities/paddle/subscription_sync_activities.go
@@ -67,6 +67,13 @@ func (a *SubscriptionSyncActivities) SyncSubscriptionToPaddle(
 	// Load the full subscription with line items.
 	sub, _, fetchErr := paddleIntegration.SyncSvc.GetSubscriptionWithLineItems(ctx, input.SubscriptionID)
 	if fetchErr != nil {
+		a.logger.Error(ctx, "SyncSubscriptionToPaddle activity failed: fetch subscription",
+			"error", fetchErr,
+			"subscription_id", input.SubscriptionID,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return fmt.Errorf("fetching subscription: %w", fetchErr)
 	}
 
@@ -91,6 +98,13 @@ func (a *SubscriptionSyncActivities) SyncSubscriptionToPaddle(
 		if ierr.IsValidation(prodErr) {
 			return temporal.NewNonRetryableApplicationError(prodErr.Error(), "ValidationError", prodErr)
 		}
+		a.logger.Error(ctx, "SyncSubscriptionToPaddle activity failed: sync products",
+			"error", prodErr,
+			"subscription_id", input.SubscriptionID,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return fmt.Errorf("syncing products: %w", prodErr)
 	}
 
@@ -139,6 +153,14 @@ func (a *SubscriptionSyncActivities) CheckSubscriptionSyncStatus(
 				"invoice_id", input.InvoiceID)
 			return &models.SubscriptionSyncStatusResult{Status: "activated"}, nil
 		}
+		a.logger.Error(ctx, "CheckSubscriptionSyncStatus activity failed: get integration",
+			"error", err,
+			"invoice_id", input.InvoiceID,
+			"subscription_id", input.SubscriptionID,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 
@@ -148,6 +170,12 @@ func (a *SubscriptionSyncActivities) CheckSubscriptionSyncStatus(
 	if subID == "" || customerID == "" {
 		inv, invErr := paddleIntegration.SyncSvc.GetInvoiceByID(ctx, input.InvoiceID)
 		if invErr != nil {
+			a.logger.Error(ctx, "CheckSubscriptionSyncStatus activity failed: fetch invoice",
+				"error", invErr,
+				"invoice_id", input.InvoiceID,
+				"tenant_id", input.TenantID,
+				"environment_id", input.EnvironmentID,
+			)
 			return nil, fmt.Errorf("fetching invoice to resolve subscription_id: %w", invErr)
 		}
 		if subID == "" {
@@ -169,6 +197,14 @@ func (a *SubscriptionSyncActivities) CheckSubscriptionSyncStatus(
 
 	activated, err := paddleIntegration.SyncSvc.GetSubscriptionMappingStatus(ctx, subID)
 	if err != nil {
+		a.logger.Error(ctx, "CheckSubscriptionSyncStatus activity failed: get subscription mapping status",
+			"error", err,
+			"subscription_id", subID,
+			"invoice_id", input.InvoiceID,
+			"customer_id", customerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 	if activated {

--- a/internal/temporal/activities/plan/plan_activities.go
+++ b/internal/temporal/activities/plan/plan_activities.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/cache"
+	"github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
-	"github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/types"
 )
 
@@ -18,12 +18,14 @@ const ActivityPrefix = "PlanActivities"
 // When registered with Temporal, methods will be called as "PlanActivities.SyncPlanPrices"
 type PlanActivities struct {
 	planService service.PlanService
+	logger      *logger.Logger
 }
 
 // NewPlanActivities creates a new PlanActivities instance
-func NewPlanActivities(planService service.PlanService) *PlanActivities {
+func NewPlanActivities(planService service.PlanService, logger *logger.Logger) *PlanActivities {
 	return &PlanActivities{
 		planService: planService,
+		logger:      logger,
 	}
 }
 
@@ -57,21 +59,26 @@ func (a *PlanActivities) SyncPlanPrices(ctx context.Context, input SyncPlanPrice
 	ctx = types.SetUserID(ctx, input.UserID)
 
 	lockKey := cache.PrefixPriceSyncLock + input.PlanID
-	log := logger.NewNoopLogger()
 	defer func() {
 		redisCache := cache.GetRedisCache()
 		if redisCache == nil {
-			log.Info(context.Background(), "price_sync_lock_release_skipped", "plan_id", input.PlanID, "lock_key", lockKey, "reason", "redis_cache_nil")
+			a.logger.Info(context.Background(), "price_sync_lock_release_skipped", "plan_id", input.PlanID, "lock_key", lockKey, "reason", "redis_cache_nil")
 			return
 		}
 		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		redisCache.Delete(releaseCtx, lockKey)
-		log.Info(ctx, "price_sync_lock_released", "plan_id", input.PlanID, "lock_key", lockKey)
+		a.logger.Info(ctx, "price_sync_lock_released", "plan_id", input.PlanID, "lock_key", lockKey)
 	}()
 
 	result, err := a.planService.SyncPlanPrices(ctx, input.PlanID)
 	if err != nil {
+		a.logger.Error(ctx, "SyncPlanPrices activity failed",
+			"error", err,
+			"plan_id", input.PlanID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 
@@ -99,19 +106,27 @@ func (a *PlanActivities) SyncPlanPricesV2(ctx context.Context, input SyncPlanPri
 	ctx = types.SetUserID(ctx, input.UserID)
 
 	lockKey := cache.PrefixPriceSyncLock + input.PlanID
-	log := logger.NewNoopLogger()
 	defer func() {
 		redisCache := cache.GetRedisCache()
 		if redisCache == nil {
-			log.Info(context.Background(), "price_sync_lock_release_skipped", "plan_id", input.PlanID, "lock_key", lockKey, "reason", "redis_cache_nil")
+			a.logger.Info(context.Background(), "price_sync_lock_release_skipped", "plan_id", input.PlanID, "lock_key", lockKey, "reason", "redis_cache_nil")
 			return
 		}
 		releaseCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		redisCache.Delete(releaseCtx, lockKey)
-		log.Info(ctx, "price_sync_lock_released", "plan_id", input.PlanID, "lock_key", lockKey, "version", "v2")
+		a.logger.Info(ctx, "price_sync_lock_released", "plan_id", input.PlanID, "lock_key", lockKey, "version", "v2")
 	}()
 
-	return a.planService.SyncPlanPricesV2(ctx, input.PlanID)
+	result, err := a.planService.SyncPlanPricesV2(ctx, input.PlanID)
+	if err != nil {
+		a.logger.Error(ctx, "SyncPlanPricesV2 activity failed",
+			"error", err,
+			"plan_id", input.PlanID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return nil, err
+	}
+	return result, nil
 }
-

--- a/internal/temporal/activities/prepareprocessedevents/prepare_processed_events_activities.go
+++ b/internal/temporal/activities/prepareprocessedevents/prepare_processed_events_activities.go
@@ -168,6 +168,13 @@ func (a *PrepareProcessedEventsActivities) RolloutToSubscriptionsActivity(
 	}
 	subsResponse, err := subscriptionService.ListSubscriptions(ctx, subscriptionFilter)
 	if err != nil {
+		logger.Error(ctx, "RolloutToSubscriptionsActivity failed",
+			"error", err,
+			"plan_id", input.PlanID,
+			"price_id", input.PriceID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to list subscriptions for plan").
 			Mark(ierr.ErrDatabase)

--- a/internal/temporal/activities/quickbooks/customer_sync_activities.go
+++ b/internal/temporal/activities/quickbooks/customer_sync_activities.go
@@ -34,14 +34,34 @@ func (a *QuickBooksCustomerSyncActivities) SyncCustomerToQuickBooks(ctx context.
 
 	qbIntegration, err := a.integrationFactory.GetQuickBooksIntegration(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "SyncCustomerToQuickBooks activity failed to get QuickBooks integration",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
 	custResp, err := a.customerService.GetCustomer(ctx, input.CustomerID)
 	if err != nil {
+		a.logger.Error(ctx, "SyncCustomerToQuickBooks activity failed to get customer",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = qbIntegration.CustomerSvc.GetOrCreateQuickBooksCustomer(ctx, custResp.Customer)
-	return err
+	if _, err := qbIntegration.CustomerSvc.GetOrCreateQuickBooksCustomer(ctx, custResp.Customer); err != nil {
+		a.logger.Error(ctx, "SyncCustomerToQuickBooks activity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/quickbooks/price_sync_activities.go
+++ b/internal/temporal/activities/quickbooks/price_sync_activities.go
@@ -92,6 +92,13 @@ func (a *QuickBooksPriceSyncActivities) SyncPriceToQuickBooks(ctx context.Contex
 					Mark(ierr.ErrNotFound),
 			)
 		}
+		a.logger.Error(ctx, "SyncPriceToQuickBooks activity failed to get QuickBooks integration",
+			"error", err,
+			"price_id", input.PriceID,
+			"plan_id", input.PlanID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get QuickBooks integration").
 			Mark(ierr.ErrInternal)
@@ -100,6 +107,13 @@ func (a *QuickBooksPriceSyncActivities) SyncPriceToQuickBooks(ctx context.Contex
 	// Get plan
 	plan, err := a.planRepo.Get(ctx, input.PlanID)
 	if err != nil {
+		a.logger.Error(ctx, "SyncPriceToQuickBooks activity failed to get plan",
+			"error", err,
+			"price_id", input.PriceID,
+			"plan_id", input.PlanID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get plan").
 			WithReportableDetails(map[string]interface{}{
@@ -111,6 +125,13 @@ func (a *QuickBooksPriceSyncActivities) SyncPriceToQuickBooks(ctx context.Contex
 	// Get price
 	priceModel, err := a.priceRepo.Get(ctx, input.PriceID)
 	if err != nil {
+		a.logger.Error(ctx, "SyncPriceToQuickBooks activity failed to get price",
+			"error", err,
+			"price_id", input.PriceID,
+			"plan_id", input.PlanID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get price").
 			WithReportableDetails(map[string]interface{}{

--- a/internal/temporal/activities/razorpay/customer_sync_activities.go
+++ b/internal/temporal/activities/razorpay/customer_sync_activities.go
@@ -34,9 +34,23 @@ func (a *CustomerSyncActivities) SyncCustomerToRazorpay(ctx context.Context, inp
 
 	razorpayIntegration, err := a.integrationFactory.GetRazorpayIntegration(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "SyncCustomerToRazorpay activity failed to get Razorpay integration",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = razorpayIntegration.CustomerSvc.EnsureCustomerSyncedToRazorpay(ctx, input.CustomerID, a.customerService)
-	return err
+	if _, err := razorpayIntegration.CustomerSvc.EnsureCustomerSyncedToRazorpay(ctx, input.CustomerID, a.customerService); err != nil {
+		a.logger.Error(ctx, "SyncCustomerToRazorpay activity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/stripe/customer_sync_activities.go
+++ b/internal/temporal/activities/stripe/customer_sync_activities.go
@@ -34,9 +34,23 @@ func (a *CustomerSyncActivities) SyncCustomerToStripe(ctx context.Context, input
 
 	stripeIntegration, err := a.integrationFactory.GetStripeIntegration(ctx)
 	if err != nil {
+		a.logger.Error(ctx, "SyncCustomerToStripe activity failed to get Stripe integration",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = stripeIntegration.CustomerSvc.EnsureCustomerSyncedToStripe(ctx, input.CustomerID, a.customerService)
-	return err
+	if _, err := stripeIntegration.CustomerSvc.EnsureCustomerSyncedToStripe(ctx, input.CustomerID, a.customerService); err != nil {
+		a.logger.Error(ctx, "SyncCustomerToStripe activity failed",
+			"error", err,
+			"customer_id", input.CustomerID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -53,6 +53,12 @@ func (s *BillingActivities) CheckDraftSubscriptionActivity(
 
 	sub, err := s.serviceParams.SubRepo.Get(ctx, input.SubscriptionID)
 	if err != nil {
+		s.logger.Error(ctx, "CheckDraftSubscriptionActivity failed",
+			"error", err,
+			"subscription_id", input.SubscriptionID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 
@@ -91,6 +97,12 @@ func (s *BillingActivities) CalculatePeriodsActivity(
 
 	periods, err := subscriptionService.CalculateBillingPeriods(ctx, input.SubscriptionID)
 	if err != nil {
+		s.logger.Error(ctx, "CalculatePeriodsActivity failed",
+			"error", err,
+			"subscription_id", input.SubscriptionID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 
@@ -165,6 +177,12 @@ func (s *BillingActivities) UpdateCurrentPeriodActivity(
 	// Get the subscription
 	sub, err := s.serviceParams.SubRepo.Get(ctx, input.SubscriptionID)
 	if err != nil {
+		s.logger.Error(ctx, "UpdateCurrentPeriodActivity failed",
+			"error", err,
+			"subscription_id", input.SubscriptionID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 
@@ -287,6 +305,12 @@ func (s *BillingActivities) CheckCancellationActivity(
 
 	sub, err := s.serviceParams.SubRepo.Get(ctx, input.SubscriptionID)
 	if err != nil {
+		s.logger.Error(ctx, "CheckCancellationActivity failed",
+			"error", err,
+			"subscription_id", input.SubscriptionID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, err
 	}
 

--- a/internal/temporal/activities/tabs/invoice_sync_activities.go
+++ b/internal/temporal/activities/tabs/invoice_sync_activities.go
@@ -33,11 +33,25 @@ func (a *InvoiceSyncActivities) SyncInvoiceToTabs(ctx context.Context, input mod
 		if ierr.IsNotFound(err) {
 			return temporal.NewNonRetryableApplicationError("Tabs connection not configured", "ConnectionNotFound", err)
 		}
+		a.logger.Error(ctx, "SyncInvoiceToTabs activity failed to get Tabs integration",
+			"error", err,
+			"invoice_id", input.InvoiceID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
-	_, err = tabsIntegration.InvoiceSvc.SyncInvoiceToTabs(ctx, tabs.TabsInvoiceSyncRequest{
+	if _, err := tabsIntegration.InvoiceSvc.SyncInvoiceToTabs(ctx, tabs.TabsInvoiceSyncRequest{
 		InvoiceID: input.InvoiceID,
-	})
-	return err
+	}); err != nil {
+		a.logger.Error(ctx, "SyncInvoiceToTabs activity failed",
+			"error", err,
+			"invoice_id", input.InvoiceID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/activities/task/task_activities.go
+++ b/internal/temporal/activities/task/task_activities.go
@@ -6,6 +6,7 @@ import (
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/ee/service"
+	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/temporal/models"
 	"github.com/flexprice/flexprice/internal/types"
 )
@@ -15,12 +16,14 @@ const TaskActivityPrefix = "TaskActivities"
 // TaskActivities contains all task-related activities
 type TaskActivities struct {
 	taskService service.TaskService
+	logger      *logger.Logger
 }
 
 // NewTaskActivities creates a new TaskActivities instance
-func NewTaskActivities(taskService service.TaskService) *TaskActivities {
+func NewTaskActivities(taskService service.TaskService, logger *logger.Logger) *TaskActivities {
 	return &TaskActivities{
 		taskService: taskService,
+		logger:      logger,
 	}
 }
 
@@ -42,6 +45,12 @@ func (a *TaskActivities) ProcessTask(ctx context.Context, input models.ProcessTa
 	if err != nil {
 		// Check if it's a timeout error and provide better context
 		if isTimeoutError(err) {
+			a.logger.Error(ctx, "ProcessTask activity timed out",
+				"error", err,
+				"task_id", input.TaskID,
+				"tenant_id", input.TenantID,
+				"environment_id", input.EnvironmentID,
+			)
 			return nil, ierr.WithError(err).
 				WithHint("Task processing timed out. This may be due to a large file or network issues. Consider using streaming processing for very large files.").
 				WithReportableDetails(map[string]interface{}{
@@ -51,6 +60,12 @@ func (a *TaskActivities) ProcessTask(ctx context.Context, input models.ProcessTa
 				Mark(ierr.ErrHTTPClient)
 		}
 
+		a.logger.Error(ctx, "ProcessTask activity failed",
+			"error", err,
+			"task_id", input.TaskID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to process task").
 			WithReportableDetails(map[string]interface{}{
@@ -62,6 +77,12 @@ func (a *TaskActivities) ProcessTask(ctx context.Context, input models.ProcessTa
 	// Get the updated task to return results
 	task, err := a.taskService.GetTask(ctx, input.TaskID)
 	if err != nil {
+		a.logger.Error(ctx, "ProcessTask activity failed to fetch updated task",
+			"error", err,
+			"task_id", input.TaskID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get updated task").
 			Mark(ierr.ErrValidation)

--- a/internal/temporal/activities/whop/invoice_sync_activities.go
+++ b/internal/temporal/activities/whop/invoice_sync_activities.go
@@ -55,6 +55,12 @@ func (a *InvoiceSyncActivities) MarkWhopInvoicePaid(
 				err,
 			)
 		}
+		a.logger.Error(ctx, "MarkWhopInvoicePaid activity failed to get Whop integration",
+			"error", err,
+			"invoice_id", input.InvoiceID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 

--- a/internal/temporal/activities/zoho/invoice_sync_activities.go
+++ b/internal/temporal/activities/zoho/invoice_sync_activities.go
@@ -33,6 +33,12 @@ func (a *InvoiceSyncActivities) SyncInvoiceToZoho(ctx context.Context, input mod
 		if ierr.IsNotFound(err) {
 			return temporal.NewNonRetryableApplicationError("Zoho Books connection not configured", "ConnectionNotFound", err)
 		}
+		a.logger.Error(ctx, "SyncInvoiceToZoho activity failed to get Zoho Books integration",
+			"error", err,
+			"invoice_id", input.InvoiceID,
+			"tenant_id", input.TenantID,
+			"environment_id", input.EnvironmentID,
+		)
 		return err
 	}
 
@@ -58,8 +64,23 @@ func (a *InvoiceSyncActivities) MarkZohoBooksInvoicePaid(ctx context.Context, in
 		if ierr.IsNotFound(err) {
 			return temporal.NewNonRetryableApplicationError("Zoho Books connection not configured", "ConnectionNotFound", err)
 		}
+		a.logger.Error(ctx, "MarkZohoBooksInvoicePaid activity failed to get Zoho Books integration",
+			"error", err,
+			"invoice_id", input.InvoiceID(),
+			"tenant_id", input.TenantID(),
+			"environment_id", input.EnvironmentID(),
+		)
 		return err
 	}
 
-	return zohoIntegration.InvoiceSvc.MarkInvoicePaidInZoho(ctx, input.InvoiceID())
+	if err := zohoIntegration.InvoiceSvc.MarkInvoicePaidInZoho(ctx, input.InvoiceID()); err != nil {
+		a.logger.Error(ctx, "MarkZohoBooksInvoicePaid activity failed",
+			"error", err,
+			"invoice_id", input.InvoiceID(),
+			"tenant_id", input.TenantID(),
+			"environment_id", input.EnvironmentID(),
+		)
+		return err
+	}
+	return nil
 }

--- a/internal/temporal/registration.go
+++ b/internal/temporal/registration.go
@@ -78,12 +78,12 @@ func RegisterWorkflowsAndActivities(
 
 	// Create activity instances with dependencies
 	planService := service.NewPlanService(params)
-	planActivities := planActivities.NewPlanActivities(planService)
+	planActivities := planActivities.NewPlanActivities(planService, params.Logger)
 
 	prepareEventsActivities := prepareProcessedEventsActivities.NewPrepareProcessedEventsActivities(params)
 
 	taskService := service.NewTaskService(params)
-	taskActivities := taskActivities.NewTaskActivities(taskService)
+	taskActivities := taskActivities.NewTaskActivities(taskService, params.Logger)
 
 	// QuickBooks price sync activities
 	qbPriceSyncActivities := qbActivities.NewQuickBooksPriceSyncActivities(
@@ -272,7 +272,7 @@ func RegisterWorkflowsAndActivities(
 
 	// Reprocess raw events activities
 	rawEventsReprocessingService := service.NewRawEventsReprocessingService(params)
-	reprocessRawEventsActivities := eventsActivities.NewReprocessRawEventsActivities(rawEventsReprocessingService)
+	reprocessRawEventsActivities := eventsActivities.NewReprocessRawEventsActivities(rawEventsReprocessingService, params.Logger)
 
 	// Cron workflow activities (reuses subscriptionService and walletService from above)
 	creditGrantService := service.NewCreditGrantService(params)
@@ -298,7 +298,7 @@ func RegisterWorkflowsAndActivities(
 	marketplaceFlushActivities := marketplaceActivities.NewFlushActivities(params, mktplaceReporter, params.Logger)
 
 	cronBundle := &cronActivityBundle{
-		creditGrant:                  cronActivities.NewCreditGrantActivities(creditGrantService),
+		creditGrant:                  cronActivities.NewCreditGrantActivities(creditGrantService, params.Logger),
 		subscription:                 cronActivities.NewSubscriptionCronActivities(subscriptionService, params.Logger),
 		walletCreditExpiry:           cronActivities.NewWalletCreditExpiryActivities(walletService, tenantService, environmentService, params.Logger),
 		webhookOutboundRetry:         cronActivities.NewWebhookOutboundRetryActivities(webhookService, params.Logger),


### PR DESCRIPTION
## **User description**
## Summary

- Adds structured `logger.Error(...)` at the terminal return-error paths of Temporal activities that previously returned the underlying service/repo/integration failure silently.
- Without a boundary log, an activity failure surfaces only as a Temporal task error with no correlated app-side context — which is how a recent v2 plan-price sync bug went undiagnosed. The related fix commit (`fix(price-sync): Subscription status filter in price sync job`) is included in this branch.
- Plan activities (V1 + V2) additionally replace `logger.NewNoopLogger()` so the lock-release info logs actually emit.

## Scope

- Sweep across `cron`, `customer`, `environment`, `events`, `export`, `invoice`, `subscription`, `task`, `plan`, and integration activities (chargebee, hubspot, nomod, paddle, quickbooks, razorpay, stripe, tabs, whop, zoho).
- Extends `NewPlanActivities` / `NewTaskActivities` / `NewCreditGrantActivities` / `NewReprocessRawEventsActivities` to accept `*logger.Logger` where the struct previously had none; call sites updated in `internal/temporal/registration.go`.
- All added logs are LL006/LL009 compliant (literal `"error"` key; `ctx` as first arg). Activities that already logged at their boundary are left alone.

## Test plan

- [x] `go build ./internal/temporal/... ./internal/ee/service/...` — clean
- [x] `go vet -vettool=./tools/bin/loglint ./internal/temporal/... ./internal/ee/service/...` — no new loglint errors (only pre-existing LL008 warnings, which `make lint-ci` filters out)
- [ ] Trigger a failing V2 plan-price sync and confirm the boundary log now emits with `plan_id`, `tenant_id`, `environment_id`, and `error` fields
- [ ] Trigger a failing integration sync (any provider) and confirm the boundary log emits

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix subscription price syncing, strengthen migration checks, and improve failure visibility

### What Changed
- V2 plan price syncing now includes active, trialing, draft, and incomplete subscriptions instead of silently omitting valid subscriptions.
- Temporal activity failures across billing, customer, subscription, alert, export, event, and integration workflows now produce searchable error records with relevant tenant and resource details.
- Price-sync lock release messages now appear in application logs, including when sync activities fail.
- Helm deployments can use an immutable image digest, apply a selected ClickHouse baseline, create Kafka topics with three partitions by default, and verify required ClickHouse tables and Kafka topics after migration.
- Sentry, Pyroscope, and email settings are now configured under the app hierarchy.

### Impact
`✅ Fewer failed V2 price synchronizations`
`✅ Faster diagnosis of failed background workflows`
`✅ Safer deployments with post-migration checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Price lookups now return a clear “Price not found” response when no published, valid price matches the requested key.
  * Subscription price synchronization now includes all eligible subscription states, reducing the risk of missed updates.
  * Improved error handling across billing, payment-provider, invoice, customer, and subscription workflows helps preserve expected processing behavior.

* **Documentation**
  * Updated API documentation to describe the price-not-found response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->