### PR TITLE
feat(price): add feature expansion to price responses

### DIFF
--- a/internal/api/dto/price.go
+++ b/internal/api/dto/price.go
@@ -113,11 +113,19 @@ type UpdatePriceRequest struct {
 
 type PriceResponse struct {
 	*price.Price
-	Meter       *MeterResponse     `json:"meter,omitempty"`
-	Plan        *PlanResponse      `json:"plan,omitempty"`
-	Addon       *AddonResponse     `json:"addon,omitempty"`
-	Group       *GroupResponse     `json:"group,omitempty"`
-	PricingUnit *PriceUnitResponse `json:"pricing_unit,omitempty"`
+	Meter       *MeterResponse        `json:"meter,omitempty"`
+	Plan        *PlanResponse         `json:"plan,omitempty"`
+	Addon       *AddonResponse        `json:"addon,omitempty"`
+	Group       *GroupResponse        `json:"group,omitempty"`
+	PricingUnit *PriceUnitResponse    `json:"pricing_unit,omitempty"`
+	Feature     *PriceFeatureResponse `json:"feature,omitempty"`
+}
+
+// PriceFeatureResponse is the price-relevant view of the metered feature behind a price
+// (resolved via the price's meter_id). Only reporting_unit is populated today; add further
+// price-relevant feature fields here rather than growing PriceResponse directly.
+type PriceFeatureResponse struct {
+	ReportingUnit *types.ReportingUnit `json:"reporting_unit,omitempty"`
 }
 
 // ListPricesResponse represents the response for listing prices

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -104,6 +104,7 @@ const (
 	// create their own Stripe customer.
 	PrefixStripeCustomerSyncLock = "stripe:customer_sync:"
 	PrefixPublishedConnections   = "published_connections:"
+	PrefixMeterFeature           = "meter:feature:v1:"
 )
 
 // GenerateKey creates a cache key from a prefix and a set of parameters

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -493,11 +493,17 @@ type OtelTracesConfig struct {
 	AuthValue           string            `mapstructure:"auth_value" validate:"omitempty"`
 	Headers             map[string]string `mapstructure:"headers" validate:"omitempty"`          // overrides otel.headers when non-empty
 	SampleRate          float64           `mapstructure:"sample_rate" default:"1.0"`             // 0.0 - 1.0
-	StorageSpansEnabled bool              `mapstructure:"storage_spans_enabled" default:"false"` // enable per-query DB/cache/ClickHouse child spans (can be noisy)
+	StorageSpansEnabled bool              `mapstructure:"storage_spans_enabled" default:"false"` // master switch for ALL DB/ClickHouse/cache child spans (can be noisy)
 	// Per-trace throttle on storage spans (0.0-1.0), applied when StorageSpansEnabled
 	// is true. Independent of SampleRate (which thins whole traces incl. server spans);
 	// this thins only the DB/cache/ClickHouse fan-out. Default 0.2; set 1.0 to debug.
 	StorageSpansSampleRate float64 `mapstructure:"storage_spans_sample_rate" default:"0.2"`
+	// Cache spans are the noisiest fan-out (fire on every get/set/delete on hot
+	// paths), so they get a per-type opt-in on top of StorageSpansEnabled.
+	// Both default false, and both require StorageSpansEnabled=true to emit —
+	// StorageSpansEnabled is the master kill switch for all storage spans.
+	RedisCacheSpansEnabled    bool `mapstructure:"redis_cache_spans_enabled" default:"false"`    // db.system=redis cache spans (also requires storage_spans_enabled)
+	InMemoryCacheSpansEnabled bool `mapstructure:"in_memory_cache_spans_enabled" default:"false"` // db.system=in_memory cache spans (also requires storage_spans_enabled)
 	// CaptureExceptions records errors (CaptureException calls, error-level logs,
 	// recovered panics) as OTel "exception" span events for SigNoz's Exceptions
 	// tab. Keep sample_rate at 1.0 so error-bearing traces are not sampled away.

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -226,6 +226,12 @@ otel:
     # spans stay 100%). 0.2 caps the fan-out; set 1.0 for full debug fidelity.
     storage_spans_enabled: false
     storage_spans_sample_rate: 0.2
+    # Cache spans get a per-type opt-in on top of storage_spans_enabled — they
+    # fire on every get/set/delete on hot paths, so operators may want DB/CH
+    # spans without the cache fan-out. Both default false and both also
+    # require storage_spans_enabled=true (that stays the master kill switch).
+    redis_cache_spans_enabled: false
+    in_memory_cache_spans_enabled: false
     # Record errors/panics as OTel "exception" span events (SigNoz Exceptions tab).
     # Replaces Sentry. Keep sample_rate at 1.0 so error traces aren't sampled away.
     capture_exceptions: true

--- a/internal/domain/feature/repository.go
+++ b/internal/domain/feature/repository.go
@@ -17,6 +17,10 @@ type Repository interface {
 	Delete(ctx context.Context, id string) error
 	ListByIDs(ctx context.Context, featureIDs []string) ([]*Feature, error)
 
+	// GetFeaturesByMeterIDs returns the published feature for each of the given meter IDs
+	// (a meter has at most one published feature).
+	GetFeaturesByMeterIDs(ctx context.Context, meterIDs []string) ([]*Feature, error)
+
 	// Group-related operations
 	GetByGroupIDs(ctx context.Context, groupIDs []string) ([]*Feature, error)
 	ClearByGroupID(ctx context.Context, groupID string) error

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -170,6 +170,12 @@ func (s *planService) GetPlans(ctx context.Context, filter *types.PlanFilter) (*
 			expandFields = append(expandFields, string(types.ExpandPriceUnit))
 		}
 
+		// If features should be expanded (root level or nested under prices), propagate to prices
+		// so each price's reporting unit (e.g. usage displayed in "minutes" vs raw "seconds") is attached
+		if filter.GetExpand().Has(types.ExpandFeatures) || filter.GetExpand().GetNested(types.ExpandPrices).Has(types.ExpandFeatures) {
+			expandFields = append(expandFields, string(types.ExpandFeatures))
+		}
+
 		// Set expand string if any expansions are requested
 		if len(expandFields) > 0 {
 			priceFilter = priceFilter.WithExpand(strings.Join(expandFields, ","))

--- a/internal/ee/service/plan_test.go
+++ b/internal/ee/service/plan_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/feature"
+	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
@@ -137,6 +139,69 @@ func (s *PlanServiceSuite) TestGetPlans() {
 	s.NoError(err)
 	s.NotNil(resp)
 	s.Equal(0, len(resp.Items))
+}
+
+// TestGetPlans_ExpandPricesFeatures verifies that POST /plans/search style filters
+// (expand="prices,features") propagate the "features" expand into the nested price
+// fetch, so each price carries its metered feature's reporting unit.
+func (s *PlanServiceSuite) TestGetPlans_ExpandPricesFeatures() {
+	_ = s.GetStores().PlanRepo.Create(s.GetContext(), &plan.Plan{
+		ID:        "plan-reporting",
+		Name:      "Plan With Reporting Unit",
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	})
+
+	testMeter := &meter.Meter{
+		ID:        "meter-reporting",
+		Name:      "Test Meter",
+		EventName: "call",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationSum,
+		},
+		BaseModel: types.GetDefaultBaseModel(s.GetContext()),
+	}
+	_ = s.GetStores().MeterRepo.CreateMeter(s.GetContext(), testMeter)
+
+	conversionRate := decimal.NewFromInt(60)
+	_ = s.GetStores().FeatureRepo.Create(s.GetContext(), &feature.Feature{
+		ID:      "feature-reporting",
+		Name:    "Call Minutes",
+		Type:    types.FeatureTypeMetered,
+		MeterID: "meter-reporting",
+		ReportingUnit: &types.ReportingUnit{
+			UnitSingular:   "minute",
+			UnitPlural:     "minutes",
+			ConversionRate: &conversionRate,
+		},
+		EnvironmentID: types.GetEnvironmentID(s.GetContext()),
+		BaseModel:     types.GetDefaultBaseModel(s.GetContext()),
+	})
+
+	_ = s.GetStores().PriceRepo.Create(s.GetContext(), &price.Price{
+		ID:         "price-reporting",
+		Amount:     decimal.NewFromInt(1),
+		Currency:   "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:   "plan-reporting",
+		MeterID:    "meter-reporting",
+		BaseModel:  types.GetDefaultBaseModel(s.GetContext()),
+	})
+
+	planFilter := types.NewPlanFilter()
+	planFilter.PlanIDs = []string{"plan-reporting"}
+	planFilter.Expand = lo.ToPtr("prices,features")
+
+	resp, err := s.service.GetPlans(s.GetContext(), planFilter)
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.Require().Len(resp.Items[0].Prices, 1)
+
+	s.Require().NotNil(resp.Items[0].Prices[0].Feature)
+	reportingUnit := resp.Items[0].Prices[0].Feature.ReportingUnit
+	s.Require().NotNil(reportingUnit)
+	s.Equal("minute", reportingUnit.UnitSingular)
+	s.Equal("minutes", reportingUnit.UnitPlural)
+	s.True(conversionRate.Equal(*reportingUnit.ConversionRate))
 }
 
 func (s *PlanServiceSuite) TestUpdatePlan() {

--- a/internal/ee/service/price.go
+++ b/internal/ee/service/price.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/priceunit"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -449,6 +450,16 @@ func (s *priceService) GetPrice(ctx context.Context, id string) (*dto.PriceRespo
 			return nil, err
 		}
 		response.Meter = dto.ToMeterResponse(meter)
+
+		featureFilter := types.NewNoLimitFeatureFilter()
+		featureFilter.MeterIDs = []string{price.MeterID}
+		featureFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+		features, err := s.FeatureRepo.List(ctx, featureFilter)
+		if err != nil {
+			s.Logger.Info(ctx, "failed to fetch feature for reporting unit", "meter_id", price.MeterID, "error", err)
+		} else if len(features) > 0 && features[0].ReportingUnit != nil {
+			response.Feature = &dto.PriceFeatureResponse{ReportingUnit: features[0].ReportingUnit}
+		}
 	}
 
 	if price.GroupID != "" {
@@ -619,6 +630,34 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 		s.Logger.Debug(ctx, "fetched meters for prices", "count", len(metersResponse.Items))
 	}
 
+	// If features are requested to be expanded, fetch the metered feature (for reporting unit) per meter in one query
+	var featuresByMeterID map[string]*feature.Feature
+	if filter.GetExpand().Has(types.ExpandFeatures) && len(prices) > 0 {
+		meterIDs := lo.Uniq(lo.FilterMap(prices, func(p *price.Price, _ int) (string, bool) {
+			return p.MeterID, p.MeterID != ""
+		}))
+
+		if len(meterIDs) > 0 {
+			featureFilter := types.NewNoLimitFeatureFilter()
+			featureFilter.MeterIDs = meterIDs
+			featureFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+
+			features, err := s.FeatureRepo.List(ctx, featureFilter)
+			if err != nil {
+				return nil, err
+			}
+
+			featuresByMeterID = make(map[string]*feature.Feature, len(features))
+			for _, f := range features {
+				if f.MeterID != "" {
+					featuresByMeterID[f.MeterID] = f
+				}
+			}
+
+			s.Logger.Debug(ctx, "fetched features for prices", "count", len(features))
+		}
+	}
+
 	// Collect entity IDs based on entity type for efficient bulk fetching
 	var planIDs []string
 	var addonIDs []string
@@ -744,6 +783,13 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 		if filter.GetExpand().Has(types.ExpandMeters) && p.MeterID != "" {
 			if m, ok := metersByID[p.MeterID]; ok {
 				response.Items[i].Meter = m
+			}
+		}
+
+		// Add feature (reporting unit) if requested and available
+		if filter.GetExpand().Has(types.ExpandFeatures) && p.MeterID != "" {
+			if f, ok := featuresByMeterID[p.MeterID]; ok && f.ReportingUnit != nil {
+				response.Items[i].Feature = &dto.PriceFeatureResponse{ReportingUnit: f.ReportingUnit}
 			}
 		}
 

--- a/internal/ee/service/price.go
+++ b/internal/ee/service/price.go
@@ -641,23 +641,11 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 			if err != nil {
 				s.Logger.Info(ctx, "failed to fetch features in bulk", "error", err)
 				// Don't fail the request, just continue without reporting units
-				featuresByMeterID = make(map[string]*feature.Feature)
+				features = nil
 			} else {
-				featuresByMeterID = make(map[string]*feature.Feature, len(features))
-				for _, f := range features {
-					if f.MeterID == "" {
-						continue
-					}
-					if existing, ok := featuresByMeterID[f.MeterID]; ok {
-						s.Logger.Info(ctx, "multiple published features for meter, keeping first match",
-							"meter_id", f.MeterID, "kept_feature_id", existing.ID, "ignored_feature_id", f.ID)
-						continue
-					}
-					featuresByMeterID[f.MeterID] = f
-				}
-
 				s.Logger.Debug(ctx, "fetched features for prices", "count", len(features))
 			}
+			featuresByMeterID = s.buildFeaturesByMeterID(ctx, features)
 		}
 	}
 
@@ -826,6 +814,26 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 	}
 
 	return response, nil
+}
+
+// buildFeaturesByMeterID maps each feature by its meter ID. A meter has at most one
+// published feature; if more than one is found, the first is kept and the rest are
+// logged (not treated as an error, since it's a recovered/skipped condition).
+func (s *priceService) buildFeaturesByMeterID(ctx context.Context, features []*feature.Feature) map[string]*feature.Feature {
+	byMeterID := make(map[string]*feature.Feature, len(features))
+	for _, f := range features {
+		if f.MeterID == "" {
+			continue
+		}
+		existing, ok := byMeterID[f.MeterID]
+		if !ok {
+			byMeterID[f.MeterID] = f
+			continue
+		}
+		s.Logger.Info(ctx, "multiple published features for meter, keeping first match",
+			"meter_id", f.MeterID, "kept_feature_id", existing.ID, "ignored_feature_id", f.ID)
+	}
+	return byMeterID
 }
 
 func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.UpdatePriceRequest) (*dto.PriceResponse, error) {

--- a/internal/ee/service/price.go
+++ b/internal/ee/service/price.go
@@ -451,10 +451,8 @@ func (s *priceService) GetPrice(ctx context.Context, id string) (*dto.PriceRespo
 		}
 		response.Meter = dto.ToMeterResponse(meter)
 
-		featureFilter := types.NewNoLimitFeatureFilter()
-		featureFilter.MeterIDs = []string{price.MeterID}
-		featureFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
-		features, err := s.FeatureRepo.List(ctx, featureFilter)
+		// A meter has at most one published feature, so features[0] is unambiguous.
+		features, err := s.FeatureRepo.GetFeaturesByMeterIDs(ctx, []string{price.MeterID})
 		if err != nil {
 			s.Logger.Info(ctx, "failed to fetch feature for reporting unit", "meter_id", price.MeterID, "error", err)
 		} else if len(features) > 0 && features[0].ReportingUnit != nil {
@@ -630,7 +628,8 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 		s.Logger.Debug(ctx, "fetched meters for prices", "count", len(metersResponse.Items))
 	}
 
-	// If features are requested to be expanded, fetch the metered feature (for reporting unit) per meter in one query
+	// If features are requested to be expanded, fetch the metered feature (for reporting unit) per meter in one query.
+	// A meter has at most one published feature, so keying by MeterID is unambiguous.
 	var featuresByMeterID map[string]*feature.Feature
 	if filter.GetExpand().Has(types.ExpandFeatures) && len(prices) > 0 {
 		meterIDs := lo.Uniq(lo.FilterMap(prices, func(p *price.Price, _ int) (string, bool) {
@@ -638,23 +637,27 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 		}))
 
 		if len(meterIDs) > 0 {
-			featureFilter := types.NewNoLimitFeatureFilter()
-			featureFilter.MeterIDs = meterIDs
-			featureFilter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
-
-			features, err := s.FeatureRepo.List(ctx, featureFilter)
+			features, err := s.FeatureRepo.GetFeaturesByMeterIDs(ctx, meterIDs)
 			if err != nil {
-				return nil, err
-			}
-
-			featuresByMeterID = make(map[string]*feature.Feature, len(features))
-			for _, f := range features {
-				if f.MeterID != "" {
+				s.Logger.Info(ctx, "failed to fetch features in bulk", "error", err)
+				// Don't fail the request, just continue without reporting units
+				featuresByMeterID = make(map[string]*feature.Feature)
+			} else {
+				featuresByMeterID = make(map[string]*feature.Feature, len(features))
+				for _, f := range features {
+					if f.MeterID == "" {
+						continue
+					}
+					if existing, ok := featuresByMeterID[f.MeterID]; ok {
+						s.Logger.Info(ctx, "multiple published features for meter, keeping first match",
+							"meter_id", f.MeterID, "kept_feature_id", existing.ID, "ignored_feature_id", f.ID)
+						continue
+					}
 					featuresByMeterID[f.MeterID] = f
 				}
-			}
 
-			s.Logger.Debug(ctx, "fetched features for prices", "count", len(features))
+				s.Logger.Debug(ctx, "fetched features for prices", "count", len(features))
+			}
 		}
 	}
 

--- a/internal/ee/service/price.go
+++ b/internal/ee/service/price.go
@@ -630,22 +630,17 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 
 	// If features are requested to be expanded, fetch the metered feature (for reporting unit) per meter in one query.
 	// A meter has at most one published feature, so keying by MeterID is unambiguous.
-	var featuresByMeterID map[string]*feature.Feature
+	featuresByMeterID := make(map[string]*feature.Feature)
 	if filter.GetExpand().Has(types.ExpandFeatures) && len(prices) > 0 {
 		meterIDs := lo.Uniq(lo.FilterMap(prices, func(p *price.Price, _ int) (string, bool) {
 			return p.MeterID, p.MeterID != ""
 		}))
 
-		if len(meterIDs) > 0 {
-			features, err := s.FeatureRepo.GetFeaturesByMeterIDs(ctx, meterIDs)
-			if err != nil {
-				s.Logger.Info(ctx, "failed to fetch features in bulk", "error", err)
-				// Don't fail the request, just continue without reporting units
-				features = nil
-			} else {
-				s.Logger.Debug(ctx, "fetched features for prices", "count", len(features))
-			}
-			featuresByMeterID = s.buildFeaturesByMeterID(ctx, features)
+		features, err := s.FeatureRepo.GetFeaturesByMeterIDs(ctx, meterIDs)
+		if err != nil {
+			s.Logger.Info(ctx, "failed to fetch features in bulk", "error", err)
+		} else {
+			featuresByMeterID = lo.KeyBy(features, func(f *feature.Feature) string { return f.MeterID })
 		}
 	}
 
@@ -779,7 +774,7 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 
 		// Add feature (reporting unit) if requested and available
 		if filter.GetExpand().Has(types.ExpandFeatures) && p.MeterID != "" {
-			if f, ok := featuresByMeterID[p.MeterID]; ok && f.ReportingUnit != nil {
+			if f, ok := featuresByMeterID[p.MeterID]; ok && f != nil && f.ReportingUnit != nil {
 				response.Items[i].Feature = &dto.PriceFeatureResponse{ReportingUnit: f.ReportingUnit}
 			}
 		}
@@ -814,26 +809,6 @@ func (s *priceService) GetPrices(ctx context.Context, filter *types.PriceFilter)
 	}
 
 	return response, nil
-}
-
-// buildFeaturesByMeterID maps each feature by its meter ID. A meter has at most one
-// published feature; if more than one is found, the first is kept and the rest are
-// logged (not treated as an error, since it's a recovered/skipped condition).
-func (s *priceService) buildFeaturesByMeterID(ctx context.Context, features []*feature.Feature) map[string]*feature.Feature {
-	byMeterID := make(map[string]*feature.Feature, len(features))
-	for _, f := range features {
-		if f.MeterID == "" {
-			continue
-		}
-		existing, ok := byMeterID[f.MeterID]
-		if !ok {
-			byMeterID[f.MeterID] = f
-			continue
-		}
-		s.Logger.Info(ctx, "multiple published features for meter, keeping first match",
-			"meter_id", f.MeterID, "kept_feature_id", existing.ID, "ignored_feature_id", f.ID)
-	}
-	return byMeterID
 }
 
 func (s *priceService) UpdatePrice(ctx context.Context, id string, req dto.UpdatePriceRequest) (*dto.PriceResponse, error) {

--- a/internal/ee/service/price_test.go
+++ b/internal/ee/service/price_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/feature"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
@@ -30,6 +31,7 @@ type PriceServiceSuite struct {
 	planRepo      *testutil.InMemoryPlanStore
 	priceUnitRepo *testutil.InMemoryPriceUnitStore
 	addonRepo     *testutil.InMemoryAddonStore
+	featureRepo   *testutil.InMemoryFeatureStore
 	logger        *logger.Logger
 }
 
@@ -44,6 +46,7 @@ func (s *PriceServiceSuite) SetupTest() {
 	s.planRepo = testutil.NewInMemoryPlanStore()
 	s.priceUnitRepo = testutil.NewInMemoryPriceUnitStore()
 	s.addonRepo = testutil.NewInMemoryAddonStore()
+	s.featureRepo = testutil.NewInMemoryFeatureStore()
 	s.logger = logger.NewNoopLogger()
 
 	serviceParams := ServiceParams{
@@ -53,6 +56,7 @@ func (s *PriceServiceSuite) SetupTest() {
 		AddonRepo:     s.addonRepo,
 		SubRepo:       testutil.NewInMemorySubscriptionStore(),
 		PriceUnitRepo: s.priceUnitRepo,
+		FeatureRepo:   s.featureRepo,
 		Logger:        s.logger,
 		DB:            testutil.NewMockPostgresClient(s.logger),
 	}
@@ -190,6 +194,135 @@ func (s *PriceServiceSuite) TestGetPrices() {
 	s.NotNil(resp)
 	s.Equal(2, resp.Pagination.Total)
 	s.Len(resp.Items, 0) // Ensure no prices are retrieved
+}
+
+// TestGetPrices_ExpandFeatures verifies that expand=features attaches each price's
+// metered feature reporting unit (e.g. raw usage in "second" displayed as "minute"),
+// resolved via the price's meter_id, and that it is absent when not requested.
+func (s *PriceServiceSuite) TestGetPrices_ExpandFeatures() {
+	testMeter := &meter.Meter{
+		ID:        "meter-reporting",
+		Name:      "Test Meter",
+		EventName: "call",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationSum,
+		},
+		BaseModel: types.GetDefaultBaseModel(s.ctx),
+	}
+	_ = s.meterRepo.CreateMeter(s.ctx, testMeter)
+
+	conversionRate := decimal.NewFromInt(60)
+	_ = s.featureRepo.Create(s.ctx, &feature.Feature{
+		ID:      "feature-reporting",
+		Name:    "Call Minutes",
+		Type:    types.FeatureTypeMetered,
+		MeterID: "meter-reporting",
+		ReportingUnit: &types.ReportingUnit{
+			UnitSingular:   "minute",
+			UnitPlural:     "minutes",
+			ConversionRate: &conversionRate,
+		},
+		EnvironmentID: types.GetEnvironmentID(s.ctx),
+		BaseModel:     types.GetDefaultBaseModel(s.ctx),
+	})
+
+	_ = s.priceRepo.Create(s.ctx, &price.Price{
+		ID:         "price-reporting",
+		Amount:     decimal.NewFromInt(1),
+		Currency:   "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:   "plan-reporting",
+		MeterID:    "meter-reporting",
+		BaseModel:  types.GetDefaultBaseModel(s.ctx),
+	})
+
+	// Without expand=features, reporting unit is not attached
+	priceFilter := types.NewPriceFilter()
+	priceFilter.EntityType = lo.ToPtr(types.PRICE_ENTITY_TYPE_PLAN)
+	resp, err := s.priceService.GetPrices(s.ctx, priceFilter)
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.Nil(resp.Items[0].Feature)
+
+	// With expand=features, reporting unit is attached from the meter's feature
+	priceFilter.Expand = lo.ToPtr(string(types.ExpandFeatures))
+	resp, err = s.priceService.GetPrices(s.ctx, priceFilter)
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.Require().NotNil(resp.Items[0].Feature)
+	s.Require().NotNil(resp.Items[0].Feature.ReportingUnit)
+	s.Equal("minute", resp.Items[0].Feature.ReportingUnit.UnitSingular)
+	s.Equal("minutes", resp.Items[0].Feature.ReportingUnit.UnitPlural)
+	s.True(conversionRate.Equal(*resp.Items[0].Feature.ReportingUnit.ConversionRate))
+}
+
+// TestGetPrices_ExpandFeatures_IgnoresDeletedFeature verifies that a deleted feature
+// left pointing at a meter (meter_id has no DB uniqueness constraint) is not picked up
+// over the live published feature on the same meter.
+func (s *PriceServiceSuite) TestGetPrices_ExpandFeatures_IgnoresDeletedFeature() {
+	testMeter := &meter.Meter{
+		ID:        "meter-reporting-2",
+		Name:      "Test Meter",
+		EventName: "call",
+		Aggregation: meter.Aggregation{
+			Type: types.AggregationSum,
+		},
+		BaseModel: types.GetDefaultBaseModel(s.ctx),
+	}
+	_ = s.meterRepo.CreateMeter(s.ctx, testMeter)
+
+	deletedConversionRate := decimal.NewFromInt(1)
+	deletedBaseModel := types.GetDefaultBaseModel(s.ctx)
+	deletedBaseModel.Status = types.StatusDeleted
+	_ = s.featureRepo.Create(s.ctx, &feature.Feature{
+		ID:      "feature-deleted",
+		Name:    "Old Deleted Feature",
+		Type:    types.FeatureTypeMetered,
+		MeterID: "meter-reporting-2",
+		ReportingUnit: &types.ReportingUnit{
+			UnitSingular:   "wrong-unit",
+			UnitPlural:     "wrong-units",
+			ConversionRate: &deletedConversionRate,
+		},
+		EnvironmentID: types.GetEnvironmentID(s.ctx),
+		BaseModel:     deletedBaseModel,
+	})
+
+	liveConversionRate := decimal.NewFromInt(60)
+	_ = s.featureRepo.Create(s.ctx, &feature.Feature{
+		ID:      "feature-live",
+		Name:    "Live Feature",
+		Type:    types.FeatureTypeMetered,
+		MeterID: "meter-reporting-2",
+		ReportingUnit: &types.ReportingUnit{
+			UnitSingular:   "minute",
+			UnitPlural:     "minutes",
+			ConversionRate: &liveConversionRate,
+		},
+		EnvironmentID: types.GetEnvironmentID(s.ctx),
+		BaseModel:     types.GetDefaultBaseModel(s.ctx),
+	})
+
+	_ = s.priceRepo.Create(s.ctx, &price.Price{
+		ID:         "price-reporting-2",
+		Amount:     decimal.NewFromInt(1),
+		Currency:   "usd",
+		EntityType: types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:   "plan-reporting-2",
+		MeterID:    "meter-reporting-2",
+		BaseModel:  types.GetDefaultBaseModel(s.ctx),
+	})
+
+	priceFilter := types.NewPriceFilter()
+	priceFilter.EntityType = lo.ToPtr(types.PRICE_ENTITY_TYPE_PLAN)
+	priceFilter.Expand = lo.ToPtr(string(types.ExpandFeatures))
+	resp, err := s.priceService.GetPrices(s.ctx, priceFilter)
+	s.NoError(err)
+	s.Require().Len(resp.Items, 1)
+	s.Require().NotNil(resp.Items[0].Feature)
+	s.Require().NotNil(resp.Items[0].Feature.ReportingUnit)
+	s.Equal("minute", resp.Items[0].Feature.ReportingUnit.UnitSingular)
+	s.True(liveConversionRate.Equal(*resp.Items[0].Feature.ReportingUnit.ConversionRate))
 }
 
 // TestGetPrices_EmptyEntityIDsDoesNotSuppressResults is a regression test for the bug where

--- a/internal/repository/ent/feature.go
+++ b/internal/repository/ent/feature.go
@@ -271,13 +271,6 @@ func (r *featureRepository) Update(ctx context.Context, f *domainFeature.Feature
 	})
 	defer FinishSpan(span)
 
-	// Capture the previous meter ID so its by-meter-ID cache entry can be invalidated
-	// too if this update moves the feature to a different meter.
-	var previousMeterID string
-	if previous, err := r.Get(ctx, f.ID); err == nil && previous != nil {
-		previousMeterID = previous.MeterID
-	}
-
 	updateQuery := client.Feature.Update().
 		Where(
 			feature.ID(f.ID),
@@ -335,9 +328,6 @@ func (r *featureRepository) Update(ctx context.Context, f *domainFeature.Feature
 	SetSpanSuccess(span)
 	r.DeleteCache(ctx, f.ID)
 	r.deleteFeatureCacheByMeterID(ctx, f.MeterID)
-	if previousMeterID != "" && previousMeterID != f.MeterID {
-		r.deleteFeatureCacheByMeterID(ctx, previousMeterID)
-	}
 	return nil
 }
 

--- a/internal/repository/ent/feature.go
+++ b/internal/repository/ent/feature.go
@@ -271,6 +271,13 @@ func (r *featureRepository) Update(ctx context.Context, f *domainFeature.Feature
 	})
 	defer FinishSpan(span)
 
+	// Capture the previous meter ID so its by-meter-ID cache entry can be invalidated
+	// too if this update moves the feature to a different meter.
+	var previousMeterID string
+	if previous, err := r.Get(ctx, f.ID); err == nil && previous != nil {
+		previousMeterID = previous.MeterID
+	}
+
 	updateQuery := client.Feature.Update().
 		Where(
 			feature.ID(f.ID),
@@ -327,6 +334,10 @@ func (r *featureRepository) Update(ctx context.Context, f *domainFeature.Feature
 
 	SetSpanSuccess(span)
 	r.DeleteCache(ctx, f.ID)
+	r.deleteFeatureCacheByMeterID(ctx, f.MeterID)
+	if previousMeterID != "" && previousMeterID != f.MeterID {
+		r.deleteFeatureCacheByMeterID(ctx, previousMeterID)
+	}
 	return nil
 }
 
@@ -343,6 +354,12 @@ func (r *featureRepository) Delete(ctx context.Context, id string) error {
 		"feature_id": id,
 	})
 	defer FinishSpan(span)
+
+	// Capture the meter ID before archiving so its by-meter-ID cache entry can be invalidated.
+	var meterID string
+	if existing, err := r.Get(ctx, id); err == nil && existing != nil {
+		meterID = existing.MeterID
+	}
 
 	_, err := client.Feature.Update().
 		Where(
@@ -376,6 +393,7 @@ func (r *featureRepository) Delete(ctx context.Context, id string) error {
 
 	SetSpanSuccess(span)
 	r.DeleteCache(ctx, id)
+	r.deleteFeatureCacheByMeterID(ctx, meterID)
 	return nil
 }
 
@@ -773,4 +791,17 @@ func (r *featureRepository) getFeatureCacheByMeterID(ctx context.Context, meterI
 		return nil
 	}
 	return f
+}
+
+func (r *featureRepository) deleteFeatureCacheByMeterID(ctx context.Context, meterID string) {
+	if meterID == "" {
+		return
+	}
+	span, ctx := cache.StartRedisCacheSpan(ctx, "feature", "delete_by_meter_id", map[string]interface{}{
+		"meter_id": meterID,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := cache.GenerateKey(ctx, cache.PrefixMeterFeature, meterID)
+	r.redisCache.ForceCacheDelete(ctx, cacheKey)
 }

--- a/internal/repository/ent/feature.go
+++ b/internal/repository/ent/feature.go
@@ -17,18 +17,20 @@ import (
 )
 
 type featureRepository struct {
-	client    postgres.IClient
-	log       *logger.Logger
-	queryOpts FeatureQueryOptions
-	cache     cache.InMemoryCache
+	client     postgres.IClient
+	log        *logger.Logger
+	queryOpts  FeatureQueryOptions
+	cache      cache.InMemoryCache
+	redisCache cache.RedisCache
 }
 
-func NewFeatureRepository(client postgres.IClient, log *logger.Logger, cache cache.InMemoryCache) domainFeature.Repository {
+func NewFeatureRepository(client postgres.IClient, log *logger.Logger, cache cache.InMemoryCache, redisCache cache.RedisCache) domainFeature.Repository {
 	return &featureRepository{
-		client:    client,
-		log:       log,
-		queryOpts: FeatureQueryOptions{},
-		cache:     cache,
+		client:     client,
+		log:        log,
+		queryOpts:  FeatureQueryOptions{},
+		cache:      cache,
+		redisCache: redisCache,
 	}
 }
 
@@ -436,6 +438,73 @@ func (r *featureRepository) ListByIDs(ctx context.Context, featureIDs []string) 
 	return result, nil
 }
 
+// GetFeaturesByMeterIDs returns the published feature for each of the given meter IDs
+// (a meter has at most one published feature), serving whatever is already cached
+// and querying only the remainder. Scoped by tenant and environment from context.
+func (r *featureRepository) GetFeaturesByMeterIDs(ctx context.Context, meterIDs []string) ([]*domainFeature.Feature, error) {
+	if len(meterIDs) == 0 {
+		return []*domainFeature.Feature{}, nil
+	}
+
+	span := StartRepositorySpan(ctx, "feature", "get_by_meter_ids", map[string]interface{}{
+		"meter_ids_count": len(meterIDs),
+	})
+	defer FinishSpan(span)
+
+	result := make([]*domainFeature.Feature, 0, len(meterIDs))
+	missing := make([]string, 0, len(meterIDs))
+	seen := make(map[string]struct{}, len(meterIDs))
+
+	for _, meterID := range meterIDs {
+		if meterID == "" {
+			continue
+		}
+		if _, dup := seen[meterID]; dup {
+			continue
+		}
+		seen[meterID] = struct{}{}
+
+		if cached := r.getFeatureCacheByMeterID(ctx, meterID); cached != nil {
+			result = append(result, cached)
+			continue
+		}
+		missing = append(missing, meterID)
+	}
+
+	if len(missing) == 0 {
+		SetSpanSuccess(span)
+		return result, nil
+	}
+
+	client := r.client.Reader(ctx)
+	features, err := client.Feature.Query().
+		Where(
+			feature.MeterIDIn(missing...),
+			feature.TenantID(types.GetTenantID(ctx)),
+			feature.EnvironmentID(types.GetEnvironmentID(ctx)),
+			feature.Status(string(types.StatusPublished)),
+		).
+		All(ctx)
+	if err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to get features by meter IDs").
+			WithReportableDetails(map[string]interface{}{
+				"meter_ids": missing,
+			}).
+			Mark(ierr.ErrDatabase)
+	}
+
+	fetched := domainFeature.FromEntList(features)
+	for _, f := range fetched {
+		r.setFeatureCacheByMeterID(ctx, f)
+		result = append(result, f)
+	}
+
+	SetSpanSuccess(span)
+	return result, nil
+}
+
 // GetByGroupIDs returns features that belong to any of the given group IDs.
 // Scoped by tenant and environment from context (consistent with Get, List, ClearByGroupID).
 func (r *featureRepository) GetByGroupIDs(ctx context.Context, groupIDs []string) ([]*domainFeature.Feature, error) {
@@ -672,4 +741,36 @@ func (r *featureRepository) DeleteCache(ctx context.Context, featureID string) {
 
 	cacheKey := cache.GenerateKey(ctx, cache.PrefixFeature, featureID)
 	r.cache.Delete(ctx, cacheKey)
+}
+
+func (r *featureRepository) setFeatureCacheByMeterID(ctx context.Context, feature *domainFeature.Feature) {
+	if feature.MeterID == "" {
+		return
+	}
+	span, ctx := cache.StartRedisCacheSpan(ctx, "feature", "set_by_meter_id", map[string]interface{}{
+		"feature_id": feature.ID,
+		"meter_id":   feature.MeterID,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := cache.GenerateKey(ctx, cache.PrefixMeterFeature, feature.MeterID)
+	r.redisCache.ForceCacheSet(ctx, cacheKey, feature, cache.ExpiryDefaultRedis)
+}
+
+func (r *featureRepository) getFeatureCacheByMeterID(ctx context.Context, meterID string) *domainFeature.Feature {
+	span, ctx := cache.StartRedisCacheSpan(ctx, "feature", "get_by_meter_id", map[string]interface{}{
+		"meter_id": meterID,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := cache.GenerateKey(ctx, cache.PrefixMeterFeature, meterID)
+	value, found := r.redisCache.ForceCacheGet(ctx, cacheKey)
+	if !found {
+		return nil
+	}
+	f, ok := cache.UnmarshalCacheValue[domainFeature.Feature](value)
+	if !ok {
+		return nil
+	}
+	return f
 }

--- a/internal/repository/factory.go
+++ b/internal/repository/factory.go
@@ -156,7 +156,7 @@ func NewInvoiceLineItemRepository(p RepositoryParams) invoice.LineItemRepository
 }
 
 func NewFeatureRepository(p RepositoryParams) feature.Repository {
-	return entRepo.NewFeatureRepository(p.EntClient, p.Logger, p.InMemoryCache)
+	return entRepo.NewFeatureRepository(p.EntClient, p.Logger, p.InMemoryCache, p.RedisCache)
 }
 
 func NewEntitlementRepository(p RepositoryParams) entitlement.Repository {

--- a/internal/testutil/inmemory_feature_store.go
+++ b/internal/testutil/inmemory_feature_store.go
@@ -314,6 +314,21 @@ func (s *InMemoryFeatureStore) ListByIDs(ctx context.Context, featureIDs []strin
 	return s.List(ctx, filter)
 }
 
+// GetFeaturesByMeterIDs returns the published feature for each of the given meter IDs.
+func (s *InMemoryFeatureStore) GetFeaturesByMeterIDs(ctx context.Context, meterIDs []string) ([]*feature.Feature, error) {
+	if len(meterIDs) == 0 {
+		return []*feature.Feature{}, nil
+	}
+
+	filter := &types.FeatureFilter{
+		QueryFilter: types.NewNoLimitQueryFilter(),
+		MeterIDs:    meterIDs,
+	}
+	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+
+	return s.List(ctx, filter)
+}
+
 // GetByGroupIDs returns features that belong to any of the given group IDs.
 func (s *InMemoryFeatureStore) GetByGroupIDs(ctx context.Context, groupIDs []string) ([]*feature.Feature, error) {
 	if len(groupIDs) == 0 {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -456,15 +456,44 @@ func (s *Service) IsSentryEnabled() bool {
 	return s.sentryEnabled
 }
 
-// IsStorageSpansEnabled reports whether per-query storage spans (DB, cache,
-// ClickHouse) should be created. Controlled by
-// FLEXPRICE_OTEL_TRACES_STORAGE_SPANS_ENABLED (default: false) to avoid span
-// volume explosion before operators have a feel for the cost.
+// IsStorageSpansEnabled is the master switch for ALL per-query storage spans
+// (DB, ClickHouse, cache). When false, no storage span emits regardless of
+// per-type toggles. Controlled by FLEXPRICE_OTEL_TRACES_STORAGE_SPANS_ENABLED
+// (default: false) to avoid span volume explosion before operators have a
+// feel for the cost. When true, DB and ClickHouse spans emit; cache spans
+// additionally require their per-type flag — see IsRedisCacheSpansEnabled /
+// IsInMemoryCacheSpansEnabled.
 func (s *Service) IsStorageSpansEnabled() bool {
 	if s == nil {
 		return false
 	}
 	return s.tracingEnabled && s.cfg.Otel.Traces.StorageSpansEnabled
+}
+
+// IsRedisCacheSpansEnabled reports whether Redis cache spans (db.system=redis)
+// should be created. Requires the master IsStorageSpansEnabled to also be true
+// — this flag is an opt-in for the noisy cache fan-out on top of the storage
+// master switch, not a replacement for it. Controlled by
+// FLEXPRICE_OTEL_TRACES_REDIS_CACHE_SPANS_ENABLED (default: false).
+func (s *Service) IsRedisCacheSpansEnabled() bool {
+	if s == nil {
+		return false
+	}
+	return s.IsStorageSpansEnabled() && s.cfg.Otel.Traces.RedisCacheSpansEnabled
+}
+
+// IsInMemoryCacheSpansEnabled reports whether in-memory cache spans
+// (db.system=in_memory) should be created. Requires the master
+// IsStorageSpansEnabled to also be true — this flag is an opt-in on top of
+// the storage master switch. In-memory hits have a completely different
+// latency profile from Redis and are gated separately so operators can enable
+// only what they need. Controlled by
+// FLEXPRICE_OTEL_TRACES_IN_MEMORY_CACHE_SPANS_ENABLED (default: false).
+func (s *Service) IsInMemoryCacheSpansEnabled() bool {
+	if s == nil {
+		return false
+	}
+	return s.IsStorageSpansEnabled() && s.cfg.Otel.Traces.InMemoryCacheSpansEnabled
 }
 
 // storageSpanSampled applies otel.traces.storage_spans_sample_rate as a per-trace
@@ -728,10 +757,18 @@ func (s *Service) startSpan(ctx context.Context, name, op string, params map[str
 // storage_spans_sample_rate (per-trace), so every storage span — DB, ClickHouse,
 // repository — obeys both regardless of call path.
 func (s *Service) startStorageSpan(ctx context.Context, name, op, dbSystem string, params map[string]interface{}) (*Span, context.Context) {
+	return s.startStorageSpanGated(ctx, name, op, dbSystem, s.IsStorageSpansEnabled(), params)
+}
+
+// startStorageSpanGated is the common implementation. The caller passes an
+// explicit spanEnabled gate so DB/CH callers can use the storage_spans_enabled
+// switch while cache callers use their per-type flag. The per-trace sample
+// rate throttle and the always-on metrics path are shared.
+func (s *Service) startStorageSpanGated(ctx context.Context, name, op, dbSystem string, spanEnabled bool, params map[string]interface{}) (*Span, context.Context) {
 	if s == nil { // a nil tracing service is a valid no-op (tracing not wired)
 		return nil, ctx
 	}
-	spanOn := s.IsStorageSpansEnabled() && s.storageSpanSampled(ctx)
+	spanOn := spanEnabled && s.storageSpanSampled(ctx)
 	if !spanOn && !s.metricsEnabled {
 		return nil, ctx
 	}
@@ -844,12 +881,29 @@ func (s *Service) StartRepositorySpan(ctx context.Context, dbSystem, repository,
 // the same code path and are tagged the same way (cache.entity distinguishes
 // what was accessed).
 //
-// Gated by otel.traces.storage_spans_enabled (via startStorageSpan) — cache
-// spans fire on every get/set/delete, so they share the same noise/volume
-// tradeoff as the other storage spans.
+// Gated per db.system on top of the storage master switch:
+//   - otel.traces.storage_spans_enabled must be true for ANY cache span to
+//     emit (master kill switch shared with DB/ClickHouse spans).
+//   - db.system=redis     additionally requires otel.traces.redis_cache_spans_enabled.
+//   - db.system=in_memory additionally requires otel.traces.in_memory_cache_spans_enabled.
+//
+// Both per-type flags default false because cache calls fire on every
+// get/set/delete and are the noisiest fan-out in a trace. Splitting the flag
+// lets operators enable DB/ClickHouse spans without dragging in cache noise,
+// while still using storage_spans_enabled as a single kill switch when they
+// want everything off.
 func (s *Service) StartCacheSpan(ctx context.Context, dbSystem, cacheEntity, operation string, params map[string]interface{}) (*Span, context.Context) {
+	var spanEnabled bool
+	switch dbSystem {
+	case "redis":
+		spanEnabled = s.IsRedisCacheSpansEnabled()
+	case "in_memory":
+		spanEnabled = s.IsInMemoryCacheSpansEnabled()
+	default:
+		spanEnabled = s.IsStorageSpansEnabled()
+	}
 	name := fmt.Sprintf("cache.%s.%s", cacheEntity, operation)
-	span, newCtx := s.startStorageSpan(ctx, name, "cache."+operation, dbSystem, params)
+	span, newCtx := s.startStorageSpanGated(ctx, name, "cache."+operation, dbSystem, spanEnabled, params)
 	if span != nil {
 		span.SetData("cache.entity", cacheEntity)
 		span.SetData("cache.operation", operation)

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -53,9 +53,9 @@ type ExpandConfig struct {
 var (
 	// PlanExpandConfig defines what can be expanded on a plan
 	PlanExpandConfig = ExpandConfig{
-		AllowedFields: []ExpandableField{ExpandPrices, ExpandMeters, ExpandEntitlements, ExpandCreditGrant, ExpandPriceUnit},
+		AllowedFields: []ExpandableField{ExpandPrices, ExpandMeters, ExpandEntitlements, ExpandCreditGrant, ExpandPriceUnit, ExpandFeatures},
 		NestedExpands: map[ExpandableField][]ExpandableField{
-			ExpandPrices:       {ExpandMeters, ExpandPriceUnit},
+			ExpandPrices:       {ExpandMeters, ExpandPriceUnit, ExpandFeatures},
 			ExpandEntitlements: {ExpandFeatures},
 			ExpandCreditGrant:  {ExpandFeatures},
 			ExpandPriceUnit:    {},
@@ -64,13 +64,14 @@ var (
 
 	// PriceExpandConfig defines what can be expanded on a price
 	PriceExpandConfig = ExpandConfig{
-		AllowedFields: []ExpandableField{ExpandMeters, ExpandPriceUnit, ExpandPlan, ExpandAddons, ExpandGroups},
+		AllowedFields: []ExpandableField{ExpandMeters, ExpandPriceUnit, ExpandPlan, ExpandAddons, ExpandGroups, ExpandFeatures},
 		NestedExpands: map[ExpandableField][]ExpandableField{
 			ExpandMeters:    {},
 			ExpandPriceUnit: {},
 			ExpandGroups:    {},
 			ExpandPlan:      {},
 			ExpandAddons:    {},
+			ExpandFeatures:  {},
 		},
 	}
 

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -53,7 +53,7 @@ type ExpandConfig struct {
 var (
 	// PlanExpandConfig defines what can be expanded on a plan
 	PlanExpandConfig = ExpandConfig{
-		AllowedFields: []ExpandableField{ExpandPrices, ExpandMeters, ExpandEntitlements, ExpandCreditGrant, ExpandPriceUnit, ExpandFeatures},
+		AllowedFields: []ExpandableField{ExpandPrices, ExpandMeters, ExpandEntitlements, ExpandCreditGrant, ExpandPriceUnit},
 		NestedExpands: map[ExpandableField][]ExpandableField{
 			ExpandPrices:       {ExpandMeters, ExpandPriceUnit, ExpandFeatures},
 			ExpandEntitlements: {ExpandFeatures},

--- a/scripts/internal/assign_plan.go
+++ b/scripts/internal/assign_plan.go
@@ -196,7 +196,7 @@ func newAssignPlanScript() (*assignPlanScript, error) {
 	priceRepo := entRepo.NewPriceRepository(client, log, redisCache)
 	meterRepo := entRepo.NewMeterRepository(client, log, cacheClient)
 	invoiceRepo := entRepo.NewInvoiceRepository(client, log, redisCache)
-	featureRepo := entRepo.NewFeatureRepository(client, log, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(client, log, cacheClient, redisCache)
 	entitlementRepo := entRepo.NewEntitlementRepository(client, log, cacheClient, redisCache)
 	eventRepo := chRepo.NewEventRepository(chStore, log)
 	processedEventRepo := chRepo.NewProcessedEventRepository(chStore, log)

--- a/scripts/internal/credit_usage_report.go
+++ b/scripts/internal/credit_usage_report.go
@@ -234,7 +234,7 @@ func newCreditUsageReportScript() (*creditUsageReportScript, error) {
 	planRepo := entRepo.NewPlanRepository(client, log, cacheClient)
 	priceRepo := entRepo.NewPriceRepository(client, log, redisCache)
 	meterRepo := entRepo.NewMeterRepository(client, log, cacheClient)
-	featureRepo := entRepo.NewFeatureRepository(client, log, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(client, log, cacheClient, redisCache)
 	entitlementRepo := entRepo.NewEntitlementRepository(client, log, cacheClient, redisCache)
 	addonRepo := entRepo.NewAddonRepository(client, log, cacheClient)
 	addonAssociationRepo := entRepo.NewAddonAssociationRepository(client, log, redisCache)

--- a/scripts/internal/csv_feature_processor.go
+++ b/scripts/internal/csv_feature_processor.go
@@ -128,7 +128,7 @@ func newCSVFeatureProcessor(tenantID, environmentID, userID string) (*CSVFeature
 	redisCache := cache.NewRedisCache()
 
 	// Initialize repositories
-	featureRepo := entRepo.NewFeatureRepository(pgClient, log, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(pgClient, log, cacheClient, redisCache)
 	meterRepo := entRepo.NewMeterRepository(pgClient, log, cacheClient)
 	priceRepo := entRepo.NewPriceRepository(pgClient, log, redisCache)
 	planRepo := entRepo.NewPlanRepository(pgClient, log, cacheClient)

--- a/scripts/internal/feature_import.go
+++ b/scripts/internal/feature_import.go
@@ -93,7 +93,7 @@ func newFeatureImportScript(tenantID, environmentID, planID string) (*featureImp
 	redisCache := cache.NewRedisCache()
 
 	// Initialize repositories
-	featureRepo := entRepo.NewFeatureRepository(pgClient, log, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(pgClient, log, cacheClient, redisCache)
 	meterRepo := entRepo.NewMeterRepository(pgClient, log, cacheClient)
 	priceRepo := entRepo.NewPriceRepository(pgClient, log, redisCache)
 	planRepo := entRepo.NewPlanRepository(pgClient, log, cacheClient)

--- a/scripts/internal/onboard_tenents.go
+++ b/scripts/internal/onboard_tenents.go
@@ -61,7 +61,7 @@ func SyncBillingCustomers() error {
 	priceRepo := ent.NewPriceRepository(client, logger, redisCache)
 	meterRepo := ent.NewMeterRepository(client, logger, cacheClient)
 	entitlementRepo := ent.NewEntitlementRepository(client, logger, cacheClient, redisCache)
-	featureRepo := ent.NewFeatureRepository(client, logger, cacheClient)
+	featureRepo := ent.NewFeatureRepository(client, logger, cacheClient, redisCache)
 	authRepo := ent.NewAuthRepository(client, logger)
 	systemEventRepo := ent.NewSystemEventRepository(client)
 

--- a/scripts/internal/pricing_import.go
+++ b/scripts/internal/pricing_import.go
@@ -94,7 +94,7 @@ func newPricingImportScript(tenantID, environmentID string) (*pricingImportScrip
 	redisCache := cache.NewRedisCache()
 
 	// Initialize repositories
-	featureRepo := entRepo.NewFeatureRepository(pgClient, log, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(pgClient, log, cacheClient, redisCache)
 	meterRepo := entRepo.NewMeterRepository(pgClient, log, cacheClient)
 	priceRepo := entRepo.NewPriceRepository(pgClient, log, redisCache)
 	planRepo := entRepo.NewPlanRepository(pgClient, log, cacheClient)

--- a/scripts/internal/setup_dummy_billing_customer.go
+++ b/scripts/internal/setup_dummy_billing_customer.go
@@ -120,7 +120,7 @@ func SetupDummyBillingCustomer() error {
 	meterRepo := entRepo.NewMeterRepository(client, appLogger, cacheClient)
 	invoiceRepo := entRepo.NewInvoiceRepository(client, appLogger, redisCache)
 	invoiceLineItemRepo := entRepo.NewInvoiceLineItemRepository(client, appLogger)
-	featureRepo := entRepo.NewFeatureRepository(client, appLogger, cacheClient)
+	featureRepo := entRepo.NewFeatureRepository(client, appLogger, cacheClient, redisCache)
 	entitlementRepo := entRepo.NewEntitlementRepository(client, appLogger, cacheClient, redisCache)
 	walletRepo := entRepo.NewWalletRepository(client, appLogger, redisCache)
 	tenantRepo := entRepo.NewTenantRepository(client, appLogger, cacheClient, redisCache)


### PR DESCRIPTION
## **CodeAnt-AI Description**
Expose metered feature reporting units with price expansions

### What Changed
- Price responses can now include a metered feature’s reporting unit, such as displaying usage in minutes instead of seconds, when `features` is requested.
- Plan responses pass feature expansion through to their nested prices.
- Deleted features are excluded so prices use the active published feature linked to their meter.
- Without feature expansion, price responses remain unchanged.

### Impact
`✅ Clearer usage units on price responses`
`✅ Consistent feature details in nested plan prices`
`✅ Deleted features no longer appear in pricing data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional feature details to price responses, including reporting units.
  * Added support for expanding features directly on prices and through plan price expansions.
  * Price feature data is resolved from the associated meter and excludes deleted features.
  * Added configurable tracing controls for Redis and in-memory cache operations.

* **Bug Fixes**
  * Feature lookup issues no longer prevent price retrieval when optional data is unavailable.
  * Plan price synchronization now includes subscriptions in additional applicable states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->